### PR TITLE
release pa_ppx_q_ast.0.11: fix build, freebsd support

### DIFF
--- a/packages/pa_ppx_parsetree/pa_ppx_parsetree.0.01/opam
+++ b/packages/pa_ppx_parsetree/pa_ppx_parsetree.0.01/opam
@@ -41,3 +41,4 @@ build: [
   [make "test"] {with-test}
 ]
 install: [make "install"]
+available: false

--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.11/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.11/opam
@@ -17,7 +17,7 @@ doc: "https://github.com/camlp5/pa_ppx_q_ast/doc"
 
 depends: [
   "ocaml"       { >= "4.10.0" }
-  "conf-diffutils" (* { >= "1.2" & with-test } *)
+  "conf-diffutils" { >= "1.2" & with-test }
   "conf-perl"
   "cppo" { >= "1.6.9" }
   "camlp5-buildscripts" { >= "0.01" }
@@ -42,6 +42,6 @@ install: [make "install"]
 url {
   src: "https://github.com/camlp5/pa_ppx_q_ast/archive/refs/tags/0.11.tar.gz"
   checksum: [
-    "sha512=3acb5600c38bad28e0529f8922ce69925167f96b632f37e5e04d44fa62bef1bb3284b13d3e7b0b72fcc5dbf89878ef520f5c506b845b84d6de7649827e1804ae"
+    "sha512=24ccdc18248962b892c6de5010c42d5fcfd23f4dc5d521f3f328e114a4db14a781baff16a9c71a647f9e71b357c0e18eb4902212762e55b99dbc88c0732054ce"
   ]
 }

--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.11/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.11/opam
@@ -1,0 +1,47 @@
+
+synopsis: "A PPX Rewriter for automating generation of data-conversion code for use with Camlp5's Q_ast"
+description:
+"""
+This is a PPX Rewriter for generating data-conversion code that is otherwise
+hand-written, when using Camlp5's Q_ast.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_q_ast"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_q_ast/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_q_ast.git"
+doc: "https://github.com/camlp5/pa_ppx_q_ast/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" }
+  "conf-diffutils" (* { >= "1.2" & with-test } *)
+  "conf-perl"
+  "cppo" { >= "1.6.9" }
+  "camlp5-buildscripts" { >= "0.01" }
+  "camlp5"      { >= "8.00.04" }
+  "pa_ppx"      { >= "0.08" }
+  "pa_ppx_migrate"      { with-test & >= "0.08" }
+  "pa_ppx_hashcons"      { >= "0.08" }
+  "pa_ppx_unique"      { >= "0.08" }
+  "pa_ppx_regexp"
+  "not-ocamlfind" { >= "0.01" }
+  "pcre2"
+  "ounit" { >= "2.2.7" & with-test}
+  "bos" { >= "0.2.0" }
+  "menhir" { >= "20220210" }
+  "mdx" { >= "2.3.0" & with-test}
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_q_ast/archive/refs/tags/0.11.tar.gz"
+  checksum: [
+    "sha512=3acb5600c38bad28e0529f8922ce69925167f96b632f37e5e04d44fa62bef1bb3284b13d3e7b0b72fcc5dbf89878ef520f5c506b845b84d6de7649827e1804ae"
+  ]
+}

--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.11/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.11/opam
@@ -42,6 +42,6 @@ install: [make "install"]
 url {
   src: "https://github.com/camlp5/pa_ppx_q_ast/archive/refs/tags/0.11.tar.gz"
   checksum: [
-    "sha512=24ccdc18248962b892c6de5010c42d5fcfd23f4dc5d521f3f328e114a4db14a781baff16a9c71a647f9e71b357c0e18eb4902212762e55b99dbc88c0732054ce"
+    "sha512=80fdc307fa9c194293a67b7296267911434d22bd3e164cea0b29d809bcecd5d7f885303638b258053b3a735737a5a0bd43171f0b98499d6d03cb56aa2f5db015"
   ]
 }

--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.11/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.11/opam
@@ -42,6 +42,6 @@ install: [make "install"]
 url {
   src: "https://github.com/camlp5/pa_ppx_q_ast/archive/refs/tags/0.11.tar.gz"
   checksum: [
-    "sha512=89c1b9115347a938da8045b54509e62c70a4a499e3d8a3ef8c1a441f9974ca4e8a284a45e420672225747755388794e0d223ef4a671bc790b716703a01038d50"
+    "sha512=833a6394be1c80d15be4de46208430e86764fc9544627595039b5697aa9cbf664f5b3ce2bf8d3625a6d7f9d7e6296a9446a084f1af1f9dd5a290d77d3cbfd7ae"
   ]
 }

--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.11/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.11/opam
@@ -42,6 +42,6 @@ install: [make "install"]
 url {
   src: "https://github.com/camlp5/pa_ppx_q_ast/archive/refs/tags/0.11.tar.gz"
   checksum: [
-    "sha512=80fdc307fa9c194293a67b7296267911434d22bd3e164cea0b29d809bcecd5d7f885303638b258053b3a735737a5a0bd43171f0b98499d6d03cb56aa2f5db015"
+    "sha512=b3aaacc468babb7d18a9e0a5b6d31d1e5a0688417a5c067473703ff3d46a195b93f375d4449741e8b5c2932f23a542a4b5f49e0235d2ed9bca16fc8bb7bbf7d4"
   ]
 }

--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.11/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.11/opam
@@ -42,6 +42,6 @@ install: [make "install"]
 url {
   src: "https://github.com/camlp5/pa_ppx_q_ast/archive/refs/tags/0.11.tar.gz"
   checksum: [
-    "sha512=b3aaacc468babb7d18a9e0a5b6d31d1e5a0688417a5c067473703ff3d46a195b93f375d4449741e8b5c2932f23a542a4b5f49e0235d2ed9bca16fc8bb7bbf7d4"
+    "sha512=89c1b9115347a938da8045b54509e62c70a4a499e3d8a3ef8c1a441f9974ca4e8a284a45e420672225747755388794e0d223ef4a671bc790b716703a01038d50"
   ]
 }


### PR DESCRIPTION
1. fix build to match camlp5-buildscripts update
2. freebsd support (conf-diffutils)