### PR TITLE
[new release] ppx_yojson (1.3.0)

### DIFF
--- a/packages/ppx_yojson/ppx_yojson.1.3.0/opam
+++ b/packages/ppx_yojson/ppx_yojson.1.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "PPX extension for Yojson literals and patterns"
+maintainer: ["Nathan Rebours <nathan.p.rebours@gmail.com>"]
+authors: ["Nathan Rebours <nathan.p.rebours@gmail.com>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/NathanReb/ppx_yojson"
+bug-reports: "https://github.com/NathanReb/ppx_yojson/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "alcotest" {with-test}
+  "ppxlib" {>= "0.18.0"}
+  "ppxlib" {with-test & >= "0.26.0"}
+  "ezjsonm" {with-test}
+  "yojson" {with-test & >= "1.6.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/NathanReb/ppx_yojson.git"
+url {
+  src:
+    "https://github.com/NathanReb/ppx_yojson/releases/download/1.3.0/ppx_yojson-1.3.0.tbz"
+  checksum: [
+    "sha256=df1b4246969d6e1e2ff53c4c41a674c9653f214d93ad1421788ba55cf539266f"
+    "sha512=a4b5663ee2dec0c0fe0dc3e4f5ec59a1d23e057c1759c2433b45318c3a64f709e7e3ab91c98b9a4e1e5c9e3290a2772f5b7450ecf58f6280e52df033a60d877a"
+  ]
+}
+x-commit-hash: "af82d6016516fc5f9f57adf0ecf1c8a51b5f7f9c"


### PR DESCRIPTION
PPX extension for Yojson literals and patterns

- Project page: <a href="https://github.com/NathanReb/ppx_yojson">https://github.com/NathanReb/ppx_yojson</a>

##### CHANGES:

### Added

- Add support for `[@as "field_name"]` attribute to allow forbidden
  ocaml record field names, such as capitalized words, to be used as JSON
  objects field names (NathanReb/ppx_yojson#40, @mefyl)

### Changed

- Ignore leading underscores in object field names allowing use
  of ocaml keywords such as `type` or `object` as JSON objects field names
  (NathanReb/ppx_yojson#40, @mefyl)
