### PR TITLE
[new release] coq-serapi (8.17.0+0.17.1)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.17.0+0.17.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.17.0+0.17.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.09.0"              }
+  "coq"                 {           >= "8.17" & < "8.18"     }
+  "cmdliner"            {           >= "1.1.0"               }
+  "ocamlfind"           {           >= "1.8.0"               }
+  "sexplib"             {           >= "v0.13.0"             }
+  "dune"                {           >= "2.0.1"               }
+  "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
+  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_sexp_conv"       {           >= "v0.13.0"             }
+  "ppx_compare"         {           >= "v0.13.0"             }
+  "ppx_hash"            {           >= "v0.13.0"             }
+  "yojson"              {           >= "1.7.0"               }
+  "ppx_deriving_yojson" {           >= "3.4"                 }
+]
+
+conflicts: [
+  "result" {< "1.5"}
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.17.0%2B0.17.1/coq-serapi-8.17.0.0.17.1.tbz"
+  checksum: [
+    "sha256=09e2b3920d40eea3bed165d9ec67a3c87a9795918adbea0f9a87ee68d2014fa4"
+    "sha512=650b8e5d09aa42d4cb9f3c2dd09d9e4217bd325f5ac9b540783775e2a132556bbfa1f9c702eba83d6480ad3d8e429171d3bd4d01194b8243c80e8d55c0825bad"
+  ]
+}
+x-commit-hash: "a224455c7ce3975fb9ebb2ad687d54b71eaabff2"


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

 - [sertop] Don't initialize `CoqworkmgrApi` (@ejgallego, ejgallego/coq-serapi#340)
 - [serlib] Compat with Jane Street libraries >= v0.16.0 (@ejgallego,
            ejgallego/coq-serapi#351)
