### PR TITLE
[new release] merlin, merlin-lib and dot-merlin-reader (4.11-500)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.11-500/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.11-500/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.0" & < "5.1" }
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {>= "4.9"}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.11-500/merlin-4.11-500.tbz"
+  checksum: [
+    "sha256=dcab8f5d308c6823821294be48e631ba9e3bdf0ab7ac88dd872887b2294be501"
+    "sha512=189c2758f22db43bdb070e848e039079676243225f6ae4b82b649099cf8ea7f4e99a75eb4698789e3cff7dd8be4b36ed648cc05ba6ac870d1265177c86c9cb03"
+  ]
+}
+x-commit-hash: "95fdafe580b11bf5203ba428e2651562137631c5"

--- a/packages/merlin-lib/merlin-lib.4.11-500/opam
+++ b/packages/merlin-lib/merlin-lib.4.11-500/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.0" & < "5.1"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.11-500/merlin-4.11-500.tbz"
+  checksum: [
+    "sha256=dcab8f5d308c6823821294be48e631ba9e3bdf0ab7ac88dd872887b2294be501"
+    "sha512=189c2758f22db43bdb070e848e039079676243225f6ae4b82b649099cf8ea7f4e99a75eb4698789e3cff7dd8be4b36ed648cc05ba6ac870d1265177c86c9cb03"
+  ]
+}
+x-commit-hash: "95fdafe580b11bf5203ba428e2651562137631c5"

--- a/packages/merlin/merlin.4.11-500/opam
+++ b/packages/merlin/merlin.4.11-500/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.0" & < "5.1"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.9"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.11-500/merlin-4.11-500.tbz"
+  checksum: [
+    "sha256=dcab8f5d308c6823821294be48e631ba9e3bdf0ab7ac88dd872887b2294be501"
+    "sha512=189c2758f22db43bdb070e848e039079676243225f6ae4b82b649099cf8ea7f4e99a75eb4698789e3cff7dd8be4b36ed648cc05ba6ac870d1265177c86c9cb03"
+  ]
+}
+x-commit-hash: "95fdafe580b11bf5203ba428e2651562137631c5"


### PR DESCRIPTION
Editor helper, provides completion, typing and source browsing in Vim and Emacs

- Project page: <a href="https://github.com/ocaml/merlin">https://github.com/ocaml/merlin</a>

##### CHANGES:

Thu Sep 24 18:01:42 CEST 2023

  + merlin binary
    - Improve error messages for missing configuration reader (ocaml/merlin#1669)
    - Fix regression causing crash when using ppxes under Windows (ocaml/merlin#1673)
    - Fix confusion between aliased modules and module types (ocaml/merlin#1676,
      fixes ocaml/merlin#1667)
    - Ignore hidden branches when listing occurrences (ocaml/merlin#1677, fixes ocaml/merlin#1671)
  + editor modes
    - emacs: fix/improve keybindings (ocaml/merlin#1668, fixes ocaml/merlin#1386):
      Unbind <kbd>C-c C-r</kbd> (to avoid shadowing `tuareg-eval-region`)
      and bind <kbd>C-c C-v</kbd> instead to `merlin-error-check`;
      rebind <kbd>C-c C-d</kbd> to `merlin-document`
      and bind <kbd>C-c M-d</kbd> and <kbd>C-c |</kbd> instead to `merlin-destruct`;
      bind <kbd>C-u C-c C-t</kbd> to `merlin-type-expr`.
      See also <https://github.com/ocaml/merlin/issues/1386#issuecomment-1701567716>
    - emacs: remove use of obsolete `defadvice` macro (ocaml/merlin#1675)
