### PR TITLE
eliom is not compatible with OCaml 5.1 (some parsetree types changed)

### DIFF
--- a/packages/eliom/eliom.10.0.0/opam
+++ b/packages/eliom/eliom.10.0.0/opam
@@ -15,7 +15,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}

--- a/packages/eliom/eliom.2.2.2/opam
+++ b/packages/eliom/eliom.2.2.2/opam
@@ -17,7 +17,7 @@ build: [
 ]
 remove: [["rm" "-rf" "%{lib}%/eliom"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.1"}
   "ocamlfind"
   "deriving-ocsigen"
   "js_of_ocaml" {< "2.0"}

--- a/packages/eliom/eliom.3.0.0/opam
+++ b/packages/eliom/eliom.3.0.0/opam
@@ -18,7 +18,7 @@ build: [
 ]
 remove: [["rm" "-rf" "%{lib}%/eliom" "%{man}%/man1/eliomc.1" "%{man}%/man1/eliomopt.1" "%{man}%/man1/eliomcp.1" "%{man}%/man1/js_of_eliom.1" "%{man}%/man1/eliomdep.1" "%{man}%/man1/eliom-destillery.1"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.1"}
   "ocamlfind"
   "deriving-ocsigen"
   "js_of_ocaml" {>= "1.3" & < "2.0"}

--- a/packages/eliom/eliom.3.0.1/opam
+++ b/packages/eliom/eliom.3.0.1/opam
@@ -18,7 +18,7 @@ build: [
 ]
 remove: [["rm" "-rf" "%{lib}%/eliom" "%{man}%/man1/eliomc.1" "%{man}%/man1/eliomopt.1" "%{man}%/man1/eliomcp.1" "%{man}%/man1/js_of_eliom.1" "%{man}%/man1/eliomdep.1" "%{man}%/man1/eliom-destillery.1"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.1"}
   "ocamlfind"
   "deriving-ocsigen"
   "js_of_ocaml" {>= "1.3" & < "2.0"}

--- a/packages/eliom/eliom.3.0.2/opam
+++ b/packages/eliom/eliom.3.0.2/opam
@@ -18,7 +18,7 @@ build: [
 ]
 remove: [["rm" "-rf" "%{lib}%/eliom" "%{man}%/man1/eliomc.1" "%{man}%/man1/eliomopt.1" "%{man}%/man1/eliomcp.1" "%{man}%/man1/js_of_eliom.1" "%{man}%/man1/eliomdep.1" "%{man}%/man1/eliom-destillery.1"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.1"}
   "ocamlfind"
   "deriving-ocsigen"
   "js_of_ocaml" {>= "1.3" & < "2.0"}

--- a/packages/eliom/eliom.3.0.3/opam
+++ b/packages/eliom/eliom.3.0.3/opam
@@ -18,7 +18,7 @@ build: [
 ]
 remove: [["rm" "-rf" "%{lib}%/eliom" "%{man}%/man1/eliomc.1" "%{man}%/man1/eliomopt.1" "%{man}%/man1/eliomcp.1" "%{man}%/man1/js_of_eliom.1" "%{man}%/man1/eliomdep.1" "%{man}%/man1/eliom-destillery.1"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.1"}
   "ocamlfind"
   "deriving-ocsigen"
   "js_of_ocaml" {>= "1.3" & < "2.0"}

--- a/packages/eliom/eliom.4.0.0/opam
+++ b/packages/eliom/eliom.4.0.0/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: [["rm" "-rf" "%{lib}%/eliom" "%{man}%/man1/eliomc.1" "%{man}%/man1/eliomopt.1" "%{man}%/man1/eliomcp.1" "%{man}%/man1/js_of_eliom.1" "%{man}%/man1/eliomdep.1" "%{man}%/man1/eliom-distillery.1"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.1"}
   "ocamlfind"
   "deriving"
   "js_of_ocaml" {>= "2.2" & < "3.0"}

--- a/packages/eliom/eliom.4.1.0/opam
+++ b/packages/eliom/eliom.4.1.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/ocsigen/eliom.git"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 build: [make]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.1"}
   "ocamlfind"
   "deriving" {>= "0.6"}
   "js_of_ocaml" {>= "2.5" & < "3.0"}

--- a/packages/eliom/eliom.4.2.0/opam
+++ b/packages/eliom/eliom.4.2.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/ocsigen/eliom.git"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 build: [make]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.1"}
   "ocamlfind"
   "camlp4" {<= "4.02+6"}
   "deriving" {>= "0.6"}

--- a/packages/eliom/eliom.5.0.0/opam
+++ b/packages/eliom/eliom.5.0.0/opam
@@ -10,7 +10,7 @@ build: [
   "PPX=false" {base-no-ppx:installed}
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.1"}
   "ocamlfind"
   "camlp4" {<= "4.02+6"}
   "deriving" {>= "0.6"}

--- a/packages/eliom/eliom.6.0.0/opam
+++ b/packages/eliom/eliom.6.0.0/opam
@@ -7,7 +7,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.1"}
   "ocamlfind"
   "deriving" {>= "0.6"}
   "lwt" {>= "2.5.0" & < "3.0.0"}

--- a/packages/eliom/eliom.6.1.0/opam
+++ b/packages/eliom/eliom.6.1.0/opam
@@ -7,7 +7,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.02.2"}
+  "ocaml" {>= "4.02.2" & < "5.1"}
   "ocamlfind"
   "deriving" {>= "0.6"}
   "lwt" {>= "2.5.0" & < "3.0.0"}

--- a/packages/eliom/eliom.6.12.1/opam
+++ b/packages/eliom/eliom.6.12.1/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.07.1"}
+  "ocaml" {>= "4.07.1" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}

--- a/packages/eliom/eliom.6.12.4/opam
+++ b/packages/eliom/eliom.6.12.4/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.07.1"}
+  "ocaml" {>= "4.07.1" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}

--- a/packages/eliom/eliom.6.13.1/opam
+++ b/packages/eliom/eliom.6.13.1/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "5.2"}

--- a/packages/eliom/eliom.6.2.0/opam
+++ b/packages/eliom/eliom.6.2.0/opam
@@ -7,7 +7,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.02.2"}
+  "ocaml" {>= "4.02.2" & < "5.1"}
   "ocamlfind"
   "deriving" {>= "0.6"}
   "lwt" {>= "2.5.0" & < "3.0.0"}

--- a/packages/eliom/eliom.6.3.0/opam
+++ b/packages/eliom/eliom.6.3.0/opam
@@ -7,7 +7,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.1"}
   "ocamlfind"
   "deriving" {>= "0.6"}
   "ppx_deriving"

--- a/packages/eliom/eliom.6.4.0/opam
+++ b/packages/eliom/eliom.6.4.0/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.06.1"}
+  "ocaml" {>= "4.06.1" & < "5.1"}
   "ocamlfind"
   "deriving" {>= "0.6"}
   "ppx_deriving"

--- a/packages/eliom/eliom.6.8.0/opam
+++ b/packages/eliom/eliom.6.8.0/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.07.1"}
+  "ocaml" {>= "4.07.1" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}

--- a/packages/eliom/eliom.6.8.1/opam
+++ b/packages/eliom/eliom.6.8.1/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.07.1"}
+  "ocaml" {>= "4.07.1" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}

--- a/packages/eliom/eliom.6.9.1/opam
+++ b/packages/eliom/eliom.6.9.1/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.07.1"}
+  "ocaml" {>= "4.07.1" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}

--- a/packages/eliom/eliom.6.9.2/opam
+++ b/packages/eliom/eliom.6.9.2/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.07.1"}
+  "ocaml" {>= "4.07.1" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}

--- a/packages/eliom/eliom.6.9.3/opam
+++ b/packages/eliom/eliom.6.9.3/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.07.1"}
+  "ocaml" {>= "4.07.1" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}

--- a/packages/eliom/eliom.7.0.0/opam
+++ b/packages/eliom/eliom.7.0.0/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "5.2"}

--- a/packages/eliom/eliom.8.4.8/opam
+++ b/packages/eliom/eliom.8.4.8/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "5.2"}

--- a/packages/eliom/eliom.8.6.0/opam
+++ b/packages/eliom/eliom.8.6.0/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "5.2"}

--- a/packages/eliom/eliom.8.8.0/opam
+++ b/packages/eliom/eliom.8.8.0/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "5.2"}

--- a/packages/eliom/eliom.8.8.1/opam
+++ b/packages/eliom/eliom.8.8.1/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "5.2"}

--- a/packages/eliom/eliom.8.9.0/opam
+++ b/packages/eliom/eliom.8.9.0/opam
@@ -15,7 +15,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}

--- a/packages/eliom/eliom.9.0.0/opam
+++ b/packages/eliom/eliom.9.0.0/opam
@@ -15,7 +15,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}

--- a/packages/eliom/eliom.9.2.1/opam
+++ b/packages/eliom/eliom.9.2.1/opam
@@ -15,7 +15,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}

--- a/packages/eliom/eliom.9.3.0/opam
+++ b/packages/eliom/eliom.9.3.0/opam
@@ -15,7 +15,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}

--- a/packages/eliom/eliom.9.4.0/opam
+++ b/packages/eliom/eliom.9.4.0/opam
@@ -15,7 +15,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1"}
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}


### PR DESCRIPTION
Fix sent upstream in https://github.com/ocsigen/eliom/pull/762
```
#=== ERROR while compiling eliom.10.0.0 =======================================#
# context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-variants.5.1.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/eliom.10.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/eliom-8-c1d12a.env
# output-file          ~/.opam/log/eliom-8-c1d12a.out
### output ###
# ocamlbuild -no-plugin -I src/ocamlbuild -no-links -use-ocamlfind build/build.native 1> /dev/null
# ocaml pkg/build.ml manpage=false native=true native-dynlink=true
# ocamlfind: Package `wikidoc' not found
# File "src/_tags", line 52, characters 50-65:
# Warning: tag "subproject" does not expect a parameter, but is used with parameter "ppx"
# File "src/_tags", line 51, characters 64-86:
# Warning: tag "subproject" does not expect a parameter, but is used with parameter "ocamlbuild"
# File "src/_tags", line 50, characters 60-78:
# Warning: tag "subproject" does not expect a parameter, but is used with parameter "server"
# File "src/_tags", line 49, characters 60-78:
# Warning: tag "subproject" does not expect a parameter, but is used with parameter "client"
# File "src/_tags", line 49, characters 60-78:
# Warning: the tag "subproject(client)" is not used in any flag or dependency declaration, so it will have no effect; it may be a typo. Otherwise you can use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
# File "src/_tags", line 50, characters 60-78:
# Warning: the tag "subproject(server)" is not used in any flag or dependency declaration, so it will have no effect; it may be a typo. Otherwise you can use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
# File "src/_tags", line 51, characters 64-86:
# Warning: the tag "subproject(ocamlbuild)" is not used in any flag or dependency declaration, so it will have no effect; it may be a typo. Otherwise you can use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
# File "src/_tags", line 52, characters 50-65:
# Warning: the tag "subproject(ppx)" is not used in any flag or dependency declaration, so it will have no effect; it may be a typo. Otherwise you can use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
# File "src/_tags", line 59, characters 40-47:
# Warning: the tag "wikidoc" is not used in any flag or dependency declaration, so it will have no effect; it may be a typo. Otherwise you can use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
# ocamlfind ocamldep -package ocamlbuild,js_of_ocaml-ocamlbuild -modules src/ocamlbuild/eliombuild.ml > src/ocamlbuild/eliombuild.ml.depends
# ocamlfind ocamlc -c -g -keep-locs -package ocamlbuild,js_of_ocaml-ocamlbuild -w +A-4-6-7@8-9@11@12-16@20@23@24@26@27@32..36-37@38-39-40@41-42@43-44@45-48-63-67@68-69-70 -I src/ocamlbuild -o src/ocamlbuild/eliombuild.cmo src/ocamlbuild/eliombuild.ml
# ocamlfind ocamlopt -c -g -keep-locs -package ocamlbuild,js_of_ocaml-ocamlbuild -w +A-4-6-7@8-9@11@12-16@20@23@24@26@27@32..36-37@38-39-40@41-42@43-44@45-48-63-67@68-69-70 -I src/ocamlbuild -o src/ocamlbuild/eliombuild.cmx src/ocamlbuild/eliombuild.ml
# ocamlfind ocamlopt -linkpkg -g -keep-locs -package ocamlbuild,js_of_ocaml-ocamlbuild -I src/ocamlbuild src/ocamlbuild/ocamlbuild_eliom.cmx src/ocamlbuild/eliombuild.cmx -o src/ocamlbuild/eliombuild.native
# ocamlfind ocamldep -package ppxlib,ppxlib.metaquot,compiler-libs.bytecomp -modules src/ppx/ppx_eliom_client_ex.ml > src/ppx/ppx_eliom_client_ex.ml.depends
# ocamlfind ocamldep -package ppxlib,ppxlib.metaquot,compiler-libs.bytecomp -modules src/ppx/ppx_eliom_client.mli > src/ppx/ppx_eliom_client.mli.depends
# ocamlfind ocamlc -c -g -keep-locs -w +A-4-6-7-9-40-42-44-48-70 -package ppxlib,ppxlib.metaquot,compiler-libs.bytecomp -I src/ppx -o src/ppx/ppx_eliom_client.cmi src/ppx/ppx_eliom_client.mli
# ocamlfind ocamlc -c -g -keep-locs -w +A-4-6-7-9-40-42-44-48-70 -package ppxlib,ppxlib.metaquot,compiler-libs.bytecomp -I src/ppx -o src/ppx/ppx_eliom_client_ex.cmo src/ppx/ppx_eliom_client_ex.ml
# ocamlfind ocamldep -package ppxlib,ppxlib.metaquot,compiler-libs.bytecomp -modules src/ppx/ppx_eliom_client.ml > src/ppx/ppx_eliom_client.ml.depends
# ocamlfind ocamldep -package ppxlib,ppxlib.metaquot,compiler-libs.bytecomp -modules src/ppx/ppx_eliom_utils.ml > src/ppx/ppx_eliom_utils.ml.depends
# ocamlfind ocamldep -package ppxlib,ppxlib.metaquot,compiler-libs.bytecomp -modules src/ppx/ppx_eliom_utils.mli > src/ppx/ppx_eliom_utils.mli.depends
# ocamlfind ocamlc -c -g -keep-locs -w +A-4-6-7-9-40-42-44-48-70 -package ppxlib,ppxlib.metaquot,compiler-libs.bytecomp -I src/ppx -o src/ppx/ppx_eliom_utils.cmi src/ppx/ppx_eliom_utils.mli
# ocamlfind ocamlopt -c -g -keep-locs -w +A-4-6-7-9-40-42-44-48-70 -package ppxlib,ppxlib.metaquot,compiler-libs.bytecomp -I src/ppx -o src/ppx/ppx_eliom_utils.cmx src/ppx/ppx_eliom_utils.ml
# + ocamlfind ocamlopt -c -g -keep-locs -w +A-4-6-7-9-40-42-44-48-70 -package ppxlib,ppxlib.metaquot,compiler-libs.bytecomp -I src/ppx -o src/ppx/ppx_eliom_utils.cmx src/ppx/ppx_eliom_utils.ml
# File "src/ppx/ppx_eliom_utils.ml", line 358, characters 20-34:
# 358 |       | Otyp_object (fields, rest) ->
#                           ^^^^^^^^^^^^^^
# Error: This pattern matches values of type 'a * 'b
#        but a pattern was expected which matches values of type
#          Outcometree.out_type.Otyp_object
# Command exited with code 2.
# make: *** [Makefile:14: native] Error 10
```