### PR TITLE
acgtk.1.5.1 is not compatible with -strict-formats

### DIFF
--- a/packages/acgtk/acgtk.1.5.1/opam
+++ b/packages/acgtk/acgtk.1.5.1/opam
@@ -12,7 +12,7 @@ build: [
 install: ["dune" "install"]
 
 depends: [
-  "ocaml" { >= "4.05.0" }
+  "ocaml" { >= "4.05.0" & < "5.1" }
   "dune" { >= "1.0" }
   "menhir" {< "20201122"}
   "ANSITerminal"


### PR DESCRIPTION
```
#=== ERROR while compiling acgtk.1.5.1 ========================================#
# context              2.2.0~alpha2 | linux/x86_64 | ocaml-variants.5.1.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/acgtk.1.5.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build --profile=release -j 127
# exit-code            1
# env-file             ~/.opam/log/acgtk-9-8a8192.env
# output-file          ~/.opam/log/acgtk-9-8a8192.out
### output ###
# File "src/utils/log.ml", line 24, characters 27-52:
# 24 |             Fmt.kpf k ppf ("%a%a: %a[%0+04.0fus] @[" ^^ fmt ^^ "@]@.")  Fmt.(styled `Magenta string) p1 Fmt.(styled `Magenta string) p2 Logs_fmt.pp_header (level, h) (Mtime.Span.to_us s)
#                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: invalid format "%a%a: %a[%0+04.0fus] @[": at character number 12, duplicate flag '0'
```