### PR TITLE
[new release] conf-diffutils 1.1

### DIFF
--- a/packages/conf-diffutils/conf-diffutils.1.1/opam
+++ b/packages/conf-diffutils/conf-diffutils.1.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+homepage: "https://www.gnu.org/software/diffutils/"
+bug-reports: "chetsky@gmail.com"
+maintainer: "chetsky@gmail.com"
+authors: "GNU Project"
+license: "GPL-3.0-or-later"
+build: [["diff" "--help"]]
+depexts: [
+  ["diffutils"] {os-family = "debian"}
+  ["diffutils"] {os-distribution = "fedora"}
+  ["diffutils"] {os-distribution = "rhel"}
+  ["diffutils"] {os-distribution = "centos"}
+  ["diffutils"] {os-distribution = "alpine"}
+  ["diffutils"] {os-distribution = "nixos"}
+  ["diffutils"] {os-family = "suse"}
+  ["diffutils"] {os-distribution = "ol"}
+  ["diffutils"] {os-distribution = "arch"}
+  ["diffutils"] {os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "Virtual package relying on diffutils"
+description:
+  "This package can only install if the diffutils binary is installed on the system."
+flags: conf


### PR DESCRIPTION
This PR adds a `conf-diffutils` 1.1 with homebrew support.

I noticed as part of releasing `mutaml` in #24104, that despite adding a `conf-diffutils` dependency the test suite was still failing due to a different `diff` version used on the macOS machines.
Version 1 of `conf-diffutils` is not set up to perform any installation steps on macOS.
Furthermore the available `diff` command confirms the different version:
```
$ diff --version
Apple diff (based on FreeBSD diff)
```
https://ocaml.ci.dev/github/jmid/mutaml/commit/4fabc0acc61b9f9ad7b47839fd21e759a48b1f78/variant/macos-homebrew-4.14.1_arm64_opam-2.1#L309-309

The 1.1 change is minimal to get ocaml-ci's homebrew machines to behave.
A more ambitious change (probably better fit for another release and PR) would be to add macports support.

CC: @chetmurthy