### PR TITLE
fix metadata typos in pyast opam files

### DIFF
--- a/packages/pyast/pyast.0.1.0/opam
+++ b/packages/pyast/pyast.0.1.0/opam
@@ -7,9 +7,9 @@ versions from Python 2.5 to Python 3.10.
 maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
 authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
 license: "BSD-2-Clause"
-homepage: "https://github.com/thierry.martinez/pyast"
-doc: "https://github.com/thierry.martinez/pyast"
-bug-reports: "https://github.com/thierry.martinez/pyast"
+homepage: "https://github.com/thierry-martinez/pyast"
+doc: "https://github.com/thierry-martinez/pyast"
+bug-reports: "https://github.com/thierry-martinez/pyast"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.8"}
@@ -38,7 +38,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/thierry.martinez/pyast.git"
+dev-repo: "git+https://github.com/thierry-martinez/pyast.git"
 url {
   src: "https://github.com/thierry-martinez/pyast/archive/refs/tags/v0.1.0.tar.gz"
   checksum: "sha512=11603fc03eb6f32ceb2ea3c0107b682aba96794490cfbf5c2cb369c67a0428515f63da56d4a3b4981390f6bca33ce6c8dffea2110d346fec0b7ac618deead4e7"

--- a/packages/pyast/pyast.0.1.1/opam
+++ b/packages/pyast/pyast.0.1.1/opam
@@ -7,9 +7,9 @@ versions from Python 2.5 to Python 3.10.
 maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
 authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
 license: "BSD-2-Clause"
-homepage: "https://github.com/thierry.martinez/pyast"
-doc: "https://github.com/thierry.martinez/pyast"
-bug-reports: "https://github.com/thierry.martinez/pyast"
+homepage: "https://github.com/thierry-martinez/pyast"
+doc: "https://github.com/thierry-martinez/pyast"
+bug-reports: "https://github.com/thierry-martinez/pyast"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.8"}
@@ -38,7 +38,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/thierry.martinez/pyast.git"
+dev-repo: "git+https://github.com/thierry-martinez/pyast.git"
 url {
   src: "https://github.com/thierry-martinez/pyast/archive/refs/tags/v0.1.1.tar.gz"
   checksum: "sha512=7f8d19d2c87b7ad0da3d58ae68177701fe7271d62a9a5bc13630d069ed643b50d8307e1fde34998c171f5410a5f9d8ff115234e8d2b34ccb10eb36752e9e90d8"

--- a/packages/pyast/pyast.0.2.0/opam
+++ b/packages/pyast/pyast.0.2.0/opam
@@ -7,9 +7,9 @@ versions from Python 2.5 to Python 3.11.
 maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
 authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
 license: "BSD-2-Clause"
-homepage: "https://github.com/thierry.martinez/pyast"
-doc: "https://github.com/thierry.martinez/pyast"
-bug-reports: "https://github.com/thierry.martinez/pyast"
+homepage: "https://github.com/thierry-martinez/pyast"
+doc: "https://github.com/thierry-martinez/pyast"
+bug-reports: "https://github.com/thierry-martinez/pyast"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.8"}
@@ -38,7 +38,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/thierry.martinez/pyast.git"
+dev-repo: "git+https://github.com/thierry-martinez/pyast.git"
 url {
   src: "https://github.com/thierry-martinez/pyast/releases/download/v0.2.0/pyast.0.2.0.tar.gz"
   checksum: "sha512=6457a333f472e72198307e65b1c3c9b4e7815547d3b84ad90338a05f3b4b701e371e109400c8a6f7ee0d629807a8b5c44489ce61c73484482271f8095a67816b"


### PR DESCRIPTION
There seems to be typos in the hompage, doc, bug-reports, and dev-repo fields in pyast's opam files.