### PR TITLE
Package llvm.15.0.7+nnp

### DIFF
--- a/packages/conf-llvm/conf-llvm.15/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.15/files/configure.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+set -x
+
+version=${1/%.?.?/}
+
+if hash brew 2>/dev/null; then
+    brew_llvm_config="$(brew --cellar)"/llvm*/${version}*/bin/llvm-config
+fi
+
+shopt -s nullglob
+for llvm_config in llvm-config-$version llvm-config-${version}.0 llvm-config${version}0 llvm-config-mp-$version llvm-config-mp-${version}.0 llvm${version}-config llvm-config-${version}-32 llvm-config-${version}-64 llvm-config $brew_llvm_config; do
+    llvm_version="`$llvm_config --version`" || true
+    case $llvm_version in
+    $version*)
+        echo "config: \"$llvm_config\"" >> conf-llvm.config
+        echo "version: \"$llvm_version\"" >> conf-llvm.config
+        exit 0;;
+    *)
+        echo "Note: '$llvm_config' doesn't match the required version. Got '$llvm_version' but required '$version'."
+        continue;;
+    esac
+done
+
+echo "Error: LLVM ${version} is not installed."
+exit 1

--- a/packages/conf-llvm/conf-llvm.15/opam
+++ b/packages/conf-llvm/conf-llvm.15/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "The LLVM team"
+homepage: "http://llvm.org"
+bug-reports: "https://llvm.org/bugs/"
+license: "MIT"
+build: [
+  ["bash" "configure.sh" version]
+]
+depends: [
+  "conf-bash" {build}
+]
+depexts: [
+  ["llvm@15"] {os-distribution = "homebrew" & os = "macos"}
+  ["llvm-15"] {os-distribution = "macports" & os = "macos"}
+  ["llvm-15-dev"] {os-family = "debian"}
+  ["llvm15-dev"] {os-distribution = "alpine"}
+  ["llvm"] {os-family = "arch"}
+  ["llvm15-devel"] {os-family = "suse"}
+  ["llvm15-devel"] {os-distribution = "fedora"}
+  ["llvm15-devel" "epel-release"] {os-distribution = "centos"}
+  ["devel/llvm15"] {os = "freebsd"}
+]
+synopsis: "Virtual package relying on llvm library installation"
+extra-files: ["configure.sh" "md5=633155a6495a7afd1c87ffd0b94e8cf9"]
+flags: conf

--- a/packages/llvm/llvm.15.0.7+nnp/opam
+++ b/packages/llvm/llvm.15.0.7+nnp/opam
@@ -7,7 +7,7 @@ authors: [
   "whitequark <whitequark@whitequark.org>"
   "The LLVM team"
 ]
-license: "Apache-2.0 with LLVM-exception"
+license: "Apache-2.0 WITH LLVM-exception"
 homepage: "http://llvm.moe"
 doc: "http://llvm.moe/ocaml"
 bug-reports: "http://llvm.org/bugs/"

--- a/packages/llvm/llvm.15.0.7+nnp/opam
+++ b/packages/llvm/llvm.15.0.7+nnp/opam
@@ -14,7 +14,7 @@ bug-reports: "http://llvm.org/bugs/"
 depends: [
   "ocaml" {>= "4.00.0"}
   "dune" {>= "2.7"}
-  "ctypes" {>= "0.4"}
+  "ctypes" {>= "0.4" & < "0.21.0"}
   "ctypes-foreign" {< "0.21.0"}
   "ounit" {with-test}
   "conf-llvm" {build & = "15"}

--- a/packages/llvm/llvm.15.0.7+nnp/opam
+++ b/packages/llvm/llvm.15.0.7+nnp/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "2.7"}
   "ctypes" {>= "0.4"}
   "ounit" {with-test}
-  "conf-llvm" {build & = version}
+  "conf-llvm" {build & = "15"}
 ]
 build: [
   ["./setup.sh" conf-llvm:config]

--- a/packages/llvm/llvm.15.0.7+nnp/opam
+++ b/packages/llvm/llvm.15.0.7+nnp/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "The OCaml bindings distributed with LLVM"
+description: "Note: LLVM should be installed first."
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: [
+  "Gordon Henriksen <gordonhenriksen@mac.com>"
+  "whitequark <whitequark@whitequark.org>"
+  "The LLVM team"
+]
+license: "Apache-2.0 with LLVM-exception"
+homepage: "http://llvm.moe"
+doc: "http://llvm.moe/ocaml"
+bug-reports: "http://llvm.org/bugs/"
+depends: [
+  "ocaml" {>= "4.00.0"}
+  "dune" {>= "2.7"}
+  "ctypes" {>= "0.4"}
+  "ounit" {with-test}
+  "conf-llvm" {build & = version}
+]
+build: [
+  ["./setup.sh" conf-llvm:config]
+  ["dune" "build" "--release" "-j" jobs]
+  ["rm" "%{name}%.install"]
+]
+install: ["./install.sh" prefix]
+dev-repo: "git+https://github.com/kit-ty-kate/llvm-dune.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/llvm-dune/releases/download/v15.0.7%2Bnnp/llvm-dune-full-minified-15.0.7+nnp.tar.gz"
+  checksum: [
+    "md5=751ae4194629d5a6a5585827462ba89b"
+    "sha512=edccf9e853747a09ec9227f97d24862c73b25972aaa1f2f8c77925a15188e9c97251b2c97e03c0c8d513f115dbe26b9ad4439d6471c1401256d947a5edb932b9"
+  ]
+}

--- a/packages/llvm/llvm.15.0.7+nnp/opam
+++ b/packages/llvm/llvm.15.0.7+nnp/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.00.0"}
   "dune" {>= "2.7"}
   "ctypes" {>= "0.4"}
+  "ctypes-foreign" {< "0.21.0"}
   "ounit" {with-test}
   "conf-llvm" {build & = "15"}
 ]


### PR DESCRIPTION
### `llvm.15.0.7+nnp`
The OCaml bindings distributed with LLVM
Note: LLVM should be installed first.



---
* Homepage: http://llvm.moe
* Source repo: git+https://github.com/kit-ty-kate/llvm-dune.git
* Bug tracker: http://llvm.org/bugs/

---
:camel: Pull-request generated by opam-publish v2.2.0