### PR TITLE
safemoney: Update documentation location

### DIFF
--- a/packages/safemoney/safemoney.0.1.0/opam
+++ b/packages/safemoney/safemoney.0.1.0/opam
@@ -6,7 +6,7 @@ maintainer: ["geoffrey.borough@outlook.com"]
 authors: ["Geoffrey Borough"]
 license: "MIT"
 homepage: "https://github.com/gborough/safemoney"
-doc: "https://github.com/gborough/safemoney/README.md"
+doc: "https://gborough.github.io/safemoney/safemoney"
 bug-reports: "https://github.com/gborough/safemoney/issues"
 depends: [
   "ocaml" {>= "4.14.0"}


### PR DESCRIPTION
Point the documentation to the correct location on generated gh-pages via dune-release