### PR TITLE
[new release] lintcstubs-arity (0.4.1)

### DIFF
--- a/packages/lintcstubs-arity/lintcstubs-arity.0.4.1/opam
+++ b/packages/lintcstubs-arity/lintcstubs-arity.0.4.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Generate headers for C bindings"
+description:
+  "Generates .h files from 'external' declarations in .ml or .cmt files. Can be used to spot mismatches in number of arguments between C primitive declared in OCaml and its implementation in the .c file."
+maintainer: ["Edwin Török <edwin.torok@cloud.com>"]
+authors: ["Edwin Török <edwin.torok@cloud.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/edwintorok/lintcstubs-arity"
+bug-reports: "https://github.com/edwintorok/lintcstubs-arity/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "ocaml-src" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/edwintorok/lintcstubs-arity.git"
+url {
+  src:
+    "https://github.com/edwintorok/lintcstubs-arity/releases/download/0.4.1/lintcstubs-arity-0.4.1.tbz"
+  checksum: [
+    "sha256=c2691d943123f11bac129dcc75fa791927af71cde7e52a8ebeae6b0f08f08e6b"
+    "sha512=5fef8b48b805ac4fad0bb9ff0f100ce3fc97f4ef564092660db5b3a4b7f797ff4b754294579f2e74e3964b584b8d4f7ea1ae6be1f4a025f9b59be7ca60a8e8c5"
+  ]
+}
+x-commit-hash: "1aa77defdfffe7ae0087666fb0e9091485559bab"


### PR DESCRIPTION
Generate headers for C bindings

- Project page: <a href="https://github.com/edwintorok/lintcstubs-arity">https://github.com/edwintorok/lintcstubs-arity</a>

##### CHANGES:

* Backport to Dune 2.7
