### PR TITLE
[new release] ppx_optint (0.2.0)

### DIFF
--- a/packages/ppx_optint/ppx_optint.0.2.0/opam
+++ b/packages/ppx_optint/ppx_optint.0.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Literals for Optint integers"
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>"]
+authors: ["Reynir Björnsson <reynir@reynir.dk>"]
+license: "ISC"
+tags: ["ppx" "optint"]
+homepage: "https://github.com/reynir/ppx_optint"
+bug-reports: "https://github.com/reynir/ppx_optint/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.5"}
+  "optint" {>= "0.1.0"}
+  "ppxlib" {>= "0.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reynir/ppx_optint.git"
+url {
+  src:
+    "https://github.com/reynir/ppx_optint/releases/download/v0.2.0/ppx_optint-0.2.0.tbz"
+  checksum: [
+    "sha256=3405fe515e1260d4c4cef2eb083f3da6d0a0145225152ca54212d60fc1d78a25"
+    "sha512=fdfab61145d1838eac7faeda89e3febdab879a26d9dc2f855bacabb0cea692b0fc80fca23c847929a3e5f5f82f3842ed991dbec4ddc09ba6ba723462ae982580"
+  ]
+}
+x-commit-hash: "e1b46c68cab5998c9e0d3545cfc9c384363981bf"


### PR DESCRIPTION
Literals for Optint integers

- Project page: <a href="https://github.com/reynir/ppx_optint">https://github.com/reynir/ppx_optint</a>

##### CHANGES:

* Use `Optint.of_unsigned_int32` and `Optint.Int63.of_unsigned_int` when possible over string conversion (@reynir, review by @dinosaure, reynir/ppx_optint#4)
