### PR TITLE
Package SZXX.4.0.1

### DIFF
--- a/packages/SZXX/SZXX.4.0.1/opam
+++ b/packages/SZXX/SZXX.4.0.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Asemio"
+authors: [
+  "Simon Grondin"
+]
+synopsis: "Streaming ZIP XML XLSX parser"
+description: """
+SZXX is a streaming and efficient XLSX, ZIP and XML parser built from the ground up for low and constant memory usage (<10Mb).
+SZXX is able to output XLSX rows while reading from a network socket without buffering any part of the file.
+It can also stream data (including network sockets) out of ZIP and XML files without buffering.
+"""
+license: "MIT"
+tags: ["Stream" "Streaming" "Excel" "ZIP" "XML" "XLSX"]
+homepage: "https://github.com/asemio/SZXX"
+dev-repo: "git://github.com/asemio/SZXX"
+doc: "https://github.com/asemio/SZXX"
+bug-reports: "https://github.com/asemio/SZXX/issues"
+depends: [
+  "ocaml" { >= "5.0.0" }
+  "dune" { >= "1.9.0" }
+
+  "angstrom" { >= "0.15.0" }
+  "core" { >= "v0.16.0" }
+  "decompress" { >= "1.4.1" }
+  "eio_main" { >= "0.12" }
+
+  "alcotest" { with-test }
+  "yojson" { with-test }
+  "ppx_deriving_yojson" { >= "3.5.2" & with-test }
+  # "ocamlformat" { = "0.25.1" } # Development
+  # "ocaml-lsp-server" # Development
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/asemio/SZXX/archive/refs/tags/4.0.1.tar.gz"
+  checksum: [
+    "md5=7899596c5da8013a459bf72a552eff98"
+    "sha512=f2addbe9243c04a7dd21d41972960ecd08c89c9071e1ba0bedac059c198426249c7f3543bead551eb7075403086e9a01c97dcf2263959ecdd978c5e76a4d8235"
+  ]
+}


### PR DESCRIPTION
### `SZXX.4.0.1`
Streaming ZIP XML XLSX parser
SZXX is a streaming and efficient XLSX, ZIP and XML parser built from the ground up for low and constant memory usage (<10Mb).
SZXX is able to output XLSX rows while reading from a network socket without buffering any part of the file.
It can also stream data (including network sockets) out of ZIP and XML files without buffering.



---
* Homepage: https://github.com/asemio/SZXX
* Source repo: git://github.com/asemio/SZXX
* Bug tracker: https://github.com/asemio/SZXX/issues

---
:camel: Pull-request generated by opam-publish v2.2.0