### PR TITLE
Add `avoid-version` flag to latest Merlin preview

### DIFF
--- a/packages/merlin-lib/merlin-lib.4.9-501preview/opam
+++ b/packages/merlin-lib/merlin-lib.4.9-501preview/opam
@@ -17,6 +17,8 @@ depends: [
   "menhirLib" {dev & >= "20201216"}
   "menhirSdk" {dev & >= "20201216"}
 ]
+available: opam-version >= "2.1.0"
+flags: avoid-version
 synopsis:
   "Merlin's libraries"
 description:

--- a/packages/merlin/merlin.4.9-501preview/opam
+++ b/packages/merlin/merlin.4.9-501preview/opam
@@ -23,6 +23,8 @@ conflicts: [
   "seq" {!= "base"}
   "base-effects"
 ]
+available: opam-version >= "2.1.0"
+flags: avoid-version
 synopsis:
   "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
 description:


### PR DESCRIPTION
As discussed with @kit-ty-kate, the latest Merlin preview for OCaml 5.1 has inconsistent versioning.

@kit-ty-kate  I guess I don't need to propagate these changes to the upstream repository ?