### PR TITLE
llvmgraph is not compatible with LLVM 15

### DIFF
--- a/packages/llvmgraph/llvmgraph.0.1/opam
+++ b/packages/llvmgraph/llvmgraph.0.1/opam
@@ -22,7 +22,7 @@ remove: ["ocamlfind" "remove" "llvmgraph"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
-  "llvm"
+  "llvm" {< "15"}
   "ocamlgraph" {< "1.8.6" & >= "1.8.5"}
   "ocamlbuild" {build}
 ]

--- a/packages/llvmgraph/llvmgraph.0.2/opam
+++ b/packages/llvmgraph/llvmgraph.0.2/opam
@@ -23,7 +23,7 @@ remove: ["ocamlfind" "remove" "llvmgraph"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
-  "llvm" {>= "3.6"}
+  "llvm" {>= "3.6" & < "15"}
   "ocamlgraph" {>= "1.8.5" & < "2.0.0"}
   "ocamlbuild" {build}
   "conf-clang" {with-test}


### PR DESCRIPTION
Now sadly requires ocamlfind users to choose if they want to link statically or dynamically with LLVM, or to switch to Dune.
```
#=== ERROR while compiling llvmgraph.0.2 ======================================#
# context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/llvmgraph.0.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -build
# exit-code            1
# env-file             ~/.opam/log/llvmgraph-7-93a228.env
# output-file          ~/.opam/log/llvmgraph-7-93a228.out
### output ###
# /home/opam/.opam/4.14/bin/ocamlfind ocamlopt -g -linkpkg -package llvm -package llvm.bitreader -package ocamlgraph -package str -I src -I test src/llvmgraph.cmxa test/colordot.cmx -o test/colordot.native
# + /home/opam/.opam/4.14/bin/ocamlfind ocamlopt -g -linkpkg -package llvm -package llvm.bitreader -package ocamlgraph -package str -I src -I test src/llvmgraph.cmxa test/colordot.cmx -o test/colordot.native
# File "_none_", line 1:
# Error: No implementations provided for the following modules:
#          Llvm referenced from src/llvmgraph.cmxa(Llvmgraph),
#            test/colordot.cmx
#          Llvm_bitreader referenced from test/colordot.cmx
# Command exited with code 2.
# E: Failure("Command ''/home/opam/.opam/4.14/bin/ocamlbuild' src/llvmgraph.cma src/llvmgraph.cmxa src/llvmgraph.a src/llvmgraph.cmxs test/colordot.native -tag debug -tag tests' terminated with error code 10")
```
cc @Drup
Only merge if #24268 is accepted