### PR TITLE
batteries.3.6.0 is not compatible with OCaml 5.1

### DIFF
--- a/packages/batteries/batteries.3.6.0/opam
+++ b/packages/batteries/batteries.3.6.0/opam
@@ -13,7 +13,7 @@ doc: "http://ocaml-batteries-team.github.io/batteries-included/hdoc2/"
 bug-reports:
   "https://github.com/ocaml-batteries-team/batteries-included/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.1"}
   "camlp-streams"
   "ocamlfind" {build & >= "1.5.3"}
   "ocamlbuild" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling batteries.3.6.0 ====================================#
# context              2.2.0~alpha2 | linux/x86_64 | ocaml-variants.5.1.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/batteries.3.6.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all
# exit-code            2
# env-file             ~/.opam/log/batteries-8-1185e8.env
# output-file          ~/.opam/log/batteries-8-1185e8.out
### output ###
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -no-alias-deps -strict-sequence -w -3 -package num,str,camlp-streams,unix -warn-error -50 -package bytes -I src -I benchsuite -I build -I qtest -I testsuite -I toplevel -I benchsuite/lib -o src/batMarshal.cmi src/batMarshal.mli
# File "src/batMarshal.mliv", lines 59-62, characters 0-13:
# Error: This variant or record definition does not match that of type
#          Marshal.extern_flags
#        An extra constructor, Compression, is provided in the original definition.
# Command exited with code 2.
```