### PR TITLE
5 packages from c-cube/qcheck

### DIFF
--- a/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.4.1/opam
+++ b/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.4.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "PPX Deriver for QCheck"
+maintainer: "valentin.chb@gmail.com"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/-/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "ocaml" {>= "4.08.0"}
+  "qcheck-core" {>= "0.19"}
+  "ppxlib" {>= "0.22.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "odoc" {with-doc}
+  "alcotest" {with-test & >= "1.4.0"}
+  "qcheck-alcotest" {with-test & >= "0.17"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/vch9/ppx_deriving_qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.21.2.tar.gz"
+  checksum: [
+    "md5=b8e3728fc1b534ee01e3c2b7e2b30bb3"
+    "sha512=67ff77a66ccf046dfede9123a322002f232a0a65b8ce1890795a4a4ba247bc5413f988e7cfd53412418036c2b907e4cbcd7dcd39d7f1fd2481aee60107b075cc"
+  ]
+}

--- a/packages/qcheck-alcotest/qcheck-alcotest.0.21.2/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.21.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Alcotest backend for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "quickcheck" "qcheck" "alcotest"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {= version}
+  "alcotest" {>= "0.8.1"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.21.2.tar.gz"
+  checksum: [
+    "md5=b8e3728fc1b534ee01e3c2b7e2b30bb3"
+    "sha512=67ff77a66ccf046dfede9123a322002f232a0a65b8ce1890795a4a4ba247bc5413f988e7cfd53412418036c2b907e4cbcd7dcd39d7f1fd2481aee60107b075cc"
+  ]
+}

--- a/packages/qcheck-core/qcheck-core.0.21.2/opam
+++ b/packages/qcheck-core/qcheck-core.0.21.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Core qcheck library"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-bytes"
+  "base-unix"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.21.2.tar.gz"
+  checksum: [
+    "md5=b8e3728fc1b534ee01e3c2b7e2b30bb3"
+    "sha512=67ff77a66ccf046dfede9123a322002f232a0a65b8ce1890795a4a4ba247bc5413f988e7cfd53412418036c2b907e4cbcd7dcd39d7f1fd2481aee60107b075cc"
+  ]
+}

--- a/packages/qcheck-ounit/qcheck-ounit.0.21.2/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.21.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "OUnit backend for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["qcheck" "quickcheck" "ounit"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {= version}
+  "ounit2"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.21.2.tar.gz"
+  checksum: [
+    "md5=b8e3728fc1b534ee01e3c2b7e2b30bb3"
+    "sha512=67ff77a66ccf046dfede9123a322002f232a0a65b8ce1890795a4a4ba247bc5413f988e7cfd53412418036c2b907e4cbcd7dcd39d7f1fd2481aee60107b075cc"
+  ]
+}

--- a/packages/qcheck/qcheck.0.21.2/opam
+++ b/packages/qcheck/qcheck.0.21.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Compatibility package for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {= version}
+  "qcheck-ounit" {= version}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.21.2.tar.gz"
+  checksum: [
+    "md5=b8e3728fc1b534ee01e3c2b7e2b30bb3"
+    "sha512=67ff77a66ccf046dfede9123a322002f232a0a65b8ce1890795a4a4ba247bc5413f988e7cfd53412418036c2b907e4cbcd7dcd39d7f1fd2481aee60107b075cc"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ppx_deriving_qcheck.0.4.1`: PPX Deriver for QCheck
-`qcheck.0.21.2`: Compatibility package for qcheck
-`qcheck-alcotest.0.21.2`: Alcotest backend for qcheck
-`qcheck-core.0.21.2`: Core qcheck library
-`qcheck-ounit.0.21.2`: OUnit backend for qcheck



---
* Homepage: https://github.com/c-cube/qcheck/

---
:camel: Pull-request generated by opam-publish v2.1.0