### PR TITLE
Remove eio upper bound in plist-xml

### DIFF
--- a/packages/plist-xml/plist-xml.0.4.0/opam
+++ b/packages/plist-xml/plist-xml.0.4.0/opam
@@ -19,8 +19,8 @@ depends: [
   "menhir" {>= "20220210"}
   "ocaml" {>= "4.13"}
   "xmlm" {>= "1.4"}
-  "eio" {with-test & >= "0.7" & < "0.12"}
-  "eio_main" {with-test & >= "0.7" & < "0.12"}
+  "eio" {with-test & >= "0.7"}
+  "eio_main" {with-test & >= "0.7"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/plist-xml/plist-xml.0.5.0/opam
+++ b/packages/plist-xml/plist-xml.0.5.0/opam
@@ -19,8 +19,8 @@ depends: [
   "menhir" {>= "20220210"}
   "ocaml" {>= "4.13"}
   "xmlm" {>= "1.4"}
-  "eio" {with-test & >= "0.7" & < "0.12"}
-  "eio_main" {with-test & >= "0.7" & < "0.12"}
+  "eio" {with-test & >= "0.7"}
+  "eio_main" {with-test & >= "0.7"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
I'm pretty sure the upper bound isn't necessary...