### PR TITLE
Package vscoq-language-server.2.0.0+coq8.18

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.0.0+coq8.18/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.0.0+coq8.18/opam
@@ -15,7 +15,7 @@ depends: [
   "coq-core" { >= "8.18" < "8.19" }
   "coq-stdlib" { >= "8.18" < "8.19" }
   "yojson"
-  "jsonrpc" { >= "1.15" }
+  "jsonrpc" { >= "1.16" }
   "ocamlfind"
   "ppx_inline_test"
   "ppx_assert"


### PR DESCRIPTION
### `vscoq-language-server.2.0.0+coq8.18`
VSCoq language server
LSP based language server for Coq and its VSCoq user interface



---
* Homepage: https://github.com/coq-community/vscoq
* Source repo: git+https://github.com/coq-community/vscoq
* Bug tracker: https://github.com/coq-community/vscoq/issues

---
:camel: Pull-request generated by opam-publish v2.0.3