### PR TITLE
[new release] melange-numeral (0.0.1)

### DIFF
--- a/packages/melange-numeral/melange-numeral.0.0.1/opam
+++ b/packages/melange-numeral/melange-numeral.0.0.1/opam
@@ -18,8 +18,8 @@ depends: [
   "dune" {>= "3.8"}
   "melange" {>= "2.0.0"}
   "reason" {>= "3.10.0"}
-  "opam-check-npm-deps" {with-test} # todo: use with-dev-setup once opam 2.2 is out
-  "ocaml-lsp-server" {with-test}
+  "opam-check-npm-deps" {with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/melange-numeral/melange-numeral.0.0.1/opam
+++ b/packages/melange-numeral/melange-numeral.0.0.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Melange bindings for Numeral"
+description: "Melange bindings for the Numeral JavaScript library."
+maintainer: [
+  "Liubomyr Mykhalchenko <liubomyr.mykhalchenko@ahrefs.com>"
+  "Denis Strelkov <denis.strelkov@ahrefs.com>"
+]
+authors: [
+  "Liubomyr Mykhalchenko <liubomyr.mykhalchenko@ahrefs.com>"
+  "Denis Strelkov <denis.strelkov@ahrefs.com>"
+]
+license: "MIT"
+tags: ["melange" "org:ahrefs"]
+homepage: "https://github.com/ahrefs/melange-numeral/"
+bug-reports: "https://github.com/ahrefs/melange-numeral/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.8"}
+  "melange" {>= "2.0.0"}
+  "reason" {>= "3.10.0"}
+  "opam-check-npm-deps" {with-test} # todo: use with-dev-setup once opam 2.2 is out
+  "ocaml-lsp-server" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/melange-numeral.git"
+depexts: [
+  ["numeral"] {npm-version = "2.0.6"}
+]
+url {
+  src:
+    "https://github.com/ahrefs/melange-numeral/releases/download/0.0.1/melange-numeral-0.0.1.tbz"
+  checksum: [
+    "sha256=cd3606e151985d7f03cc2bae6fe1be990c8cf1f2af1e3d712f03e94b029026a8"
+    "sha512=7af281a5c1507d46562954ec979c553a9d9150fef7c66d5c3866f5b89eceae1989049fbf05d6824b30d1dbc88f4ead6bccec458b0d0b1ad53d923161c091ec62"
+  ]
+}
+x-commit-hash: "1b9ce60b6c708bd2e8e8b5b3df62283df9bf950d"


### PR DESCRIPTION
Melange bindings for Numeral

- Project page: <a href="https://github.com/ahrefs/melange-numeral/">https://github.com/ahrefs/melange-numeral/</a>

##### CHANGES:

Initial release.

Migrated to Melange v2.
