### PR TITLE
duff < 0.5 is not compatible with OCaml 5.1

### DIFF
--- a/packages/duff/duff.0.1/opam
+++ b/packages/duff/duff.0.1/opam
@@ -13,7 +13,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.1"}
   "jbuilder" {>= "1.0+beta9"}
   "fmt"
   "cstruct" {< "6.1.0"}

--- a/packages/duff/duff.0.2/opam
+++ b/packages/duff/duff.0.2/opam
@@ -20,7 +20,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"    {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.1"}
   "dune"
   "fmt"
   "cstruct"  {< "6.1.0"}

--- a/packages/duff/duff.0.3/opam
+++ b/packages/duff/duff.0.3/opam
@@ -19,7 +19,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"    {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.1"}
   "dune"     {>= "2.0.0"}
   "fmt"
   "bigarray-compat"

--- a/packages/duff/duff.0.4/opam
+++ b/packages/duff/duff.0.4/opam
@@ -19,7 +19,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"    {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.1"}
   "dune"     {>= "2.0.0"}
   "fmt"
   "bigarray-compat"


### PR DESCRIPTION
Local open shadows a local hash value
```
#=== ERROR while compiling duff.0.4 ===========================================#
# context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-variants.5.1.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/duff.0.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p duff -j 127
# exit-code            1
# env-file             ~/.opam/log/duff-9-c579a2.env
# output-file          ~/.opam/log/duff-9-c579a2.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlopt.opt -w -40 -g -I lib/.duff.objs/byte -I lib/.duff.objs/native -I /home/opam/.opam/5.1/lib/bigarray-compat -I /home/opam/.opam/5.1/lib/fmt -I /home/opam/.opam/5.1/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -o lib/.duff.objs/native/duff.cmx -c -impl lib/duff.ml)
# File "lib/duff.ml", line 702, characters 42-46:
# 702 |            next = htable.(Uint32.(to_int (hash land hmask)));
#                                                 ^^^^
# Error: This expression has type Uint32.t -> int
#        but an expression was expected of type int32
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.duff.objs/byte -I /home/opam/.opam/5.1/lib/bigarray-compat -I /home/opam/.opam/5.1/lib/fmt -I /home/opam/.opam/5.1/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -o lib/.duff.objs/byte/duff.cmo -c -impl lib/duff.ml)
# File "lib/duff.ml", line 702, characters 42-46:
# 702 |            next = htable.(Uint32.(to_int (hash land hmask)));
#                                                 ^^^^
# Error: This expression has type Uint32.t -> int
#        but an expression was expected of type int32
```