### PR TITLE
Add support for enabling OCaml's thread sanitizer mode

### DIFF
--- a/packages/conf-unwind/conf-unwind.0/opam
+++ b/packages/conf-unwind/conf-unwind.0/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libunwind-devel"] {os-distribution = "rhel"}
   ["libunwind-devel"] {os-distribution = "fedora"}
   ["libunwind-dev"] {os-distribution = "alpine"}
-  ["libunwind"] {os-distribution = "homebrew" & os = "macos"}
+  ["libunwind-headers"] {os-distribution = "homebrew" & os = "macos"}
 ]
 synopsis: "Virtual package relying on libunwind"
 description:"

--- a/packages/conf-unwind/conf-unwind.0/opam
+++ b/packages/conf-unwind/conf-unwind.0/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "David Allsopp <david@tarides.com>"
+homepage: "https://www.nongnu.org/libunwind/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: ["David Mosberger, Dave Watson, et al"]
+license: "MIT"
+build: [["pkg-config" "libunwind"]]
+depends: ["conf-pkg-config" {build}]
+depexts: [
+  ["libunwind-dev"] {os-family = "debian"}
+  ["libunwind-devel"] {os-distribution = "centos"}
+  ["libunwind-devel"] {os-distribution = "rhel"}
+  ["libunwind-devel"] {os-distribution = "fedora"}
+  ["libunwind-dev"] {os-distribution = "alpine"}
+  ["libunwind"] {os-distribution = "homebrew" & os = "macos"}
+]
+synopsis: "Virtual package relying on libunwind"
+description:"
+This package can only install if libunwind is installed on the system.
+"
+flags: conf

--- a/packages/conf-unwind/conf-unwind.0/opam
+++ b/packages/conf-unwind/conf-unwind.0/opam
@@ -4,7 +4,7 @@ homepage: "https://www.nongnu.org/libunwind/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["David Mosberger, Dave Watson, et al"]
 license: "MIT"
-build: [["pkg-config" "libunwind"]]
+build: [["pkg-config" "--short-errors" "--print-errors" "libunwind"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libunwind-dev"] {os-family = "debian"}

--- a/packages/ocaml-option-tsan/ocaml-option-tsan.1/opam
+++ b/packages/ocaml-option-tsan/ocaml-option-tsan.1/opam
@@ -1,0 +1,14 @@
+opam-version: "2.0"
+synopsis: "Set OCaml to be compiled with thread sanitizer support"
+depends: [
+  "ocaml-variants" {post & >= "5.2.0~"}
+]
+conflicts: [
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-32bit"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitier"
+]
+maintainer: "platform@lists.ocaml.org"
+flags: compiler

--- a/packages/ocaml-option-tsan/ocaml-option-tsan.1/opam
+++ b/packages/ocaml-option-tsan/ocaml-option-tsan.1/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis: "Set OCaml to be compiled with ThreadSanitizer support"
 depends: [
   "ocaml-variants" {post & >= "5.2.0~"}
-  "conf-unwind"
+  "conf-unwind" {build}
 ]
 conflicts: [
   "ocaml-option-afl"

--- a/packages/ocaml-option-tsan/ocaml-option-tsan.1/opam
+++ b/packages/ocaml-option-tsan/ocaml-option-tsan.1/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 synopsis: "Set OCaml to be compiled with thread sanitizer support"
 depends: [
   "ocaml-variants" {post & >= "5.2.0~"}
+  "conf-unwind"
 ]
 conflicts: [
   "ocaml-option-afl"

--- a/packages/ocaml-option-tsan/ocaml-option-tsan.1/opam
+++ b/packages/ocaml-option-tsan/ocaml-option-tsan.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Set OCaml to be compiled with thread sanitizer support"
+synopsis: "Set OCaml to be compiled with ThreadSanitizer support"
 depends: [
   "ocaml-variants" {post & >= "5.2.0~"}
   "conf-unwind"

--- a/packages/ocaml-options-only-afl/ocaml-options-only-afl.1/opam
+++ b/packages/ocaml-options-only-afl/ocaml-options-only-afl.1/opam
@@ -15,6 +15,7 @@ conflicts: [
   "ocaml-option-nnpchecker"
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
+  "ocaml-option-tsan"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-options-only-flambda-fp/ocaml-options-only-flambda-fp.1/opam
+++ b/packages/ocaml-options-only-flambda-fp/ocaml-options-only-flambda-fp.1/opam
@@ -14,6 +14,7 @@ conflicts: [
   "ocaml-option-nnpchecker"
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
+  "ocaml-option-tsan"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-options-only-fp/ocaml-options-only-fp.1/opam
+++ b/packages/ocaml-options-only-fp/ocaml-options-only-fp.1/opam
@@ -15,6 +15,7 @@ conflicts: [
   "ocaml-option-nnpchecker"
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
+  "ocaml-option-tsan"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-options-only-nnp/ocaml-options-only-nnp.1/opam
+++ b/packages/ocaml-options-only-nnp/ocaml-options-only-nnp.1/opam
@@ -15,6 +15,7 @@ conflicts: [
   "ocaml-option-nnpchecker"
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
+  "ocaml-option-tsan"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-options-only-nnpchecker/ocaml-options-only-nnpchecker.1/opam
+++ b/packages/ocaml-options-only-nnpchecker/ocaml-options-only-nnpchecker.1/opam
@@ -15,6 +15,7 @@ conflicts: [
   "ocaml-option-nnp"
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
+  "ocaml-option-tsan"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1+bytecode-only/opam
+++ b/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1+bytecode-only/opam
@@ -16,6 +16,9 @@ conflicts: [
   "ocaml-option-static"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-tsan"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1/opam
+++ b/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1/opam
@@ -18,6 +18,7 @@ conflicts: [
   "ocaml-option-nnpchecker"
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
+  "ocaml-option-tsan"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-options-only-tsan/ocaml-options-only-tsan.1/opam
+++ b/packages/ocaml-options-only-tsan/ocaml-options-only-tsan.1/opam
@@ -1,11 +1,12 @@
 opam-version: "2.0"
-synopsis: "Ensure that OCaml is compiled with flambda activated, and no other custom options"
-depends: ["ocaml-option-flambda"]
+synopsis: "Ensure that OCaml is compiled with TSAN support enabled, and no other custom options"
+depends: ["ocaml-option-tsan"]
 conflicts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
   "ocaml-option-default-unsafe-string"
+  "ocaml-option-flambda"
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-no-flat-float-array"
@@ -15,7 +16,6 @@ conflicts: [
   "ocaml-option-nnpchecker"
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
-  "ocaml-option-tsan"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-options-only-tsan/ocaml-options-only-tsan.1/opam
+++ b/packages/ocaml-options-only-tsan/ocaml-options-only-tsan.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Ensure that OCaml is compiled with TSAN support enabled, and no other custom options"
+synopsis: "Ensure that OCaml is compiled with ThreadSanitizer support enabled, and no other custom options"
 depends: ["ocaml-option-tsan"]
 conflicts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
+++ b/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
@@ -20,6 +20,7 @@ conflicts: [
   "ocaml-option-nnpchecker"
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
+  "ocaml-option-tsan"
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+trunk/opam
@@ -34,6 +34,7 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--enable-tsan" {ocaml-option-tsan:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed}
@@ -81,4 +82,5 @@ depopts: [
   "ocaml-option-leak-sanitizer"
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
+  "ocaml-option-tsan"
 ]


### PR DESCRIPTION
Now that https://github.com/ocaml/ocaml/pull/12114, this adds the glue necessary for turning on tsan support in trunk, cf. the long-existing `ocaml-option-afl` for turning on AFL fuzz in a switch, etc.

Various shed colours to choose - precise name of `ocaml-option-tsan` (we have `ocaml-option-address-sanitizer`, etc. but these are for the C compiler - it may be want `ocaml-option-thread-sanitizer` even though it's a bit of a mouthful) and similarly whether it's `conf-unwind` or `conf-libunwind`).

NB Updating `ocaml-options-vanilla` _doesn't_ `ocaml-base-compiler` recompile switches (they do "recompile" ocaml-options-vanilla).