### PR TITLE
Package tdigest.2.2.0

### DIFF
--- a/packages/tdigest/tdigest.2.2.0/opam
+++ b/packages/tdigest/tdigest.2.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Simon Grondin"
+authors: [
+  "Simon Grondin"
+  "Will Welch"
+]
+synopsis: "OCaml implementation of the T-Digest algorithm"
+description: """
+The T-Digest is a data structure and algorithm for constructing an approximate distribution for a collection of real numbers presented as a stream.
+
+The T-Digest can estimate percentiles or quantiles extremely accurately even at the tails, while using a fraction of the space.
+
+Additionally, the T-Digest is concatenable, making it a good fit for distributed systems. The internal state of a T-Digest can be exported as a binary string, and the concatenation of any number of those strings can then be imported to form a new T-Digest.
+"""
+license: "MIT"
+homepage: "https://github.com/SGrondin/tdigest"
+dev-repo: "git://github.com/SGrondin/tdigest"
+doc: "https://github.com/SGrondin/tdigest"
+bug-reports: "https://github.com/SGrondin/tdigest/issues"
+depends: [
+  "ocaml" { >= "4.10.0" }
+  "dune" { >= "1.9.0" }
+
+  "base" { >= "v0.15.0" & < "v0.17.0" }
+  "ppx_sexp_conv" { >= "v0.16.0" }
+
+  "ppx_expect" { >= "v0.16.0" & with-test }
+  "ppx_custom_printf" { >= "v0.16.0" & with-test }
+  # "ocamlformat" { = "0.25.1" } # Development
+  # "ocaml-lsp-server" # Development
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/SGrondin/tdigest/archive/refs/tags/2.2.0.tar.gz"
+  checksum: [
+    "md5=04bf837d0c57ecd9221a2b796c1123de"
+    "sha512=b6821d4da761f068a23421290ce8d222ed00df96fb7a0dc89694dc37eabc3b20ba3394b99a93a6e24b39b405673e6711589d9874d8dac250da686f474599b353"
+  ]
+}


### PR DESCRIPTION
### `tdigest.2.2.0`
OCaml implementation of the T-Digest algorithm
The T-Digest is a data structure and algorithm for constructing an approximate distribution for a collection of real numbers presented as a stream.

The T-Digest can estimate percentiles or quantiles extremely accurately even at the tails, while using a fraction of the space.

Additionally, the T-Digest is concatenable, making it a good fit for distributed systems. The internal state of a T-Digest can be exported as a binary string, and the concatenation of any number of those strings can then be imported to form a new T-Digest.



---
* Homepage: https://github.com/SGrondin/tdigest
* Source repo: git://github.com/SGrondin/tdigest
* Bug tracker: https://github.com/SGrondin/tdigest/issues

---
:camel: Pull-request generated by opam-publish v2.2.0