### PR TITLE
Fix conf-openbabel on openbabel 3

### DIFF
--- a/packages/conf-openbabel/conf-openbabel.0.1/files/test.cpp
+++ b/packages/conf-openbabel/conf-openbabel.0.1/files/test.cpp
@@ -1,8 +1,0 @@
-#include <openbabel/mol.h>
-
-// compile with: c++ -I/usr/include/openbabel-2.0 test.c -lopenbabel
-
-int main () {
-  OpenBabel::OBMol mol;
-  return 0;
-}

--- a/packages/conf-openbabel/conf-openbabel.0.1/opam
+++ b/packages/conf-openbabel/conf-openbabel.0.1/opam
@@ -4,22 +4,8 @@ homepage: "http://openbabel.org/"
 license: "GPL-1.0-or-later"
 authors: "http://openbabel.org/wiki/THANKS"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-build: [
-  [ "c++"
-    "-I/usr/include/openbabel-2.0"
-    "-I/usr/include/openbabel3"
-    "test.cpp"
-    "-lopenbabel"
-  ] {os != "macos"}
-  [
-    "c++"
-    "-I/usr/local/include/openbabel-2.0"
-    "-I/usr/local/include/openbabel3"
-    "test.cpp"
-    "-L/usr/local/lib"
-    "-lopenbabel"
-  ] {os = "macos"}
-]
+build: [["pkg-config" "openbabel-3"]]
+depends: ["conf-pkg-config" {build}]
 x-ci-accept-failures: ["debian-11" "debian-unstable" "alpine-3.18"]
 depexts: [
   ["libopenbabel-dev"] {os-family = "debian" | os-family = "ubuntu"}
@@ -34,5 +20,4 @@ synopsis: "Virtual package relying on openbabel library installation"
 description: """
 This package can only install if the openbabel devel library is installed
 on the system."""
-extra-files: ["test.cpp" "md5=0a2f6ad381a1624089cd12718bfbfdd8"]
 flags: conf

--- a/packages/conf-openbabel/conf-openbabel.0.1/opam
+++ b/packages/conf-openbabel/conf-openbabel.0.1/opam
@@ -22,7 +22,7 @@ build: [
 ]
 x-ci-accept-failures: ["debian-11" "debian-unstable"]
 depexts: [
-  ["libopenbabel-dev"] {os-family = "debian"}
+  ["libopenbabel-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["open-babel"] {os = "macos" & os-distribution = "homebrew"}
   ["openbabel-devel"] {os-distribution = "centos"}
 ]

--- a/packages/conf-openbabel/conf-openbabel.0.1/opam
+++ b/packages/conf-openbabel/conf-openbabel.0.1/opam
@@ -6,7 +6,14 @@ authors: "http://openbabel.org/wiki/THANKS"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [["sh" "-c" "pkg-config openbabel-2.0 || pkg-config openbabel-3"]]
 depends: ["conf-pkg-config" {build}]
-x-ci-accept-failures: ["debian-11" "debian-unstable" "alpine-3.18"]
+x-ci-accept-failures: [
+  "debian-11"
+  "debian-unstable"
+  "alpine-3.18"
+  "oraclelinux-7"
+  "oraclelinux-8"
+  "oraclelinux-9"
+]
 depexts: [
   ["libopenbabel-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["openbabel"] {os-distribution = "arch"}

--- a/packages/conf-openbabel/conf-openbabel.0.1/opam
+++ b/packages/conf-openbabel/conf-openbabel.0.1/opam
@@ -20,7 +20,7 @@ build: [
     "-lopenbabel"
   ] {os = "macos"}
 ]
-x-ci-accept-failures: ["debian-11" "debian-unstable"]
+x-ci-accept-failures: ["debian-11" "debian-unstable" "alpine-3.18"]
 depexts: [
   ["libopenbabel-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["open-babel"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-openbabel/conf-openbabel.0.1/opam
+++ b/packages/conf-openbabel/conf-openbabel.0.1/opam
@@ -24,6 +24,7 @@ x-ci-accept-failures: ["debian-11" "debian-unstable" "alpine-3.18"]
 depexts: [
   ["libopenbabel-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["openbabel"] {os-distribution = "arch"}
+  ["openbabel-devel"] {os-distribution = "fedora"}
   ["open-babel"] {os = "macos" & os-distribution = "homebrew"}
   ["openbabel-devel"] {os-distribution = "centos"}
 ]

--- a/packages/conf-openbabel/conf-openbabel.0.1/opam
+++ b/packages/conf-openbabel/conf-openbabel.0.1/opam
@@ -4,7 +4,7 @@ homepage: "http://openbabel.org/"
 license: "GPL-1.0-or-later"
 authors: "http://openbabel.org/wiki/THANKS"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-build: [["pkg-config" "openbabel-3"]]
+build: [["sh" "-c" "pkg-config openbabel-2.0 || pkg-config openbabel-3"]]
 depends: ["conf-pkg-config" {build}]
 x-ci-accept-failures: ["debian-11" "debian-unstable" "alpine-3.18"]
 depexts: [

--- a/packages/conf-openbabel/conf-openbabel.0.1/opam
+++ b/packages/conf-openbabel/conf-openbabel.0.1/opam
@@ -5,11 +5,16 @@ license: "GPL-1.0-or-later"
 authors: "http://openbabel.org/wiki/THANKS"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
-  ["c++" "-I/usr/include/openbabel-2.0" "test.cpp" "-lopenbabel"]
-    {os != "macos"}
+  [ "c++"
+    "-I/usr/include/openbabel-2.0"
+    "-I/usr/include/openbabel3"
+    "test.cpp"
+    "-lopenbabel"
+  ] {os != "macos"}
   [
     "c++"
     "-I/usr/local/include/openbabel-2.0"
+    "-I/usr/local/include/openbabel3"
     "test.cpp"
     "-L/usr/local/lib"
     "-lopenbabel"

--- a/packages/conf-openbabel/conf-openbabel.0.1/opam
+++ b/packages/conf-openbabel/conf-openbabel.0.1/opam
@@ -28,6 +28,7 @@ depexts: [
   ["openbabel-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["open-babel"] {os = "macos" & os-distribution = "homebrew"}
   ["openbabel-devel"] {os-distribution = "centos"}
+  ["openbabel"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on openbabel library installation"
 description: """

--- a/packages/conf-openbabel/conf-openbabel.0.1/opam
+++ b/packages/conf-openbabel/conf-openbabel.0.1/opam
@@ -25,6 +25,7 @@ depexts: [
   ["libopenbabel-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["openbabel"] {os-distribution = "arch"}
   ["openbabel-devel"] {os-distribution = "fedora"}
+  ["openbabel-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["open-babel"] {os = "macos" & os-distribution = "homebrew"}
   ["openbabel-devel"] {os-distribution = "centos"}
 ]

--- a/packages/conf-openbabel/conf-openbabel.0.1/opam
+++ b/packages/conf-openbabel/conf-openbabel.0.1/opam
@@ -23,6 +23,7 @@ build: [
 x-ci-accept-failures: ["debian-11" "debian-unstable" "alpine-3.18"]
 depexts: [
   ["libopenbabel-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["openbabel"] {os-distribution = "arch"}
   ["open-babel"] {os = "macos" & os-distribution = "homebrew"}
   ["openbabel-devel"] {os-distribution = "centos"}
 ]


### PR DESCRIPTION
Here's a third PR to reduce noise - this one in `conf-openbabel`.
The error triggers when I release a new QCheck release, e.g. in #24313 because of the dependency of `lbvs_consent`  on `conf-openbabel` which therefore fails with, e.g., `lbvs_consent.2.1.2 (failed: conf-openbabel.0.1 failed to build)`

The issue here is that the `openbabel` version obtained by `apt-get install libopenbabel-dev` [is installed in `/usr/include/openbabel3`](https://packages.debian.org/sid/amd64/libopenbabel-dev/filelist)
I've also checked locally on my homebrew mac, that `brew install open-babel` installs into `/usr/local/include/openbabel3`

For backwards compatibility, I've left the `openbabel-2.0` entries as is.

Finally, `opam var os-family` yields `ubuntu` on Linux Mint, so I included a fix akin to https://github.com/ocaml/opam-repository/pull/24375