### PR TITLE
Fix older versions of domainslib

### DIFF
--- a/packages/domainslib/domainslib.0.3.0/opam
+++ b/packages/domainslib/domainslib.0.3.0/opam
@@ -9,6 +9,7 @@ dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
 bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
 tags: ["org:ocamllabs"]
 depends: [
+  "ocaml" {< "5.0.0"}
   "dune" {>= "1.8"}
   "base-domains"
 ]

--- a/packages/domainslib/domainslib.0.3.1/opam
+++ b/packages/domainslib/domainslib.0.3.1/opam
@@ -9,6 +9,7 @@ dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
 bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
 tags: ["org:ocamllabs"]
 depends: [
+  "ocaml" {< "5.0.0"}
   "dune" {>= "1.8"}
   "base-domains"
 ]

--- a/packages/domainslib/domainslib.0.4.0/opam
+++ b/packages/domainslib/domainslib.0.4.0/opam
@@ -13,6 +13,7 @@ depends: [
   "base-domains"
   "mirage-clock-unix" {with-test}
 ]
+available: false # Not compatible with 4.12.0+domains nor 5.0.0~alpha0 and newer. Was compatible only with trunk for a short period of time.
 build: ["dune" "build" "-p" name "-j" jobs]
 url {
   src: "https://github.com/ocaml-multicore/domainslib/archive/0.4.0.tar.gz"

--- a/packages/domainslib/domainslib.0.4.1/opam
+++ b/packages/domainslib/domainslib.0.4.1/opam
@@ -13,6 +13,7 @@ depends: [
   "dune" {>= "1.8"}
   "mirage-clock-unix" {with-test}
 ]
+available: false # Not compatible with 4.12.0+domains nor 5.0.0~alpha0 and newer. Was compatible only with trunk for a short period of time.
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
 url {


### PR DESCRIPTION
 Those are not compatible with OCaml >= 5.0.0~alpha0, was only compatible with unreleased versions.
```
#=== ERROR while compiling domainslib.0.3.1 ===================================#
# context              2.2.0~alpha | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/domainslib.0.3.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p domainslib -j 255
# exit-code            1
# env-file             ~/.opam/log/domainslib-8-618be4.env
# output-file          ~/.opam/log/domainslib-8-618be4.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.domainslib.objs/byte -no-alias-deps -open Domainslib__ -o lib/.domainslib.objs/byte/domainslib__Ws_deque.cmo -c -impl lib/ws_deque.ml)
# File "lib/ws_deque.ml", line 192, characters 8-29:
# 192 |         Domain.Sync.cpu_relax ();
#               ^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module Domain.Sync
```
```
#=== ERROR while compiling domainslib.0.4.1 ===================================#
# context              2.2.0~alpha | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/domainslib.0.4.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p domainslib -j 47
# exit-code            1
# env-file             ~/.opam/log/domainslib-8-fef492.env
# output-file          ~/.opam/log/domainslib-8-fef492.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.domainslib.objs/byte -intf-suffix .ml -no-alias-deps -open Domainslib__ -o lib/.domainslib.objs/byte/domainslib__Task.cmo -c -impl lib/task.ml)
# File "lib/task.ml", line 27, characters 7-10:
# 27 | type _ eff += Wait : 'a promise * task_chan -> 'a eff
#             ^^^
# Error: Unbound type constructor eff
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I lib/.domainslib.objs/byte -I lib/.domainslib.objs/native -intf-suffix .ml -no-alias-deps -open Domainslib__ -o lib/.domainslib.objs/native/domainslib__Task.cmx -c -impl lib/task.ml)
# File "lib/task.ml", line 27, characters 7-10:
# 27 | type _ eff += Wait : 'a promise * task_chan -> 'a eff
#             ^^^
# Error: Unbound type constructor eff
```