### PR TITLE
Disable runtest on lwd.0.1

### DIFF
--- a/packages/lwd/lwd.0.1/opam
+++ b/packages/lwd/lwd.0.1/opam
@@ -23,7 +23,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
Here's another small PR to reduce noise - this one in `lwd.0.1`.

The error triggers when I release a new QCheck release because of the dependency, e.g. in https://github.com/ocaml/opam-repository/pull/24313 https://github.com/ocaml/opam-repository/pull/23805 https://github.com/ocaml/opam-repository/pull/23741 where it fails with `(failed: exception Sys_error("lwd_infix.ml: No such file or directory"))`

This was fixed temporarily in `lwd.0.2` by disabling the inline tests in commit https://github.com/let-def/lwd/commit/5ab38ed70147fb720102cf0b7828785ddb7f038d
and later more sustainably in `lwd.0.3` by commit https://github.com/let-def/lwd/commit/3c446b45b2d9e81bc72b57ada168fe7923f9b02c

To avoid spending too much energy on backporting either of these to `0.1`, the PR simply suggests to disable `runtest` :shrug: 