### PR TITLE
Restrict ctypes-foreign.0.18.0 to ctypes < 0.21.0

### DIFF
--- a/packages/ctypes-foreign/ctypes-foreign.0.18.0/opam
+++ b/packages/ctypes-foreign/ctypes-foreign.0.18.0/opam
@@ -5,7 +5,7 @@ dev-repo: "git+http://github.com/yallop/ocaml-ctypes.git"
 bug-reports: "http://github.com/yallop/ocaml-ctypes/issues"
 license: "MIT"
 depends: [
-  "ctypes" {post}
+  "ctypes" {post & < "0.21.0"}
   "conf-pkg-config" {build}
   "conf-libffi" {>= "2.0.0"}
 ]


### PR DESCRIPTION
The only versions installing `ctypes.foreign` if this package is present.