### PR TITLE
[new release] mirage-net-xen (2 packages) (2.1.3)

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.2.1.3/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.2.1.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+license:       "ISC"
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "mirage-xen" {>= "7.0.0"}
+  "netchannel" {= version}
+  "lwt-dllist"
+  "logs" {>= "0.5.0"}
+]
+
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v2.1.3/mirage-net-xen-2.1.3.tbz"
+  checksum: [
+    "sha256=80ea736386e7f4bf3091b795897cbf5d09b12aaa897ddf7d6dc1d0162b5814e1"
+    "sha512=15ba54927d73ed0701ece6a3f03b4cc3b85c43c11405c55476aad75dc6a4d7709ead34d8a095b518282dce7c75d349b7605a8c87655265cf251858157a4e288e"
+  ]
+}
+x-commit-hash: "47fcb6007b72708eb9fd68e7dac98a5ad185e80a"

--- a/packages/netchannel/netchannel.2.1.3/opam
+++ b/packages/netchannel/netchannel.2.1.3/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+license:       "ISC"
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "mirage-xen" {>= "7.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-profile" {>="0.3"}
+  "shared-memory-ring" {>="3.0.0"}
+  "sexplib" {>= "113.01.00"}
+  "logs" {>= "0.5.0"}
+  "lwt-dllist"
+  "result" {>= "1.5"}
+  "macaddr" {>= "5.2.0"}
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+
+Note: the `Netif` module is the public API.
+The `Netchannel` API is still under development.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v2.1.3/mirage-net-xen-2.1.3.tbz"
+  checksum: [
+    "sha256=80ea736386e7f4bf3091b795897cbf5d09b12aaa897ddf7d6dc1d0162b5814e1"
+    "sha512=15ba54927d73ed0701ece6a3f03b4cc3b85c43c11405c55476aad75dc6a4d7709ead34d8a095b518282dce7c75d349b7605a8c87655265cf251858157a4e288e"
+  ]
+}
+x-commit-hash: "47fcb6007b72708eb9fd68e7dac98a5ad185e80a"


### PR DESCRIPTION
Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol

- Project page: <a href="https://github.com/mirage/mirage-net-xen">https://github.com/mirage/mirage-net-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-xen/">https://mirage.github.io/mirage-net-xen/</a>

##### CHANGES:

* xenstore: read_backend now waits for the backend-id key to be written by
  Xen before reading it to avoid raising an exception (@palainp, mirage/mirage-net-xen#107)
