### PR TITLE
Mark existing Lwt versions as incompatible with ocaml.5.1

### DIFF
--- a/packages/lwt/lwt.5.6.0/opam
+++ b/packages/lwt/lwt.5.6.0/opam
@@ -20,7 +20,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.8.0"}
   "dune-configurator"
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.1"}
   "ocplib-endian"
 
   # Until https://github.com/aantron/bisect_ppx/pull/327.

--- a/packages/lwt/lwt.5.6.1/opam
+++ b/packages/lwt/lwt.5.6.1/opam
@@ -20,7 +20,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.8.0"}
   "dune-configurator"
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.1"}
   "ocplib-endian"
 
   # Until https://github.com/aantron/bisect_ppx/pull/327.


### PR DESCRIPTION
Because: https://github.com/ocsigen/lwt/pull/995

Also see: https://github.com/ocaml/opam-repository/pull/24213#issuecomment-1669306812