### PR TITLE
kind2.1.5.0 is not compatible with -strict-formats

### DIFF
--- a/packages/kind2/kind2.1.5.0/opam
+++ b/packages/kind2/kind2.1.5.0/opam
@@ -15,7 +15,7 @@ homepage: "https://kind2-mc.github.io/kind2"
 doc: "https://kind.cs.uiowa.edu/kind2_user_doc"
 bug-reports: "https://github.com/kind2-mc/kind2/issues"
 depends: [
-  "ocaml" {>= "4.09"}
+  "ocaml" {>= "4.09" & < "5.1"}
   "dune" {>= "2.7"}
   "dune-build-info"
   "menhir" {< "20211215"}


### PR DESCRIPTION
```
#=== ERROR while compiling kind2.1.5.0 ========================================#
# context              2.2.0~alpha2 | linux/x86_64 | ocaml-variants.5.1.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/kind2.1.5.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p kind2 -j 47 @install
# exit-code            1
# env-file             ~/.opam/log/kind2-8-5141d7.env
# output-file          ~/.opam/log/kind2-8-5141d7.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlopt.opt -w -40 -g -I src/.kind2dev.objs/byte -I src/.kind2dev.objs/native -I /home/opam/.opam/5.1/lib/dune-build-info -I /home/opam/.opam/5.1/lib/menhirLib -I /home/opam/.opam/5.1/lib/num -I /home/opam/.opam/5.1/lib/ocaml/str -I /home/opam/.opam/5.1/lib/ocaml/threads -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/stdint -I /home/opam/.opam/5.1/lib/yojson -I /home/opam/.opam/5.1/lib/zmq -intf-suffix .ml -no-alias-deps -o src/.kind2dev.objs/native/flags.cmx -c -impl src/flags.ml)
# File "src/flags.ml", lines 2726-2729, characters 10-11:
# 2726 | .........."\
# 2727 |             Wallclock timeout in seconds@ \
# 2728 |             Default: %1.f\
# 2729 |           "
# Error: invalid format "Wallclock timeout in seconds@ Default: %1.f": at character number 41, '.' without precision
```