### PR TITLE
Package binaryen.0.23.0

### DIFF
--- a/packages/binaryen/binaryen.0.23.0/opam
+++ b/packages/binaryen/binaryen.0.23.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "4.1.0" & < "6.0.0"}
+  "libbinaryen" {>= "113.0.0" & < "114.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.23.0/binaryen-archive-v0.23.0.tar.gz"
+  checksum: [
+    "md5=621e8b23e3180793ebbcf86959e82fb2"
+    "sha512=019925e91d673c75e727db03d21878e424a8bb5886370726846c51769faf93b5edf94cdd8ef687d70d02bb4d1ee8611616205aa35f1dce7cc0cc7913061eac60"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.23.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.23.0](https://github.com/grain-lang/binaryen.ml/compare/v0.22.0...v0.23.0) (2023-09-27)


### ⚠ BREAKING CHANGES

* Remove `type_system`
* Remove `string_new_replace` operation
* Remove `string_new_replace_array` operation
* Upgrade to libbinaryen v113 ([#194](https://github.com/grain-lang/binaryen.ml/issues/194))

### Features

* Add `string_encode_lossy_utf8_array` operation ([7d222e0](https://github.com/grain-lang/binaryen.ml/commit/7d222e0f8ebc0cfb45e7c07304a59e9559accedc))
* Add `string_encode_lossy_utf8` operation ([7d222e0](https://github.com/grain-lang/binaryen.ml/commit/7d222e0f8ebc0cfb45e7c07304a59e9559accedc))
* Add `string_new_lossy_utf8_array` operation ([7d222e0](https://github.com/grain-lang/binaryen.ml/commit/7d222e0f8ebc0cfb45e7c07304a59e9559accedc))
* Add `string_new_lossy_utf8` operation ([7d222e0](https://github.com/grain-lang/binaryen.ml/commit/7d222e0f8ebc0cfb45e7c07304a59e9559accedc))
* Upgrade to libbinaryen v113 ([#194](https://github.com/grain-lang/binaryen.ml/issues/194)) ([7d222e0](https://github.com/grain-lang/binaryen.ml/commit/7d222e0f8ebc0cfb45e7c07304a59e9559accedc))


### Miscellaneous Chores

* Remove `string_new_replace_array` operation ([7d222e0](https://github.com/grain-lang/binaryen.ml/commit/7d222e0f8ebc0cfb45e7c07304a59e9559accedc))
* Remove `string_new_replace` operation ([7d222e0](https://github.com/grain-lang/binaryen.ml/commit/7d222e0f8ebc0cfb45e7c07304a59e9559accedc))
* Remove `type_system` ([7d222e0](https://github.com/grain-lang/binaryen.ml/commit/7d222e0f8ebc0cfb45e7c07304a59e9559accedc))

---
:camel: Pull-request generated by opam-publish v2.0.3