### PR TITLE
mark bitwuzla-bin.0.0.0 as deprecated

### DIFF
--- a/packages/bitwuzla-bin/bitwuzla-bin.0.0.0/opam
+++ b/packages/bitwuzla-bin/bitwuzla-bin.0.0.0/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 synopsis: "Bitwuzla SMT solver executable"
+flags: deprecated
 description: """
 
 Standalone installer for the SMT solver Bitwuzla.

--- a/packages/bitwuzla-bin/bitwuzla-bin.0.0.0/opam
+++ b/packages/bitwuzla-bin/bitwuzla-bin.0.0.0/opam
@@ -3,7 +3,8 @@ synopsis: "Bitwuzla SMT solver executable"
 flags: deprecated
 description: """
 
-Standalone installer for the SMT solver Bitwuzla.
+/!\ Deprecated. Standalone installer for the SMT solver Bitwuzla.
+OCaml users should use instead one of the packages bitwuzla, bitwuzla-c or the latest version bitwuzla-cxx to access the Bitwuzla API.
 
 Bitwuzla is a Satisfiability Modulo Theories (SMT) solver for the theories of fixed-size bit-vectors, arrays and uninterpreted functions and their combinations. Its name is derived from an Austrian dialect expression that can be translated as “someone who tinkers with bits”."""
 maintainer: ["Frédéric Recoules <frederic.recoules@cea.fr>"]

--- a/packages/bitwuzla-bin/bitwuzla-bin.1.0.0/opam
+++ b/packages/bitwuzla-bin/bitwuzla-bin.1.0.0/opam
@@ -2,7 +2,8 @@ opam-version: "2.0"
 synopsis: "Bitwuzla SMT solver executable"
 description: """
 
-Standalone installer for the SMT solver Bitwuzla.
+/!\ Aging. Standalone installer for the SMT solver Bitwuzla.
+OCaml users should use instead one of the packages bitwuzla, bitwuzla-c or the latest version bitwuzla-cxx to access the Bitwuzla API.
 
 Bitwuzla is a Satisfiability Modulo Theories (SMT) solver for the theories of fixed-size bit-vectors, arrays and uninterpreted functions and their combinations. Its name is derived from an Austrian dialect expression that can be translated as “someone who tinkers with bits”."""
 maintainer: ["Frédéric Recoules <frederic.recoules@cea.fr>"]


### PR DESCRIPTION
This package seems to have compilation errors with newer compilers (https://github.com/ocaml/opam-repository/pull/24429#issuecomment-1718724110).
As of today, the version `1.0.0` seems to still work.

Note: this package has little things to do in the opam repository as it contains only C/C++ sources.
I published it a while ago because I thought it could help people to automatically install the bitwuzla SMT solver (substitute for `apt` et cie.). If it is possible, it can be removed -- I think nobody is using it and no Opam package depends on it.
Ocaml user should use `bitwuzla`, `bitwuzla-c` or the latest version `bitwuzla-cxx` for access to the API. 