### PR TITLE
[new release] moonpool (0.4)

### DIFF
--- a/packages/moonpool/moonpool.0.4/opam
+++ b/packages/moonpool/moonpool.0.4/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Pools of threads supported by a pool of domains"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["thread" "pool" "domain"]
+homepage: "https://github.com/c-cube/moonpool"
+bug-reports: "https://github.com/c-cube/moonpool/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.0"}
+  "either" {>= "1.0"}
+  "trace" {with-test}
+  "qcheck-core" {with-test & >= "0.19"}
+  "odoc" {with-doc}
+  "mdx" {>= "1.9.0" & with-test}
+]
+depopts: [
+  "domain-local-await" {>= "0.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/moonpool.git"
+url {
+  src:
+    "https://github.com/c-cube/moonpool/releases/download/v0.4/moonpool-0.4.tbz"
+  checksum: [
+    "sha256=6f4edc335dfa1a5d9349509b6dd7501b6f59f68cd743eceec42aacd8d27df57f"
+    "sha512=338d9f42c3306616953649600f54cefe3d57deacf8b809c56d402d0c510705f9a90b4ea68907fa5a52ad77d51f159575358891a1dfb8dfea69c7fad05f6676d2"
+  ]
+}
+x-commit-hash: "43ca60ff150ffcba1ed0f901f640b86a025b795e"


### PR DESCRIPTION
Pools of threads supported by a pool of domains

- Project page: <a href="https://github.com/c-cube/moonpool">https://github.com/c-cube/moonpool</a>

##### CHANGES:

- add `Fut.{reify_error,bind_reify_error}`
- full lifecycle for worker domains, where a domain
    will shutdown if no thread runs on it, after a
    short delay.

- fix: generalize type of `create_arg`
- perf: in `Bb_queue`, only signal condition on push if queue was empty
