### PR TITLE
[new release] ppxlib (0.31.0)

### DIFF
--- a/packages/ppx_rapper/ppx_rapper.1.0.1/opam
+++ b/packages/ppx_rapper/ppx_rapper.1.0.1/opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
+  "ppxlib" {with-test & < 0.31.1}
   "base"
   "caqti" {< "2.0.0~"}
   "caqti-lwt" {< "2.0.0~"}

--- a/packages/ppx_rapper/ppx_rapper.1.0.2/opam
+++ b/packages/ppx_rapper/ppx_rapper.1.0.2/opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
+  "ppxlib" {with-test & < 0.31.1}
   "base"
   "caqti" {< "2.0.0~"}
   "caqti-lwt" {< "2.0.0~"}

--- a/packages/ppx_rapper/ppx_rapper.1.1.0/opam
+++ b/packages/ppx_rapper/ppx_rapper.1.1.0/opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
+  "ppxlib" {with-test & < 0.31.1}
   "base"
   "caqti" {< "2.0.0~"}
   "caqti-lwt" {< "2.0.0~"}

--- a/packages/ppx_rapper/ppx_rapper.1.1.1/opam
+++ b/packages/ppx_rapper/ppx_rapper.1.1.1/opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
+  "ppxlib" {with-test & < 0.31.1}
   "base"
   "caqti" {< "2.0.0~"}
   "caqti-lwt" {< "2.0.0~"}

--- a/packages/ppx_rapper/ppx_rapper.1.2.0/opam
+++ b/packages/ppx_rapper/ppx_rapper.1.2.0/opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
+  "ppxlib" {with-test & < 0.31.1}
   "base"
   "caqti" {< "2.0.0~"}
   "caqti-lwt" {< "2.0.0~"}

--- a/packages/ppx_rapper/ppx_rapper.2.0.0/opam
+++ b/packages/ppx_rapper/ppx_rapper.2.0.0/opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
+  "ppxlib" {with-test & < 0.31.1}
   "base"
   "caqti" {< "2.0.0~"}
   "caqti-lwt" {< "2.0.0~"}

--- a/packages/ppx_rapper/ppx_rapper.3.0.0/opam
+++ b/packages/ppx_rapper/ppx_rapper.3.0.0/opam
@@ -11,6 +11,7 @@ depends: [
   "ocaml" {>= "4.07"}
   "pg_query"
   "ppxlib" {>= "0.3.1"}
+  "ppxlib" {with-test & < 0.31.1}
   "base" {>= "v0.11.1"}
   "caqti" {>= "1.2.0" & < "2.0.0~"}
 ]

--- a/packages/ppx_rapper/ppx_rapper.3.1.0/opam
+++ b/packages/ppx_rapper/ppx_rapper.3.1.0/opam
@@ -12,6 +12,7 @@ depends: [
   "ocaml" {>= "4.07"}
   "pg_query" {>= "0.9.6"}
   "ppxlib" {>= "0.3.1"}
+  "ppxlib" {with-test & < 0.31.1}
   "base" {>= "v0.11.1"}
   "caqti" {>= "1.7.0" & < "2.0.0~"}
 ]

--- a/packages/ppxlib/ppxlib.0.31.0/opam
+++ b/packages/ppxlib/ppxlib.0.31.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Standard infrastructure for ppx rewriters"
+description: """
+Ppxlib is the standard infrastructure for ppx rewriters
+and other programs that manipulate the in-memory representation of
+OCaml programs, a.k.a the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04.1" & < "5.2.0" & != "5.1.0~alpha1"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0" {>= "v0.12"}
+  "sexplib0" {with-test & >= "v0.15"}
+  "stdlib-shims"
+  "ocamlfind" {with-test}
+  "re" {with-test & >= "1.9.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-migrate-parsetree" {< "2.0.0"}
+  "base-effects"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.31.0/ppxlib-0.31.0.tbz"
+  checksum: [
+    "sha256=d21676654e57faa12d7895caffe8703b64521d66efcf152491871a55b2ae41d8"
+    "sha512=63f2d327cfc5382476f812670d304aade91b3ea8f10420d6fc9e7078112368d99dbf43dfda9c2c2cf91341b71c37c45c1fe1d54fecde2348560f9d3c48571603"
+  ]
+}
+x-commit-hash: "e765a30151347f8044ce077d103d3828db8d5409"


### PR DESCRIPTION
Standard infrastructure for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Fix support for OCaml 5.1: migrated code preserves generative
  functor warnings, without creating more. Locations are better
  preserved. (ocaml-ppx/ppxlib#432, @pitag-ha, @panglesd)

- Driver: Add `-unused-code-warnings` command-line flag. (ocaml-ppx/ppxlib#444, @ceastlund)

- Add `?warning` flag to `Deriving.Generator.make`. (ocaml-ppx/ppxlib#440, @jacksonzou123 via @ceastlund)

- Restore the "path_arg" functionality in the V3 API (ocaml-ppx/ppxlib#431, @ELLIOTTCABLE)

- Expose migration/copying/etc. functions for all AST types needed by `Pprintast` (ocaml-ppx/ppxlib#454, @antalsz)

- Preserve quoted attributes on antiquotes in metaquot (ocaml-ppx/ppxlib#441, @ncik-roberts)

- Attribute namespaces: Fix semantics of reserving multi-component namespaces (ocaml-ppx/ppxlib#443, @ncik-roberts)
