### PR TITLE
Add constraint for tsdl.1.0.0

### DIFF
--- a/packages/tsdl/tsdl.1.0.0/opam
+++ b/packages/tsdl/tsdl.1.0.0/opam
@@ -37,7 +37,7 @@ depends: [
   "ctypes" {>= "0.14.0"}
   "ctypes-foreign"
 ]
-available: os-distribution != "opensuse-leap" | os-version >= "16"
+available: (os-distribution != "opensuse-leap" | os-version >= "16") & (os-distribution != "ubuntu" | os-version >= "20.04") & (os-distribution != "debian" | os-version > "10")
 build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
 dev-repo: "git+https://erratique.ch/repos/tsdl.git"
 url {

--- a/packages/tsdl/tsdl.1.0.0/opam
+++ b/packages/tsdl/tsdl.1.0.0/opam
@@ -37,7 +37,12 @@ depends: [
   "ctypes" {>= "0.14.0"}
   "ctypes-foreign"
 ]
-available: (os-distribution != "opensuse-leap" | os-version >= "16") & (os-distribution != "ubuntu" | os-version >= "20.04") & (os-distribution != "debian" | os-version > "10")
+available: os-distribution != "opensuse-leap" | os-version >= "16"
+x-ci-accept-failures: [
+  "ubuntu-18.04",
+  "debian-10",
+  "oraclelinux-8" # sys package "SDL2-devel" not available
+]
 build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
 dev-repo: "git+https://erratique.ch/repos/tsdl.git"
 url {

--- a/packages/tsdl/tsdl.1.0.0/opam
+++ b/packages/tsdl/tsdl.1.0.0/opam
@@ -39,8 +39,8 @@ depends: [
 ]
 available: os-distribution != "opensuse-leap" | os-version >= "16"
 x-ci-accept-failures: [
-  "ubuntu-18.04",
-  "debian-10",
+  "ubuntu-18.04"
+  "debian-10"
   "oraclelinux-8" # sys package "SDL2-devel" not available
 ]
 build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]


### PR DESCRIPTION
tsdl.1.0.0 doesn't build on ubuntu 18.04 or debian 10.