### PR TITLE
[new release] lintcstubs-arity (0.2.2)

### DIFF
--- a/packages/lintcstubs-arity/lintcstubs-arity.0.2.2/opam
+++ b/packages/lintcstubs-arity/lintcstubs-arity.0.2.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Generate headers for C bindings"
+description:
+  "Generates .h files from 'external' declarations in .ml or .cmt files. Can be used to spot mismatches in number of arguments between C primitive declared in OCaml and its implementation in the .c file."
+maintainer: ["Edwin Török <edwin.torok@cloud.com>"]
+authors: ["Edwin Török <edwin.torok@cloud.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/edwintorok/lintcstubs-arity"
+bug-reports: "https://github.com/edwintorok/lintcstubs-arity/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "ocaml-src" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/edwintorok/lintcstubs-arity.git"
+url {
+  src:
+    "https://github.com/edwintorok/lintcstubs-arity/releases/download/0.2.2/lintcstubs-arity-0.2.2.tbz"
+  checksum: [
+    "sha256=8404776464f04fa0fd324c0b5f7ec1529438d3097c867882319b7076d609288e"
+    "sha512=b80dcd892a7e9d068c8980d361e86a55c061e3b4b2504b85239df43fcaea60163144afdf42c92c4a76fee773e0431a86e5fa51be3478e3549f8b31dee1ccd540"
+  ]
+}
+x-commit-hash: "55a505a50d0833421185abd4dfb31bd9e2842488"


### PR DESCRIPTION
Generate headers for C bindings

- Project page: <a href="https://github.com/edwintorok/lintcstubs-arity">https://github.com/edwintorok/lintcstubs-arity</a>

##### CHANGES:

* Drop extra _XOPEN_SOURCE define that is not necessary in general
