### PR TITLE
improve depexts for several conf packages

### DIFF
--- a/packages/conf-autoconf/conf-autoconf.0.1/opam
+++ b/packages/conf-autoconf/conf-autoconf.0.1/opam
@@ -23,6 +23,7 @@ depexts: [
   ["autoconf"] {os-distribution = "ol"}
   ["autoconf"] {os-distribution = "rhel"}
   ["system:autoconf"] {os = "win32" & os-distribution = "cygwinports"}
+  ["autoconf"] {os-distribution = "cygwin"}
   ["autoconf"] {os-family = "suse" | os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on autoconf installation"

--- a/packages/conf-cairo/conf-cairo.1/opam
+++ b/packages/conf-cairo/conf-cairo.1/opam
@@ -24,6 +24,7 @@ depexts: [
   ["cairo"] {os-family = "arch"}
   ["cairo"] {os = "macos" & os-distribution = "homebrew"}
   ["cairo"] {os = "win32" & os-distribution = "cygwinports"}
+  ["libcairo-devel"] {os-distribution = "cygwin"}
 ]
 synopsis: "Virtual package relying on a Cairo system installation"
 description:

--- a/packages/conf-graphviz/conf-graphviz.0.1/opam
+++ b/packages/conf-graphviz/conf-graphviz.0.1/opam
@@ -21,6 +21,7 @@ depexts: [
   ["graphviz"] {os = "openbsd"}
   ["graphics/graphviz"] {os = "freebsd"}
   ["system:graphviz"] {os = "win32" & os-distribution = "cygwinports"}
+  ["graphviz"] {os-distribution = "cygwin"}
 ]
 synopsis: "Virtual package relying on graphviz installation"
 description:

--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -16,6 +16,7 @@ depexts: [
   ["gtk3-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gtk3"] {os-family = "arch"}
   ["gtk3"] {os = "win32" & os-distribution = "cygwinports"}
+  ["libgtk3-devel"] {os-distribution = "cygwin"}
 ]
 post-messages: [
   "This package requires gtk+ 3.0 development packages installed on your system"

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
@@ -17,6 +17,7 @@ depexts: [
   ["gtksourceview3-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gtksourceview3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
   ["gtksourceview3.0"] {os = "win32" & os-distribution = "cygwinports"}
+  ["libgtksourceview3.0-devel"] { os-distribution = "cygwin"}
 ]
 synopsis: "Virtual package relying on a GtkSourceView-3 system installation"
 description:

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
@@ -8,7 +8,7 @@ build: [["pkg-config" "--short-errors" "--print-errors" "gtksourceview-3.0"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["gtksourceview-dev"] {os-distribution = "alpine"}
-  ["gtksourceview3"] {os-distribution = "arch"}
+  ["gtksourceview3"] {os-family = "arch"}
   ["epel-release" "gtksourceview3-devel"] {os-distribution = "centos"}
   ["libgtksourceview-3.0-dev"] {os-family = "debian"}
   ["gtksourceview3-devel"] {os-distribution = "fedora"}

--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -17,6 +17,7 @@ depexts: [
   ["zlib"] {os-distribution = "homebrew" & os = "macos"}
   ["zlib"] {os-family = "arch"}
   ["zlib"] {os = "win32" & os-distribution = "cygwinports"}
+  ["zlib-devel"] {os-distribution = "cygwin"}
 ]
 synopsis: "Virtual package relying on zlib"
 description:


### PR DESCRIPTION
There are two commits:

- the first replaces an `os-distribution` with `os-family`, after testing on an Arch-based system (I don't remember which one exactly, sorry) which had the same package name;
- the second one adds several Cygwin package names for `conf-` packages used by Frama-C.

I'm using MobaXterm, with the following relevant config environment:

```
arch              x86_32                                                   # Inferred from system
opam-version      2.0.7                                                    # The currently running opam version
os                cygwin                                                   # Inferred from system
os-distribution   cygwin                                                   # Inferred from system
os-family         windows                                                  # Inferred from system
os-version        unknown                                                  # Inferred from system
```

So I'm not sure I should use `os` or `os-distribution` in the depexts I added; for now I used `os-distribution`, but if you prefer `os`, I can change it.