### PR TITLE
[new release] thread-table (1.0.0)

### DIFF
--- a/packages/thread-table/thread-table.1.0.0/opam
+++ b/packages/thread-table/thread-table.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A lock-free thread-safe integer keyed hash table"
+description:
+  "A minimalist lock-free thread-safe integer keyed hash table with zero synchronization overhead on lookups designed for associating thread specific state with threads within a domain."
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/thread-table"
+bug-reports: "https://github.com/ocaml-multicore/thread-table/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.08"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/thread-table.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/thread-table/releases/download/1.0.0/thread-table-1.0.0.tbz"
+  checksum: [
+    "sha256=a48cd88463597df9442c4baa69ccc06091ca77ba71e438d3609fbae0f3b81ddd"
+    "sha512=f857cec49a59cba206b8cc2c580f8c5252c95c7676e81b4c5326d07fc6a7da592785cf011c91d4e6f39f8c5766e280f559c58e02a5077d472577784d646cc2e5"
+  ]
+}
+x-commit-hash: "7a31ebaad645cd8e99e0742d21b61d3014dbe265"


### PR DESCRIPTION
A lock-free thread-safe integer keyed hash table

- Project page: <a href="https://github.com/ocaml-multicore/thread-table">https://github.com/ocaml-multicore/thread-table</a>

## 1.0.0

- Use `inline never` for atomicity on old compilers (@polytypic)
- Use bit mixing (@polytypic)
- Change `find` to use `raise_notrace` for performance (@polytypic)
- Change license to ISC from 0BSD (@tarides)
