### PR TITLE
[new release] uring (0.7)

### DIFF
--- a/packages/uring/uring.0.7/opam
+++ b/packages/uring/uring.0.7/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Linux io_uring"
+description:
+  "Bindings to the Linux io_uring kernel IO interfaces. See https://github.com/ocaml-multicore/eio for a higher-level API using this."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Sadiq Jaffer" "Thomas Leonard"]
+homepage: "https://github.com/ocaml-multicore/ocaml-uring"
+doc: "https://ocaml-multicore.github.io/ocaml-uring/"
+bug-reports: "https://github.com/ocaml-multicore/ocaml-uring/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "cstruct" {>= "6.0.1"}
+  "ocaml" {>= "4.12.0"}
+  "dune-configurator"
+  "lwt" {with-test & >= "5.0.0"}
+  "bechamel" {>= "0.1.0" & with-test}
+  "logs" {with-test & >= "0.5.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "fmt" {>= "0.8.10"}
+  "optint" {>= "0.1.0"}
+  "mdx" {>= "2.1.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/ocaml-uring.git"
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+]
+available: [os = "linux"]
+license: ["ISC" "MIT"]
+x-ci-accept-failures: [
+  "centos-7" # default C compiler does not support stdatomic.h
+  "oraclelinux-7" # default C compiler does not support stdatomic.h
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/ocaml-uring/releases/download/v0.7/uring-0.7.tbz"
+  checksum: [
+    "sha256=921c55f1a658bdda981a36f56b6ec943e2bcca0ece24de338894f68733481503"
+    "sha512=56f445ea25b7de37cab566931a2edbbf090b8a19a5d81350a157019400c476cb75daa11a7296aaffa6a5ec350cf851b364638b4c806586734616f2c71891880f"
+  ]
+}
+x-commit-hash: "673d908ece23dfaa1ebaee653717015b82e8132e"


### PR DESCRIPTION
OCaml bindings for Linux io_uring

- Project page: <a href="https://github.com/ocaml-multicore/ocaml-uring">https://github.com/ocaml-multicore/ocaml-uring</a>
- Documentation: <a href="https://ocaml-multicore.github.io/ocaml-uring/">https://ocaml-multicore.github.io/ocaml-uring/</a>

##### CHANGES:

- Add `statx` support (@patricoferris, @talex5, @avsm ocaml-multicore/ocaml-uring#95 ocaml-multicore/ocaml-uring#97).

- Add type annotations to tests (@patricoferris ocaml-multicore/ocaml-uring#96, reviewed by @talex5).
  Fixes MDX tests on OCaml 5.1.

- Update liburing to 2.4 (@anmonteiro ocaml-multicore/ocaml-uring#93, reviewed by @talex5).

- Fix accidental shadowing in `ocaml_uring_get_msghdr_fds` (@talex5 ocaml-multicore/ocaml-uring#91, reviewed by @avsm).
