### PR TITLE
Add: brr.0.0.6, note.0.0.3

### DIFF
--- a/packages/brr/brr.0.0.6/opam
+++ b/packages/brr/brr.0.0.6/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Browser programming toolkit for OCaml"
+description: """\
+Brr is a toolkit for programming browsers in OCaml with the
+[`js_of_ocaml`][jsoo] compiler. It provides:
+
+* Interfaces to a selection of browser APIs.
+* An OCaml console developer tool for live interaction 
+  with programs running in web pages.
+* A JavaScript FFI for idiomatic OCaml programming.
+
+Brr is distributed under the ISC license. It depends on the
+`js_of_ocaml` compiler and runtime – but not on its libraries or
+syntax extension.
+
+[jsoo]: https://ocsigen.org/js_of_ocaml
+
+Homepage: <https://erratique.ch/software/brr>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The brr programmers"
+license: ["ISC" "BSD-3-Clause"]
+tags: ["reactive" "declarative" "frp" "front-end" "browser" "org:erratique"]
+homepage: "https://erratique.ch/software/brr"
+doc: "https://erratique.ch/software/brr/doc/"
+bug-reports: "https://github.com/dbuenzli/brr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "js_of_ocaml-compiler" {>= "4.1.0"}
+  "js_of_ocaml-toplevel" {>= "4.1.0"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/brr.git"
+url {
+  src: "https://erratique.ch/software/brr/releases/brr-0.0.6.tbz"
+  checksum:
+    "sha512=21b8a32ca21ab824a65397d94bc6588dc66884e155c0106ebe2329387a511b6e5a6062ffe1bd621557322854c0f33e49763319131eab3451ba36da1b3f065d2b"
+}

--- a/packages/note/note.0.0.3/opam
+++ b/packages/note/note.0.0.3/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Declarative events and signals for OCaml"
+description: """\
+Note is an OCaml library for functional reactive programming (FRP). It
+provides support to program with time varying values: declarative
+events and signals.
+
+Note also has (optional and experimental) support for reactive browser
+programming with the [brr] library.
+
+Note is distributed under the ISC license.
+
+Homepage: <http://erratique.ch/software/note>  
+
+[brr]: https://erratique.ch/software/brr"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The note programmers"
+license: "ISC"
+tags: [
+  "reactive" "declarative" "signal" "event" "frp" "org:erratique" "browser"
+]
+homepage: "https://erratique.ch/software/note"
+doc: "https://erratique.ch/software/note/doc/"
+bug-reports: "https://github.com/dbuenzli/note/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+]
+depopts: ["brr"]
+conflicts: [
+  "brr" {< "0.0.6"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-brr"
+  "%{brr:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/note.git"
+url {
+  src: "https://erratique.ch/software/note/releases/note-0.0.3.tbz"
+  checksum:
+    "sha512=cd972d9066fc712625fd143f5bfe94f66d0c8c47adcd0c0dcde698cf7a88a4b8065bc6a39252916f7f2dd763d5c525a0826be9b33d564af5e260e1577b3e6d31"
+}


### PR DESCRIPTION
* Add: `brr.0.0.6` [home](https://erratique.ch/software/brr), [doc](https://erratique.ch/software/brr/doc/), [issues](https://github.com/dbuenzli/brr/issues)  
  *Browser programming toolkit for OCaml*
* Add: `note.0.0.3` [home](https://erratique.ch/software/note), [doc](https://erratique.ch/software/note/doc/), [issues](https://github.com/dbuenzli/note/issues)  
  *Declarative events and signals for OCaml*


---

#### `brr` v0.0.6 2023-07-29 Zagreb

- The experimental library `brr.note` has been migrated to the `note.brr`
  library available via the `note` package. The toplevel modules 
  were renamed from `Brr_note*` to `Note_brr*`.
  
- Fix encoding mess in `Brr.Uri` which tried to expose a model that is
  not workable in practice due to the way the URI standard is defined.
  
  * Accessors and `Uri.with_uri` no longer perform percent decoding and 
    encoding for you.
  * Added helper functions `Uri.[with_]{query,fragment}_params`.
  * Added helper functions `Uri.[with_]{path_segments}`.
  
  Thanks to Max Lang for the report and making sure the new API makes
  sense ([#50](https://github.com/dbuenzli/brr/issues/50)).

- Add canvas color space support (note: unsupported on Firefox for now).

  * `C2d.attrs`, add `color_space` and `will_read_frequently` attributes.
  * Add `C2d.Image_data.color_space` and a `?color_space` optional argument
    to `C2d.{create,get}_image_data` and `C2d.Image_data.create`.

- `Brr.Blob.{array_buffer,text,data_uri}`: add an optional argument
  `?progress`. If provided the load happens via a `FileReader` object
  and load progress is reported ([#39](https://github.com/dbuenzli/brr/issues/39)).

- Updated developer tool console to Manifest V3 ([#44](https://github.com/dbuenzli/brr/issues/44)).

---

#### `note` v0.0.3 2023-07-39 Zagreb

- Add the `note.brr` experimental library. This used to be `brr.note`
  in `brr`. The toplevel modules have been renamed from `Brr_note*` to
  `Note_brr*`. `brr` becomes an optional dependency of `note`.

---

Use `b0 -- .opam.publish brr.0.0.6 note.0.0.3` to update the pull request.