### PR TITLE
CamlPDF v2.6

### DIFF
--- a/packages/camlpdf/camlpdf.2.6/opam
+++ b/packages/camlpdf/camlpdf.2.6/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+maintainer: "contact@coherentgraphics.co.uk"
+authors: ["John Whitington"]
+homepage: "http://github.com/johnwhitington/camlpdf"
+bug-reports: "http://github.com/johnwhitington/camlpdf/issues"
+dev-repo: "git://github.com/johnwhitington/camlpdf"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+build: [[make]]
+install: [[make "install"]]
+depends: [
+  "ocaml" {>= "4.10"}
+  "ocamlfind" {build}
+]
+synopsis: "Read, write and modify PDF files"
+url {
+  src: "https://github.com/johnwhitington/camlpdf/archive/v2.6.zip"
+  checksum: "sha256=0625166be89e2d29990273bcba70a5ea2747301e8b7cf4f510c8f2fbc02da7ae"
+}


### PR DESCRIPTION
Am having trouble with opam publish (bug reported) so please forgive me doing this one manually.

Other than the checksum and download link, the only change is the removal of `conf-which`. We now use `ocamlopt -version` to check whether to build native instead.