### PR TITLE
[new release] domain-local-await (1.0.0)

### DIFF
--- a/packages/domain-local-await/domain-local-await.1.0.0/opam
+++ b/packages/domain-local-await/domain-local-await.1.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A scheduler independent blocking mechanism"
+description:
+  "A low level mechanism intended for writing higher level libraries that need to block in a scheduler friendly manner."
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/domain-local-await"
+bug-reports: "https://github.com/ocaml-multicore/domain-local-await/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.12.0"}
+  "thread-table" {>= "1.0.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/domain-local-await.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/domain-local-await/releases/download/1.0.0/domain-local-await-1.0.0.tbz"
+  checksum: [
+    "sha256=2a28d683489349da9bc245dde4aaf7ffde2eac39bc405498da53261a352ec46a"
+    "sha512=dba7f1d3053f711f3d4887acbc8f30abd5b26c379321aa2247b3162919bae4b28e8de8b687f815c478cfbb58ee438597a94968cfe10e7f0a0a1aaad88cfeb13c"
+  ]
+}
+x-commit-hash: "c0bc225ec413eb783424bfc941ed31af9b1cbdff"


### PR DESCRIPTION
A scheduler independent blocking mechanism

- Project page: <a href="https://github.com/ocaml-multicore/domain-local-await">https://github.com/ocaml-multicore/domain-local-await</a>

##### CHANGES:

All notable changes to this project will be documented in this file.

## 1.0.0

- Internal improvements (@polytypic)
- Change license to ISC from 0BSD (@tarides)

## 0.2.1

- Support OCaml 4.12.0+ (@polytypic)
- Use lock-free thread-safe hash table for per thread configuration (@polytypic)

## 0.2.0

- Avoid unnecessary type alias for `(module Thread)` (@polytypic)
- Fix to update per thread configuration atomically (@polytypic)

## 0.1.0

- Initial version of scheduler independent blocking mechanism (@polytypic)
