### PR TITLE
Package ocsigen-toolkit.3.3.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.3.3.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.3.3.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "js_of_ocaml" {>= "4.1.0"}
+  "eliom" {>= "6.12.1"}
+  "calendar" {>= "2.0.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsigen-toolkit/archive/refs/tags/3.3.0.tar.gz"
+  checksum: [
+    "md5=e6c82fd637bd0ad882e7119ca971d44e"
+    "sha512=55fa7d28bb691295f53b8e2da4e042c1fce2beca1a76c0e663b508e8d7fdb9f863048d5886ea608e29df3e5d5573528cd1d34d36eb443a206e38b8366369529b"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.3.3.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.2.0