### PR TITLE
2 packages from git.sr.ht/~soni/shuttle_http/archive/0.11.0.tar.gz

### DIFF
--- a/packages/shuttle_http/shuttle_http.0.11.0/opam
+++ b/packages/shuttle_http/shuttle_http.0.11.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Async library for HTTP/1.1 servers and clients"
+description:
+  "Shuttle_http is a low level library for implementing HTTP/1.1 web services and clients in OCaml."
+maintainer: "Anurag Soni <anurag@sonianurag.com>"
+authors: "Anurag Soni"
+license: "MIT"
+tags: ["http-server" "http-client" "http" "http1.1" "async"]
+homepage: "https://sr.ht/~soni/shuttle_http"
+bug-reports: "https://todo.sr.ht/~soni/shuttle_http"
+depends: [
+  "dune" {>= "3.1"}
+  "async" {>= "v0.16.0"}
+  "async_ssl" {>= "v0.16.0"}
+  "core" {>= "v0.16.0"}
+  "jane_rope" {>= "v0.16.0"}
+  "ocaml" {>= "4.14.0"}
+  "ppx_jane" {>= "v0.16.0"}
+  "re2" {>= "v0.16.0"}
+  "core_unix" {with-test}
+  "odoc" {with-doc}
+]
+available: arch = "x86_64" | arch = "arm64"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://git.sr.ht/~soni/shuttle_http"
+url {
+  src: "https://git.sr.ht/~soni/shuttle_http/archive/0.11.0.tar.gz"
+  checksum: [
+    "md5=c18e89676a71564229afaf9d40a64ebb"
+    "sha512=12d9dc7f6ab96147c14469bb48f56b5f528633d7925033aea99b303976868cc762919228057511a8d658c76496636c69f9e283c91d76eadbb7bd5443c492d939"
+  ]
+}

--- a/packages/shuttle_websocket/shuttle_websocket.0.11.0/opam
+++ b/packages/shuttle_websocket/shuttle_websocket.0.11.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Websocket support for HTTP/1.1 servers using Async"
+description:
+  "Shuttle_websocket is a companion library for shuttle_http that provides a HTTP service that performs websocket negotiation for HTTP/1.1 servers."
+maintainer: "Anurag Soni <anurag@sonianurag.com>"
+authors: "Anurag Soni"
+license: "MIT"
+tags: ["http-server" "websocket"]
+homepage: "https://sr.ht/~soni/shuttle_http"
+bug-reports: "https://todo.sr.ht/~soni/shuttle_http"
+depends: [
+  "dune" {>= "3.1"}
+  "shuttle_http" {= version}
+  "async_websocket"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://git.sr.ht/~soni/shuttle_http"
+url {
+  src: "https://git.sr.ht/~soni/shuttle_http/archive/0.11.0.tar.gz"
+  checksum: [
+    "md5=c18e89676a71564229afaf9d40a64ebb"
+    "sha512=12d9dc7f6ab96147c14469bb48f56b5f528633d7925033aea99b303976868cc762919228057511a8d658c76496636c69f9e283c91d76eadbb7bd5443c492d939"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `shuttle_http.0.11.0`: Async library for HTTP/1.1 servers and clients
- `shuttle_websocket.0.11.0`: Websocket support for HTTP/1.1 servers using Async



---
* Homepage: https://sr.ht/~soni/shuttle_http
* Source repo: git+https://git.sr.ht/~soni/shuttle_http
* Bug tracker: https://todo.sr.ht/~soni/shuttle_http

---
:camel: Pull-request generated by opam-publish v2.2.0