### PR TITLE
Package ppx_accessor.v0.16.1

### DIFF
--- a/packages/ppx_accessor/ppx_accessor.v0.16.1/opam
+++ b/packages/ppx_accessor/ppx_accessor.v0.16.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_accessor"
+bug-reports: "https://github.com/janestreet/ppx_accessor/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_accessor.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_accessor/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"    {>= "4.14.0"}
+  "accessor" {>= "v0.16" & < "v0.17"}
+  "base"     {>= "v0.16" & < "v0.17"}
+  "dune"     {>= "2.0.0"}
+  "ppxlib"   {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "[@@deriving] plugin to generate accessors for use with the Accessor libraries"
+description: "
+Automatically generate accessors given a type definition.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_accessor/archive/refs/tags/v0.16.1.tar.gz"
+  checksum: [
+    "md5=c30d3d03fc9433ad835c1d31ef9d5ca0"
+    "sha512=e6be30b7aeb323ab87bbb075540523b4b823dd01ae917f81458e94a26d67ae44194645272c162faba3f96d480cd17e0c8649e9754a40f42a6f2f4c268fd195cb"
+  ]
+}


### PR DESCRIPTION
### `ppx_accessor.v0.16.1`
[@@deriving] plugin to generate accessors for use with the Accessor libraries
Automatically generate accessors given a type definition.



---
* Homepage: https://github.com/janestreet/ppx_accessor
* Source repo: git+https://github.com/janestreet/ppx_accessor.git
* Bug tracker: https://github.com/janestreet/ppx_accessor/issues

---
:camel: Pull-request generated by opam-publish v2.2.0