### PR TITLE
[new release] tar (4 packages) (2.6.0)

### DIFF
--- a/packages/tar-eio/tar-eio.2.6.0/opam
+++ b/packages/tar-eio/tar-eio.2.6.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files using Eio"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library uses Eio to provide a portable tar library.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "eio" {>= "0.10.0" & < "0.12"}
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.6.0/tar-2.6.0.tbz"
+  checksum: [
+    "sha256=caff0cb7046343e2bff7fc0f9217e4e31235555e4c4889fb194792985b6fb1ee"
+    "sha512=61cedd25de48cfa8092b4e03e275139ff27aa36f3e24f936bc90e2974e3c52b2460db214b3f8480c6d45bbc59bf2232623dd840b4ce445077393a71e0d005903"
+  ]
+}
+x-commit-hash: "b5503192b0d6141680a1fa802a8ca52017ebb0d7"

--- a/packages/tar-mirage/tar-mirage.2.6.0/opam
+++ b/packages/tar-mirage/tar-mirage.2.6.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Read and write tar format files via MirageOS interfaces"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library is functorised over external OS dependencies
+to facilitate embedding within MirageOS.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.9.0"}
+  "lwt" {>= "5.6.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "mirage-kv" {>= "6.0.0"}
+  "optint"
+  "ptime"
+  "tar" {= version}
+  "mirage-block-unix" {with-test & >= "2.13.0"}
+  "mirage-clock-unix" {with-test & >= "4.0.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "alcotest-lwt" {>= "1.7.0" & with-test}
+  "tar-unix" {with-test & = version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.6.0/tar-2.6.0.tbz"
+  checksum: [
+    "sha256=caff0cb7046343e2bff7fc0f9217e4e31235555e4c4889fb194792985b6fb1ee"
+    "sha512=61cedd25de48cfa8092b4e03e275139ff27aa36f3e24f936bc90e2974e3c52b2460db214b3f8480c6d45bbc59bf2232623dd840b4ce445077393a71e0d005903"
+  ]
+}
+x-commit-hash: "b5503192b0d6141680a1fa802a8ca52017ebb0d7"

--- a/packages/tar-unix/tar-unix.2.6.0/opam
+++ b/packages/tar-unix/tar-unix.2.6.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files from Unix"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library provides a Unix or Windows compatible interface.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "lwt"
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.6.0/tar-2.6.0.tbz"
+  checksum: [
+    "sha256=caff0cb7046343e2bff7fc0f9217e4e31235555e4c4889fb194792985b6fb1ee"
+    "sha512=61cedd25de48cfa8092b4e03e275139ff27aa36f3e24f936bc90e2974e3c52b2460db214b3f8480c6d45bbc59bf2232623dd840b4ce445077393a71e0d005903"
+  ]
+}
+x-commit-hash: "b5503192b0d6141680a1fa802a8ca52017ebb0d7"

--- a/packages/tar/tar.2.6.0/opam
+++ b/packages/tar/tar.2.6.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files in pure OCaml"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "camlp-streams"
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "decompress" {>= "1.5.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.6.0/tar-2.6.0.tbz"
+  checksum: [
+    "sha256=caff0cb7046343e2bff7fc0f9217e4e31235555e4c4889fb194792985b6fb1ee"
+    "sha512=61cedd25de48cfa8092b4e03e275139ff27aa36f3e24f936bc90e2974e3c52b2460db214b3f8480c6d45bbc59bf2232623dd840b4ce445077393a71e0d005903"
+  ]
+}
+x-commit-hash: "b5503192b0d6141680a1fa802a8ca52017ebb0d7"


### PR DESCRIPTION
Decode and encode tar format files in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-tar">https://github.com/mirage/ocaml-tar</a>
- Documentation: <a href="https://mirage.github.io/ocaml-tar/">https://mirage.github.io/ocaml-tar/</a>

##### CHANGES:

- Add eio backend for tar in `tar-eio` (@patricoferris, review by @talex5, @reynir, mirage/ocaml-tar#132)
- Also apply backwards compatibility fix when GNU LongName is used.
  The compatibility fix is unfortunately also applied for unknown-to-ocaml-tar link indicators (reported by @gravicappa in mirage/ocaml-tar#129, @reynir, mirage/ocaml-tar#133)
