### PR TITLE
Add a Github Action that removes the "needs reporter action" label when the issue or PR has been commented on

### DIFF
--- a/.github/workflows/unlabel.yml
+++ b/.github/workflows/unlabel.yml
@@ -4,8 +4,9 @@ on:
     types: [created]
 jobs:
   remove_label:
+    if: ${{ !contains(fromJSON(vars.MAINTAINERS), github.event.comment.user.login) && contains(github.event.issue.labels.*.name, fromJSON(vars.LABEL_TO_REMOVE)) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-remove-labels@v1
         with:
-          labels: "needs reporter action"
+          labels: ${{ fromJSON(vars.LABEL_TO_REMOVE) }}

--- a/.github/workflows/unlabel.yml
+++ b/.github/workflows/unlabel.yml
@@ -1,0 +1,11 @@
+name: Remove Label
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  remove_label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: "needs reporter action"


### PR DESCRIPTION
Labeling PRs and issues allows opam-repository maintainers to more efficiently see which PRs need a review or which ones are waiting for inputs from the person who opened the PR/issue.

This PR adds a bot to opam-repository which will be triggered everytime there is a comment and removes the label `needs reporter action` so that we don’t skip the PR if we missed the notification that the action has been taken.