### PR TITLE
[new release] pcre2 (7.5.2)

### DIFF
--- a/packages/pcre2/pcre2.7.5.2/opam
+++ b/packages/pcre2/pcre2.7.5.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "Bindings to the Perl Compatibility Regular Expressions library (version 2)"
+description: """
+pcre2-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+maintainer: ["Chet Murthy <chetsky@gmail.com>"]
+authors: ["Markus Mottl <markus.mottl@gmail.com>"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/camlp5/pcre2-ocaml"
+bug-reports: "https://github.com/camlp5/pcre2-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "dune-configurator"
+  "conf-libpcre2-8" {build}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/camlp5/pcre2-ocaml.git"
+url {
+  src:
+    "https://github.com/camlp5/pcre2-ocaml/releases/download/7.5.2/pcre2-7.5.2.tbz"
+  checksum: [
+    "sha256=da3b9a6e566707c64ab78468fb4c453e930716740e3ae911566f6a378d0562c8"
+    "sha512=951205a368cb6b613f89cc3b20384786d972fb8f91b9ccef907f90f55568fb33a2e3df4a54dc7ea28811f192c328798503c4361a32ba29aa1b145de54a487b43"
+  ]
+}
+x-commit-hash: "c6e88b9aa567ad444ef999b9b101ae5041f4be0b"


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library (version 2)

- Project page: <a href="https://github.com/camlp5/pcre2-ocaml">https://github.com/camlp5/pcre2-ocaml</a>

##### CHANGES:

## 7.5.2 (2023-09-06)

* fixed bug in `full_split`, added first unit-test for same

## 7.5.1 (2023-09-01)

* Created pcre2-ocaml bindings based on original pcre-ocaml project
