### PR TITLE
utop < 2.12.0 is not compatible with OCaml 5.1

### DIFF
--- a/packages/utop/utop.2.10.0/opam
+++ b/packages/utop/utop.2.10.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/ocaml-community/utop"
 bug-reports: "https://github.com/ocaml-community/utop/issues"
 doc: "https://ocaml-community.github.io/utop/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.1"}
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}

--- a/packages/utop/utop.2.11.0/opam
+++ b/packages/utop/utop.2.11.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/ocaml-community/utop"
 bug-reports: "https://github.com/ocaml-community/utop/issues"
 doc: "https://ocaml-community.github.io/utop/"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1"}
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}


### PR DESCRIPTION
`compiler-libs`'s types changed
```
#=== ERROR while compiling utop.2.11.0 ========================================#
# context              2.2.0~alpha2 | linux/x86_64 | ocaml-variants.5.1.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/utop.2.11.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p utop -j 71
# exit-code            1
# env-file             ~/.opam/log/utop-8-872f8a.env
# output-file          ~/.opam/log/utop-8-872f8a.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -safe-string -g -bin-annot -I src/lib/.uTop.objs/byte -I /home/opam/.opam/5.1/lib/bytes -I /home/opam/.opam/5.1/lib/findlib -I /home/opam/.opam/5.1/lib/lambda-term -I /home/opam/.opam/5.1/lib/logs -I /home/opam/.opam/5.1/lib/lwt -I /home/opam/.opam/5.1/lib/lwt/unix -I /home/opam/.opam/5.1/lib/lwt_react -I /home/opam/.opam/5.1/lib/mew -I /home/opam/.opam/5.1/lib/mew_vi -I /home/opam/.opam/5.1/lib/ocaml/compiler-libs -I /home/opam/.opam/5.1/lib/ocaml/threads -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/ocplib-endian -I /home/opam/.opam/5.1/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.1/lib/react -I /home/opam/.opam/5.1/lib/result -I /home/opam/.opam/5.1/lib/trie -I /home/opam/.opam/5.1/lib/uchar -I /home/opam/.opam/5.1/lib/uucp -I /home/opam/.opam/5.1/lib/uuseg -I /home/opam/.opam/5.1/lib/uutf -I /home/opam/.opam/5.1/lib/zed -intf-suffix .ml -no-alias-deps -o src/lib/.uTop.objs/byte/uTop_main.cmo -c -impl src/lib/uTop_main.pp.ml)
# File "src/lib/uTop_main.ml", lines 680-683, characters 29-46:
# Warning 8 [partial-match]: this pattern-matching is not exhaustive.
# Here is an example of a case that is not matched:
# Pextra_ty (_, _)
# 
# File "src/lib/uTop_main.ml", lines 767-777, characters 8-9:
# Error: Some record fields are undefined: pvb_constraint
```