### PR TITLE
Move some unavailable pkgs to opam-source-archives

### DIFF
--- a/packages/lucid/lucid.0.1.5/opam
+++ b/packages/lucid/lucid.0.1.5/opam
@@ -18,7 +18,7 @@ Lucid has no runtime dependencies, but building it requires dune.
 "
 authors: "Tarun Agarwal <me@tarunagarwal.me>"
 url {
-  src: "https://github.com/kodwx/Lucid/archive/v0.1.5.tar.gz"
+  src: "https://raw.githubusercontent.com/ocaml/opam-source-archives/HEAD/lucid-0.1.5.tar.gz"
   checksum: [
     "md5=a9ea439ccba707b5a206cf2a316caeda"
     "sha512=4d2a58563f673d55c47f3fb2d44ce553bf1074762ebc4edb02720e54684b6573a3fb8271450c27656639b5692be1a0d36c681c852dace360182c735a7cd9e82b"

--- a/packages/rosa/rosa.0.2.0/opam
+++ b/packages/rosa/rosa.0.2.0/opam
@@ -19,7 +19,7 @@ Rosa has no runtime dependencies but building it requires dune.
 "
 authors: "Tarun Agarwal <me@tarunagarwal.me>"
 url {
-  src: "https://github.com/kodwx/Rosa/archive/v0.2.0.tar.gz"
+  src: "https://raw.githubusercontent.com/ocaml/opam-source-archives/HEAD/rosa-0.2.0.tar.gz"
   checksum: [
     "md5=bcda7e412ae9de54994243b252f25a9e"
     "sha512=e3c4c8a3149da5292ee7463c00a6fb48fd9a3edfa5ab1336f578bb9a8278798e32cd95eababbb0a58294aaf55414d326975d04c88e952aab69bdd4990292c409"

--- a/packages/simlog/simlog.0.0.3/opam
+++ b/packages/simlog/simlog.0.0.3/opam
@@ -31,7 +31,7 @@ build: [
 dev-repo: "git+https://github.com/muqiuhan/simlog.git"
 synopsis: ""
 url {
-  src: "https://github.com/muqiuhan/simlog/archive/v0.0.3.tar.gz"
+  src: "https://raw.githubusercontent.com/ocaml/opam-source-archives/HEAD/simlog-0.0.3.tar.gz"
   checksum: [
     "md5=ad5996746f01fd105b6c315e1293ecc3"
     "sha512=2df7530caf721be80b268a98d68cdca7efb83debf5676a248da247daddd6e87d8e2ec745d1463ef3b205ffa32dff02f709e17762c0f7ca865951bf5bf10fda09"


### PR DESCRIPTION
Depends on https://github.com/ocaml/opam-source-archives/pull/22 being merged first.