### PR TITLE
[new release] lintcstubs (2 packages) (0.3.2)

### DIFF
--- a/packages/lintcstubs-arity/lintcstubs-arity.0.2.2/opam
+++ b/packages/lintcstubs-arity/lintcstubs-arity.0.2.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Generate headers for C bindings"
+description:
+  "Generates .h files from 'external' declarations in .ml or .cmt files. Can be used to spot mismatches in number of arguments between C primitive declared in OCaml and its implementation in the .c file."
+maintainer: ["Edwin Török <edwin.torok@cloud.com>"]
+authors: ["Edwin Török <edwin.torok@cloud.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/edwintorok/lintcstubs-arity"
+bug-reports: "https://github.com/edwintorok/lintcstubs-arity/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "ocaml-src" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/edwintorok/lintcstubs-arity.git"
+url {
+  src:
+    "https://github.com/edwintorok/lintcstubs-arity/releases/download/0.2.2/lintcstubs-arity-0.2.2.tbz"
+  checksum: [
+    "sha256=8404776464f04fa0fd324c0b5f7ec1529438d3097c867882319b7076d609288e"
+    "sha512=b80dcd892a7e9d068c8980d361e86a55c061e3b4b2504b85239df43fcaea60163144afdf42c92c4a76fee773e0431a86e5fa51be3478e3549f8b31dee1ccd540"
+  ]
+}
+x-commit-hash: "55a505a50d0833421185abd4dfb31bd9e2842488"

--- a/packages/lintcstubs-gen/lintcstubs-gen.0.3.3/opam
+++ b/packages/lintcstubs-gen/lintcstubs-gen.0.3.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "OCaml C stub wrapper generator"
+description:
+  "Generates a C model for how OCaml C primitives can be called. Link with a C model of the OCaml runtime, or run a static analyzer to find incorrect API/macro usage that leads to race conditions."
+maintainer: ["Edwin Török <edwin.torok@cloud.com>"]
+authors: ["Edwin Török <edwin.torok@cloud.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/edwintorok/lintcstubs"
+bug-reports: "https://github.com/edwintorok/lintcstubs/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.14"}
+  "lintcstubs-arity" {>= "0.2.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/edwintorok/lintcstubs.git"
+url {
+  src:
+    "https://github.com/edwintorok/lintcstubs/releases/download/0.3.3/lintcstubs-0.3.3.tbz"
+  checksum: [
+    "sha256=cdd597bdabdad3e6b3b189d4b132ccf62cfd07a60d44708e1c7bcf233020987a"
+    "sha512=ae835149ea5311267dd6ccca42a03e636858c02c6b1a8fecdcac0abced3f80fd3f467e729f1ac88bd1e7c72f6e596731f880708d42f2dfd92b73a3e3116d5d66"
+  ]
+}
+x-commit-hash: "71ec385e8380f7a71238f336350ca20052094c21"

--- a/packages/lintcstubs/lintcstubs.0.3.3/opam
+++ b/packages/lintcstubs/lintcstubs.0.3.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "OCaml C stub static analyzer"
+description:
+  "Uses a generated C model for how OCaml C primitives can be called. Run a static analyzer to find incorrect API/macro usage that leads to race conditions."
+maintainer: ["Edwin Török <edwin.torok@cloud.com>"]
+authors: ["Edwin Török <edwin.torok@cloud.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/edwintorok/lintcstubs"
+bug-reports: "https://github.com/edwintorok/lintcstubs/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.14"}
+  "lintcstubs-gen" {= version}
+  "goblint" {>= "2.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/edwintorok/lintcstubs.git"
+url {
+  src:
+    "https://github.com/edwintorok/lintcstubs/releases/download/0.3.3/lintcstubs-0.3.3.tbz"
+  checksum: [
+    "sha256=cdd597bdabdad3e6b3b189d4b132ccf62cfd07a60d44708e1c7bcf233020987a"
+    "sha512=ae835149ea5311267dd6ccca42a03e636858c02c6b1a8fecdcac0abced3f80fd3f467e729f1ac88bd1e7c72f6e596731f880708d42f2dfd92b73a3e3116d5d66"
+  ]
+}
+x-commit-hash: "71ec385e8380f7a71238f336350ca20052094c21"


### PR DESCRIPTION
OCaml C stub static analyzer

- Project page: <a href="https://github.com/edwintorok/lintcstubs">https://github.com/edwintorok/lintcstubs</a>

##### CHANGES:

* Fix 32-bit and bytecode-only compatibility
