### PR TITLE
[new release] rtree (0.1.1)

### DIFF
--- a/packages/rtree/rtree.0.1.1/opam
+++ b/packages/rtree/rtree.0.1.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A pure OCaml R-Tree implementation"
+description:
+  "This implements a simple, functional R-Tree library in pure OCaml with support for efficient bulk loading of values."
+maintainer: ["patrick@sirref.org"]
+authors: ["Marius A. Eriksen" "Patrick Ferris"]
+license: "BSD-3-Clause"
+tags: ["spatial" "index"]
+homepage: "https://github.com/geocaml/ocaml-rtree"
+bug-reports: "https://github.com/geocaml/ocaml-rtree/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "repr" {>= "0.4.0"}
+  "bechamel" {with-test}
+  "vg" {with-test}
+  "ounit2" {with-test}
+  "mdx" {with-test & >= "2.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/geocaml/ocaml-rtree.git"
+url {
+  src:
+    "https://github.com/geocaml/ocaml-rtree/releases/download/v0.1.1/rtree-0.1.1.tbz"
+  checksum: [
+    "sha256=408c9600703ea96f3ccd9f99dea853d5cb6c76c05e7e546ac18d90fc42426147"
+    "sha512=0d658adce2995dbe2de8bf5a93161fe0013872152417472cbf5bb00d8eed99a073e3942ad7cc6bb4e9d37d90853a58adb712fa5e9837301e4cd5c2ed68ebbaa5"
+  ]
+}
+x-commit-hash: "a7a9718718371a978507fb097504060ca01b9c17"


### PR DESCRIPTION
A pure OCaml R-Tree implementation

- Project page: <a href="https://github.com/geocaml/ocaml-rtree">https://github.com/geocaml/ocaml-rtree</a>

##### CHANGES:

## Bugs, Fixes and Optimisations

 - Remove extra length calculations (geocaml/ocaml-rtree#16, @lindig)
 - Remove some polymorphic comparisons and replace with `Float` functions (geocaml/ocaml-rtree#15, @patricoferris)
 - Fix stack overflows in OMT and Rectangle.merge (geocaml/ocaml-rtree#14, @patricoferris, reported by @lindig)
