### PR TITLE
[new release] tyxml (4 packages) (4.6.0)

### DIFF
--- a/packages/current_web/current_web.0.5/opam
+++ b/packages/current_web/current_web.0.5/opam
@@ -29,7 +29,7 @@ depends: [
   "cohttp" {>= "2.2.0"}
   "cohttp-lwt" {>= "2.2.0"}
   "cohttp-lwt-unix" {>= "2.2.0"}
-  "tyxml" {>= "4.4.0"}
+  "tyxml" {>= "4.4.0" & < "4.6.0"}
   "routes" {>= "0.8.0" & < "2.0.0"}
   "dune" {>= "2.0"}
   "conf-graphviz"

--- a/packages/current_web/current_web.0.6.1/opam
+++ b/packages/current_web/current_web.0.6.1/opam
@@ -29,7 +29,7 @@ depends: [
   "prometheus" {>= "0.7"}
   "prometheus-app" {< "1.2"}
   "cohttp-lwt-unix" {>= "4.0.0"}
-  "tyxml" {>= "4.4.0"}
+  "tyxml" {>= "4.4.0" & < "4.6.0"}
   "csv" {>= "2.4"}
   "routes" {>= "0.8.0" & < "2.0.0"}
   "dune" {>= "2.9"}

--- a/packages/current_web/current_web.0.6.2/opam
+++ b/packages/current_web/current_web.0.6.2/opam
@@ -30,7 +30,7 @@ depends: [
   "prometheus" {>= "0.7"}
   "prometheus-app" {>= "1.2"}
   "cohttp-lwt-unix" {>= "4.0.0"}
-  "tyxml" {>= "4.4.0"}
+  "tyxml" {>= "4.4.0" & < "4.6.0"}
   "csv" {>= "2.4"}
   "routes" {>= "0.8.0" & < "2.0.0"}
   "dune" {>= "2.9"}

--- a/packages/current_web/current_web.0.6.4/opam
+++ b/packages/current_web/current_web.0.6.4/opam
@@ -47,7 +47,7 @@ depends: [
   "session-cohttp-lwt"
   "sexplib" {>= "v0.14.0"}
   "sqlite3" {>= "5.0.2"}
-  "tyxml" {>= "4.4.0"}
+  "tyxml" {>= "4.4.0" & < "4.6.0"}
   "uri" {>= "4.0.0"}
   "yojson" {>= "1.7.0"}
   "odoc" {with-doc}

--- a/packages/current_web/current_web.0.6/opam
+++ b/packages/current_web/current_web.0.6/opam
@@ -27,7 +27,7 @@ depends: [
   "prometheus" {>= "0.7"}
   "prometheus-app" {< "1.2"}
   "cohttp-lwt-unix" {>= "4.0.0"}
-  "tyxml" {>= "4.4.0"}
+  "tyxml" {>= "4.4.0" & < "4.6.0"}
   "routes" {>= "0.8.0" & < "2.0.0"}
   "dune" {>= "2.9"}
   "conf-graphviz"

--- a/packages/eliom/eliom.10.0.0/opam
+++ b/packages/eliom/eliom.10.0.0/opam
@@ -28,7 +28,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.6.0"}
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
-  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "tyxml" {>= "4.4.0" & < "4.6.0"}
   "ocsigenserver" {>= "5.0.0" & < "5.1.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}

--- a/packages/eliom/eliom.10.1.0/opam
+++ b/packages/eliom/eliom.10.1.0/opam
@@ -28,7 +28,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.6.0"}
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
-  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "tyxml" {>= "4.4.0" & < "4.6.0"}
   "ocsigenserver" {>= "5.1.0" & < "6.0.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}

--- a/packages/eliom/eliom.8.9.0/opam
+++ b/packages/eliom/eliom.8.9.0/opam
@@ -28,7 +28,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.6.0"}
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
-  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "tyxml" {>= "4.4.0" & < "4.6.0"}
   "ocsigenserver" {>= "4.0.1" & < "5.0.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}

--- a/packages/eliom/eliom.9.0.0/opam
+++ b/packages/eliom/eliom.9.0.0/opam
@@ -28,7 +28,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.6.0"}
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
-  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "tyxml" {>= "4.4.0" & < "4.6.0"}
   "ocsigenserver" {>= "5.0.0" & < "5.1.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}

--- a/packages/eliom/eliom.9.2.1/opam
+++ b/packages/eliom/eliom.9.2.1/opam
@@ -28,7 +28,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.6.0"}
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
-  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "tyxml" {>= "4.4.0" & < "4.6.0"}
   "ocsigenserver" {>= "5.0.0" & < "5.1.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}

--- a/packages/eliom/eliom.9.3.0/opam
+++ b/packages/eliom/eliom.9.3.0/opam
@@ -28,7 +28,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.6.0"}
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
-  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "tyxml" {>= "4.4.0" & < "4.6.0"}
   "ocsigenserver" {>= "5.0.0" & < "5.1.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}

--- a/packages/eliom/eliom.9.4.0/opam
+++ b/packages/eliom/eliom.9.4.0/opam
@@ -28,7 +28,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.6.0"}
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
-  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "tyxml" {>= "4.4.0" & < "4.6.0"}
   "ocsigenserver" {>= "5.0.0" & < "5.1.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}

--- a/packages/tyxml-jsx/tyxml-jsx.4.6.0/opam
+++ b/packages/tyxml-jsx/tyxml-jsx.4.6.0/opam
@@ -11,7 +11,7 @@ It works with textual trees, virtual DOM trees, or any TyXML module.
 """
 maintainer: ["dev@ocsigen.org"]
 authors: ["The ocsigen team"]
-license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocsigen/tyxml"
 doc: "https://ocsigen.org/tyxml/latest/manual/intro"
 bug-reports: "https://github.com/ocsigen/tyxml/issues"

--- a/packages/tyxml-jsx/tyxml-jsx.4.6.0/opam
+++ b/packages/tyxml-jsx/tyxml-jsx.4.6.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "JSX syntax to write TyXML documents"
+description: """
+```reason
+open Tyxml;
+let to_reason = <a href="reasonml.github.io/"> "Reason!" </a>
+```
+ 
+The TyXML JSX allow to write TyXML documents with reason's JSX syntax. 
+It works with textual trees, virtual DOM trees, or any TyXML module.
+"""
+maintainer: ["dev@ocsigen.org"]
+authors: ["The ocsigen team"]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocsigen/tyxml"
+doc: "https://ocsigen.org/tyxml/latest/manual/intro"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04"}
+  "tyxml" {= version}
+  "tyxml-syntax" {= version}
+  "alcotest" {with-test}
+  "reason" {with-test}
+  "ppxlib" {>= "0.18"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocsigen/tyxml.git"
+url {
+  src:
+    "https://github.com/ocsigen/tyxml/releases/download/4.6.0/tyxml-4.6.0.tbz"
+  checksum: [
+    "sha256=bfeb673c6b4e120a4eca4c48448add47dc3f8d02c2b40f63ffdccc4e91c902dd"
+    "sha512=69750eeaf467014282087bf9628f3278f3e5f00f4c7400358750d208664cfc3f79a5cba16767d2935e53477d1a6862fe08c5b801b69052ec12e09d1a93a5e9b4"
+  ]
+}
+x-commit-hash: "d2916535536f2134bad7793a598ba5b7327cae41"

--- a/packages/tyxml-lwd/tyxml-lwd.0.2/opam
+++ b/packages/tyxml-lwd/tyxml-lwd.0.2/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/let-def/lwd/issues"
 depends: [
   "dune" {>= "2.7"}
   "lwd" {= version}
-  "tyxml" {>= "4.5.0"}
+  "tyxml" {>= "4.5.0" & < "4.6.0"}
   "js_of_ocaml"
   "js_of_ocaml-ppx"
   "odoc" {with-doc}

--- a/packages/tyxml-lwd/tyxml-lwd.0.3/opam
+++ b/packages/tyxml-lwd/tyxml-lwd.0.3/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/let-def/lwd/issues"
 depends: [
   "dune" {>= "2.7"}
   "lwd" {= version}
-  "tyxml" {>= "4.5.0"}
+  "tyxml" {>= "4.5.0" & < "4.6.0"}
   "js_of_ocaml"
   "js_of_ocaml-ppx"
   "odoc" {with-doc}

--- a/packages/tyxml-ppx/tyxml-ppx.4.6.0/opam
+++ b/packages/tyxml-ppx/tyxml-ppx.4.6.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "PPX to write TyXML documents with the HTML syntax"
+description: """
+```ocaml
+open Tyxml
+let%html to_ocaml = "<a href='ocaml.org'>OCaml!</a>"
+```
+ 
+The TyXML PPX allow to write TyXML documents using the traditional HTML syntax. 
+It works with textual trees, virtual DOM trees, or any TyXML module.
+"""
+maintainer: ["dev@ocsigen.org"]
+authors: ["The ocsigen team"]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocsigen/tyxml"
+doc: "https://ocsigen.org/tyxml/latest/manual/intro"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04"}
+  "tyxml" {= version}
+  "tyxml-syntax" {= version}
+  "alcotest" {with-test}
+  "markup" {>= "0.7.2"}
+  "ppxlib" {>= "0.18"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocsigen/tyxml.git"
+url {
+  src:
+    "https://github.com/ocsigen/tyxml/releases/download/4.6.0/tyxml-4.6.0.tbz"
+  checksum: [
+    "sha256=bfeb673c6b4e120a4eca4c48448add47dc3f8d02c2b40f63ffdccc4e91c902dd"
+    "sha512=69750eeaf467014282087bf9628f3278f3e5f00f4c7400358750d208664cfc3f79a5cba16767d2935e53477d1a6862fe08c5b801b69052ec12e09d1a93a5e9b4"
+  ]
+}
+x-commit-hash: "d2916535536f2134bad7793a598ba5b7327cae41"

--- a/packages/tyxml-ppx/tyxml-ppx.4.6.0/opam
+++ b/packages/tyxml-ppx/tyxml-ppx.4.6.0/opam
@@ -11,7 +11,7 @@ It works with textual trees, virtual DOM trees, or any TyXML module.
 """
 maintainer: ["dev@ocsigen.org"]
 authors: ["The ocsigen team"]
-license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocsigen/tyxml"
 doc: "https://ocsigen.org/tyxml/latest/manual/intro"
 bug-reports: "https://github.com/ocsigen/tyxml/issues"

--- a/packages/tyxml-syntax/tyxml-syntax.4.6.0/opam
+++ b/packages/tyxml-syntax/tyxml-syntax.4.6.0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis: "Common layer for the JSX and PPX syntaxes for Tyxml"
 maintainer: ["dev@ocsigen.org"]
 authors: ["The ocsigen team"]
-license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocsigen/tyxml"
 doc: "https://ocsigen.org/tyxml/latest/manual/intro"
 bug-reports: "https://github.com/ocsigen/tyxml/issues"

--- a/packages/tyxml-syntax/tyxml-syntax.4.6.0/opam
+++ b/packages/tyxml-syntax/tyxml-syntax.4.6.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Common layer for the JSX and PPX syntaxes for Tyxml"
+maintainer: ["dev@ocsigen.org"]
+authors: ["The ocsigen team"]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocsigen/tyxml"
+doc: "https://ocsigen.org/tyxml/latest/manual/intro"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04"}
+  "alcotest" {with-test}
+  "ppxlib" {>= "0.18"}
+  "re" {>= "1.5.0"}
+  "uutf" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocsigen/tyxml.git"
+url {
+  src:
+    "https://github.com/ocsigen/tyxml/releases/download/4.6.0/tyxml-4.6.0.tbz"
+  checksum: [
+    "sha256=bfeb673c6b4e120a4eca4c48448add47dc3f8d02c2b40f63ffdccc4e91c902dd"
+    "sha512=69750eeaf467014282087bf9628f3278f3e5f00f4c7400358750d208664cfc3f79a5cba16767d2935e53477d1a6862fe08c5b801b69052ec12e09d1a93a5e9b4"
+  ]
+}
+x-commit-hash: "d2916535536f2134bad7793a598ba5b7327cae41"

--- a/packages/tyxml-syntax/tyxml-syntax.4.6.0/opam
+++ b/packages/tyxml-syntax/tyxml-syntax.4.6.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.04"}
   "alcotest" {with-test}
   "ppxlib" {>= "0.18"}
-  "re" {>= "1.5.0"}
+  "re" {>= "1.7.2"}
   "uutf" {>= "1.0.0"}
   "odoc" {with-doc}
 ]

--- a/packages/tyxml/tyxml.4.6.0/opam
+++ b/packages/tyxml/tyxml.4.6.0/opam
@@ -4,7 +4,7 @@ description:
   "TyXML provides a set of convenient combinators that uses the OCaml type system to ensure the validity of the generated documents. TyXML can be used with any representation of HTML and SVG: the textual one, provided directly by this package, or DOM trees (`js_of_ocaml-tyxml`) virtual DOM (`virtual-dom`) and reactive or replicated trees (`eliom`). You can also create your own representation and use it to instantiate a new set of combinators."
 maintainer: ["dev@ocsigen.org"]
 authors: ["The ocsigen team"]
-license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocsigen/tyxml"
 doc: "https://ocsigen.org/tyxml/latest/manual/intro"
 bug-reports: "https://github.com/ocsigen/tyxml/issues"

--- a/packages/tyxml/tyxml.4.6.0/opam
+++ b/packages/tyxml/tyxml.4.6.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.04"}
   "alcotest" {with-test}
-  "re" {>= "1.5.0"}
+  "re" {>= "1.7.2"}
   "seq"
   "uutf" {>= "1.0.0"}
   "odoc" {with-doc}

--- a/packages/tyxml/tyxml.4.6.0/opam
+++ b/packages/tyxml/tyxml.4.6.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A library for building correct HTML and SVG documents"
+description:
+  "TyXML provides a set of convenient combinators that uses the OCaml type system to ensure the validity of the generated documents. TyXML can be used with any representation of HTML and SVG: the textual one, provided directly by this package, or DOM trees (`js_of_ocaml-tyxml`) virtual DOM (`virtual-dom`) and reactive or replicated trees (`eliom`). You can also create your own representation and use it to instantiate a new set of combinators."
+maintainer: ["dev@ocsigen.org"]
+authors: ["The ocsigen team"]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocsigen/tyxml"
+doc: "https://ocsigen.org/tyxml/latest/manual/intro"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04"}
+  "alcotest" {with-test}
+  "re" {>= "1.5.0"}
+  "seq"
+  "uutf" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocsigen/tyxml.git"
+url {
+  src:
+    "https://github.com/ocsigen/tyxml/releases/download/4.6.0/tyxml-4.6.0.tbz"
+  checksum: [
+    "sha256=bfeb673c6b4e120a4eca4c48448add47dc3f8d02c2b40f63ffdccc4e91c902dd"
+    "sha512=69750eeaf467014282087bf9628f3278f3e5f00f4c7400358750d208664cfc3f79a5cba16767d2935e53477d1a6862fe08c5b801b69052ec12e09d1a93a5e9b4"
+  ]
+}
+x-commit-hash: "d2916535536f2134bad7793a598ba5b7327cae41"


### PR DESCRIPTION
A library for building correct HTML and SVG documents

- Project page: <a href="https://github.com/ocsigen/tyxml">https://github.com/ocsigen/tyxml</a>
- Documentation: <a href="https://ocsigen.org/tyxml/latest/manual/intro">https://ocsigen.org/tyxml/latest/manual/intro</a>

##### CHANGES:

* Update for OCaml 5.0 and drop support for OCaml 4.2.0
  (ocsigen/tyxml#312 by @rr0gi)

* Add additional variants to `linktype` for the `rel` attribute
  (Leon @LogicalOverflow Vack)

* Expand options for `autocomplete` attribute on `<input>` elements
  (ocsigen/tyxml#302 by Aron @aronerben Erben)

* Fix the SVG element `<animate>` (by the way, deprecate `animation` et
  al. in favor of `animate` et al.)
  (ocsigen/tyxml#306 by Idir @ilankri Lankri)

* Add support for `dialog` element and `onclose` attribute
  (ocsigen/tyxml#301 by Julien Sagot)
* Add an escape hatch for emitting attributes with non-standard names
  in jsx or ppx code (a leading `_` character on attribute name)
  (ocsigen/tyxml#295 Chas @cemerick Emerick)
* Add support for `type` attribute on `<script>` elements
  (ocsigen/tyxml#293 by Ulrik @ulrikstrid Strid and Chas @cemerick Emerick)

* Add svg `fill-rule` attribute
  (ocsigen/tyxml#294 by Eric @dedbox Griffis)
