### PR TITLE
conf-readline: include opensuse

### DIFF
--- a/packages/conf-readline/conf-readline.1/opam
+++ b/packages/conf-readline/conf-readline.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["readline"] {os = "freebsd"}
   ["readline"] {os = "macos" & os-distribution = "homebrew"}
   ["readline"] {os = "macos" & os-distribution = "macports"}
+  ["readline-devel"] {os-family = "suse" | os-family = "opensuse"}
 ]
 
 homepage: "https://gitlab.inria.fr/vtourneu/readline-ocaml"


### PR DESCRIPTION
Changes due to @vtourneur from https://github.com/ocaml/opam-repository/pull/24475