### PR TITLE
DkML 2.0.3

### DIFF
--- a/packages/conf-dkml-sys-opam/conf-dkml-sys-opam.1/opam
+++ b/packages/conf-dkml-sys-opam/conf-dkml-sys-opam.1/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+homepage: "https://diskuv.gitlab.io/diskuv-ocaml"
+bug-reports: "https://github.com/diskuv/dkml-runtime-apps/issues"
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+depends: [
+  # should dkml-runtime-common-native be a flags:conf package since it is a dependency
+  # of a flags:conf package?
+  "dkml-runtime-common-native" {>= "1.0.2~prerel17"}
+]
+build: [
+  [ "sh" "-eufxc" "echo '%{dkml-sys-opam-exe}%' > opam-exe"]  { ?dkml-sys-opam-exe}
+  [ "sh" "-eufxc" "command -v opam > opam-exe"]               {!?dkml-sys-opam-exe}
+
+  # Load crossplatform-functions.sh to get a sha256 tool.
+  [
+    "sh"
+    "-eufxc"
+    """
+    # Load common functions
+    . '%{dkml-runtime-common-native:lib}%/unix/crossplatform-functions.sh'
+
+    OPAM_EXE=$(cat opam-exe)
+    # Translate the opam executable location into different path styles
+    # * We use long paths (not DOS 8.3) for the file-depends:[] since opam as of
+    #   2.1 gives frequent warnings of missing files when DOS 8.3 is used.
+    if [ -x /usr/bin/cygpath ]; then
+      /usr/bin/cygpath -alm "$OPAM_EXE" > var.exe.location.mixed
+      /usr/bin/cygpath -aw "$OPAM_EXE"  > var.exe.location.native
+    else
+      printf '%s\n' "$OPAM_EXE" > var.exe.location.mixed
+      printf '%s\n' "$OPAM_EXE" > var.exe.location.native
+    fi
+
+    # Get sha256 checksum
+    sha256compute $(cat var.exe.location.mixed) > opam-exe.sha256
+
+    # Write <pkgname>.config
+    #   confer: https://opam.ocaml.org/doc/Manual.html#lt-pkgname-gt-config
+    backslash='\\'
+    {
+      printf 'opam-version: "2.0"\n'
+      printf 'file-depends: [ [ "%s" "sha256=%s" ] ]\n' "`cat var.exe.location.mixed`" "`cat opam-exe.sha256`"
+      printf 'variables {\n'
+      printf '  location-native: "%s"\n' "`cat var.exe.location.native`" | sed "s/[$backslash]/$backslash$backslash$backslash$backslash/g"
+      printf '  location-mixed: "%s"\n' "`cat var.exe.location.mixed`"
+      printf '}\n'
+    } > '%{name}%.config'
+    """
+  ]
+]
+synopsis: "Virtual package relying on the opam executable"
+description:
+  """\
+This package will set package variables with the location of the opam
+executable.
+
+If the opam variable 'dkml-sys-opam-exe' is available, its value will become
+the location of the opam executable. Otherwise the PATH is searched to find
+opam.
+
+A 'file-depends' trigger will reinstall conf-dkml-sys-opam when the opam executable changes.
+
+The %{conf-dkml-sys-opam:location-native}% variable will be the native (Win32, Unix) location
+of opam, while %{conf-dkml-sys-opam:location-mixed}% will be the
+location of opam using only forward slashes (/).
+"""
+flags: conf

--- a/packages/conf-withdkml/conf-withdkml.2/opam
+++ b/packages/conf-withdkml/conf-withdkml.2/opam
@@ -75,30 +75,8 @@ of with-dkml.exe, while %{conf-withdkml:location-mixed}% will be the
 location of with-dkml.exe using only forward slashes (/).
 """
 flags: conf
-x-ci-accept-failures: [
-  # Currently opam CI does not have with-dkml.exe on any
-  # platform. Perhaps it never will?
-  "alpine-3.12"
-  "alpine-3.13"
-  "alpine-3.14"
-  "alpine-3.15"
-  "alpine-3.16"
-  "archlinux"
-  "centos-7"
-  "centos-8"
-  "debian-10"
-  "debian-11"
-  "debian-testing"
-  "debian-unstable"
-  "fedora-33"
-  "fedora-34"
-  "macos-homebrew"
-  "opensuse-15.2"
-  "opensuse-15.3"
-  "oraclelinux-7"
-  "oraclelinux-8"
-  "ubuntu-16.04"
-  "ubuntu-18.04"
-  "ubuntu-20.04"
-  "ubuntu-20.10"
-]
+# DkML 2.0.3: checking for MSYS2 CLANG64 is the best way to detect DkML
+# using opam variables. Would really prefer that [conf-withdkml] could
+# be surrounded by an opam try-catch construct, but that sounds like a
+# big change (introduce a new, early prepare phase?) to the opam solver.
+available: msystem = "CLANG64"

--- a/packages/conf-withdkml/conf-withdkml.2/opam
+++ b/packages/conf-withdkml/conf-withdkml.2/opam
@@ -1,0 +1,104 @@
+opam-version: "2.0"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+homepage: "https://diskuv.gitlab.io/diskuv-ocaml"
+bug-reports: "https://github.com/diskuv/dkml-runtime-apps/issues"
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+depends: [
+  # should dkml-runtime-common-native be a flags:conf package since it is a dependency
+  # of a flags:conf package?
+  "dkml-runtime-common-native" {>= "1.0.2~prerel17"}
+]
+build: [
+  # Load crossplatform-functions.sh to get the canonical with-dkml.exe location.
+  # Don't just use whatever is in the PATH since with-dkml.exe may be
+  # inside the Opam switch.
+  # TODO: All of this should work directly using Command Prompt syntax when
+  # {os = "win32"}
+
+  #   <dkmldir>/vendor/drc/
+  ["rm" "-rf" "dkmldir/vendor/drc"]
+  ["install" "-d" "dkmldir/vendor/drc"]
+  ["cp" "-r" "%{dkml-runtime-common-native:lib}%/all" "dkmldir/vendor/drc"]
+  ["cp" "-r" "%{dkml-runtime-common-native:lib}%/unix" "dkmldir/vendor/drc"]
+  #   <dkmldir>/.dkmlroot
+  ["install" "%{dkml-runtime-common-native:lib}%/template.dkmlroot" "dkmldir/.dkmlroot"]
+
+  [
+    "sh"
+    "-eufxc"
+    """
+    # Load common functions
+    . dkmldir/vendor/drc/unix/crossplatform-functions.sh
+
+    # Set WITHDKMLEXE_BUILDHOST and WITHDKMLEXE_DOS83_OR_BUILDHOST
+    autodetect_withdkmlexe
+
+    # Translate with-dkml location into different path styles
+    # * We use long paths (not DOS 8.3) for the file-depends:[] since opam as of
+    #   2.1 gives frequent warnings of missing files when DOS 8.3 is used.
+    if [ -x /usr/bin/cygpath ]; then
+      /usr/bin/cygpath -alm "$WITHDKMLEXE_BUILDHOST"          > var.with-dkml.location.mixed
+      /usr/bin/cygpath -aw "$WITHDKMLEXE_DOS83_OR_BUILDHOST"  > var.with-dkml.location.native
+    else
+      printf '%s\n' "$WITHDKMLEXE_BUILDHOST"          > var.with-dkml.location.mixed
+      printf '%s\n' "$WITHDKMLEXE_DOS83_OR_BUILDHOST" > var.with-dkml.location.native
+    fi
+
+    # Get sha256 checksum
+    sha256compute $(cat var.with-dkml.location.mixed) > with-dkml.sha256
+
+    # Write <pkgname>.config
+    #   confer: https://opam.ocaml.org/doc/Manual.html#lt-pkgname-gt-config
+    backslash='\\'
+    {
+      printf 'opam-version: "2.0"\n'
+      printf 'file-depends: [ [ "%s" "sha256=%s" ] ]\n' "$(< var.with-dkml.location.mixed )" "$(< with-dkml.sha256 )"
+      printf 'variables {\n'
+      printf '  location-native: "%s"\n' "$(< var.with-dkml.location.native)" | sed "s/[$backslash]/$backslash$backslash$backslash$backslash/g"
+      printf '  location-mixed: "%s"\n' "$(< var.with-dkml.location.mixed )"
+      printf '}\n'
+    } > '%{name}%.config'
+    """
+  ]
+]
+synopsis: "Virtual package relying on with-dkml.exe"
+description:
+  """\
+This package can only install if the with-dkml.exe program is installed in
+a DKML home or a DKSDK noabi directory.
+
+A 'file-depends' trigger will reinstall conf-withdkml when with-dkml.exe changes.
+
+The %{conf-withdkml:location-native}% variable will be the native (Win32, Unix) location
+of with-dkml.exe, while %{conf-withdkml:location-mixed}% will be the
+location of with-dkml.exe using only forward slashes (/).
+"""
+flags: conf
+x-ci-accept-failures: [
+  # Currently opam CI does not have with-dkml.exe on any
+  # platform. Perhaps it never will?
+  "alpine-3.12"
+  "alpine-3.13"
+  "alpine-3.14"
+  "alpine-3.15"
+  "alpine-3.16"
+  "archlinux"
+  "centos-7"
+  "centos-8"
+  "debian-10"
+  "debian-11"
+  "debian-testing"
+  "debian-unstable"
+  "fedora-33"
+  "fedora-34"
+  "macos-homebrew"
+  "opensuse-15.2"
+  "opensuse-15.3"
+  "oraclelinux-7"
+  "oraclelinux-8"
+  "ubuntu-16.04"
+  "ubuntu-18.04"
+  "ubuntu-20.04"
+  "ubuntu-20.10"
+]

--- a/packages/dkml-apps/dkml-apps.2.0.3/opam
+++ b/packages/dkml-apps/dkml-apps.2.0.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "CLI applications available in Diskuv OCaml installations"
+description:
+  "'dkml-fswatch' is a Windows port of fswatch suitable for 'dune --watch'."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://diskuv.gitlab.io/diskuv-ocaml"
+bug-reports: "https://github.com/diskuv/dkml-runtime-apps/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.1"}
+  "bos" {>= "0.2.1"}
+  "dune-configurator" {>= "2.9.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-apps.git"
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-runtime-apps.tar.gz"
+  checksum: [
+    "sha512=2ce9072b22f1f5d7c5131ecba558f5a09fceed6b9e15bf24bdf5edad0d1d328bab27928405850a7402326105bd2ebe7d34787efb739caf7bc5723f140966a56d"
+  ]
+}

--- a/packages/dkml-base-compiler/dkml-base-compiler.4.14.0~v2.0.3/opam
+++ b/packages/dkml-base-compiler/dkml-base-compiler.4.14.0~v2.0.3/opam
@@ -1,0 +1,253 @@
+opam-version: "2.0"
+# Composite version format is M.N.O~vA.B.C[~prelP]
+# where:
+# - M.N.O is OCaml compiler version
+# - A.B.C is the DKML version of the dkml-runtime-common
+# - P is optional DKML prerelease version
+# Examples:
+# - 4.14.0~prerel69 (legacy format) < 4.14.0~v0.4.0 < 4.14.0~v0.4.1~prerel69 < 4.14.0~v0.4.1
+# Confer: Version Ordering in https://opam.ocaml.org/doc/Manual.html#Package-Formulas
+synopsis: "OCaml cross-compiler and libraries from the DKML distribution that works with at least Win32 and macOS"
+description:
+  """The DKML distribution of the OCaml bytecode and native compiler, Stdlib and the other OCaml libraries (str, unix, bigarray, etc.).
+A cross-compiler for macOS x86_64 to macOS arm64 is included; for build consistency the regular OCaml compiler will be for x86_64 regardless of whether the build machine is Apple Silicon.
+Install with something like: opam switch create dkml-4.14.0 '--formula="dkml-base-compiler" {>= "4.14.0~" & < "4.13.0~"}'"""
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-compiler"
+bug-reports: "https://github.com/diskuv/dkml-compiler/issues"
+depends: [
+  "ocaml" {= "4.14.0" & post}
+
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+
+  "dkml-runtime-common-native" {= "2.0.3"}
+]
+depopts: [
+  "ocaml-option-32bit"
+  "dkml-option-debuginfo"
+  "dkml-option-minsize"
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+available: [
+  opam-version >= "2.1.0" &
+  ( (arch = "x86_64" & (os = "linux" | os = "win32" | os = "macos")) |
+    (arch = "x86_32" & (os = "linux" | os = "win32")) |
+    (arch = "arm64" & os = "macos") )
+]
+build: [
+  # Dump Homebrew, which is needed for reproducible build auditing in drc's crossplatform-functions.sh.
+  # TODO: Move the brewbundle.sh to drc, or in drc skip reproducible build auditing if bundle tap is not installable
+  # WAS: ["sh" "scripts/macos-bundle-dump.sh"] {os = "macos"}
+  ["touch" "Brewfile"] {os = "macos"}
+
+  # OCaml source code
+  ["install" "-d" "dl/ocaml/flexdll"]
+  ["tar" "xCfz" "dl/ocaml"          "dl/ocaml.tar.gz"   "--strip-components=1"]
+  ["tar" "xCfz" "dl/ocaml/flexdll"  "dl/flexdll.tar.gz" "--strip-components=1"]
+
+  # Debugging for 4.14.0 `Env.Error(_)` and `Persistent_env.Error(_)`
+  # Example:
+  #   Fatal error: exception Persistent_env.Error(_)
+  #   Raised at Persistent_env.error in file "typing/persistent_env.ml", line 33, characters 16-33
+  #   Called from Persistent_env.acknowledge_pers_struct in file "typing/persistent_env.ml", line 196, characters 2-109
+  #   Called from Persistent_env.find_pers_struct in file "typing/persistent_env.ml", line 227, characters 17-64
+  #   Called from Persistent_env.find in file "typing/persistent_env.ml", line 266, characters 6-41
+  #   Called from Env.lookup_ident_module in file "typing/env.ml", line 2764, characters 16-31
+  #   Called from Env.lookup_module_path in file "typing/env.ml", line 3045, characters 12-62
+  #   Called from Typemod.type_open_ in file "typing/typemod.ml", line 108, characters 13-71
+  #   Called from Typemod.initial_env.open_module in file "typing/typemod.ml", line 130, characters 12-51
+  #   Called from Typemod.initial_env in file "typing/typemod.ml", line 165, characters 9-26
+  #   Called from Topcommon.initialize_toplevel_env in file "toplevel/topcommon.ml", line 281, characters 18-40
+  #   Called from UTop_main.common_init in file "src/lib/uTop_main.ml", line 1384, characters 2-1921
+  #   Called from UTop_main.main_aux in file "src/lib/uTop_main.ml", line 1476, characters 6-30
+  #   Called from UTop_main.main_internal in file "src/lib/uTop_main.ml", line 1497, characters 4-25  
+  ["install" "debug/env.ml" "debug/persistent_env.ml" "dl/ocaml/typing/"] {dkml-debug-env-failures & version > "4.14.0~v1.2.1~" & version <= "4.14.0"}
+
+  # Create a DKMLDIR. Its structure mimics a git submodule setup.
+  #   <dkmldir>/.dkmlroot
+  ["install" "-d" "dkmldir"]
+  #     4.14.0~v0.4.1          --dkml-semver--> 0.4.1
+  #     4.14.0~v0.4.1~prerel69 --dkml-semver--> 0.4.1-prerel69
+  ["sh" "-eufc" "printf 'dkml_root_version=%s\\n' '%{version}%' | sed 's/[0-9.]*~v//; s/~/-/' > dkmldir/.dkmlroot"]
+
+  #   <dkmldir>/vendor/drc/
+  ["install" "-d" "dkmldir/vendor/drc"]
+  #     tar through pipe is essentially an rsync (without requiring rsync)
+  ["sh" "-eufc" "tar cCf '%{dkml-runtime-common-native:lib}%/' - . | tar xCf dkmldir/vendor/drc/ -"]
+
+  #   <dkmldir>/vendor/dkml-compiler/
+  ["install" "-d" "dkmldir/vendor/dkml-compiler/src" "dkmldir/vendor/dkml-compiler/env"]
+  #     only the standard compiler environment is needed for the base compiler. However options play a part.
+  ["install"
+    # default (unpatched) options
+    "env/standard-compiler-env-to-ocaml-configure-env.sh"
+    "dkmldir/vendor/dkml-compiler/env/"
+  ]
+  ["sh" "-eufc"
+    # https://learn.microsoft.com/en-us/cpp/build/reference/z7-zi-zi-debug-information-format?view=msvc-170
+    # https://learn.microsoft.com/en-us/cpp/assembler/masm/ml-and-ml64-command-line-reference?view=msvc-170
+    """
+    sed 's/^INJECT_CFLAGS=$/INJECT_CFLAGS=-Z7/; s/^DEFAULT_AS=$/DEFAULT_AS=ml/; s/^INJECT_ASFLAGS=$/INJECT_ASFLAGS="-Zd -Zi"/' \
+      env/standard-compiler-env-to-ocaml-configure-env.sh > \
+      dkmldir/vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh
+    """
+  ] {dkml-option-debuginfo:installed & os = "win32" & arch = "x86_32"}
+  ["sh" "-eufc"
+    """
+    sed 's/^INJECT_CFLAGS=$/INJECT_CFLAGS=-Z7/; s/^DEFAULT_AS=$/DEFAULT_AS=ml64/; s/^INJECT_ASFLAGS=$/INJECT_ASFLAGS="-Zd -Zi"/' \
+      env/standard-compiler-env-to-ocaml-configure-env.sh > \
+      dkmldir/vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh
+    """
+  ] {dkml-option-debuginfo:installed & os = "win32" & arch = "x86_64"}
+  ["sh" "-eufc"
+    """
+    sed 's/^INJECT_CFLAGS=$/INJECT_CFLAGS=-Z7/; s/^DEFAULT_AS=$/DEFAULT_AS=armasm64/; s/^INJECT_ASFLAGS=$/INJECT_ASFLAGS="-Zd -Zi"/' \
+      env/standard-compiler-env-to-ocaml-configure-env.sh > \
+      dkmldir/vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh
+    """
+  ] {dkml-option-debuginfo:installed & os = "win32" & arch = "arm64"}
+  ["sh" "-eufc"
+    """
+    sed 's/^INJECT_CFLAGS=$/INJECT_CFLAGS="-g -O0"/; s/^INJECT_ASFLAGS=$/INJECT_ASFLAGS="-g -O0"/' \
+      env/standard-compiler-env-to-ocaml-configure-env.sh > \
+      dkmldir/vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh
+    """
+  ] {dkml-option-debuginfo:installed & os = "linux"}
+  ["sh" "-eufc"
+    # -Os optimizes for size. Useful for CPUs with small cache sizes. Confer https://wiki.gentoo.org/wiki/GCC_optimization
+    "sed 's/^INJECT_CFLAGS=$/INJECT_CFLAGS=-Os/ \
+      env/standard-compiler-env-to-ocaml-configure-env.sh > \
+      dkmldir/vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh"
+  ] {dkml-option-minsize:installed & os = "linux"}
+  #     tar through pipe is essentially an rsync (without requiring rsync)
+  ["sh" "-eufc" "tar cCf src/ - . | tar xCf dkmldir/vendor/dkml-compiler/src/ -"]
+
+  #   <dkmldir>/vendor/dkml-compiler/bin/bootstrap-ocamlc.opt.exe
+  #   to speed up compile
+  ["install" "-d" "dkmldir/vendor/dkml-compiler/bin"]
+  ["install" "dl/windows_x86-ocamlc.opt.exe" "dkmldir/vendor/dkml-compiler/bin/bootstrap-ocamlc.opt.exe"]     { os = "win32" & (arch = "x86_32" |  ocaml-option-32bit:installed) }
+  ["install" "dl/windows_x86_64-ocamlc.opt.exe" "dkmldir/vendor/dkml-compiler/bin/bootstrap-ocamlc.opt.exe"]  { os = "win32" & (arch = "x86_64" & !ocaml-option-32bit:installed) }
+  ["install" "dl/linux_x86-ocamlc.opt" "dkmldir/vendor/dkml-compiler/bin/bootstrap-ocamlc.opt.exe"]           { os = "linux" & (arch = "x86_32" |  ocaml-option-32bit:installed) }
+  ["install" "dl/linux_x86_64-ocamlc.opt" "dkmldir/vendor/dkml-compiler/bin/bootstrap-ocamlc.opt.exe"]        { os = "linux" & (arch = "x86_64" & !ocaml-option-32bit:installed) }
+  ["install" "dl/darwin_x86_64-ocamlc.opt" "dkmldir/vendor/dkml-compiler/bin/bootstrap-ocamlc.opt.exe"]       { os = "macos" & arch = "x86_64" }
+  ["install" "dl/darwin_arm64-ocamlc.opt" "dkmldir/vendor/dkml-compiler/bin/bootstrap-ocamlc.opt.exe"]        { os = "macos" & arch = "arm64" }
+]
+install: [
+  # Run r-c-ocaml-1-setup.sh
+  [
+    "env" "TOPDIR=dkmldir/vendor/drc/all/emptytop"
+      "DKML_REPRODUCIBLE_SYSTEM_BREWFILE=%{_:build}%/Brewfile"
+      "bash"
+      "dkmldir/vendor/dkml-compiler/src/r-c-ocaml-1-setup.sh"
+      "-d" "dkmldir"
+      "-t" "%{prefix}%"
+      "-f" "src-ocaml"
+      "-g" "%{_:share}%/mlcross"
+      "-v" "dl/ocaml"
+      #   If the ocamlc.opt is not present (perhaps not available on the platform),
+      #   the option will be dropped by r-c-ocaml-1-setup.sh. Just an optimization!
+      "-c" "vendor/dkml-compiler/bin/bootstrap-ocamlc.opt.exe"
+      "-z"
+      #   Windows flexlink flags that affect the built ocaml.exe, ocamlc.opt.exe, etc.
+      #   It is nice with the toplevel ocaml.exe to be able to debug it when the toplevel
+      #   loads in other (stublib) DLLs, for example.
+      "-l"                  { os = "win32" & dkml-option-debuginfo:installed }
+      " -link /DEBUG:FULL"  { os = "win32" & dkml-option-debuginfo:installed }
+      #   No debug/instrumented runtime when dkml-option-debuginfo not installed
+      "-m"                                                      { !dkml-option-debuginfo:installed }
+      "--disable-debug-runtime --disable-instrumented-runtime"  { !dkml-option-debuginfo:installed }
+      "-n"                                                      { !dkml-option-debuginfo:installed }
+      "--disable-debug-runtime --disable-instrumented-runtime"  { !dkml-option-debuginfo:installed }
+      #   Host architectures
+      "-ewindows_x86"     { os = "win32" & (arch = "x86_32" |  ocaml-option-32bit:installed) }
+      "-ewindows_x86_64"  { os = "win32" & (arch = "x86_64" & !ocaml-option-32bit:installed) }
+      "-elinux_x86"       { os = "linux" & (arch = "x86_32" |  ocaml-option-32bit:installed) }
+      "-elinux_x86_64"    { os = "linux" & (arch = "x86_64" & !ocaml-option-32bit:installed) }
+      "-edarwin_x86_64"   { os = "macos" & arch = "x86_64" }
+      "-edarwin_arm64"    { os = "macos" & arch = "arm64" }
+      #   Target architectures (if cross-compiling; similar to dkml-component-staging-ocamlrun.opam)
+      #     TODO: With the -adarwin_x86_64 configuration below, an Apple Silicon machine will produce an arm64 ocamlopt.opt
+      #     in the staging-files/darwin_arm64 directory,
+      #     and that ocamlopt.opt will create x86_64 OCaml native executables. So that darwin_arm64/bin/ocamlopt.opt will not
+      #     run on an x86_64 machine.
+      #     The -adarwin_arm64 configuration is similar but has one important difference. The config will produce an x86_64
+      #     ocamlopt.opt, in the staging-files/darwin_x86_64 directory, and that ocamlopt.opt will create arm64 OCaml native
+      #     executables. But that darwin_x86_64/bin/ocamlopt.opt _will_ run on almost _all_ Apple Silicon (arm64) machines
+      #     because of Rosetta2. The only major exception is Opam CI has disabled Rosetta2 as of Nov 8, 2022.
+      #     Ideally we would have [-aHOST] and [-aHOST-TARGET]. That is: -adarwin_x86_64, -adarwin_arm64 and
+      #     -adarwin_x86_64-darwin_arm64. But that cross specification has ripple effects that needs time (technical debt) to
+      #     get right. Luckily our build machines are always Apple x86_64 (GitHub Actions and GitLab CI/CD), and even if the
+      #     build machines were Apple Silicon we typically only care about the generated artifacts (the target ABI).
+      "-adarwin_x86_64=vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh" { os = "macos" & arch = "arm64" }
+      "-adarwin_arm64=vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh"  { os = "macos" & arch = "x86_64" }
+      #     TODO: Would be nice to bundle the 3 Android cross-compilers here since they are already supported
+      #     by DKML, but I (jonahbeckford@) doubt there is an Android NDK available on the Opam hosts.
+      #     Confer: https://github.com/diskuv/diskuv-ocaml-ghmirror/runs/4831077050
+      #     Perhaps the Android NDK should just be downloaded via an 'android-option-ndk23' package? That would give control of the NDK version.
+      # "-aandroid_arm64v8a=vendor/dkml-compiler/env/github-actions-ci-to-ocaml-configure-env.sh;android_x86_64=vendor/dkml-compiler/env/github-actions-ci-to-ocaml-configure-env.sh"] { os = "linux" & !ocaml-option-32bit:installed }
+      # "-aandroid_arm32v7a=vendor/dkml-compiler/env/github-actions-ci-to-ocaml-configure-env.sh" { os = "linux" & ocaml-option-32bit:installed }
+      "-k" "vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh"
+  ]
+
+  # Run r-c-ocaml-2-build_host-noargs.sh
+  [
+    "sh" "scripts/build.sh"
+    "-p" "%{prefix}%"
+    "-s" "r-c-ocaml-2-build_host-noargs.sh"
+  ]
+
+  # Run r-c-ocaml-3-build_cross-noargs.sh (typically a no-op unless we are cross-compiling)
+  [
+    "sh" "scripts/build.sh"
+    "-p" "%{prefix}%"
+    "-s" "r-c-ocaml-3-build_cross-noargs.sh"
+  ]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-compiler.git"
+extra-source "dl/ocaml.tar.gz" {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.0.tar.gz"
+  checksum: "sha256=39f44260382f28d1054c5f9d8bf4753cb7ad64027da792f7938344544da155e8"
+}
+extra-source "dl/flexdll.tar.gz" {
+  src: "https://github.com/ocaml/flexdll/archive/0.43.tar.gz"
+  checksum: "sha256=10e171ab7d2f8b2f238b53bb9944d4b26686f5703fbc1c059532791bc91be949"
+}
+extra-source "dl/homebrew-bundle.tar.gz" {
+  src: "https://github.com/Homebrew/homebrew-bundle/archive/437c67db2f160369fec3a3892e3c577b6b3a4d2c.tar.gz"
+  checksum: [
+    "sha256=ecb6b03b2d0210369f23e3f8f64cd939a4bba633db08db62a49894653e053df4"
+  ]
+}
+# BEGIN: Managed by `dune build '@gen-opam' --auto-promote`
+extra-source "dl/windows_x86-ocamlc.opt.exe" {
+  src: "https://github.com/diskuv/dkml-compiler/releases/download/1.2.0-prep4/windows_x86-ocamlc.opt.exe"
+  checksum: "sha256=e6f3b091200c094b3f4c667a4333276a1e806b6a4dc60d3b576067f2f60b85e1"
+}
+extra-source "dl/windows_x86_64-ocamlc.opt.exe" {
+  src: "https://github.com/diskuv/dkml-compiler/releases/download/1.2.0-prep4/windows_x86_64-ocamlc.opt.exe"
+  checksum: "sha256=bd37004e7a9c94ac79c56824e056ad122d919065e7c10c390a43b5e33cece6ab"
+}
+extra-source "dl/linux_x86-ocamlc.opt" {
+  src: "https://github.com/diskuv/dkml-compiler/releases/download/1.2.0-prep4/linux_x86-ocamlc.opt"
+  checksum: "sha256=df8eb4e4d3a4e2e01ea0a37561ec999b64edb688ebed420b30451923bd68fc6b"
+}
+extra-source "dl/linux_x86_64-ocamlc.opt" {
+  src: "https://github.com/diskuv/dkml-compiler/releases/download/1.2.0-prep4/linux_x86_64-ocamlc.opt"
+  checksum: "sha256=a5d2914c0901e9bc9ca481fd4c9ea7fd8b79becc2d12dcd8c74142e43e18349f"
+}
+extra-source "dl/darwin_x86_64-ocamlc.opt" {
+  src: "https://github.com/diskuv/dkml-compiler/releases/download/1.2.0-prep4/darwin_x86_64-ocamlc.opt"
+  checksum: "sha256=98744a85497cba6670feb0f6d1e705286b5fddfa47f56ea180517733f4c6a54b"
+}
+# END: Managed by `dune build '@gen-opam' --auto-promote`
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-compiler.tar.gz"
+  checksum: [
+    "sha512=aee86bc5aee04c6853ca1220d5ebbb2d08830c95506da241a93a492de79b3d61fbe893e12bbfa9e50851b988224fa803e2b538070cbd06d3f77bbdabc77a9c78"
+  ]
+}

--- a/packages/dkml-build-desktop/dkml-build-desktop.2.0.3/opam
+++ b/packages/dkml-build-desktop/dkml-build-desktop.2.0.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Tools for building desktop executables"
+description: "Tools for building desktop executables"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://gitlab.com/dkml/components/dkml-component-desktop"
+doc:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/blob/main/README.md"
+bug-reports:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "re" {>= "1.10.0"}
+  "diskuvbox" {>= "0.1.0"}
+  "yaml" {>= "3.0.0" & with-test}
+  "with-dkml" {>= version}
+  "dkml-runtime-common" {>= version}
+  "dkml-runtime-distribution" {>= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/components/dkml-component-desktop.git"
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-component-desktop.tar.gz"
+  checksum: [
+    "sha512=47200536999985c5ccd1e660bd5f1b1ff5c22eb9ece8bfa88da4ef346ba4e80afc259a005f6baaddcb0e586b5a1607c3e7ef3c4c7c02d8f9323b3048662f054c"
+  ]
+}

--- a/packages/dkml-compiler-env/dkml-compiler-env.2.0.3/opam
+++ b/packages/dkml-compiler-env/dkml-compiler-env.2.0.3/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "Scripts to configure DKML compilation in various environments"
+description: "Scripts to configure DKML compilation in various environments"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-compiler"
+bug-reports: "https://github.com/diskuv/dkml-compiler/issues"
+depends: []
+dev-repo: "git+https://github.com/diskuv/dkml-compiler.git"
+build: []
+install: [
+  [".\\install-env.cmd"  "%{_:lib}%"] {os = "win32"}
+  ["sh" "./install-env.sh" "%{_:lib}%"]  {!(os = "win32")}
+]
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-compiler.tar.gz"
+  checksum: [
+    "sha512=aee86bc5aee04c6853ca1220d5ebbb2d08830c95506da241a93a492de79b3d61fbe893e12bbfa9e50851b988224fa803e2b538070cbd06d3f77bbdabc77a9c78"
+  ]
+}

--- a/packages/dkml-compiler-src/dkml-compiler-src.2.0.3/opam
+++ b/packages/dkml-compiler-src/dkml-compiler-src.2.0.3/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "Source code used to build the DkML compiler"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-compiler"
+bug-reports: "https://github.com/diskuv/dkml-compiler/issues"
+depends: [
+  "diskuvbox" {>= "0.1.0"}
+]
+build: []
+install: [
+  ["diskuvbox" "copy-dir" "src" "%{_:lib}%/src/src"]
+  ["diskuvbox" "copy-dir" "env" "%{_:lib}%/src/env"]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-compiler.git"
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-compiler.tar.gz"
+  checksum: [
+    "sha512=aee86bc5aee04c6853ca1220d5ebbb2d08830c95506da241a93a492de79b3d61fbe893e12bbfa9e50851b988224fa803e2b538070cbd06d3f77bbdabc77a9c78"
+  ]
+}

--- a/packages/dkml-component-common-desktop/dkml-component-common-desktop.2.0.3/opam
+++ b/packages/dkml-component-common-desktop/dkml-component-common-desktop.2.0.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Common code for installers of desktop executables for all DKML installable platforms"
+description:
+  "`desktop` provides desktop executables for all DKML installable platforms"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://gitlab.com/dkml/components/dkml-component-desktop"
+doc:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/blob/main/README.md"
+bug-reports:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "dkml-install" {>= "0.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/components/dkml-component-desktop.git"
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-component-desktop.tar.gz"
+  checksum: [
+    "sha512=47200536999985c5ccd1e660bd5f1b1ff5c22eb9ece8bfa88da4ef346ba4e80afc259a005f6baaddcb0e586b5a1607c3e7ef3c4c7c02d8f9323b3048662f054c"
+  ]
+}

--- a/packages/dkml-component-ocamlcompiler-common/dkml-component-ocamlcompiler-common.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-ocamlcompiler-common/dkml-component-ocamlcompiler-common.4.14.0~v2.0.3/opam
@@ -1,0 +1,89 @@
+opam-version: "2.0"
+synopsis: "DkML common code for ocamlcompiler"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://gitlab.com/dkml/components/dkml-component-ocamlcompiler"
+doc:
+  "https://gitlab.com/dkml/components/dkml-component-ocamlcompiler/-/blob/main/README.md"
+bug-reports:
+  "https://gitlab.com/dkml/components/dkml-component-ocamlcompiler/-/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "dkml-install" {>= "0.2.0"}
+  "crunch" {>= "3.3.1"}
+  "re" {>= "1.10.0"}
+  "dkml-compiler-src" {>= "2.0.2"}
+  "dkml-component-staging-dkmlconfdir" {>= "0.1.0"}
+  "dkml-component-staging-ocamlrun" {>= "4.12.1~"}
+  "dkml-runtime-common" {>= "2.0.2"}
+  "dkml-runtime-distribution" {>= "2.0.2"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["dkml-option-vcpkg"]
+dev-repo:
+  "git+https://gitlab.com/dkml/components/dkml-component-ocamlcompiler.git"
+build: [
+  # Portable shell scripts for OCaml compiling
+  #
+  # ** The only portable shell scripts needed are that that compile the bytecode
+  # ** interpreter for use in the dkml-component-staging-ocamlrun build:[] section.
+  # ** Any other logic needed for compiling the full native-code compiler
+  # ** can be done in OCaml bytecode. But since the portable shell scripts
+  # ** do 90% of the work needed for the native-code compiler, no strong
+  # ** reason (yet) to convert the native-code compiler installation into OCaml
+  # ** bytecode.
+  #
+  #   Create a minimal DKMLDIR (no dkml-runtime-distribution) that can build
+  #   the r-c-ocaml-* OCaml compiler. Its structure mimics a
+  #   git submodule setup.
+  #
+  #   <dkmldir>/vendor/drc/
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-common:lib}%/all" "dkmldir/vendor/drc/all"]
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-common:lib}%/unix" "dkmldir/vendor/drc/unix"]
+  #   <dkmldir>/.dkmlroot
+  ["diskuvbox" "copy-file" "%{dkml-runtime-common:lib}%/template.dkmlroot" "dkmldir/.dkmlroot"]
+
+  #   <dkmldir>/vendor/dkml-compiler/
+  ["diskuvbox" "copy-dir" "%{dkml-compiler-src:lib}%/src" "dkmldir/vendor/dkml-compiler"]
+
+  # Build component
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+install: [
+  # Copy minimal dkmldir into staging, adding distribution which has
+  # PowerShell scripts and other Unix scripts needed by setup-userprofile.ps1
+
+  #   Clone minimal dkmldir
+  ["diskuvbox" "copy-dir" "dkmldir" "%{_:share}%/staging-files/windows_x86/dkmldir"]
+  ["diskuvbox" "copy-dir" "dkmldir" "%{_:share}%/staging-files/windows_x86_64/dkmldir"]
+  #   Unpack runtime-distribution
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-distribution:lib}%/src/none" "%{_:share}%/staging-files/windows_x86/dkmldir/vendor/drd/src/none"]
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-distribution:lib}%/src/none" "%{_:share}%/staging-files/windows_x86_64/dkmldir/vendor/drd/src/none"]
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-distribution:lib}%/src/unix" "%{_:share}%/staging-files/windows_x86/dkmldir/vendor/drd/src/unix"]
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-distribution:lib}%/src/unix" "%{_:share}%/staging-files/windows_x86_64/dkmldir/vendor/drd/src/unix"]
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-distribution:lib}%/src/windows" "%{_:share}%/staging-files/windows_x86/dkmldir/vendor/drd/src/windows"]
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-distribution:lib}%/src/windows" "%{_:share}%/staging-files/windows_x86_64/dkmldir/vendor/drd/src/windows"]
+
+  # Copy assets
+  ["diskuvbox" "copy-dir" "assets/staging-files/win32" "%{_:share}%/staging-files/windows_x86"]
+  ["diskuvbox" "copy-dir" "assets/staging-files/win32" "%{_:share}%/staging-files/windows_x86_64"]
+]
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-component-ocamlcompiler.tar.gz"
+  checksum: [
+    "sha512=4536259e816365f5d15f32ec8e447e4a9afeb1cdc14b8b9a43b1a6a2cbe6e898984056b07124a16a13ec49596a29cf40d6f3d2200adc19657deb36b1c5d43ec8"
+  ]
+}

--- a/packages/dkml-component-ocamlcompiler-common/dkml-component-ocamlcompiler-common.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-ocamlcompiler-common/dkml-component-ocamlcompiler-common.4.14.0~v2.0.3/opam
@@ -11,6 +11,7 @@ bug-reports:
 depends: [
   "dune" {>= "3.6"}
   "dkml-install" {>= "0.2.0"}
+  "base64" {>= "3.5.0"}
   "crunch" {>= "3.3.1"}
   "re" {>= "1.10.0"}
   "dkml-compiler-src" {>= "2.0.2"}

--- a/packages/dkml-component-ocamlcompiler-network/dkml-component-ocamlcompiler-network.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-ocamlcompiler-network/dkml-component-ocamlcompiler-network.4.14.0~v2.0.3/opam
@@ -1,0 +1,123 @@
+opam-version: "2.0"
+synopsis: "DkML network staging component for ocamlcompiler"
+description:
+  "Network installed component for OCaml bytecode and native compiler"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://gitlab.com/dkml/components/dkml-component-ocamlcompiler"
+doc:
+  "https://gitlab.com/dkml/components/dkml-component-ocamlcompiler/-/blob/main/README.md"
+bug-reports:
+  "https://gitlab.com/dkml/components/dkml-component-ocamlcompiler/-/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "dkml-install" {>= "0.2.0"}
+  "diskuvbox" {>= "0.1.0"}
+  "dkml-compiler-src" {>= "2.0.2"}
+  "dkml-component-ocamlcompiler-common" {= version}
+  "dkml-component-offline-unixutils" {>= "0.1.0"}
+  "dkml-component-offline-opamshim"
+    {>= "2.2.0~" & < "2.2.0~dkml20220000" | > "2.2.0~dkml99999999"}
+  "dkml-runtime-common" {>= "2.0.2"}
+  "base64" {>= "3.5.0"}
+  "diskuvbox" {>= "0.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo:
+  "git+https://gitlab.com/dkml/components/dkml-component-ocamlcompiler.git"
+build: [
+  # OCaml source code
+  ["install" "-d" "dl/ocaml/flexdll"]
+  ["tar" "xCfz" "dl/ocaml"          "dl/ocaml.tar.gz"   "--strip-components=1"]
+  ["tar" "xCfz" "dl/ocaml/flexdll"  "dl/flexdll.tar.gz" "--strip-components=1"]
+
+  # Portable shell scripts for OCaml compiling
+  #
+  # ** The only portable shell scripts needed are that that compile the bytecode
+  # ** interpreter for use in the dkml-component-staging-ocamlrun build:[] section.
+  # ** Any other logic needed for compiling the full native-code compiler
+  # ** can be done in OCaml bytecode. But since the portable shell scripts
+  # ** do 90% of the work needed for the native-code compiler, no strong
+  # ** reason (yet) to convert the native-code compiler installation into OCaml
+  # ** bytecode.
+  #
+  #   Create a minimal DKMLDIR (no dkml-runtime-distribution) that can build
+  #   the r-c-ocaml-* OCaml compiler. Its structure mimics a
+  #   git submodule setup.
+  #
+  #   <dkmldir>/vendor/drc/
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-common:lib}%/all" "dkmldir/vendor/drc/all"]
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-common:lib}%/unix" "dkmldir/vendor/drc/unix"]
+  #   <dkmldir>/.dkmlroot
+  ["diskuvbox" "copy-file" "%{dkml-runtime-common:lib}%/template.dkmlroot" "dkmldir/.dkmlroot"]
+
+  #   <dkmldir>/vendor/dkml-compiler/
+  ["diskuvbox" "copy-dir" "%{dkml-compiler-src:lib}%/src" "dkmldir/vendor/dkml-compiler"]
+
+  # Build component
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+install: [
+  # Needed for [get_needs_install_admin_important_paths] when it calls setup-machine.ps1
+  #   Clone minimal dkmldir
+  ["diskuvbox" "copy-dir" "dkmldir" "%{_:share}%/staging-files/windows_x86/dkmldir"]
+  ["diskuvbox" "copy-dir" "dkmldir" "%{_:share}%/staging-files/windows_x86_64/dkmldir"]
+  #   Unpack runtime-distribution
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-distribution:lib}%/src/none" "%{_:share}%/staging-files/windows_x86/dkmldir/vendor/drd/src/none"]
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-distribution:lib}%/src/none" "%{_:share}%/staging-files/windows_x86_64/dkmldir/vendor/drd/src/none"]
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-distribution:lib}%/src/unix" "%{_:share}%/staging-files/windows_x86/dkmldir/vendor/drd/src/unix"]
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-distribution:lib}%/src/unix" "%{_:share}%/staging-files/windows_x86_64/dkmldir/vendor/drd/src/unix"]
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-distribution:lib}%/src/windows" "%{_:share}%/staging-files/windows_x86/dkmldir/vendor/drd/src/windows"]
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-distribution:lib}%/src/windows" "%{_:share}%/staging-files/windows_x86_64/dkmldir/vendor/drd/src/windows"]
+  #   Copy assets
+  ["diskuvbox" "copy-dir" "assets/staging-files/win32" "%{_:share}%/staging-files/windows_x86"]
+  ["diskuvbox" "copy-dir" "assets/staging-files/win32" "%{_:share}%/staging-files/windows_x86_64"]
+
+  #   Run r-c-ocaml-1-setup.sh ... just the OCaml runtime since not yet relocatable!
+  #   With an OCaml runtime that is the same version as the full OCaml system we want
+  #   to compile, the OCaml system should be compiled quicker (no bootstrap necessary).
+  #
+  #   ** It may seem redundant to recreate the same reproducible directory that
+  #   ** is available in ocamlrun. BUT ... it is a bad idea to couple the
+  #   ** bytecode interpreter that runs the installer plugins to the same
+  #   ** version as the OCaml compiler we are installing for the end-user.
+  [
+    "sh" "-eufc"
+    """
+    env TOPDIR=dkmldir/vendor/drc/all/emptytop \
+      dkmldir/vendor/dkml-compiler/src/r-c-ocaml-1-setup.sh \
+      -d dkmldir \
+      -t '%{_:share}%/staging-files/generic' \
+      -v dl/ocaml \
+      -r \
+      -z \
+      -k vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh
+    """
+  ]
+]
+extra-source "dl/ocaml.tar.gz" {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.0.tar.gz"
+  checksum: "sha256=39f44260382f28d1054c5f9d8bf4753cb7ad64027da792f7938344544da155e8"
+}
+extra-source "dl/flexdll.tar.gz" {
+  src: "https://github.com/alainfrisch/flexdll/archive/0.42.tar.gz"
+  checksum: "sha256=a2dce0a0d2f2c5c9f52f65e281db7405f51ff22dc71cdbf494eb241c8a4bdf0f"
+}
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-component-ocamlcompiler.tar.gz"
+  checksum: [
+    "sha512=4536259e816365f5d15f32ec8e447e4a9afeb1cdc14b8b9a43b1a6a2cbe6e898984056b07124a16a13ec49596a29cf40d6f3d2200adc19657deb36b1c5d43ec8"
+  ]
+}

--- a/packages/dkml-component-ocamlcompiler-network/dkml-component-ocamlcompiler-network.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-ocamlcompiler-network/dkml-component-ocamlcompiler-network.4.14.0~v2.0.3/opam
@@ -20,7 +20,6 @@ depends: [
   "dkml-component-offline-opamshim"
     {>= "2.2.0~" & < "2.2.0~dkml20220000" | > "2.2.0~dkml99999999"}
   "dkml-runtime-common" {>= "2.0.2"}
-  "base64" {>= "3.5.0"}
   "diskuvbox" {>= "0.1.0"}
   "odoc" {with-doc}
 ]

--- a/packages/dkml-component-ocamlcompiler-offline/dkml-component-ocamlcompiler-offline.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-ocamlcompiler-offline/dkml-component-ocamlcompiler-offline.4.14.0~v2.0.3/opam
@@ -1,0 +1,115 @@
+opam-version: "2.0"
+synopsis: "DkML offline staging component for ocamlcompiler"
+description:
+  "Offline installed component for OCaml bytecode and native compiler"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://gitlab.com/dkml/components/dkml-component-ocamlcompiler"
+doc:
+  "https://gitlab.com/dkml/components/dkml-component-ocamlcompiler/-/blob/main/README.md"
+bug-reports:
+  "https://gitlab.com/dkml/components/dkml-component-ocamlcompiler/-/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "dkml-install" {>= "0.2.0"}
+  "diskuvbox" {>= "0.1.0"}
+  "dkml-compiler-src" {>= "2.0.2"}
+  "dkml-component-ocamlcompiler-common" {= version}
+  "dkml-component-offline-unixutils" {>= "0.1.0"}
+  "dkml-component-staging-ocamlrun" {>= "4.12.1~"}
+  "dkml-component-offline-opamshim"
+    {>= "2.2.0~" & < "2.2.0~dkml20220000" | > "2.2.0~dkml99999999"}
+  "dkml-runtime-common" {>= "2.0.2"}
+  "base64" {>= "3.5.0"}
+  "diskuvbox" {>= "0.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo:
+  "git+https://gitlab.com/dkml/components/dkml-component-ocamlcompiler.git"
+build: [
+  # OCaml source code
+  ["install" "-d" "dl/ocaml/flexdll"]
+  ["tar" "xCfz" "dl/ocaml"          "dl/ocaml.tar.gz"   "--strip-components=1"]
+  ["tar" "xCfz" "dl/ocaml/flexdll"  "dl/flexdll.tar.gz" "--strip-components=1"]
+
+  # Portable shell scripts for OCaml compiling
+  #
+  # ** The only portable shell scripts needed are that that compile the bytecode
+  # ** interpreter for use in the dkml-component-staging-ocamlrun build:[] section.
+  # ** Any other logic needed for compiling the full native-code compiler
+  # ** can be done in OCaml bytecode. But since the portable shell scripts
+  # ** do 90% of the work needed for the native-code compiler, no strong
+  # ** reason (yet) to convert the native-code compiler installation into OCaml
+  # ** bytecode.
+  #
+  #   Create a minimal DKMLDIR (no dkml-runtime-distribution) that can build
+  #   the r-c-ocaml-* OCaml compiler. Its structure mimics a
+  #   git submodule setup.
+  #
+  #   <dkmldir>/vendor/drc/
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-common:lib}%/all" "dkmldir/vendor/drc/all"]
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-common:lib}%/unix" "dkmldir/vendor/drc/unix"]
+  #   <dkmldir>/.dkmlroot
+  ["diskuvbox" "copy-file" "%{dkml-runtime-common:lib}%/template.dkmlroot" "dkmldir/.dkmlroot"]
+
+  #   <dkmldir>/vendor/dkml-compiler/
+  ["diskuvbox" "copy-dir" "%{dkml-compiler-src:lib}%/src" "dkmldir/vendor/dkml-compiler"]
+
+  # Build component
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+install: [
+  #   Run r-c-ocaml-1-setup.sh ... just the OCaml runtime since not yet relocatable!
+  #   With an OCaml runtime that is the same version as the full OCaml system we want
+  #   to compile, the OCaml system should be compiled quicker (no bootstrap necessary).
+  #
+  #   ** It may seem redundant to recreate the same reproducible directory that
+  #   ** is available in ocamlrun. BUT ... it is a bad idea to couple the
+  #   ** bytecode interpreter that runs the installer plugins to the same
+  #   ** version as the OCaml compiler we are installing for the end-user.
+  [
+    "sh" "-eufc"
+    """
+    env TOPDIR=dkmldir/vendor/drc/all/emptytop \
+      dkmldir/vendor/dkml-compiler/src/r-c-ocaml-1-setup.sh \
+      -d dkmldir \
+      -t '%{_:share}%/staging-files/generic' \
+      -v dl/ocaml \
+      -r \
+      -z \
+      -k vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh
+    """
+  ]
+
+  # 1b. Remove unnecessary generic/src/ocaml which is only needed for debugging
+  #     native code, and generic/share which is also a waste since bytecode
+  #     edition is full of binaries that can't be reproduced (missing a C
+  #     compiler!)
+  ["rm" "-rf" "%{_:share}%/staging-files/generic/src" "%{_:share}%/staging-files/generic/share"]
+]
+extra-source "dl/ocaml.tar.gz" {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.0.tar.gz"
+  checksum: "sha256=39f44260382f28d1054c5f9d8bf4753cb7ad64027da792f7938344544da155e8"
+}
+extra-source "dl/flexdll.tar.gz" {
+  src: "https://github.com/alainfrisch/flexdll/archive/0.42.tar.gz"
+  checksum: "sha256=a2dce0a0d2f2c5c9f52f65e281db7405f51ff22dc71cdbf494eb241c8a4bdf0f"
+}
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-component-ocamlcompiler.tar.gz"
+  checksum: [
+    "sha512=4536259e816365f5d15f32ec8e447e4a9afeb1cdc14b8b9a43b1a6a2cbe6e898984056b07124a16a13ec49596a29cf40d6f3d2200adc19657deb36b1c5d43ec8"
+  ]
+}

--- a/packages/dkml-component-ocamlcompiler-offline/dkml-component-ocamlcompiler-offline.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-ocamlcompiler-offline/dkml-component-ocamlcompiler-offline.4.14.0~v2.0.3/opam
@@ -21,7 +21,6 @@ depends: [
   "dkml-component-offline-opamshim"
     {>= "2.2.0~" & < "2.2.0~dkml20220000" | > "2.2.0~dkml99999999"}
   "dkml-runtime-common" {>= "2.0.2"}
-  "base64" {>= "3.5.0"}
   "diskuvbox" {>= "0.1.0"}
   "odoc" {with-doc}
 ]

--- a/packages/dkml-component-offline-desktop-ci/dkml-component-offline-desktop-ci.2.0.3/opam
+++ b/packages/dkml-component-offline-desktop-ci/dkml-component-offline-desktop-ci.2.0.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Offline install of the CI flavor of desktop executables"
+description:
+  "`desktop` provides desktop executables for all DKML installable platforms"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://gitlab.com/dkml/components/dkml-component-desktop"
+doc:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/blob/main/README.md"
+bug-reports:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "dkml-component-staging-withdkml" {= version}
+  "dkml-component-staging-desktop-ci" {= version}
+  "dkml-component-common-desktop" {= version}
+  "dkml-component-staging-ocamlrun" {>= "4.12.1~"}
+  "dkml-install" {>= "0.2.0"}
+  "diskuvbox" {>= "0.1.0"}
+  "ezjsonm" {>= "1.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/components/dkml-component-desktop.git"
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-component-desktop.tar.gz"
+  checksum: [
+    "sha512=47200536999985c5ccd1e660bd5f1b1ff5c22eb9ece8bfa88da4ef346ba4e80afc259a005f6baaddcb0e586b5a1607c3e7ef3c4c7c02d8f9323b3048662f054c"
+  ]
+}

--- a/packages/dkml-component-offline-desktop-full/dkml-component-offline-desktop-full.2.0.3/opam
+++ b/packages/dkml-component-offline-desktop-full/dkml-component-offline-desktop-full.2.0.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Offline install of the Full flavor of desktop executables"
+description:
+  "`desktop` provides desktop executables for all DKML installable platforms"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://gitlab.com/dkml/components/dkml-component-desktop"
+doc:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/blob/main/README.md"
+bug-reports:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "dkml-component-staging-withdkml" {= version}
+  "dkml-component-staging-desktop-full" {= version}
+  "dkml-component-common-desktop" {= version}
+  "dkml-component-staging-ocamlrun" {>= "4.12.1~"}
+  "dkml-install" {>= "0.2.0"}
+  "diskuvbox" {>= "0.1.0"}
+  "ezjsonm" {>= "1.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/components/dkml-component-desktop.git"
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-component-desktop.tar.gz"
+  checksum: [
+    "sha512=47200536999985c5ccd1e660bd5f1b1ff5c22eb9ece8bfa88da4ef346ba4e80afc259a005f6baaddcb0e586b5a1607c3e7ef3c4c7c02d8f9323b3048662f054c"
+  ]
+}

--- a/packages/dkml-component-offline-ocamlrun/dkml-component-offline-ocamlrun.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-offline-ocamlrun/dkml-component-offline-ocamlrun.4.14.0~v2.0.3/opam
@@ -32,8 +32,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/diskuv/dkml-component-ocamlrun.git"
 url {
-  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-component-ocamlrun.tar.gz"
+  src: "https://github.com/diskuv/dkml-component-ocamlrun/archive/refs/tags/2.0.3.tar.gz"
   checksum: [
-    "sha512=1f4e909b3e89911e85da27601ba30018699007166715b2575d90cdd7ebd7837d7daa6bd6059ad5d4367be7ec18704d8ad80c180b77f69b3b608ac8901f09082e"
+    "sha512=5af90233f830b324935de89caff38f6a6c46eff14506958030dac26b6bc741405c7170491b46c94c7a19034e1f072b08bed4925b47afa6e539ec9fda92aadff7"
   ]
 }

--- a/packages/dkml-component-offline-ocamlrun/dkml-component-offline-ocamlrun.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-offline-ocamlrun/dkml-component-offline-ocamlrun.4.14.0~v2.0.3/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/diskuv/dkml-component-ocamlrun"
 bug-reports: "https://github.com/diskuv/dkml-component-ocamlrun/issues"
 depends: [
   "dune" {>= "3.6"}
-  "dkml-install" {>= "0.2.0"}
+  "dkml-install" {>= "0.4.0"}
   "dkml-component-staging-ocamlrun" {= version}
   "diskuvbox" {>= "0.1.0"}
   "odoc" {with-doc}

--- a/packages/dkml-component-offline-ocamlrun/dkml-component-offline-ocamlrun.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-offline-ocamlrun/dkml-component-offline-ocamlrun.4.14.0~v2.0.3/opam
@@ -8,7 +8,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-component-ocamlrun"
 bug-reports: "https://github.com/diskuv/dkml-component-ocamlrun/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.6"}
   "dkml-install" {>= "0.2.0"}
   "dkml-component-staging-ocamlrun" {= version}
   "diskuvbox" {>= "0.1.0"}

--- a/packages/dkml-component-offline-ocamlrun/dkml-component-offline-ocamlrun.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-offline-ocamlrun/dkml-component-offline-ocamlrun.4.14.0~v2.0.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "DKML staging component for ocamlrun"
+description:
+  "Standalone bytecode distribution of OCaml in <share>/staging-files containing just ocamlrun, the OCaml Stdlib and the other OCaml libraries (str, unix, bigarray, etc.)"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-component-ocamlrun"
+bug-reports: "https://github.com/diskuv/dkml-component-ocamlrun/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "dkml-install" {>= "0.2.0"}
+  "dkml-component-staging-ocamlrun" {= version}
+  "diskuvbox" {>= "0.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-component-ocamlrun.git"
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-component-ocamlrun.tar.gz"
+  checksum: [
+    "sha512=1f4e909b3e89911e85da27601ba30018699007166715b2575d90cdd7ebd7837d7daa6bd6059ad5d4367be7ec18704d8ad80c180b77f69b3b608ac8901f09082e"
+  ]
+}

--- a/packages/dkml-component-offline-ocamlrun/dkml-component-offline-ocamlrun.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-offline-ocamlrun/dkml-component-offline-ocamlrun.4.14.0~v2.0.3/opam
@@ -8,7 +8,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-component-ocamlrun"
 bug-reports: "https://github.com/diskuv/dkml-component-ocamlrun/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "3.0"}
   "dkml-install" {>= "0.2.0"}
   "dkml-component-staging-ocamlrun" {= version}
   "diskuvbox" {>= "0.1.0"}

--- a/packages/dkml-component-staging-desktop-ci/dkml-component-staging-desktop-ci.2.0.3/opam
+++ b/packages/dkml-component-staging-desktop-ci/dkml-component-staging-desktop-ci.2.0.3/opam
@@ -1,0 +1,113 @@
+opam-version: "2.0"
+synopsis:
+  "Collection of end-user installers of the CI flavor of desktop executables"
+description:
+  "`desktop` provides desktop executables for all DKML installable platforms"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://gitlab.com/dkml/components/dkml-component-desktop"
+doc:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/blob/main/README.md"
+bug-reports:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/issues"
+depends: [
+  "conf-dkml-sys-opam"
+  "dkml-build-desktop" {= version}
+  "dkml-install" {>= "0.2.0"}
+  "diskuvbox" {>= "0.1.0"}
+  "dune" {>= "3.6" & = "3.8.3" | = "3.8.3+shim"}
+  "dkml-apps" {= "2.0.3"}
+  "dkml-exe" {= "2.0.3"}
+  "metapp" {= "0.4.4+win"}
+  "ocaml-compiler-libs" {= "v0.12.4"}
+  "ocamlfind" {= "1.9.5"}
+  "ppx_derivers" {= "1.2.1"}
+  "ppxlib" {= "0.30.0"}
+  "refl" {= "0.4.1"}
+  "stdcompat" {= "19+optautoconf"}
+  "stdlib-shims" {= "0.3.0"}
+  "traverse" {= "0.3.0"}
+  "with-dkml" {= "2.0.3"}
+  "xdg" {= "3.9.0"}
+  "odoc" {with-doc}
+]
+depopts: ["conf-withdkml"]
+dev-repo: "git+https://gitlab.com/dkml/components/dkml-component-desktop.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+
+  # BEGIN build-flavor-ci. DO NOT EDIT THE LINES IN THIS SECTION
+  # Managed by bump-packages.cmake. TODO: Use [opam] from dkml-component-opam
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files metapp > opamshow-metapp.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files ocaml-compiler-libs > opamshow-ocaml-compiler-libs.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files ocamlfind > opamshow-ocamlfind.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files ppx_derivers > opamshow-ppx_derivers.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files ppxlib > opamshow-ppxlib.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files refl > opamshow-refl.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files stdcompat > opamshow-stdcompat.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files stdlib-shims > opamshow-stdlib-shims.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files traverse > opamshow-traverse.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files xdg > opamshow-xdg.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files dkml-apps > opamshow-dkml-apps.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files dkml-exe > opamshow-dkml-exe.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files dune > opamshow-dune.txt" ]
+  # END build-flavor-ci. DO NOT EDIT THE LINES ABOVE
+
+  # NOTE: Below ocaml.exe + binaries and stdlib can replace the now
+  # wasted space of [staging-ocamlrun] in the installer
+
+  # Need stdlib since can't mix end-user compiled stdlib with our currently compiled stdlib, or else:
+  #   The files C:/Users/WDAGUT~1/AppData/Local/Programs/DISKUV~1/lib/ocaml\stdlib.cmi
+  #      and C:\Users\WDAGUT~1\AppData\Local\Programs\DISKUV~1\desktop\bc\lib\logs\logs.cmi
+  #      make inconsistent assumptions over interface CamlinternalFormatBasics
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{conf-dkml-sys-opam:location-mixed}%' show --readonly --list-files dkml-base-compiler | awk -f scripts/stdlib.awk > opamshow-stdlib.txt" ]
+
+  # Need ocaml.exe and other binaries for "offline" installer
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{conf-dkml-sys-opam:location-mixed}%' show --readonly --list-files dkml-base-compiler | awk -f scripts/ocamlexe.awk > opamshow-ocamlexe.txt" ]
+
+  # Overwrite opamshow-dkml-apps.txt to exclude what we staged in staging-dkmlconfdir. There should not be overlap.
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{conf-dkml-sys-opam:location-mixed}%' show --readonly --list-files dkml-apps | grep -v dkml-confdir > opamshow-dkml-apps.txt" ]
+]
+install: [
+  # BEGIN install-flavor-ci. DO NOT EDIT THE LINES IN THIS SECTION
+  # Managed by bump-packages.cmake
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-metapp.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-ocaml-compiler-libs.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-ocamlfind.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-ppx_derivers.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-ppxlib.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-refl.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-stdcompat.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-stdlib-shims.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-traverse.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-xdg.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-dkml-apps.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/install" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-dkml-exe.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/install" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-dune.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/install" ]
+  # END install-flavor-ci. DO NOT EDIT THE LINES ABOVE
+
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-stdlib.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-ocamlexe.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+
+  [ "diskuvbox" "copy-file" "%{with-dkml:bin}%/with-dkml%{exe}%" "%{_:share}%/staging-files/%{dkml-abi}%/install/bin/dune%{exe}%" ]
+  [ "diskuvbox" "copy-file" "%{dune:bin}%/dune%{exe}%"      "%{_:share}%/staging-files/%{dkml-abi}%/install/bin/dune-real%{exe}%" ] {!(conf-withdkml:installed)}
+  [ "diskuvbox" "copy-file" "%{dune:bin}%/dune-real%{exe}%" "%{_:share}%/staging-files/%{dkml-abi}%/install/bin/dune-real%{exe}%" ] {  conf-withdkml:installed}
+]
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-component-desktop.tar.gz"
+  checksum: [
+    "sha512=47200536999985c5ccd1e660bd5f1b1ff5c22eb9ece8bfa88da4ef346ba4e80afc259a005f6baaddcb0e586b5a1607c3e7ef3c4c7c02d8f9323b3048662f054c"
+  ]
+}

--- a/packages/dkml-component-staging-desktop-full/dkml-component-staging-desktop-full.2.0.3/opam
+++ b/packages/dkml-component-staging-desktop-full/dkml-component-staging-desktop-full.2.0.3/opam
@@ -1,0 +1,190 @@
+opam-version: "2.0"
+synopsis:
+  "Collection of end-user installers of the Full flavor of desktop executables"
+description:
+  "`desktop` provides desktop executables for all DKML installable platforms"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://gitlab.com/dkml/components/dkml-component-desktop"
+doc:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/blob/main/README.md"
+bug-reports:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/issues"
+depends: [
+  "conf-dkml-sys-opam"
+  "dkml-build-desktop" {= version}
+  "dkml-install" {>= "0.2.0"}
+  "diskuvbox" {>= "0.1.0"}
+  "dune" {>= "3.6" & = "3.8.3" | = "3.8.3+shim"}
+  "base" {= "v0.16.1"}
+  "conf-sqlite3" {= "3.1+cpkgs"}
+  "csexp" {= "1.5.2"}
+  "dkml-apps" {= "2.0.3"}
+  "dkml-exe" {= "2.0.3"}
+  "graphics" {= "5.1.2"}
+  "lambda-term" {= "3.3.1"}
+  "logs" {= "0.7.0"}
+  "lwt" {= "5.6.1"}
+  "lwt_react" {= "1.2.0"}
+  "metapp" {= "0.4.4+win"}
+  "mew" {= "0.1.0"}
+  "mew_vi" {= "0.5.0"}
+  "ocaml-compiler-libs" {= "v0.12.4"}
+  "ocaml-lsp-server" {= "1.16.2"}
+  "ocamlfind" {= "1.9.5"}
+  "ocamlformat" {= "0.25.1"}
+  "ocp-indent" {= "1.8.2-windowssupport"}
+  "ocplib-endian" {= "1.2"}
+  "odoc" {= "2.2.0"}
+  "ppx_derivers" {= "1.2.1"}
+  "ppxlib" {= "0.30.0"}
+  "react" {= "1.2.2"}
+  "refl" {= "0.4.1"}
+  "result" {= "1.5"}
+  "sexplib0" {= "v0.16.0"}
+  "sqlite3" {= "5.1.0+msvc"}
+  "stdcompat" {= "19+optautoconf"}
+  "stdlib-shims" {= "0.3.0"}
+  "traverse" {= "0.3.0"}
+  "trie" {= "1.0.0"}
+  "uchar" {= "0.0.2"}
+  "utop" {= "2.13.1"}
+  "uucp" {= "15.0.0"}
+  "uuseg" {= "15.0.0"}
+  "uutf" {= "1.0.3"}
+  "with-dkml" {= "2.0.3"}
+  "xdg" {= "3.9.0"}
+  "zed" {= "3.2.2"}
+]
+depopts: ["conf-withdkml"]
+dev-repo: "git+https://gitlab.com/dkml/components/dkml-component-desktop.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+
+  # BEGIN build-flavor-full. DO NOT EDIT THE LINES IN THIS SECTION
+  # Managed by bump-packages.cmake. TODO: Use [opam] from dkml-component-opam
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files base > opamshow-base.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files conf-sqlite3 > opamshow-conf-sqlite3.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files csexp > opamshow-csexp.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files graphics > opamshow-graphics.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files lambda-term > opamshow-lambda-term.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files logs > opamshow-logs.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files lwt > opamshow-lwt.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files lwt_react > opamshow-lwt_react.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files metapp > opamshow-metapp.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files mew > opamshow-mew.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files mew_vi > opamshow-mew_vi.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files ocaml-compiler-libs > opamshow-ocaml-compiler-libs.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files ocamlfind > opamshow-ocamlfind.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files ocplib-endian > opamshow-ocplib-endian.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files ppx_derivers > opamshow-ppx_derivers.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files ppxlib > opamshow-ppxlib.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files react > opamshow-react.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files refl > opamshow-refl.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files result > opamshow-result.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files sexplib0 > opamshow-sexplib0.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files sqlite3 > opamshow-sqlite3.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files stdcompat > opamshow-stdcompat.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files stdlib-shims > opamshow-stdlib-shims.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files traverse > opamshow-traverse.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files trie > opamshow-trie.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files uchar > opamshow-uchar.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files utop > opamshow-utop.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files uucp > opamshow-uucp.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files uuseg > opamshow-uuseg.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files uutf > opamshow-uutf.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files xdg > opamshow-xdg.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files zed > opamshow-zed.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files dkml-apps > opamshow-dkml-apps.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files dkml-exe > opamshow-dkml-exe.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files dune > opamshow-dune.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files ocaml-lsp-server > opamshow-ocaml-lsp-server.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files ocamlformat > opamshow-ocamlformat.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files ocp-indent > opamshow-ocp-indent.txt" ]
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{dkml-sys-opam-exe}%' show --readonly --list-files odoc > opamshow-odoc.txt" ]
+  # END build-flavor-full. DO NOT EDIT THE LINES ABOVE
+
+  # NOTE: Below ocaml.exe + binaries and stdlib can replace the now
+  # wasted space of [staging-ocamlrun] in the installer
+
+  # Need stdlib since can't mix end-user compiled stdlib with our currently compiled stdlib, or else:
+  #   The files C:/Users/WDAGUT~1/AppData/Local/Programs/DISKUV~1/lib/ocaml\stdlib.cmi
+  #      and C:\Users\WDAGUT~1\AppData\Local\Programs\DISKUV~1\desktop\bc\lib\logs\logs.cmi
+  #      make inconsistent assumptions over interface CamlinternalFormatBasics
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{conf-dkml-sys-opam:location-mixed}%' show --readonly --list-files dkml-base-compiler | awk -f scripts/stdlib.awk > opamshow-stdlib.txt" ]
+
+  # Need ocaml.exe and other binaries for "offline" installer
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{conf-dkml-sys-opam:location-mixed}%' show --readonly --list-files dkml-base-compiler | awk -f scripts/ocamlexe.awk > opamshow-ocamlexe.txt" ]
+
+  # Overwrite opamshow-dkml-apps.txt to exclude what we staged in staging-dkmlconfdir. There should not be overlap.
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{conf-dkml-sys-opam:location-mixed}%' show --readonly --list-files dkml-apps | grep -v dkml-confdir > opamshow-dkml-apps.txt" ]
+]
+install: [
+  # BEGIN install-flavor-full. DO NOT EDIT THE LINES IN THIS SECTION
+  # Managed by bump-packages.cmake
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-base.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-conf-sqlite3.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-csexp.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-graphics.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-lambda-term.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-logs.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-lwt.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-lwt_react.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-metapp.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-mew.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-mew_vi.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-ocaml-compiler-libs.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-ocamlfind.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-ocplib-endian.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-ppx_derivers.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-ppxlib.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-react.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-refl.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-result.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-sexplib0.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-sqlite3.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-stdcompat.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-stdlib-shims.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-traverse.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-trie.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-uchar.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-utop.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-uucp.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-uuseg.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-uutf.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-xdg.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-zed.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-dkml-apps.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/install" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-dkml-exe.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/install" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-dune.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/install" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-ocaml-lsp-server.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/install" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-ocamlformat.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/install" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-ocp-indent.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/install" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-odoc.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/install" ]
+  # END install-flavor-full. DO NOT EDIT THE LINES ABOVE
+
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-stdlib.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-ocamlexe.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%/compile" ]
+
+  [ "diskuvbox" "copy-file" "%{with-dkml:bin}%/with-dkml%{exe}%" "%{_:share}%/staging-files/%{dkml-abi}%/install/bin/dune%{exe}%" ]
+  [ "diskuvbox" "copy-file" "%{dune:bin}%/dune%{exe}%"      "%{_:share}%/staging-files/%{dkml-abi}%/install/bin/dune-real%{exe}%" ] {!(conf-withdkml:installed)}
+  [ "diskuvbox" "copy-file" "%{dune:bin}%/dune-real%{exe}%" "%{_:share}%/staging-files/%{dkml-abi}%/install/bin/dune-real%{exe}%" ] {  conf-withdkml:installed}
+]
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-component-desktop.tar.gz"
+  checksum: [
+    "sha512=47200536999985c5ccd1e660bd5f1b1ff5c22eb9ece8bfa88da4ef346ba4e80afc259a005f6baaddcb0e586b5a1607c3e7ef3c4c7c02d8f9323b3048662f054c"
+  ]
+}

--- a/packages/dkml-component-staging-dkmlconfdir/dkml-component-staging-dkmlconfdir.2.0.3/opam
+++ b/packages/dkml-component-staging-dkmlconfdir/dkml-component-staging-dkmlconfdir.2.0.3/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Places conf-dkmldir binary into the DKML staging-files"
+description: "Places conf-dkmldir binary into the DKML staging-files"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://gitlab.com/dkml/components/dkml-component-desktop"
+doc:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/blob/main/README.md"
+bug-reports:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/issues"
+depends: [
+  "conf-dkml-sys-opam"
+  "dkml-build-desktop" {= version}
+  "dkml-install" {>= "0.2.0"}
+  "dune" {>= "3.6" & = "3.8.3" | = "3.8.3+shim"}
+  "dkml-apps" {= "2.0.3"}
+  "diskuvbox" {>= "0.1.0"}
+  "sexplib" {>= "v0.14.0"}
+  "bos" {>= "0.2.1"}
+  "ppx_sexp_conv" {>= "v0.14.3"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://gitlab.com/dkml/components/dkml-component-desktop.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{conf-dkml-sys-opam:location-mixed}%' show --readonly --list-files dkml-apps | grep dkml-confdir > opamshow-dkml-apps-only-dkml-confdir.txt" ]
+]
+install: [
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-dkml-apps-only-dkml-confdir.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%" ]
+]
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-component-desktop.tar.gz"
+  checksum: [
+    "sha512=47200536999985c5ccd1e660bd5f1b1ff5c22eb9ece8bfa88da4ef346ba4e80afc259a005f6baaddcb0e586b5a1607c3e7ef3c4c7c02d8f9323b3048662f054c"
+  ]
+}

--- a/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.14.0~v2.0.3/opam
@@ -1,0 +1,195 @@
+opam-version: "2.0"
+synopsis: "DKML staging component for ocamlrun"
+description:
+  "Standalone bytecode distribution of OCaml in <share>/staging-files containing just ocamlrun, the OCaml Stdlib and the other OCaml libraries (str, unix, bigarray, etc.)"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-component-ocamlrun"
+bug-reports: "https://github.com/diskuv/dkml-component-ocamlrun/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "dkml-install" {>= "0.2.0"}
+  "dkml-runtime-common" {>= "1.0.2~prerel9"}
+  "dkml-compiler-src"
+  "diskuvbox" {>= "0.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-component-ocamlrun.git"
+available: [ os = "macos" | (os = "linux" & (arch = "x86_32" | arch = "x86_64")) | os = "win32" ]
+build: [
+  # OCaml source code
+  ["install" "-d" "dl/ocaml/flexdll"]
+  ["tar" "xCfz" "dl/ocaml"          "dl/ocaml.tar.gz"   "--strip-components=1"]
+  ["tar" "xCfz" "dl/ocaml/flexdll"  "dl/flexdll.tar.gz" "--strip-components=1"]
+
+  # Create a DKMLDIR. Its structure mimics a git submodule setup.
+  #   <dkmldir>/vendor/drc/
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-common:lib}%/all" "dkmldir/vendor/drc/all"]
+  ["diskuvbox" "copy-dir" "%{dkml-runtime-common:lib}%/unix" "dkmldir/vendor/drc/unix"]
+  #   <dkmldir>/.dkmlroot
+  ["diskuvbox" "copy-file" "%{dkml-runtime-common:lib}%/template.dkmlroot" "dkmldir/.dkmlroot"]
+
+  #   <dkmldir>/vendor/dkml-compiler/
+  ["diskuvbox" "copy-dir" "%{dkml-compiler-src:lib}%/src" "dkmldir/vendor/dkml-compiler"]
+
+  # If brew is installed, try to capture list of bundles for reproducible build auditing in drc's crossplatform-functions.sh.
+  ["sh" "%{dkml-runtime-common:lib}%/macos/brewbundle.sh"] {os-distribution = "homebrew"}
+
+  # Developers:
+  #   Uncomment to test your own scripts
+  #[ "diskuvbox" "copy-file" "r-c-ocaml-1-setup.sh" "dkmldir/vendor/dkml-compiler/src/r-c-ocaml-1-setup.sh" ]
+
+  # --------------
+  # Build component and .api library
+  # --------------
+
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+install: [
+  # --------------
+  # First pass
+  # --------------
+
+  # [0] Avoid permission denied copying onto read-only files in step [1]
+  [
+    "sh" "-eufxc" """
+    if [ -e '%{_:share}%/staging-files' ]; then
+      chmod -R u+w '%{_:share}%/staging-files'
+      rm -rf '%{_:share}%/staging-files'
+    fi
+    """
+  ]
+
+  # [1] Run r-c-ocaml-1-setup.sh
+  [
+    "env" "TOPDIR=dkmldir/vendor/drc/all/emptytop"
+      "DKML_REPRODUCIBLE_SYSTEM_BREWFILE=%{_:build}%/Brewfile"
+      "bash"
+      "dkmldir/vendor/dkml-compiler/src/r-c-ocaml-1-setup.sh"
+      "-d" "dkmldir"
+      "-f" "src/ocaml-1"
+      "-k" "vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh"
+      "-v" "dl/ocaml"
+      #   Host-compile into staging-files/<host-abi>
+      "-t" "%{_:share}%/staging-files"
+      "-pwindows_x86_64"  { os = "win32" }
+      "-plinux_x86"       { os = "linux" & arch = "x86_32" }
+      "-plinux_x86_64"    { os = "linux" & arch = "x86_64" }
+      "-pdarwin_x86_64"   { os = "macos" & arch = "x86_64" }
+      "-pdarwin_arm64"    { os = "macos" & arch = "arm64" }
+      #   ABIs
+      "-ewindows_x86_64"  { os = "win32" }
+      "-elinux_x86"       { os = "linux" & arch = "x86_32" }
+      "-elinux_x86_64"    { os = "linux" & arch = "x86_64" }
+      "-edarwin_x86_64"   { os = "macos" & arch = "x86_64" }
+      "-edarwin_arm64"    { os = "macos" & arch = "arm64" }
+      #   Cross-compile into staging-files/<cross-abi>
+      "-g" "."
+      #   Target architectures (if cross-compiling; similar to dkml-base-compiler.opam)
+      #     TODO: With the -adarwin_x86_64 configuration below, an Apple Silicon machine will produce an arm64 ocamlopt.opt
+      #     in the staging-files/darwin_arm64 directory,
+      #     and that ocamlopt.opt will create x86_64 OCaml native executables. So that darwin_arm64/bin/ocamlopt.opt will not
+      #     run on an x86_64 machine.
+      #     The -adarwin_arm64 configuration is similar but has one important difference. The config will produce an x86_64
+      #     ocamlopt.opt, in the staging-files/darwin_x86_64 directory, and that ocamlopt.opt will create arm64 OCaml native
+      #     executables. But that darwin_x86_64/bin/ocamlopt.opt _will_ run on almost _all_ Apple Silicon (arm64) machines
+      #     because of Rosetta2. The only major exception is Opam CI has disabled Rosetta2 as of Nov 8, 2022.
+      #     Ideally we would have [-aHOST] and [-aHOST-TARGET]. That is: -adarwin_x86_64, -adarwin_arm64 and
+      #     -adarwin_x86_64-darwin_arm64. But that cross specification has ripple effects that needs time (technical debt) to
+      #     get right. Luckily our build machines are always Apple x86_64 (GitHub Actions and GitLab CI/CD), and even if the
+      #     build machines were Apple Silicon we typically only care about the generated artifacts (the target ABI).
+      "-adarwin_x86_64=vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh" { os = "macos" & arch = "arm64" }
+      "-adarwin_arm64=vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh"  { os = "macos" & arch = "x86_64" }
+      #     For any non cross-compiling platforms we save time and space by
+      #     only building the runtime.
+      "-r"                                        { os = "win32" | (os = "linux" & (arch = "x86_32" | arch = "x86_64")) }
+  ]
+
+  # [1] Run r-c-ocaml-2-build_host-noargs.sh
+  [
+    "sh" "-eufc"
+    "cd '%{_:share}%/staging-files' && echo 1 - host && share/dkml/repro/100co/vendor/dkml-compiler/src/r-c-ocaml-2-build_host-noargs.sh"
+  ]
+
+  # [1] Run r-c-ocaml-3-build_cross-noargs.sh if cross-compiling,
+  # which will place its output into staging-files/<cross-abi>
+  # (confer: "-g" "%{_:share}%/staging-files")
+  [
+    "sh" "-eufc"
+    "cd '%{_:share}%/staging-files' && echo 1 - cross && share/dkml/repro/100co/vendor/dkml-compiler/src/r-c-ocaml-3-build_cross-noargs.sh"
+  ] { os = "macos" }
+
+  # --------------
+  # Second pass
+  #   For platforms that can do multiple _host_ ABIs _without_ cross-compiling.
+  #   * MSVC can trivially do 32-bit and 64-bit without cross-compiling.
+  #   * Most often Linux can as well as long as `gcc -m32` is configured.
+  #     However for ease of use in GitHub Actions we expect Linux 32-bit and
+  #     Linux 64-bit to be done with different Opam switches.
+  # --------------
+
+  # [2] Run r-c-ocaml-1-setup.sh
+  [
+    "env" "TOPDIR=dkmldir/vendor/drc/all/emptytop"
+      "DKML_REPRODUCIBLE_SYSTEM_BREWFILE=%{_:build}%/Brewfile"
+      "bash"
+      "dkmldir/vendor/dkml-compiler/src/r-c-ocaml-1-setup.sh"
+      "-d" "dkmldir"
+      "-f" "src/ocaml-2"
+      "-r" # Build runtime only
+      "-k" "vendor/dkml-compiler/env/standard-compiler-env-to-ocaml-configure-env.sh"
+      "-v" "dl/ocaml"
+      #   Host-compile into staging-files/<host-abi>
+      "-t" "%{_:share}%/staging-files"
+      "-pwindows_x86"     { os = "win32" }
+      #   ABIs
+      "-ewindows_x86"     { os = "win32" }
+  ] { !(os = "macos") & !(os = "linux") }
+
+  # [2] Run r-c-ocaml-2-build_host-noargs.sh
+  [
+    "sh" "-eufc"
+    "cd '%{_:share}%/staging-files' && echo 2 - host && share/dkml/repro/100co/vendor/dkml-compiler/src/r-c-ocaml-2-build_host-noargs.sh"
+  ] { !(os = "macos") & !(os = "linux") }
+
+  # --------------
+  # Clean build files
+  # --------------
+
+  [ "rm" "-rf" "%{_:share}%/staging-files/share" ]
+  [ "rm" "-rf" "%{_:share}%/staging-files/src" ]
+]
+extra-source "dl/ocaml.tar.gz" {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.0.tar.gz"
+  checksum: "sha256=39f44260382f28d1054c5f9d8bf4753cb7ad64027da792f7938344544da155e8"
+}
+extra-source "dl/flexdll.tar.gz" {
+  src: "https://github.com/alainfrisch/flexdll/archive/0.42.tar.gz"
+  checksum: "sha256=a2dce0a0d2f2c5c9f52f65e281db7405f51ff22dc71cdbf494eb241c8a4bdf0f"
+}
+extra-source "dl/homebrew-bundle.tar.gz" {
+  src: "https://github.com/Homebrew/homebrew-bundle/archive/437c67db2f160369fec3a3892e3c577b6b3a4d2c.tar.gz"
+  checksum: [
+    "sha256=ecb6b03b2d0210369f23e3f8f64cd939a4bba633db08db62a49894653e053df4"
+  ]
+}
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-component-ocamlrun.tar.gz"
+  checksum: [
+    "sha512=1f4e909b3e89911e85da27601ba30018699007166715b2575d90cdd7ebd7837d7daa6bd6059ad5d4367be7ec18704d8ad80c180b77f69b3b608ac8901f09082e"
+  ]
+}

--- a/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.14.0~v2.0.3/opam
@@ -8,7 +8,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-component-ocamlrun"
 bug-reports: "https://github.com/diskuv/dkml-component-ocamlrun/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "3.0"}
   "dkml-install" {>= "0.2.0"}
   "dkml-runtime-common" {>= "1.0.2~prerel9"}
   "dkml-compiler-src"

--- a/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.14.0~v2.0.3/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/diskuv/dkml-component-ocamlrun"
 bug-reports: "https://github.com/diskuv/dkml-component-ocamlrun/issues"
 depends: [
   "dune" {>= "3.6"}
-  "dkml-install" {>= "0.2.0"}
+  "dkml-install" {>= "0.4.0"}
   "dkml-runtime-common" {>= "1.0.2~prerel9"}
   "dkml-compiler-src"
   "diskuvbox" {>= "0.1.0"}

--- a/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.14.0~v2.0.3/opam
@@ -8,7 +8,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-component-ocamlrun"
 bug-reports: "https://github.com/diskuv/dkml-component-ocamlrun/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.6"}
   "dkml-install" {>= "0.2.0"}
   "dkml-runtime-common" {>= "1.0.2~prerel9"}
   "dkml-compiler-src"

--- a/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.14.0~v2.0.3/opam
+++ b/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.14.0~v2.0.3/opam
@@ -188,8 +188,8 @@ extra-source "dl/homebrew-bundle.tar.gz" {
   ]
 }
 url {
-  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-component-ocamlrun.tar.gz"
+  src: "https://github.com/diskuv/dkml-component-ocamlrun/archive/refs/tags/2.0.3.tar.gz"
   checksum: [
-    "sha512=1f4e909b3e89911e85da27601ba30018699007166715b2575d90cdd7ebd7837d7daa6bd6059ad5d4367be7ec18704d8ad80c180b77f69b3b608ac8901f09082e"
+    "sha512=5af90233f830b324935de89caff38f6a6c46eff14506958030dac26b6bc741405c7170491b46c94c7a19034e1f072b08bed4925b47afa6e539ec9fda92aadff7"
   ]
 }

--- a/packages/dkml-component-staging-withdkml/dkml-component-staging-withdkml.2.0.3/opam
+++ b/packages/dkml-component-staging-withdkml/dkml-component-staging-withdkml.2.0.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Places with-dkml binary into the DKML staging-files"
+description: "Places with-dkml binary into the DKML staging-files"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://gitlab.com/dkml/components/dkml-component-desktop"
+doc:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/blob/main/README.md"
+bug-reports:
+  "https://gitlab.com/dkml/components/dkml-component-desktop/-/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "conf-dkml-sys-opam"
+  "dkml-build-desktop" {= version}
+  "dkml-install" {>= "0.2.0"}
+  "diskuvbox" {>= "0.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://gitlab.com/dkml/components/dkml-component-desktop.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+
+  [ "sh" "-c" "OPAMLOGS=$PWD '%{conf-dkml-sys-opam:location-mixed}%' show --readonly --list-files with-dkml > opamshow-with-dkml.txt" ]
+]
+install: [
+  [ "dkml-desktop-copy-installed" "--file-list" "opamshow-with-dkml.txt" "--opam-switch-prefix" "%{prefix}%" "--output-dir" "%{_:share}%/staging-files/%{dkml-abi}%" ]
+]
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-component-desktop.tar.gz"
+  checksum: [
+    "sha512=47200536999985c5ccd1e660bd5f1b1ff5c22eb9ece8bfa88da4ef346ba4e80afc259a005f6baaddcb0e586b5a1607c3e7ef3c4c7c02d8f9323b3048662f054c"
+  ]
+}

--- a/packages/dkml-exe-lib/dkml-exe-lib.2.0.3/opam
+++ b/packages/dkml-exe-lib/dkml-exe-lib.2.0.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "Library containing all the code for the 'dkml' (Diskuv OCaml) executable"
+description:
+  "'dkml init' creates a local Windows-friendly Opam switch configured with DKML Opam repositories and options"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://diskuv.gitlab.io/diskuv-ocaml"
+bug-reports: "https://github.com/diskuv/dkml-runtime-apps/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.1"}
+  "dkml-runtimelib" {= version}
+  "dkml-runtimescripts" {= version}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-apps.git"
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-runtime-apps.tar.gz"
+  checksum: [
+    "sha512=2ce9072b22f1f5d7c5131ecba558f5a09fceed6b9e15bf24bdf5edad0d1d328bab27928405850a7402326105bd2ebe7d34787efb739caf7bc5723f140966a56d"
+  ]
+}

--- a/packages/dkml-exe/dkml-exe.2.0.3/opam
+++ b/packages/dkml-exe/dkml-exe.2.0.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "'dkml' (Diskuv OCaml) executable"
+description:
+  "'dkml init' creates a local Windows-friendly Opam switch configured with DKML Opam repositories and options"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://diskuv.gitlab.io/diskuv-ocaml"
+bug-reports: "https://github.com/diskuv/dkml-runtime-apps/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "dkml-exe-lib" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-apps.git"
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-runtime-apps.tar.gz"
+  checksum: [
+    "sha512=2ce9072b22f1f5d7c5131ecba558f5a09fceed6b9e15bf24bdf5edad0d1d328bab27928405850a7402326105bd2ebe7d34787efb739caf7bc5723f140966a56d"
+  ]
+}

--- a/packages/dkml-installer-ocaml-common/dkml-installer-ocaml-common.2.0.3/opam
+++ b/packages/dkml-installer-ocaml-common/dkml-installer-ocaml-common.2.0.3/opam
@@ -31,6 +31,6 @@ dev-repo: "git+https://github.com/diskuv/dkml-installer-ocaml.git"
 url {
   src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-installer-ocaml.tar.gz"
   checksum: [
-    "sha512=338863dbd359bb2149cfddc94968f83fbb2fc0ea7a5f9c3bfce7f18424f3fd4dd38173d38721e8d59a2c547fec382faab91c5e67df2595f1dfba57e91ac91d14"
+    "sha512=559f12ccaa0455c0e6630da2dc342293bfcf2001d935bb470b99a11a613e4b36b7f29ae76ecd675fc8c9669a45fd16196f6a329a04e54280af3b44710138cda4"
   ]
 }

--- a/packages/dkml-installer-ocaml-common/dkml-installer-ocaml-common.2.0.3/opam
+++ b/packages/dkml-installer-ocaml-common/dkml-installer-ocaml-common.2.0.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Common code for the network and offline DkML installers for OCaml"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-installer-ocaml"
+bug-reports: "https://github.com/diskuv/dkml-installer-ocaml/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-package-console" {>= "0.5.0"}
+  "dkml-workflows" {>= "1.1.0" & build}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-installer-ocaml.git"
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-installer-ocaml.tar.gz"
+  checksum: [
+    "sha512=338863dbd359bb2149cfddc94968f83fbb2fc0ea7a5f9c3bfce7f18424f3fd4dd38173d38721e8d59a2c547fec382faab91c5e67df2595f1dfba57e91ac91d14"
+  ]
+}

--- a/packages/dkml-installer-ocaml-network/dkml-installer-ocaml-network.2.0.3/opam
+++ b/packages/dkml-installer-ocaml-network/dkml-installer-ocaml-network.2.0.3/opam
@@ -85,6 +85,6 @@ install: [
 url {
   src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-installer-ocaml.tar.gz"
   checksum: [
-    "sha512=338863dbd359bb2149cfddc94968f83fbb2fc0ea7a5f9c3bfce7f18424f3fd4dd38173d38721e8d59a2c547fec382faab91c5e67df2595f1dfba57e91ac91d14"
+    "sha512=559f12ccaa0455c0e6630da2dc342293bfcf2001d935bb470b99a11a613e4b36b7f29ae76ecd675fc8c9669a45fd16196f6a329a04e54280af3b44710138cda4"
   ]
 }

--- a/packages/dkml-installer-ocaml-network/dkml-installer-ocaml-network.2.0.3/opam
+++ b/packages/dkml-installer-ocaml-network/dkml-installer-ocaml-network.2.0.3/opam
@@ -1,0 +1,90 @@
+opam-version: "2.0"
+synopsis: "DkML network installer generator for OCaml"
+description:
+  "Generates a network installer for OCaml, including Visual Studio and Git on Windows, and including a OCaml compiler built during installation time"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-installer-ocaml"
+bug-reports: "https://github.com/diskuv/dkml-installer-ocaml/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "odoc" {>= "1.5.3" & with-doc}
+  "ocaml" {>= "4.12.1~"}
+  "dkml-installer-ocaml-common" {= version}
+  "dkml-component-ocamlcompiler-network" {>= "4.14.0~" & < "4.14.1~"}
+  "dkml-component-offline-desktop-full" {>= "0.1.0"}
+  "dkml-component-offline-opamshim" {>= "2.2.0~alpha0~20221104"}
+  "dkml-install-installer" {>= "0.5.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-installer-ocaml.git"
+install: [
+  # Create the installer executable after `dune install` (which is after
+  # `build:[]` section) so Dune can do plugin rewriting since Dune edits (yes!)
+  # the executables.
+  # The installers will be in $OPAM/share/dkml-installer-ocaml/.
+  # For the benefit of Windows and macOS we keep the build directory name ("iw")
+  # small.
+  [ "install" "-d" "%{_:share}%/w" "%{_:share}%/t" ]
+  [
+    "_build/install/default/bin/dkml-installer-ocaml-network-create-installers%{exe}%"
+    #   Debug logs
+    "-vv"
+    "--program-version"
+    "2.0.3"
+
+    "--component=ocamlcompiler-network"
+    "--component=offline-desktop-full"
+    "--component=offline-opamshim"
+
+    # Only Windows, Linux (dockcross manylinux2014) and Darwin Intel which
+    # corresponds to the build environments of GitHub workflow setup-dkml.yml.
+    # Later can add Dune cross-compiler to get Darwin ARM64.
+    "--abi=windows_x86"
+    "--abi=windows_x86_64"
+    # "--abi=linux_x86"
+    # "--abi=linux_x86_64"
+    # "--abi=darwin_x86_64"
+
+    "--work-dir"
+    "%{_:share}%/w"
+    "--target-dir"
+    "%{_:share}%/t"
+
+    "--runner-admin-exe"
+    "_build/install/$(dune-context)/bin/dkml-installer-ocaml-network-admin-runner%{exe}%"
+    "--runner-user-exe"
+    "_build/install/$(dune-context)/bin/dkml-installer-ocaml-network-user-runner%{exe}%"
+
+    "--packager-install-exe"
+    "_build/install/$(dune-context)/bin/dkml-installer-ocaml-network-package-install%{exe}%"
+    "--packager-uninstall-exe"
+    "_build/install/$(dune-context)/bin/dkml-installer-ocaml-network-package-uninstall%{exe}%"
+    "--packager-setup-bytecode"
+    "_build/install/$(dune-context)/bin/dkml-installer-ocaml-network-package-setup.bc%{exe}%"
+    "--packager-uninstaller-bytecode"
+    "_build/install/$(dune-context)/bin/dkml-installer-ocaml-network-package-uninstaller.bc%{exe}%"
+  ]
+]
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-installer-ocaml.tar.gz"
+  checksum: [
+    "sha512=338863dbd359bb2149cfddc94968f83fbb2fc0ea7a5f9c3bfce7f18424f3fd4dd38173d38721e8d59a2c547fec382faab91c5e67df2595f1dfba57e91ac91d14"
+  ]
+}

--- a/packages/dkml-installer-ocaml-offline/dkml-installer-ocaml-offline.2.0.3/opam
+++ b/packages/dkml-installer-ocaml-offline/dkml-installer-ocaml-offline.2.0.3/opam
@@ -83,6 +83,6 @@ install: [
 url {
   src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-installer-ocaml-byte.tar.gz"
   checksum: [
-    "sha512=7b2c42a3faef49c24bd76d457818a727b26c2c218de324b846717288d23676316635fb705fb6059f576f3d8308663e35d03c82d5570032db5fe05e4c018b47b9"
+    "sha512=779fc595819009f3fa5ac0dee773b492363705cf44e14cd3d28aeca85807aa44568adb971e16d8122b1c0f8d3a134fcf1a92daeb2952decd218e481c8eb8614f"
   ]
 }

--- a/packages/dkml-installer-ocaml-offline/dkml-installer-ocaml-offline.2.0.3/opam
+++ b/packages/dkml-installer-ocaml-offline/dkml-installer-ocaml-offline.2.0.3/opam
@@ -1,0 +1,88 @@
+opam-version: "2.0"
+synopsis: "DkML offline installer generator for OCaml"
+description:
+  "Generates an offline installer for OCaml. The offline installer only supports bytecode unless the end-user machine has a C + ASM compilers (ex. Visual Studio on Windows) at the same location as the build machine"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-installer-ocaml"
+bug-reports: "https://github.com/diskuv/dkml-installer-ocaml/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "odoc" {>= "1.5.3" & with-doc}
+  "ocaml" {>= "4.12.1~"}
+  "dkml-component-ocamlcompiler-offline" {>= "4.14.0~" & < "4.14.1~"}
+  "dkml-component-offline-desktop-full" {>= "0.1.0"}
+  "dkml-install-installer" {>= "0.5.0"}
+  "dkml-workflows" {>= "1.1.0" & build}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-installer-ocaml.git"
+install: [
+  # Create the installer executable after `dune install` (which is after
+  # `build:[]` section) so Dune can do plugin rewriting since Dune edits (yes!)
+  # the executables.
+  # The installers will be in $OPAM/share/dkml-installer-ocaml/.
+  # For the benefit of Windows and macOS we keep the build directory name ("iw")
+  # small.
+  [ "install" "-d" "%{_:share}%/w" "%{_:share}%/t" ]
+  [
+    "_build/install/default/bin/dkml-installer-ocaml-offline-create-installers%{exe}%"
+    #   Debug logs
+    "-vv"
+    "--program-version"
+    "2.0.3"
+
+    "--component=ocamlcompiler-offline"
+    "--component=offline-desktop-full"
+
+    # Only Windows, Linux (dockcross manylinux2014) and Darwin Intel which
+    # corresponds to the build environments of GitHub workflow setup-dkml.yml.
+    # Later can add Dune cross-compiler to get Darwin ARM64.
+    "--abi=windows_x86"
+    "--abi=windows_x86_64"
+    # "--abi=linux_x86"
+    # "--abi=linux_x86_64"
+    # "--abi=darwin_x86_64"
+
+    "--work-dir"
+    "%{_:share}%/w"
+    "--target-dir"
+    "%{_:share}%/t"
+
+    "--runner-admin-exe"
+    "_build/install/$(dune-context)/bin/dkml-installer-ocaml-offline-admin-runner%{exe}%"
+    "--runner-user-exe"
+    "_build/install/$(dune-context)/bin/dkml-installer-ocaml-offline-user-runner%{exe}%"
+
+    "--packager-install-exe"
+    "_build/install/$(dune-context)/bin/dkml-installer-ocaml-offline-package-install%{exe}%"
+    "--packager-uninstall-exe"
+    "_build/install/$(dune-context)/bin/dkml-installer-ocaml-offline-package-uninstall%{exe}%"
+    "--packager-setup-bytecode"
+    "_build/install/$(dune-context)/bin/dkml-installer-ocaml-offline-package-setup.bc%{exe}%"
+    "--packager-uninstaller-bytecode"
+    "_build/install/$(dune-context)/bin/dkml-installer-ocaml-offline-package-uninstaller.bc%{exe}%"
+  ]
+]
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-installer-ocaml-byte.tar.gz"
+  checksum: [
+    "sha512=7b2c42a3faef49c24bd76d457818a727b26c2c218de324b846717288d23676316635fb705fb6059f576f3d8308663e35d03c82d5570032db5fe05e4c018b47b9"
+  ]
+}

--- a/packages/dkml-runtime-common-native/dkml-runtime-common-native.2.0.3/opam
+++ b/packages/dkml-runtime-common-native/dkml-runtime-common-native.2.0.3/opam
@@ -28,6 +28,6 @@ install: [
 url {
   src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-runtime-common.tar.gz"
   checksum: [
-    "sha512=52052e5958f5f51000dc826d3c0a9bd5caa246b035aaaa915ace7a3f8414b39133cbc5adbee16e46b6179a08a3c8d2470540cd44f879f67d5d1c0271884952d0"
+    "sha512=8d7dcf4e26bea1622d212f94b55d9f9cfe6e21ecdc92f5a8629e94dbe588f0684a6353e6e2417fca1a8fe676c23157b9eda88fbe2e8fd686c77d2b635f02a94c"
   ]
 }

--- a/packages/dkml-runtime-common-native/dkml-runtime-common-native.2.0.3/opam
+++ b/packages/dkml-runtime-common-native/dkml-runtime-common-native.2.0.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Common runtime code used in DKML"
+description: "Common runtime code used in DKML.
+
+This package has no dependencies and is what you should include
+in dependencies of custom OCaml compilers.
+
+The runtime code will be available in the 'lib/dkml-runtime-common-native' folder
+of your Opam switch or findlib installation.
+
+If you use opam-monorepo you should install dkml-runtime-common instead."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-runtime-common"
+bug-reports: "https://github.com/diskuv/dkml-runtime-common/issues"
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-common.git"
+#   Must not rely on OCaml (ex. diskuvbox or dune) because this
+#   package is a dependency of OCaml compilers like dkml-base-compiler!
+depends: []
+install: [
+  # TODO: opam does not quote when there is a space in the _:lib
+  # so we have to avoid the (correct) Command Prompt shell. Needs a bug
+  # report. (jonahbeckford@ 2023-01-11)
+  #[".\\install.cmd" "\"%{_:lib}%\""] { os = "win32"}
+  ["sh" "./install.sh"   "%{_:lib}%"] # {!(os = "win32")}
+]
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-runtime-common.tar.gz"
+  checksum: [
+    "sha512=52052e5958f5f51000dc826d3c0a9bd5caa246b035aaaa915ace7a3f8414b39133cbc5adbee16e46b6179a08a3c8d2470540cd44f879f67d5d1c0271884952d0"
+  ]
+}

--- a/packages/dkml-runtime-common/dkml-runtime-common.2.0.3/opam
+++ b/packages/dkml-runtime-common/dkml-runtime-common.2.0.3/opam
@@ -19,6 +19,6 @@ build: [
 url {
   src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-runtime-common.tar.gz"
   checksum: [
-    "sha512=52052e5958f5f51000dc826d3c0a9bd5caa246b035aaaa915ace7a3f8414b39133cbc5adbee16e46b6179a08a3c8d2470540cd44f879f67d5d1c0271884952d0"
+    "sha512=8d7dcf4e26bea1622d212f94b55d9f9cfe6e21ecdc92f5a8629e94dbe588f0684a6353e6e2417fca1a8fe676c23157b9eda88fbe2e8fd686c77d2b635f02a94c"
   ]
 }

--- a/packages/dkml-runtime-common/dkml-runtime-common.2.0.3/opam
+++ b/packages/dkml-runtime-common/dkml-runtime-common.2.0.3/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "Common runtime code used in DKML"
+description: "Common runtime code used in DKML.
+
+The runtime code will be available in the 'lib/dkml-runtime-common' folder
+of your Opam switch or findlib installation."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-runtime-common"
+bug-reports: "https://github.com/diskuv/dkml-runtime-common/issues"
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-common.git"
+depends: [
+  "dune" {>= "2.9"}
+]
+build: [
+  ["dune" "build" "-p" name]
+]
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-runtime-common.tar.gz"
+  checksum: [
+    "sha512=52052e5958f5f51000dc826d3c0a9bd5caa246b035aaaa915ace7a3f8414b39133cbc5adbee16e46b6179a08a3c8d2470540cd44f879f67d5d1c0271884952d0"
+  ]
+}

--- a/packages/dkml-runtime-distribution/dkml-runtime-distribution.2.0.3/opam
+++ b/packages/dkml-runtime-distribution/dkml-runtime-distribution.2.0.3/opam
@@ -29,6 +29,6 @@ install: [
 url {
   src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-runtime-distribution.tar.gz"
   checksum: [
-    "sha512=2925e68ddd68c83eeed87b2050e2c82099ecae7c656b580a0ef2674f3b9b5ee957ff0fb85d6732af5f9e0f74e9672ff02cb6ac7b27f71ef338bdc99878289152"
+    "sha512=814ac052cad9449e36567409575f732d901fc960b0f35fab83b25666f6e5a541890cbab9ea0c76784ce997e547b6663a6c083e3add4ef5e770f6ec29f13cf474"
   ]
 }

--- a/packages/dkml-runtime-distribution/dkml-runtime-distribution.2.0.3/opam
+++ b/packages/dkml-runtime-distribution/dkml-runtime-distribution.2.0.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Scripts used by the Diskuv OCaml distribution during installation"
+description: """
+Scripts used by the Diskuv OCaml distribution during the installation of:
+* a local project (ie. a Opam switch created with `dkml init`)
+* a user profile (ex. OCaml binaries installed within the user's home directory)
+* a machine (ex. system or Administrator assembly/C compilers)"""
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-runtime-distribution"
+bug-reports: "https://github.com/diskuv/dkml-runtime-distribution/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.1~" & < "4.12.2~" | >= "4.14.0~" & < "4.14.1~"}
+  "diskuvbox" {>= "0.1.0" & build}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-distribution.git"
+# Until Dune 3+ the auto-generated '.opam' will have an invalid ["dune" "install" ...] step
+# that messes up with cross-compilation. Customized it to remove it.
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} "@doc" {with-doc}]
+]
+install: [
+  ["diskuvbox" "copy-dir" "src" "%{_:lib}%/src"]
+]
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-runtime-distribution.tar.gz"
+  checksum: [
+    "sha512=2925e68ddd68c83eeed87b2050e2c82099ecae7c656b580a0ef2674f3b9b5ee957ff0fb85d6732af5f9e0f74e9672ff02cb6ac7b27f71ef338bdc99878289152"
+  ]
+}

--- a/packages/dkml-runtimelib/dkml-runtimelib.2.0.3/opam
+++ b/packages/dkml-runtimelib/dkml-runtimelib.2.0.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Runtime library used by CLI applications and Opam plugins in a Diskuv OCaml installation"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://diskuv.gitlab.io/diskuv-ocaml"
+bug-reports: "https://github.com/diskuv/dkml-runtime-apps/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.1"}
+  "bos" {>= "0.2.1"}
+  "sexplib" {>= "0.14.0"}
+  "dkml-c-probe" {>= "3.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-apps.git"
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-runtime-apps.tar.gz"
+  checksum: [
+    "sha512=2ce9072b22f1f5d7c5131ecba558f5a09fceed6b9e15bf24bdf5edad0d1d328bab27928405850a7402326105bd2ebe7d34787efb739caf7bc5723f140966a56d"
+  ]
+}

--- a/packages/dkml-runtimescripts/dkml-runtimescripts.2.0.3/opam
+++ b/packages/dkml-runtimescripts/dkml-runtimescripts.2.0.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Runtime scripts used by CLI applications and Opam plugins in a Diskuv OCaml installation"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://diskuv.gitlab.io/diskuv-ocaml"
+bug-reports: "https://github.com/diskuv/dkml-runtime-apps/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.1"}
+  "bos" {>= "0.2.1"}
+  "fpath" {>= "0.7.0"}
+  "re" {>= "1.10.0"}
+  "rresult" {>= "0.7.0"}
+  "dkml-compiler-env" {= version}
+  "dkml-runtime-common" {= version}
+  "dkml-runtime-distribution" {= version}
+  "crunch" {>= "3.3.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-apps.git"
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-runtime-apps.tar.gz"
+  checksum: [
+    "sha512=2ce9072b22f1f5d7c5131ecba558f5a09fceed6b9e15bf24bdf5edad0d1d328bab27928405850a7402326105bd2ebe7d34787efb739caf7bc5723f140966a56d"
+  ]
+}

--- a/packages/dkml-workflows/dkml-workflows.2.0.3/opam
+++ b/packages/dkml-workflows/dkml-workflows.2.0.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis:
+  "GitLab CI/CD and GitHub Action workflows used by and with Diskuv OCaml (DKML) tooling"
+description:
+  "GitLab CI/CD and GitHub Action workflows used by and with Diskuv OCaml (DKML) tooling."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-workflows"
+bug-reports: "https://github.com/diskuv/dkml-workflows/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.1"}
+  "crunch" {>= "3.3.1"}
+  "jingoo" {>= "1.4.4"}
+  "uutf" {>= "1.0.3"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-workflows.git"
+# Until Dune 3+ the auto-generated '.opam' will have an invalid ["dune" "install" ...] step
+# that messes up with cross-compilation. Customized it to remove it.
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} "@doc" {with-doc}]
+]
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-workflows.tar.gz"
+  checksum: [
+    "sha512=12f5c685bb0c81ba50238b7edf38f72816c14a75912ffa249fa6fc5ab076d08570654d635d0021cc23c779bf4cf5bf1e9a7773684e25063070af7c56f56d3fb1"
+  ]
+}

--- a/packages/opam-dkml/opam-dkml.2.0.3/opam
+++ b/packages/opam-dkml/opam-dkml.2.0.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Opam plugin for Diskuv OCaml (DKML). Deprecated; use 'dkml' executable instead"
+description:
+  "An opam plugin where 'opam dkml init' creates a local Windows-friendly Opam switch configured with DKML Opam repositories and options"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://diskuv.gitlab.io/diskuv-ocaml"
+bug-reports: "https://github.com/diskuv/dkml-runtime-apps/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "dkml-exe-lib" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-apps.git"
+flags: plugin
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-runtime-apps.tar.gz"
+  checksum: [
+    "sha512=2ce9072b22f1f5d7c5131ecba558f5a09fceed6b9e15bf24bdf5edad0d1d328bab27928405850a7402326105bd2ebe7d34787efb739caf7bc5723f140966a56d"
+  ]
+}

--- a/packages/with-dkml/with-dkml.2.0.3/opam
+++ b/packages/with-dkml/with-dkml.2.0.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Gives Windows access to Opam and MSYS2 environments"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://diskuv.gitlab.io/diskuv-ocaml"
+bug-reports: "https://github.com/diskuv/dkml-runtime-apps/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.1"}
+  "dkml-runtimelib" {= version}
+  "dkml-runtime-common" {= version}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "sha" {>= "1.15.2"}
+  "crunch" {>= "3.3.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-apps.git"
+url {
+  src: "https://gitlab.com/dkml/distributions/dkml/-/releases/2.0.3/downloads/src.dkml-runtime-apps.tar.gz"
+  checksum: [
+    "sha512=2ce9072b22f1f5d7c5131ecba558f5a09fceed6b9e15bf24bdf5edad0d1d328bab27928405850a7402326105bd2ebe7d34787efb739caf7bc5723f140966a56d"
+  ]
+}


### PR DESCRIPTION
Status:

- [ ] The DkML distribution is blocked on `dkml-base-compiler` getting into the `ocaml` package. That will be `ocaml.4.14.2`.