### PR TITLE
lwt 5.7.0 has a breaking change -- Lwt_result.catch now takes a function

### DIFF
--- a/packages/opam-compiler/opam-compiler.0.1.0/opam
+++ b/packages/opam-compiler/opam-compiler.0.1.0/opam
@@ -15,6 +15,7 @@ depends: [
   "github-unix"
   "lwt_ssl"
   "re"
+  "lwt" {< "5.7.0"}
   "alcotest" {>= "1.2.0" & with-test}
 ]
 build: [

--- a/packages/opam-compiler/opam-compiler.0.1.1/opam
+++ b/packages/opam-compiler/opam-compiler.0.1.1/opam
@@ -15,6 +15,7 @@ depends: [
   "github-unix"
   "lwt_ssl"
   "re"
+  "lwt" {< "5.7.0"}
   "alcotest" {>= "1.2.0" & with-test}
 ]
 build: [


### PR DESCRIPTION
 (unit -> 'a t) rather than a promise ('a t).

The error was:
```
(cd _build/default && /home/opam/.opam/5.1/bin/ocamlopt.opt -w -40 -g -I lib/.opam_compiler.objs/byte -I lib/.opam_compiler.objs/native -I /home/opam/.opam/5.1/lib/angstrom -I /home/opam/.opam/5.1/lib/astring -I /home/opam/.opam/5.1/lib/atdgen -I /home/opam/.opam/5.1/lib/atdgen-runtime -I /home/opam/.opam/5.1/lib/base64 -I /home/opam/.opam/5.1/lib/bigstringaf -I /home/opam/.opam/5.1/lib/biniou -I /home/opam/.opam/5.1/lib/bos -I /home/opam/.opam/5.1/lib/bytes -I /home/opam/.opam/5.1/lib/camlp-streams -I /home/opam/.opam/5.1/lib/cmdliner -I /home/opam/.opam/5.1/lib/cohttp -I /home/opam/.opam/5.1/lib/cohttp-lwt -I /home/opam/.opam/5.1/lib/cohttp-lwt-unix -I /home/opam/.opam/5.1/lib/conduit -I /home/opam/.opam/5.1/lib/conduit-lwt -I /home/opam/.opam/5.1/lib/conduit-lwt-unix -I /home/opam/.opam/5.1/lib/domain-name -I /home/opam/.opam/5.1/lib/easy-format -I /home/opam/.opam/5.1/lib/fmt -I /home/opam/.opam/5.1/lib/fpath -I /home/opam/.opam/5.1/lib/github -I /home/opam/.opam/5.1/lib/github-data -I /home/opam/.opam/5.1/lib/github-unix -I /home/opam/.opam/5.1/lib/ipaddr -I /home/opam/.opam/5.1/lib/ipaddr-sexp -I /home/opam/.opam/5.1/lib/ipaddr/unix -I /home/opam/.opam/5.1/lib/logs -I /home/opam/.opam/5.1/lib/lwt -I /home/opam/.opam/5.1/lib/lwt/unix -I /home/opam/.opam/5.1/lib/lwt_ssl -I /home/opam/.opam/5.1/lib/macaddr -I /home/opam/.opam/5.1/lib/magic-mime -I /home/opam/.opam/5.1/lib/ocaml/threads -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/ocplib-endian -I /home/opam/.opam/5.1/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.1/lib/parsexp -I /home/opam/.opam/5.1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.1/lib/re -I /home/opam/.opam/5.1/lib/rresult -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/sexplib -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/ssl -I /home/opam/.opam/5.1/lib/stringext -I /home/opam/.opam/5.1/lib/uri -I /home/opam/.opam/5.1/lib/uri-sexp -I /home/opam/.opam/5.1/lib/uri/services -I /home/opam/.opam/5.1/lib/yojson -intf-suffix .ml -no-alias-deps -open Opam_compiler -o lib/.opam_compiler.objs/native/opam_compiler__Github_client.cmx -c -impl lib/github_client.ml) File "lib/github_client.ml", line 28, characters 6-35:
28 |       get_pr pr |> Github.Monad.run |> Lwt_result.catch |> Lwt_main.run
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: This expression has type Github_t.pull Lwt.t
       but an expression was expected of type unit -> 'a Lwt.t
       Hint: Did you forget to wrap the expression using `fun () ->'?
```

Observed in https://github.com/ocaml/opam-repository/pull/24461, /cc @emillon (who's registered as maintainer of "opam-compiler").