### PR TITLE
[new release] lintcstubs-arity (0.4.0)

### DIFF
--- a/packages/lintcstubs-arity/lintcstubs-arity.0.4.0/opam
+++ b/packages/lintcstubs-arity/lintcstubs-arity.0.4.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Generate headers for C bindings"
+description:
+  "Generates .h files from 'external' declarations in .ml or .cmt files. Can be used to spot mismatches in number of arguments between C primitive declared in OCaml and its implementation in the .c file."
+maintainer: ["Edwin Török <edwin.torok@cloud.com>"]
+authors: ["Edwin Török <edwin.torok@cloud.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/edwintorok/lintcstubs-arity"
+bug-reports: "https://github.com/edwintorok/lintcstubs-arity/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "ocaml-src" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/edwintorok/lintcstubs-arity.git"
+url {
+  src:
+    "https://github.com/edwintorok/lintcstubs-arity/releases/download/0.4.0/lintcstubs-arity-0.4.0.tbz"
+  checksum: [
+    "sha256=730d239b258a0b0ad5ec50bdbfb5061fc0d2a33894a2a5c471766668cb7c5354"
+    "sha512=9c332af38626c1f2efa035059fa9605a182f1fad91a3beb1fae1615e05d4568506f3bfd3e5cc3002bdb1b453ad0700604c21e96d06393b4dead4998fb50ac4d0"
+  ]
+}
+x-commit-hash: "72c27f33e64c3e34cbc2e795c9308fe7a5176f9c"


### PR DESCRIPTION
Generate headers for C bindings

- Project page: <a href="https://github.com/edwintorok/lintcstubs-arity">https://github.com/edwintorok/lintcstubs-arity</a>

##### CHANGES:

* Backport to Dune 2.7
