### PR TITLE
uunf and uuseg: adjust next Unicode release bounds.

### DIFF
--- a/packages/uunf/uunf.15.0.0/opam
+++ b/packages/uunf/uunf.15.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "1.0.3"}
-  "uucd" {dev & >= "15.0.0" & < "16.0.0"}
+  "uucd" {dev & >= "15.0.0" & < "15.1.0"}
 ]
 depopts: ["uutf" "cmdliner"]
 conflicts: [

--- a/packages/uuseg/uuseg.15.0.0/opam
+++ b/packages/uuseg/uuseg.15.0.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "1.0.3"}
-  "uucp" {>= "15.0.0" & < "16.0.0"}
+  "uucp" {>= "15.0.0" & < "15.1.0"}
 ]
 depopts: ["uutf" "cmdliner"]
 conflicts: [


### PR DESCRIPTION
The next Unicode release is going to be a point release. 

`uucd` and `uucp` follow the Unicode release version numbers so this needs to be adjusted as mentioned.