### PR TITLE
not-ocamlfind is not compatible with BSDs

### DIFF
--- a/packages/not-ocamlfind/not-ocamlfind.0.05/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.05/opam
@@ -16,6 +16,7 @@ depends: [
   "sexplib" {>= "v0.13.0"}
   "rresult" {>= "0.6.0"}
 ]
+available: os-family != "bsd"
 build: [
   ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-custom" "-no-topfind" {preinstalled}]
   [make "all"]

--- a/packages/not-ocamlfind/not-ocamlfind.0.07.01/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.07.01/opam
@@ -17,6 +17,7 @@ depends: [
   "rresult" {>= "0.6.0"}
   "ocamlgraph" {>= "2.0.0"}
 ]
+available: os-family != "bsd"
 depexts: [
   [
     "xdot"

--- a/packages/not-ocamlfind/not-ocamlfind.0.07.02/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.07.02/opam
@@ -17,6 +17,7 @@ depends: [
   "ocamlgraph" {>= "2.0.0"}
   "conf-which"
 ]
+available: os-family != "bsd"
 depexts: [
   [
     "xdot"

--- a/packages/not-ocamlfind/not-ocamlfind.0.07/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.07/opam
@@ -16,6 +16,7 @@ depends: [
   "rresult" {>= "0.6.0"}
   "ocamlgraph" {>= "1.8.8" & < "2.0.0"}
 ]
+available: os-family != "bsd"
 depexts: [
   [
     "xdot"

--- a/packages/not-ocamlfind/not-ocamlfind.0.08/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.08/opam
@@ -18,6 +18,7 @@ depends: [
   "ocamlgraph" {>= "2.0.0"}
   "conf-which"
 ]
+available: os-family != "bsd"
 depexts: [
   [
     "xdot"

--- a/packages/not-ocamlfind/not-ocamlfind.0.09/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.09/opam
@@ -18,6 +18,7 @@ depends: [
   "ocamlgraph" {>= "2.0.0"}
   "conf-which"
 ]
+available: os-family != "bsd"
 depexts: [
   [
     "xdot"

--- a/packages/not-ocamlfind/not-ocamlfind.0.10/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.10/opam
@@ -18,6 +18,7 @@ depends: [
   "ocamlgraph" {>= "2.0.0"}
   "conf-which"
 ]
+available: os-family != "bsd"
 depexts: [
   [
     "xdot"


### PR DESCRIPTION
Expects /bin/bash to be present
```
[ERROR] Actions cancelled because of a system error:
/usr/local/bin/opam: "create_process" failed on /usr/home/opam/.opam/4.14.1/.opam-switch/build/not-ocamlfind.0.10/./configure: No such file or directory
```
Fixed upstream in https://github.com/chetmurthy/not-ocamlfind/commit/acdd3ed4f53877e95803e9c966479eee1f256e70 but not released yet

cc @chetmurthy 