### PR TITLE
tezos-rpc-http: fix upper bound for resto-cohttp

### DIFF
--- a/packages/tezos-rpc-http/tezos-rpc-http.17.2/opam
+++ b/packages/tezos-rpc-http/tezos-rpc-http.17.2/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" { >= "4.14" & < "5.0" }
   "tezos-base" { = version }
   "tezos-rpc" { = version }
-  "resto-cohttp" { >= "1.0" }
+  "resto-cohttp" { >= "1.0" & < "1.2"}
   "uri" { >= "3.1.0" }
 ]
 build: [


### PR DESCRIPTION
Otherwise it fails with:

```
  File "src/lib_rpc_http/RPC_server.ml", line 1:
  Error: The implementation src/lib_rpc_http/RPC_server.ml
         does not match the interface src/lib_rpc_http/.tezos_rpc_http_server.objs/byte/tezos_rpc_http_server__RPC_server.cmi:
          Values do not match:
            val launch :
              ?host:string ->
              server ->
              ?conn_closed:(Cohttp_lwt_unix.Server.conn -> unit) ->
              ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
          is not included in
            val launch :
              ?host:string ->
              server ->
              ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
          The type
            ?host:string ->
            server ->
            ?conn_closed:(Cohttp_lwt_unix.Server.conn -> unit) ->
            ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
          is not compatible with the type
            ?host:string ->
            server ->
            ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
          Type
            ?conn_closed:(Cohttp_lwt_unix.Server.conn -> unit) ->
            ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
          is not compatible with type
            ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
          File "src/lib_rpc_http/RPC_server.mli", lines 51-56, characters 0-12:
            Expected declaration
          File "src/server.mli", lines 124-130, characters 2-14:
            Actual declaration
```