### PR TITLE
ocp-index is not compatible with OCaml 5.1 (compiler-libs API changed)

### DIFF
--- a/packages/ocp-index/ocp-index.1.3.3/opam
+++ b/packages/ocp-index/ocp-index.1.3.3/opam
@@ -15,7 +15,7 @@ tags: ["org:ocamlpro" "org:typerex"]
 homepage: "http://www.typerex.org/ocp-index.html"
 bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.1"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}

--- a/packages/ocp-index/ocp-index.1.3.4/opam
+++ b/packages/ocp-index/ocp-index.1.3.4/opam
@@ -21,7 +21,7 @@ tags: [ "org:ocamlpro" "org:typerex" ]
 dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}


### PR DESCRIPTION
Upstream fix in https://github.com/OCamlPro/ocp-index/pull/166
```
#=== ERROR while compiling ocp-index.1.3.4 ====================================#
# context              2.2.0~alpha2 | linux/x86_64 | ocaml-variants.5.1.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/ocp-index.1.3.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ocp-index -j 127
# exit-code            1
# env-file             ~/.opam/log/ocp-index-8-ca23ed.env
# output-file          ~/.opam/log/ocp-index-8-ca23ed.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -w -9 -g -bin-annot -I libs/.indexLib.objs/byte -I /home/opam/.opam/5.1/lib/bytes -I /home/opam/.opam/5.1/lib/ocaml/compiler-libs -I /home/opam/.opam/5.1/lib/ocp-indent/lexer -I /home/opam/.opam/5.1/lib/ocp-indent/utils -intf-suffix .ml -no-alias-deps -o libs/.indexLib.objs/byte/indexBuild.cmo -c -impl libs/indexBuild.pp.ml)
# File "libs/indexBuild.ml", line 226, characters 17-26:
# Error: This pattern matches values of type 'a * 'b
#        but a pattern was expected which matches values of type
#          Outcometree.out_type.Otyp_alias
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlopt.opt -w -40 -w -9 -g -I libs/.indexLib.objs/byte -I libs/.indexLib.objs/native -I /home/opam/.opam/5.1/lib/bytes -I /home/opam/.opam/5.1/lib/ocaml/compiler-libs -I /home/opam/.opam/5.1/lib/ocp-indent/lexer -I /home/opam/.opam/5.1/lib/ocp-indent/utils -intf-suffix .ml -no-alias-deps -o libs/.indexLib.objs/native/indexBuild.cmx -c -impl libs/indexBuild.pp.ml)
# File "libs/indexBuild.ml", line 226, characters 17-26:
# Error: This pattern matches values of type 'a * 'b
#        but a pattern was expected which matches values of type
#          Outcometree.out_type.Otyp_alias
```