### PR TITLE
Fix upper bounds on tests using mdx

### DIFF
--- a/packages/cohttp-eio/cohttp-eio.6.0.0~alpha0/opam
+++ b/packages/cohttp-eio/cohttp-eio.6.0.0~alpha0/opam
@@ -41,7 +41,6 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@cohttp-eio/runtest"
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/cohttp-eio/cohttp-eio.6.0.0~alpha0/opam
+++ b/packages/cohttp-eio/cohttp-eio.6.0.0~alpha0/opam
@@ -41,7 +41,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@cohttp-eio/runtest" {with-test}
+    "@cohttp-eio/runtest"
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/containers-data/containers-data.3.11/opam
+++ b/packages/containers-data/containers-data.3.11/opam
@@ -5,7 +5,7 @@ license: "BSD-2-Clause"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32" & ocaml:version < "5.1.0"}
 ]
 depends: [
   "ocaml" { >= "4.03.0" }

--- a/packages/eio_main/eio_main.0.6/opam
+++ b/packages/eio_main/eio_main.0.6/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
   "eio_linux" {= version & os = "linux"}
-  "mdx" {>= "1.10.0" & with-test}
+  "mdx" {>= "1.10.0" & < "2.3.1" & with-test}
   "eio_luv" {= version}
   "odoc" {with-doc}
 ]

--- a/packages/eio_main/eio_main.0.7/opam
+++ b/packages/eio_main/eio_main.0.7/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
   "eio_linux" {= version & os = "linux"}
-  "mdx" {>= "1.10.0" & with-test}
+  "mdx" {>= "1.10.0" & < "2.3.1" & with-test}
   "eio_luv" {= version}
   "odoc" {with-doc}
 ]

--- a/packages/eio_main/eio_main.0.8.1/opam
+++ b/packages/eio_main/eio_main.0.8.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.0"}
   "eio_linux" {= version & os = "linux"}
-  "mdx" {>= "1.10.0" & with-test}
+  "mdx" {>= "1.10.0" & < "2.3.1" & with-test}
   "eio_luv" {= version}
   "odoc" {with-doc}
 ]

--- a/packages/eio_main/eio_main.0.9/opam
+++ b/packages/eio_main/eio_main.0.9/opam
@@ -9,7 +9,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.7"}
-  "mdx" {>= "2.2.0" & with-test}
+  "mdx" {>= "2.2.0" & < "2.3.1" & with-test}
   "eio_linux" {= version & os = "linux"}
   "eio_posix" {= version & os != "win32"}
   "eio_luv" {= version & (os = "win32" | with-test)}

--- a/packages/lwt_eio/lwt_eio.0.2/opam
+++ b/packages/lwt_eio/lwt_eio.0.2/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.9"}
   "eio" {>= "0.2" & < "0.11"}
   "lwt"
-  "mdx" {>= "1.10.0" & with-test}
+  "mdx" {>= "1.10.0" & < "2.3.1" & with-test}
   "eio_main" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/lwt_eio/lwt_eio.0.3/opam
+++ b/packages/lwt_eio/lwt_eio.0.3/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.9"}
   "eio" {>= "0.7" & < "0.11"}
   "lwt"
-  "mdx" {>= "1.10.0" & with-test}
+  "mdx" {>= "1.10.0" & < "2.3.1" & with-test}
   "eio_main" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/par_incr/par_incr.0.1/opam
+++ b/packages/par_incr/par_incr.0.1/opam
@@ -30,7 +30,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version < "5.1"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/uring/uring.0.4/opam
+++ b/packages/uring/uring.0.4/opam
@@ -31,7 +31,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version < "5.1"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/uring/uring.0.5/opam
+++ b/packages/uring/uring.0.5/opam
@@ -31,7 +31,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version < "5.1"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/uring/uring.0.6/opam
+++ b/packages/uring/uring.0.6/opam
@@ -31,7 +31,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version < "5.1.0"}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
Seen on: https://github.com/ocaml/opam-repository/pull/24535

Ping @jonahbeckford: are the errors in [diskuvbox](https://github.com/ocaml/opam-repository/commit/d5a9a4b4ab92825f9b88a5c78a8ae089c59e41c8) and [dkml-install-runner](https://github.com/ocaml/opam-repository/commit/e9ad8109c9e54c8fb55025f91e612033d83ffcb0) actual errors – incompatibility with ocaml 5.1 – or it is all right to just prevent the tests in this case?