### PR TITLE
conf-python-3-7: consider python 3.11

### DIFF
--- a/packages/conf-python-3-7/conf-python-3-7.1.0.0/files/configure.sh
+++ b/packages/conf-python-3-7/conf-python-3-7.1.0.0/files/configure.sh
@@ -1,4 +1,4 @@
-for version in 3.10 3.9 3.8 3.7; do
+for version in 3.11 3.10 3.9 3.8 3.7; do
     python_exe="python$version"
     if "$python_exe" test.py; then
         echo "python3: \"$python_exe\"" >> conf-python-3-7.config

--- a/packages/conf-python-3-7/conf-python-3-7.1.0.0/opam
+++ b/packages/conf-python-3-7/conf-python-3-7.1.0.0/opam
@@ -40,5 +40,5 @@ python-3.7 will be used.
 """
 extra-files: [
   ["test.py" "sha512=a9d993b9380d636fc2aff8af6bae1078ad14a2af4e510b7c437d5f1e01cd125b7f12e15fb8f0e0c4536d2f7d6aa0d36aafdf2f9da828ac7686df6dc782fa1a23"]
-  ["configure.sh" "sha512=d2dc0f2a0867aa04ffbaf28fd8fdac745036454cc4dbeb56d59344dfab80c09e8c30ff57a311667880164164e44aa9efd917cfdeed330fb5f224ee201a841206"]]
+  ["configure.sh" "sha512=119e7ab0f6763705b4b06ff6ac1e9724687ea824709ce1bc6a3752cc1f262a6c050c92bbc0f10fe78c9b6a07705cb29422a0063433ff38c00cba8fb58af3ec0b"]]
 flags: conf


### PR DESCRIPTION
Some builds are now failing because the system has Python 3.11, which `conf-python-3-7` doesn't detect.