### PR TITLE
higher-bound constraint on ocaml version for mdx packages

### DIFF
--- a/packages/mdx/mdx.1.11.1/opam
+++ b/packages/mdx/mdx.1.11.1/opam
@@ -21,7 +21,7 @@ homepage: "https://github.com/realworldocaml/mdx"
 bug-reports: "https://github.com/realworldocaml/mdx/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0.0"}
   "ocamlfind"
   "fmt" {>= "0.8.7"}
   "cppo" {build & >= "1.1.0"}

--- a/packages/mdx/mdx.2.0.0/opam
+++ b/packages/mdx/mdx.2.0.0/opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/realworldocaml/mdx"
 bug-reports: "https://github.com/realworldocaml/mdx/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0.0"}
   "ocamlfind"
   "fmt" {>= "0.8.7"}
   "cppo" {build}

--- a/packages/mdx/mdx.2.1.0/opam
+++ b/packages/mdx/mdx.2.1.0/opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/realworldocaml/mdx"
 bug-reports: "https://github.com/realworldocaml/mdx/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0.0"}
   "ocamlfind"
   "fmt" {>= "0.8.7"}
   "cppo" {build & >= "1.1.0"}

--- a/packages/mdx/mdx.2.2.0/opam
+++ b/packages/mdx/mdx.2.2.0/opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/realworldocaml/mdx"
 bug-reports: "https://github.com/realworldocaml/mdx/issues"
 depends: [
   "dune" {>= "3.5"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1.0"}
   "ocamlfind"
   "fmt" {>= "0.8.7"}
   "cppo" {build & >= "1.1.0"}

--- a/packages/mdx/mdx.2.2.1/opam
+++ b/packages/mdx/mdx.2.2.1/opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/realworldocaml/mdx"
 bug-reports: "https://github.com/realworldocaml/mdx/issues"
 depends: [
   "dune" {>= "3.5"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1.0"}
   "ocamlfind"
   "fmt" {>= "0.8.7"}
   "cppo" {build & >= "1.1.0"}


### PR DESCRIPTION
There have been some errors in the revdeps of the CI of some other packages pointing to mdx issues. This PR adds missing upper-bound constraints.