### PR TITLE
[new release] semver (0.2.0)

### DIFF
--- a/packages/semver/semver.0.2.0/opam
+++ b/packages/semver/semver.0.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Semantic Versioning (semver) library"
+description:
+  "Semver is a lightweight library for parsing, comparing, and manipulating version identifiers in 3 parts such as \"1.2.3\". \"Semver\" stands for Semantic Versioning and refers to the standard documented at https://semver.org/. This library is independent from the opam package named \"semver2\"."
+maintainer: ["Rudi Grinberg" "Martin Jambon"]
+authors: ["Tikhon Jelvis" "Rudi Grinberg"]
+license: "BSD-3-Clause"
+tags: ["semver" "semantic versioning" "version"]
+homepage: "https://github.com/rgrinberg/ocaml-semver"
+doc: "https://rgrinberg.github.io/ocaml-semver"
+bug-reports: "https://github.com/rgrinberg/ocaml-semver/issues"
+depends: [
+  "alcotest" {with-test}
+  "dune"
+  "ocaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/rgrinberg/ocaml-semver.git"
+url {
+  src:
+    "https://github.com/rgrinberg/ocaml-semver/releases/download/0.2.0/semver-0.2.0.tbz"
+  checksum: [
+    "sha256=68cdaea4c4d8f3071a93ab1adff99951c95fe1dc01a5fa5d2ee384d22525dad9"
+    "sha512=a12a102481cab6ac511345287e199433300cb8c3f19d095095eeba7140a70d783cd3d4b8146d8b41df64ca7257ce610b8debf9c86ccf160d00e71f27fef6bee9"
+  ]
+}
+x-commit-hash: "49a81a10efa7416607e15522faf3e8fda3d29e34"


### PR DESCRIPTION
Semantic Versioning (semver) library

- Project page: <a href="https://github.com/rgrinberg/ocaml-semver">https://github.com/rgrinberg/ocaml-semver</a>
- Documentation: <a href="https://rgrinberg.github.io/ocaml-semver">https://rgrinberg.github.io/ocaml-semver</a>

##### CHANGES:

* Migrated of the build system from Oasis/Ocamlbuild to Dune.
* Migrated of the test framework from OUnit to Alcotest.
* Added the `Semver.equal` function.
* Fixed `Semver.query` and `Semver.query_str`.
