### PR TITLE
2 packages from diskuv/dkml-runtime-common at 2.0.3

### DIFF
--- a/packages/dkml-runtime-common-native/dkml-runtime-common-native.2.0.3/opam
+++ b/packages/dkml-runtime-common-native/dkml-runtime-common-native.2.0.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Common runtime code used in DKML"
+description: """\
+Common runtime code used in DKML.
+
+This package has no dependencies and is what you should include
+in dependencies of custom OCaml compilers.
+
+The runtime code will be available in the 'lib/dkml-runtime-common-native' folder
+of your Opam switch or findlib installation.
+
+If you use opam-monorepo you should install dkml-runtime-common instead."""
+maintainer: "opensource+diskuv-ocaml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-runtime-common"
+bug-reports: "https://github.com/diskuv/dkml-runtime-common/issues"
+build: ["sh" "tests/crossplatform-tests.sh"] {with-test & !(os = "win32")}
+install: ["sh" "./install.sh" "%{_:lib}%"]
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-common.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-runtime-common/releases/download/2.0.3-r2/src.tar.gz"
+  checksum: [
+    "md5=626bdd0ad0d40b8e159a3cbfdb5b4443"
+    "sha512=f17617d40e128a0943ed33390eb5c8bc7751d4667fbec7ef711d11433f3be3e6137e9710b0a1001ee0c5810c86fdc3b690f13a7ce252af845efea193148585fc"
+  ]
+}

--- a/packages/dkml-runtime-common/dkml-runtime-common.2.0.3/opam
+++ b/packages/dkml-runtime-common/dkml-runtime-common.2.0.3/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Common runtime code used in DKML"
+description: """\
+Common runtime code used in DKML.
+
+The runtime code will be available in the 'lib/dkml-runtime-common' folder
+of your Opam switch or findlib installation."""
+maintainer: "opensource+diskuv-ocaml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-runtime-common"
+bug-reports: "https://github.com/diskuv/dkml-runtime-common/issues"
+depends: [
+  "dune" {>= "2.9"}
+]
+build: ["dune" "build" "-p" name]
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-common.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-runtime-common/releases/download/2.0.3-r2/src.tar.gz"
+  checksum: [
+    "md5=626bdd0ad0d40b8e159a3cbfdb5b4443"
+    "sha512=f17617d40e128a0943ed33390eb5c8bc7751d4667fbec7ef711d11433f3be3e6137e9710b0a1001ee0c5810c86fdc3b690f13a7ce252af845efea193148585fc"
+  ]
+}


### PR DESCRIPTION
Common runtime code used in DKML

This pull-request concerns:
- `dkml-runtime-common.2.0.3`
- `dkml-runtime-common-native.2.0.3`



---
* Homepage: https://github.com/diskuv/dkml-runtime-common
* Source repo: git+https://github.com/diskuv/dkml-runtime-common.git
* Bug tracker: https://github.com/diskuv/dkml-runtime-common/issues

---
:camel: Pull-request generated by opam-publish v2.2.0