### PR TITLE
[update] conf-fswatch 11-0.1.3 & fswatch 11-0.1.3 add support for bsd os-family

### DIFF
--- a/packages/conf-fswatch/conf-fswatch.11-0.1.3/opam
+++ b/packages/conf-fswatch/conf-fswatch.11-0.1.3/opam
@@ -6,8 +6,9 @@ bug-reports: "https://github.com/kandu/ocaml-fswatch/issues"
 license: "MIT"
 
 build: [
-  ["sh" "-exec" "cc -I/usr/local/include/libfswatch/c -I/usr/include/libfswatch/c $CFLAGS test.c -lfswatch"] { !(os-distribution = "homebrew" & arch = "arm64") }
+  ["sh" "-exec" "cc -I/usr/local/include/libfswatch/c -I/usr/include/libfswatch/c $CFLAGS test.c -lfswatch"] { !(os-distribution = "homebrew" & arch = "arm64") & os-family != "bsd"}
   ["sh" "-exec" "cc -I$(brew --prefix)/include/libfswatch/c -L$(brew --prefix)/lib $CFLAGS test.c -lfswatch"] { os-distribution = "homebrew" & arch = "arm64" }
+  ["sh" "-exec" "cc -I/usr/local/include/libfswatch/c -I/usr/include/libfswatch/c $CFLAGS test.c -L/usr/local/lib -lfswatch"] {os-family = "bsd"}
 ]
 
 depexts: [

--- a/packages/fswatch/fswatch.11-0.1.3/opam
+++ b/packages/fswatch/fswatch.11-0.1.3/opam
@@ -6,11 +6,14 @@ bug-reports: "https://github.com/kandu/ocaml-fswatch/issues"
 license: "MIT"
 dev-repo: "git+https://github.com/kandu/ocaml-fswatch"
 build: [
-  ["sh" "-exec" "echo \\(-I/usr/local/include/libfswatch/c -I/usr/include/libfswatch/c\\) > fswatch/src/inc_cflags"] { !(os-distribution = "homebrew" & arch = "arm64") }
-  ["sh" "-exec" "echo -lfswatch > fswatch/src/inc_libs"] { !(os-distribution = "homebrew" & arch = "arm64") }
+  ["sh" "-exec" "echo \\(-I/usr/local/include/libfswatch/c -I/usr/include/libfswatch/c\\) > fswatch/src/inc_cflags"] { !(os-distribution = "homebrew" & arch = "arm64") & os-family != "bsd" }
+  ["sh" "-exec" "echo -lfswatch > fswatch/src/inc_libs"] { !(os-distribution = "homebrew" & arch = "arm64") & os-family != "bsd" }
 
   ["sh" "-exec" "echo -I$(brew --prefix)/include/libfswatch/c > fswatch/src/inc_cflags"] { os-distribution = "homebrew" & arch = "arm64" }
   ["sh" "-exec" "echo \\(-L$(brew --prefix)/lib -lfswatch\\) > fswatch/src/inc_libs"] { os-distribution = "homebrew" & arch = "arm64" }
+
+  ["sh" "-exec" "echo -I/usr/local/include/libfswatch/c > fswatch/src/inc_cflags"] { os-family = "bsd" }
+  ["sh" "-exec" "echo \\(-L/usr/local/lib -lfswatch\\) > fswatch/src/inc_libs"] { os-family = "bsd" }
 
   ["dune" "build" "-p" name "-j" jobs]
 ]


### PR DESCRIPTION
Dear opam-repository maintainers, sorry for bothering you again.

I just setup a freebsd system and make ocaml-fswatch  work on it.
Only the opam files need update so this is a PR only updates the existing 11-0.1.3 version of ocaml-fswatch.