### PR TITLE
[new release] pcre2 (7.5.1)

### DIFF
--- a/packages/pcre2/pcre2.7.5.1/opam
+++ b/packages/pcre2/pcre2.7.5.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis:
+  "Bindings to the Perl Compatibility Regular Expressions library (version 2)"
+description: """
+pcre2-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+maintainer: ["Chet Murthy <chetsky@gmail.com>"]
+authors: ["Markus Mottl <markus.mottl@gmail.com>"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/camlp5/pcre2-ocaml"
+bug-reports: "https://github.com/camlp5/pcre2-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "dune-configurator"
+  "conf-libpcre2-8" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/camlp5/pcre2-ocaml.git"
+url {
+  src:
+    "https://github.com/camlp5/pcre2-ocaml/releases/download/7.5.1/pcre2-7.5.1.tbz"
+  checksum: [
+    "sha256=7d61a944801a9cccc6d1184f1609b463cb242864d24c8d12dea9bfe14ce16977"
+    "sha512=59bbb9fb4caf54b47c38177dd7fdb0a2e6fa06847c3bc225ea0b170b0dbdda1fbe7cc0a62a6b6fcdb8984b58bd077bfc0a154eee1b7c7389932edb320406bb20"
+  ]
+}
+x-commit-hash: "344460e660cf1e2fdccaff3d86410c5e9249cb38"


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library (version 2)

- Project page: <a href="https://github.com/camlp5/pcre2-ocaml">https://github.com/camlp5/pcre2-ocaml</a>

##### CHANGES:

## 7.5.1 (2023-09-01)

* Created pcre2-ocaml bindings based on original pcre-ocaml project
