### PR TITLE
[new release] dream-html (1.0.0)

### DIFF
--- a/packages/dream-html/dream-html.1.0.0/opam
+++ b/packages/dream-html/dream-html.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v1.0.0/dream-html-1.0.0.tbz"
+  checksum: [
+    "sha256=99574f8f41112c98f01e32c74fd6020dc6879bbf5339f2f8366be0954a4215dd"
+    "sha512=0283fc6119f155894f95a773b1aed8b457bae6ae65a811aba45983664abc010d2954549d480b7d7a80c15f96707d7af9df7446d5874ff1a305690662fc5b8730"
+  ]
+}
+x-commit-hash: "2ca77526867f947a1f8b3b66c09aed95d09ee1c4"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
