### PR TITLE
Package satyrographos.0.0.2.13

### DIFF
--- a/packages/satyrographos/satyrographos.0.0.2.13/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.13/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: [
+  "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+]
+homepage: "https://github.com/na4zagin3/satyrographos"
+dev-repo: "git+https://github.com/na4zagin3/satyrographos.git"
+bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
+license: "LGPL-3.0-or-later"
+build: [
+  ["dune" "subst"] {dev}
+  ["sed" "-i.bak" "-e" "s/%%%%VERSION_NUM%%%%/%{version}%/" "bin/main.ml"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.11.0"}
+
+  "conf-diffutils" {with-test}
+  "dune" {>= "2.7"}
+  "fileutils"
+  "menhir" {>= "20181006"}
+  "ppx_import"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ocamlgraph"
+  ( "opam-format" {>= "2.0.4" & < "2.2"}
+    & "opam-state" {>= "2.0.4" & < "2.2"}
+    & "ocaml" {< "4.12.0"}
+  | "opam-format" {>= "2.1.0" & < "2.2"}
+    & "opam-state" {>= "2.1.0" & < "2.2"}
+    & "ocaml" {>= "4.12.0"}
+  )
+  "re" { >= "1.9.0" }
+  "stringext" {with-test}
+  "uri" {>= "3.0.0"}
+  "uri-sexp" {>= "3.0.0"}
+  "yaml" {>= "3.0" & < "4.0"}
+  "yaml-sexp" {>= "3.0" & < "4.0"}
+  "yojson"
+
+  # Janestreet Libs
+  "core" {>= "v0.15" & < "v0.17"}
+  "core_unix"
+  "ppx_jane"
+  "shexp"
+]
+
+synopsis: "A package manager for SATySFi"
+description: """
+Satyrographos is a package manager for [SATySFi].
+
+Satyrographos is distributed under the LGPL-3.0 license.
+
+
+  [SATySFi]: https://github.com/gfngfn/SATySFi
+  [Satyrographos]: https://github.com/na4zagin3/satyrographos"""
+url {
+  src:
+    "https://github.com/na4zagin3/satyrographos/archive/refs/tags/v0.0.2.13.tar.gz"
+  checksum: [
+    "md5=76ceabf41952e1e1c9f630e743d02f78"
+    "sha512=c798de5aaf493c1c8224684240f491ce9fbb2a61f206b375b96970b7de16e604b51b3b73626013f5f276974399bea4e7272349789a334e39a440c301ab999111"
+  ]
+}


### PR DESCRIPTION
### `satyrographos.0.0.2.13`
A package manager for SATySFi
Satyrographos is a package manager for [SATySFi].

Satyrographos is distributed under the LGPL-3.0 license.


  [SATySFi]: https://github.com/gfngfn/SATySFi
  [Satyrographos]: https://github.com/na4zagin3/satyrographos



---
* Homepage: https://github.com/na4zagin3/satyrographos
* Source repo: git+https://github.com/na4zagin3/satyrographos.git
* Bug tracker: https://github.com/na4zagin3/satyrographos/issues

---
:camel: Pull-request generated by opam-publish v2.2.0