### PR TITLE
s/team AT robur dot io/team AT robur dot coop/

### DIFF
--- a/packages/dns-certify/dns-certify.4.0.0/opam
+++ b/packages/dns-certify/dns-certify.4.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.4.1.0/opam
+++ b/packages/dns-certify/dns-certify.4.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.4.2.0/opam
+++ b/packages/dns-certify/dns-certify.4.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.4.3.0/opam
+++ b/packages/dns-certify/dns-certify.4.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.4.3.1/opam
+++ b/packages/dns-certify/dns-certify.4.3.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.4.4.0/opam
+++ b/packages/dns-certify/dns-certify.4.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.4.4.1/opam
+++ b/packages/dns-certify/dns-certify.4.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.4.5.0/opam
+++ b/packages/dns-certify/dns-certify.4.5.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.4.6.0/opam
+++ b/packages/dns-certify/dns-certify.4.6.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.4.6.1/opam
+++ b/packages/dns-certify/dns-certify.4.6.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.4.6.2/opam
+++ b/packages/dns-certify/dns-certify.4.6.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.4.6.3/opam
+++ b/packages/dns-certify/dns-certify.4.6.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.5.0.0/opam
+++ b/packages/dns-certify/dns-certify.5.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.5.0.1/opam
+++ b/packages/dns-certify/dns-certify.5.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.6.0.0/opam
+++ b/packages/dns-certify/dns-certify.6.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.6.0.1/opam
+++ b/packages/dns-certify/dns-certify.6.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.6.0.2/opam
+++ b/packages/dns-certify/dns-certify.6.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.6.1.0/opam
+++ b/packages/dns-certify/dns-certify.6.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.6.1.1/opam
+++ b/packages/dns-certify/dns-certify.6.1.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.6.1.2/opam
+++ b/packages/dns-certify/dns-certify.6.1.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.6.1.3/opam
+++ b/packages/dns-certify/dns-certify.6.1.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.6.1.4/opam
+++ b/packages/dns-certify/dns-certify.6.1.4/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.6.2.0/opam
+++ b/packages/dns-certify/dns-certify.6.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.6.2.1/opam
+++ b/packages/dns-certify/dns-certify.6.2.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.6.2.2/opam
+++ b/packages/dns-certify/dns-certify.6.2.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.6.3.0/opam
+++ b/packages/dns-certify/dns-certify.6.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.6.4.0/opam
+++ b/packages/dns-certify/dns-certify.6.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.6.4.1/opam
+++ b/packages/dns-certify/dns-certify.6.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.7.0.0/opam
+++ b/packages/dns-certify/dns-certify.7.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.7.0.1/opam
+++ b/packages/dns-certify/dns-certify.7.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.7.0.2/opam
+++ b/packages/dns-certify/dns-certify.7.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-certify/dns-certify.7.0.3/opam
+++ b/packages/dns-certify/dns-certify.7.0.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.4.0.0/opam
+++ b/packages/dns-cli/dns-cli.4.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.4.1.0/opam
+++ b/packages/dns-cli/dns-cli.4.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.4.2.0/opam
+++ b/packages/dns-cli/dns-cli.4.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.4.3.0/opam
+++ b/packages/dns-cli/dns-cli.4.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.4.3.1/opam
+++ b/packages/dns-cli/dns-cli.4.3.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.4.4.0/opam
+++ b/packages/dns-cli/dns-cli.4.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.4.4.1/opam
+++ b/packages/dns-cli/dns-cli.4.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.4.5.0/opam
+++ b/packages/dns-cli/dns-cli.4.5.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.4.6.0/opam
+++ b/packages/dns-cli/dns-cli.4.6.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.4.6.1/opam
+++ b/packages/dns-cli/dns-cli.4.6.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.4.6.2/opam
+++ b/packages/dns-cli/dns-cli.4.6.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.4.6.3/opam
+++ b/packages/dns-cli/dns-cli.4.6.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.5.0.0/opam
+++ b/packages/dns-cli/dns-cli.5.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.5.0.1/opam
+++ b/packages/dns-cli/dns-cli.5.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.6.0.0/opam
+++ b/packages/dns-cli/dns-cli.6.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.6.0.1/opam
+++ b/packages/dns-cli/dns-cli.6.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.6.0.2/opam
+++ b/packages/dns-cli/dns-cli.6.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.6.1.0/opam
+++ b/packages/dns-cli/dns-cli.6.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.6.1.1/opam
+++ b/packages/dns-cli/dns-cli.6.1.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.6.1.2/opam
+++ b/packages/dns-cli/dns-cli.6.1.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.6.1.3/opam
+++ b/packages/dns-cli/dns-cli.6.1.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.6.1.4/opam
+++ b/packages/dns-cli/dns-cli.6.1.4/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.6.2.0/opam
+++ b/packages/dns-cli/dns-cli.6.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.6.2.1/opam
+++ b/packages/dns-cli/dns-cli.6.2.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.6.2.2/opam
+++ b/packages/dns-cli/dns-cli.6.2.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.6.3.0/opam
+++ b/packages/dns-cli/dns-cli.6.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.6.4.0/opam
+++ b/packages/dns-cli/dns-cli.6.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.6.4.1/opam
+++ b/packages/dns-cli/dns-cli.6.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.7.0.0/opam
+++ b/packages/dns-cli/dns-cli.7.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.7.0.1/opam
+++ b/packages/dns-cli/dns-cli.7.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.7.0.2/opam
+++ b/packages/dns-cli/dns-cli.7.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-cli/dns-cli.7.0.3/opam
+++ b/packages/dns-cli/dns-cli.7.0.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-client-lwt/dns-client-lwt.7.0.0/opam
+++ b/packages/dns-client-lwt/dns-client-lwt.7.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client-lwt/dns-client-lwt.7.0.1/opam
+++ b/packages/dns-client-lwt/dns-client-lwt.7.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client-lwt/dns-client-lwt.7.0.2/opam
+++ b/packages/dns-client-lwt/dns-client-lwt.7.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client-lwt/dns-client-lwt.7.0.3/opam
+++ b/packages/dns-client-lwt/dns-client-lwt.7.0.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client-mirage/dns-client-mirage.7.0.0/opam
+++ b/packages/dns-client-mirage/dns-client-mirage.7.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client-mirage/dns-client-mirage.7.0.1/opam
+++ b/packages/dns-client-mirage/dns-client-mirage.7.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client-mirage/dns-client-mirage.7.0.2/opam
+++ b/packages/dns-client-mirage/dns-client-mirage.7.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client-mirage/dns-client-mirage.7.0.3/opam
+++ b/packages/dns-client-mirage/dns-client-mirage.7.0.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.4.0.0/opam
+++ b/packages/dns-client/dns-client.4.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns-client/issues"

--- a/packages/dns-client/dns-client.4.1.0/opam
+++ b/packages/dns-client/dns-client.4.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.4.2.0/opam
+++ b/packages/dns-client/dns-client.4.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.4.3.0/opam
+++ b/packages/dns-client/dns-client.4.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.4.3.1/opam
+++ b/packages/dns-client/dns-client.4.3.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.4.4.0/opam
+++ b/packages/dns-client/dns-client.4.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.4.4.1/opam
+++ b/packages/dns-client/dns-client.4.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.4.5.0/opam
+++ b/packages/dns-client/dns-client.4.5.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.4.6.0/opam
+++ b/packages/dns-client/dns-client.4.6.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.4.6.1/opam
+++ b/packages/dns-client/dns-client.4.6.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.4.6.2/opam
+++ b/packages/dns-client/dns-client.4.6.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.4.6.3/opam
+++ b/packages/dns-client/dns-client.4.6.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.5.0.0/opam
+++ b/packages/dns-client/dns-client.5.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.5.0.1/opam
+++ b/packages/dns-client/dns-client.5.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.6.0.0/opam
+++ b/packages/dns-client/dns-client.6.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.6.0.1/opam
+++ b/packages/dns-client/dns-client.6.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.6.0.2/opam
+++ b/packages/dns-client/dns-client.6.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.6.1.0/opam
+++ b/packages/dns-client/dns-client.6.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.6.1.1/opam
+++ b/packages/dns-client/dns-client.6.1.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.6.1.2/opam
+++ b/packages/dns-client/dns-client.6.1.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.6.1.3/opam
+++ b/packages/dns-client/dns-client.6.1.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.6.1.4/opam
+++ b/packages/dns-client/dns-client.6.1.4/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.6.2.0/opam
+++ b/packages/dns-client/dns-client.6.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.6.2.1/opam
+++ b/packages/dns-client/dns-client.6.2.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.6.2.2/opam
+++ b/packages/dns-client/dns-client.6.2.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.6.3.0/opam
+++ b/packages/dns-client/dns-client.6.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.6.4.0/opam
+++ b/packages/dns-client/dns-client.6.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.6.4.1/opam
+++ b/packages/dns-client/dns-client.6.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.7.0.0/opam
+++ b/packages/dns-client/dns-client.7.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.7.0.1/opam
+++ b/packages/dns-client/dns-client.7.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.7.0.2/opam
+++ b/packages/dns-client/dns-client.7.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-client/dns-client.7.0.3/opam
+++ b/packages/dns-client/dns-client.7.0.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Joe Hill"]
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"

--- a/packages/dns-mirage/dns-mirage.4.0.0/opam
+++ b/packages/dns-mirage/dns-mirage.4.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.4.1.0/opam
+++ b/packages/dns-mirage/dns-mirage.4.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.4.2.0/opam
+++ b/packages/dns-mirage/dns-mirage.4.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.4.3.0/opam
+++ b/packages/dns-mirage/dns-mirage.4.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.4.3.1/opam
+++ b/packages/dns-mirage/dns-mirage.4.3.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.4.4.0/opam
+++ b/packages/dns-mirage/dns-mirage.4.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.4.4.1/opam
+++ b/packages/dns-mirage/dns-mirage.4.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.4.5.0/opam
+++ b/packages/dns-mirage/dns-mirage.4.5.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.4.6.0/opam
+++ b/packages/dns-mirage/dns-mirage.4.6.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.4.6.1/opam
+++ b/packages/dns-mirage/dns-mirage.4.6.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.4.6.2/opam
+++ b/packages/dns-mirage/dns-mirage.4.6.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.4.6.3/opam
+++ b/packages/dns-mirage/dns-mirage.4.6.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.5.0.0/opam
+++ b/packages/dns-mirage/dns-mirage.5.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.5.0.1/opam
+++ b/packages/dns-mirage/dns-mirage.5.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.6.0.0/opam
+++ b/packages/dns-mirage/dns-mirage.6.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.6.0.1/opam
+++ b/packages/dns-mirage/dns-mirage.6.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.6.0.2/opam
+++ b/packages/dns-mirage/dns-mirage.6.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.6.1.0/opam
+++ b/packages/dns-mirage/dns-mirage.6.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.6.1.1/opam
+++ b/packages/dns-mirage/dns-mirage.6.1.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.6.1.2/opam
+++ b/packages/dns-mirage/dns-mirage.6.1.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.6.1.3/opam
+++ b/packages/dns-mirage/dns-mirage.6.1.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.6.1.4/opam
+++ b/packages/dns-mirage/dns-mirage.6.1.4/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.6.2.0/opam
+++ b/packages/dns-mirage/dns-mirage.6.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.6.2.1/opam
+++ b/packages/dns-mirage/dns-mirage.6.2.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.6.2.2/opam
+++ b/packages/dns-mirage/dns-mirage.6.2.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.6.3.0/opam
+++ b/packages/dns-mirage/dns-mirage.6.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.6.4.0/opam
+++ b/packages/dns-mirage/dns-mirage.6.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.6.4.1/opam
+++ b/packages/dns-mirage/dns-mirage.6.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.7.0.0/opam
+++ b/packages/dns-mirage/dns-mirage.7.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.7.0.1/opam
+++ b/packages/dns-mirage/dns-mirage.7.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.7.0.2/opam
+++ b/packages/dns-mirage/dns-mirage.7.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-mirage/dns-mirage.7.0.3/opam
+++ b/packages/dns-mirage/dns-mirage.7.0.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.4.0.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.4.1.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.4.2.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.4.3.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.4.3.1/opam
+++ b/packages/dns-resolver/dns-resolver.4.3.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.4.4.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.4.4.1/opam
+++ b/packages/dns-resolver/dns-resolver.4.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.4.5.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.5.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.4.6.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.6.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.4.6.1/opam
+++ b/packages/dns-resolver/dns-resolver.4.6.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.4.6.2/opam
+++ b/packages/dns-resolver/dns-resolver.4.6.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.4.6.3/opam
+++ b/packages/dns-resolver/dns-resolver.4.6.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.5.0.0/opam
+++ b/packages/dns-resolver/dns-resolver.5.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.5.0.1/opam
+++ b/packages/dns-resolver/dns-resolver.5.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.6.0.0/opam
+++ b/packages/dns-resolver/dns-resolver.6.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.6.0.1/opam
+++ b/packages/dns-resolver/dns-resolver.6.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.6.0.2/opam
+++ b/packages/dns-resolver/dns-resolver.6.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.6.1.0/opam
+++ b/packages/dns-resolver/dns-resolver.6.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.6.1.1/opam
+++ b/packages/dns-resolver/dns-resolver.6.1.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.6.1.2/opam
+++ b/packages/dns-resolver/dns-resolver.6.1.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.6.1.3/opam
+++ b/packages/dns-resolver/dns-resolver.6.1.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.6.1.4/opam
+++ b/packages/dns-resolver/dns-resolver.6.1.4/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.6.2.0/opam
+++ b/packages/dns-resolver/dns-resolver.6.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.6.2.1/opam
+++ b/packages/dns-resolver/dns-resolver.6.2.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.6.2.2/opam
+++ b/packages/dns-resolver/dns-resolver.6.2.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.6.3.0/opam
+++ b/packages/dns-resolver/dns-resolver.6.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.6.4.0/opam
+++ b/packages/dns-resolver/dns-resolver.6.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.6.4.1/opam
+++ b/packages/dns-resolver/dns-resolver.6.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.7.0.0/opam
+++ b/packages/dns-resolver/dns-resolver.7.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.7.0.1/opam
+++ b/packages/dns-resolver/dns-resolver.7.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.7.0.2/opam
+++ b/packages/dns-resolver/dns-resolver.7.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-resolver/dns-resolver.7.0.3/opam
+++ b/packages/dns-resolver/dns-resolver.7.0.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.4.0.0/opam
+++ b/packages/dns-server/dns-server.4.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.4.1.0/opam
+++ b/packages/dns-server/dns-server.4.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.4.2.0/opam
+++ b/packages/dns-server/dns-server.4.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.4.3.0/opam
+++ b/packages/dns-server/dns-server.4.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.4.3.1/opam
+++ b/packages/dns-server/dns-server.4.3.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.4.4.0/opam
+++ b/packages/dns-server/dns-server.4.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.4.4.1/opam
+++ b/packages/dns-server/dns-server.4.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.4.5.0/opam
+++ b/packages/dns-server/dns-server.4.5.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.4.6.0/opam
+++ b/packages/dns-server/dns-server.4.6.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.4.6.1/opam
+++ b/packages/dns-server/dns-server.4.6.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.4.6.2/opam
+++ b/packages/dns-server/dns-server.4.6.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.4.6.3/opam
+++ b/packages/dns-server/dns-server.4.6.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.5.0.0/opam
+++ b/packages/dns-server/dns-server.5.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.5.0.1/opam
+++ b/packages/dns-server/dns-server.5.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.6.0.0/opam
+++ b/packages/dns-server/dns-server.6.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.6.0.1/opam
+++ b/packages/dns-server/dns-server.6.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.6.0.2/opam
+++ b/packages/dns-server/dns-server.6.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.6.1.0/opam
+++ b/packages/dns-server/dns-server.6.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.6.1.1/opam
+++ b/packages/dns-server/dns-server.6.1.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.6.1.2/opam
+++ b/packages/dns-server/dns-server.6.1.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.6.1.3/opam
+++ b/packages/dns-server/dns-server.6.1.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.6.1.4/opam
+++ b/packages/dns-server/dns-server.6.1.4/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.6.2.0/opam
+++ b/packages/dns-server/dns-server.6.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.6.2.1/opam
+++ b/packages/dns-server/dns-server.6.2.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.6.2.2/opam
+++ b/packages/dns-server/dns-server.6.2.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.6.3.0/opam
+++ b/packages/dns-server/dns-server.6.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.6.4.0/opam
+++ b/packages/dns-server/dns-server.6.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.6.4.1/opam
+++ b/packages/dns-server/dns-server.6.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.7.0.0/opam
+++ b/packages/dns-server/dns-server.7.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.7.0.1/opam
+++ b/packages/dns-server/dns-server.7.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.7.0.2/opam
+++ b/packages/dns-server/dns-server.7.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-server/dns-server.7.0.3/opam
+++ b/packages/dns-server/dns-server.7.0.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.4.4.0/opam
+++ b/packages/dns-stub/dns-stub.4.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.4.4.1/opam
+++ b/packages/dns-stub/dns-stub.4.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.4.5.0/opam
+++ b/packages/dns-stub/dns-stub.4.5.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.4.6.0/opam
+++ b/packages/dns-stub/dns-stub.4.6.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.4.6.1/opam
+++ b/packages/dns-stub/dns-stub.4.6.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.4.6.2/opam
+++ b/packages/dns-stub/dns-stub.4.6.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.4.6.3/opam
+++ b/packages/dns-stub/dns-stub.4.6.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.5.0.0/opam
+++ b/packages/dns-stub/dns-stub.5.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.5.0.1/opam
+++ b/packages/dns-stub/dns-stub.5.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.6.0.0/opam
+++ b/packages/dns-stub/dns-stub.6.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.6.0.1/opam
+++ b/packages/dns-stub/dns-stub.6.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.6.0.2/opam
+++ b/packages/dns-stub/dns-stub.6.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.6.1.0/opam
+++ b/packages/dns-stub/dns-stub.6.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.6.1.1/opam
+++ b/packages/dns-stub/dns-stub.6.1.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.6.1.2/opam
+++ b/packages/dns-stub/dns-stub.6.1.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.6.1.3/opam
+++ b/packages/dns-stub/dns-stub.6.1.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.6.1.4/opam
+++ b/packages/dns-stub/dns-stub.6.1.4/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.6.2.0/opam
+++ b/packages/dns-stub/dns-stub.6.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.6.2.1/opam
+++ b/packages/dns-stub/dns-stub.6.2.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.6.2.2/opam
+++ b/packages/dns-stub/dns-stub.6.2.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.6.3.0/opam
+++ b/packages/dns-stub/dns-stub.6.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.6.4.0/opam
+++ b/packages/dns-stub/dns-stub.6.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.6.4.1/opam
+++ b/packages/dns-stub/dns-stub.6.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.7.0.0/opam
+++ b/packages/dns-stub/dns-stub.7.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.7.0.1/opam
+++ b/packages/dns-stub/dns-stub.7.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.7.0.2/opam
+++ b/packages/dns-stub/dns-stub.7.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-stub/dns-stub.7.0.3/opam
+++ b/packages/dns-stub/dns-stub.7.0.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.4.0.0/opam
+++ b/packages/dns-tsig/dns-tsig.4.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.4.1.0/opam
+++ b/packages/dns-tsig/dns-tsig.4.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.4.2.0/opam
+++ b/packages/dns-tsig/dns-tsig.4.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.4.3.0/opam
+++ b/packages/dns-tsig/dns-tsig.4.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.4.3.1/opam
+++ b/packages/dns-tsig/dns-tsig.4.3.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.4.4.0/opam
+++ b/packages/dns-tsig/dns-tsig.4.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.4.4.1/opam
+++ b/packages/dns-tsig/dns-tsig.4.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.4.5.0/opam
+++ b/packages/dns-tsig/dns-tsig.4.5.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.4.6.0/opam
+++ b/packages/dns-tsig/dns-tsig.4.6.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.4.6.1/opam
+++ b/packages/dns-tsig/dns-tsig.4.6.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.4.6.2/opam
+++ b/packages/dns-tsig/dns-tsig.4.6.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.4.6.3/opam
+++ b/packages/dns-tsig/dns-tsig.4.6.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.5.0.0/opam
+++ b/packages/dns-tsig/dns-tsig.5.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.5.0.1/opam
+++ b/packages/dns-tsig/dns-tsig.5.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.6.0.0/opam
+++ b/packages/dns-tsig/dns-tsig.6.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.6.0.1/opam
+++ b/packages/dns-tsig/dns-tsig.6.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.6.0.2/opam
+++ b/packages/dns-tsig/dns-tsig.6.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.6.1.0/opam
+++ b/packages/dns-tsig/dns-tsig.6.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.6.1.1/opam
+++ b/packages/dns-tsig/dns-tsig.6.1.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.6.1.2/opam
+++ b/packages/dns-tsig/dns-tsig.6.1.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.6.1.3/opam
+++ b/packages/dns-tsig/dns-tsig.6.1.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.6.1.4/opam
+++ b/packages/dns-tsig/dns-tsig.6.1.4/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.6.2.0/opam
+++ b/packages/dns-tsig/dns-tsig.6.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.6.2.1/opam
+++ b/packages/dns-tsig/dns-tsig.6.2.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.6.2.2/opam
+++ b/packages/dns-tsig/dns-tsig.6.2.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.6.3.0/opam
+++ b/packages/dns-tsig/dns-tsig.6.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.6.4.0/opam
+++ b/packages/dns-tsig/dns-tsig.6.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.6.4.1/opam
+++ b/packages/dns-tsig/dns-tsig.6.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.7.0.0/opam
+++ b/packages/dns-tsig/dns-tsig.7.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.7.0.1/opam
+++ b/packages/dns-tsig/dns-tsig.7.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.7.0.2/opam
+++ b/packages/dns-tsig/dns-tsig.7.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns-tsig/dns-tsig.7.0.3/opam
+++ b/packages/dns-tsig/dns-tsig.7.0.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.4.0.0/opam
+++ b/packages/dns/dns.4.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.4.1.0/opam
+++ b/packages/dns/dns.4.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.4.2.0/opam
+++ b/packages/dns/dns.4.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.4.3.0/opam
+++ b/packages/dns/dns.4.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.4.3.1/opam
+++ b/packages/dns/dns.4.3.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.4.4.0/opam
+++ b/packages/dns/dns.4.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.4.4.1/opam
+++ b/packages/dns/dns.4.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.4.5.0/opam
+++ b/packages/dns/dns.4.5.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.4.6.0/opam
+++ b/packages/dns/dns.4.6.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.4.6.1/opam
+++ b/packages/dns/dns.4.6.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.4.6.2/opam
+++ b/packages/dns/dns.4.6.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.4.6.3/opam
+++ b/packages/dns/dns.4.6.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.5.0.0/opam
+++ b/packages/dns/dns.5.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.5.0.1/opam
+++ b/packages/dns/dns.5.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.6.0.0/opam
+++ b/packages/dns/dns.6.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.6.0.1/opam
+++ b/packages/dns/dns.6.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.6.0.2/opam
+++ b/packages/dns/dns.6.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.6.1.0/opam
+++ b/packages/dns/dns.6.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.6.1.1/opam
+++ b/packages/dns/dns.6.1.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.6.1.2/opam
+++ b/packages/dns/dns.6.1.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.6.1.3/opam
+++ b/packages/dns/dns.6.1.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.6.1.4/opam
+++ b/packages/dns/dns.6.1.4/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.6.2.0/opam
+++ b/packages/dns/dns.6.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.6.2.1/opam
+++ b/packages/dns/dns.6.2.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.6.2.2/opam
+++ b/packages/dns/dns.6.2.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.6.3.0/opam
+++ b/packages/dns/dns.6.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.6.4.0/opam
+++ b/packages/dns/dns.6.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.6.4.1/opam
+++ b/packages/dns/dns.6.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.7.0.0/opam
+++ b/packages/dns/dns.7.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.7.0.1/opam
+++ b/packages/dns/dns.7.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.7.0.2/opam
+++ b/packages/dns/dns.7.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dns/dns.7.0.3/opam
+++ b/packages/dns/dns.7.0.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dnssec/dnssec.6.2.0/opam
+++ b/packages/dnssec/dnssec.6.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dnssec/dnssec.6.2.1/opam
+++ b/packages/dnssec/dnssec.6.2.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dnssec/dnssec.6.2.2/opam
+++ b/packages/dnssec/dnssec.6.2.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dnssec/dnssec.6.3.0/opam
+++ b/packages/dnssec/dnssec.6.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dnssec/dnssec.6.4.0/opam
+++ b/packages/dnssec/dnssec.6.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dnssec/dnssec.6.4.1/opam
+++ b/packages/dnssec/dnssec.6.4.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dnssec/dnssec.7.0.0/opam
+++ b/packages/dnssec/dnssec.7.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dnssec/dnssec.7.0.1/opam
+++ b/packages/dnssec/dnssec.7.0.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dnssec/dnssec.7.0.2/opam
+++ b/packages/dnssec/dnssec.7.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"

--- a/packages/dnssec/dnssec.7.0.3/opam
+++ b/packages/dnssec/dnssec.7.0.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "team AT robur dot io"
+maintainer: "team AT robur dot coop"
 authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
 homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"


### PR DESCRIPTION
We moved away from robur.io to robur.coop - I think these are the last occurences of `robur{., dot }io`.