### PR TITLE
Restore dropped improvement to the OCaml 5.1.0 packages

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0/opam
@@ -5,7 +5,7 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml"
+dev-repo: "git+https://github.com/ocaml/ocaml#5.1"
 depends: [
   "ocaml" {= "5.1.0" & post}
   "base-unix" {post}
@@ -14,7 +14,7 @@ depends: [
   "base-domains" {post}
   "base-nnp" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
@@ -2,10 +2,17 @@ opam-version: "2.0"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.1.0"
 maintainer: "platform@lists.ocaml.org"
-authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml.git#5.0"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.1"
 depends: [
   "ocaml" {= "5.1.0" & post}
   "base-unix" {post}
@@ -13,7 +20,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
@@ -42,15 +49,9 @@ build: [
     "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
     "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
     "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
-    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
     "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
-    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
-    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
-    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
-    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
     "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
     "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
-    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
     "LIBS=-static" {ocaml-option-static:installed}
     "--disable-warn-error"
   ]
@@ -62,16 +63,6 @@ url {
   checksum: "sha256=43a3ac7aab7f8880f2bb6221317be55319b356e517622fdc28359fe943e6a450"
 }
 extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
-conflicts: [ "ocaml-option-fp" ]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"


### PR DESCRIPTION
The #24433 PR that added the 5.1.0 dropped  various improvements ( #24130, #24341, #22668) and fixes on the ocaml package made during the rc process.

This PR restores those, cc @dra27, and I will try to improve the release process to avoid this issue next time.