### PR TITLE
Package plato.1.1.3

### DIFF
--- a/packages/plato/plato.1.1.3/opam
+++ b/packages/plato/plato.1.1.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Python Library Adapted To OCaml"
+maintainer: "Marc Chevalier <github@marc-chevalier.com>"
+authors: "Marc Chevalier <github@marc-chevalier.com>"
+homepage: "https://github.com/marc-chevalier/plato"
+dev-repo: "git://github.com/marc-chevalier/plato"
+bug-reports: "https://github.com/marc-chevalier/plato/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "2.0.0"}
+  "re" {>= "1.9.0"}
+  "stdcompat" {>= "13"}
+  "cppo" {>= "1.6.6"}
+  "ounit2" {with-test & >= "2.0.8"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+license: "MIT"
+description: """
+Python Library Adapted To Ocaml
+
+Plato provides some parts of Python standard library I was missing in OCaml.
+That means things relevant in OCaml (typically, not GC related), without a
+existing great OCaml library (like `re` for `re` or `yojson` for `json`).
+"""
+url {
+  src:
+    "https://github.com/marc-chevalier/plato/archive/refs/tags/1.1.3.tar.gz"
+  checksum: [
+    "md5=4857a49b04ceb297c1eb4b2715d5a47a"
+    "sha512=daef493c84ce23e11b21f595a3f2f744edcd3741e698f6b21895bcfb79b2c8b36687da3e621ae9bd79612c2bbfdbbd9e624829ea2bb0c118b2c3fbffa2f48d99"
+  ]
+}


### PR DESCRIPTION
### `plato.1.1.3`
Python Library Adapted To OCaml
Python Library Adapted To Ocaml

Plato provides some parts of Python standard library I was missing in OCaml.
That means things relevant in OCaml (typically, not GC related), without a
existing great OCaml library (like `re` for `re` or `yojson` for `json`).



---
* Homepage: https://github.com/marc-chevalier/plato
* Source repo: git://github.com/marc-chevalier/plato
* Bug tracker: https://github.com/marc-chevalier/plato/issues

---
:camel: Pull-request generated by opam-publish v2.2.0