### PR TITLE
4 packages from diskuv/dkml-install-api at 0.4.0

### DIFF
--- a/packages/dkml-component-offline-ocamlrun/dkml-component-offline-ocamlrun.4.12.1~v1.0.2/opam
+++ b/packages/dkml-component-offline-ocamlrun/dkml-component-offline-ocamlrun.4.12.1~v1.0.2/opam
@@ -9,9 +9,10 @@ homepage: "https://github.com/diskuv/dkml-component-ocamlrun"
 bug-reports: "https://github.com/diskuv/dkml-component-ocamlrun/issues"
 depends: [
   "dune" {>= "2.9"}
-  "dkml-install" {>= "0.2.0"}
+  "dkml-install" {>= "0.2.0" & < "0.4.0"}
   "dkml-component-staging-ocamlrun" {= version}
   "diskuvbox" {>= "0.1.0"}
+  "ocaml" {< "5.1.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/dkml-component-offline-opam/dkml-component-offline-opam.2.2.0~alpha0~20221104/opam
+++ b/packages/dkml-component-offline-opam/dkml-component-offline-opam.2.2.0~alpha0~20221104/opam
@@ -29,7 +29,7 @@ depends: [
   "dkml-component-staging-opam32" {= version}
   "dkml-component-staging-opam64" {= version}
   "dkml-component-staging-ocamlrun" {>= "4.12.1~"}
-  "dkml-install" {>= "0.2.0"}
+  "dkml-install" {>= "0.2.0" & < "0.4.0"}
   "diskuvbox" {>= "0.1.0"}
   "odoc" {with-doc}
 ]

--- a/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.12.1~v1.0.2/opam
+++ b/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.12.1~v1.0.2/opam
@@ -178,9 +178,9 @@ extra-source "dl/flexdll.tar.gz" {
   checksum: "sha256=51a6ef2e67ff475c33a76b3dc86401a0f286c9a3339ee8145053ea02d2fb5974"
 }
 extra-source "dl/homebrew-bundle.tar.gz" {
-  src: "https://github.com/Homebrew/homebrew-bundle/archive/4756e4c4cf95485c5ea4da27375946c1dac2c71d.tar.gz"
+  src: "https://github.com/Homebrew/homebrew-bundle/archive/437c67db2f160369fec3a3892e3c577b6b3a4d2c.tar.gz"
   checksum: [
-    "sha256=10c024ca7871cea36b4c27b2601971d3fa6cba6f37855613baf0026d0f555e76"
+    "sha256=ecb6b03b2d0210369f23e3f8f64cd939a4bba633db08db62a49894653e053df4"
   ]
 }
 extra-source "dl/dkml-compiler.tar.gz" {

--- a/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.12.1~v1.0.2/opam
+++ b/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.12.1~v1.0.2/opam
@@ -14,9 +14,15 @@ depends: [
 ]
 dev-repo: "git+https://github.com/diskuv/dkml-component-ocamlrun.git"
 available: [ os = "macos" | (os = "linux" & (arch = "x86_32" | arch = "x86_64")) | os = "win32" ]
+build-env: [
+  [HOMEBREW_NO_AUTO_UPDATE = "1"]
+]
 build: [
   # Homebrew's bundle tap, needed for reproducible build auditing in drc's crossplatform-functions.sh.
-  ["sh" "src/opamtime/brewbundle.sh"] {os = "macos"}
+  # TODO: Move the brewbundle.sh to drc, or in drc skip reproducible build auditing if bundle tap is not installable
+  # WAS: ["sh" "src/opamtime/brewbundle.sh"] {os = "macos"}
+  # NOW: Use an empty Brewfule
+  ["touch" "Brewfile"] {os = "macos"}
 
   # OCaml source code
   ["install" "-d" "dl/ocaml/flexdll"]

--- a/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0~alpha0~20221104/opam
+++ b/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0~alpha0~20221104/opam
@@ -154,9 +154,9 @@ extra-source "dl/opam.tar.gz" {
   ]
 }
 extra-source "dl/homebrew-bundle.tar.gz" {
-  src: "https://github.com/Homebrew/homebrew-bundle/archive/4756e4c4cf95485c5ea4da27375946c1dac2c71d.tar.gz"
+  src: "https://github.com/Homebrew/homebrew-bundle/archive/437c67db2f160369fec3a3892e3c577b6b3a4d2c.tar.gz"
   checksum: [
-    "sha256=10c024ca7871cea36b4c27b2601971d3fa6cba6f37855613baf0026d0f555e76"
+    "sha256=ecb6b03b2d0210369f23e3f8f64cd939a4bba633db08db62a49894653e053df4"
   ]
 }
 

--- a/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0~alpha0~20221104/opam
+++ b/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0~alpha0~20221104/opam
@@ -1,4 +1,4 @@
-opam-version: "2.0"
+ opam-version: "2.0"
 synopsis: "DKML component for 32-bit versions of opam"
 description: """
 For 32-bit capable platforms, opam, opam-putenv and opam-installer will be in <share>/staging-files/<platform>.
@@ -36,9 +36,15 @@ depopts: [
   "ocaml-option-32bit"
 ]
 dev-repo: "git+https://github.com/diskuv/dkml-component-opam.git"
+build-env: [
+  [HOMEBREW_NO_AUTO_UPDATE = "1"]
+]
 build: [
   # Homebrew's bundle tap, needed for reproducible build auditing in drc's crossplatform-functions.sh.
-  ["sh" "src/opamtime/brewbundle.sh"] {os = "macos"}
+  # TODO: Move the brewbundle.sh to drc, or in drc skip reproducible build auditing if bundle tap is not installable
+  # WAS: ["sh" "src/opamtime/brewbundle.sh"] {os = "macos"}
+  # NOW: Use an empty Brewfule
+  ["touch" "Brewfile"] {os = "macos"}
 
   # Opam source code
   ["install" "-d" "dl/opam"]

--- a/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0~alpha0~20221104/opam
+++ b/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0~alpha0~20221104/opam
@@ -40,9 +40,15 @@ depopts: [
   "ocaml-option-32bit"
 ]
 dev-repo: "git+https://github.com/diskuv/dkml-component-opam.git"
+build-env: [
+  [HOMEBREW_NO_AUTO_UPDATE = "1"]
+]
 build: [
   # Homebrew's bundle tap, needed for reproducible build auditing in drc's crossplatform-functions.sh.
-  ["sh" "src/opamtime/brewbundle.sh"] {os = "macos"}
+  # TODO: Move the brewbundle.sh to drc, or in drc skip reproducible build auditing if bundle tap is not installable
+  # WAS: ["sh" "src/opamtime/brewbundle.sh"] {os = "macos"}
+  # NOW: Use an empty Brewfule
+  ["touch" "Brewfile"] {os = "macos"}
 
   # Opam source code
   ["install" "-d" "dl/opam"]

--- a/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0~alpha0~20221104/opam
+++ b/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0~alpha0~20221104/opam
@@ -202,9 +202,9 @@ extra-source "dl/opam.tar.gz" {
   ]
 }
 extra-source "dl/homebrew-bundle.tar.gz" {
-  src: "https://github.com/Homebrew/homebrew-bundle/archive/4756e4c4cf95485c5ea4da27375946c1dac2c71d.tar.gz"
+  src: "https://github.com/Homebrew/homebrew-bundle/archive/437c67db2f160369fec3a3892e3c577b6b3a4d2c.tar.gz"
   checksum: [
-    "sha256=10c024ca7871cea36b4c27b2601971d3fa6cba6f37855613baf0026d0f555e76"
+    "sha256=ecb6b03b2d0210369f23e3f8f64cd939a4bba633db08db62a49894653e053df4"
   ]
 }
 

--- a/packages/dkml-install-installer/dkml-install-installer.0.4.0/opam
+++ b/packages/dkml-install-installer/dkml-install-installer.0.4.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Build tools for DKML installers"
+description:
+  "Build-time executables that can generate Dune include files which will compile essential end-user executables."
+maintainer: "opensource+diskuv-ocaml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "dune" {>= "2.9"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.1"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "crunch" {>= "3.3.1"}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.4.0/dkml-install-api-0.4.0.tar.gz"
+  checksum: [
+    "md5=1b3f42a06b0643eb502e6f65d1769b98"
+    "sha512=55d47cb8c570f3e9fbdb5f4f7960c86fbe357df6c5364c82c9eb326150693fa1dbffe3fa3f5682e355f770c5f3c53bd7ce88ec1d1d9eefecceb8f44ed8b1d326"
+  ]
+}

--- a/packages/dkml-install-runner/dkml-install-runner.0.4.0/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.4.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Runner executable for Diskuv OCaml (DKML) installation"
+description:
+  "The runner executable is responsible for loading and running all DKML installation components."
+maintainer: "opensource+diskuv-ocaml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-install" {= version}
+  "dune" {>= "2.9"}
+  "ppx_expect" {>= "v0.14.1"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.1"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "diskuvbox" {>= "0.1.1"}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.4.0/dkml-install-api-0.4.0.tar.gz"
+  checksum: [
+    "md5=1b3f42a06b0643eb502e6f65d1769b98"
+    "sha512=55d47cb8c570f3e9fbdb5f4f7960c86fbe357df6c5364c82c9eb326150693fa1dbffe3fa3f5682e355f770c5f3c53bd7ce88ec1d1d9eefecceb8f44ed8b1d326"
+  ]
+}

--- a/packages/dkml-install/dkml-install.0.4.0/opam
+++ b/packages/dkml-install/dkml-install.0.4.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "API and registry for Diskuv OCaml (DKML) installation components"
+description:
+  "All DKML installation components implement the interfaces exposed in this API."
+maintainer: "opensource+diskuv-ocaml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dune" {>= "2.9"}
+  "ppx_deriving" {>= "5.2.1"}
+  "result" {>= "1.5"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.1"}
+  "fmt" {>= "0.8.9"}
+  "tsort" {>= "2.1.0"}
+  "diskuvbox" {>= "0.1.1" & with-test}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.4.0/dkml-install-api-0.4.0.tar.gz"
+  checksum: [
+    "md5=1b3f42a06b0643eb502e6f65d1769b98"
+    "sha512=55d47cb8c570f3e9fbdb5f4f7960c86fbe357df6c5364c82c9eb326150693fa1dbffe3fa3f5682e355f770c5f3c53bd7ce88ec1d1d9eefecceb8f44ed8b1d326"
+  ]
+}

--- a/packages/dkml-package-console/dkml-package-console.0.4.0/opam
+++ b/packages/dkml-package-console/dkml-package-console.0.4.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Console setup and uninstall executables for Diskuv OCaml (DKML) installation"
+description:
+  "The setup and uninstall executables are responsible for launching the DKML runners."
+maintainer: "opensource+diskuv-ocaml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "dune" {>= "2.9"}
+  "diskuvbox" {>= "0.1.1"}
+  "crunch" {>= "3.3.1"}
+  "dkml-component-xx-console" {>= "0.1.1"}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.4.0/dkml-install-api-0.4.0.tar.gz"
+  checksum: [
+    "md5=1b3f42a06b0643eb502e6f65d1769b98"
+    "sha512=55d47cb8c570f3e9fbdb5f4f7960c86fbe357df6c5364c82c9eb326150693fa1dbffe3fa3f5682e355f770c5f3c53bd7ce88ec1d1d9eefecceb8f44ed8b1d326"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`dkml-install.0.4.0`: API and registry for Diskuv OCaml (DKML) installation components
-`dkml-install-installer.0.4.0`: Build tools for DKML installers
-`dkml-install-runner.0.4.0`: Runner executable for Diskuv OCaml (DKML) installation
-`dkml-package-console.0.4.0`: Console setup and uninstall executables for Diskuv OCaml (DKML) installation

*and* it tightens the reverse deps bounds for:

- `dkml-component-offline-ocamlrun.4.12.1~v1.0.2`
- `dkml-component-offline-opam.2.2.0~alpha0~20221104`

*and* it fixes rev-deps macos build failures for:

- `dkml-component-staging-ocamlrun.4.12.1~v1.0.2`
- `dkml-component-staging-opam32.2.2.0~alpha0~20221104`
- `dkml-component-staging-opam64.2.2.0~alpha0~20221104`

---
* Homepage: https://github.com/diskuv/dkml-install-api
* Source repo: git+https://github.com/diskuv/dkml-install-api.git
* Bug tracker: https://github.com/diskuv/dkml-install-api/issues

---
:camel: Pull-request generated by opam-publish v2.1.0