### PR TITLE
opentelemetry-cohttp-lwt is not compatible with cohttp 6

### DIFF
--- a/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.5/opam
+++ b/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.5/opam
@@ -12,7 +12,7 @@ depends: [
   "opentelemetry-lwt" {= version}
   "odoc" {with-doc}
   "lwt" {>= "5.3"}
-  "cohttp-lwt" {>= "4.0.0"}
+  "cohttp-lwt" {>= "4.0.0" & < "6.0.0~"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Fails with 
```
 File "src/integrations/cohttp/opentelemetry_cohttp_lwt.ml", line 232, characters 10-16:
# 232 |   (module Traced : Cohttp_lwt.S.Client)
#                 ^^^^^^
# Error: Signature mismatch:
#        ...
#        The value `set_cache' is required but not provided
#        File "cohttp-lwt/src/s.ml", line 190, characters 2-30:
#          Expected declaration
```