### PR TITLE
reason-react: add upper bound to `reason` dep

### DIFF
--- a/packages/melange/melange.1.0.0/opam
+++ b/packages/melange/melange.1.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dune-build-info"
   "cppo" {build}
   "ounit" {with-test}
-  "reason" {with-test}
+  "reason" {with-test & < "3.10.0"}
   "ppxlib" {>= "0.24.0"}
   "menhir" {>= "20201214"}
   "reactjs-jsx-ppx" {with-test}

--- a/packages/reason-react/reason-react.0.11.0/opam
+++ b/packages/reason-react/reason-react.0.11.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.13.0"}
   "melange" {>= "1.0.0" & < "2.0.0"}
   "reactjs-jsx-ppx"
-  "reason" {>= "3.6.0"}
+  "reason" {>= "3.6.0" & < "3.10.0"}
   "ocaml-lsp-server" {with-test}
   "opam-check-npm-deps" {= "1.0.0" & with-dev-setup}
   "odoc" {with-doc}


### PR DESCRIPTION
The next version of the `reason` package will include a change that might break users of `reason-react`: https://github.com/reasonml/reason/pull/2721. 

This PR adds an upper bound in advance, to prevent any future issues.

cc @anmonteiro @davesnx.