### PR TITLE
update not-ocamlfind (0.12): change build to avoid freebsd-specific build error

### DIFF
--- a/packages/not-ocamlfind/not-ocamlfind.0.12/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.12/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A small frontend for ocamlfind that adds a few useful commands"
+license: "MIT"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+
+(* Gerd wrote most of this code; I just modified it (and probably
+introduced bugs.  This is to silence opam *)
+
+authors: "Chet Murthy <chetsky@gmail.com>"
+homepage: "https://github.com/chetmurthy/not-ocamlfind"
+bug-reports: "Chet Murthy <chetsky@gmail.com>"
+depends: [
+  "ocamlfind" {>= "1.8.0"}
+  "camlp-streams"
+  "conf-m4" {build}
+  "fmt" {>= "0.8.8"}
+  "rresult" {>= "0.6.0"}
+  "ocamlgraph" {>= "2.0.0"}
+  "conf-which"
+]
+depexts: [
+  [
+    "xdot"
+  ] {os-family = "debian"}
+]
+build: [
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-custom" "-no-topfind" {preinstalled}]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
+url {
+  src: "https://github.com/chetmurthy/not-ocamlfind/archive/refs/tags/0.12.tar.gz"
+  checksum: [
+    "sha512=44b64691a86c475e8f143f45ee0660e9fd20e75ff2f19f3c86266486fbdebc5a2082ae0d0ed4a43f78cda802afdfd4b648c5a8f2d00e49deb7188dccff35978f"
+  ]
+}


### PR DESCRIPTION
on Freebsd somehow the timestamps can get messed-up, causing a part of the build that should not run, to run anyway.  So I disabled that part of the build.