### PR TITLE
Constrain Links.0.9.7

### DIFF
--- a/packages/links/links.0.9.7/opam
+++ b/packages/links/links.0.9.7/opam
@@ -15,7 +15,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.08.0" & < "5.0"}
+  "ocaml" {>= "4.08.0" & < "5.0~"}
   "dune" {>= "2.7"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}

--- a/packages/links/links.0.9.7/opam
+++ b/packages/links/links.0.9.7/opam
@@ -15,7 +15,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "dune" {>= "2.7"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}


### PR DESCRIPTION
The installation of Links.0.9.7 with OCaml 5.0 silently fails (c.f. links-lang/links#1176). This patch puts an upper bound on the required version of the OCaml compiler such that OPAM will no longer attempt to install Links.0.9.7 with OCaml 5.0.

We have fixed the compatibility issues with OCaml 5.0 in our development repository. We will make a separate release to have an OCaml 5 compatiable package of Links available on OPAM.