### PR TITLE
[new release] carton, carton-lwt and carton-git (v0.7.0)

### DIFF
--- a/packages/carton-git/carton-git.0.7.0/opam
+++ b/packages/carton-git/carton-git.0.7.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACK file in OCaml"
+description: """\
+Carton is an implementation of the PACK file
+in OCaml. PACK file is used by Git to store Git objects. Carton is more
+abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "carton" {= version}
+  "carton-lwt" {= version}
+  "bigstringaf" {>= "0.9.0"}
+  "lwt"
+  "fpath"
+  "result"
+  "fmt" {>= "0.8.9"}
+  "base-unix"
+  "decompress" {>= "1.4.3"}
+  "astring" {>= "0.8.5"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "cstruct" {>= "6.1.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "rresult" {>= "0.6.0" & with-test}
+  "ke" {>= "0.6" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.7.0/git-carton-v0.7.0.tbz"
+  checksum: [
+    "sha256=bd690125d3f8669442130ceb14ccec7476b2e15ca25e2c7ffb5ab393eef20ef9"
+    "sha512=5ac302ba7f1eef653ff7991bca251bafa635150c80f6d3e47e4da3d32298df78f332f5d86c1f78c81f7ceb93216febf501cb943efc44c3122249e583782d62a9"
+  ]
+}
+x-commit-hash: "7ade6dda540ee839cb29a39419a8d0b133f4bf9e"

--- a/packages/carton-lwt/carton-lwt.0.7.0/opam
+++ b/packages/carton-lwt/carton-lwt.0.7.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACK file in OCaml"
+description: """\
+Carton is an implementation of the PACK file
+in OCaml. PACK file is used by Git to store Git objects. Carton is more
+abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "carton" {= version}
+  "lwt"
+  "decompress" {>= "1.4.3"}
+  "optint" {>= "0.0.4"}
+  "bigstringaf" {>= "0.9.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "cstruct" {>= "6.1.0" & with-test}
+  "fmt" {>= "0.8.9" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "result" {>= "1.5" & with-test}
+  "rresult" {>= "0.6.0" & with-test}
+  "ke" {>= "0.6" & with-test}
+  "base64" {>= "3.4.0" & with-test}
+  "bos" {>= "0.2.0" & with-test}
+  "checkseum" {>= "0.3.3" & with-test}
+  "digestif" {>= "1.1.2" & with-test}
+  "fpath" {>= "0.7.3" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.7.0/git-carton-v0.7.0.tbz"
+  checksum: [
+    "sha256=bd690125d3f8669442130ceb14ccec7476b2e15ca25e2c7ffb5ab393eef20ef9"
+    "sha512=5ac302ba7f1eef653ff7991bca251bafa635150c80f6d3e47e4da3d32298df78f332f5d86c1f78c81f7ceb93216febf501cb943efc44c3122249e583782d62a9"
+  ]
+}
+x-commit-hash: "7ade6dda540ee839cb29a39419a8d0b133f4bf9e"

--- a/packages/carton/carton.0.7.0/opam
+++ b/packages/carton/carton.0.7.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACKv2 file in OCaml"
+description: """\
+Carton is an implementation of the PACKv2 file
+in OCaml. PACKv2 file is used by Git to store Git objects.
+Carton is more abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "ke" {>= "0.6"}
+  "duff" {>= "0.5"}
+  "decompress" {>= "1.4.3"}
+  "cstruct" {>= "6.1.0"}
+  "optint" {>= "0.0.4"}
+  "bigstringaf" {>= "0.9.0"}
+  "checkseum" {>= "0.3.3"}
+  "logs"
+  "cmdliner" {>= "1.1.0"}
+  "hxd" {>= "0.3.2"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "result"
+  "rresult"
+  "fpath"
+  "base64" {with-test & >= "3.0.0"}
+  "bos"
+  "digestif" {>= "1.1.2"}
+  "base-unix" {with-test}
+  "base-threads" {with-test}
+  "alcotest" {with-test}
+  "crowbar" {with-test & >= "0.2.1"}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "lwt" {>= "5.3.0" & with-test}
+  "ocamlfind" {>= "1.8.1" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.7.0/git-carton-v0.7.0.tbz"
+  checksum: [
+    "sha256=bd690125d3f8669442130ceb14ccec7476b2e15ca25e2c7ffb5ab393eef20ef9"
+    "sha512=5ac302ba7f1eef653ff7991bca251bafa635150c80f6d3e47e4da3d32298df78f332f5d86c1f78c81f7ceb93216febf501cb943efc44c3122249e583782d62a9"
+  ]
+}
+x-commit-hash: "7ade6dda540ee839cb29a39419a8d0b133f4bf9e"

--- a/packages/carton/carton.0.7.0/opam
+++ b/packages/carton/carton.0.7.0/opam
@@ -42,7 +42,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-git.git"
 url {


### PR DESCRIPTION
Implementation of PACKv2 file in OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Extend the API with the ability to choose the compression level (@dinosaure, mirage/ocaml-git#616)
- Extend the API about `*.idx` file and be able to map entries (@dinosaure, mirage/ocaml-git#619)
