### PR TITLE
Package tdigest.2.1.3

### DIFF
--- a/packages/tdigest/tdigest.2.1.3/opam
+++ b/packages/tdigest/tdigest.2.1.3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Simon Grondin"
+authors: [
+  "Simon Grondin"
+  "Will Welch"
+]
+synopsis: "OCaml implementation of the T-Digest algorithm"
+description: """
+The T-Digest is a data structure and algorithm for constructing an approximate distribution for a collection of real numbers presented as a stream.
+
+The T-Digest can estimate percentiles or quantiles extremely accurately even at the tails, while using a fraction of the space.
+
+Additionally, the T-Digest is concatenable, making it a good fit for distributed systems. The internal state of a T-Digest can be exported as a binary string, and the concatenation of any number of those strings can then be imported to form a new T-Digest.
+"""
+license: "MIT"
+homepage: "https://github.com/SGrondin/tdigest"
+dev-repo: "git://github.com/SGrondin/tdigest"
+doc: "https://github.com/SGrondin/tdigest"
+bug-reports: "https://github.com/SGrondin/tdigest/issues"
+depends: [
+  "ocaml" { >= "4.10.0" }
+  "dune" { >= "1.9.0" }
+
+  "core" { >= "v0.15.0" & < "v0.17.0" }
+  # "ocamlformat" { = "0.25.1" } # Development
+  # "ocaml-lsp-server" # Development
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/SGrondin/tdigest/archive/refs/tags/2.1.3.tar.gz"
+  checksum: [
+    "md5=60569f9c1605439334f55429d6c4bd9b"
+    "sha512=f6a0eb96f4cad5dabf79ff67397846af8d52230f3e2816860e1211dcf85a9119521a8796ad046426026110820f2b52a76c0728f95fe909ab9b6cc34f97f86882"
+  ]
+}


### PR DESCRIPTION
### `tdigest.2.1.3`
OCaml implementation of the T-Digest algorithm
The T-Digest is a data structure and algorithm for constructing an approximate distribution for a collection of real numbers presented as a stream.

The T-Digest can estimate percentiles or quantiles extremely accurately even at the tails, while using a fraction of the space.

Additionally, the T-Digest is concatenable, making it a good fit for distributed systems. The internal state of a T-Digest can be exported as a binary string, and the concatenation of any number of those strings can then be imported to form a new T-Digest.



---
* Homepage: https://github.com/SGrondin/tdigest
* Source repo: git://github.com/SGrondin/tdigest
* Bug tracker: https://github.com/SGrondin/tdigest/issues

---
:camel: Pull-request generated by opam-publish v2.2.0