### PR TITLE
fix leaflet.0.1 checksum

### DIFF
--- a/packages/leaflet/leaflet.0.1/opam
+++ b/packages/leaflet/leaflet.0.1/opam
@@ -42,7 +42,7 @@ dev-repo: "git+https://git.zapashcanon.fr/swrup/leaflet.git"
 url {
   src: "https://git.zapashcanon.fr/swrup/leaflet/archive/0.1.tar.gz"
   checksum: [
-    "md5=b58ad586c7afc3b008f454ff66541b16"
-    "sha512=bf0f46329e64a7c20019ffccc8acde998becb79310edf920e062f4f4f268e3b7860138d049921fefbc9195e27c1060562cac6c6d716f7051ef97c818acffcd63"
+    "md5=b00b81623836a5a71e570959ec02a30d"
+    "sha512=98f5ae081b413ee3950aa08ab95007df51b6d9e2a2449a505ed48f59775d0a637dc0ddc9139125e34e5130884fba7e5044da8bdbf506a495bed03cb0a146d97c"
   ]
 }


### PR DESCRIPTION
Hello,

This should fix #24176
Leaflet package had a checksum issue  because of a bad gitea configuration (same as in #23180)