### PR TITLE
[new release] odoc (2.2.1)

### DIFF
--- a/packages/odoc/odoc.2.2.1/opam
+++ b/packages/odoc/odoc.2.2.1/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+homepage: "http://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+authors: [
+  "Thomas Refis <trefis@janestreet.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Leo White <leo@lpw25.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Lubega Simon <lubegasimon73@gmail.com>"
+]
+maintainer: "Jon Ludlam <jon@recoil.org>"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml documentation generator"
+description: """
+Odoc is a documentation generator for OCaml. It reads doc comments,
+delimited with `(** ... *)`, and outputs HTML. 
+"""
+
+depends: [
+  "odoc-parser" {>= "2.0.0"}
+  "astring"
+  "cmdliner" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "3.0.2"}
+  "fpath"
+  "ocaml" {>= "4.02.0"}
+  "result"
+  "tyxml" {>= "4.3.0"}
+  "fmt"
+
+  "ocamlfind" {with-test}
+  "yojson" {< "2.0.0" & with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+  "conf-jq" {with-test}
+
+  "ppx_expect" {with-test}
+  "bos" {with-test}
+  "crunch" {with-test}
+
+  ("ocaml" {< "4.07.0" & with-test} | "bisect_ppx" {with-test & > "2.5.0"})
+  ("ocaml" {< "4.03.0" & with-test} | "mdx" {with-test})
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/2.2.1/odoc-2.2.1.tbz"
+  checksum: [
+    "sha256=1786e53bf0824fe1c7c7b81d2a7d846846a5d11677969e6396361f77a3816803"
+    "sha512=044e37eb3dcc77d9cc8124be558cce77a438723b90225273fb3401d3315c57c8c2f395a48ebd1b6aacc01b00cbfa4bd0be1923d2bd9bd3cc92d0604eadaabc4f"
+  ]
+}
+x-commit-hash: "2d8a6776c19ffa995ae285cd1dfc27f2fea3820a"


### PR DESCRIPTION
OCaml documentation generator

- Project page: <a href="http://github.com/ocaml/odoc">http://github.com/ocaml/odoc</a>
- Documentation: <a href="https://ocaml.github.io/odoc/">https://ocaml.github.io/odoc/</a>

##### CHANGES:

Additions
- OCaml 5.1.0 compatibility (@Octachron, ocaml/odoc#956)
