### PR TITLE
satyrographos.0.0.2.13: Update the lower version constraint on core

### DIFF
--- a/packages/satyrographos/satyrographos.0.0.2.13/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.13/opam
@@ -43,7 +43,7 @@ depends: [
   "yojson"
 
   # Janestreet Libs
-  "core" {>= "v0.15" & < "v0.17"}
+  "core" {>= "v0.14" & < "v0.17"}
   "core_unix"
   "ppx_jane"
   "shexp"


### PR DESCRIPTION
`satyrographos.0.0.2.13` actually compiles with `core.v0.14`.  As `satysfi.0.0.8`, which is in a custom repo, requires `base.v0.14`, the lower version constraint on core should be updated.