### PR TITLE
5 packages from benfaerber/liquid-ml at 0.1.2

### DIFF
--- a/packages/liquid_interpreter/liquid_interpreter.0.1.2/opam
+++ b/packages/liquid_interpreter/liquid_interpreter.0.1.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "The interpreter for Liquid"
+description: """
+The interpreter for Liquid
+"""
+maintainer: "faerberbendev@protonmail.com"
+authors: ["Ben Faerber"]
+homepage: "https://github.com/benfaerber/liquid-ml"
+bug-reports: "https://github.com/benfaerber/liquid-ml/issues"
+dev-repo: "git+https://github.com/benfaerber/liquid-ml.git"
+license: "MIT"
+depends: [
+    "ocaml" { >= "4.11" }
+    "dune" { >= "2.5" }
+    "base" { >= "0.15.0" }
+    "core" { >= "0.15.0" }
+    "stdio" { >= "0.15.0" }
+    "re2" { >= "0.13.0" }
+    "liquid_syntax" { = version }
+    "liquid_parser" { = version }
+    "liquid_std" { = version }
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/benfaerber/liquid-ml/archive/refs/tags/0.1.2.tar.gz"
+  checksum: [
+    "md5=ddfb85944a4604cfe8e614363862f882"
+    "sha512=7a9e4582f8a773e953f6fb124c757a883f4528c130a1fc53c19c74b9a4006e505d4fcf0014393624c8e57c463a96db653e922f951cc88802f552a6fcef7eb097"
+  ]
+}

--- a/packages/liquid_ml/liquid_ml.0.1.2/opam
+++ b/packages/liquid_ml/liquid_ml.0.1.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Shopify's Liquid templating language in OCaml"
+description: """
+Shopify's Liquid templating language for OCaml!
+"""
+maintainer: "faerberbendev@protonmail.com"
+authors: ["Ben Faerber"]
+homepage: "https://github.com/benfaerber/liquid-ml"
+bug-reports: "https://github.com/benfaerber/liquid-ml/issues"
+dev-repo: "git+https://github.com/benfaerber/liquid-ml.git"
+license: "MIT"
+
+depends: [
+    "ocaml" { >= "4.11" }
+    "dune" { >= "2.5" }
+    "base" { >= "0.15.0" }
+    "core" { >= "0.15.0" }
+    "stdio" { >= "0.15.0" }
+    "re2" { >= "0.13.0" }
+    "liquid_syntax" { = version }
+    "liquid_parser" { = version }
+    "liquid_std" { = version }
+    "liquid_interpreter" { = version }
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/benfaerber/liquid-ml/archive/refs/tags/0.1.2.tar.gz"
+  checksum: [
+    "md5=ddfb85944a4604cfe8e614363862f882"
+    "sha512=7a9e4582f8a773e953f6fb124c757a883f4528c130a1fc53c19c74b9a4006e505d4fcf0014393624c8e57c463a96db653e922f951cc88802f552a6fcef7eb097"
+  ]
+}

--- a/packages/liquid_parser/liquid_parser.0.1.2/opam
+++ b/packages/liquid_parser/liquid_parser.0.1.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "The parser for Liquid"
+description: """
+The parser for Liquid
+"""
+maintainer: "faerberbendev@protonmail.com"
+authors: ["Ben Faerber"]
+homepage: "https://github.com/benfaerber/liquid-ml"
+bug-reports: "https://github.com/benfaerber/liquid-ml/issues"
+dev-repo: "git+https://github.com/benfaerber/liquid-ml.git"
+license: "MIT"
+
+depends: [
+    "ocaml" { >= "4.11" }
+    "dune" { >= "2.5" }
+    "base" { >= "0.15.0" }
+    "core" { >= "0.15.0" }
+    "stdio" { >= "0.15.0" }
+    "re2" { >= "0.13.0" }
+    "liquid_syntax" { = version }
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/benfaerber/liquid-ml/archive/refs/tags/0.1.2.tar.gz"
+  checksum: [
+    "md5=ddfb85944a4604cfe8e614363862f882"
+    "sha512=7a9e4582f8a773e953f6fb124c757a883f4528c130a1fc53c19c74b9a4006e505d4fcf0014393624c8e57c463a96db653e922f951cc88802f552a6fcef7eb097"
+  ]
+}

--- a/packages/liquid_std/liquid_std.0.1.2/opam
+++ b/packages/liquid_std/liquid_std.0.1.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "The Standard Libarary for Liquid"
+description: """
+The Standard Libarary for Liquid
+"""
+maintainer: "faerberbendev@protonmail.com"
+authors: ["Ben Faerber"]
+homepage: "https://github.com/benfaerber/liquid-ml"
+bug-reports: "https://github.com/benfaerber/liquid-ml/issues"
+dev-repo: "git+https://github.com/benfaerber/liquid-ml.git"
+license: "MIT"
+depends: [
+    "ocaml" { >= "4.11" }
+    "dune" { >= "2.5" }
+    "base" { >= "0.15.0" }
+    "core" { >= "0.15.0" }
+    "stdio" { >= "0.15.0" }
+    "re2" { >= "0.13.0" }
+    "base64" { >= "3.5.1" }
+    "sha" { >= "1.0" }
+    "liquid_syntax" { = version }
+    "liquid_parser" { = version }
+    "liquid_syntax" { = version }
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/benfaerber/liquid-ml/archive/refs/tags/0.1.2.tar.gz"
+  checksum: [
+    "md5=ddfb85944a4604cfe8e614363862f882"
+    "sha512=7a9e4582f8a773e953f6fb124c757a883f4528c130a1fc53c19c74b9a4006e505d4fcf0014393624c8e57c463a96db653e922f951cc88802f552a6fcef7eb097"
+  ]
+}

--- a/packages/liquid_syntax/liquid_syntax.0.1.2/opam
+++ b/packages/liquid_syntax/liquid_syntax.0.1.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "The Syntax Definitions for Liquid"
+description: """
+The Syntax Definitions for Liquid
+"""
+maintainer: "faerberbendev@protonmail.com"
+authors: ["Ben Faerber"]
+homepage: "https://github.com/benfaerber/liquid-ml"
+bug-reports: "https://github.com/benfaerber/liquid-ml/issues"
+dev-repo: "git+https://github.com/benfaerber/liquid-ml.git"
+license: "MIT"
+depends: [ 
+    "ocaml" { >= "4.11" }
+    "dune" { >= "2.5" }
+    "base" { >= "0.15.0" }
+    "core" { >= "0.15.0" } 
+    "stdio" { >= "0.10.0" } 
+    "re2" { >= "0.13.0" }
+    "batteries" { >= "3.1.0" } 
+    "calendar" { >= "3.0.0"}
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/benfaerber/liquid-ml/archive/refs/tags/0.1.2.tar.gz"
+  checksum: [
+    "md5=ddfb85944a4604cfe8e614363862f882"
+    "sha512=7a9e4582f8a773e953f6fb124c757a883f4528c130a1fc53c19c74b9a4006e505d4fcf0014393624c8e57c463a96db653e922f951cc88802f552a6fcef7eb097"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `liquid_interpreter.0.1.2`: The interpreter for Liquid
- `liquid_ml.0.1.2`: Shopify's Liquid templating language in OCaml
- `liquid_parser.0.1.2`: The parser for Liquid
- `liquid_std.0.1.2`: The Standard Libarary for Liquid
- `liquid_syntax.0.1.2`: The Syntax Definitions for Liquid



---
* Homepage: https://github.com/benfaerber/liquid-ml
* Source repo: git+https://github.com/benfaerber/liquid-ml.git
* Bug tracker: https://github.com/benfaerber/liquid-ml/issues

---
:camel: Pull-request generated by opam-publish v2.2.0