### PR TITLE
[new release] conf-fswatch 11-0.1.3 & fswatch 11-0.1.3

### DIFF
--- a/packages/conf-fswatch/conf-fswatch.11-0.1.3/files/test.c
+++ b/packages/conf-fswatch/conf-fswatch.11-0.1.3/files/test.c
@@ -1,0 +1,5 @@
+#include <libfswatch.h>
+
+int main(void) {
+  return 0;
+}

--- a/packages/conf-fswatch/conf-fswatch.11-0.1.3/opam
+++ b/packages/conf-fswatch/conf-fswatch.11-0.1.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://github.com/kandu/ocaml-fswatch/"
+bug-reports: "https://github.com/kandu/ocaml-fswatch/issues"
+license: "MIT"
+
+build: [
+  ["sh" "-exec" "cc -I/usr/local/include/libfswatch/c -I/usr/include/libfswatch/c $CFLAGS test.c -lfswatch"] { !(os-distribution = "homebrew" & arch = "arm64") }
+  ["sh" "-exec" "cc -I$(brew --prefix)/include/libfswatch/c $CFLAGS test.c -lfswatch"] { os-distribution = "homebrew" & arch = "arm64" }
+]
+
+depexts: [
+  ["libfswatch-dev"] {os-family = "debian"}
+  ["fswatch"] {os-distribution = "arch"}
+  ["sys-fs/fswatch"] {os-distribution = "gentoo"}
+  ["fswatch-mon"] {os = "freebsd"}
+  ["fswatch"] {os = "macos" & os-distribution = "homebrew"}
+]
+
+synopsis: "Virtual package relying on libfswatch installation"
+description: "This package can install only if the libfswatch is available on the system"
+
+extra-files: [
+  "test.c" "md5=76de29f84e4438235abc7ce83423b545"
+]
+
+flags: [conf]

--- a/packages/fswatch/fswatch.11-0.1.3/opam
+++ b/packages/fswatch/fswatch.11-0.1.3/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://github.com/kandu/ocaml-fswatch/"
+bug-reports: "https://github.com/kandu/ocaml-fswatch/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/kandu/ocaml-fswatch"
+build: [
+  ["sh" "-exec" "echo \\(-I/usr/local/include/libfswatch/c -I/usr/include/libfswatch/c\\) > fswatch/src/inc_cflags"] { !(os-distribution = "homebrew" & arch = "arm64") }
+  ["sh" "-exec" "echo -lfswatch > fswatch/src/inc_libs"] { !(os-distribution = "homebrew" & arch = "arm64") }
+
+  ["sh" "-exec" "echo -I$(brew --prefix)/include/libfswatch/c > fswatch/src/inc_cflags"] { os-distribution = "homebrew" & arch = "arm64" }
+  ["sh" "-exec" "echo \\(-L$(brew --prefix)/lib -lfswatch\\) > fswatch/src/inc_libs"] { os-distribution = "homebrew" & arch = "arm64" }
+
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-fswatch"
+  "dune" {>= "1.4"}
+]
+
+synopsis: "Bindings for libfswatch -- file change monitor"
+description: """fswatch is a file change monitor that receives notifications when the contents of the specified files or directories are modified."""
+
+url {
+  src: "https://github.com/kandu/ocaml-fswatch/archive/11-0.1.3.tar.gz"
+  checksum: "md5=10ff6b35632fde8057e93552d35e831a"
+}


### PR DESCRIPTION
Changes:
* compatible with silicon mac

Issue #22256 is still there. The debian maintainer of that package is still incompetent, so build failure on debian os-family is expected.