### PR TITLE
[new release] lwt_eio (0.4)

### DIFF
--- a/packages/lwt_eio/lwt_eio.0.4/opam
+++ b/packages/lwt_eio/lwt_eio.0.4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Run Lwt code within Eio"
+description:
+  "An Lwt engine that allows running Lwt within an Eio event loop."
+maintainer: ["talex5@gmail.com"]
+authors: ["Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/lwt_eio"
+doc: "https://ocaml-multicore.github.io/lwt_eio"
+bug-reports: "https://github.com/ocaml-multicore/lwt_eio/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "eio" {>= "0.11"}
+  "lwt" {>= "5.7.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "eio_main" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/lwt_eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/lwt_eio/releases/download/v0.4/lwt_eio-0.4.tbz"
+  checksum: [
+    "sha256=cab13f499bbe070ba08ccae575a2dd6b9d8338668519b5fd16bc718bc0764065"
+    "sha512=52ed4f029ed813c82ae50e3a27799c6d9b3859bdfd2cf389f68afae939422cd328395c5e1301c0fbf3c8cd637dd1f87485b8ebac337c582e6acf0dca222e28b9"
+  ]
+}
+x-commit-hash: "8279f4cc89046315d244780fde3b149bed8b250f"


### PR DESCRIPTION
Run Lwt code within Eio

- Project page: <a href="https://github.com/ocaml-multicore/lwt_eio">https://github.com/ocaml-multicore/lwt_eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/lwt_eio">https://ocaml-multicore.github.io/lwt_eio</a>

##### CHANGES:

- Get Lwt and Eio to share the SIGCHLD handler (@talex5 ocaml-multicore/lwt_eio#19).
  Otherwise, Lwt replaces Eio's handler and may prevent Eio from noticing child processes finishing.

- Don't allow cancelling things after forking (@talex5 ocaml-multicore/lwt_eio#21).
  With io_uring, this will mess up the parent's ring.

- Add `Lwt_eio.run_lwt_in_main` (@talex5 ocaml-multicore/lwt_eio#20).
  This is useful if your program uses multiple Eio domains and you want to run some Lwt code from any of them.

- Fix some Eio deprecation warnings (@talex5 ocaml-multicore/lwt_eio#18).
