### PR TITLE
[new release] ocaml-version (3.6.2)

### DIFF
--- a/packages/ocaml-version/ocaml-version.3.6.2/opam
+++ b/packages/ocaml-version/ocaml-version.3.6.2/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """
+This library provides facilities to parse version numbers of the OCaml compiler, and enumerates the various official OCaml releases and configuration variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the `patch` and `extra` fields are optional.  This library offers the following functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under the Ecosystem category.
+- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+license: "ISC"
+tags: ["org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-version"
+doc: "https://ocurrent.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-version/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.07.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-version/releases/download/v3.6.2/ocaml-version-3.6.2.tbz"
+  checksum: [
+    "sha256=5c9d31abbd59891dfda6140850b5c50cb1e88f71e7b712c8fafda0474069feb2"
+    "sha512=9d8c849bad6a9347508fedcc4f7afbfaff138264ab8e9066f2e6090491170964b9415e71028ea084501dd7009a88f18acb4bc913cab1ccd58921cbf16a19edbe"
+  ]
+}
+x-commit-hash: "496b14cdf826a737841526b753ebad8c3656a85a"


### PR DESCRIPTION
Manipulate, parse and generate OCaml compiler version strings

- Project page: <a href="https://github.com/ocurrent/ocaml-version">https://github.com/ocurrent/ocaml-version</a>
- Documentation: <a href="https://ocurrent.github.io/ocaml-version/doc">https://ocurrent.github.io/ocaml-version/doc</a>

##### CHANGES:

 * OCaml 5.1.0 update (@Octachron ocurrent/ocaml-version#65)
 * Update code comment on Releases module inline with implementation. (@tmcgilchrist ocurrent/ocaml-version#63)
 * Put 5.1.0 in beta state and add 5.2.0 (trunk) (@kit-ty-kate ocurrent/ocaml-version#62)
