### PR TITLE
streamable.v0.16.0 is not compatible with OCaml >= 5.1

### DIFF
--- a/packages/streamable/streamable.v0.16.0/opam
+++ b/packages/streamable/streamable.v0.16.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"            {>= "4.14.0"}
+  "ocaml"            {>= "4.14.0" & < "5.1"}
   "async_kernel"     {>= "v0.16" & < "v0.17"}
   "async_rpc_kernel" {>= "v0.16" & < "v0.17"}
   "base"             {>= "v0.16" & < "v0.17"}


### PR DESCRIPTION
`Stdlib.Type` is shadowing one of the modules used
```
#=== ERROR while compiling streamable.v0.16.0 =================================#
# context              2.2.0~alpha2 | linux/x86_64 | ocaml-variants.5.1.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/streamable.v0.16.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p streamable -j 31
# exit-code            1
# env-file             ~/.opam/log/streamable-8-a041fc.env
# output-file          ~/.opam/log/streamable-8-a041fc.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I ppx/src/.ppx_streamable.objs/byte -I /home/opam/.opam/5.1/lib/base -I /home/opam/.opam/5.1/lib/base/base_internalhash_types -I /home/opam/.opam/5.1/lib/base/caml -I /home/opam/.opam/5.1/lib/base/md5 -I /home/opam/.opam/5.1/lib/base/shadow_stdlib -I /home/opam/.opam/5.1/lib/base_quickcheck -I /home/opam/.opam/5.1/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.1/lib/bin_prot -I /home/opam/.opam/5.1/lib/bin_prot/shape -I /home/opam/.opam/5.1/lib/fieldslib -I /home/opam/.opam/5.1/lib/jane-street-headers -I /home/opam/.opam/5.1/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.1/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.1/lib/ocaml/compiler-libs -I /home/opam/.opam/5.1/lib/parsexp -I /home/opam/.opam/5.1/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_derivers -I /home/opam/.opam/5.1/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_expect/collector -I /home/opam/.opam/5.1/lib/ppx_expect/common -I /home/opam/.opam/5.1/lib/ppx_expect/config -I /home/opam/.opam/5.1/lib/ppx_expect/config_types -I /home/opam/.opam/5.1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_inline_test/config -I /home/opam/.opam/5.1/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_log/types -I /home/opam/.opam/5.1/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_stable_witness/runtime -I /home/opam/.opam/5.1/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/5.1/lib/ppxlib -I /home/opam/.opam/5.1/lib/ppxlib/ast -I /home/opam/.opam/5.1/lib/ppxlib/astlib -I /home/opam/.opam/5.1/lib/ppxlib/print_diff -I /home/opam/.opam/5.1/lib/ppxlib/stdppx -I /home/opam/.opam/5.1/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.1/lib/sexplib -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/splittable_random -I /home/opam/.opam/5.1/lib/stdio -I /home/opam/.opam/5.1/lib/stdlib-shims -I /home/opam/.opam/5.1/lib/time_now -I /home/opam/.opam/5.1/lib/typerep -I /home/opam/.opam/5.1/lib/variantslib -no-alias-deps -open Ppx_streamable__ -o ppx/src/.ppx_streamable.objs/byte/ppx_streamable__Clause.cmi -c -intf ppx/src/clause.pp.mli)
# File "ppx/src/clause.mli", line 25, characters 22-28:
# 25 |     { children      : Type.t               list
#                            ^^^^^^
# Error: Unbound type constructor Type.t
```