### PR TITLE
[new release] lintcstubs-arity (0.2.0)

### DIFF
--- a/packages/lintcstubs-arity/lintcstubs-arity.0.2.0/opam
+++ b/packages/lintcstubs-arity/lintcstubs-arity.0.2.0/opam
@@ -8,7 +8,7 @@ license: "LGPL-2.1-or-later"
 homepage: "https://github.com/edwintorok/lintcstubs-arity"
 bug-reports: "https://github.com/edwintorok/lintcstubs-arity/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "3.0"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]

--- a/packages/lintcstubs-arity/lintcstubs-arity.0.2.0/opam
+++ b/packages/lintcstubs-arity/lintcstubs-arity.0.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Generate headers for C bindings"
+description:
+  "Generates .h files from 'external' declarations in .ml or .cmt files. Can be used to spot mismatches in number of arguments between C primitive declared in OCaml and its implementation in the .c file."
+maintainer: ["Edwin Török <edwin.torok@cloud.com>"]
+authors: ["Edwin Török <edwin.torok@cloud.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/edwintorok/lintcstubs-arity"
+bug-reports: "https://github.com/edwintorok/lintcstubs-arity/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "ocaml-src" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/edwintorok/lintcstubs-arity.git"
+url {
+  src:
+    "https://github.com/edwintorok/lintcstubs-arity/releases/download/0.2.0/lintcstubs-arity-0.2.0.tbz"
+  checksum: [
+    "sha256=444d308068d6fc880e63768e7ac75ef68391dbf3caf47a7c4b05cb3bede95b31"
+    "sha512=1ff82e3e3490a3995b04d06ddf4478f135591f2576f0bee519448f647a4632fe5d8bab8d99daa7819b709e3a165779657b2225d7bd7ed4d0537fe952781a08ea"
+  ]
+}
+x-commit-hash: "362f3f0d44f2f89d70ff9f55c20974b7f9b6d996"

--- a/packages/lintcstubs-arity/lintcstubs-arity.0.2.0/opam
+++ b/packages/lintcstubs-arity/lintcstubs-arity.0.2.0/opam
@@ -25,7 +25,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & os-family != "alpine"}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
Generate headers for C bindings

- Project page: <a href="https://github.com/edwintorok/lintcstubs-arity">https://github.com/edwintorok/lintcstubs-arity</a>

##### CHANGES:

* Add `lintcstubs_arity_cmt` tool that supports generating prototypes for unboxed arguments in primitives (requires OCaml 4.10+)
* Add a README.md that shows how to use the tool and full examples with both `dune` and `Makefile`
* Add a minimal example that shows how to embed/build the tool as part of another project
* Enable tests in the CI
