### PR TITLE
frama-c 24-27.1 tests are not compatible with ocamlgraph 2.1

### DIFF
--- a/packages/frama-c/frama-c.24.0/opam
+++ b/packages/frama-c/frama-c.24.0/opam
@@ -118,6 +118,7 @@ depends: [
   "ocaml" { >= "4.08.1" }
   "ocamlfind" # needed beyond build stage, used by -load-module
   "ocamlgraph" { >= "1.8.8" }
+  "ocamlgraph" { with-test & < "2.1.0" }
   "why3" { >= "1.4.0" & < "1.5~" }
   "yojson" {>= "1.6.0" & < "2.1.0" & ( < "2.0.0" | ! with-test)}
   "zarith" {>= "1.5"}

--- a/packages/frama-c/frama-c.25.0/opam
+++ b/packages/frama-c/frama-c.25.0/opam
@@ -118,6 +118,7 @@ depends: [
   "ocaml" { >= "4.08.1" }
   "ocamlfind" # needed beyond build stage, used by -load-module
   "ocamlgraph" { >= "1.8.8" }
+  "ocamlgraph" { with-test & < "2.1.0" }
   "ppx_deriving"
   "ppx_deriving_yojson"
   "ppx_import" {>= "1.8.0" & < "2.0"}

--- a/packages/frama-c/frama-c.25.0~beta/opam
+++ b/packages/frama-c/frama-c.25.0~beta/opam
@@ -118,6 +118,7 @@ depends: [
   "ocaml" { >= "4.08.1" }
   "ocamlfind" # needed beyond build stage, used by -load-module
   "ocamlgraph" { >= "1.8.8" }
+  "ocamlgraph" { with-test & < "2.1.0" }
   "why3" {>= "1.5.0" & < "1.6~"}
   "yojson" {>= "1.6.0" & < "2.1.0" & ( < "2.0.0" | ! with-test)}
   "zarith" {>= "1.5"}

--- a/packages/frama-c/frama-c.26.0/opam
+++ b/packages/frama-c/frama-c.26.0/opam
@@ -118,6 +118,7 @@ depends: [
   "ocaml" { >= "4.11.1" }
   "ocamlfind" # needed beyond build stage, used by -load-module
   "ocamlgraph" { >= "1.8.8" }
+  "ocamlgraph" { with-test & < "2.1.0" }
   "why3" {>= "1.5.1" & < "1.6~"}
   "yojson" {>= "1.6.0" & < "2.1.0" & (< "2.0.0" | !with-test)}
   "zarith" { >= "1.5" }

--- a/packages/frama-c/frama-c.26.0~beta/opam
+++ b/packages/frama-c/frama-c.26.0~beta/opam
@@ -120,6 +120,7 @@ depends: [
   "ocaml" { >= "4.11.1" }
   "ocamlfind" # needed beyond build stage, used by -load-module
   "ocamlgraph" { >= "1.8.8" }
+  "ocamlgraph" { with-test & < "2.1.0" }
   "why3" {>= "1.5.1" & < "1.6~"}
   "yojson" {>= "1.6.0" & < "2.1.0" & ( < "2.0.0" | ! with-test)}
   "zarith" { >= "1.5" }

--- a/packages/frama-c/frama-c.26.1/opam
+++ b/packages/frama-c/frama-c.26.1/opam
@@ -119,6 +119,7 @@ depends: [
   "ocaml" { >= "4.11.1" }
   "ocamlfind" # needed beyond build stage, used by -load-module
   "ocamlgraph" { >= "1.8.8" }
+  "ocamlgraph" { with-test & < "2.1.0" }
   "why3" {>= "1.5.1" & < "1.6~"}
   "yojson" {>= "1.6.0" & < "2.1.0" & (< "2.0.0" | !with-test)}
   "zarith" { >= "1.5" }

--- a/packages/frama-c/frama-c.27.0/opam
+++ b/packages/frama-c/frama-c.27.0/opam
@@ -126,6 +126,7 @@ depends: [
   "ocaml" { >= "4.11.1" }
   "ocamlfind" # needed beyond build stage, used by -load-module
   "ocamlgraph" { >= "1.8.8" }
+  "ocamlgraph" { with-test & < "2.1.0" }
   "odoc" { with-doc }
   "why3" { >= "1.6.0" }
   "yaml" { >= "3.0.0" }

--- a/packages/frama-c/frama-c.27.0~beta/opam
+++ b/packages/frama-c/frama-c.27.0~beta/opam
@@ -122,6 +122,7 @@ depends: [
   "ocaml" { >= "4.11.1" }
   "ocamlfind" # needed beyond build stage, used by -load-module
   "ocamlgraph" { >= "1.8.8" }
+  "ocamlgraph" { with-test & < "2.1.0" }
   "why3" { >= "1.6.0" }
   "yaml" { >= "3.0.0" }
   "yojson" {>= "1.6.0" & (>= "2.0.1" | !with-test)}

--- a/packages/frama-c/frama-c.27.1/opam
+++ b/packages/frama-c/frama-c.27.1/opam
@@ -125,6 +125,7 @@ depends: [
   "ocaml" { >= "4.11.1" }
   "ocamlfind" # needed beyond build stage, used by -load-module
   "ocamlgraph" { >= "1.8.8" }
+  "ocamlgraph" { with-test & < "2.1.0" }
   "odoc" { with-doc }
   "why3" { >= "1.6.0" }
   "yaml" { >= "3.0.0" }


### PR DESCRIPTION
Due to an extra newline added to the output in ocamlgraph. See the discussion on https://github.com/ocaml/opam-repository/pull/24362