### PR TITLE
mark xapi-stdext-unix available only on macos / linux

### DIFF
--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.14.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.14.0/opam
@@ -20,7 +20,7 @@ depends: [
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
 ]
-available: [ os = "linux" ]
+available: [ os = "macos" | os = "linux" ]
 synopsis:
   "A deprecated collection of utility functions - Unix module extensions"
 description: """

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.16.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.16.0/opam
@@ -20,7 +20,7 @@ depends: [
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
 ]
-available: [ os = "linux" ]
+available: [ os = "macos" | os = "linux" ]
 synopsis:
   "A deprecated collection of utility functions - Unix module extensions"
 description: """

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.19.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.19.0/opam
@@ -38,3 +38,4 @@ url {
   ]
 }
 x-commit-hash: "690d233cf37c4e523e17e9b5ed74a118804bc9f5"
+available: [ os = "macos" | os = "linux" ]

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.20.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.20.0/opam
@@ -13,7 +13,7 @@ depends: [
   "odoc" {with-doc}
   "xapi-stdext-pervasives" {= version}
 ]
-available: os-family != "alpine"
+available: [ ( os = "macos" | os = "linux" ) & os-family != "alpine" ]
 build: [
   [
     "dune"

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.21.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.21.0/opam
@@ -13,7 +13,7 @@ depends: [
   "odoc" {with-doc}
   "xapi-stdext-pervasives" {= version}
 ]
-available: os-family != "alpine"
+available: [ ( os = "macos" | os = "linux" ) & os-family != "alpine" ]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.22.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.22.0/opam
@@ -38,3 +38,4 @@ url {
   ]
 }
 x-commit-hash: "059facbcd54b0da2f2df1de1bb3b5f728c6a35b7"
+available: [ os = "macos" | os = "linux" ]


### PR DESCRIPTION
- related to https://github.com/ocaml/opam-repository/pull/24280
  - should fix the CI errors

CI fails to install xapi-stdext-unix on freebsd distros.
Looking at the source code it's clear that the stubs would only work for macos / linux.
```
#=== ERROR while compiling xapi-stdext-unix.4.22.0 ============================#
# context              2.1.5 | freebsd/x86_64 | ocaml-base-compiler.4.14.1 | file:///usr/home/opam/opam-repository
# path                 /usr/home/opam/.opam/4.14.1/.opam-switch/build/xapi-stdext-unix.4.22.0
# command              /usr/home/opam/.opam/4.14.1/bin/dune build -p xapi-stdext-unix -j 1 @install
# exit-code            1
# env-file             /usr/home/opam/.opam/log/xapi-stdext-unix-63927-a2af1e.env
# output-file          /usr/home/opam/.opam/log/xapi-stdext-unix-63927-a2af1e.out
### output ###
# File "lib/xapi-stdext-unix/dune", line 13, characters 6-19:
# 13 |       unixext_stubs
#            ^^^^^^^^^^^^^
# (cd _build/default/lib/xapi-stdext-unix && /usr/bin/cc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -I /usr/home/opam/.opam/4.14.1/lib/ocaml -I /usr/home/opam/.opam/4.14.1/lib/base64 -I /usr/home/opam/.opam/4.14.1/lib/fd-send-recv -I /usr/home/opam/.opam/4.14.1/lib/logs -I /usr/home/opam/.opam/4.14.1/lib/ocaml/threads -I /usr/home/opam/.opam/4.14.1/lib/ppx_sexp_conv/runtime-lib -I /usr/home/opam/.opam/4.14.1/lib/result -I /usr/home/opam/.opam/4.14.1/lib/rpclib -I /usr/home/opam/.opam/4.14.1/lib/rpclib/core -I /usr/home/opam/.opam/4.14.1/lib/rpclib/internals -I /usr/home/opam/.opam/4.14.1/lib/rpclib/json -I /usr/home/opam/.opam/4.14.1/lib/rpclib/xml -I /usr/home/opam/.opam/4.14.1/lib/rresult -I /usr/home/opam/.opam/4.14.1/lib/seq -I /usr/home/opam/.opam/4.14.1/lib/sexplib0 -I /usr/home/opam/.opam/4.14.1/lib/xapi-backtrace -I /usr/home/opam/.opam/4.14.1/lib/xapi-stdext-pervasives -I /usr/home/opam/.opam/4.14.1/lib/xmlm -I /usr/home/opam/.opam/4.14.1/lib/yojson -o unixext_stubs.o -c unixext_stubs.c)
# unixext_stubs.c:97:3: error: "Don't know how to use setsockopt on this platform"
# # error "Don't know how to use setsockopt on this platform"
#   ^
# unixext_stubs.c:109:22: error: use of undeclared identifier 'TCP_LEVEL'
#         if(setsockopt(c_fd, TCP_LEVEL, TCP_KEEPCNT, &optval, optlen) < 0) {
#                             ^
# unixext_stubs.c:119:22: error: use of undeclared identifier 'TCP_LEVEL'
#         if(setsockopt(c_fd, TCP_LEVEL, TCP_KEEPINTVL, &optval, optlen) < 0) {
#                             ^
# unixext_stubs.c:131:7: warning: assigning to 'value *' (aka 'long *') from 'const value *' (aka 'const long *') discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
#                 exn = caml_named_value("unixext.unix_error");
#                     ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# 1 warning and 3 errors generated.
```