### PR TITLE
eliom 9.0.0-10.0.0 is not compatible with ocsigenserver 5.1.0

### DIFF
--- a/packages/eliom/eliom.10.0.0/opam
+++ b/packages/eliom/eliom.10.0.0/opam
@@ -29,7 +29,7 @@ depends: [
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
   "tyxml" {>= "4.4.0" & < "5.0.0"}
-  "ocsigenserver" {>= "5.0.0" & < "6.0.0"}
+  "ocsigenserver" {>= "5.0.0" & < "5.1.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}
   "base-bytes"

--- a/packages/eliom/eliom.9.0.0/opam
+++ b/packages/eliom/eliom.9.0.0/opam
@@ -29,7 +29,7 @@ depends: [
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
   "tyxml" {>= "4.4.0" & < "5.0.0"}
-  "ocsigenserver" {>= "5.0.0" & < "6.0.0"}
+  "ocsigenserver" {>= "5.0.0" & < "5.1.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}
   "base-bytes"

--- a/packages/eliom/eliom.9.2.1/opam
+++ b/packages/eliom/eliom.9.2.1/opam
@@ -29,7 +29,7 @@ depends: [
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
   "tyxml" {>= "4.4.0" & < "5.0.0"}
-  "ocsigenserver" {>= "5.0.0" & < "6.0.0"}
+  "ocsigenserver" {>= "5.0.0" & < "5.1.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}
   "base-bytes"

--- a/packages/eliom/eliom.9.3.0/opam
+++ b/packages/eliom/eliom.9.3.0/opam
@@ -29,7 +29,7 @@ depends: [
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
   "tyxml" {>= "4.4.0" & < "5.0.0"}
-  "ocsigenserver" {>= "5.0.0" & < "6.0.0"}
+  "ocsigenserver" {>= "5.0.0" & < "5.1.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}
   "base-bytes"

--- a/packages/eliom/eliom.9.4.0/opam
+++ b/packages/eliom/eliom.9.4.0/opam
@@ -29,7 +29,7 @@ depends: [
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
   "tyxml" {>= "4.4.0" & < "5.0.0"}
-  "ocsigenserver" {>= "5.0.0" & < "6.0.0"}
+  "ocsigenserver" {>= "5.0.0" & < "5.1.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}
   "base-bytes"


### PR DESCRIPTION
Fails with
```
+ ocamlfind ocamlc -c -g -keep-locs -thread -package js_of_ocaml-ppx_deriving_json -package xml-light -package react,lwt_react,js_of_ocaml -package lwt,ocsigenserver,ocsipersist,tyxml.functor -w +A-4-6-7@8-9@11@12-16@20@23@24@26@27@32..36-37@38-39-40@41-42@43-44@45-48-63-67@68-69-70 -I /home/opam/.opam/4.14/lib/js_of_ocaml -I src/lib -I src/lib/server -o src/lib/server/eliom_parameter.cmi src/lib/server/eliom_parameter.mli
File "src/lib/eliom_parameter.server.mli", line 63, characters 5-16:
Error: Unbound module Pcre
```

Seen on https://github.com/ocaml/opam-repository/pull/24508