### PR TITLE
Package ocolor.1.3.1

### DIFF
--- a/packages/ocolor/ocolor.1.3.1/opam
+++ b/packages/ocolor/ocolor.1.3.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Print with style in your terminal using Format's semantic tags"
+maintainer: "Marc Chevalier <ocolor@marc-chevalier.com>"
+authors: "Marc Chevalier <ocolor@marc-chevalier.com>"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.6.3"}
+  "cppo" {build & >= "1.6.5"}
+  "ounit2" {with-test & >= "2.0.8"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+homepage: "https://github.com/marc-chevalier/ocolor"
+bug-reports: "https://github.com/marc-chevalier/ocolor/issues"
+dev-repo: "git+https://github.com/marc-chevalier/ocolor.git"
+license: "MIT"
+description: """
+This package provides a nice way to use ANSI escape codes thanks to Format's
+semantic tags. This mode is compositional: ending a style restore the previous
+one, instead of destroying everything.
+This package also allows using directly ANSI escape codes (with Printf).
+
+Note that this library does not intend to handle anything else than ANSI escape
+codes (in particular, not the old Windows style of styling). Moreover, it aims
+to be as pure as possible, so insensitive to the environment. As a consequence,
+there is no mechanism to detect terminal's settings. However, some configuration
+is possible, but must be done manually.
+"""
+url {
+  src:
+    "https://github.com/marc-chevalier/ocolor/archive/refs/tags/1.3.1.tar.gz"
+  checksum: [
+    "md5=648a95f1829c7a26172e7168e969962d"
+    "sha512=f825b57889f4ca6f074688c736c26c98192d1bee37e05d81c991b6a75d4e06009656afe6430f55426e83e6a6922f791e5d8b7cccf56f908b940702bd21eebec9"
+  ]
+}


### PR DESCRIPTION
### `ocolor.1.3.1`
Print with style in your terminal using Format's semantic tags
This package provides a nice way to use ANSI escape codes thanks to Format's
semantic tags. This mode is compositional: ending a style restore the previous
one, instead of destroying everything.
This package also allows using directly ANSI escape codes (with Printf).

Note that this library does not intend to handle anything else than ANSI escape
codes (in particular, not the old Windows style of styling). Moreover, it aims
to be as pure as possible, so insensitive to the environment. As a consequence,
there is no mechanism to detect terminal's settings. However, some configuration
is possible, but must be done manually.



---
* Homepage: https://github.com/marc-chevalier/ocolor
* Source repo: git+https://github.com/marc-chevalier/ocolor.git
* Bug tracker: https://github.com/marc-chevalier/ocolor/issues

---
:camel: Pull-request generated by opam-publish v2.2.0