### PR TITLE
chamo.3.0 not available

### DIFF
--- a/packages/chamo/chamo.3.0/opam
+++ b/packages/chamo/chamo.3.0/opam
@@ -36,3 +36,4 @@ url {
     "sha512=f5d2980bf67c5e8b98dd8e0d8eaa7fdf96c762c2bc5907d7eba3737978d27dfff76a37cea29d1470a78b77aa0114655a65c723d4eeebad8198d23703294d724d"
   ]
 }
+available: false


### PR DESCRIPTION
```
$ opam source chamo.3.0
[ERROR] Download failed: https://framagit.org/zoggy/chamo/-/archive/3.0/chamo-3.0.tar.bz2 (Bad checksum, expected md5=fbd7d56177cd3e15475403f364bb6086)
```