### PR TITLE
[new release] lintcstubs-arity (0.2.1)

### DIFF
--- a/packages/lintcstubs-arity/lintcstubs-arity.0.2.1/opam
+++ b/packages/lintcstubs-arity/lintcstubs-arity.0.2.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Generate headers for C bindings"
+description:
+  "Generates .h files from 'external' declarations in .ml or .cmt files. Can be used to spot mismatches in number of arguments between C primitive declared in OCaml and its implementation in the .c file."
+maintainer: ["Edwin Török <edwin.torok@cloud.com>"]
+authors: ["Edwin Török <edwin.torok@cloud.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/edwintorok/lintcstubs-arity"
+bug-reports: "https://github.com/edwintorok/lintcstubs-arity/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "ocaml-src" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/edwintorok/lintcstubs-arity.git"
+url {
+  src:
+    "https://github.com/edwintorok/lintcstubs-arity/releases/download/0.2.1/lintcstubs-arity-0.2.1.tbz"
+  checksum: [
+    "sha256=39a8e357ecc08fced6e9020edb0526e57999a0bf833700d6d9f759b85792c49b"
+    "sha512=0a509a862916f541692aed9569dc212b7fcf1c5d1eb08a01d77007c3d211b4e5dcba9f5ddd86689b16149c3799d185d885d768c08e21c1ab153b8831909f6edf"
+  ]
+}
+x-commit-hash: "50f2c6a94cdfd5ed5ce27c7a2c76d67be478d85d"


### PR DESCRIPTION
Generate headers for C bindings

- Project page: <a href="https://github.com/edwintorok/lintcstubs-arity">https://github.com/edwintorok/lintcstubs-arity</a>

##### CHANGES:

* Build fixes and version constraints
