### PR TITLE
Add: uucd.15.1.0, uucp.15.1.0, uunf.15.1.0, uuseg.15.1.0

### DIFF
--- a/packages/uucd/uucd.15.1.0/opam
+++ b/packages/uucd/uucd.15.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Unicode character database decoder for OCaml"
+description: """\
+Uucd is an OCaml module to decode the data of the [Unicode character 
+database][1] from its XML [representation][2]. It provides high-level 
+(but not necessarily efficient) access to the data so that efficient 
+representations can be extracted.
+
+Uucd is made of a single module, depends on [Xmlm][xmlm] and is distributed
+under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr44/
+[2]: http://www.unicode.org/reports/tr42/
+[xmlm]: http://erratique.ch/software/xmlm 
+
+Home page: http://erratique.ch/software/uucd"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uucd programmers"
+license: "ISC"
+tags: ["unicode" "database" "decoder" "org:erratique"]
+homepage: "https://erratique.ch/software/uucd"
+doc: "https://erratique.ch/software/uucd/doc/Uucd"
+bug-reports: "https://github.com/dbuenzli/uucd/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "xmlm"
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/uucd.git"
+url {
+  src: "https://erratique.ch/software/uucd/releases/uucd-15.1.0.tbz"
+  checksum:
+    "sha512=22ff943321825882e66f60dc057d1e1dee9aa50f31e5d9f3487f100ac0a33338831e211ce152f3a4586da95931a43a71f66ad0528e932cd531848522a9951e90"
+}

--- a/packages/uucp/uucp.15.1.0/opam
+++ b/packages/uucp/uucp.15.1.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Unicode character properties for OCaml"
+description: """\
+Uucp is an OCaml library providing efficient access to a selection of
+character properties of the [Unicode character database].
+
+Uucp is distributed under the ISC license. It has no dependency.
+
+Home page: <http://erratique.ch/software/uucp>
+
+[Unicode character database]: http://www.unicode.org/reports/tr44/"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uucp programmers"
+license: "ISC"
+tags: ["unicode" "text" "character" "org:erratique"]
+homepage: "https://erratique.ch/software/uucp"
+doc: "https://erratique.ch/software/uucp/doc/"
+bug-reports: "https://github.com/dbuenzli/uucp/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "uucd" {with-test & dev & >= "15.1.0" & < "16.0.0"}
+  "uunf" {with-test}
+]
+depopts: ["uunf" "cmdliner"]
+conflicts: [
+  "uunf" {< "15.1.0" | >= "16.0.0"}
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-uunf"
+  "%{uunf:installed}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+post-messages:
+  "If the build fails with \"ocamlopt.opt got signal and exited\", issue 'ulimit -s unlimited' and retry."
+    {failure & (arch = "ppc64" | arch = "arm64")}
+dev-repo: "git+https://erratique.ch/repos/uucp.git"
+url {
+  src: "https://erratique.ch/software/uucp/releases/uucp-15.1.0.tbz"
+  checksum:
+    "sha512=998f94fadb72357b15a3042a3d11c31b3e16f281822673f2defdd515cd1394d55de1817628be8bd5c030175f9e62c53630d4139a1c0253800f9fb898b0f11364"
+}

--- a/packages/uunf/uunf.15.1.0/opam
+++ b/packages/uunf/uunf.15.1.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Unicode text normalization for OCaml"
+description: """\
+Uunf is an OCaml library for normalizing Unicode text. It supports all
+Unicode [normalization forms]. The library is independent from any IO
+mechanism or Unicode text data structure and it can process text
+without a complete in-memory representation.
+
+Uunf is distributed under the ISC license. It has no dependency.
+
+[normalization forms]: http://www.unicode.org/reports/tr15/
+
+Homepage: <http://erratique.ch/software/uunf>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uunf programmers"
+license: "ISC"
+tags: ["unicode" "text" "normalization" "org:erratique"]
+homepage: "https://erratique.ch/software/uunf"
+doc: "https://erratique.ch/software/uunf/doc/Uunf"
+bug-reports: "https://github.com/dbuenzli/uunf/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "uucd" {dev & >= "15.1.0" & < "16.0.0"}
+]
+depopts: ["uutf" "cmdliner"]
+conflicts: [
+  "uutf" {< "1.0.0"}
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-uutf"
+  "%{uutf:installed}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+post-messages:
+  "If the build fails with \"ocamlopt.opt got signal and exited\", issue 'ulimit -s unlimited' and retry."
+    {failure & (arch = "ppc64" | arch = "arm64")}
+dev-repo: "git+https://erratique.ch/repos/uunf.git"
+url {
+  src: "https://erratique.ch/software/uunf/releases/uunf-15.1.0.tbz"
+  checksum:
+    "sha512=1df1edbcb37da80e6d96eedd5e01c43c81275eca727a53d91a777d01f30cf0b964968c7be1d943e574e40ad4acb75c86e42976b3048dacb2c798b38475d0a6d0"
+}

--- a/packages/uuseg/uuseg.15.1.0/opam
+++ b/packages/uuseg/uuseg.15.1.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Unicode text segmentation for OCaml"
+description: """\
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the [Unicode
+line breaking algorithm][2] to detect line break opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg is distributed under the ISC license. It depends on [Uucp].
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/
+[Uucp]: http://erratique.ch/software/uucp
+
+Homepage: <http://erratique.ch/software/uuseg>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uuseg programmers"
+license: "ISC"
+tags: ["unicode" "text" "segmentation" "org:erratique"]
+homepage: "https://erratique.ch/software/uuseg"
+doc: "https://erratique.ch/software/uuseg/doc/"
+bug-reports: "https://github.com/dbuenzli/uuseg/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "uucp" {>= "15.1.0" & < "16.0.0"}
+]
+depopts: ["uutf" "cmdliner"]
+conflicts: [
+  "uutf" {< "1.0.0"}
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-uutf"
+  "%{uutf:installed}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/uuseg.git"
+url {
+  src: "https://erratique.ch/software/uuseg/releases/uuseg-15.1.0.tbz"
+  checksum:
+    "sha512=1e9460dc5a856c985d40c61fd1560bdfdb8bbaf8d7430405814589b47d4a7f7869658d1e3198c7a9132412e9b4b85402ceb4bda5040da426b69e9aef4222a23a"
+}


### PR DESCRIPTION
* Add: `uucd.15.1.0` [home](https://erratique.ch/software/uucd), [doc](https://erratique.ch/software/uucd/doc/Uucd), [issues](https://github.com/dbuenzli/uucd/issues)  
  *Unicode character database decoder for OCaml*
* Add: `uucp.15.1.0` [home](https://erratique.ch/software/uucp), [doc](https://erratique.ch/software/uucp/doc/), [issues](https://github.com/dbuenzli/uucp/issues)  
  *Unicode character properties for OCaml*
* Add: `uunf.15.1.0` [home](https://erratique.ch/software/uunf), [doc](https://erratique.ch/software/uunf/doc/Uunf), [issues](https://github.com/dbuenzli/uunf/issues)  
  *Unicode text normalization for OCaml*
* Add: `uuseg.15.1.0` [home](https://erratique.ch/software/uuseg), [doc](https://erratique.ch/software/uuseg/doc/), [issues](https://github.com/dbuenzli/uuseg/issues)  
  *Unicode text segmentation for OCaml*


---

#### `uucd` v15.1.0 2023-09-15 Zagreb

- support for Unicode 15.1.0

---

#### `uucp` v15.1.0 2023-09-15 Zagreb

- Unicode 15.1.0 support.
- Require OCaml 4.14.0.
- Use module aliases for the property modules. Only pay for the
  modules you use ([#2](https://github.com/dbuenzli/uucp/issues/2)).
- Use the standard library UTF decoders in the sample code and in
  `ucharinfo` ([#23](https://github.com/dbuenzli/uucp/issues/23)).
- The `Num.numeric_value` had to be changed to accomodate for the
  data. It now returns either NaN or a list of numbers. This is due to
  the interpretation of U+5146 and U+79ED which is locale dependent
  and thus can represent multiple values. In all other cases you
  should get singelton lists so far.
- Rename `Uucd.Cjk.ids_bin_op` to `Uucd.Cjk.ids_binary_operator`.
- Rename `Uucd.Cjk.ids_tri_op` to `Uccd.Cjk.ids_trinary_operator`.
- Add `Uucd.Cjk.ids_unary_operator`, support for the new `IDS_Unary_Operator`
  property.
- Add `Uucd.Id.is_id_compat_math_{start,continue}`, support for the new
  `ID_Compat_Math_{Start,Continue}` properties.
- Add `Uucd.Case.Nfkc_simple_fold.fold`, support for the new 
  `NFKC_Simple_Casefold` property.
- Add `Uucd.Break.indic_conjunct_break`, support for the new 
  `Indic_Conjunct_Break` property.

---

#### `uunf` v15.1.0 2022-09-15 Zagreb

- Unicode 15.1.0 support. 
- Requires OCaml 4.14.0.
- The `Uunf_string` module was rewritten to use the standard library
  UTF decoders and was moved to the `uunf` library. The `uunf.string`
  library is deprecated, it warns on usage and simply requires `uunf`.
- The sample code was rewritten to use the standard library UTF
  decoders.

---

#### `uuseg` v15.1.0 2023-09-15 Zagreb

- Unicode 15.1.0 support. 
- Requires OCaml 4.14.0 for the UTF decoders.
- The `Uuseg_string` module was rewritten to use the standard library
  UTF decoders and was moved to the `uuseg` library. The `uuseg.string`
  library is deprecated, it warns on usage and simply requires `uuseg`.
- The sample code was rewritten to use the standard library UTF
  decoders.

---

Use `b0 -- .opam publish uucd.15.1.0 uucp.15.1.0 uunf.15.1.0 uuseg.15.1.0` to update the pull request.