### PR TITLE
hardcaml-llvmsim is not compatible with LLVM 15

### DIFF
--- a/packages/hardcaml-llvmsim/hardcaml-llvmsim.0.3.0/opam
+++ b/packages/hardcaml-llvmsim/hardcaml-llvmsim.0.3.0/opam
@@ -13,7 +13,7 @@ depends: [
   "hardcaml" {>= "1.2.0" & < "2.0.0"}
   "ctypes"
   "ctypes-foreign"
-  "llvm" {>= "3.8"}
+  "llvm" {>= "3.8" & < "15"}
 ]
 synopsis: "HardCaml simulation backend using LLVM"
 url {


### PR DESCRIPTION
Same as https://github.com/ocaml/opam-repository/pull/24270
cc @andrewray 
Only merge if https://github.com/ocaml/opam-repository/pull/24268 is accepted