### PR TITLE
Add an upper bound for facile.1.1

### DIFF
--- a/packages/facile/facile.1.1/opam
+++ b/packages/facile/facile.1.1/opam
@@ -10,7 +10,7 @@ patches: [
 ]
 install: [make "install"]
 synopsis: "Constraint programming library over integer finite domains"
-depends: ["ocaml"]
+depends: ["ocaml" {< "5.0.0"}]
 extra-files: [
   ["ocaml_4.00.patch" "md5=cbc214d5dd007d1062821b4d96e85ad0"]
   ["facile.install" "md5=a03d20fcd54d7277982caf03b05354fa"]


### PR DESCRIPTION
Facile.1.1 uses `Pervasives` and hence doesn't work on OCaml 5+