### PR TITLE
[new release] ansi (0.7.0)

### DIFF
--- a/packages/ansi/ansi.0.7.0/opam
+++ b/packages/ansi/ansi.0.7.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "ANSI escape sequence parser"
+description:
+  "This package provides a basic ANSI escape parser, allowing the OCurrent web UI to show logs in colour."
+maintainer: [
+  "Antonin Décimo <antonin@tarides.com>"
+  "Navin Keswani <navin@novemberkilo.io>"
+  "<talex5@gmail.com>"
+]
+authors: ["Antonin Décimo <antonin@tarides.com>" "talex5@gmail.com"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ansi"
+doc: "https://ocurrent.github.io/ansi/"
+bug-reports: "https://github.com/ocurrent/ansi/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.10.0"}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "tyxml"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ansi.git"
+url {
+  src:
+    "https://github.com/ocurrent/ansi/releases/download/0.7.0/ansi-0.7.0.tbz"
+  checksum: [
+    "sha256=672b6a131eebc7d1291a4ad9ad4414a89e251e181e67e83b4ec90cb578e4a8a4"
+    "sha512=314bc4ef3ce6fd23dd46033478e6e9fd2307704697603b6d20354f4eaf69666b16c0bdd960e5b347f587465e60f42bb3f21ac1e266cdebd042709d9125791bf0"
+  ]
+}
+x-commit-hash: "f3508f96faeafd463ba22525761c1fa732f2281c"


### PR DESCRIPTION
ANSI escape sequence parser

- Project page: <a href="https://github.com/ocurrent/ansi">https://github.com/ocurrent/ansi</a>
- Documentation: <a href="https://ocurrent.github.io/ansi/">https://ocurrent.github.io/ansi/</a>

##### CHANGES:

* Fix CSS for italic. (ocurrent/ansi#18, @haochenx)

* Respect reverse attr when default color is active. (ocurrent/ansi#17, @haochenx)

* Support faint and double underline styles. (ocurrent/ansi#14, @MisterDA)
