### PR TITLE
3 packages from mefyl/timmy at 1.0.4

### DIFF
--- a/packages/timmy-jsoo/timmy-jsoo.1.0.4/opam
+++ b/packages/timmy-jsoo/timmy-jsoo.1.0.4/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Js_of_ocaml bindings for Timmy"
+maintainer: "mefyl <mefyl@gruntech.org>"
+authors: "mefyl <mefyl@gruntech.org>"
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/mefyl/timmy"
+bug-reports: "https://github.com/mefyl/timmy/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "alcotest" {with-test & >= "1.4.0"}
+  "conf-npm" {with-test}
+  "fmt"
+  "js_of_ocaml"
+  "js_of_ocaml-ppx"
+  "timmy" {= version}
+  "odoc" {with-doc}
+]
+depopts: ["schematic-jsoo"]
+conflicts: [
+  "schematic-jsoo" {< "0.18.2" | >= "0.19.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mefyl/timmy.git"
+pin-depends: [
+  ["landmarks.1.4" "git+https://github.com/routineco/landmarks.git#js"]
+  ["landmarks-ppx.1.4" "git+https://github.com/routineco/landmarks.git#js"]
+]
+url {
+  src: "https://github.com/mefyl/timmy/archive/refs/tags/1.0.4.tar.gz"
+  checksum: [
+    "md5=c8bda198fd548c288fd067217fef22aa"
+    "sha512=f168d44b45b453addf0aee02eaf992b6669dc0843cea992ab8a35fefb3a1b76e8225da03424e59369703cce5c788a1eac04f8490c7c8b3977c60da1898811ddf"
+  ]
+}

--- a/packages/timmy-unix/timmy-unix.1.0.4/opam
+++ b/packages/timmy-unix/timmy-unix.1.0.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Unix clock implementation for Timmy"
+maintainer: "mefyl <mefyl@gruntech.org>"
+authors: "mefyl <mefyl@gruntech.org>"
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/mefyl/timmy"
+bug-reports: "https://github.com/mefyl/timmy/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "alcotest" {with-test & >= "1.4.0"}
+  "conf-tzdata" {with-test}
+  "fmt"
+  "timmy" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mefyl/timmy.git"
+url {
+  src: "https://github.com/mefyl/timmy/archive/refs/tags/1.0.4.tar.gz"
+  checksum: [
+    "md5=c8bda198fd548c288fd067217fef22aa"
+    "sha512=f168d44b45b453addf0aee02eaf992b6669dc0843cea992ab8a35fefb3a1b76e8225da03424e59369703cce5c788a1eac04f8490c7c8b3977c60da1898811ddf"
+  ]
+}

--- a/packages/timmy/timmy.1.0.4/opam
+++ b/packages/timmy/timmy.1.0.4/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Time and calendar library"
+maintainer: "mefyl <mefyl@gruntech.org>"
+authors: "mefyl <mefyl@gruntech.org>"
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/mefyl/timmy"
+bug-reports: "https://github.com/mefyl/timmy/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "base"
+  "fmt" {>= "0.8.7"}
+  "ocaml" {>= "4.08.0"}
+  "ppx_here"
+  "ppx_deriving" {>= "5.0"}
+  "ptime"
+  "alcotest" {with-test & >= "1.4.0"}
+  "odoc" {with-doc}
+  "cmdliner" {dev & with-test}
+  "opam-file-format" {dev & with-test}
+  "sexplib" {dev & with-test}
+  "stdio" {dev & with-test}
+  "shexp" {dev & with-test}
+]
+depopts: ["js_of_ocaml" "schematic"]
+conflicts: [
+  "schematic" {< "0.18.2" | >= "0.19.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mefyl/timmy.git"
+pin-depends: [
+  ["landmarks.1.4" "git+https://github.com/routineco/landmarks.git#js"]
+  ["landmarks-ppx.1.4" "git+https://github.com/routineco/landmarks.git#js"]
+]
+url {
+  src: "https://github.com/mefyl/timmy/archive/refs/tags/1.0.4.tar.gz"
+  checksum: [
+    "md5=c8bda198fd548c288fd067217fef22aa"
+    "sha512=f168d44b45b453addf0aee02eaf992b6669dc0843cea992ab8a35fefb3a1b76e8225da03424e59369703cce5c788a1eac04f8490c7c8b3977c60da1898811ddf"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `timmy.1.0.4`: Time and calendar library
- `timmy-jsoo.1.0.4`: Js_of_ocaml bindings for Timmy
- `timmy-unix.1.0.4`: Unix clock implementation for Timmy



---
* Homepage: https://github.com/mefyl/timmy
* Source repo: git+https://github.com/mefyl/timmy.git
* Bug tracker: https://github.com/mefyl/timmy/issues

---
:camel: Pull-request generated by opam-publish v2.2.0