### PR TITLE
[new release] capnp (3.6.0)

### DIFF
--- a/packages/capnp/capnp.3.6.0/opam
+++ b/packages/capnp/capnp.3.6.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Paul Pelzl <pelzlpj@gmail.com>"
+authors: "Paul Pelzl <pelzlpj@gmail.com>"
+homepage: "https://github.com/capnproto/capnp-ocaml"
+bug-reports: "https://github.com/capnproto/capnp-ocaml/issues"
+license: "BSD-2-Clause"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.3"}
+  "result"
+  "base" {>= "v0.11"}
+  "stdio"
+  "base_quickcheck" {with-test}
+  "ocplib-endian" {>= "0.7"}
+  "res"
+  "stdint" {>= "0.5.1"}
+  "ounit2" {with-test}
+  "conf-capnproto" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+]
+dev-repo: "git+https://github.com/capnproto/capnp-ocaml.git"
+synopsis:
+  "OCaml code generation plugin for the Cap'n Proto serialization framework"
+description: """
+Cap'n Proto is a multi-language code generation framework designed for
+high performance through the use of lazy parsing and arena allocation.
+This package provides a plugin for the Cap'n Proto compiler which enables
+OCaml code generation, as well as corresponding runtime library support."""
+url {
+  src:
+    "https://github.com/capnproto/capnp-ocaml/releases/download/v3.6.0/capnp-3.6.0.tbz"
+  checksum: [
+    "sha256=d141d6ea5889fb9cc9ceef70408dd410ca0d84edae1d1208d4f90ca74ce77b18"
+    "sha512=7d70da54317c8ec13b5129343fc9558e7fe387fc41ac0524cd9363153d47cf293ea36c5d598ab04d9817292cb84d5e764c9446ae29eebcb01976b937a82192b0"
+  ]
+}
+x-commit-hash: "cc461758431a77e6c7854f8e1875c2f91dca8ef2"


### PR DESCRIPTION
OCaml code generation plugin for the Cap'n Proto serialization framework

- Project page: <a href="https://github.com/capnproto/capnp-ocaml">https://github.com/capnproto/capnp-ocaml</a>

##### CHANGES:

- Update README to talk about stdint, not uint (reported by @liyishuai).
  Also, remove out-of-date list of runtime packages needed. The build system can sort that out.

- Remove all `inlined` attributes (@talex5 capnproto/capnp-ocaml#87 capnproto/capnp-ocaml#88).
  These cause confusing compiler warnings for users, which can't be disabled automatically,
  and the inlining isn't being used anyway since https://github.com/capnproto/capnp-ocaml/pull/83.

- Fix "Unknown interface" error (@talex5 capnproto/capnp-ocaml#85).
  It reported the UUID of the actual object, not the UUID that was requested.
  Also, add `Registry.pp_interface` for better error messages.

- Minor opam fixes (@talex5 capnproto/capnp-ocaml#84).
  Depend on dune >= 2.3 and don't try to build benchmarks; that only works on some platforms.

- Bump minimum OCaml version to 4.08.
  4.07 doesn't work due to https://github.com/janestreet/base/issues/94.
