### PR TITLE
[new release] opam-check-npm-deps (1.0.0)

### DIFF
--- a/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "reason" {>= "3.8.1" & < "4.0.0"}
   "dune" {>= "3.8"}
   "opam-client" {>= "2.1.2" & < "2.2.0"}
-  "mccs" {>= "1.11+14"}
+  "mccs" {>= "1.1+14"}
   "angstrom"
   "bos"
   "lwt_ppx"

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
@@ -35,7 +35,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
@@ -15,6 +15,7 @@ depends: [
   "opam-client" {>= "2.1.2" & < "2.2.0"}
   "mccs" {>= "1.1+14"}
   "angstrom" {>= "0.15.0"}
+  "fmt" {>= "0.9.0"}
   "bos"
   "lwt_ppx"
   "ppx_deriving_yojson"

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.14.0"}
   "reason" {>= "3.8.1" & < "4.0.0"}
   "dune" {>= "3.8"}
-  "opam-client" {>= "2.1.2" & < "2.2.0"}
+  "opam-client" {>= "2.1.3" & < "2.2"}
   "mccs" {>= "1.1+14"}
   "angstrom" {>= "0.15.0"}
   "fmt" {>= "0.9.0"}
@@ -23,10 +23,9 @@ depends: [
   "ppx_inline_test"
   "ppx_let"
   "ppx_sexp_conv"
-  "ocaml-lsp-server" {dev}
-  "ocamlformat" {dev}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1" & opam-version < "2.2"
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "3.8"}
   "opam-client" {>= "2.1.2" & < "2.2.0"}
   "mccs" {>= "1.1+14"}
-  "angstrom"
+  "angstrom" {>= "0.15.0"}
   "bos"
   "lwt_ppx"
   "ppx_deriving_yojson"

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
@@ -13,6 +13,7 @@ depends: [
   "reason" {>= "3.8.1" & < "4.0.0"}
   "dune" {>= "3.8"}
   "opam-client" {>= "2.1.2" & < "2.2.0"}
+  "mccs" {>= "1.11+14"}
   "angstrom"
   "bos"
   "lwt_ppx"

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis:
+  "An opam plugin to check for npm depexts inside the node_modules folder"
+description:
+  "Provides the `opam check-npm-deps` command, which given an opam switch, gathers all the depexts belonging to the npm platform and their version constraints, and checks the `node_modules` folder to see if the constraints are satisfied."
+maintainer: ["Javier Chávarri"]
+authors: ["Javier Chávarri"]
+license: "MIT"
+homepage: "https://github.com/jchavarri/opam-check-npm-deps"
+bug-reports: "https://github.com/jchavarri/opam-check-npm-deps/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "reason" {>= "3.8.1" & < "4.0.0"}
+  "dune" {>= "3.8"}
+  "opam-client" {>= "2.1.2" & < "2.2.0"}
+  "angstrom"
+  "bos"
+  "lwt_ppx"
+  "ppx_deriving_yojson"
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_let"
+  "ppx_sexp_conv"
+  "ocaml-lsp-server" {dev}
+  "ocamlformat" {dev}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jchavarri/opam-check-npm-deps.git"
+flags: plugin
+url {
+  src:
+    "https://github.com/jchavarri/opam-check-npm-deps/releases/download/1.0.0/opam-check-npm-deps-1.0.0.tbz"
+  checksum: [
+    "sha256=dce793b588d997b299e371847c9a4c85c3e446a55f6c6e56f99d71cfaf31c967"
+    "sha512=4cef4b1456d9da7a2539d43344c81aed6f19332125cfc08e183a18b3085bf421eee20e93fcaee4ff6cb7f4add295e343d2def877eb9680fe62a5d9fe23b88bbb"
+  ]
+}
+x-commit-hash: "1978cca0ea36d79f5f05a5c3b80f930f4922921e"


### PR DESCRIPTION
An opam plugin to check for npm depexts inside the node_modules folder

- Project page: <a href="https://github.com/jchavarri/opam-check-npm-deps">https://github.com/jchavarri/opam-check-npm-deps</a>

##### CHANGES:

- Initial version
- Read `depexts` field from all the opam files of the installed packages in the
  switch
- Check the depexts that include filters using the `npm-version` variable
  against the installed npm packages in `node_modules`
