### PR TITLE
Package binaryen.0.22.0

### DIFF
--- a/packages/binaryen/binaryen.0.22.0/opam
+++ b/packages/binaryen/binaryen.0.22.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "4.1.0" & < "6.0.0"}
+  "libbinaryen" {>= "112.0.0" & < "113.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.22.0/binaryen-archive-v0.22.0.tar.gz"
+  checksum: [
+    "md5=26bc06ba2b789f33896531c3dbaf0b56"
+    "sha512=f9b914b073838c96f17a178531346f0dff231a1b8f9effdab9060578dd8e5ac539df3b53b60800f72f07ff4070b30cb7bbbf40dccbbea1207f75af9d2b431263"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.22.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.22.0](https://github.com/grain-lang/binaryen.ml/compare/v0.21.0...v0.22.0) (2023-09-14)


### ⚠ BREAKING CHANGES

* Rename `dataref` to `structref`
* Rename `data` to `struct_` in `Heap_type`
* Remove `equirecursive` in `Type_system`
* Properly resolve ops externals to their type
* Replace `Expression.Ref.is` with `Expression.Ref.is_null`
* Remove Ops that no longer exist in Binaryen
* Upgrade to libbinaryen v112 ([#188](https://github.com/grain-lang/binaryen.ml/issues/188))

### Features

* Add i31 expressions ([46c97c2](https://github.com/grain-lang/binaryen.ml/commit/46c97c2e92d95ffbe880c084ce3c13c503240e58))
* Add new Binaryen ops ([46c97c2](https://github.com/grain-lang/binaryen.ml/commit/46c97c2e92d95ffbe880c084ce3c13c503240e58))
* Add new optimization passes ([46c97c2](https://github.com/grain-lang/binaryen.ml/commit/46c97c2e92d95ffbe880c084ce3c13c503240e58))
* Replace `Expression.Ref.is` with `Expression.Ref.is_null` ([46c97c2](https://github.com/grain-lang/binaryen.ml/commit/46c97c2e92d95ffbe880c084ce3c13c503240e58))
* Upgrade to libbinaryen v112 ([#188](https://github.com/grain-lang/binaryen.ml/issues/188)) ([46c97c2](https://github.com/grain-lang/binaryen.ml/commit/46c97c2e92d95ffbe880c084ce3c13c503240e58))


### Bug Fixes

* Properly resolve ops externals to their type ([46c97c2](https://github.com/grain-lang/binaryen.ml/commit/46c97c2e92d95ffbe880c084ce3c13c503240e58))


### Miscellaneous Chores

* Remove `equirecursive` in `Type_system` ([46c97c2](https://github.com/grain-lang/binaryen.ml/commit/46c97c2e92d95ffbe880c084ce3c13c503240e58))
* Remove Ops that no longer exist in Binaryen ([46c97c2](https://github.com/grain-lang/binaryen.ml/commit/46c97c2e92d95ffbe880c084ce3c13c503240e58))
* Rename `data` to `struct_` in `Heap_type` ([46c97c2](https://github.com/grain-lang/binaryen.ml/commit/46c97c2e92d95ffbe880c084ce3c13c503240e58))
* Rename `dataref` to `structref` ([46c97c2](https://github.com/grain-lang/binaryen.ml/commit/46c97c2e92d95ffbe880c084ce3c13c503240e58))

---
:camel: Pull-request generated by opam-publish v2.0.3