### PR TITLE
ppx_rapper 1.2.0 & 2.0.0’s tests are not compatible with caqti 2.0.0

### DIFF
--- a/packages/ppx_rapper/ppx_rapper.1.2.0/opam
+++ b/packages/ppx_rapper/ppx_rapper.1.2.0/opam
@@ -14,6 +14,7 @@ depends: [
   "base"
   "caqti"
   "caqti-lwt"
+  "caqti" {with-test & < "2.0.0~"}
   "caqti-type-calendar" {with-test}
 ]
 build: [

--- a/packages/ppx_rapper/ppx_rapper.2.0.0/opam
+++ b/packages/ppx_rapper/ppx_rapper.2.0.0/opam
@@ -14,6 +14,7 @@ depends: [
   "base"
   "caqti"
   "caqti-lwt"
+  "caqti" {with-test & < "2.0.0~"}
   "caqti-type-calendar" {with-test}
 ]
 build: [


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/24264
```
#=== ERROR while compiling ppx_rapper.2.0.0 ===================================#
# context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/ppx_rapper.2.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ppx_rapper -j 255 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/ppx_rapper-7-71798e.env
# output-file          ~/.opam/log/ppx_rapper-7-71798e.out
### output ###
# File "dune-project", line 1, characters 11-16:
# 1 | (lang dune 2.0.1)
#                ^^^^^
# Warning: The ".1" part is ignored here.
# This version is parsed as just 2.0.
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I lib-runtime/.rapper.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/caqti -I /home/opam/.opam/4.14/lib/caqti-lwt -I /home/opam/.opam/4.14/lib/caqti/platform -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt-dllist -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/mtime -I /home/opam/.opam/4.14/lib/mtime/clock/os -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -intf-suffix .ml -no-alias-deps -o lib-runtime/.rapper.objs/byte/rapper.cmo -c -impl lib-runtime/rapper.ml)
# File "lib-runtime/rapper.ml", line 49, characters 40-55:
# 49 |     let add t x (Pack (t', x')) = Pack (Caqti_type.tup2 t' t, (x', x))
#                                              ^^^^^^^^^^^^^^^
# Alert deprecated: Caqti_type.tup2
# Renamed to t2.
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I lib-runtime/.rapper.objs/byte -I lib-runtime/.rapper.objs/native -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/caqti -I /home/opam/.opam/4.14/lib/caqti-lwt -I /home/opam/.opam/4.14/lib/caqti/platform -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt-dllist -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/mtime -I /home/opam/.opam/4.14/lib/mtime/clock/os -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -intf-suffix .ml -no-alias-deps -o lib-runtime/.rapper.objs/native/rapper.cmx -c -impl lib-runtime/rapper.ml)
# File "lib-runtime/rapper.ml", line 49, characters 40-55:
# 49 |     let add t x (Pack (t', x')) = Pack (Caqti_type.tup2 t' t, (x', x))
#                                              ^^^^^^^^^^^^^^^
# Alert deprecated: Caqti_type.tup2
# Renamed to t2.
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I test/runtime/.test_compiles.eobjs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/calendar -I /home/opam/.opam/4.14/lib/caqti -I /home/opam/.opam/4.14/lib/caqti-lwt -I /home/opam/.opam/4.14/lib/caqti-type-calendar -I /home/opam/.opam/4.14/lib/caqti/platform -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt-dllist -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/mtime -I /home/opam/.opam/4.14/lib/mtime/clock/os -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I lib-runtime/.rapper.objs/byte -no-alias-deps -open Dune__exe -o test/runtime/.test_compiles.eobjs/byte/dune__exe__Test_compiles.cmo -c -impl test/runtime/test_compiles.pp.ml)
# File "test/runtime/test_compiles.ml", lines 7-13, characters 2-12:
#  7 | ..[%rapper
#  8 |     execute
#  9 |       {sql|
# 10 |       UPDATE users
# 11 |       SET (username, email, bio) = (%string{username}, %string{email}, %string?{bio})
# 12 |       WHERE id = %int{id}
# 13 |       |sql}]
# Error: Unbound value exec
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I test/runtime/.test_compiles.eobjs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/calendar -I /home/opam/.opam/4.14/lib/caqti -I /home/opam/.opam/4.14/lib/caqti-lwt -I /home/opam/.opam/4.14/lib/caqti-type-calendar -I /home/opam/.opam/4.14/lib/caqti/platform -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt-dllist -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/mtime -I /home/opam/.opam/4.14/lib/mtime/clock/os -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I lib-runtime/.rapper.objs/byte -no-alias-deps -open Dune__exe -o test/runtime/.test_compiles.eobjs/byte/dune__exe__Test_compiles_base.cmo -c -impl test/runtime/test_compiles_base.pp.ml)
# File "test/runtime/test_compiles_base.ml", lines 9-15, characters 2-12:
#  9 | ..[%rapper
# 10 |     execute
# 11 |       {sql|
# 12 |       UPDATE users
# 13 |       SET (username, email, bio) = (%string{username}, %string{email}, %string?{bio})
# 14 |       WHERE id = %int{id}
# 15 |       |sql}]
# Error: Unbound value exec
```