### PR TITLE
Lwt revdeps constraints

### DIFF
--- a/packages/aws-s3-lwt/aws-s3-lwt.4.4.0/opam
+++ b/packages/aws-s3-lwt/aws-s3-lwt.4.4.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.05.0" & < "5.0.0"}
   "dune"
   "aws-s3" {= "4.4.0" }
-  "lwt"
+  "lwt" {< "5.7.0"}
   "conduit-lwt-unix" {< "5.0.0"}
 ]
 synopsis: "Ocaml library for accessing Amazon S3 - Lwt version"

--- a/packages/aws-s3-lwt/aws-s3-lwt.4.4.1/opam
+++ b/packages/aws-s3-lwt/aws-s3-lwt.4.4.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "dune"
   "aws-s3" {= version}
-  "lwt"
+  "lwt" {< "5.7.0"}
   "conduit-lwt-unix" {< "5.0.0"}
 ]
 synopsis: "Ocaml library for accessing Amazon S3 - Lwt version"

--- a/packages/aws-s3-lwt/aws-s3-lwt.4.5.0/opam
+++ b/packages/aws-s3-lwt/aws-s3-lwt.4.5.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "dune"
   "aws-s3" {= version}
-  "lwt"
+  "lwt" {< "5.7.0"}
   "conduit-lwt-unix" {< "5.0.0"}
 ]
 synopsis: "Ocaml library for accessing Amazon S3 - Lwt version"

--- a/packages/aws-s3-lwt/aws-s3-lwt.4.5.1/opam
+++ b/packages/aws-s3-lwt/aws-s3-lwt.4.5.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "dune"
   "aws-s3" {= version}
-  "lwt"
+  "lwt" {< "5.7.0"}
   "conduit-lwt-unix" {< "5.0.0"}
 ]
 synopsis: "Ocaml library for accessing Amazon S3 - Lwt version"

--- a/packages/aws-s3-lwt/aws-s3-lwt.4.6.0/opam
+++ b/packages/aws-s3-lwt/aws-s3-lwt.4.6.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "2.0.0"}
   "aws-s3" {= version}
-  "lwt"
+  "lwt" {< "5.7.0"}
   "conduit-lwt-unix" {>= "5.0.0"}
 ]
 synopsis: "Ocaml library for accessing Amazon S3 - Lwt version"

--- a/packages/aws-s3-lwt/aws-s3-lwt.4.7.0/opam
+++ b/packages/aws-s3-lwt/aws-s3-lwt.4.7.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "2.0.0"}
   "aws-s3" {= version}
-  "lwt"
+  "lwt" {< "5.7.0"}
   "conduit-lwt-unix" {>= "5.0.0"}
 ]
 synopsis: "Ocaml library for accessing Amazon S3 - Lwt version"

--- a/packages/aws-s3-lwt/aws-s3-lwt.4.8.0/opam
+++ b/packages/aws-s3-lwt/aws-s3-lwt.4.8.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "2.0.0"}
   "aws-s3" {= version}
-  "lwt"
+  "lwt" {< "5.7.0"}
   "conduit-lwt-unix" {>= "5.0.0"}
 ]
 synopsis: "Ocaml library for accessing Amazon S3 - Lwt version"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.0.2/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.0.2/opam
@@ -12,7 +12,7 @@ depends: [
   "dune-rpc" {= version}
   "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
-  "lwt" {>= "5.3.0"}
+  "lwt" {>= "5.3.0" & < "5.7.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.0.3/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.0.3/opam
@@ -12,7 +12,7 @@ depends: [
   "dune-rpc" {= version}
   "result" {>= "1.5.0"}
   "csexp" {>= "1.5.0"}
-  "lwt" {>= "5.3.0"}
+  "lwt" {>= "5.3.0" & < "5.7.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.1.0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune-rpc" {= version}
   "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
-  "lwt" {>= "5.3.0"}
+  "lwt" {>= "5.3.0" & < "5.7.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.1.1/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.1.1/opam
@@ -12,7 +12,7 @@ depends: [
   "dune-rpc" {= version}
   "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
-  "lwt" {>= "5.3.0"}
+  "lwt" {>= "5.3.0" & < "5.7.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.10.0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.10.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune-rpc" {= version}
   "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
-  "lwt" {>= "5.3.0"}
+  "lwt" {>= "5.3.0" & < "5.7.0"}
   "base-unix"
   "odoc" {with-doc}
 ]

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.2.0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.2.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune-rpc" {= version}
   "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
-  "lwt" {>= "5.3.0"}
+  "lwt" {>= "5.3.0" & < "5.7.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.3.0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.3.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune-rpc" {= version}
   "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
-  "lwt" {>= "5.3.0"}
+  "lwt" {>= "5.3.0" & < "5.7.0"}
   "base-unix"
   "odoc" {with-doc}
 ]

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.3.1/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.3.1/opam
@@ -12,7 +12,7 @@ depends: [
   "dune-rpc" {= version}
   "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
-  "lwt" {>= "5.3.0"}
+  "lwt" {>= "5.3.0" & < "5.7.0"}
   "base-unix"
   "odoc" {with-doc}
 ]

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.4.0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.4.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune-rpc" {= version}
   "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
-  "lwt" {>= "5.3.0"}
+  "lwt" {>= "5.3.0" & < "5.7.0"}
   "base-unix"
   "odoc" {with-doc}
 ]

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.4.1/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.4.1/opam
@@ -12,7 +12,7 @@ depends: [
   "dune-rpc" {= version}
   "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
-  "lwt" {>= "5.3.0"}
+  "lwt" {>= "5.3.0" & < "5.7.0"}
   "base-unix"
   "odoc" {with-doc}
 ]

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.5.0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.5.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune-rpc" {= version}
   "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
-  "lwt" {>= "5.3.0"}
+  "lwt" {>= "5.3.0" & < "5.7.0"}
   "base-unix"
   "odoc" {with-doc}
 ]

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.6.0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.6.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune-rpc" {= version}
   "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
-  "lwt" {>= "5.3.0"}
+  "lwt" {>= "5.3.0" & < "5.7.0"}
   "base-unix"
   "odoc" {with-doc}
 ]

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.6.1/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.6.1/opam
@@ -12,7 +12,7 @@ depends: [
   "dune-rpc" {= version}
   "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
-  "lwt" {>= "5.3.0"}
+  "lwt" {>= "5.3.0" & < "5.7.0"}
   "base-unix"
   "odoc" {with-doc}
 ]

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.6.2/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.6.2/opam
@@ -12,7 +12,7 @@ depends: [
   "dune-rpc" {= version}
   "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
-  "lwt" {>= "5.3.0"}
+  "lwt" {>= "5.3.0" & < "5.7.0"}
   "base-unix"
   "odoc" {with-doc}
 ]

--- a/packages/ocsigen-start/ocsigen-start.4.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.1.0/opam
@@ -24,6 +24,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "re" {>= "1.7.2"}
+  "lwt" {< "5.7.0"}
 ]
 depexts: [
   ["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.4.3.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.3.0/opam
@@ -24,6 +24,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "re" {>= "1.7.2"}
+  "lwt" {< "5.7.0"}
 ]
 depexts: [
   ["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.4.4.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.4.0/opam
@@ -30,6 +30,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "re" {>= "1.7.2"}
+  "lwt" {< "5.7.0"}
 ]
 depexts: [
   ["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.4.5.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.5.0/opam
@@ -30,6 +30,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "re" {>= "1.7.2"}
+  "lwt" {< "5.7.0"}
 ]
 depexts: [
   ["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.4.6.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.6.0/opam
@@ -31,6 +31,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "re" {>= "1.7.2"}
+  "lwt" {< "5.7.0"}
 ]
 depexts: [
   ["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}


### PR DESCRIPTION
Addressing revdeps errors which are linked to removal of deprecated values in Lwt. See https://github.com/ocaml/opam-repository/pull/24213#issuecomment-1667998101 for details.

Note that none of the packages changed here are at their latest version. Hence I don't think we need to ping the authors/maintainers.