### PR TITLE
4 packages from diskuv/dkml-install-api at 0.5.1

### DIFF
--- a/packages/dkml-install-installer/dkml-install-installer.0.5.1/opam
+++ b/packages/dkml-install-installer/dkml-install-installer.0.5.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Build tools for DkML installers"
+description:
+  "Build-time executables that can generate Dune include files which will compile essential end-user executables."
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "crunch" {>= "3.3.1"}
+  "odoc" {with-doc}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.5.1/src.tar.gz"
+  checksum: [
+    "md5=4636532b5971d7aa058b492448b02908"
+    "sha512=66e28e6c47b3de638601f0002289849d9af6bcbb9a2eb816d1dfe640bf3e5a350ad16b99d88b474b7be2482de480b5dd1fad4dbf87c702ee421bc033a3ca1327"
+  ]
+}

--- a/packages/dkml-install-runner/dkml-install-runner.0.5.1/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.5.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Runner executable for DkML installation"
+description:
+  "The runner executable is responsible for loading and running all DkML installation components."
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "dkml-install" {= version}
+  "ppx_expect" {>= "v0.14.1"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.1"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "diskuvbox" {>= "0.1.1"}
+  "odoc" {with-doc}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.5.1/src.tar.gz"
+  checksum: [
+    "md5=4636532b5971d7aa058b492448b02908"
+    "sha512=66e28e6c47b3de638601f0002289849d9af6bcbb9a2eb816d1dfe640bf3e5a350ad16b99d88b474b7be2482de480b5dd1fad4dbf87c702ee421bc033a3ca1327"
+  ]
+}

--- a/packages/dkml-install/dkml-install.0.5.1/opam
+++ b/packages/dkml-install/dkml-install.0.5.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "API and registry for DkML installation components"
+description:
+  "All DkML installation components implement the interfaces exposed in this API."
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "ppx_deriving" {>= "5.2.1"}
+  "result" {>= "1.5"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.1"}
+  "fmt" {>= "0.8.9"}
+  "tsort" {>= "2.1.0"}
+  "diskuvbox" {>= "0.1.1" & with-test}
+  "odoc" {with-doc}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.5.1/src.tar.gz"
+  checksum: [
+    "md5=4636532b5971d7aa058b492448b02908"
+    "sha512=66e28e6c47b3de638601f0002289849d9af6bcbb9a2eb816d1dfe640bf3e5a350ad16b99d88b474b7be2482de480b5dd1fad4dbf87c702ee421bc033a3ca1327"
+  ]
+}

--- a/packages/dkml-package-console/dkml-package-console.0.5.1/opam
+++ b/packages/dkml-package-console/dkml-package-console.0.5.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Console setup and uninstall executables for DkML installation"
+description:
+  "The setup and uninstall executables are responsible for launching the DkML runners."
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "diskuvbox" {>= "0.1.1"}
+  "crunch" {>= "3.3.1"}
+  "dkml-component-xx-console" {>= "0.1.1"}
+  "odoc" {with-doc}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.5.1/src.tar.gz"
+  checksum: [
+    "md5=4636532b5971d7aa058b492448b02908"
+    "sha512=66e28e6c47b3de638601f0002289849d9af6bcbb9a2eb816d1dfe640bf3e5a350ad16b99d88b474b7be2482de480b5dd1fad4dbf87c702ee421bc033a3ca1327"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `dkml-install.0.5.1`: API and registry for DkML installation components
- `dkml-install-installer.0.5.1`: Build tools for DkML installers
- `dkml-install-runner.0.5.1`: Runner executable for DkML installation
- `dkml-package-console.0.5.1`: Console setup and uninstall executables for DkML installation



---
* Homepage: https://github.com/diskuv/dkml-install-api
* Source repo: git+https://github.com/diskuv/dkml-install-api.git
* Bug tracker: https://github.com/diskuv/dkml-install-api/issues

---
:camel: Pull-request generated by opam-publish v2.2.0