### PR TITLE
Patch prbnmcn-stats 0.0.2 and 0.0.3 tests

### DIFF
--- a/packages/prbnmcn-stats/prbnmcn-stats.0.0.2/files/convergence-test.patch
+++ b/packages/prbnmcn-stats/prbnmcn-stats.0.0.2/files/convergence-test.patch
@@ -1,0 +1,27 @@
+From 6e24cbdebf8e35cc00878d059cf3fd88ba07f7d2 Mon Sep 17 00:00:00 2001
+From: Jan Midtgaard <mail@janmidtgaard.dk>
+Date: Thu, 28 Sep 2023 10:04:02 +0200
+Subject: [PATCH] Disable kl convergence test on OCaml > 4
+
+---
+ test/dist_test.ml | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/test/dist_test.ml b/test/dist_test.ml
+index aa16588..c92fb42 100644
+--- a/test/dist_test.ml
++++ b/test/dist_test.ml
+@@ -122,7 +122,9 @@ let make_conv_test distname f =
+   let lst = List.hd (List.rev dists) in
+   lst /. fst <=. 0.3
+ 
+-let () = make_conv_test "kl" (fun () -> convergent_sequence Fin.Float.Dist.kl)
++let () =
++  if Char.equal Sys.ocaml_version.[0] '4'
++  then make_conv_test "kl" (fun () -> convergent_sequence Fin.Float.Dist.kl)
+ 
+ let () =
+   make_conv_test "l1" (fun () -> convergent_sequence (Fin.Float.Dist.lp ~p:1.))
+-- 
+2.25.1
+

--- a/packages/prbnmcn-stats/prbnmcn-stats.0.0.2/opam
+++ b/packages/prbnmcn-stats/prbnmcn-stats.0.0.2/opam
@@ -14,6 +14,7 @@ depends: [
   "prbnmcn-linalg" {= "0.0.1"}
   "odoc" {with-doc}
 ]
+patches: ["convergence-test.patch"]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/prbnmcn-stats/prbnmcn-stats.0.0.2/opam
+++ b/packages/prbnmcn-stats/prbnmcn-stats.0.0.2/opam
@@ -29,6 +29,9 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/igarnier/prbnmcn-stats"
+extra-files: [
+  ["convergence-test.patch" "md5=df24d5ccce26295d0deca4b203da52e4"]
+]
 url {
   src: "https://github.com/igarnier/prbnmcn-stats/archive/0.0.2.tar.gz"
   checksum: [

--- a/packages/prbnmcn-stats/prbnmcn-stats.0.0.3/files/convergence-test.patch
+++ b/packages/prbnmcn-stats/prbnmcn-stats.0.0.3/files/convergence-test.patch
@@ -1,0 +1,27 @@
+From 6e24cbdebf8e35cc00878d059cf3fd88ba07f7d2 Mon Sep 17 00:00:00 2001
+From: Jan Midtgaard <mail@janmidtgaard.dk>
+Date: Thu, 28 Sep 2023 10:04:02 +0200
+Subject: [PATCH] Disable kl convergence test on OCaml > 4
+
+---
+ test/dist_test.ml | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/test/dist_test.ml b/test/dist_test.ml
+index aa16588..c92fb42 100644
+--- a/test/dist_test.ml
++++ b/test/dist_test.ml
+@@ -122,7 +122,9 @@ let make_conv_test distname f =
+   let lst = List.hd (List.rev dists) in
+   lst /. fst <=. 0.3
+ 
+-let () = make_conv_test "kl" (fun () -> convergent_sequence Fin.Float.Dist.kl)
++let () =
++  if Char.equal Sys.ocaml_version.[0] '4'
++  then make_conv_test "kl" (fun () -> convergent_sequence Fin.Float.Dist.kl)
+ 
+ let () =
+   make_conv_test "l1" (fun () -> convergent_sequence (Fin.Float.Dist.lp ~p:1.))
+-- 
+2.25.1
+

--- a/packages/prbnmcn-stats/prbnmcn-stats.0.0.3/opam
+++ b/packages/prbnmcn-stats/prbnmcn-stats.0.0.3/opam
@@ -16,6 +16,7 @@ depends: [
   "prbnmcn-linalg" {= "0.0.1"}
   "odoc" {with-doc}
 ]
+patches: ["convergence-test.patch"]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/prbnmcn-stats/prbnmcn-stats.0.0.3/opam
+++ b/packages/prbnmcn-stats/prbnmcn-stats.0.0.3/opam
@@ -31,6 +31,9 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/igarnier/prbnmcn-stats"
+extra-files: [
+  ["convergence-test.patch" "md5=df24d5ccce26295d0deca4b203da52e4"]
+]
 url {
   src: "https://github.com/igarnier/prbnmcn-stats/archive/0.0.3.tar.gz"
   checksum: [


### PR DESCRIPTION
`prbnmcn-stats.0.0.2` and `0.0.3` contain a 'convergence test' which fails on OCaml 5.
The failure triggers whenever I roll a new release of QCheck, on which `prbnmcn-stats` depends, and thus adds needless noise. See, e.g., these 3 most recent occurrences: https://github.com/ocaml/opam-repository/pull/24313 https://github.com/ocaml/opam-repository/pull/23805 https://github.com/ocaml/opam-repository/pull/23741

The test failure does not trigger on OCaml 4 - with 4.12 being the lower bound in the opam file.
This PR therefore contains a small patch to disable the failing test on OCaml 5+.
A cruder fix would be to disable all tests on OCaml 5+.
