### PR TITLE
[new release] reason-react and reason-react-ppx (0.12.0)

### DIFF
--- a/packages/reason-react-ppx/reason-react-ppx.0.12.0/opam
+++ b/packages/reason-react-ppx/reason-react-ppx.0.12.0/opam
@@ -13,7 +13,7 @@ homepage: "https://reasonml.github.io/reason-react"
 doc: "https://reasonml.github.io/reason-react"
 bug-reports: "https://github.com/reasonml/reason-react/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.9"}
   "ocaml" {>= "4.13.0"}
   "reason" {>= "3.6.0" & < "3.10.0"}
   "ppxlib" {>= "0.28.0"}

--- a/packages/reason-react-ppx/reason-react-ppx.0.12.0/opam
+++ b/packages/reason-react-ppx/reason-react-ppx.0.12.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "React.js JSX PPX"
+description: "ReasonReact JSX PPX"
+maintainer: [
+  "David Sancho <dsnxmoreno@gmail.com>"
+  "Antonio Monteiro <anmonteiro@gmail.com>"
+]
+authors: [
+  "Cheng Lou <chenglou92@gmail.com>" "Ricky Vetter <rickywvetter@gmail.com>"
+]
+license: "MIT"
+homepage: "https://reasonml.github.io/reason-react"
+doc: "https://reasonml.github.io/reason-react"
+bug-reports: "https://github.com/reasonml/reason-react/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.13.0"}
+  "reason" {>= "3.6.0" & < "3.10.0"}
+  "ppxlib" {>= "0.28.0"}
+  "merlin" {with-test}
+  "ocamlformat" {= "0.24.0" & with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reasonml/reason-react.git"
+url {
+  src:
+    "https://github.com/reasonml/reason-react/releases/download/0.12.0/reason-react-0.12.0.tbz"
+  checksum: [
+    "sha256=8e2d62ea3d42896ef23928131cd70cd37870632a87481554269a7d0635da59b1"
+    "sha512=879f015ef57ef88d6cbc09b09e82b3f23a9ab1e481f34ba4987dec2a6a46ed903c48b69f7e2875ef24cde6bd873e3d8022b9018ec42004240572c61bc39e1921"
+  ]
+}
+x-commit-hash: "d799f423342ffbfd609cedb027766814efd1e041"

--- a/packages/reason-react-ppx/reason-react-ppx.0.12.0/opam
+++ b/packages/reason-react-ppx/reason-react-ppx.0.12.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.13.0"}
   "reason" {>= "3.6.0" & < "3.10.0"}
   "ppxlib" {>= "0.28.0"}
-  "merlin" {with-test}
+  "merlin" {= "4.10-414" & with-test}
   "ocamlformat" {= "0.24.0" & with-dev-setup}
   "odoc" {with-doc}
 ]

--- a/packages/reason-react-ppx/reason-react-ppx.0.12.0/opam
+++ b/packages/reason-react-ppx/reason-react-ppx.0.12.0/opam
@@ -31,7 +31,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/reason-react/reason-react.0.12.0/opam
+++ b/packages/reason-react/reason-react.0.12.0/opam
@@ -36,7 +36,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/reason-react/reason-react.0.12.0/opam
+++ b/packages/reason-react/reason-react.0.12.0/opam
@@ -16,7 +16,7 @@ homepage: "https://reasonml.github.io/reason-react"
 doc: "https://reasonml.github.io/reason-react"
 bug-reports: "https://github.com/reasonml/reason-react/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.9"}
   "ocaml" {>= "4.13.0"}
   "melange" {>= "1.0.0"}
   "reason-react-ppx" {= version}

--- a/packages/reason-react/reason-react.0.12.0/opam
+++ b/packages/reason-react/reason-react.0.12.0/opam
@@ -22,7 +22,6 @@ depends: [
   "reason-react-ppx" {= version}
   "reason" {>= "3.6.0" & < "3.10.0"}
   "ocaml-lsp-server" {with-test}
-  "merlin" {= "4.10-414" & with-test}
   "opam-check-npm-deps" {= "1.0.0" & with-dev-setup}
   "ocamlformat" {= "0.24.0" & with-dev-setup}
   "odoc" {with-doc}

--- a/packages/reason-react/reason-react.0.12.0/opam
+++ b/packages/reason-react/reason-react.0.12.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Reason bindings for React.js"
+description: """
+ReasonReact helps you use Reason to build React components with deeply integrated, strong, static type safety.
+
+It is designed and built by people using Reason and React in large, mission critical production React codebases."""
+maintainer: [
+  "David Sancho <dsnxmoreno@gmail.com>"
+  "Antonio Monteiro <anmonteiro@gmail.com>"
+]
+authors: [
+  "Cheng Lou <chenglou92@gmail.com>" "Ricky Vetter <rickywvetter@gmail.com>"
+]
+license: "MIT"
+homepage: "https://reasonml.github.io/reason-react"
+doc: "https://reasonml.github.io/reason-react"
+bug-reports: "https://github.com/reasonml/reason-react/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.13.0"}
+  "melange" {>= "1.0.0"}
+  "reason-react-ppx"
+  "reason" {>= "3.6.0" & < "3.10.0"}
+  "ocaml-lsp-server" {with-test}
+  "merlin" {= "4.10-414" & with-test}
+  "opam-check-npm-deps" {= "1.0.0" & with-dev-setup}
+  "ocamlformat" {= "0.24.0" & with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reasonml/reason-react.git"
+depexts: [
+  ["react"] {npm-version = "^17.0.0 || ^18.0.0"}
+  ["react-dom"] {npm-version = "^17.0.0 || ^18.0.0"}
+]
+url {
+  src:
+    "https://github.com/reasonml/reason-react/releases/download/0.12.0/reason-react-0.12.0.tbz"
+  checksum: [
+    "sha256=8e2d62ea3d42896ef23928131cd70cd37870632a87481554269a7d0635da59b1"
+    "sha512=879f015ef57ef88d6cbc09b09e82b3f23a9ab1e481f34ba4987dec2a6a46ed903c48b69f7e2875ef24cde6bd873e3d8022b9018ec42004240572c61bc39e1921"
+  ]
+}
+x-commit-hash: "d799f423342ffbfd609cedb027766814efd1e041"

--- a/packages/reason-react/reason-react.0.12.0/opam
+++ b/packages/reason-react/reason-react.0.12.0/opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "3.8"}
   "ocaml" {>= "4.13.0"}
   "melange" {>= "1.0.0"}
-  "reason-react-ppx"
+  "reason-react-ppx" {= version}
   "reason" {>= "3.6.0" & < "3.10.0"}
   "ocaml-lsp-server" {with-test}
   "merlin" {= "4.10-414" & with-test}


### PR DESCRIPTION
Reason bindings for React.js

- Project page: <a href="https://reasonml.github.io/reason-react">https://reasonml.github.io/reason-react</a>
- Documentation: <a href="https://reasonml.github.io/reason-react">https://reasonml.github.io/reason-react</a>

##### CHANGES:

* Migrate the reason-react PPX and library to the [new React JSX
transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)
  (@anmonteiro in [reasonml/reason-react#714](https://github.com/reasonml/reason-react/pull/714))
* Add `suppressHydrationWarning` to supported props (@davesnx in
[reasonml/reason-react#721](https://github.com/reasonml/reason-react/pull/721))
* Rename `reactjs-jsx-ppx` to `reason-react-ppx` ([@davesnx in reasonml/reason-react#732](https://github.com/reasonml/reason-react/pull/732))
* Fix locations for lower and uppercase components so that merlin / editor
  integration can get type defs on hover ([@jchavarri in reasonml/reason-react#748](https://github.com/reasonml/reason-react/pull/748))
* Refine types for `key` attributes ([@anmonteiro in reasonml/reason-react#750](https://github.com/reasonml/reason-react/pull/750))
* Bump React depext to v17-18 reasonml/reason-react#777 ([@jchavarri in reasonml/reason-react#777](https://github.com/reasonml/reason-react/pull/777/files))
* Make optional props optional properly
 ([@davesnx in reasonml/reason-react#776](https://github.com/reasonml/reason-react/commit/0a98c07abaeea7ad5d217f8d4c157289e38aa639))
