### PR TITLE
petrol’s tests are not compatible with caqti-lwt 2.0.0

### DIFF
--- a/packages/petrol/petrol.1.0.0/opam
+++ b/packages/petrol/petrol.1.0.0/opam
@@ -17,6 +17,7 @@ depends: [
   "caqti" {>= "1.8.0"}
   "caqti-lwt" {>= "1.8.0"}
   "caqti-driver-sqlite3" {>= "1.8.0"}
+  "caqti-lwt" {with-test & < "2.0.0~"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
lwt.unix is no longer implicitly pulled through caqti-lwt.
Seen in https://github.com/ocaml/opam-repository/pull/24264
```
#=== ERROR while compiling petrol.1.0.0 =======================================#
# context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/petrol.1.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p petrol -j 255 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/petrol-7-2d96d2.env
# output-file          ~/.opam/log/petrol-7-2d96d2.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.petrol.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/caqti -I /home/opam/.opam/4.14/lib/caqti-driver-sqlite3 -I /home/opam/.opam/4.14/lib/caqti-lwt -I /home/opam/.opam/4.14/lib/caqti/platform -I /home/opam/.opam/4.14/lib/caqti/platform/unix -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt-dllist -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/mtime -I /home/opam/.opam/4.14/lib/mtime/clock/os -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/sqlite3 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -no-alias-deps -open Petrol__ -o lib/.petrol.objs/byte/petrol__Type.cmo -c -impl lib/type.ml)
# File "lib/type.ml", line 57, characters 4-19:
# 57 |     Caqti_type.tup2 (ty_to_caqti_ty h) (ty_list_to_caqti_ty t)
#          ^^^^^^^^^^^^^^^
# Alert deprecated: Caqti_type.tup2
# Renamed to t2.
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I lib/.petrol.objs/byte -I lib/.petrol.objs/native -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/caqti -I /home/opam/.opam/4.14/lib/caqti-driver-sqlite3 -I /home/opam/.opam/4.14/lib/caqti-lwt -I /home/opam/.opam/4.14/lib/caqti/platform -I /home/opam/.opam/4.14/lib/caqti/platform/unix -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt-dllist -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/mtime -I /home/opam/.opam/4.14/lib/mtime/clock/os -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/sqlite3 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -intf-suffix .ml -no-alias-deps -open Petrol__ -o lib/.petrol.objs/native/petrol__Type.cmx -c -impl lib/type.ml)
# File "lib/type.ml", line 57, characters 4-19:
# 57 |     Caqti_type.tup2 (ty_to_caqti_ty h) (ty_list_to_caqti_ty t)
#          ^^^^^^^^^^^^^^^
# Alert deprecated: Caqti_type.tup2
# Renamed to t2.
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I test/.test_utils.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/caqti -I /home/opam/.opam/4.14/lib/caqti-driver-sqlite3 -I /home/opam/.opam/4.14/lib/caqti-lwt -I /home/opam/.opam/4.14/lib/caqti/platform -I /home/opam/.opam/4.14/lib/caqti/platform/unix -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt-dllist -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/mtime -I /home/opam/.opam/4.14/lib/mtime/clock/os -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/sqlite3 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I lib/.petrol.objs/byte -no-alias-deps -o test/.test_utils.objs/byte/test_utils.cmo -c -impl test/test_utils.ml)
# File "test/test_utils.ml", line 4, characters 8-20:
# 4 |   match Lwt_main.run expr with
#             ^^^^^^^^^^^^
# Error: Unbound module Lwt_main
```