### PR TITLE
[new release] reason-react (2 packages) (0.13.0)

### DIFF
--- a/packages/reason-react-ppx/reason-react-ppx.0.13.0/opam
+++ b/packages/reason-react-ppx/reason-react-ppx.0.13.0/opam
@@ -18,7 +18,6 @@ depends: [
   "ocaml" {>= "5.1.0"}
   "reason" {>= "3.10.0"}
   "ppxlib" {>= "0.28.0"}
-  "merlin" {= "4.9-501preview" & with-test}
   "ocamlformat" {= "0.24.0" & with-dev-setup}
   "odoc" {with-doc}
 ]

--- a/packages/reason-react-ppx/reason-react-ppx.0.13.0/opam
+++ b/packages/reason-react-ppx/reason-react-ppx.0.13.0/opam
@@ -14,7 +14,8 @@ doc: "https://reasonml.github.io/reason-react"
 bug-reports: "https://github.com/reasonml/reason-react/issues"
 depends: [
   "dune" {>= "3.9"}
-  "ocaml" {>= "5.1.0" & < "5.2.0"}
+  "melange" {>= "2.0.0"}
+  "ocaml" {>= "5.1.0"}
   "reason" {>= "3.10.0"}
   "ppxlib" {>= "0.28.0"}
   "merlin" {= "4.9-501preview" & with-test}

--- a/packages/reason-react-ppx/reason-react-ppx.0.13.0/opam
+++ b/packages/reason-react-ppx/reason-react-ppx.0.13.0/opam
@@ -20,6 +20,7 @@ depends: [
   "ppxlib" {>= "0.28.0"}
   "merlin" {= "4.9-501preview" & with-test}
   "ocamlformat" {= "0.24.0" & with-dev-setup}
+  "reason-react" {with-test & =version & post}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/reason-react-ppx/reason-react-ppx.0.13.0/opam
+++ b/packages/reason-react-ppx/reason-react-ppx.0.13.0/opam
@@ -20,7 +20,6 @@ depends: [
   "ppxlib" {>= "0.28.0"}
   "merlin" {= "4.9-501preview" & with-test}
   "ocamlformat" {= "0.24.0" & with-dev-setup}
-  "reason-react" {with-test & =version & post}
   "odoc" {with-doc}
 ]
 build: [
@@ -33,7 +32,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/reason-react-ppx/reason-react-ppx.0.13.0/opam
+++ b/packages/reason-react-ppx/reason-react-ppx.0.13.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "React.js JSX PPX"
+description: "ReasonReact JSX PPX"
+maintainer: [
+  "David Sancho <dsnxmoreno@gmail.com>"
+  "Antonio Monteiro <anmonteiro@gmail.com>"
+]
+authors: [
+  "Cheng Lou <chenglou92@gmail.com>" "Ricky Vetter <rickywvetter@gmail.com>"
+]
+license: "MIT"
+homepage: "https://reasonml.github.io/reason-react"
+doc: "https://reasonml.github.io/reason-react"
+bug-reports: "https://github.com/reasonml/reason-react/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "5.1.0" & < "5.2.0"}
+  "reason" {>= "3.10.0"}
+  "ppxlib" {>= "0.28.0"}
+  "merlin" {= "4.9-501preview" & with-test}
+  "ocamlformat" {= "0.24.0" & with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reasonml/reason-react.git"
+url {
+  src:
+    "https://github.com/reasonml/reason-react/releases/download/0.13.0/reason-react-0.13.0.tbz"
+  checksum: [
+    "sha256=dad3cbafddc591904549b8b323a813174628e620d70bb589684b71cfa6ba7bb7"
+    "sha512=76eaac3479e1f5e7663ef2eca3cb67de829715dde40fc8928379b8c3be05166b5ef3010afede6ab1e3eeb20f7e3452e9d11a5760cbee210e514b5319b59a9b35"
+  ]
+}
+x-commit-hash: "3971e42df555f3c8fb5b4eab94a26e8e51d79f02"

--- a/packages/reason-react/reason-react.0.13.0/opam
+++ b/packages/reason-react/reason-react.0.13.0/opam
@@ -36,7 +36,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/reason-react/reason-react.0.13.0/opam
+++ b/packages/reason-react/reason-react.0.13.0/opam
@@ -17,7 +17,7 @@ doc: "https://reasonml.github.io/reason-react"
 bug-reports: "https://github.com/reasonml/reason-react/issues"
 depends: [
   "dune" {>= "3.9"}
-  "ocaml" {>= "5.1.0" & < "5.2.0"}
+  "ocaml" {>= "5.1.0"}
   "melange" {>= "2.0.0"}
   "reason-react-ppx" {= version}
   "reason" {>= "3.10.0"}

--- a/packages/reason-react/reason-react.0.13.0/opam
+++ b/packages/reason-react/reason-react.0.13.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Reason bindings for React.js"
+description: """
+ReasonReact helps you use Reason to build React components with deeply integrated, strong, static type safety.
+
+It is designed and built by people using Reason and React in large, mission critical production React codebases."""
+maintainer: [
+  "David Sancho <dsnxmoreno@gmail.com>"
+  "Antonio Monteiro <anmonteiro@gmail.com>"
+]
+authors: [
+  "Cheng Lou <chenglou92@gmail.com>" "Ricky Vetter <rickywvetter@gmail.com>"
+]
+license: "MIT"
+homepage: "https://reasonml.github.io/reason-react"
+doc: "https://reasonml.github.io/reason-react"
+bug-reports: "https://github.com/reasonml/reason-react/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "5.1.0" & < "5.2.0"}
+  "melange" {>= "2.0.0"}
+  "reason-react-ppx" {= version}
+  "reason" {>= "3.10.0"}
+  "ocaml-lsp-server" {with-test}
+  "opam-check-npm-deps" {= "1.0.0" & with-dev-setup}
+  "ocamlformat" {= "0.24.0" & with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reasonml/reason-react.git"
+depexts: [
+  ["react"] {npm-version = "^17.0.0 || ^18.0.0"}
+  ["react-dom"] {npm-version = "^17.0.0 || ^18.0.0"}
+]
+url {
+  src:
+    "https://github.com/reasonml/reason-react/releases/download/0.13.0/reason-react-0.13.0.tbz"
+  checksum: [
+    "sha256=dad3cbafddc591904549b8b323a813174628e620d70bb589684b71cfa6ba7bb7"
+    "sha512=76eaac3479e1f5e7663ef2eca3cb67de829715dde40fc8928379b8c3be05166b5ef3010afede6ab1e3eeb20f7e3452e9d11a5760cbee210e514b5319b59a9b35"
+  ]
+}
+x-commit-hash: "3971e42df555f3c8fb5b4eab94a26e8e51d79f02"


### PR DESCRIPTION
Reason bindings for React.js

- Project page: <a href="https://reasonml.github.io/reason-react">https://reasonml.github.io/reason-react</a>
- Documentation: <a href="https://reasonml.github.io/reason-react">https://reasonml.github.io/reason-react</a>

##### CHANGES:

* Support for Melange v2
* Remove legacy `ReactDOMRe` and `ReasonReact` modules (@anmonteiro in
  [reasonml/reason-react#782](https://github.com/reasonml/reason-react/pull/782))
* Fix `React.useCallback*` for callbacks with multiple arguments (@anmonteiro
  in [reasonml/reason-react#786](https://github.com/reasonml/reason-react/pull/786))
