### PR TITLE
[new release] decompress (2 packages) (1.5.3)

### DIFF
--- a/packages/decompress/decompress.1.5.3/opam
+++ b/packages/decompress/decompress.1.5.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of Zlib and GZip in OCaml"
+description: """Decompress is an implementation of Zlib and GZip in OCaml
+
+It provides a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.8.0"}
+  "cmdliner"    {>= "1.1.0"}
+  "optint"      {>= "0.1.0"}
+  "checkseum"   {>= "0.2.0"}
+  "bigstringaf" {with-test & >= "0.9.0"}
+  "alcotest"    {with-test & >= "1.7.0"}
+  "fmt"         {with-test & >= "0.8.7"}
+  "camlzip"     {>= "1.10" & with-test}
+  "base64"      {>= "3.0.0" & with-test}
+  "crowbar"     {with-test & >= "0.2"}
+  "rresult"     {with-test}
+  "bos"         {with-test & >= "0.2.1"}
+  "astring"     {with-test & >= "0.8.5"}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.5.3/decompress-1.5.3.tbz"
+  checksum: [
+    "sha256=f91e6978beff3fcb61440d32f7c99c99f1e8654b4fb18408741d36035373ac60"
+    "sha512=c3f402404f76075e6f692ea36e701134a5d833824d5d1166365c6c81fb18b309270bf288ce4c118ac44fd0366d9b6eea0a6309255678d8e1bd2bbfa7ba843461"
+  ]
+}
+x-commit-hash: "52ff65a1c234a98d925ceaba8df7f08c1754e8e5"

--- a/packages/rfc1951/rfc1951.1.5.3/opam
+++ b/packages/rfc1951/rfc1951.1.5.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of RFC1951 in OCaml"
+description: """This package provide an implementation of RFC1951 in OCaml.
+
+We provide a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.07.0"}
+  "dune"       {>= "2.8"}
+  "decompress" {= version}
+  "checkseum"
+  "optint"
+  "ctypes"     {with-test & >= "0.18.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.5.3/decompress-1.5.3.tbz"
+  checksum: [
+    "sha256=f91e6978beff3fcb61440d32f7c99c99f1e8654b4fb18408741d36035373ac60"
+    "sha512=c3f402404f76075e6f692ea36e701134a5d833824d5d1166365c6c81fb18b309270bf288ce4c118ac44fd0366d9b6eea0a6309255678d8e1bd2bbfa7ba843461"
+  ]
+}
+x-commit-hash: "52ff65a1c234a98d925ceaba8df7f08c1754e8e5"


### PR DESCRIPTION
Implementation of Zlib and GZip in OCaml

- Project page: <a href="https://github.com/mirage/decompress">https://github.com/mirage/decompress</a>
- Documentation: <a href="https://mirage.github.io/decompress/">https://mirage.github.io/decompress/</a>

##### CHANGES:

- Delete `libdecompress.a` (@dinosaure, mirage/decompress#152)

  This artifact is unused and complexify the distribution. We decided to delete
  it. If people want to use `libdecompress.a`, we can provide an other package
  which will implement the `ctypes` ceremony to safely produce a
  `libdecompress.a`.

- Lint dependencies (lower bounds) (@dinosaure, mirage/decompress#153)
- Remove unsafe accesses into our `decompress.lzo` implementation
  (@dinosaure, mirage/decompress#154)
- Improve and fix our `decompress.lzo` implementation
  (@dinosaure, mirage/decompress#155, mirage/decompress#158, mirage/decompress#159)
