### PR TITLE
llopt is not compatible with LLVM 15

### DIFF
--- a/packages/llopt/llopt.1.0.0/opam
+++ b/packages/llopt/llopt.1.0.0/opam
@@ -10,7 +10,7 @@ build: ["jbuilder" "build" "-p" "llopt" "-j" jobs]
 depends: [
   "ocaml"
   "jbuilder" {>= "1.0+beta7"}
-  "llvm" {>= "3.5"}
+  "llvm" {>= "3.5" & < "15"}
   "cmdliner"
 ]
 synopsis: "Just a tiny LLVM-IR optimizer for testing stuff."


### PR DESCRIPTION
`Llvm_passmgr_builder.populate_lto_pass_manager` was removed.
```
#=== ERROR while compiling llopt.1.0.0 ========================================#
# context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/llopt.1.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build jbuilder build -p llopt -j 31
# exit-code            1
# env-file             ~/.opam/log/llopt-7-f51271.env
# output-file          ~/.opam/log/llopt-7-f51271.out
### output ###
#       ocamlc src/.llopt.eobjs/config.{cmi,cmo,cmt}
# File "src/config.ml", line 1:
# Warning 70 [missing-mli]: Cannot find interface file.
#       ocamlc src/.llopt.eobjs/llopt.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w A-44 -safe-string -g -bin-annot -I src/.llopt.eobjs -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/llvm -I /home/opam/.opam/4.14/lib/llvm/all_backends -I /home/opam/.opam/4.14/lib/llvm/irreader -I /home/opam/.opam/4.14/lib/llvm/passmgr_builder -I /home/opam/.opam/4.14/lib/llvm/target -no-alias-deps -o src/.llopt.eobjs/llopt.cmo -c -impl src/llopt.ml)
# File "src/llopt.ml", line 43, characters 4-50:
# 43 |     Llvm_passmgr_builder.populate_lto_pass_manager
#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Llvm_passmgr_builder.populate_lto_pass_manager
```