### PR TITLE
Package SZXX.4.1.0

### DIFF
--- a/packages/SZXX/SZXX.4.1.0/opam
+++ b/packages/SZXX/SZXX.4.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Asemio"
+authors: [
+  "Simon Grondin"
+]
+synopsis: "Streaming ZIP XML XLSX parser"
+description: """
+SZXX is a streaming and efficient XLSX, ZIP and XML parser built from the ground up for low and constant memory usage (<10Mb).
+SZXX is able to output XLSX rows while reading from a network socket without buffering any part of the file.
+It can also stream data (including network sockets) out of ZIP and XML files without buffering.
+"""
+license: "MIT"
+tags: ["XLSX" "Excel" "ZIP" "XML" "spreadsheet" "Stream" "Streaming"]
+homepage: "https://github.com/asemio/SZXX"
+dev-repo: "git://github.com/asemio/SZXX"
+doc: "https://github.com/asemio/SZXX"
+bug-reports: "https://github.com/asemio/SZXX/issues"
+depends: [
+  "ocaml" { >= "5.0.0" }
+  "dune" { >= "1.9.0" }
+
+  "angstrom" { >= "0.15.0" }
+  "base" { >= "v0.16.0" }
+  "ppx_sexp_conv" { >= "v0.16.0" }
+  "ppx_compare" { >= "v0.16.0" }
+  "ppx_custom_printf" { >= "v0.16.0" }
+  "decompress" { >= "1.4.1" }
+  "eio_main" { >= "0.12" }
+  "ptime" { >= "0.8.6" }
+
+  "alcotest" { with-test }
+  "yojson" { with-test }
+  "ppx_deriving_yojson" { >= "3.5.2" & with-test }
+  # "ocamlformat" { = "0.25.1" } # Development
+  # "ocaml-lsp-server" # Development
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/asemio/SZXX/archive/refs/tags/4.1.0.tar.gz"
+  checksum: [
+    "md5=6ac602e40f480e5b1eb51589494e0888"
+    "sha512=4ff1d6107552028bc23e7c11a7478f53b5e12299ac020df2ee1c1a7c464b9221a0a745439f6e00b9505c0d515ce1c17454ddd9b40ef9dc4ef40612a403b4a196"
+  ]
+}


### PR DESCRIPTION
### `SZXX.4.1.0`
Streaming ZIP XML XLSX parser
SZXX is a streaming and efficient XLSX, ZIP and XML parser built from the ground up for low and constant memory usage (<10Mb).
SZXX is able to output XLSX rows while reading from a network socket without buffering any part of the file.
It can also stream data (including network sockets) out of ZIP and XML files without buffering.



---
* Homepage: https://github.com/asemio/SZXX
* Source repo: git://github.com/asemio/SZXX
* Bug tracker: https://github.com/asemio/SZXX/issues

---
:camel: Pull-request generated by opam-publish v2.2.0