### PR TITLE
[new release] opam-check-npm-deps (2.0.0)

### DIFF
--- a/packages/opam-check-npm-deps/opam-check-npm-deps.2.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.2.0.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis:
+  "An opam plugin to check for npm depexts inside the node_modules folder"
+description:
+  "Provides the `opam check-npm-deps` command, which given an opam switch, gathers all the depexts belonging to the npm platform and their version constraints, and checks the `node_modules` folder to see if the constraints are satisfied."
+maintainer: ["Javier Chávarri"]
+authors: ["Javier Chávarri"]
+license: "MIT"
+homepage: "https://github.com/jchavarri/opam-check-npm-deps"
+bug-reports: "https://github.com/jchavarri/opam-check-npm-deps/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "reason" {>= "3.8.1"}
+  "dune" {>= "3.8"}
+  "opam-client" {>= "2.2" & < "2.3"}
+  "mccs" {>= "1.1+14"}
+  "angstrom" {>= "0.15.0"}
+  "fmt" {>= "0.9.0"}
+  "bos"
+  "lwt_ppx"
+  "ppx_deriving_yojson"
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_let"
+  "ppx_sexp_conv"
+  "odoc" {with-doc}
+]
+available: opam-version >= "2.2" & opam-version < "2.3"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jchavarri/opam-check-npm-deps.git"
+flags: plugin
+url {
+  src:
+    "https://github.com/jchavarri/opam-check-npm-deps/releases/download/2.0.0/opam-check-npm-deps-2.0.0.tbz"
+  checksum: [
+    "sha256=81017d547d9a4b9efc87d0729eccc069513e85c982156f5bd3e1d0dc14521d25"
+    "sha512=7a3bd5ffcabb88697cfb943f1be4e5c354b7079c2cccb59a42ef62543eb8c1b895377d737af66703cf22f51c144f2cae07d5c6054c6f3c583cef49dd299b2d91"
+  ]
+}
+x-commit-hash: "4228046199f16e5c22dfb280a5c50ae1e4aa7781"

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.2.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.2.0.0/opam
@@ -45,8 +45,8 @@ url {
   src:
     "https://github.com/jchavarri/opam-check-npm-deps/releases/download/2.0.0/opam-check-npm-deps-2.0.0.tbz"
   checksum: [
-    "sha256=81017d547d9a4b9efc87d0729eccc069513e85c982156f5bd3e1d0dc14521d25"
-    "sha512=7a3bd5ffcabb88697cfb943f1be4e5c354b7079c2cccb59a42ef62543eb8c1b895377d737af66703cf22f51c144f2cae07d5c6054c6f3c583cef49dd299b2d91"
+    "sha256=7b7e90c13fd933516d2b72fbc0484481a765f51134d41bfa277712ffdc16daa2"
+    "sha512=1ab9b2898d01b7193309d8a2fae9709973f3f7fed2e9fa8a50f7809da21b2a4042341d16b81b74d40b84807c728862b85e8dffc252806e0de41025eafdee3844"
   ]
 }
-x-commit-hash: "4228046199f16e5c22dfb280a5c50ae1e4aa7781"
+x-commit-hash: "dffa1f2c9e787420e71dc6507e825305c4ac8e1d"


### PR DESCRIPTION
An opam plugin to check for npm depexts inside the node_modules folder

- Project page: <a href="https://github.com/jchavarri/opam-check-npm-deps">https://github.com/jchavarri/opam-check-npm-deps</a>

##### CHANGES:

- Support opam 2.2
