### PR TITLE
[new release] lwt_eio (0.5)

### DIFF
--- a/packages/lwt_eio/lwt_eio.0.5/opam
+++ b/packages/lwt_eio/lwt_eio.0.5/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Run Lwt code within Eio"
+description:
+  "An Lwt engine that allows running Lwt within an Eio event loop."
+maintainer: ["talex5@gmail.com"]
+authors: ["Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/lwt_eio"
+doc: "https://ocaml-multicore.github.io/lwt_eio"
+bug-reports: "https://github.com/ocaml-multicore/lwt_eio/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "eio" {>= "0.12"}
+  "lwt" {>= "5.7.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "eio_main" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/lwt_eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/lwt_eio/releases/download/v0.5/lwt_eio-0.5.tbz"
+  checksum: [
+    "sha256=4a39fe8a401ebe02f15d0b075616fc95ae7f48cdb8ab198a4fe4e577477224b7"
+    "sha512=465a87ae097121260bcc9e178a618613e9b98c8868cb1023b90168fa5e408e410a054f699a2c912cd39cacdb6cdf64d3c6145ac259e39e85f3ace4dda27b2afc"
+  ]
+}
+x-commit-hash: "4e388e5ae2766db377afb8ae72800885924fd7ee"


### PR DESCRIPTION
Run Lwt code within Eio

- Project page: <a href="https://github.com/ocaml-multicore/lwt_eio">https://github.com/ocaml-multicore/lwt_eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/lwt_eio">https://ocaml-multicore.github.io/lwt_eio</a>

##### CHANGES:

- Add debug mode (@talex5 ocaml-multicore/lwt_eio#24).
  Passing `Lwt_eio.with_event_loop ~debug:true` enables a new debug mode,
  which detects attempts to perform effects from Lwt code.

- Update to Eio 0.12 (@talex5 ocaml-multicore/lwt_eio#23).
