### PR TITLE
5 packages from imandra-ai/ocaml-opentelemetry at 0.6

### DIFF
--- a/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.6/opam
+++ b/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.6/opam
@@ -41,6 +41,6 @@ url {
     "https://github.com/imandra-ai/ocaml-opentelemetry/archive/refs/tags/v0.6.tar.gz"
   checksum: [
     "md5=bb3860b2d9941bbb3680aef45f8db3d8"
-    "sha512=a66f9781fdef825addefa3a9c425a454c98f388ae0e476cf216a555d1573291347668a9aa6461ae17074b17504622cd77bbb2302edb55d18b32324d112e782ffkk"
+    "sha512=a66f9781fdef825addefa3a9c425a454c98f388ae0e476cf216a555d1573291347668a9aa6461ae17074b17504622cd77bbb2302edb55d18b32324d112e782ff"
   ]
 }

--- a/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.6/opam
+++ b/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.6/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Collector client for opentelemetry, using cohttp + lwt"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: "the Imandra team and contributors"
+license: "MIT"
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "mtime" {>= "1.4"}
+  "opentelemetry" {= version}
+  "pbrt" {>= "2.2"}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "lwt_ppx" {>= "2.0"}
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/archive/refs/tags/v0.6.tar.gz"
+  checksum: [
+    "md5=759c028739d027414ad35cface56789f"
+    "sha512=c78fad3b3282f6d1337dcc8ecf55b38294801d4b470558752112826206b9e5e20679c213c9ef5fcd0d223e3fe81214b275b8d146a57c7b59a26d4ef381e06162"
+  ]
+}

--- a/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.6/opam
+++ b/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.6/opam
@@ -40,7 +40,7 @@ url {
   src:
     "https://github.com/imandra-ai/ocaml-opentelemetry/archive/refs/tags/v0.6.tar.gz"
   checksum: [
-    "md5=759c028739d027414ad35cface56789f"
-    "sha512=c78fad3b3282f6d1337dcc8ecf55b38294801d4b470558752112826206b9e5e20679c213c9ef5fcd0d223e3fe81214b275b8d146a57c7b59a26d4ef381e06162"
+    "md5=bb3860b2d9941bbb3680aef45f8db3d8"
+    "sha512=a66f9781fdef825addefa3a9c425a454c98f388ae0e476cf216a555d1573291347668a9aa6461ae17074b17504622cd77bbb2302edb55d18b32324d112e782ffkk"
   ]
 }

--- a/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.6/opam
+++ b/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.6/opam
@@ -20,6 +20,8 @@ depends: [
   "lwt_ppx" {>= "2.0"}
   "cohttp-lwt"
   "cohttp-lwt-unix"
+  "alcotest" {with-test}
+  "opentelemetry-client-ocurl" {with-test & = version}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.6/opam
+++ b/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.6/opam
@@ -39,6 +39,6 @@ url {
     "https://github.com/imandra-ai/ocaml-opentelemetry/archive/refs/tags/v0.6.tar.gz"
   checksum: [
     "md5=bb3860b2d9941bbb3680aef45f8db3d8"
-    "sha512=a66f9781fdef825addefa3a9c425a454c98f388ae0e476cf216a555d1573291347668a9aa6461ae17074b17504622cd77bbb2302edb55d18b32324d112e782ffkk"
+    "sha512=a66f9781fdef825addefa3a9c425a454c98f388ae0e476cf216a555d1573291347668a9aa6461ae17074b17504622cd77bbb2302edb55d18b32324d112e782ff"
   ]
 }

--- a/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.6/opam
+++ b/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.6/opam
@@ -18,6 +18,8 @@ depends: [
   "odoc" {with-doc}
   "ezcurl" {>= "0.2.3"}
   "ocurl"
+  "alcotest" {with-test}
+  "opentelemetry-client-cohttp-lwt" {with-test & = version}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.6/opam
+++ b/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.6/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Collector client for opentelemetry, using http + ezcurl"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: "the Imandra team and contributors"
+license: "MIT"
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "mtime" {>= "1.4"}
+  "opentelemetry" {= version}
+  "pbrt" {>= "2.3"}
+  "odoc" {with-doc}
+  "ezcurl" {>= "0.2.3"}
+  "ocurl"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/archive/refs/tags/v0.6.tar.gz"
+  checksum: [
+    "md5=759c028739d027414ad35cface56789f"
+    "sha512=c78fad3b3282f6d1337dcc8ecf55b38294801d4b470558752112826206b9e5e20679c213c9ef5fcd0d223e3fe81214b275b8d146a57c7b59a26d4ef381e06162"
+  ]
+}

--- a/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.6/opam
+++ b/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.6/opam
@@ -38,7 +38,7 @@ url {
   src:
     "https://github.com/imandra-ai/ocaml-opentelemetry/archive/refs/tags/v0.6.tar.gz"
   checksum: [
-    "md5=759c028739d027414ad35cface56789f"
-    "sha512=c78fad3b3282f6d1337dcc8ecf55b38294801d4b470558752112826206b9e5e20679c213c9ef5fcd0d223e3fe81214b275b8d146a57c7b59a26d4ef381e06162"
+    "md5=bb3860b2d9941bbb3680aef45f8db3d8"
+    "sha512=a66f9781fdef825addefa3a9c425a454c98f388ae0e476cf216a555d1573291347668a9aa6461ae17074b17504622cd77bbb2302edb55d18b32324d112e782ffkk"
   ]
 }

--- a/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.6/opam
+++ b/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.6/opam
@@ -38,6 +38,6 @@ url {
     "https://github.com/imandra-ai/ocaml-opentelemetry/archive/refs/tags/v0.6.tar.gz"
   checksum: [
     "md5=bb3860b2d9941bbb3680aef45f8db3d8"
-    "sha512=a66f9781fdef825addefa3a9c425a454c98f388ae0e476cf216a555d1573291347668a9aa6461ae17074b17504622cd77bbb2302edb55d18b32324d112e782ffkk"
+    "sha512=a66f9781fdef825addefa3a9c425a454c98f388ae0e476cf216a555d1573291347668a9aa6461ae17074b17504622cd77bbb2302edb55d18b32324d112e782ff"
   ]
 }

--- a/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.6/opam
+++ b/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.6/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Opentelemetry tracing for Cohttp HTTP servers"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: "the Imandra team and contributors"
+license: "MIT"
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "opentelemetry" {= version}
+  "opentelemetry-lwt" {= version}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "cohttp-lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/archive/refs/tags/v0.6.tar.gz"
+  checksum: [
+    "md5=759c028739d027414ad35cface56789f"
+    "sha512=c78fad3b3282f6d1337dcc8ecf55b38294801d4b470558752112826206b9e5e20679c213c9ef5fcd0d223e3fe81214b275b8d146a57c7b59a26d4ef381e06162"
+  ]
+}

--- a/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.6/opam
+++ b/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.6/opam
@@ -17,6 +17,9 @@ depends: [
   "odoc" {with-doc}
   "lwt" {>= "5.3"}
   "cohttp-lwt" {>= "4.0.0"}
+  "alcotest" {with-test}
+  "opentelemetry-client-cohttp-lwt" {with-test & = version}
+  "opentelemetry-client-ocurl" {with-test & = version}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.6/opam
+++ b/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.6/opam
@@ -37,7 +37,7 @@ url {
   src:
     "https://github.com/imandra-ai/ocaml-opentelemetry/archive/refs/tags/v0.6.tar.gz"
   checksum: [
-    "md5=759c028739d027414ad35cface56789f"
-    "sha512=c78fad3b3282f6d1337dcc8ecf55b38294801d4b470558752112826206b9e5e20679c213c9ef5fcd0d223e3fe81214b275b8d146a57c7b59a26d4ef381e06162"
+    "md5=bb3860b2d9941bbb3680aef45f8db3d8"
+    "sha512=a66f9781fdef825addefa3a9c425a454c98f388ae0e476cf216a555d1573291347668a9aa6461ae17074b17504622cd77bbb2302edb55d18b32324d112e782ffkk"
   ]
 }

--- a/packages/opentelemetry-lwt/opentelemetry-lwt.0.6/opam
+++ b/packages/opentelemetry-lwt/opentelemetry-lwt.0.6/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Lwt-compatible instrumentation for https://opentelemetry.io"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: "the Imandra team and contributors"
+license: "MIT"
+tags: ["instrumentation" "tracing" "opentelemetry" "datadog" "lwt"]
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "ambient-context"
+  "opentelemetry" {= version}
+  "cohttp-lwt-unix" {with-test}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "lwt_ppx" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/archive/refs/tags/v0.6.tar.gz"
+  checksum: [
+    "md5=759c028739d027414ad35cface56789f"
+    "sha512=c78fad3b3282f6d1337dcc8ecf55b38294801d4b470558752112826206b9e5e20679c213c9ef5fcd0d223e3fe81214b275b8d146a57c7b59a26d4ef381e06162"
+  ]
+}

--- a/packages/opentelemetry-lwt/opentelemetry-lwt.0.6/opam
+++ b/packages/opentelemetry-lwt/opentelemetry-lwt.0.6/opam
@@ -39,7 +39,7 @@ url {
   src:
     "https://github.com/imandra-ai/ocaml-opentelemetry/archive/refs/tags/v0.6.tar.gz"
   checksum: [
-    "md5=759c028739d027414ad35cface56789f"
-    "sha512=c78fad3b3282f6d1337dcc8ecf55b38294801d4b470558752112826206b9e5e20679c213c9ef5fcd0d223e3fe81214b275b8d146a57c7b59a26d4ef381e06162"
+    "md5=bb3860b2d9941bbb3680aef45f8db3d8"
+    "sha512=a66f9781fdef825addefa3a9c425a454c98f388ae0e476cf216a555d1573291347668a9aa6461ae17074b17504622cd77bbb2302edb55d18b32324d112e782ffkk"
   ]
 }

--- a/packages/opentelemetry-lwt/opentelemetry-lwt.0.6/opam
+++ b/packages/opentelemetry-lwt/opentelemetry-lwt.0.6/opam
@@ -19,6 +19,9 @@ depends: [
   "odoc" {with-doc}
   "lwt" {>= "5.3"}
   "lwt_ppx" {>= "2.0"}
+  "alcotest" {with-test}
+  "opentelemetry-client-cohttp-lwt" {with-test & = version}
+  "opentelemetry-client-ocurl" {with-test & = version}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/opentelemetry-lwt/opentelemetry-lwt.0.6/opam
+++ b/packages/opentelemetry-lwt/opentelemetry-lwt.0.6/opam
@@ -40,6 +40,6 @@ url {
     "https://github.com/imandra-ai/ocaml-opentelemetry/archive/refs/tags/v0.6.tar.gz"
   checksum: [
     "md5=bb3860b2d9941bbb3680aef45f8db3d8"
-    "sha512=a66f9781fdef825addefa3a9c425a454c98f388ae0e476cf216a555d1573291347668a9aa6461ae17074b17504622cd77bbb2302edb55d18b32324d112e782ffkk"
+    "sha512=a66f9781fdef825addefa3a9c425a454c98f388ae0e476cf216a555d1573291347668a9aa6461ae17074b17504622cd77bbb2302edb55d18b32324d112e782ff"
   ]
 }

--- a/packages/opentelemetry/opentelemetry.0.6/opam
+++ b/packages/opentelemetry/opentelemetry.0.6/opam
@@ -45,6 +45,6 @@ url {
     "https://github.com/imandra-ai/ocaml-opentelemetry/archive/refs/tags/v0.6.tar.gz"
   checksum: [
     "md5=bb3860b2d9941bbb3680aef45f8db3d8"
-    "sha512=a66f9781fdef825addefa3a9c425a454c98f388ae0e476cf216a555d1573291347668a9aa6461ae17074b17504622cd77bbb2302edb55d18b32324d112e782ffkk"
+    "sha512=a66f9781fdef825addefa3a9c425a454c98f388ae0e476cf216a555d1573291347668a9aa6461ae17074b17504622cd77bbb2302edb55d18b32324d112e782ff"
   ]
 }

--- a/packages/opentelemetry/opentelemetry.0.6/opam
+++ b/packages/opentelemetry/opentelemetry.0.6/opam
@@ -44,7 +44,7 @@ url {
   src:
     "https://github.com/imandra-ai/ocaml-opentelemetry/archive/refs/tags/v0.6.tar.gz"
   checksum: [
-    "md5=759c028739d027414ad35cface56789f"
-    "sha512=c78fad3b3282f6d1337dcc8ecf55b38294801d4b470558752112826206b9e5e20679c213c9ef5fcd0d223e3fe81214b275b8d146a57c7b59a26d4ef381e06162"
+    "md5=bb3860b2d9941bbb3680aef45f8db3d8"
+    "sha512=a66f9781fdef825addefa3a9c425a454c98f388ae0e476cf216a555d1573291347668a9aa6461ae17074b17504622cd77bbb2302edb55d18b32324d112e782ffkk"
   ]
 }

--- a/packages/opentelemetry/opentelemetry.0.6/opam
+++ b/packages/opentelemetry/opentelemetry.0.6/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Instrumentation for https://opentelemetry.io"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: "the Imandra team and contributors"
+license: "MIT"
+tags: ["instrumentation" "tracing" "opentelemetry" "datadog" "jaeger"]
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "ptime"
+  "ambient-context"
+  "odoc" {with-doc}
+  "alcotest" {with-test}
+  "pbrt" {>= "2.3"}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup & >= "0.24" & < "0.25"}
+]
+depopts: ["trace"]
+conflicts: [
+  "trace" {< "0.4" | >= "0.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/archive/refs/tags/v0.6.tar.gz"
+  checksum: [
+    "md5=759c028739d027414ad35cface56789f"
+    "sha512=c78fad3b3282f6d1337dcc8ecf55b38294801d4b470558752112826206b9e5e20679c213c9ef5fcd0d223e3fe81214b275b8d146a57c7b59a26d4ef381e06162"
+  ]
+}

--- a/packages/opentelemetry/opentelemetry.0.6/opam
+++ b/packages/opentelemetry/opentelemetry.0.6/opam
@@ -17,6 +17,8 @@ depends: [
   "ambient-context"
   "odoc" {with-doc}
   "alcotest" {with-test}
+  "opentelemetry-client-cohttp-lwt" {with-test & = version}
+  "opentelemetry-client-ocurl" {with-test & = version}
   "pbrt" {>= "2.3"}
   "ocaml-lsp-server" {with-dev-setup}
   "ocamlformat" {with-dev-setup & >= "0.24" & < "0.25"}


### PR DESCRIPTION
This pull-request concerns:
- `opentelemetry.0.6`: Instrumentation for https://opentelemetry.io
- `opentelemetry-client-cohttp-lwt.0.6`: Collector client for opentelemetry, using cohttp + lwt
- `opentelemetry-client-ocurl.0.6`: Collector client for opentelemetry, using http + ezcurl
- `opentelemetry-cohttp-lwt.0.6`: Opentelemetry tracing for Cohttp HTTP servers
- `opentelemetry-lwt.0.6`: Lwt-compatible instrumentation for https://opentelemetry.io

CHANGES:

- fix ticker thread shutdown
- migrated to OTEL proto files v1.0
- replace `Thread_local` with `ocaml-ambient-context`, allowing for implicit scope in Lwt/Eio contexts (imandra-ai/ocaml-opentelemetry#34)
- update `ocaml-trace` interface to use the new `trace.0.3`-style API (breaking, see imandra-ai/ocaml-opentelemetry#34)

---
* Homepage: https://github.com/imandra-ai/ocaml-opentelemetry
* Source repo: git+https://github.com/imandra-ai/ocaml-opentelemetry.git
* Bug tracker: https://github.com/imandra-ai/ocaml-opentelemetry/issues

---
:camel: Pull-request generated by opam-publish v2.2.0