### PR TITLE
Add Frama-Clang package, take 2

### DIFF
--- a/packages/conf-libclang/conf-libclang.15/opam
+++ b/packages/conf-libclang/conf-libclang.15/opam
@@ -15,7 +15,7 @@ depends: [
 ]
 depexts: [
   ["llvm@15"] {os = "macos"}
-  ["llvm" "clang"] {os-distribution = "arch"}
+  ["llvm15" "clang15"] {os-distribution = "arch"}
   ["libclang-15-dev" "libclang-cpp15-dev" "llvm-15-dev"]
     {(os-distribution = "ubuntu" & os-version >= "22.10")}
   ["libclang-14-dev" "libclang-cpp14-dev" "llvm-14-dev"]

--- a/packages/conf-llvm/conf-llvm.14.0.6/opam
+++ b/packages/conf-llvm/conf-llvm.14.0.6/opam
@@ -15,7 +15,7 @@ depexts: [
   ["llvm-14"] {os-distribution = "macports" & os = "macos"}
   ["llvm-14-dev"] {os-family = "debian"}
   ["llvm14-dev"] {os-distribution = "alpine"}
-  ["llvm"] {os-family = "arch"}
+  ["llvm14"] {os-family = "arch"}
   ["llvm14-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["llvm14-devel"] {os-distribution = "fedora"}
   ["llvm14-devel" "epel-release"] {os-distribution = "centos"}

--- a/packages/conf-llvm/conf-llvm.15/opam
+++ b/packages/conf-llvm/conf-llvm.15/opam
@@ -15,7 +15,7 @@ depexts: [
   ["llvm-15"] {os-distribution = "macports" & os = "macos"}
   ["llvm-15-dev" "zlib1g-dev" "libzstd-dev"] {os-family = "debian"}
   ["llvm15-dev"] {os-distribution = "alpine"}
-  ["llvm"] {os-family = "arch"}
+  ["llvm15"] {os-family = "arch"}
   ["llvm15-devel"] {os-family = "suse"}
   ["llvm15-devel"] {os-distribution = "fedora"}
   ["llvm15-devel" "epel-release"] {os-distribution = "centos"}

--- a/packages/frama-clang/frama-clang.0.0.14/files/CMakeLists.txt.patch
+++ b/packages/frama-clang/frama-clang.0.0.14/files/CMakeLists.txt.patch
@@ -1,5 +1,5 @@
 diff --git a/framaCIRGen_src/CMakeLists.txt b/framaCIRGen_src/CMakeLists.txt
-index 6ba2fd3c..847e961d 100644
+index 6ba2fd3c..b4e9aa32 100644
 --- a/framaCIRGen_src/CMakeLists.txt
 +++ b/framaCIRGen_src/CMakeLists.txt
 @@ -20,7 +20,7 @@
@@ -16,7 +16,7 @@ index 6ba2fd3c..847e961d 100644
  set(CMAKE_CXX_EXTENSIONS OFF)
  
 +find_program(LLVM_CONFIG
-+  NAMES llvm-config llvm-config-15 llvm-config-14
++  NAMES $ENV{OPAM_LLVM_CONFIG} llvm-config llvm-config-15 llvm-config-14
 +        llvm-config-13 llvm-config-12 llvm-config-11
 +  REQUIRED)
 +

--- a/packages/frama-clang/frama-clang.0.0.14/files/CMakeLists.txt.patch
+++ b/packages/frama-clang/frama-clang.0.0.14/files/CMakeLists.txt.patch
@@ -1,0 +1,31 @@
+diff --git a/framaCIRGen_src/CMakeLists.txt b/framaCIRGen_src/CMakeLists.txt
+index 6ba2fd3c..9e59699c 100644
+--- a/framaCIRGen_src/CMakeLists.txt
++++ b/framaCIRGen_src/CMakeLists.txt
+@@ -20,7 +20,7 @@
+ #                                                                        #
+ ##########################################################################
+ 
+-cmake_minimum_required(VERSION 3.6)
++cmake_minimum_required(VERSION 3.18)
+ 
+ project(FramaCIRGen C CXX)
+ 
+@@ -28,6 +28,17 @@ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CXX_EXTENSIONS OFF)
+ 
++find_program(LLVM_CONFIG
++  NAMES llvm-config llvm-config-15 llvm-config-14
++        llvm-config-13 llvm-config-12 llvm-config-11
++  REQUIRED)
++
++execute_process(COMMAND ${LLVM_CONFIG} --cmakedir OUTPUT_VARIABLE CMAKE_LLVM_PREFIX)
++
++cmake_path(GET CMAKE_LLVM_PREFIX PARENT_PATH CMAKE_LLVM_CLANG_PREFIX)
++set(Clang_DIR ${CMAKE_LLVM_CLANG_PREFIX}/clang)
++set(LLVM_DIR ${CMAKE_LLVM_CLANG_PREFIX}/llvm)
++
+ find_package(Clang REQUIRED)
+ find_package(LLVM REQUIRED)
+ 

--- a/packages/frama-clang/frama-clang.0.0.14/files/CMakeLists.txt.patch
+++ b/packages/frama-clang/frama-clang.0.0.14/files/CMakeLists.txt.patch
@@ -1,5 +1,5 @@
 diff --git a/framaCIRGen_src/CMakeLists.txt b/framaCIRGen_src/CMakeLists.txt
-index 6ba2fd3c..9e59699c 100644
+index 6ba2fd3c..847e961d 100644
 --- a/framaCIRGen_src/CMakeLists.txt
 +++ b/framaCIRGen_src/CMakeLists.txt
 @@ -20,7 +20,7 @@
@@ -7,7 +7,7 @@ index 6ba2fd3c..9e59699c 100644
  ##########################################################################
  
 -cmake_minimum_required(VERSION 3.6)
-+cmake_minimum_required(VERSION 3.18)
++cmake_minimum_required(VERSION 3.20)
  
  project(FramaCIRGen C CXX)
  

--- a/packages/frama-clang/frama-clang.0.0.14/files/build.sh.patch
+++ b/packages/frama-clang/frama-clang.0.0.14/files/build.sh.patch
@@ -1,0 +1,10 @@
+diff --git a/framaCIRGen_src/build.sh b/framaCIRGen_src/build.sh
+index cdd9fcd0..103d6f9c 100755
+--- a/framaCIRGen_src/build.sh
++++ b/framaCIRGen_src/build.sh
+@@ -1,4 +1,4 @@
+-#! /usr/bin/bash
++#! /bin/sh
+ ##########################################################################
+ #                                                                        #
+ #  This file is part of Frama-Clang                                      #

--- a/packages/frama-clang/frama-clang.0.0.14/files/build.sh.patch.in
+++ b/packages/frama-clang/frama-clang.0.0.14/files/build.sh.patch.in
@@ -1,5 +1,5 @@
 diff --git a/framaCIRGen_src/build.sh b/framaCIRGen_src/build.sh
-index cdd9fcd0..103d6f9c 100755
+index cdd9fcd0..d20fcbfb 100755
 --- a/framaCIRGen_src/build.sh
 +++ b/framaCIRGen_src/build.sh
 @@ -1,4 +1,4 @@
@@ -8,3 +8,10 @@ index cdd9fcd0..103d6f9c 100755
  ##########################################################################
  #                                                                        #
  #  This file is part of Frama-Clang                                      #
+@@ -21,5 +21,5 @@
+ #                                                                        #
+ ##########################################################################
+ 
+-cmake .
++OPAM_LLVM_CONFIG=%{conf-llvm:config}% cmake .
+ make -j

--- a/packages/frama-clang/frama-clang.0.0.14/opam
+++ b/packages/frama-clang/frama-clang.0.0.14/opam
@@ -51,8 +51,12 @@ url {
 
 patches: [ "CMakeLists.txt.patch" "build.sh.patch" ]
 
+build-env: [
+ [ OPAM_LLVM_CONFIG = "%{conf-llvm:config%}" ]
+]
+
 extra-files: [
-  ["CMakeLists.txt.patch" "sha256=6bebf0ee9b8fb0249407e957238928250aecf7d4e063f88b30d6ce05e4d7c5f2"]
+  ["CMakeLists.txt.patch" "sha256=6b69ba205c2277b921546322f0997fb6765c7fb553410a3e5b579230aa9f3202"]
   ["build.sh.patch" "sha256=bedae6cc981aee9173fae576f092cefcfa01e69b54c7775870e144c6a3f16d1b"]
 ]
 

--- a/packages/frama-clang/frama-clang.0.0.14/opam
+++ b/packages/frama-clang/frama-clang.0.0.14/opam
@@ -52,6 +52,13 @@ url {
 patches: [ "CMakeLists.txt.patch" "build.sh.patch" ]
 
 extra-files: [
-  ["CMakeLists.txt.patch" "sha256=d463f66cf4c24ae64ea419aa9a0b9b5d0df2ca205f5ec8307d8ac5f275ecee96"]
+  ["CMakeLists.txt.patch" "sha256=6bebf0ee9b8fb0249407e957238928250aecf7d4e063f88b30d6ce05e4d7c5f2"]
   ["build.sh.patch" "sha256=bedae6cc981aee9173fae576f092cefcfa01e69b54c7775870e144c6a3f16d1b"]
+]
+
+x-ci-accept-failures: [
+  # cmake version too old
+  "debian-10"
+  "debian-11"
+  "ubuntu-20.04"
 ]

--- a/packages/frama-clang/frama-clang.0.0.14/opam
+++ b/packages/frama-clang/frama-clang.0.0.14/opam
@@ -23,7 +23,7 @@ depends: [
   "camlp-streams"
   "conf-llvm" {>= "11.0.0"}
   "conf-libclang" {>= "11.0.0"}
-  "conf-clang"
+  "conf-clang" { os-family = "debian" }
   "conf-cmake"
   "odoc" {with-doc}
 ]

--- a/packages/frama-clang/frama-clang.0.0.14/opam
+++ b/packages/frama-clang/frama-clang.0.0.14/opam
@@ -52,6 +52,6 @@ url {
 patches: [ "CMakeLists.txt.patch" "build.sh.patch" ]
 
 extra-files: [
-  "CMakeLists.txt.patch" "sha256=d463f66cf4c24ae64ea419aa9a0b9b5d0df2ca205f5ec8307d8ac5f275ecee96"
-  "build.sh.patch" "sha256=bedae6cc981aee9173fae576f092cefcfa01e69b54c7775870e144c6a3f16d1b"
+  ["CMakeLists.txt.patch" "sha256=d463f66cf4c24ae64ea419aa9a0b9b5d0df2ca205f5ec8307d8ac5f275ecee96"]
+  ["build.sh.patch" "sha256=bedae6cc981aee9173fae576f092cefcfa01e69b54c7775870e144c6a3f16d1b"]
 ]

--- a/packages/frama-clang/frama-clang.0.0.14/opam
+++ b/packages/frama-clang/frama-clang.0.0.14/opam
@@ -23,6 +23,7 @@ depends: [
   "camlp-streams"
   "conf-llvm" {>= "11.0.0"}
   "conf-libclang" {>= "11.0.0"}
+  "conf-clang"
   "conf-cmake"
   "odoc" {with-doc}
 ]

--- a/packages/frama-clang/frama-clang.0.0.14/opam
+++ b/packages/frama-clang/frama-clang.0.0.14/opam
@@ -49,15 +49,12 @@ url {
   checksum: [ "sha256=fa6b471814007322fcb4ea56addbe94cd49c570e17b1f33d633bc5e3fc8e0913" ]
 }
 
+substs: [ "build.sh.patch" ]
 patches: [ "CMakeLists.txt.patch" "build.sh.patch" ]
-
-build-env: [
- [ OPAM_LLVM_CONFIG = "%{conf-llvm:config%}" ]
-]
 
 extra-files: [
   ["CMakeLists.txt.patch" "sha256=6b69ba205c2277b921546322f0997fb6765c7fb553410a3e5b579230aa9f3202"]
-  ["build.sh.patch" "sha256=bedae6cc981aee9173fae576f092cefcfa01e69b54c7775870e144c6a3f16d1b"]
+  ["build.sh.patch.in" "sha256=6a780e39eb21f37852c9aef8da6ff25e548bf1745ec1a4b91a36297d416187f8"]
 ]
 
 x-ci-accept-failures: [

--- a/packages/frama-clang/frama-clang.0.0.14/opam
+++ b/packages/frama-clang/frama-clang.0.0.14/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Frama-C plug-in based on Clang for parsing C++ files"
+description: """
+This Frama-C plug-in parse C++ files that may content ACSL++ annotations.
+"""
+maintainer: "Virgile.Prevosto@cea.fr"
+authors: [
+  "David Cok"
+  "Virgile Prevosto"
+  "Franck Védrine"
+]
+license: "LGPL-2.1-only"
+homepage: "https://frama-c.com/frama-clang.html"
+dev-repo: "git+https://git.frama-c.com/pub/frama-clang.git"
+bug-reports: "https://git.frama-c.com/pub/frama-clang/-/issues"
+tags: ["Frama-C" "formal specification" "C++" "plugins" "ACSL" "ACSL++"]
+
+depends: [
+  "dune" {>= "3.2"}
+  "frama-c" {>= "27.0~" & < "28.0~"}
+  "zarith" {>= "1.5"}
+  "camlp5"
+  "camlp-streams"
+  "conf-llvm" {>= "11.0.0"}
+  "conf-libclang" {>= "11.0.0"}
+  "conf-cmake"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+
+url {
+  src: "https://git.frama-c.com/pub/frama-clang/-/archive/0.0.14/frama-clang-0.0.14.tar.bz2"
+  checksum: [ "sha256=fa6b471814007322fcb4ea56addbe94cd49c570e17b1f33d633bc5e3fc8e0913" ]
+}

--- a/packages/frama-clang/frama-clang.0.0.14/opam
+++ b/packages/frama-clang/frama-clang.0.0.14/opam
@@ -48,3 +48,7 @@ url {
   src: "https://git.frama-c.com/pub/frama-clang/-/archive/0.0.14/frama-clang-0.0.14.tar.bz2"
   checksum: [ "sha256=fa6b471814007322fcb4ea56addbe94cd49c570e17b1f33d633bc5e3fc8e0913" ]
 }
+
+patches: [ "CMakeLists.txt.patch" ]
+
+extra-files: [ "CMakeLists.txt.patch" "sha256=d463f66cf4c24ae64ea419aa9a0b9b5d0df2ca205f5ec8307d8ac5f275ecee96" ]

--- a/packages/frama-clang/frama-clang.0.0.14/opam
+++ b/packages/frama-clang/frama-clang.0.0.14/opam
@@ -49,6 +49,9 @@ url {
   checksum: [ "sha256=fa6b471814007322fcb4ea56addbe94cd49c570e17b1f33d633bc5e3fc8e0913" ]
 }
 
-patches: [ "CMakeLists.txt.patch" ]
+patches: [ "CMakeLists.txt.patch" "build.sh.patch" ]
 
-extra-files: [ "CMakeLists.txt.patch" "sha256=d463f66cf4c24ae64ea419aa9a0b9b5d0df2ca205f5ec8307d8ac5f275ecee96" ]
+extra-files: [
+  "CMakeLists.txt.patch" "sha256=d463f66cf4c24ae64ea419aa9a0b9b5d0df2ca205f5ec8307d8ac5f275ecee96"
+  "build.sh.patch" "sha256=bedae6cc981aee9173fae576f092cefcfa01e69b54c7775870e144c6a3f16d1b"
+]


### PR DESCRIPTION
This PR supersedes #22222 , especially now that `conf-libclang` includes `libclang-cpp` packages in depexts for distributions that separates C and C++ bindings (i.e. #22442). Beyond frama-clang itself, I've also changed a few things in conf-llvm and conf-libclang:

- updated `conf-libclang.15`: the `arch` depext must now install `llvm15` and `clang15`, as the unsuffixed packages now install v16.
- updated `conf-llvm.14.0.6`: the `arch` depext must now install `llvm14`
- added `conf-llvm.15.0.7` (this is the patchlevel on Arch for package `llvm15`).

Of course, this last point can be removed if this conflicts with #24330

I understand that support for llvm 16 is the subject of PR #23630, hence I haven't tried to touch that.
