### PR TITLE
[new release] lintcstubs-arity (0.1.0)

### DIFF
--- a/packages/lintcstubs-arity/lintcstubs-arity.0.1.0/opam
+++ b/packages/lintcstubs-arity/lintcstubs-arity.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Generate headers for C bindings"
+description:
+  "Generates .h files from 'external' declarations in .ml files. Can be used to spot mismatches in number of arguments between C primitive declared in OCaml and its implementation in the .c file."
+maintainer: ["Edwin Török <edwin.torok@cloud.com>"]
+authors: ["Edwin Török <edwin.torok@cloud.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/edwintorok/lintcstubs-arity"
+bug-reports: "https://github.com/edwintorok/lintcstubs-arity/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "ocaml-src" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/edwintorok/lintcstubs-arity.git"
+url {
+  src:
+    "https://github.com/edwintorok/lintcstubs-arity/releases/download/0.1.0/lintcstubs-arity-0.1.0.tbz"
+  checksum: [
+    "sha256=ef40d8e4296142d51716ea8e4670cbc293effa86ac7b743a53b24719ac9ac5f9"
+    "sha512=e9867ba83596f682583a21cb7be2a8c36842fd96b2f9ca0f3406a6383df872a191f7bf8871d26969ec1b6ef898b8da8df1011e686637407f0e91cf77dab9557a"
+  ]
+}
+x-commit-hash: "6e8b0c7c80a512da2865217e2073595d175c54db"


### PR DESCRIPTION
Generate headers for C bindings

- Project page: <a href="https://github.com/edwintorok/lintcstubs-arity">https://github.com/edwintorok/lintcstubs-arity</a>

##### CHANGES:

First release
