### PR TITLE
Base v0.16.2 does not build on Windows

### DIFF
--- a/packages/base/base.v0.16.2/opam
+++ b/packages/base/base.v0.16.2/opam
@@ -16,6 +16,7 @@ depends: [
   "dune"              {>= "2.0.0"}
   "dune-configurator"
 ]
+available: os != "win32"
 synopsis: "Full standard library replacement for OCaml"
 description: "
 Full standard library replacement for OCaml


### PR DESCRIPTION
Add an OS restriction to Base v0.16.2.