### PR TITLE
reason-react: add depexts

### DIFF
--- a/packages/reason-react/reason-react.0.11.0/opam
+++ b/packages/reason-react/reason-react.0.11.0/opam
@@ -22,7 +22,7 @@ depends: [
   "reactjs-jsx-ppx"
   "reason" {>= "3.6.0"}
   "ocaml-lsp-server" {with-test}
-  "opam-check-npm-deps" {"1.0.0" = with-dev-setup}
+  "opam-check-npm-deps" {= "1.0.0" & with-dev-setup}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/reason-react/reason-react.0.11.0/opam
+++ b/packages/reason-react/reason-react.0.11.0/opam
@@ -49,6 +49,6 @@ url {
 }
 x-commit-hash: "dbc2f61f6626de47dd607609f13a678ecd59e462"
 depexts: [
-  ["react"] {npm-version = "^16.0.0"}
-  ["react-dom"] {npm-version = "^16.0.0"}
+  ["react"] {npm-version = "^16.0.0 || ^17.0.0"}
+  ["react-dom"] {npm-version = "^16.0.0 || ^17.0.0"}
 ]

--- a/packages/reason-react/reason-react.0.11.0/opam
+++ b/packages/reason-react/reason-react.0.11.0/opam
@@ -22,6 +22,7 @@ depends: [
   "reactjs-jsx-ppx"
   "reason" {>= "3.6.0"}
   "ocaml-lsp-server" {with-test}
+  "opam-check-npm-deps" {"1.0.0" = with-dev-setup}
   "odoc" {with-doc}
 ]
 build: [
@@ -47,3 +48,7 @@ url {
   ]
 }
 x-commit-hash: "dbc2f61f6626de47dd607609f13a678ecd59e462"
+depexts: [
+  ["react"] {npm-version = "^16.0.0"}
+  ["react-dom"] {npm-version = "^16.0.0"}
+]


### PR DESCRIPTION
Now that `opam-check-npm-deps` plugin [has been published](https://github.com/ocaml/opam-repository/pull/24251), this change makes use of it by adding a `depexts` field to the `reason-react` package to reflect the dependency on the underlying `react` and `react-dom` npm packages.

I am not sure how to reflect the dependency on the opam plugin version 1.0.0, so I am using the soon to be added `with-dev-setup` variable for it, as this will be mostly a development time check.