### PR TITLE
jasmin <= 2023.06.0 is not compatible with ocaml 5

### DIFF
--- a/packages/jasmin/jasmin.2022.04.0/opam
+++ b/packages/jasmin/jasmin.2022.04.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/jasmin-lang/jasmin/issues"
 dev-repo: "git+https://github.com/jasmin-lang/jasmin.git"
 
 depends: [
-  "ocaml" {>= "4.08.0" & build}
+  "ocaml" {>= "4.08.0" & < "5.0" & build}
   "batteries" {>= "3.2.0"}
   "menhir" {>= "20160825" & build }
   "menhirLib"

--- a/packages/jasmin/jasmin.2022.09.0/opam
+++ b/packages/jasmin/jasmin.2022.09.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/jasmin-lang/jasmin/issues"
 dev-repo: "git+https://github.com/jasmin-lang/jasmin.git"
 
 depends: [
-  "ocaml" {>= "4.08.0" & build}
+  "ocaml" {>= "4.08.0" & < "5.0" & build}
   "batteries" {>= "3.4.0"}
   "menhir" {>= "20160825" & build}
   "menhirLib"

--- a/packages/jasmin/jasmin.2022.09.2/opam
+++ b/packages/jasmin/jasmin.2022.09.2/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/jasmin-lang/jasmin/issues"
 dev-repo: "git+https://github.com/jasmin-lang/jasmin.git"
 
 depends: [
-  "ocaml" {>= "4.08.0" & build}
+  "ocaml" {>= "4.08.0" & < "5.0" & build}
   "batteries" {>= "3.4.0"}
   "menhir" {>= "20160825" & build}
   "menhirLib"

--- a/packages/jasmin/jasmin.2022.09.3/opam
+++ b/packages/jasmin/jasmin.2022.09.3/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/jasmin-lang/jasmin/issues"
 dev-repo: "git+https://github.com/jasmin-lang/jasmin.git"
 
 depends: [
-  "ocaml" {>= "4.08.0" & build}
+  "ocaml" {>= "4.08.0" & < "5.0" & build}
   "batteries" {>= "3.4.0"}
   "menhir" {>= "20160825" & build}
   "menhirLib"

--- a/packages/jasmin/jasmin.2023.06.0/opam
+++ b/packages/jasmin/jasmin.2023.06.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/jasmin-lang/jasmin/issues"
 dev-repo: "git+https://github.com/jasmin-lang/jasmin.git"
 
 depends: [
-  "ocaml" {>= "4.11" & build}
+  "ocaml" {>= "4.11" & < "5.0" & build}
   "batteries" {>= "3.4.0"}
   "menhir" {>= "20160825" & build}
   "menhirLib"


### PR DESCRIPTION
Fails with

```
#=== ERROR while compiling jasmin.2023.06.0 ===================================#
 context              2.2.0~alpha2~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.0/.opam-switch/build/jasmin.2023.06.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build make -C compiler build
 exit-code            2
 env-file             ~/.opam/log/jasmin-7-7015b2.env
 output-file          ~/.opam/log/jasmin-7-7015b2.out
### output ###
 make: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/jasmin.2023.06.0/compiler'
 rm -f jasminc jazz2tex
 dune build entry/jasminc.exe
 (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -rectypes -g -I safetylib/.jasmin_checksafety.objs/byte -I safetylib/.jasmin_checksafety.objs/native -I /home/opam/.opam/5.0/lib/apron -I /home/opam/.opam/5.0/lib/batteries -I /home/opam/.opam/5.0/lib/bigarray-compat -I /home/opam/.opam/5.0/lib/camlp-streams -I /home/opam/.opam/5.0/lib/gmp -I /home/opam/.opam/5.0/lib/menhirLib -I /home/opam/.opam/5.0/lib/num -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/yojson -I /home/opam/.opam/5.0/lib/zarith -I src/.jasmin.objs/byte -I src/.jasmin.objs/native -intf-suffix .ml -no-alias-deps -opaque -open Jasmin_checksafety -o safetylib/.jasmin_checksafety.objs/native/jasmin_checksafety__SafetyInterpreter.cmx -c -impl safetylib/safetyInterpreter.ml)
 File "safetylib/safetyInterpreter.ml", line 1372, characters 14-30:
 1372 |       let s = String.lowercase s in
                      ^^^^^^^^^^^^^^^^
 Error: Unbound value String.lowercase
 make: *** [Makefile:48: native] Error 1
 make: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/jasmin.2023.06.0/compiler'
```