### PR TITLE
Package async_ssl.v0.16.1

### DIFF
--- a/packages/async_ssl/async_ssl.v0.16.1/opam
+++ b/packages/async_ssl/async_ssl.v0.16.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/async_ssl"
+bug-reports: "https://github.com/janestreet/async_ssl/issues"
+dev-repo: "git+https://github.com/janestreet/async_ssl.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/async_ssl/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"             {>= "4.14.0"}
+  "async"             {>= "v0.16" & < "v0.17"}
+  "base"              {>= "v0.16" & < "v0.17"}
+  "core"              {>= "v0.16" & < "v0.17"}
+  "ppx_jane"          {>= "v0.16" & < "v0.17"}
+  "ppx_optcomp"       {>= "v0.16" & < "v0.17"}
+  "stdio"             {>= "v0.16" & < "v0.17"}
+  "conf-libssl"
+  "ctypes"            {>= "0.18.0"}
+  "ctypes-foreign"
+  "dune"              {>= "2.0.0"}
+  "dune-configurator"
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "An Async-pipe-based interface with OpenSSL"
+description: "
+This library allows you to create an SSL client and server, with
+encrypted communication between both.
+"
+url {
+  src:
+    "https://github.com/janestreet/async_ssl/archive/refs/tags/v0.16.1.tar.gz"
+  checksum: [
+    "md5=7e404ed41467b7ac0ef985f5ac6eccd8"
+    "sha512=e4545e91d15d43f1a53ca8d05e8b7d39d11627671d0da2b2b02451b197387b396a310d51397decbd6448fc2bb13aa237b052685263dea4e2010f7884ad94371d"
+  ]
+}


### PR DESCRIPTION
### `async_ssl.v0.16.1`
An Async-pipe-based interface with OpenSSL
This library allows you to create an SSL client and server, with
encrypted communication between both.



---
* Homepage: https://github.com/janestreet/async_ssl
* Source repo: git+https://github.com/janestreet/async_ssl.git
* Bug tracker: https://github.com/janestreet/async_ssl/issues

---
:camel: Pull-request generated by opam-publish v2.2.0