### PR TITLE
[new release] uri, uri-sexp, uri-re and uri-bench (4.4.0)

### DIFF
--- a/packages/uri-bench/uri-bench.4.4.0/opam
+++ b/packages/uri-bench/uri-bench.4.4.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "Benchmarking package for ocaml-uri"
+description: """
+This is a benchmarking package for the OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2.0"}
+  "uri" {= version}
+  "core_bench" {with-test & >= "v0.14.0"}
+  "core_unix" {with-test & >= "v0.14.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v4.4.0/uri-4.4.0.tbz"
+  checksum: [
+    "sha256=cdabaf6ef5cd2161e59cc7b74c6e4a68ecb80a9f4e96002e338e1b6bf17adec4"
+    "sha512=88374143e0d8aaf6d40aa3cbd7593f9832e9c9727738c6e651498125150c83d5646e13b5737d5c3e81484dd041127f67f8acea13fdc0300ac4e46107559f8ae2"
+  ]
+}
+x-commit-hash: "c336c796f4deb8979a4c7ceea3bef34b46240623"

--- a/packages/uri-bench/uri-bench.4.4.0/opam
+++ b/packages/uri-bench/uri-bench.4.4.0/opam
@@ -19,7 +19,7 @@ depends: [
   "core_unix" {>= "v0.14.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/packages/uri-bench/uri-bench.4.4.0/opam
+++ b/packages/uri-bench/uri-bench.4.4.0/opam
@@ -12,7 +12,7 @@ description: """
 This is a benchmarking package for the OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification for parsing URI or URLs.
 """
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.2.0"}
   "uri" {= version}
   "core_bench" {>= "v0.14.0"}

--- a/packages/uri-bench/uri-bench.4.4.0/opam
+++ b/packages/uri-bench/uri-bench.4.4.0/opam
@@ -15,8 +15,8 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.2.0"}
   "uri" {= version}
-  "core_bench" {with-test & >= "v0.14.0"}
-  "core_unix" {with-test & >= "v0.14.0"}
+  "core_bench" {>= "v0.14.0"}
+  "core_unix" {>= "v0.14.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/uri-re/uri-re.4.4.0/opam
+++ b/packages/uri-re/uri-re.4.4.0/opam
@@ -25,7 +25,7 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
 ]
 messages: [ "Deprecated. This package is outdated, you should consider using uri instead" ]
 url {

--- a/packages/uri-re/uri-re.4.4.0/opam
+++ b/packages/uri-re/uri-re.4.4.0/opam
@@ -23,7 +23,7 @@ depends: [
   "crowbar" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
 ]

--- a/packages/uri-re/uri-re.4.4.0/opam
+++ b/packages/uri-re/uri-re.4.4.0/opam
@@ -13,7 +13,7 @@ This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3
 for parsing URI or URLs.
 """
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.2.0"}
   "ounit2" {with-test & >= "1.0.2"}
   "ppx_sexp_conv" {with-test & >= "v0.9.0"}

--- a/packages/uri-re/uri-re.4.4.0/opam
+++ b/packages/uri-re/uri-re.4.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2.0"}
+  "ounit2" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  "re" {>= "1.9.0"}
+  "stringext" {>= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+messages: [ "Deprecated. This package is outdated, you should consider using uri instead" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v4.4.0/uri-4.4.0.tbz"
+  checksum: [
+    "sha256=cdabaf6ef5cd2161e59cc7b74c6e4a68ecb80a9f4e96002e338e1b6bf17adec4"
+    "sha512=88374143e0d8aaf6d40aa3cbd7593f9832e9c9727738c6e651498125150c83d5646e13b5737d5c3e81484dd041127f67f8acea13fdc0300ac4e46107559f8ae2"
+  ]
+}
+x-commit-hash: "c336c796f4deb8979a4c7ceea3bef34b46240623"

--- a/packages/uri-re/uri-re.4.4.0/opam
+++ b/packages/uri-re/uri-re.4.4.0/opam
@@ -19,6 +19,7 @@ depends: [
   "ppx_sexp_conv" {with-test & >= "v0.9.0"}
   "re" {>= "1.9.0"}
   "stringext" {>= "1.4.0"}
+  "uri" {= version}
   "crowbar" {with-test}
 ]
 build: [

--- a/packages/uri-re/uri-re.4.4.0/opam
+++ b/packages/uri-re/uri-re.4.4.0/opam
@@ -19,6 +19,7 @@ depends: [
   "ppx_sexp_conv" {with-test & >= "v0.9.0"}
   "re" {>= "1.9.0"}
   "stringext" {>= "1.4.0"}
+  "crowbar" {with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/uri-sexp/uri-sexp.4.4.0/opam
+++ b/packages/uri-sexp/uri-sexp.4.4.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ounit2" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/packages/uri-sexp/uri-sexp.4.4.0/opam
+++ b/packages/uri-sexp/uri-sexp.4.4.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+ocaml-uri with sexp support
+"""
+depends: [
+  "uri" {= version}
+  "dune" {>= "1.2.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "sexplib0"
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v4.4.0/uri-4.4.0.tbz"
+  checksum: [
+    "sha256=cdabaf6ef5cd2161e59cc7b74c6e4a68ecb80a9f4e96002e338e1b6bf17adec4"
+    "sha512=88374143e0d8aaf6d40aa3cbd7593f9832e9c9727738c6e651498125150c83d5646e13b5737d5c3e81484dd041127f67f8acea13fdc0300ac4e46107559f8ae2"
+  ]
+}
+x-commit-hash: "c336c796f4deb8979a4c7ceea3bef34b46240623"

--- a/packages/uri/uri.4.4.0/opam
+++ b/packages/uri/uri.4.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2.0"}
+  "ounit2" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  "crowbar" {with-test & >= "0.2"}
+  "stringext" {>= "1.4.0"}
+  "angstrom" {>= "0.14.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v4.4.0/uri-4.4.0.tbz"
+  checksum: [
+    "sha256=cdabaf6ef5cd2161e59cc7b74c6e4a68ecb80a9f4e96002e338e1b6bf17adec4"
+    "sha512=88374143e0d8aaf6d40aa3cbd7593f9832e9c9727738c6e651498125150c83d5646e13b5737d5c3e81484dd041127f67f8acea13fdc0300ac4e46107559f8ae2"
+  ]
+}
+x-commit-hash: "c336c796f4deb8979a4c7ceea3bef34b46240623"

--- a/packages/uri/uri.4.4.0/opam
+++ b/packages/uri/uri.4.4.0/opam
@@ -13,7 +13,7 @@ This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3
 for parsing URI or URLs.
 """
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.2.0"}
   "ounit2" {with-test & >= "1.0.2"}
   "ppx_sexp_conv" {with-test & >= "v0.9.0"}

--- a/packages/uri/uri.4.4.0/opam
+++ b/packages/uri/uri.4.4.0/opam
@@ -22,7 +22,7 @@ depends: [
   "angstrom" {>= "0.14.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
 ]

--- a/packages/uri/uri.4.4.0/opam
+++ b/packages/uri/uri.4.4.0/opam
@@ -24,7 +24,7 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
 ]
 url {
   src:


### PR DESCRIPTION
An RFC3986 URI/URL parsing library

- Project page: <a href="https://github.com/mirage/ocaml-uri">https://github.com/mirage/ocaml-uri</a>
- Documentation: <a href="https://mirage.github.io/ocaml-uri/">https://mirage.github.io/ocaml-uri/</a>

##### CHANGES:

* **breaking change** Fix parsing & printing of IPv6 addresses in the host part of an uri

  If we follow the RFC3986 correctly, IPv6 must be surrounded by '[' and ']'. Old versions
  of `ocaml-uri` escaped these characters. The new version interprets these characters to
  recognize an IPv6 address.

  Users should take note of this change in behaviour, which fixes a number of bugs in HTTP
  requests. (@anmonteiro, review by several maintainers, mirage/ocaml-uri#169)
* Upgrade tests to `ounit2` (@Alessandro-Barbieri, mirage/ocaml-uri#161)
