### PR TITLE
[new release] tiny_httpd (2 packages) (0.14)

### DIFF
--- a/packages/tiny_httpd/tiny_httpd.0.14/opam
+++ b/packages/tiny_httpd/tiny_httpd.0.14/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Minimal HTTP server using good old threads"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "base-threads"
+  "result"
+  "seq"
+  "ocaml" { >= "4.05.0" }
+  "odoc" {with-doc}
+  "conf-libcurl" {with-test}
+  "ptime" {with-test}
+  "qcheck-core" {with-test & >= "0.9" }
+  "ptime" {with-test}
+]
+tags: [ "http" "thread" "server" "tiny_httpd" "http_of_dir" "simplehttpserver" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+post-messages: "tiny http server, with blocking IOs. Also ships with a `http_of_dir` program."
+url {
+  src:
+    "https://github.com/c-cube/tiny_httpd/releases/download/0.14/tiny_httpd-0.14.tbz"
+  checksum: [
+    "sha256=23feafd49bcb14fd43b7af513ba8d02d53ee07e2ae544195d65082a8fd69c07e"
+    "sha512=64bdc8a5608c923fdfe807dfdb7b43a7b3aadf68f854190d331552cbf12cc43d6cf63d885f07d1d1f8eaa5edf93d96656f68f7d219ac10898d8b3c7d33d1b095"
+  ]
+}
+x-commit-hash: "ac1c1ab502d368c1d6d58010e6629b9369c1dc2f"

--- a/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.14/opam
+++ b/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.14/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Interface to camlzip for tiny_httpd"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "camlzip" {>= "1.06"}
+  "tiny_httpd" { = version }
+  "ocaml" { >= "4.05.0" }
+  "odoc" {with-doc}
+]
+tags: [ "http" "thread" "server" "gzip" "camlzip" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+url {
+  src:
+    "https://github.com/c-cube/tiny_httpd/releases/download/0.14/tiny_httpd-0.14.tbz"
+  checksum: [
+    "sha256=23feafd49bcb14fd43b7af513ba8d02d53ee07e2ae544195d65082a8fd69c07e"
+    "sha512=64bdc8a5608c923fdfe807dfdb7b43a7b3aadf68f854190d331552cbf12cc43d6cf63d885f07d1d1f8eaa5edf93d96656f68f7d219ac10898d8b3c7d33d1b095"
+  ]
+}
+x-commit-hash: "ac1c1ab502d368c1d6d58010e6629b9369c1dc2f"


### PR DESCRIPTION
Minimal HTTP server using good old threads

- Project page: <a href="https://github.com/c-cube/tiny_httpd/">https://github.com/c-cube/tiny_httpd/</a>
- Documentation: <a href="https://c-cube.github.io/tiny_httpd/">https://c-cube.github.io/tiny_httpd/</a>

##### CHANGES:

- breaking: `set_top_handler` takes a stream request, for more generality

- Don't let client handling threads handle SIGINT/SIGHUP
- improve termination behavior (wait for threads to terminate when shutting down server)
- Preserve client address down to Request.t
- add `Tiny_httpd_io` module, abstraction over IOs (output/input) as better IO channels
    than the stdlib's
- add `Tiny_httpd_html.to_writer`
- add `IO.Writer.t`, a push based stream.
- add `Server.run_exn`
- add `Tiny_httpd_pool`
- server: add `IO_BACKEND` abstraction; implement a unix version of it

- perf: use TCP_NODELAY for client sockets
- perf: use a resource pool to recycle buffers, improves memory consumption and GC pressure
