### PR TITLE
Support conf-unwind on FreeBSD, Arch, OpenSuse, and Oracle Linux

### DIFF
--- a/packages/conf-unwind/conf-unwind.0/opam
+++ b/packages/conf-unwind/conf-unwind.0/opam
@@ -18,6 +18,11 @@ depexts: [
   ["libunwind-headers"] {os-distribution = "homebrew" & os = "macos"}
   ["libunwind"] {os = "freebsd"}
 ]
+x-ci-accept-failures: [
+￼ "oraclelinux-7"
+￼ "oraclelinux-8"
+￼ "oraclelinux-9"
+]
 synopsis: "Virtual package relying on libunwind"
 description:"
 This package can only install if libunwind is installed on the system.

--- a/packages/conf-unwind/conf-unwind.0/opam
+++ b/packages/conf-unwind/conf-unwind.0/opam
@@ -12,6 +12,7 @@ depexts: [
   ["libunwind-devel"] {os-distribution = "rhel"}
   ["libunwind-devel"] {os-distribution = "fedora"}
   ["libunwind-dev"] {os-distribution = "alpine"}
+  ["libunwind"] {os-distribution = "arch"}
   ["libunwind-headers"] {os-distribution = "homebrew" & os = "macos"}
   ["libunwind"] {os = "freebsd"}
 ]

--- a/packages/conf-unwind/conf-unwind.0/opam
+++ b/packages/conf-unwind/conf-unwind.0/opam
@@ -14,7 +14,7 @@ depexts: [
   ["libunwind-dev"] {os-distribution = "alpine"}
   ["libunwind"] {os-distribution = "arch"}
   ["libunwind"] {os-family = "suse" | os-family = "opensuse"}
-  ["libunwind"] {os-distribution = "ol"}
+  ["libunwind-devel"] {os-distribution = "ol"}
   ["libunwind-headers"] {os-distribution = "homebrew" & os = "macos"}
   ["libunwind"] {os = "freebsd"}
 ]

--- a/packages/conf-unwind/conf-unwind.0/opam
+++ b/packages/conf-unwind/conf-unwind.0/opam
@@ -14,6 +14,7 @@ depexts: [
   ["libunwind-dev"] {os-distribution = "alpine"}
   ["libunwind"] {os-distribution = "arch"}
   ["libunwind"] {os-family = "suse" | os-family = "opensuse"}
+  ["libunwind"] {os-distribution = "ol"}
   ["libunwind-headers"] {os-distribution = "homebrew" & os = "macos"}
   ["libunwind"] {os = "freebsd"}
 ]

--- a/packages/conf-unwind/conf-unwind.0/opam
+++ b/packages/conf-unwind/conf-unwind.0/opam
@@ -4,7 +4,7 @@ homepage: "https://www.nongnu.org/libunwind/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["David Mosberger, Dave Watson, et al"]
 license: "MIT"
-build: [["pkg-config" "--short-errors" "--print-errors" "libunwind"]]
+build: [["pkg-config" "--short-errors" "--print-errors" "libunwind"] {os != "macos"}]
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libunwind-dev"] {os-family = "debian" | os-family = "ubuntu"}

--- a/packages/conf-unwind/conf-unwind.0/opam
+++ b/packages/conf-unwind/conf-unwind.0/opam
@@ -13,6 +13,7 @@ depexts: [
   ["libunwind-devel"] {os-distribution = "fedora"}
   ["libunwind-dev"] {os-distribution = "alpine"}
   ["libunwind-headers"] {os-distribution = "homebrew" & os = "macos"}
+  ["libunwind"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on libunwind"
 description:"

--- a/packages/conf-unwind/conf-unwind.0/opam
+++ b/packages/conf-unwind/conf-unwind.0/opam
@@ -13,6 +13,7 @@ depexts: [
   ["libunwind-devel"] {os-distribution = "fedora"}
   ["libunwind-dev"] {os-distribution = "alpine"}
   ["libunwind"] {os-distribution = "arch"}
+  ["libunwind"] {os-family = "suse" | os-family = "opensuse"}
   ["libunwind-headers"] {os-distribution = "homebrew" & os = "macos"}
   ["libunwind"] {os = "freebsd"}
 ]

--- a/packages/conf-unwind/conf-unwind.0/opam
+++ b/packages/conf-unwind/conf-unwind.0/opam
@@ -13,7 +13,7 @@ depexts: [
   ["libunwind-devel"] {os-distribution = "fedora"}
   ["libunwind-dev"] {os-distribution = "alpine"}
   ["libunwind"] {os-distribution = "arch"}
-  ["libunwind"] {os-family = "suse" | os-family = "opensuse"}
+  ["libunwind-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libunwind-devel"] {os-distribution = "ol"}
   ["libunwind-headers"] {os-distribution = "homebrew" & os = "macos"}
   ["libunwind"] {os = "freebsd"}


### PR DESCRIPTION
This little PR adds `conf-unwind` support for FreeBSD where [the underlying system package should be installable as `libunwind`](https://www.freshports.org/devel/libunwind/)

I expect errors from the still unsupported Linux distros (arch, opensuse, oraclelinux) and macOS.