### PR TITLE
graphicspdf is not compatible with camlpdf 2.6

### DIFF
--- a/packages/graphicspdf/graphicspdf.2.2.1/opam
+++ b/packages/graphicspdf/graphicspdf.2.2.1/opam
@@ -6,7 +6,7 @@ remove: [["ocamlfind" "remove" "graphicspdf"]]
 depends: [
   "ocaml"
   "ocamlfind"
-  "camlpdf" {>= "2.2.1"}
+  "camlpdf" {>= "2.2.1" & < "2.6"}
 ]
 homepage: "http://github.com/johnwhitington/graphicspdf"
 bug-reports: "http://github.com/johnwhitington/graphicspdf/issues"


### PR DESCRIPTION
Noticed in https://github.com/ocaml/opam-repository/pull/24262
```
#=== ERROR while compiling graphicspdf.2.2.1 ==================================#
# context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/graphicspdf.2.2.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/graphicspdf-7-9099a9.env
# output-file          ~/.opam/log/graphicspdf-7-9099a9.out
### output ###
# make[1]: Entering directory '/home/opam/.opam/4.14/.opam-switch/build/graphicspdf.2.2.1'
# ocamlfind ocamlc -package camlpdf -c graphicspdf.mli
# ocamlfind ocamlc -package camlpdf -c -g graphicspdf.ml
# File "graphicspdf.ml", line 239, characters 9-35:
# 239 |         {Pdfgraphics.path_transform =
#                ^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pdfgraphics
# make[1]: *** [OCamlMakefile:951: graphicspdf.cmo] Error 2
# make[1]: Leaving directory '/home/opam/.opam/4.14/.opam-switch/build/graphicspdf.2.2.1'
# make: *** [OCamlMakefile:716: byte-code-library] Error 2
```