### PR TITLE
[new release] thread-table (1.0.0)

### DIFF
--- a/packages/thread-table/thread-table.1.0.0/opam
+++ b/packages/thread-table/thread-table.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A lock-free thread-safe integer keyed hash table"
+description:
+  "A minimalist lock-free thread-safe integer keyed hash table with zero synchronization overhead on lookups designed for associating thread specific state with threads within a domain."
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/thread-table"
+bug-reports: "https://github.com/ocaml-multicore/thread-table/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.08"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/thread-table.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/thread-table/releases/download/1.0.0/thread-table-1.0.0.tbz"
+  checksum: [
+    "sha256=3b2ac9edeb4093f249d78fe75ca260470087875415f166ce31c57f4ba24ee49c"
+    "sha512=793b19ca799f05a088083cebc90bf7ef08c4c204b035e0e48b61ffc088749f2b063bb7a05b798cfa814c72df6491b4d9ff96b3a508c5e3bed2ebbcf47c741659"
+  ]
+}
+x-commit-hash: "d98848de454ff55fd771e0126e6f923bf3c3df36"


### PR DESCRIPTION
A lock-free thread-safe integer keyed hash table

- Project page: <a href="https://github.com/ocaml-multicore/thread-table">https://github.com/ocaml-multicore/thread-table</a>

## 1.0.0

- Use bit mixing (@polytypic)
- Change `find` to use `raise_notrace` for performance (@polytypic)
- Change license to ISC from 0BSD (@tarides)
