### PR TITLE
Package lwt.5.7.0

### DIFF
--- a/packages/lwt/lwt.5.7.0/opam
+++ b/packages/lwt/lwt.5.7.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Raphaël Proust <code@bnwr.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.8.0"}
+  "dune-configurator"
+  "ocaml" {>= "4.08"}
+  "ocplib-endian"
+
+  # Until https://github.com/aantron/bisect_ppx/pull/327.
+  # "bisect_ppx" {dev & >= "2.0.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+build: [
+  ["dune" "exec" "-p" name "src/unix/config/discover.exe" "--" "--save"
+    "--use-libev" "%{conf-libev:installed}%"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+url {
+  src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.7.0.tar.gz"
+  checksum: [
+    "md5=737039d29d45b2d2b35db6931c8d75c6"
+    "sha512=42e629920783428673b99c9d7a639237c9e6b35079b5d907bc67e7ea506acf9edadc48cec580bdcfd2410ed9412bf5e6bcc8b09de2fa7d35ce1490973d05ddd1"
+  ]
+}


### PR DESCRIPTION
### `lwt.5.7.0`
Promises and event-driven I/O
A promise is a value that may become determined in the future.

Lwt provides typed, composable promises. Promises that are resolved by I/O are
resolved by Lwt in parallel.

Meanwhile, OCaml code, including code creating and waiting on promises, runs in
a single thread by default. This reduces the need for locks or other
synchronization primitives. Code can be run in parallel on an opt-in basis.



---
* Homepage: https://github.com/ocsigen/lwt
* Source repo: git+https://github.com/ocsigen/lwt.git
* Bug tracker: https://github.com/ocsigen/lwt/issues

---
:camel: Pull-request generated by opam-publish v2.2.0