### PR TITLE
[new release] caisar (0.2.1)

### DIFF
--- a/packages/caisar/caisar.0.2.1/opam
+++ b/packages/caisar/caisar.0.2.1/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis:
+  "A platform for characterizing the safety and robustness of artificial intelligence based software"
+maintainer: [
+  "LAISER team, Software Safety and Security Laboratory, CEA-List"
+]
+authors: ["LAISER team, Software Safety and Security Laboratory, CEA-List"]
+license: "LGPL-2.1-only"
+homepage: "https://git.frama-c.com/pub/caisar"
+doc: "https://git.frama-c.com/pub/caisar"
+bug-reports: "https://git.frama-c.com/pub/caisar/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.13"}
+  "dune-site" {>= "2.9.0"}
+  "piqi" {>= "0.7.6"}
+  "piqilib" {>= "0.6.14"}
+  "zarith" {>= "1.7"}
+  "ocplib-endian" {>= "1.0"}
+  "base" {>= "v0.15.1"}
+  "stdio" {>= "v0.14.0"}
+  "cmdliner" {>= "1.1.1"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "yojson" {>= "1.7.0"}
+  "menhirLib" {>= "20210310"}
+  "csv" {>= "2.4"}
+  "why3" {>= "1.6.0"}
+  "re" {>= "1.10.4"}
+  "fpath" {>= "0.7.3"}
+  "yaml" {>= "3.1.0"}
+  "ocaml-protoc-plugin" {>= "4.2.0"}
+  "stdio" {>= "v0.14.0"}
+  "ocamlgraph" {>= "1.8.8"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_inline_test" {>= "0.12.0"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/caisar.git"
+url {
+  src:
+    "https://git.frama-c.com/api/v4/projects/1082/packages/generic/caisar/0.2.1/caisar-0.2.1.tbz"
+  checksum: [
+    "sha256=a9a704f1e4e255eee2e9b0333e6c7b0e3e002293ce0068faa1c3d7c18d209997"
+    "sha512=7e35bd5527f82c5c6f62452c88e2971907a4eab89fd4efb699b99eb95f730d752908d51c47e104dcff5ceb58cf24c87d3399cb42e09a47691440927463168abb"
+  ]
+}
+x-commit-hash: "1636bc847f29c3243b26af91240ed10b4e848b09"


### PR DESCRIPTION
This is a minor release, mostly concerning simplifying packaging before the next release. This means that packages that were previously published separately (caisar-onnx, caisar-ovo, caisar-ir, caisar-csv, caisar-xgboost, defined [here](https://github.com/ocaml/opam-repository/pull/23975)) are no more needed nor relevant.

CHANGES:

- [packaging] Simplify CAISAR packaging structure by merging onnx, ovo, csv and onnx libraries into the main repo.