### PR TITLE
diskuvbox.0.1.1 does not work with ocaml.5.1+

### DIFF
--- a/packages/diskuvbox/diskuvbox.0.1.1/opam
+++ b/packages/diskuvbox/diskuvbox.0.1.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/diskuv/diskuvbox/issues"
 depends: [
   "dune" {>= "2.9"}
   "odoc" {>= "1.5.3" & with-doc}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "5.1"}
   "ppx_deriving" {>= "5.2.1"}
   "bos" {>= "0.2.0"}
   "fmt" {>= "0.8.9"}


### PR DESCRIPTION
Fix `revdeps` failure in https://github.com/ocaml/opam-repository/pull/24448 caused by `diskuvbox.0.1.1`