### PR TITLE
[new release] ocamlregextkit (1.0.0)

### DIFF
--- a/packages/ocamlregextkit/ocamlregextkit.1.0.0/opam
+++ b/packages/ocamlregextkit/ocamlregextkit.1.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "A regular expression toolkit for OCaml"
+description:
+  "Provides data structures and algorithms for Regular Expressions, Deterministic Finite Automata, and Non-Deterministic Finite Automata"
+maintainer: ["Dominic Too"]
+authors: ["Dominic Too"]
+license: "GPL-3.0-or-later"
+tags: [
+  "automata"
+  "regular expressions"
+  "regular languages"
+  "regex"
+  "library"
+  "DFA"
+  "NFA"
+  "RE"
+]
+homepage: "https://github.com/toodom02/ocamlregextkit"
+doc: "https://toodom02.github.io/ocamlregextkit/"
+bug-reports: "https://github.com/toodom02/ocamlregextkit/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/toodom02/ocamlregextkit.git"
+url {
+  src:
+    "https://github.com/toodom02/ocamlregextkit/releases/download/v1.0.0/ocamlregextkit-1.0.0.tbz"
+  checksum: [
+    "sha256=8edee54b513ce6320296e1f6723a4359a80c4fa759d2cd6c91594dd8a6b1c2a0"
+    "sha512=f2a00da2dd7d6aa9b212b2dd252f2b09c407375884d19bc94512ea258281cee783b3716460f02ce550f779f7f19ddbf7dfec70577f3b93abae7ccfe0f9e29477"
+  ]
+}
+x-commit-hash: "e55526581aafc17c3e6f7f6ff81c553a42f3116c"


### PR DESCRIPTION
A regular expression toolkit for OCaml

- Project page: <a href="https://github.com/toodom02/ocamlregextkit">https://github.com/toodom02/ocamlregextkit</a>
- Documentation: <a href="https://toodom02.github.io/ocamlregextkit/">https://toodom02.github.io/ocamlregextkit/</a>

##### CHANGES:

### Added

 - Removed extraneous fields from ADT and enforced single source of truth.

 - Use inplace mutations of automata for functions `prune`, `merge_alphabets` and `minimise`.
