### PR TITLE
Mark base.v0.16.2 as unavailable on Win32

### DIFF
--- a/packages/base/base.v0.16.2/opam
+++ b/packages/base/base.v0.16.2/opam
@@ -6,6 +6,7 @@ bug-reports: "https://github.com/janestreet/base/issues"
 dev-repo: "git+https://github.com/janestreet/base.git"
 doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
 license: "MIT"
+available: os != "win32" # https://github.com/ocaml/opam-repository/issues/24151
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]


### PR DESCRIPTION
Root cause https://github.com/janestreet/base/issues/157
Fixes https://github.com/ocaml/opam-repository/issues/24151