### PR TITLE
[new release] runtime_events_tools (0.5.0)

### DIFF
--- a/packages/opsian/opsian.0.1/opam
+++ b/packages/opsian/opsian.0.1/opam
@@ -9,11 +9,14 @@ bug-reports: "https://github.com/Opsian/opsian-ocaml/issues"
 depends: [
   "dune" {>= "2.8"}
   ("ocaml" {>= "4.12.0" & < "5.0.0"} |
-   ("ocaml" {>= "5.0.0"} & "runtime_events_tools" {< "0.5"}))
+   ("ocaml" {>= "5.0.0"} & "runtime_events_tools"))
   "conf-automake"
   "conf-perl"
   "conf-liblzma"
   "conf-libtool"
+]
+conflicts: [
+  "runtime_events_tools" {>= "0.5"}
 ]
 available:
   arch != "arm32" & arch != "x86_32" & arch != "s390x" & os-family != "arch" &

--- a/packages/opsian/opsian.0.1/opam
+++ b/packages/opsian/opsian.0.1/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/Opsian/opsian-ocaml/issues"
 depends: [
   "dune" {>= "2.8"}
   ("ocaml" {>= "4.12.0" & < "5.0.0"} |
-   ("ocaml" {>= "5.0.0"} & "runtime_events_tools"))
+   ("ocaml" {>= "5.0.0"} & "runtime_events_tools" {< "0.5"}))
   "conf-automake"
   "conf-perl"
   "conf-liblzma"

--- a/packages/runtime_events_tools/runtime_events_tools.0.5.0/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.5.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "5.0.0~"}
   "ocamlfind"
   "hdr_histogram"
-  "cmdliner"
+  "cmdliner" {>= "1.1.0"}
   "tracing"
   "menhir" {with-test}
   "odoc" {with-doc}
@@ -30,6 +30,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: arch != "arm64" & arch != "arm32"
 dev-repo: "git+https://github.com/tarides/runtime_events_tools.git"
 url {
   src:

--- a/packages/runtime_events_tools/runtime_events_tools.0.5.0/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.5.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Tools for the runtime events tracing system in OCaml"
+description: "Various tools for the runtime events tracing system in OCaml"
+maintainer: ["Sadiq Jaffer" "KC Sivaramakrishnan" "Sudha Parimala"]
+authors: ["Sadiq Jaffer"]
+license: "ISC"
+homepage: "https://github.com/tarides/runtime_events_tools"
+bug-reports: "https://github.com/tarides/runtime_events_tools/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "5.0.0~"}
+  "ocamlfind"
+  "hdr_histogram"
+  "cmdliner"
+  "tracing"
+  "menhir" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/runtime_events_tools.git"
+url {
+  src:
+    "https://github.com/tarides/runtime_events_tools/releases/download/0.5.0/runtime_events_tools-0.5.0.tbz"
+  checksum: [
+    "sha256=818258e2f81d42327cee846dda9fec5a863e926152903be3f4e5c686ee660270"
+    "sha512=50c5ecdae4a73c4f26d68da21265c8ee2731bff76445db9e637237793d7024a272f78f6a57650e51c70a459843a656c19d5ee79d2e5aeed0460983adb67fe548"
+  ]
+}
+x-commit-hash: "60270d3e42f4b17025de5ba195a08f39b6d4f390"


### PR DESCRIPTION
Tools for the runtime events tracing system in OCaml

- Project page: <a href="https://github.com/tarides/runtime_events_tools">https://github.com/tarides/runtime_events_tools</a>

##### CHANGES:

* Custom events for json (tarides/runtime_events_tools#24, @Sudha247)
* Improvements to correct gc-stats (tarides/runtime_events_tools#19, @Sudha247)
* olly trace: ingest custom events starting from OCaml 5.1 (tarides/runtime_events_tools#17, @TheLortex)
