### PR TITLE
conan and pa_ppx_regexp are not compatible with re 1.11

### DIFF
--- a/packages/conan/conan.0.0.1/opam
+++ b/packages/conan/conan.0.0.1/opam
@@ -11,7 +11,7 @@ doc: "https://mirage.github.io/conan/"
 bug-reports: "https://github.com/mirage/conan/issues"
 depends: [
   "ocaml"               {>= "4.08.0" & < "5.0.0"}
-  "re"                  {>= "1.9.0"}
+  "re"                  {>= "1.9.0" & < "1.11.0"}
   "dune"                {>= "2.9.0"}
   "uutf"
   "ptime"

--- a/packages/conan/conan.0.0.2/opam
+++ b/packages/conan/conan.0.0.2/opam
@@ -11,7 +11,7 @@ doc: "https://mirage.github.io/conan/"
 bug-reports: "https://github.com/mirage/conan/issues"
 depends: [
   "ocaml"               {>= "4.08.0" & < "5.0"}
-  "re"                  {>= "1.9.0"}
+  "re"                  {>= "1.9.0" & < "1.11.0"}
   "dune"                {>= "2.9.0"}
   "uutf"
   "ptime"

--- a/packages/conan/conan.0.0.3/opam
+++ b/packages/conan/conan.0.0.3/opam
@@ -11,7 +11,7 @@ doc: "https://mirage.github.io/conan/"
 bug-reports: "https://github.com/mirage/conan/issues"
 depends: [
   "ocaml"               {>= "4.08.0" & < "5.1~"}
-  "re"                  {>= "1.9.0"}
+  "re"                  {>= "1.9.0" & < "1.11.0"}
   "dune"                {>= "2.9.0"}
   "uutf"
   "ptime"

--- a/packages/conan/conan.0.0.4/opam
+++ b/packages/conan/conan.0.0.4/opam
@@ -11,7 +11,7 @@ doc: "https://mirage.github.io/conan/"
 bug-reports: "https://github.com/mirage/conan/issues"
 depends: [
   "ocaml"               {>= "4.08.0"}
-  "re"                  {>= "1.9.0"}
+  "re"                  {>= "1.9.0" & < "1.11.0"}
   "dune"                {>= "2.9.0"}
   "uutf"
   "ptime"

--- a/packages/pa_ppx_regexp/pa_ppx_regexp.0.01/opam
+++ b/packages/pa_ppx_regexp/pa_ppx_regexp.0.01/opam
@@ -27,6 +27,7 @@ depends: [
   "fmt"
   "pcre"
   "re"
+  "re" {< "1.11.0" & with-test}
 ]
 build: [
   [make "sys"]


### PR DESCRIPTION
Fails with
```
=== ERROR while compiling conan.0.0.1 ========================================#
 context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
 path                 ~/.opam/4.14/.opam-switch/build/conan.0.0.1
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p conan -j 255
 exit-code            1
 env-file             ~/.opam/log/conan-7-3ee948.env
 output-file          ~/.opam/log/conan-7-3ee948.out
\## output ###
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I src/.conan.objs/byte -I src/.conan.objs/native -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/re/pcre -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/uutf -intf-suffix .ml -no-alias-deps -open Conan__ -o src/.conan.objs/native/conan__Serialize.cmx -c -impl src/serialize.ml)
 File "src/serialize.ml", line 177, characters 6-21:
 177 |     | Re.View.Group t -> group ppf (Re.View.view t)
             ^^^^^^^^^^^^^^^
 Error: The constructor Re.View.Group expects 2 argument(s),
        but is applied here to 1 argument(s)
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.conan.objs/byte -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/re/pcre -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/uutf -intf-suffix .ml -no-alias-deps -open Conan__ -o src/.conan.objs/byte/conan__Serialize.cmo -c -impl src/serialize.ml)
 File "src/serialize.ml", line 177, characters 6-21:
 177 |     | Re.View.Group t -> group ppf (Re.View.view t)
             ^^^^^^^^^^^^^^^
 Error: The constructor Re.View.Group expects 2 argument(s),
        but is applied here to 1 argument(s)
```

Seen on https://github.com/ocaml/opam-repository/pull/24296