### PR TITLE
Add: htmlit.0.1.0

### DIFF
--- a/packages/htmlit/htmlit.0.1.0/opam
+++ b/packages/htmlit/htmlit.0.1.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "HTML generation combinators for OCaml"
+description: """\
+Htmlit is an OCaml library providing simple but subtle combinators for
+generating HTML fragments and pages.
+
+Htmlit is distributed under the ISC license. It has no dependencies.
+
+Homepage: <https://erratique.ch/software/htmlit>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The htmlit programmers"
+license: "ISC"
+tags: ["web" "html" "org:erratique"]
+homepage: "https://erratique.ch/software/htmlit"
+doc: "https://erratique.ch/software/htmlit/doc"
+bug-reports: "https://github.com/dbuenzli/htmlit/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/htmlit.git"
+url {
+  src: "https://erratique.ch/software/htmlit/releases/htmlit-0.1.0.tbz"
+  checksum:
+    "sha512=b51050da1bdabd9dc96f362fe75d53098523146698cdd442fab1fa882ed7052a29cb61c0e68dc13631be4aef9c4cb6eec1c890e08a29372d2864a1599e49b94c"
+}


### PR DESCRIPTION
* Add: `htmlit.0.1.0` [home](https://erratique.ch/software/htmlit), [doc](https://erratique.ch/software/htmlit/doc), [issues](https://github.com/dbuenzli/htmlit/issues)  
  *HTML generation combinators for OCaml*


---

#### `htmlit` v0.1.0 2023-07-30 Zagreb


First release.


---

Use `b0 -- .opam.publish htmlit.0.1.0` to update the pull request.