### PR TITLE
Fix checksums for timmy.1.0.0.

### DIFF
--- a/packages/timmy-jsoo/timmy-jsoo.1.0.0/opam
+++ b/packages/timmy-jsoo/timmy-jsoo.1.0.0/opam
@@ -38,7 +38,7 @@ dev-repo: "git+https://github.com/mefyl/timmy.git"
 url {
   src: "https://github.com/mefyl/timmy/archive/refs/tags/1.0.0.tar.gz"
   checksum: [
-    "md5=be0602624de7f037064601c41c2eb21d"
-    "sha512=e3f90db1c93f2931dbecb5c982ec513f562e1d8b24e840270d5a0ac26bd03b40292e498f7cbf1eedb8b89bb7eebd26a03279aaf11873cad6d4d970df7029f2aa"
+    "md5=8ff18d53b9432f7d944adc31230736ff"
+    "sha512=0395308f402131b0333a8ee94c878d78e7698573e1c6bc943911692003b8d81949598e524e7ce0c9438cd4a3cf6298a58a868b24df7b5a5e1342ea263bd51a60"
   ]
 }

--- a/packages/timmy-unix/timmy-unix.1.0.0/opam
+++ b/packages/timmy-unix/timmy-unix.1.0.0/opam
@@ -32,7 +32,7 @@ dev-repo: "git+https://github.com/mefyl/timmy.git"
 url {
   src: "https://github.com/mefyl/timmy/archive/refs/tags/1.0.0.tar.gz"
   checksum: [
-    "md5=be0602624de7f037064601c41c2eb21d"
-    "sha512=e3f90db1c93f2931dbecb5c982ec513f562e1d8b24e840270d5a0ac26bd03b40292e498f7cbf1eedb8b89bb7eebd26a03279aaf11873cad6d4d970df7029f2aa"
+    "md5=8ff18d53b9432f7d944adc31230736ff"
+    "sha512=0395308f402131b0333a8ee94c878d78e7698573e1c6bc943911692003b8d81949598e524e7ce0c9438cd4a3cf6298a58a868b24df7b5a5e1342ea263bd51a60"
   ]
 }

--- a/packages/timmy/timmy.1.0.0/opam
+++ b/packages/timmy/timmy.1.0.0/opam
@@ -44,7 +44,7 @@ dev-repo: "git+https://github.com/mefyl/timmy.git"
 url {
   src: "https://github.com/mefyl/timmy/archive/refs/tags/1.0.0.tar.gz"
   checksum: [
-    "md5=be0602624de7f037064601c41c2eb21d"
-    "sha512=e3f90db1c93f2931dbecb5c982ec513f562e1d8b24e840270d5a0ac26bd03b40292e498f7cbf1eedb8b89bb7eebd26a03279aaf11873cad6d4d970df7029f2aa"
+    "md5=8ff18d53b9432f7d944adc31230736ff"
+    "sha512=0395308f402131b0333a8ee94c878d78e7698573e1c6bc943911692003b8d81949598e524e7ce0c9438cd4a3cf6298a58a868b24df7b5a5e1342ea263bd51a60"
   ]
 }


### PR DESCRIPTION
For a reason that escapes my comprehension, the checksums for Timmy 1.0.0 seem to be wrong.

Fixes https://github.com/mefyl/timmy/issues/1.