### PR TITLE
h2-eio: add upper bound on gluten-eio

### DIFF
--- a/packages/h2-eio/h2-eio.0.10.0/opam
+++ b/packages/h2-eio/h2-eio.0.10.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
   "h2" {= version}
-  "gluten-eio" {>= "0.4.1"}
+  "gluten-eio" {>= "0.4.1" & < "0.5.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
the new release of gluten-eio adds a `~sw` argument which will break earlier versions of h2-eio.