### PR TITLE
[new release] bare_encoding (0.3.1)

### DIFF
--- a/packages/bare_encoding/bare_encoding.0.3.1/opam
+++ b/packages/bare_encoding/bare_encoding.0.3.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "BARE encoding, see https://baremessages.org/"
+maintainer: ["simon cruanes"]
+authors: ["simon cruanes"]
+license: "MIT"
+tags: ["encoding" "binary" "bare"]
+homepage: "https://github.com/c-cube/bare-ocaml"
+bug-reports: "https://github.com/c-cube/bare-ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08"}
+  "qcheck-core" {with-test & >= "0.20"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/bare-ocaml.git"
+url {
+  src:
+    "https://github.com/c-cube/bare-ocaml/releases/download/v0.3.1/bare_encoding-0.3.1.tbz"
+  checksum: [
+    "sha256=29c842dc6ed864345c8c7ff601fa6bdae53a50000ff5342cd8ace4d3d0021ba6"
+    "sha512=2785df62a58786dd8ca68c9c1fb1cb0dcc8a8b3dfd9f79a3cad201f5870718ea8524ce3b4bf3dbbab06d3b63733deb2100bf712f730772be1ee1c5a6dabba402"
+  ]
+}
+x-commit-hash: "cd99002d6d81205b2c1f7f26c52f02d483b02611"


### PR DESCRIPTION
BARE encoding, see https://baremessages.org/

- Project page: <a href="https://github.com/c-cube/bare-ocaml">https://github.com/c-cube/bare-ocaml</a>

##### CHANGES:

- bugfix in codegen of pretty printers
- modernize build and tests
