### PR TITLE
Package opam-ed.0.4

### DIFF
--- a/packages/opam-ed/opam-ed.0.4/opam
+++ b/packages/opam-ed/opam-ed.0.4/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/AltGr/opam-ed"
+bug-reports: "https://github.com/AltGr/opam-ed/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "cmdliner" {>= "1.0.0"}
+  "opam-file-format" {>= "2.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/AltGr/opam-ed.git"
+synopsis: "Command-line edition tool for handling the opam file syntax"
+description: """
+opam-ed can read and write files in the general opam syntax. It provides a small CLI with some useful commands for mechanically extracting or modifying the file contents.
+
+The specification for the syntax itself is available at:
+    http://opam.ocaml.org/doc/Manual.html#Common-file-format
+"""
+url {
+  src: "https://github.com/AltGr/opam-ed/archive/0.4.tar.gz"
+  checksum: [
+    "md5=f2a065cdaca8436bd4879c75d6209ed6"
+    "sha512=baad099460dee04dad48ddc55af1ce3671e0e694d1b0ec5d3ea58b3972f9444379fcb6d0413277ec24dbda9cd01b7b31ea112e470e32721ea223b69c90550009"
+  ]
+}

--- a/packages/opam-ed/opam-ed.0.4/opam
+++ b/packages/opam-ed/opam-ed.0.4/opam
@@ -11,7 +11,7 @@ depends: [
   "opam-file-format" {>= "2.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {opam-version < "2.0.9" | os-family != "alpine"} # See https://github.com/ocaml/opam/issues/5462
 dev-repo: "git+https://github.com/AltGr/opam-ed.git"
 synopsis: "Command-line edition tool for handling the opam file syntax"
 description: """


### PR DESCRIPTION
### `opam-ed.0.4`
Command-line edition tool for handling the opam file syntax
opam-ed can read and write files in the general opam syntax. It provides a small CLI with some useful commands for mechanically extracting or modifying the file contents.

The specification for the syntax itself is available at:
    http://opam.ocaml.org/doc/Manual.html#Common-file-format



---
* Homepage: https://github.com/AltGr/opam-ed
* Source repo: git+https://github.com/AltGr/opam-ed.git
* Bug tracker: https://github.com/AltGr/opam-ed/issues

---
:camel: Pull-request generated by opam-publish v2.1.0