### PR TITLE
Fix opam-* < 2.0.7 when the CI environment variable is set

### DIFF
--- a/packages/opam-client/opam-client.2.0.0/opam
+++ b/packages/opam-client/opam-client.2.0.0/opam
@@ -35,3 +35,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
   checksum: "md5=385612adf8733f6816cfcbc39e3e1b50"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-client/opam-client.2.0.0~beta/opam
+++ b/packages/opam-client/opam-client.2.0.0~beta/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta2.tar.gz"
   checksum: "md5=e27cfdb0b8c6f4c3133f983e4c50b7dd"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-client/opam-client.2.0.0~beta3.1/opam
+++ b/packages/opam-client/opam-client.2.0.0~beta3.1/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta3.1.tar.gz"
   checksum: "md5=092d3e53ee4649a50a3b30bdfd72646b"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-client/opam-client.2.0.0~beta3/opam
+++ b/packages/opam-client/opam-client.2.0.0~beta3/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta3.tar.gz"
   checksum: "md5=19ce08c078494cf5640b65843ce650ab"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-client/opam-client.2.0.0~beta5/opam
+++ b/packages/opam-client/opam-client.2.0.0~beta5/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
   checksum: "md5=9347fabff36c99bc631b30b1007e20db"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-client/opam-client.2.0.0~rc/opam
+++ b/packages/opam-client/opam-client.2.0.0~rc/opam
@@ -35,3 +35,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
   checksum: "md5=ae216e3ea0a9388cc9f711a2a9925557"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-client/opam-client.2.0.0~rc2/opam
+++ b/packages/opam-client/opam-client.2.0.0~rc2/opam
@@ -35,3 +35,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc2.tar.gz"
   checksum: "md5=86a60db4df8412db09cef82cf26cf335"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-client/opam-client.2.0.0~rc3/opam
+++ b/packages/opam-client/opam-client.2.0.0~rc3/opam
@@ -35,3 +35,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc3.tar.gz"
   checksum: "md5=5b782a93c6784304e61dfe9d56349b09"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-client/opam-client.2.0.1/opam
+++ b/packages/opam-client/opam-client.2.0.1/opam
@@ -41,3 +41,6 @@ opam 2.0 development libraries
 
 Actions on the opam root, switches, installations, and front-end.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-client/opam-client.2.0.2/opam
+++ b/packages/opam-client/opam-client.2.0.2/opam
@@ -41,3 +41,6 @@ opam 2.0 development libraries
 
 Actions on the opam root, switches, installations, and front-end.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-client/opam-client.2.0.3/opam
+++ b/packages/opam-client/opam-client.2.0.3/opam
@@ -41,3 +41,6 @@ opam 2.0 development libraries
 
 Actions on the opam root, switches, installations, and front-end.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-client/opam-client.2.0.4/opam
+++ b/packages/opam-client/opam-client.2.0.4/opam
@@ -41,3 +41,6 @@ opam 2.0 development libraries
 
 Actions on the opam root, switches, installations, and front-end.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-client/opam-client.2.0.5/opam
+++ b/packages/opam-client/opam-client.2.0.5/opam
@@ -41,3 +41,6 @@ opam 2.0 development libraries
 
 Actions on the opam root, switches, installations, and front-end.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-client/opam-client.2.0.6/opam
+++ b/packages/opam-client/opam-client.2.0.6/opam
@@ -41,3 +41,6 @@ opam 2.0 development libraries
 
 Actions on the opam root, switches, installations, and front-end.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-core/opam-core.2.0.0/opam
+++ b/packages/opam-core/opam-core.2.0.0/opam
@@ -38,3 +38,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
   checksum: "md5=385612adf8733f6816cfcbc39e3e1b50"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-core/opam-core.2.0.0~beta/opam
+++ b/packages/opam-core/opam-core.2.0.0~beta/opam
@@ -37,3 +37,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta2.tar.gz"
   checksum: "md5=e27cfdb0b8c6f4c3133f983e4c50b7dd"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-core/opam-core.2.0.0~beta3.1/opam
+++ b/packages/opam-core/opam-core.2.0.0~beta3.1/opam
@@ -37,3 +37,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta3.1.tar.gz"
   checksum: "md5=092d3e53ee4649a50a3b30bdfd72646b"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-core/opam-core.2.0.0~beta3/opam
+++ b/packages/opam-core/opam-core.2.0.0~beta3/opam
@@ -37,3 +37,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta3.tar.gz"
   checksum: "md5=19ce08c078494cf5640b65843ce650ab"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-core/opam-core.2.0.0~beta5/opam
+++ b/packages/opam-core/opam-core.2.0.0~beta5/opam
@@ -34,3 +34,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
   checksum: "md5=9347fabff36c99bc631b30b1007e20db"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-core/opam-core.2.0.0~rc/opam
+++ b/packages/opam-core/opam-core.2.0.0~rc/opam
@@ -38,3 +38,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
   checksum: "md5=ae216e3ea0a9388cc9f711a2a9925557"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-core/opam-core.2.0.0~rc2/opam
+++ b/packages/opam-core/opam-core.2.0.0~rc2/opam
@@ -38,3 +38,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc2.tar.gz"
   checksum: "md5=86a60db4df8412db09cef82cf26cf335"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-core/opam-core.2.0.0~rc3/opam
+++ b/packages/opam-core/opam-core.2.0.0~rc3/opam
@@ -38,3 +38,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc3.tar.gz"
   checksum: "md5=5b782a93c6784304e61dfe9d56349b09"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-core/opam-core.2.0.1/opam
+++ b/packages/opam-core/opam-core.2.0.1/opam
@@ -44,3 +44,6 @@ opam 2.0 development libraries
 Small standard library extensions, and generic system interaction modules used
 by opam.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-core/opam-core.2.0.2/opam
+++ b/packages/opam-core/opam-core.2.0.2/opam
@@ -44,3 +44,6 @@ opam 2.0 development libraries
 Small standard library extensions, and generic system interaction modules used
 by opam.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-core/opam-core.2.0.3/opam
+++ b/packages/opam-core/opam-core.2.0.3/opam
@@ -44,3 +44,6 @@ opam 2.0 development libraries
 Small standard library extensions, and generic system interaction modules used
 by opam.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-core/opam-core.2.0.4/opam
+++ b/packages/opam-core/opam-core.2.0.4/opam
@@ -44,3 +44,6 @@ opam 2.0 development libraries
 Small standard library extensions, and generic system interaction modules used
 by opam.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-core/opam-core.2.0.5/opam
+++ b/packages/opam-core/opam-core.2.0.5/opam
@@ -44,3 +44,6 @@ opam 2.0 development libraries
 Small standard library extensions, and generic system interaction modules used
 by opam.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-core/opam-core.2.0.6/opam
+++ b/packages/opam-core/opam-core.2.0.6/opam
@@ -44,3 +44,6 @@ opam 2.0 development libraries
 Small standard library extensions, and generic system interaction modules used
 by opam.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-devel/opam-devel.2.0.0/opam
+++ b/packages/opam-devel/opam-devel.2.0.0/opam
@@ -43,3 +43,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
   checksum: "md5=385612adf8733f6816cfcbc39e3e1b50"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-devel/opam-devel.2.0.0~beta/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~beta/opam
@@ -42,3 +42,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta2.tar.gz"
   checksum: "md5=e27cfdb0b8c6f4c3133f983e4c50b7dd"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-devel/opam-devel.2.0.0~beta3.1/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~beta3.1/opam
@@ -44,3 +44,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta3.1.tar.gz"
   checksum: "md5=092d3e53ee4649a50a3b30bdfd72646b"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-devel/opam-devel.2.0.0~beta3/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~beta3/opam
@@ -44,3 +44,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta3.tar.gz"
   checksum: "md5=19ce08c078494cf5640b65843ce650ab"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-devel/opam-devel.2.0.0~beta5/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~beta5/opam
@@ -44,3 +44,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
   checksum: "md5=9347fabff36c99bc631b30b1007e20db"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-devel/opam-devel.2.0.0~rc/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~rc/opam
@@ -47,3 +47,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
   checksum: "md5=ae216e3ea0a9388cc9f711a2a9925557"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-devel/opam-devel.2.0.0~rc2/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~rc2/opam
@@ -44,3 +44,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc2.tar.gz"
   checksum: "md5=86a60db4df8412db09cef82cf26cf335"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-devel/opam-devel.2.0.0~rc3/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~rc3/opam
@@ -44,3 +44,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc3.tar.gz"
   checksum: "md5=5b782a93c6784304e61dfe9d56349b09"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-devel/opam-devel.2.0.1/opam
+++ b/packages/opam-devel/opam-devel.2.0.1/opam
@@ -49,3 +49,6 @@ This package compiles (bootstraps) opam 2.0.0. For consistency and safety of the
 installation, the binaries are not installed into the PATH, but into
 lib/opam-devel, from where the user can manually install them system-wide.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-devel/opam-devel.2.0.2/opam
+++ b/packages/opam-devel/opam-devel.2.0.2/opam
@@ -49,3 +49,6 @@ This package compiles (bootstraps) opam 2.0.0. For consistency and safety of the
 installation, the binaries are not installed into the PATH, but into
 lib/opam-devel, from where the user can manually install them system-wide.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-devel/opam-devel.2.0.3/opam
+++ b/packages/opam-devel/opam-devel.2.0.3/opam
@@ -49,3 +49,6 @@ This package compiles (bootstraps) opam 2.0.0. For consistency and safety of the
 installation, the binaries are not installed into the PATH, but into
 lib/opam-devel, from where the user can manually install them system-wide.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-devel/opam-devel.2.0.4/opam
+++ b/packages/opam-devel/opam-devel.2.0.4/opam
@@ -49,3 +49,6 @@ This package compiles (bootstraps) opam 2.0.0. For consistency and safety of the
 installation, the binaries are not installed into the PATH, but into
 lib/opam-devel, from where the user can manually install them system-wide.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-devel/opam-devel.2.0.5/opam
+++ b/packages/opam-devel/opam-devel.2.0.5/opam
@@ -49,3 +49,6 @@ This package compiles (bootstraps) opam 2.0.5. For consistency and safety of the
 installation, the binaries are not installed into the PATH, but into
 lib/opam-devel, from where the user can manually install them system-wide.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-devel/opam-devel.2.0.6/opam
+++ b/packages/opam-devel/opam-devel.2.0.6/opam
@@ -49,3 +49,6 @@ This package compiles (bootstraps) opam 2.0.6. For consistency and safety of the
 installation, the binaries are not installed into the PATH, but into
 lib/opam-devel, from where the user can manually install them system-wide.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-format/opam-format.2.0.0/opam
+++ b/packages/opam-format/opam-format.2.0.0/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
   checksum: "md5=385612adf8733f6816cfcbc39e3e1b50"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-format/opam-format.2.0.0~beta/opam
+++ b/packages/opam-format/opam-format.2.0.0~beta/opam
@@ -30,3 +30,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta2.tar.gz"
   checksum: "md5=e27cfdb0b8c6f4c3133f983e4c50b7dd"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-format/opam-format.2.0.0~beta3.1/opam
+++ b/packages/opam-format/opam-format.2.0.0~beta3.1/opam
@@ -30,3 +30,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta3.1.tar.gz"
   checksum: "md5=092d3e53ee4649a50a3b30bdfd72646b"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-format/opam-format.2.0.0~beta3/opam
+++ b/packages/opam-format/opam-format.2.0.0~beta3/opam
@@ -30,3 +30,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta3.tar.gz"
   checksum: "md5=19ce08c078494cf5640b65843ce650ab"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-format/opam-format.2.0.0~beta5/opam
+++ b/packages/opam-format/opam-format.2.0.0~beta5/opam
@@ -30,3 +30,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
   checksum: "md5=9347fabff36c99bc631b30b1007e20db"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-format/opam-format.2.0.0~rc/opam
+++ b/packages/opam-format/opam-format.2.0.0~rc/opam
@@ -33,3 +33,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
   checksum: "md5=ae216e3ea0a9388cc9f711a2a9925557"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-format/opam-format.2.0.0~rc2/opam
+++ b/packages/opam-format/opam-format.2.0.0~rc2/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc2.tar.gz"
   checksum: "md5=86a60db4df8412db09cef82cf26cf335"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-format/opam-format.2.0.0~rc3/opam
+++ b/packages/opam-format/opam-format.2.0.0~rc3/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc3.tar.gz"
   checksum: "md5=5b782a93c6784304e61dfe9d56349b09"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-format/opam-format.2.0.1/opam
+++ b/packages/opam-format/opam-format.2.0.1/opam
@@ -39,3 +39,6 @@ opam 2.0 development libraries
 
 Definition of opam datastructures and its file interface.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-format/opam-format.2.0.2/opam
+++ b/packages/opam-format/opam-format.2.0.2/opam
@@ -39,3 +39,6 @@ opam 2.0 development libraries
 
 Definition of opam datastructures and its file interface.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-format/opam-format.2.0.3/opam
+++ b/packages/opam-format/opam-format.2.0.3/opam
@@ -39,3 +39,6 @@ opam 2.0 development libraries
 
 Definition of opam datastructures and its file interface.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-format/opam-format.2.0.4/opam
+++ b/packages/opam-format/opam-format.2.0.4/opam
@@ -39,3 +39,6 @@ opam 2.0 development libraries
 
 Definition of opam datastructures and its file interface.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-format/opam-format.2.0.5/opam
+++ b/packages/opam-format/opam-format.2.0.5/opam
@@ -39,3 +39,6 @@ opam 2.0 development libraries
 
 Definition of opam datastructures and its file interface.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-format/opam-format.2.0.6/opam
+++ b/packages/opam-format/opam-format.2.0.6/opam
@@ -39,3 +39,6 @@ opam 2.0 development libraries
 
 Definition of opam datastructures and its file interface.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-installer/opam-installer.2.0.0/opam
+++ b/packages/opam-installer/opam-installer.2.0.0/opam
@@ -39,3 +39,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
   checksum: "md5=385612adf8733f6816cfcbc39e3e1b50"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-installer/opam-installer.2.0.0~beta5/opam
+++ b/packages/opam-installer/opam-installer.2.0.0~beta5/opam
@@ -30,3 +30,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
   checksum: "md5=9347fabff36c99bc631b30b1007e20db"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-installer/opam-installer.2.0.0~rc/opam
+++ b/packages/opam-installer/opam-installer.2.0.0~rc/opam
@@ -39,3 +39,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
   checksum: "md5=ae216e3ea0a9388cc9f711a2a9925557"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-installer/opam-installer.2.0.0~rc2/opam
+++ b/packages/opam-installer/opam-installer.2.0.0~rc2/opam
@@ -39,3 +39,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc2.tar.gz"
   checksum: "md5=86a60db4df8412db09cef82cf26cf335"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-installer/opam-installer.2.0.0~rc3/opam
+++ b/packages/opam-installer/opam-installer.2.0.0~rc3/opam
@@ -39,3 +39,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc3.tar.gz"
   checksum: "md5=5b782a93c6784304e61dfe9d56349b09"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-installer/opam-installer.2.0.1/opam
+++ b/packages/opam-installer/opam-installer.2.0.1/opam
@@ -44,3 +44,6 @@ through opam.
 
 [1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-installer/opam-installer.2.0.2/opam
+++ b/packages/opam-installer/opam-installer.2.0.2/opam
@@ -43,3 +43,6 @@ through opam.
 
 [1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-installer/opam-installer.2.0.3/opam
+++ b/packages/opam-installer/opam-installer.2.0.3/opam
@@ -43,3 +43,6 @@ through opam.
 
 [1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-installer/opam-installer.2.0.4/opam
+++ b/packages/opam-installer/opam-installer.2.0.4/opam
@@ -43,3 +43,6 @@ through opam.
 
 [1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-installer/opam-installer.2.0.5/opam
+++ b/packages/opam-installer/opam-installer.2.0.5/opam
@@ -43,3 +43,6 @@ through opam.
 
 [1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-installer/opam-installer.2.0.6/opam
+++ b/packages/opam-installer/opam-installer.2.0.6/opam
@@ -43,3 +43,6 @@ through opam.
 
 [1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-repository/opam-repository.2.0.0/opam
+++ b/packages/opam-repository/opam-repository.2.0.0/opam
@@ -33,3 +33,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
   checksum: "md5=385612adf8733f6816cfcbc39e3e1b50"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-repository/opam-repository.2.0.0~beta/opam
+++ b/packages/opam-repository/opam-repository.2.0.0~beta/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta2.tar.gz"
   checksum: "md5=e27cfdb0b8c6f4c3133f983e4c50b7dd"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-repository/opam-repository.2.0.0~beta3.1/opam
+++ b/packages/opam-repository/opam-repository.2.0.0~beta3.1/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta3.1.tar.gz"
   checksum: "md5=092d3e53ee4649a50a3b30bdfd72646b"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-repository/opam-repository.2.0.0~beta3/opam
+++ b/packages/opam-repository/opam-repository.2.0.0~beta3/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta3.tar.gz"
   checksum: "md5=19ce08c078494cf5640b65843ce650ab"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-repository/opam-repository.2.0.0~beta5/opam
+++ b/packages/opam-repository/opam-repository.2.0.0~beta5/opam
@@ -31,3 +31,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
   checksum: "md5=9347fabff36c99bc631b30b1007e20db"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-repository/opam-repository.2.0.0~rc/opam
+++ b/packages/opam-repository/opam-repository.2.0.0~rc/opam
@@ -34,3 +34,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
   checksum: "md5=ae216e3ea0a9388cc9f711a2a9925557"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-repository/opam-repository.2.0.0~rc2/opam
+++ b/packages/opam-repository/opam-repository.2.0.0~rc2/opam
@@ -33,3 +33,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc2.tar.gz"
   checksum: "md5=86a60db4df8412db09cef82cf26cf335"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-repository/opam-repository.2.0.0~rc3/opam
+++ b/packages/opam-repository/opam-repository.2.0.0~rc3/opam
@@ -33,3 +33,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc3.tar.gz"
   checksum: "md5=5b782a93c6784304e61dfe9d56349b09"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-repository/opam-repository.2.0.1/opam
+++ b/packages/opam-repository/opam-repository.2.0.1/opam
@@ -39,3 +39,6 @@ opam 2.0 development libraries
 This library includes repository and remote sources handling, including
 curl/wget, rsync, git, mercurial, darcs backends.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-repository/opam-repository.2.0.2/opam
+++ b/packages/opam-repository/opam-repository.2.0.2/opam
@@ -39,3 +39,6 @@ opam 2.0 development libraries
 This library includes repository and remote sources handling, including
 curl/wget, rsync, git, mercurial, darcs backends.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-repository/opam-repository.2.0.3/opam
+++ b/packages/opam-repository/opam-repository.2.0.3/opam
@@ -39,3 +39,6 @@ opam 2.0 development libraries
 This library includes repository and remote sources handling, including
 curl/wget, rsync, git, mercurial, darcs backends.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-repository/opam-repository.2.0.4/opam
+++ b/packages/opam-repository/opam-repository.2.0.4/opam
@@ -39,3 +39,6 @@ opam 2.0 development libraries
 This library includes repository and remote sources handling, including
 curl/wget, rsync, git, mercurial, darcs backends.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-repository/opam-repository.2.0.5/opam
+++ b/packages/opam-repository/opam-repository.2.0.5/opam
@@ -39,3 +39,6 @@ opam 2.0 development libraries
 This library includes repository and remote sources handling, including
 curl/wget, rsync, git, mercurial, darcs backends.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-repository/opam-repository.2.0.6/opam
+++ b/packages/opam-repository/opam-repository.2.0.6/opam
@@ -39,3 +39,6 @@ opam 2.0 development libraries
 This library includes repository and remote sources handling, including
 curl/wget, rsync, git, mercurial, darcs backends.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-solver/opam-solver.2.0.0/opam
+++ b/packages/opam-solver/opam-solver.2.0.0/opam
@@ -36,3 +36,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
   checksum: "md5=385612adf8733f6816cfcbc39e3e1b50"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-solver/opam-solver.2.0.0~beta/opam
+++ b/packages/opam-solver/opam-solver.2.0.0~beta/opam
@@ -34,3 +34,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta2.tar.gz"
   checksum: "md5=e27cfdb0b8c6f4c3133f983e4c50b7dd"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-solver/opam-solver.2.0.0~beta3.1/opam
+++ b/packages/opam-solver/opam-solver.2.0.0~beta3.1/opam
@@ -34,3 +34,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta3.1.tar.gz"
   checksum: "md5=092d3e53ee4649a50a3b30bdfd72646b"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-solver/opam-solver.2.0.0~beta3/opam
+++ b/packages/opam-solver/opam-solver.2.0.0~beta3/opam
@@ -34,3 +34,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta3.tar.gz"
   checksum: "md5=19ce08c078494cf5640b65843ce650ab"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-solver/opam-solver.2.0.0~beta5/opam
+++ b/packages/opam-solver/opam-solver.2.0.0~beta5/opam
@@ -34,3 +34,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
   checksum: "md5=9347fabff36c99bc631b30b1007e20db"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-solver/opam-solver.2.0.0~rc/opam
+++ b/packages/opam-solver/opam-solver.2.0.0~rc/opam
@@ -37,3 +37,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
   checksum: "md5=ae216e3ea0a9388cc9f711a2a9925557"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-solver/opam-solver.2.0.0~rc2/opam
+++ b/packages/opam-solver/opam-solver.2.0.0~rc2/opam
@@ -36,3 +36,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc2.tar.gz"
   checksum: "md5=86a60db4df8412db09cef82cf26cf335"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-solver/opam-solver.2.0.0~rc3/opam
+++ b/packages/opam-solver/opam-solver.2.0.0~rc3/opam
@@ -36,3 +36,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc3.tar.gz"
   checksum: "md5=5b782a93c6784304e61dfe9d56349b09"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-solver/opam-solver.2.0.1/opam
+++ b/packages/opam-solver/opam-solver.2.0.1/opam
@@ -42,3 +42,6 @@ opam 2.0 development libraries
 Solver and Cudf interaction. This library is based on the Cudf and Dose
 libraries, and handles calls to the external solver from opam.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-solver/opam-solver.2.0.2/opam
+++ b/packages/opam-solver/opam-solver.2.0.2/opam
@@ -42,3 +42,6 @@ opam 2.0 development libraries
 Solver and Cudf interaction. This library is based on the Cudf and Dose
 libraries, and handles calls to the external solver from opam.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-solver/opam-solver.2.0.3/opam
+++ b/packages/opam-solver/opam-solver.2.0.3/opam
@@ -42,3 +42,6 @@ opam 2.0 development libraries
 Solver and Cudf interaction. This library is based on the Cudf and Dose
 libraries, and handles calls to the external solver from opam.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-solver/opam-solver.2.0.4/opam
+++ b/packages/opam-solver/opam-solver.2.0.4/opam
@@ -42,3 +42,6 @@ opam 2.0 development libraries
 Solver and Cudf interaction. This library is based on the Cudf and Dose
 libraries, and handles calls to the external solver from opam.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-solver/opam-solver.2.0.5/opam
+++ b/packages/opam-solver/opam-solver.2.0.5/opam
@@ -42,3 +42,6 @@ opam 2.0 development libraries
 Solver and Cudf interaction. This library is based on the Cudf and Dose
 libraries, and handles calls to the external solver from opam.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-solver/opam-solver.2.0.6/opam
+++ b/packages/opam-solver/opam-solver.2.0.6/opam
@@ -42,3 +42,6 @@ opam 2.0 development libraries
 Solver and Cudf interaction. This library is based on the Cudf and Dose
 libraries, and handles calls to the external solver from opam.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-state/opam-state.2.0.0/opam
+++ b/packages/opam-state/opam-state.2.0.0/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc4.tar.gz"
   checksum: "md5=385612adf8733f6816cfcbc39e3e1b50"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-state/opam-state.2.0.0~beta/opam
+++ b/packages/opam-state/opam-state.2.0.0~beta/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta2.tar.gz"
   checksum: "md5=e27cfdb0b8c6f4c3133f983e4c50b7dd"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-state/opam-state.2.0.0~beta3.1/opam
+++ b/packages/opam-state/opam-state.2.0.0~beta3.1/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta3.1.tar.gz"
   checksum: "md5=092d3e53ee4649a50a3b30bdfd72646b"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-state/opam-state.2.0.0~beta3/opam
+++ b/packages/opam-state/opam-state.2.0.0~beta3/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta3.tar.gz"
   checksum: "md5=19ce08c078494cf5640b65843ce650ab"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-state/opam-state.2.0.0~beta5/opam
+++ b/packages/opam-state/opam-state.2.0.0~beta5/opam
@@ -30,3 +30,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-beta5.tar.gz"
   checksum: "md5=9347fabff36c99bc631b30b1007e20db"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-state/opam-state.2.0.0~rc/opam
+++ b/packages/opam-state/opam-state.2.0.0~rc/opam
@@ -33,3 +33,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc.tar.gz"
   checksum: "md5=ae216e3ea0a9388cc9f711a2a9925557"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-state/opam-state.2.0.0~rc2/opam
+++ b/packages/opam-state/opam-state.2.0.0~rc2/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc2.tar.gz"
   checksum: "md5=86a60db4df8412db09cef82cf26cf335"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-state/opam-state.2.0.0~rc3/opam
+++ b/packages/opam-state/opam-state.2.0.0~rc3/opam
@@ -32,3 +32,6 @@ url {
   src: "https://github.com/ocaml/opam/archive/2.0.0-rc3.tar.gz"
   checksum: "md5=5b782a93c6784304e61dfe9d56349b09"
 }
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-state/opam-state.2.0.1/opam
+++ b/packages/opam-state/opam-state.2.0.1/opam
@@ -38,3 +38,6 @@ opam 2.0 development libraries
 
 Handling of the ~/.opam hierarchy, repository and switch states.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-state/opam-state.2.0.2/opam
+++ b/packages/opam-state/opam-state.2.0.2/opam
@@ -38,3 +38,6 @@ opam 2.0 development libraries
 
 Handling of the ~/.opam hierarchy, repository and switch states.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-state/opam-state.2.0.3/opam
+++ b/packages/opam-state/opam-state.2.0.3/opam
@@ -38,3 +38,6 @@ opam 2.0 development libraries
 
 Handling of the ~/.opam hierarchy, repository and switch states.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-state/opam-state.2.0.4/opam
+++ b/packages/opam-state/opam-state.2.0.4/opam
@@ -38,3 +38,6 @@ opam 2.0 development libraries
 
 Handling of the ~/.opam hierarchy, repository and switch states.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-state/opam-state.2.0.5/opam
+++ b/packages/opam-state/opam-state.2.0.5/opam
@@ -38,3 +38,6 @@ opam 2.0 development libraries
 
 Handling of the ~/.opam hierarchy, repository and switch states.
 """
+build-env: [
+  [CI = ""]
+]

--- a/packages/opam-state/opam-state.2.0.6/opam
+++ b/packages/opam-state/opam-state.2.0.6/opam
@@ -38,3 +38,6 @@ opam 2.0 development libraries
 
 Handling of the ~/.opam hierarchy, repository and switch states.
 """
+build-env: [
+  [CI = ""]
+]


### PR DESCRIPTION
e.g. in opam-repo-ci
```
#=== ERROR while compiling opam-core.2.0.6 ====================================#
# context              2.2.0~alpha2~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/opam-core.2.0.6
# command              ~/.opam/opam-init/hooks/sandbox.sh build make opam-core.install
# exit-code            2
# env-file             ~/.opam/log/opam-core-7-6bdbb2.env
# output-file          ~/.opam/log/opam-core-7-6bdbb2.out
### output ###
# dune build  -p opam-core opam-core.install
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w +a-4-40-42-44-48 -safe-string -warn-error A-3 -g -bin-annot -I src/core/.opam_core.objs/byte -I /home/opam/.opam/4.14/lib/ocamlgraph -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/stdlib-shims -no-alias-deps -o src/core/.opam_core.objs/byte/opamStubsTypes.cmo -c -impl src/core/opamStubsTypes.ml)
# File "src/core/opamStubsTypes.ml", line 1:
# Error (warning 70 [missing-mli]): Cannot find interface file.
# make: *** [Makefile:104: opam-core.install] Error 1
```
This behaviour was fixed in 2.0.7 with https://github.com/ocaml/opam/pull/4143/files#diff-90d08e583c4c9c6f391b2ae90f819f600a6326928ea9512c9e0c6d98e9f29ac2R3980