### PR TITLE
[new release] multicore-magic (1.0.1)

### DIFF
--- a/packages/multicore-magic/multicore-magic.1.0.1/opam
+++ b/packages/multicore-magic/multicore-magic.1.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Low-level multicore utilities for OCaml"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-magic"
+bug-reports: "https://github.com/ocaml-multicore/multicore-magic/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.12.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {>= "2.2.0" & with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-magic.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-magic/releases/download/1.0.1/multicore-magic-1.0.1.tbz"
+  checksum: [
+    "sha256=8558a2e2328f901ac9d896fb7d441d13494d2c8703fca8a5a13b184f9ccb3427"
+    "sha512=02cdbd50c504e634464ebb8cc938abeb90883e46353ffad4512f2b1c7a316618befe02cfa2f3c055e5e6ff9dea56def05a1602d3dc6c3caa7c31b1882ba64683"
+  ]
+}
+x-commit-hash: "fce97baf620fef42a3578ff01ead13c18ec68a60"


### PR DESCRIPTION
Low-level multicore utilities for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/multicore-magic">https://github.com/ocaml-multicore/multicore-magic</a>

## 1.0.1

- Ported the library to OCaml 4 (@polytypic)
- License changed to ISC from 0BSD (@tarides)
