### PR TITLE
[new release] lz4 (1.3.0)

### DIFF
--- a/packages/lz4/lz4.1.3.0/opam
+++ b/packages/lz4/lz4.1.3.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Bindings to the LZ4 compression algorithm"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/whitequark/ocaml-lz4"
+doc: "https://whitequark.github.io/ocaml-lz4/"
+bug-reports: "https://github.com/whitequark/ocaml-lz4/issues"
+dev-repo: "git+https://github.com/whitequark/ocaml-lz4.git"
+tags: [ "lz4" "compression" "decompression" ]
+build: [
+  ["dune" "build" "@install" "-j" jobs "-p" name]
+  ["dune" "runtest" "-j" jobs "-p" name] {with-test}
+  ["dune" "build" "@doc" "-j" jobs "-p" name] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "conf-liblz4"
+  "dune" { >= "2.0" }
+  "dune-configurator"
+  "ctypes" {>= "0.4.1"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+url {
+  src:
+    "https://github.com/whitequark/ocaml-lz4/releases/download/v1.3.0/lz4-1.3.0.tbz"
+  checksum: [
+    "sha256=3cbbd2003916442d8ec797e48f0c8433e1a50e98c549777ad0de2e0fb774248e"
+    "sha512=54859f27d4b7c9d60be056951f0dd8617fabe7400c0a35842bb65c7f795d1859dbfec678ceea82f9c3d3521f97e7b049d06553a21a70d50d8ba69c83d4031290"
+  ]
+}
+x-commit-hash: "029464669ea4c1c23669e3e39d55b417e06a3978"


### PR DESCRIPTION
Bindings to the LZ4 compression algorithm

- Project page: <a href="https://github.com/whitequark/ocaml-lz4">https://github.com/whitequark/ocaml-lz4</a>
- Documentation: <a href="https://whitequark.github.io/ocaml-lz4/">https://whitequark.github.io/ocaml-lz4/</a>

##### CHANGES:

- Use pkg-config via dune-configurator to find lz4
- add missing ctypes.stubs lib dep
- fix deprecation warning
