### PR TITLE
awsm-lwt is not compatible with cohttp 6.0.0

### DIFF
--- a/packages/awsm-lwt/awsm-lwt.0.1.0/opam
+++ b/packages/awsm-lwt/awsm-lwt.0.1.0/opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {>= "3.6"}
   "awsm"
   "lwt"
-  "cohttp-lwt-unix"
+  "cohttp-lwt-unix" {< "6.0.0~"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/awsm/awsm.0.1.0/opam
+++ b/packages/awsm/awsm.0.1.0/opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {>= "3.6"}
   "awsm-codegen"
   "base64" {>= "3.1.0"}
-  "cohttp" {>= "0.21.0"}
+  "cohttp" {>= "0.21.0" & < "6.0.0~"}
   "cryptokit"
   "xmlm"
   "zarith"


### PR DESCRIPTION
Fails with
```
#=== ERROR while compiling awsm-lwt.0.1.0 =====================================#
# context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/awsm-lwt.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p awsm-lwt -j 255 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/awsm-lwt-7-b8764a.env
# output-file          ~/.opam/log/awsm-lwt-7-b8764a.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -open Core -open Printf -g -bin-annot -I test/.test_auth.eobjs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/awsm -I /home/opam/.opam/4.14/lib/awsm-codegen -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/caml_threads -I /home/opam/.opam/4.14/lib/core_kernel/caml_unix -I /home/opam/.opam/4.14/lib/core_kernel/flags -I /home/opam/.opam/4.14/lib/core_unix -I /home/opam/.opam/4.14/lib/core_unix/error_checking_mutex -I /home/opam/.opam/4.14/lib/core_unix/filename_unix -I /home/opam/.opam/4.14/lib/core_unix/signal_unix -I /home/opam/.opam/4.14/lib/core_unix/sys_unix -I /home/opam/.opam/4.14/lib/cryptokit -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/gen -I /home/opam/.opam/4.14/lib/http -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/common -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocamlgraph -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_derivers -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppxlib -I /home/opam/.opam/4.14/lib/ppxlib/ast -I /home/opam/.opam/4.14/lib/ppxlib/astlib -I /home/opam/.opam/4.14/lib/ppxlib/print_diff -I /home/opam/.opam/4.14/lib/ppxlib/stdppx -I /home/opam/.opam/4.14/lib/ppxlib/traverse_builtins -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/re/pcre -I /home/opam/.opam/4.14/lib/re/perl -I /home/opam/.opam/4.14/lib/sedlex -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib/unix -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/spawn -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/xmlm -I /home/opam/.opam/4.14/lib/yojson -I /home/opam/.opam/4.14/lib/zarith -no-alias-deps -open Dune__exe -o test/.test_auth.eobjs/byte/dune__exe__Import.cmo -c -impl test/import.ml)
# File "test/import.ml", line 6, characters 12-31:
# 6 |     include Cohttp.Request.Make (Cohttp__String_io.M)
#                 ^^^^^^^^^^^^^^^^^^^
# Alert deprecated: module Cohttp.Request.Make
# This functor is not part of the public API.
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -open Core -open Printf -g -I test/.test_auth.eobjs/byte -I test/.test_auth.eobjs/native -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/awsm -I /home/opam/.opam/4.14/lib/awsm-codegen -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/caml_threads -I /home/opam/.opam/4.14/lib/core_kernel/caml_unix -I /home/opam/.opam/4.14/lib/core_kernel/flags -I /home/opam/.opam/4.14/lib/core_unix -I /home/opam/.opam/4.14/lib/core_unix/error_checking_mutex -I /home/opam/.opam/4.14/lib/core_unix/filename_unix -I /home/opam/.opam/4.14/lib/core_unix/signal_unix -I /home/opam/.opam/4.14/lib/core_unix/sys_unix -I /home/opam/.opam/4.14/lib/cryptokit -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/gen -I /home/opam/.opam/4.14/lib/http -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/common -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocamlgraph -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_derivers -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppxlib -I /home/opam/.opam/4.14/lib/ppxlib/ast -I /home/opam/.opam/4.14/lib/ppxlib/astlib -I /home/opam/.opam/4.14/lib/ppxlib/print_diff -I /home/opam/.opam/4.14/lib/ppxlib/stdppx -I /home/opam/.opam/4.14/lib/ppxlib/traverse_builtins -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/re/pcre -I /home/opam/.opam/4.14/lib/re/perl -I /home/opam/.opam/4.14/lib/sedlex -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib/unix -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/spawn -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/xmlm -I /home/opam/.opam/4.14/lib/yojson -I /home/opam/.opam/4.14/lib/zarith -intf-suffix .ml -no-alias-deps -open Dune__exe -o test/.test_auth.eobjs/native/dune__exe__Import.cmx -c -impl test/import.ml)
# File "test/import.ml", line 6, characters 12-31:
# 6 |     include Cohttp.Request.Make (Cohttp__String_io.M)
#                 ^^^^^^^^^^^^^^^^^^^
# Alert deprecated: module Cohttp.Request.Make
# This functor is not part of the public API.
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -open Core -open Printf -g -bin-annot -I lib/lwt/.awsm_lwt.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/awsm -I /home/opam/.opam/4.14/lib/awsm-codegen -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cohttp-lwt-unix -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-lwt-unix -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/caml_threads -I /home/opam/.opam/4.14/lib/core_kernel/caml_unix -I /home/opam/.opam/4.14/lib/core_kernel/flags -I /home/opam/.opam/4.14/lib/core_unix -I /home/opam/.opam/4.14/lib/core_unix/error_checking_mutex -I /home/opam/.opam/4.14/lib/core_unix/filename_unix -I /home/opam/.opam/4.14/lib/core_unix/signal_unix -I /home/opam/.opam/4.14/lib/core_unix/sys_unix -I /home/opam/.opam/4.14/lib/cryptokit -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/gen -I /home/opam/.opam/4.14/lib/http -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/common -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocamlgraph -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_derivers -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppxlib -I /home/opam/.opam/4.14/lib/ppxlib/ast -I /home/opam/.opam/4.14/lib/ppxlib/astlib -I /home/opam/.opam/4.14/lib/ppxlib/print_diff -I /home/opam/.opam/4.14/lib/ppxlib/stdppx -I /home/opam/.opam/4.14/lib/ppxlib/traverse_builtins -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/re/pcre -I /home/opam/.opam/4.14/lib/re/perl -I /home/opam/.opam/4.14/lib/sedlex -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib/unix -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/spawn -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/xmlm -I /home/opam/.opam/4.14/lib/yojson -I /home/opam/.opam/4.14/lib/zarith -no-alias-deps -open Awsm_lwt -o lib/lwt/.awsm_lwt.objs/byte/awsm_lwt__Import.cmo -c -impl lib/lwt/import.pp.ml)
# File "lib/lwt/import.ml", line 27, characters 20-39:
# 27 |   module Response = Cohttp_lwt.Response
#                          ^^^^^^^^^^^^^^^^^^^
# Alert deprecated: module Cohttp_lwt.Response
# Use Cohttp.Response directly
# File "lib/lwt/import.ml", line 14, characters 20-39:
# 14 |   module Response = Cohttp_lwt.Response
#                          ^^^^^^^^^^^^^^^^^^^
# Alert deprecated: module Cohttp_lwt.Response
# Use Cohttp.Response directly
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -open Core -open Printf -g -I lib/lwt/.awsm_lwt.objs/byte -I lib/lwt/.awsm_lwt.objs/native -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/awsm -I /home/opam/.opam/4.14/lib/awsm-codegen -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cohttp-lwt-unix -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-lwt-unix -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/caml_threads -I /home/opam/.opam/4.14/lib/core_kernel/caml_unix -I /home/opam/.opam/4.14/lib/core_kernel/flags -I /home/opam/.opam/4.14/lib/core_unix -I /home/opam/.opam/4.14/lib/core_unix/error_checking_mutex -I /home/opam/.opam/4.14/lib/core_unix/filename_unix -I /home/opam/.opam/4.14/lib/core_unix/signal_unix -I /home/opam/.opam/4.14/lib/core_unix/sys_unix -I /home/opam/.opam/4.14/lib/cryptokit -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/gen -I /home/opam/.opam/4.14/lib/http -I /home/opam/.opam/4.14/lib/http/__private__/http_bytebuffer -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/common -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocamlgraph -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_derivers -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppxlib -I /home/opam/.opam/4.14/lib/ppxlib/ast -I /home/opam/.opam/4.14/lib/ppxlib/astlib -I /home/opam/.opam/4.14/lib/ppxlib/print_diff -I /home/opam/.opam/4.14/lib/ppxlib/stdppx -I /home/opam/.opam/4.14/lib/ppxlib/traverse_builtins -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/re/pcre -I /home/opam/.opam/4.14/lib/re/perl -I /home/opam/.opam/4.14/lib/sedlex -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib/unix -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/spawn -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/xmlm -I /home/opam/.opam/4.14/lib/yojson -I /home/opam/.opam/4.14/lib/zarith -intf-suffix .ml -no-alias-deps -open Awsm_lwt -o lib/lwt/.awsm_lwt.objs/native/awsm_lwt__Import.cmx -c -impl lib/lwt/import.pp.ml)
# File "lib/lwt/import.ml", line 27, characters 20-39:
# 27 |   module Response = Cohttp_lwt.Response
#                          ^^^^^^^^^^^^^^^^^^^
# Alert deprecated: module Cohttp_lwt.Response
# Use Cohttp.Response directly
# File "lib/lwt/import.ml", line 14, characters 20-39:
# 14 |   module Response = Cohttp_lwt.Response
#                          ^^^^^^^^^^^^^^^^^^^
# Alert deprecated: module Cohttp_lwt.Response
# Use Cohttp.Response directly
# File "test/dune", line 2, characters 7-16:
# 2 |  (name test_auth)
#            ^^^^^^^^^
# (cd _build/default/test && ./test_auth.exe ../vendor/aws4_testsuite/) > _build/default/test/test_auth.output
# Uncaught exception:
#   
#   (Failure "Could not match: \"\\r\\n\"")
# 
# Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
# Called from Dune__exe__Aws4_testsuite.Req.of_file in file "test/aws4_testsuite.ml", line 39, characters 25-49
# Called from Dune__exe__Test_auth.test_canonical_request in file "test/test_auth.ml", line 37, characters 24-59
# Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
# Called from Base__List0.iter in file "src/list0.ml" (inlined), line 25, characters 16-35
# Called from Dune__exe__Test_auth in file "test/test_auth.ml", line 77, characters 2-48
```