### PR TITLE
Package queenshead.0.1

### DIFF
--- a/packages/queenshead/queenshead.0.1/opam
+++ b/packages/queenshead/queenshead.0.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "British pub name generator"
+description: "Generate names for British pubs."
+license: "MIT"
+homepage: "https://gitlab.com/raphael-proust/queenshead"
+doc: "https://gitlab.com/raphael-proust/queenshead"
+bug-reports: "https://gitlab.com/raphael-proust/queenshead/-/issues"
+authors: [ "Raphaël Proust <code@bnwr.net>" ]
+maintainer: [ "Raphaël Proust <code@bnwr.net>" ]
+dev-repo: "git+https://gitlab.com/raphael-proust/queenshead.git"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.14.0"}
+  "crunch"
+  "cmdliner" {>= "1.2.0"}
+  "bos" {>= "0.2"}
+  "astring" {>= "0.8"}
+]
+build: [ ["dune" "build" "-p" name "-j" jobs] ]
+url {
+  src:
+    "https://gitlab.com/raphael-proust/queenshead/-/archive/0.1/queenshead-0.1.tar.gz"
+  checksum: [
+    "md5=f1707876b20ea8353ddb89c9c31c5868"
+    "sha512=92aa1d5c392525f68c0aad534596245c75cc0470202c31fdaaf88f7b1dc0a503a26dd21f0f3fe290d97c0f39ed17e9b57d43abbff9d90800aa452f9bd24686e1"
+  ]
+}


### PR DESCRIPTION
### `queenshead.0.1`
British pub name generator
Generate names for British pubs.



---
* Homepage: https://gitlab.com/raphael-proust/queenshead
* Source repo: git+https://gitlab.com/raphael-proust/queenshead.git
* Bug tracker: https://gitlab.com/raphael-proust/queenshead/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0