### PR TITLE
re2.v0.16.0: does not compile on arm32

### DIFF
--- a/packages/re2/re2.v0.16.0/opam
+++ b/packages/re2/re2.v0.16.0/opam
@@ -25,3 +25,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/re2-v0.16.0.tar.gz"
 checksum: "sha256=391f3bf8019beeca300d8e496d7998792e596f9dd75b535d334eb78c08859104"
 }
+available: [ arch != "arm32" ]


### PR DESCRIPTION
error is

```
g++: error: unrecognized command-line option '-m32'; did you mean '-mbe32'?
```