### PR TITLE
Package readline.0.1

### DIFF
--- a/packages/readline/readline.0.1/opam
+++ b/packages/readline/readline.0.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://gitlab.inria.fr/vtourneu/readline-ocaml/issues"
 depends: [
   "dune" {>= "3.7"}
   "ocaml" {>= "4.14"}
-  "conf-readline" {>= "1.1"}
+  "conf-readline" {>= "1"}
   "odoc" {with-doc}
 ]
 build: [
@@ -29,7 +29,7 @@ dev-repo: "git+https://gitlab.inria.fr/vtourneu/readline-ocaml.git"
 url {
   src: "https://pimo.id/6a69c6dd/readline-0.1.tar.gz"
   checksum: [
-    "md5=46f97d3a6e6d1ad21cfac2400815e4fa"
-    "sha512=f8bcdc95816238a9b9ada25186e74566ebca103fe30484e6e1eebeeaaaebf278621906c8f6a49938e01962af2d187929e476e2341142be97d3c7e7c3659105de"
+    "md5=7eff44c6ab2f3232345e3394a73ef58f"
+    "sha512=04e43fb7b386fee972ccc544b863dc257770049ff705e2faefd3a9c6a992f4a5b6ebd32a6347ea30903618343eab41db958829c263ea01dcc09a42208a3d4abd"
   ]
 }

--- a/packages/readline/readline.0.1/opam
+++ b/packages/readline/readline.0.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://gitlab.inria.fr/vtourneu/readline-ocaml/issues"
 depends: [
   "dune" {>= "3.7"}
   "ocaml" {>= "4.14"}
-  "conf-readline" {>= "0.0"}
+  "conf-readline"
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/readline/readline.0.1/opam
+++ b/packages/readline/readline.0.1/opam
@@ -29,7 +29,7 @@ dev-repo: "git+https://gitlab.inria.fr/vtourneu/readline-ocaml.git"
 url {
   src: "https://pimo.id/6a69c6dd/readline-0.1.tar.gz"
   checksum: [
-    "md5=4c4d634bc03adf9c879ad7c28db4d32f"
-    "sha512=dba1460d2f539714ab37ae38df8e9cc53fc389b176144575834f5db2646b06c107f979136db2a6728ff63ac01b1b7291e909f191aaa1ad04d98cc9cf51d3c6f8"
+    "md5=46f97d3a6e6d1ad21cfac2400815e4fa"
+    "sha512=f8bcdc95816238a9b9ada25186e74566ebca103fe30484e6e1eebeeaaaebf278621906c8f6a49938e01962af2d187929e476e2341142be97d3c7e7c3659105de"
   ]
 }

--- a/packages/readline/readline.0.1/opam
+++ b/packages/readline/readline.0.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for GNU readline"
+maintainer: ["vincent.tourneur@inria.fr"]
+authors: ["Sylvain Pogodalla" "Vincent Tourneur"]
+license: "CeCILL-2.0+"
+homepage: "https://gitlab.inria.fr/vtourneu/readline-ocaml"
+bug-reports: "https://gitlab.inria.fr/vtourneu/readline-ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.14"}
+  "conf-readline" {>= "0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.inria.fr/vtourneu/readline-ocaml.git"
+url {
+  src: "https://pimo.id/6a69c6dd/readline-0.1.tar.gz"
+  checksum: [
+    "md5=4c4d634bc03adf9c879ad7c28db4d32f"
+    "sha512=dba1460d2f539714ab37ae38df8e9cc53fc389b176144575834f5db2646b06c107f979136db2a6728ff63ac01b1b7291e909f191aaa1ad04d98cc9cf51d3c6f8"
+  ]
+}

--- a/packages/readline/readline.0.1/opam
+++ b/packages/readline/readline.0.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://gitlab.inria.fr/vtourneu/readline-ocaml/issues"
 depends: [
   "dune" {>= "3.7"}
   "ocaml" {>= "4.14"}
-  "conf-readline"
+  "conf-readline" {>= "1.1"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
### `readline.0.1`
OCaml bindings for GNU readline



---
* Homepage: https://gitlab.inria.fr/vtourneu/readline-ocaml
* Source repo: git+https://gitlab.inria.fr/vtourneu/readline-ocaml.git
* Bug tracker: https://gitlab.inria.fr/vtourneu/readline-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.2.0