### PR TITLE
Add a TSan backport switch on top of 5.1.0~rc2

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.1.0~rc2+tsan/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~rc2+tsan/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~rc2+tsan/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~rc2+tsan/opam
@@ -1,0 +1,75 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "OCaml 5.1.0 release candidate 2, with ThreadSanitizer support"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://github.com/ocaml/ocaml"
+bug-reports: "https://github.com/ocaml/ocaml"
+dev-repo: "git+https://github.com/ocaml-multicore/ocaml-tsan.git#5.1.0-rc2+tsan"
+depends: [
+  "ocaml" {= "5.1.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build-env: [
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "--enable-tsan"
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml-multicore/ocaml-tsan/archive/5.1.0-rc2+tsan.tar.gz"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+conflicts: [
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-32bit"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+]


### PR DESCRIPTION
This proposes to add the `5.1.0~rc2+tsan` switch. As TSan will not be available until the release of OCaml 5.2, @avsm [suggested](https://github.com/ocaml/ocaml/pull/12114#issuecomment-1570253357) that there be a backport on 5.1, so that people can experiment with TSan without too many package issues.

Currently 5.1 is not released yet, only its 5.1.0~rc2, but having the ability to do `opam switch create 5.1.0~rc2+tsan` would be nice to let people try out TSan at ICFP this week.

When 5.1.0 is released, if there’s agreement, I will propose the same kind of backport.

The pointed compiler revision is simply `5.1.0-rc2` with the TSan PR backported (no significant conflicts to report) and an additional commit to silence a TSan false alarm whose fix did not make it into 5.1.

