### PR TITLE
Add constraint in weevil's dep to ppx_expect

### DIFF
--- a/packages/weevil/weevil.0.1.1/opam
+++ b/packages/weevil/weevil.0.1.1/opam
@@ -18,7 +18,7 @@ depends: [
   "tezos-client-014-PtKathma" {= "15.0"}
   "conduit-lwt-unix" {>= "6.0.1"}
   "lwt_ppx" {>= "2.1.0"}
-  "ppx_expect" {>= "v0.15.1"}
+  "ppx_expect" {>= "v0.15.1" & < "v0.16.0"}
   "ppx_deriving_qcheck" {>= "0.3.0"}
   "qcheck-alcotest" {>= "0.20"}
   "bisect_ppx" {>= "2.5.0"}


### PR DESCRIPTION
To fix

```
#=== ERROR while compiling weevil.0.1.1 =======================================#
# context              2.2.0~alpha2~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/weevil.0.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p weevil -j 71
# exit-code            1
# env-file             ~/.opam/log/weevil-7-57d3ff.env
# output-file          ~/.opam/log/weevil-7-57d3ff.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/test_utils/.test_utils.objs/byte -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/common -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_derivers -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_expect/payload -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/expander -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/libname -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppxlib -I /home/opam/.opam/4.14/lib/ppxlib/ast -I /home/opam/.opam/4.14/lib/ppxlib/astlib -I /home/opam/.opam/4.14/lib/ppxlib/print_diff -I /home/opam/.opam/4.14/lib/ppxlib/stdppx -I /home/opam/.opam/4.14/lib/ppxlib/traverse_builtins -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/time_now -no-alias-deps -open Test_utils -o src/test_utils/.test_utils.objs/byte/test_utils__Include.cmo -c -impl src/test_utils/include.pp.ml)
# File "src/test_utils/include.ml", lines 14-16, characters 2-37:
# 14 | ..Expect_test_config_types.S
# 15 |   with module IO_run = Lwt_io_run
# 16 |    and module IO_flush = Lwt_io_flush
# Error: The signature constrained by `with' has no component named IO_run
```

As seen on https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/d2db5c588577d03962918130242ad7ee38c8f41d/variant/compilers,4.14,repr.0.7.0,revdeps,weevil.0.1.1