### PR TITLE
[new release] multicore-magic (2.0.0)

### DIFF
--- a/packages/multicore-magic/multicore-magic.2.0.0/opam
+++ b/packages/multicore-magic/multicore-magic.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Low-level multicore utilities for OCaml"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-magic"
+bug-reports: "https://github.com/ocaml-multicore/multicore-magic/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.12.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {>= "2.2.0" & with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-magic.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-magic/releases/download/2.0.0/multicore-magic-2.0.0.tbz"
+  checksum: [
+    "sha256=5bd1d3fd68c7f71ec6846c13fd92a9ec5948d02bd4eec83d37529e055c21e02d"
+    "sha512=1b2f380e2e4d2b3ee2d6f244ea46e16b6907ee595ac7440cc9eba4977ba13ecba26aa095f739d061cfb2a358f3f0990ee4955d69aee7161eb1b6f98308cd4df8"
+  ]
+}
+x-commit-hash: "24716a47b1cc881955c4d8fa9a80944e10850dc7"


### PR DESCRIPTION
Low-level multicore utilities for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/multicore-magic">https://github.com/ocaml-multicore/multicore-magic</a>

## 2.0.0

- Changed the semantics of `copy_as_padded` to not always copy and to not
  guarantee that `length_of_padded_array*` works with it. These semantic changes
  allow better use of the OCaml allocator to guarantee cache friendly alignment.
  (@polytypic)
