### PR TITLE
Batteries 3.7 upper bounds

### DIFF
--- a/packages/acpc/acpc.1.0/opam
+++ b/packages/acpc/acpc.1.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml"
   "obuild" {build}
   "base-unix"
-  "batteries"
+  "batteries" {< "3.7"}
   "dolog" {= "0.6"}
   "vector3"
   "parmap"

--- a/packages/acpc/acpc.1.1.1/opam
+++ b/packages/acpc/acpc.1.1.1/opam
@@ -23,7 +23,7 @@ depends: [
   "bitv"
   "obuild" {build}
   "base-unix"
-  "batteries"
+  "batteries" {< "3.7"}
   "dolog" {< "4.0.0"}
   "vector3"
   "parmap"

--- a/packages/acpc/acpc.1.1/opam
+++ b/packages/acpc/acpc.1.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml"
   "obuild" {build}
   "base-unix"
-  "batteries"
+  "batteries" {< "3.7"}
   "dolog" {= "0.6"}
   "vector3"
   "parmap"

--- a/packages/acpc/acpc.1.2.1/opam
+++ b/packages/acpc/acpc.1.2.1/opam
@@ -42,7 +42,7 @@ depends: [
   "ocaml" {>= "4.00.1"}
   "obuild" {build}
   "base-unix"
-  "batteries"
+  "batteries" {< "3.7"}
   "dolog" {> "0.6" & < "4.0.0"}
   "vector3"
   "parmap"

--- a/packages/acpc/acpc.1.2.2/opam
+++ b/packages/acpc/acpc.1.2.2/opam
@@ -42,7 +42,7 @@ depends: [
   "ocaml" {>= "4.00.1"}
   "obuild" {build}
   "base-unix"
-  "batteries"
+  "batteries" {< "3.7"}
   "dolog" {> "0.6" & < "4.0.0"}
   "vector3"
   "parmap"

--- a/packages/acpc/acpc.1.2.3/opam
+++ b/packages/acpc/acpc.1.2.3/opam
@@ -42,7 +42,7 @@ depends: [
   "ocaml" {>= "4.00.1"}
   "obuild" {build}
   "base-unix"
-  "batteries"
+  "batteries" {< "3.7"}
   "dolog" {< "4.0.0"}
   "fileutils"
   "vector3"

--- a/packages/acpc/acpc.1.2/opam
+++ b/packages/acpc/acpc.1.2/opam
@@ -42,7 +42,7 @@ depends: [
   "ocaml" {>= "4.00.1"}
   "obuild" {build}
   "base-unix"
-  "batteries"
+  "batteries" {< "3.7"}
   "dolog" {= "0.6"}
   "vector3"
   "parmap"

--- a/packages/cpm/cpm.1.0.0/opam
+++ b/packages/cpm/cpm.1.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {> "3.12.1"}
   "ocamlfind"
   "obuild" {build}
-  "batteries"
+  "batteries" {< "3.7"}
 ]
 synopsis:
   "Classification Performance Metrics library (ROC AUC, BEDROC AUC, EF, PM, etc.)"

--- a/packages/cpm/cpm.2.0.0/opam
+++ b/packages/cpm/cpm.2.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {> "3.12.1"}
   "ocamlfind"
   "obuild" {build}
-  "batteries"
+  "batteries" {< "3.7"}
 ]
 synopsis:
   "Classification Performance Metrics library (ROC AUC, BEDROC AUC, EF, PM, etc.)"

--- a/packages/cpm/cpm.3.0.0/opam
+++ b/packages/cpm/cpm.3.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {> "3.12.1"}
   "ocamlfind"
   "obuild" {build}
-  "batteries"
+  "batteries" {< "3.7"}
 ]
 synopsis:
   "Classification Performance Metrics library (ROC AUC, BEDROC AUC, EF, PM, etc.)"

--- a/packages/daft/daft.0.0.2/opam
+++ b/packages/daft/daft.0.0.2/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml"
   "obuild" {build}
   "dolog" {< "4.0.0"}
-  "batteries"
+  "batteries" {< "3.7"}
   "fileutils" {< "0.5.0"}
   "zmq" {< "5.1.4"}
   "cryptokit"

--- a/packages/daft/daft.0.0.3/opam
+++ b/packages/daft/daft.0.0.3/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml"
   "obuild" {build}
   "dolog" {>= "4.0.0" & < "5.0.0"}
-  "batteries"
+  "batteries" {< "3.7"}
   "fileutils"
   "zmq" {>= "5.0.0" & < "5.1.4"}
   "cryptokit"

--- a/packages/get_line/get_line.1.0.0/opam
+++ b/packages/get_line/get_line.1.0.0/opam
@@ -18,7 +18,7 @@ remove: [
 depends: [
   "ocaml"
   "obuild" {build}
-  "batteries"
+  "batteries" {< "3.7"}
 ]
 synopsis: "output line at index i from file f (or a range of lines)"
 flags: light-uninstall

--- a/packages/get_line/get_line.2.1.0/opam
+++ b/packages/get_line/get_line.2.1.0/opam
@@ -20,7 +20,7 @@ depends: [
   "obuild" {build}
   "core" {< "v0.9"}
   "core_kernel" {< "v0.9"}
-  "batteries"
+  "batteries" {< "3.7"}
 ]
 synopsis: "output line at index i from file f (or a range of lines)"
 flags: light-uninstall

--- a/packages/get_line/get_line.2.1.1/opam
+++ b/packages/get_line/get_line.2.1.1/opam
@@ -18,7 +18,7 @@ remove: [
 depends: [
   "ocaml"
   "obuild" {build}
-  "batteries" {>= "2.6.0"}
+  "batteries" {>= "2.6.0" & < "3.7"}
 ]
 synopsis: "output line at index i from file f (or a range of lines)"
 flags: light-uninstall

--- a/packages/get_line/get_line.3.0.0/opam
+++ b/packages/get_line/get_line.3.0.0/opam
@@ -18,7 +18,7 @@ remove: [
 depends: [
   "ocaml"
   "obuild" {build}
-  "batteries" {>= "2.6.0"}
+  "batteries" {>= "2.6.0" & < "3.7"}
 ]
 synopsis: "output line at index i from file f (or a range of lines)"
 flags: light-uninstall

--- a/packages/pb-plugin/pb-plugin.1.0.0/opam
+++ b/packages/pb-plugin/pb-plugin.1.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "pb"
   "dune" {>= "1.11"}
   "integers"
-  "batteries"
+  "batteries" {< "3.7"}
   "angstrom" {>= "0.10.0"}
   "faraday"
   "ounit" {with-test & >= "2.0"}


### PR DESCRIPTION
It seems that in all cases the failure is related to the use of `obuild`.
Adding a conflict with obuild or batteries in either package seems overkill, instead I have added upper bounds on the packages that failed to build.

Failures were seen in https://github.com/ocaml/opam-repository/pull/24327