### PR TITLE
2 packages from darioteixeira/pgocaml at 4.4.0

### DIFF
--- a/packages/macaque/macaque.0.7.2/opam
+++ b/packages/macaque/macaque.0.7.2/opam
@@ -24,7 +24,7 @@ remove: [
 depends: [
   "ocaml"
   "ocamlfind" {build}
-  "pgocaml" {>= "2.2"}
+  "pgocaml" {>= "2.2" & < "4.4.0"}
   "camlp4"
   "ocamlbuild" {build}
 ]

--- a/packages/macaque/macaque.0.7.4/opam
+++ b/packages/macaque/macaque.0.7.4/opam
@@ -13,7 +13,7 @@ remove: ["ocamlfind" "remove" "macaque"]
 depends: [
   "ocaml"
   "ocamlfind" {build}
-  "pgocaml" {>= "2.2"}
+  "pgocaml" {>= "2.2" & < "4.4.0"}
   "oasis" {build & >= "0.4.4"}
   "camlp4"
 ]

--- a/packages/macaque/macaque.0.8/opam
+++ b/packages/macaque/macaque.0.8/opam
@@ -12,7 +12,7 @@ install: [ make "install" ]
 depends: [
   "ocaml"
   "ocamlfind" {build}
-  "pgocaml" {>= "2.2"}
+  "pgocaml" {>= "2.2" & < "4.4.0"}
   "oasis" {>= "0.4.4"}
   "camlp4"
 ]

--- a/packages/pgocaml/pgocaml.4.4.0/opam
+++ b/packages/pgocaml/pgocaml.4.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Native OCaml interface to PostgreSQL databases"
+description: """
+PGOCaml provides an interface to PostgreSQL databases for OCaml applications.
+Note that it speaks the PostgreSQL wire protocol directly, and therefore does
+not need to create bindings to the PostgreSQL libpq C library.
+The PPX syntax extension is now packaged separately as 'pgocaml_ppx'.
+You will want to take a look at it if you're considering using PGOCaml.
+"""
+maintainer: "dario.teixeira@nleyten.com"
+authors: ["Richard W.M. Jones <rich@annexia.org>"]
+homepage: "https://github.com/darioteixeira/pgocaml"
+bug-reports: "https://github.com/darioteixeira/pgocaml/issues"
+dev-repo: "git+https://github.com/darioteixeira/pgocaml.git"
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "calendar" {>= "2.0"}
+  "camlp-streams"
+  "csv"
+  "dune" {>= "1.10"}
+  "hex"
+  "ocaml" {>= "4.07"}
+  "ppx_sexp_conv"
+  "re" {>= "1.5.0"}
+  "ppx_deriving" {>= "4.2"}
+  "rresult"
+  "sexplib"
+]
+url {
+  src:
+    "https://github.com/darioteixeira/pgocaml/archive/refs/tags/v4.4.0.tar.gz"
+  checksum: [
+    "md5=efdcb7b660e45a67c1e261849a16e5e0"
+    "sha512=0b200510ec6f7ab1f8fb4f98f9d792e6a2a7b446028926ee6d04b4b66130e580b4be4a018027c1e07e41fa78a569ed8a6c316638398d8c5b85d369aef12f77ef"
+  ]
+}

--- a/packages/pgocaml_ppx/pgocaml_ppx.4.4.0/opam
+++ b/packages/pgocaml_ppx/pgocaml_ppx.4.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "PPX extension for PGOCaml"
+description: """
+PGOCaml provides an interface to PostgreSQL databases for OCaml applications.
+This PPX syntax extension enables one to directly embed SQL statements inside
+the OCaml code. The extension uses the 'describe' feature of PostgreSQL to
+obtain type information about the database. This allows PGOCaml to check at
+compile-time if the program is indeed consistent with the database structure.
+"""
+maintainer: "dario.teixeira@nleyten.com"
+authors: ["Richard W.M. Jones <rich@annexia.org>"]
+homepage: "https://github.com/darioteixeira/pgocaml"
+bug-reports: "https://github.com/darioteixeira/pgocaml/issues"
+dev-repo: "git+https://github.com/darioteixeira/pgocaml.git"
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "dune" {>= "1.10"}
+  "ocaml" {>= "4.07"}
+  "pgocaml" {= version}
+  "ppxlib" {>= "0.16.0"}
+  "ppx_optcomp"
+]
+url {
+  src:
+    "https://github.com/darioteixeira/pgocaml/archive/refs/tags/v4.4.0.tar.gz"
+  checksum: [
+    "md5=efdcb7b660e45a67c1e261849a16e5e0"
+    "sha512=0b200510ec6f7ab1f8fb4f98f9d792e6a2a7b446028926ee6d04b4b66130e580b4be4a018027c1e07e41fa78a569ed8a6c316638398d8c5b85d369aef12f77ef"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `pgocaml.4.4.0`: Native OCaml interface to PostgreSQL databases
- `pgocaml_ppx.4.4.0`: PPX extension for PGOCaml



---
* Homepage: https://github.com/darioteixeira/pgocaml
* Source repo: git+https://github.com/darioteixeira/pgocaml.git
* Bug tracker: https://github.com/darioteixeira/pgocaml/issues

---
:camel: Pull-request generated by opam-publish v2.2.0