### PR TITLE
Add an upper bound for operf-micro

### DIFF
--- a/packages/operf-micro/operf-micro.1.1.1/opam
+++ b/packages/operf-micro/operf-micro.1.1.1/opam
@@ -15,7 +15,7 @@ operf-micro is a small tool coming with a set of micro benchmarks for the OCaml
 compiler. It provides a minimal framework to compare the performances of 
 different versions of the compiler."""
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
 ]
 url {
   src:


### PR DESCRIPTION
`operf-micro.1.1.1` uses `Pervasives` and hence doesn't work on OCaml 5+