### PR TITLE
ppx_accessor >= v0.15.0 is not compatible with OCaml >= 5.1

### DIFF
--- a/packages/ppx_accessor/ppx_accessor.v0.15.0/opam
+++ b/packages/ppx_accessor/ppx_accessor.v0.15.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"    {>= "4.09.0"}
+  "ocaml"    {>= "4.09.0" & < "5.1"}
   "accessor" {>= "v0.15" & < "v0.16"}
   "base"     {>= "v0.15" & < "v0.16"}
   "dune"     {>= "2.0.0"}

--- a/packages/ppx_accessor/ppx_accessor.v0.16.0/opam
+++ b/packages/ppx_accessor/ppx_accessor.v0.16.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"    {>= "4.14.0"}
+  "ocaml"    {>= "4.14.0" & < "5.1"}
   "accessor" {>= "v0.16" & < "v0.17"}
   "base"     {>= "v0.16" & < "v0.17"}
   "dune"     {>= "2.0.0"}


### PR DESCRIPTION
`Stdlib.Type` is shadowing one of the modules used
```
#=== ERROR while compiling ppx_accessor.v0.16.0 ===============================#
# context              2.2.0~alpha2 | linux/x86_64 | ocaml-variants.5.1.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/ppx_accessor.v0.16.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ppx_accessor -j 127
# exit-code            1
# env-file             ~/.opam/log/ppx_accessor-8-611885.env
# output-file          ~/.opam/log/ppx_accessor-8-611885.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.ppx_accessor.objs/byte -I /home/opam/.opam/5.1/lib/base -I /home/opam/.opam/5.1/lib/base/base_internalhash_types -I /home/opam/.opam/5.1/lib/base/caml -I /home/opam/.opam/5.1/lib/base/shadow_stdlib -I /home/opam/.opam/5.1/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.1/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.1/lib/ocaml/compiler-libs -I /home/opam/.opam/5.1/lib/ppx_derivers -I /home/opam/.opam/5.1/lib/ppxlib -I /home/opam/.opam/5.1/lib/ppxlib/ast -I /home/opam/.opam/5.1/lib/ppxlib/astlib -I /home/opam/.opam/5.1/lib/ppxlib/print_diff -I /home/opam/.opam/5.1/lib/ppxlib/stdppx -I /home/opam/.opam/5.1/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -open Ppx_accessor__ -o src/.ppx_accessor.objs/byte/ppx_accessor.cmo -c -impl src/ppx_accessor.pp.ml)
# File "src/ppx_accessor.ml", line 17, characters 37-49:
# 17 |   List.concat_map tds ~f:(Fn.compose Type.to_strs Type.of_type_declaration)
#                                           ^^^^^^^^^^^^
# Error: Unbound value Type.to_strs
```