### PR TITLE
Package algaeff.1.0.0

### DIFF
--- a/packages/algaeff/algaeff.1.0.0/opam
+++ b/packages/algaeff/algaeff.1.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Reusable Effects-Based Components"
+description: """
+This OCaml library collects reusable effects-based components we have identified while developing our proof assistants based on algebraic effects.
+"""
+maintainer: "favonia <favonia@gmail.com>"
+authors: "The RedPRL Development Team"
+license: "Apache-2.0"
+homepage: "https://github.com/RedPRL/algaeff"
+bug-reports: "https://github.com/RedPRL/algaeff/issues"
+dev-repo: "git+https://github.com/RedPRL/algaeff.git"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "5.0"}
+  "alcotest" {>= "1.5" & with-test}
+  "qcheck-core" {>= "0.18" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
+url {
+  src: "https://github.com/RedPRL/algaeff/archive/refs/tags/1.0.0.tar.gz"
+  checksum: [
+    "md5=203805788d40cba3bfa6f86f689f2561"
+    "sha512=865e575963b04d20711f4b2f7f95444c58ed039700a6771cf41088f05a0032c7b04190e9692a3e38cef93c976c9a0bb8a058466da11b871be84d344397e04a50"
+  ]
+}


### PR DESCRIPTION
### `algaeff.1.0.0`
Reusable Effects-Based Components
This OCaml library collects reusable effects-based components we have identified while developing our proof assistants based on algebraic effects.



---
* Homepage: https://github.com/RedPRL/algaeff
* Source repo: git+https://github.com/RedPRL/algaeff.git
* Bug tracker: https://github.com/RedPRL/algaeff/issues

---
:camel: Pull-request generated by opam-publish v2.2.0