### PR TITLE
[new release] domain-local-timeout (1.0.0)

### DIFF
--- a/packages/domain-local-timeout/domain-local-timeout.1.0.0/opam
+++ b/packages/domain-local-timeout/domain-local-timeout.1.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A scheduler independent timeout mechanism"
+description:
+  "A low level mechanism intended for writing higher level libraries that need to be able to have scheduler friendly timeouts."
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/domain-local-timeout"
+bug-reports: "https://github.com/ocaml-multicore/domain-local-timeout/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.12.0"}
+  "psq" {>= "0.2.1"}
+  "mtime" {>= "2.0.0"}
+  "thread-table" {>= "1.0.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "domain-local-await" {>= "1.0.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/domain-local-timeout.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/domain-local-timeout/releases/download/1.0.0/domain-local-timeout-1.0.0.tbz"
+  checksum: [
+    "sha256=8a2f719e34341bc83af774fcd8c21c7f3583b87f4dff10d01e820a2ae47e2855"
+    "sha512=4d2885077857b0266361192f07a86a9b2f7c7d2f5510adc175aa5e010e82e424404d8081286f22da6fc368489d82a247230f2d63d419d0c437c736b6ac4cbb52"
+  ]
+}
+x-commit-hash: "044b9a88d2bc3d5feaf93ba2473041b35dedf81b"


### PR DESCRIPTION
A scheduler independent timeout mechanism

- Project page: <a href="https://github.com/ocaml-multicore/domain-local-timeout">https://github.com/ocaml-multicore/domain-local-timeout</a>

## 1.0.0

- Internal improvements (@polytypic)
