### PR TITLE
[new release] beluga (1.1.1)

### DIFF
--- a/packages/beluga/beluga.1.1.1/opam
+++ b/packages/beluga/beluga.1.1.1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis:
+  "Implementation of contextual modal logic for reasoning with higher-order abstract syntax"
+maintainer: ["marc-antoine.ouimet@mail.mcgill.ca"]
+authors: [
+  "Brigitte Pientka"
+  "Joshua Dunfield"
+  "Andrew Cave"
+  "Jacob Thomas Errington"
+  "Junyoung Clare Jang"
+  "Marc-Antoine Ouimet"
+]
+license: "GPL-3.0-only"
+homepage: "http://complogic.cs.mcgill.ca/beluga/"
+bug-reports: "https://github.com/Beluga-lang/Beluga/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "dune-build-info" {>= "3.7.0"}
+  "extlib" {>= "1.7.9"}
+  "gen" {>= "1.0"}
+  "linenoise" {>= "1.4.0"}
+  "ocaml" {>= "4.14"}
+  "sedlex" {>= "2.5"}
+  "omd" {>= "1.3.2"}
+  "uri" {>= "4.2.0"}
+  "ocamlformat" {= "0.25.1" & with-test}
+  "yojson" {>= "2.0.2" & with-test}
+  "ounit2" {>= "2.2.6" & with-test}
+  "bisect_ppx" {>= "2.8.1" & with-test}
+  "odoc" {>= "2.2.0" & with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Beluga-lang/Beluga.git"
+run-test: [make "test"]
+url {
+  src: "https://github.com/Beluga-lang/Beluga/releases/download/v1.1.1/beluga-1.1.1.tbz"
+  checksum: [
+    "sha256=a1feed16ff859a47859a73b89f751911744f1ed427c6dfd24466d0f817a9fa6b"
+    "sha512=a6dcddfc74a8abdf0578ad249fa7fda52168ec7d991784236dbac3ac331777bf3a14d8fc205c8c2b734409eabc008966276a5683c51449322122a3f52c69e96e"
+  ]
+}
+x-commit-hash: "21c2f0551e916246f7ee1a7ab2206d02939e0cd5"


### PR DESCRIPTION
Implementation of contextual modal logic for reasoning with higher-order abstract syntax

- Project page: <a href="http://complogic.cs.mcgill.ca/beluga/">http://complogic.cs.mcgill.ca/beluga/</a>

##### CHANGES:

### Added

- Added support for fixity pragmas before declarations.

### Changed

- Updated the Beluga mode for Emacs to use the `'cl-lib` library instead of `'cl`.

### Fixed

- Colouring of error messages is fixed for the Beluga mode for Emacs using the `'ansi-color` library (requires Emacs >= v28.1).