### PR TITLE
[new release] ca-certs-nss (3.92)

### DIFF
--- a/packages/ca-certs-nss/ca-certs-nss.3.92/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.92/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "X.509 trust anchors extracted from Mozilla's NSS"
+description: """
+Trust anchors extracted from Mozilla's NSS certdata.txt package,
+to be used in MirageOS unikernels.
+"""
+maintainer: ["Hannes Mehnert <hannes@mehnert.org>"]
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+license: "ISC"
+homepage: "https://github.com/mirage/ca-certs-nss"
+doc: "https://mirage.github.io/ca-certs-nss/doc"
+bug-reports: "https://github.com/mirage/ca-certs-nss/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "mirage-crypto"
+  "mirage-clock" {>= "3.0.0"}
+  "x509" {>= "0.15.0"}
+  "ocaml" {>= "4.08.0"}
+  "logs" {build}
+  "fmt" {build & >= "0.8.7"}
+  "bos" {build}
+  "cmdliner" {build & >= "1.1.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ca-certs-nss.git"
+tags: ["org:mirage"]
+url {
+  src:
+    "https://github.com/mirage/ca-certs-nss/releases/download/v3.92/ca-certs-nss-3.92.tbz"
+  checksum: [
+    "sha256=17a785e6340ef6a24009095d69df2f6b98d73e3d39a3ad4bf01a754835c70538"
+    "sha512=d5ab99fb92769e0a484a239630fe243255ce3e80461f685b586febd2b3d44e835a48fa0a6b352c26fa75792e22289a2c4d180be8be25545c8edc355cbb4557e3"
+  ]
+}
+x-commit-hash: "77151a8f4cde0f9701f719dee39946a8fc608e0c"


### PR DESCRIPTION
X.509 trust anchors extracted from Mozilla's NSS

- Project page: <a href="https://github.com/mirage/ca-certs-nss">https://github.com/mirage/ca-certs-nss</a>
- Documentation: <a href="https://mirage.github.io/ca-certs-nss/doc">https://mirage.github.io/ca-certs-nss/doc</a>

##### CHANGES:

* Update to NSS 3.92 (July 27th 2023)
