### PR TITLE
Package libbinaryen.113.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.113.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.113.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "6.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v113.0.0/libbinaryen-v113.0.0.tar.gz"
+  checksum: [
+    "md5=77c5d53bdeda81a9375290196a9f4d42"
+    "sha512=9227feb522877bc2b05932dfe5b137d79b9a0a661263fc8168b44648570300338cbb8224bb6707e4cb5a59e127eb72eab10a35af7c91491d6a05e8f7e55b7412"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.113.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [113.0.0](https://github.com/grain-lang/libbinaryen/compare/v112.0.0...v113.0.0) (2023-09-14)


### ⚠ BREAKING CHANGES

* Upgrade to libbinaryen v113 ([#83](https://github.com/grain-lang/libbinaryen/issues/83))

### Features

* Upgrade to libbinaryen v113 ([#83](https://github.com/grain-lang/libbinaryen/issues/83)) ([f19e9a9](https://github.com/grain-lang/libbinaryen/commit/f19e9a95c7c4300e99ba72b3b1658e28f8379e13))

---
:camel: Pull-request generated by opam-publish v2.0.3