### PR TITLE
[new release] lambda-term (3.3.2)

### DIFF
--- a/packages/lambda-term/lambda-term.3.3.2/opam
+++ b/packages/lambda-term/lambda-term.3.3.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Terminal manipulation library for OCaml"
+description: """
+Lambda-term is a cross-platform library for manipulating the terminal. It
+provides an abstraction for keys, mouse events, colors, as well as a set of
+widgets to write curses-like applications. The main objective of lambda-term is
+to provide a higher level functional interface to terminal manipulation than,
+for example, ncurses, by providing a native OCaml interface instead of bindings
+to a C library. Lambda-term integrates with zed to provide text edition
+facilities in console applications."""
+maintainer: ["opam-devel@lists.ocaml.org"]
+authors: ["Jérémie Dimino"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/lambda-term"
+bug-reports: "https://github.com/ocaml-community/lambda-term/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "logs"
+  "lwt" {>= "4.2.0"}
+  "lwt_react"
+  "mew_vi" {>= "0.5.0" & < "0.6.0"}
+  "react"
+  "zed" {>= "3.2.0" & < "4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-community/lambda-term.git"
+url {
+  src:
+    "https://github.com/ocaml-community/lambda-term/archive/refs/tags/3.3.2.tar.gz"
+  checksum: [
+    "sha512=78648768644058337e22c79cf1fbb1a36472b24f11b1dc0461fc38419be6ec01b02d8d0ac45fed0bc99f91ba4c0f19d3bda113e834e064bee973b734527b9766"
+  ]
+}
+x-commit-hash: "cade31f3c56f1e52fa6d297ddb78f37d09062761"

--- a/packages/lambda-term/lambda-term.3.3.2/opam
+++ b/packages/lambda-term/lambda-term.3.3.2/opam
@@ -8,7 +8,7 @@ to provide a higher level functional interface to terminal manipulation than,
 for example, ncurses, by providing a native OCaml interface instead of bindings
 to a C library. Lambda-term integrates with zed to provide text edition
 facilities in console applications."""
-maintainer: ["opam-devel@lists.ocaml.org"]
+maintainer: ["ZAN DoYe <zandoye+ocaml@gmail.com>"]
 authors: ["Jérémie Dimino"]
 license: "BSD-3-Clause"
 homepage: "https://github.com/ocaml-community/lambda-term"


### PR DESCRIPTION
3.3.2 (2023-08-09)
------------------

* `LTerm_vi`: fix a downward-action issue when act in empty content