### PR TITLE
[new release] odoc (2 packages) (2.3.0)

### DIFF
--- a/packages/mdx/mdx.1.11.1/opam
+++ b/packages/mdx/mdx.1.11.1/opam
@@ -32,7 +32,7 @@ depends: [
   "re" {>= "1.7.2"}
   "result"
   "ocaml-version" {>= "2.3.0"}
-  "odoc-parser" {>= "0.9.0"}
+  "odoc-parser" {>= "0.9.0" & < "2.3.0"}
   "lwt" {with-test}
   "alcotest" {with-test}
   "cmdliner" {with-test & < "1.1.0"}

--- a/packages/mdx/mdx.2.0.0/opam
+++ b/packages/mdx/mdx.2.0.0/opam
@@ -29,7 +29,7 @@ depends: [
   "re" {>= "1.7.2"}
   "result"
   "ocaml-version" {>= "2.3.0"}
-  "odoc-parser" {>= "0.9.0"}
+  "odoc-parser" {>= "0.9.0" & < "2.3.0"}
   "lwt" {with-test}
   "alcotest" {with-test}
   "cmdliner" {with-test & < "1.1.0"}

--- a/packages/mdx/mdx.2.1.0/opam
+++ b/packages/mdx/mdx.2.1.0/opam
@@ -29,7 +29,7 @@ depends: [
   "re" {>= "1.7.2"}
   "result"
   "ocaml-version" {>= "2.3.0"}
-  "odoc-parser" {>= "1.0.0"}
+  "odoc-parser" {>= "1.0.0" & < "2.3.0"}
   "lwt" {with-test}
   "alcotest" {with-test}
   "cmdliner" {with-test & < "1.1.0"}

--- a/packages/mdx/mdx.2.2.0/opam
+++ b/packages/mdx/mdx.2.2.0/opam
@@ -28,7 +28,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "re" {>= "1.7.2"}
   "ocaml-version" {>= "2.3.0"}
-  "odoc-parser" {>= "1.0.0"}
+  "odoc-parser" {>= "1.0.0" & < "2.3.0"}
   "lwt" {with-test}
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/packages/mdx/mdx.2.2.1/opam
+++ b/packages/mdx/mdx.2.2.1/opam
@@ -28,7 +28,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "re" {>= "1.7.2"}
   "ocaml-version" {>= "2.3.0"}
-  "odoc-parser" {>= "1.0.0"}
+  "odoc-parser" {>= "1.0.0" & < "2.3.0"}
   "lwt" {with-test}
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/packages/mdx/mdx.2.3.0/opam
+++ b/packages/mdx/mdx.2.3.0/opam
@@ -28,7 +28,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "re" {>= "1.7.2"}
   "ocaml-version" {>= "2.3.0"}
-  "odoc-parser" {>= "1.0.0"}
+  "odoc-parser" {>= "1.0.0" & < "2.3.0"}
   "lwt" {with-test}
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.16.1/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.16.1/opam
@@ -31,7 +31,7 @@ depends: [
   "ordering"
   "dune-build-info"
   "spawn"
-  "odoc-parser" {>= "2.0.0"}
+  "odoc-parser" {>= "2.0.0" & < "2.3.0"}
   "ppx_expect" {>= "v0.15.0" & with-test}
   "ocamlformat" {with-test & = "0.24.1"}
   "ocamlc-loc" {>= "3.7.0"}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.16.2/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.16.2/opam
@@ -31,7 +31,7 @@ depends: [
   "ordering"
   "dune-build-info"
   "spawn"
-  "odoc-parser" {>= "2.0.0"}
+  "odoc-parser" {>= "2.0.0" & < "2.3.0"}
   "ppx_expect" {>= "v0.15.0" & with-test}
   "ocamlformat" {with-test & = "0.24.1"}
   "ocamlc-loc" {>= "3.7.0"}

--- a/packages/ocamlformat/ocamlformat.0.24.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.24.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml-version" {>= "3.3.0" & < "3.6.0"}
   "ocamlformat-rpc-lib" {with-test & = version}
   "ocp-indent"
-  "odoc-parser" {>= "2.0.0" & < "3.0.0"}
+  "odoc-parser" {>= "2.0.0" & < "2.3.0"}
   "re" {>= "1.7.2"}
   "stdio"
   "uuseg" {>= "10.0.0"}

--- a/packages/odoc-parser/odoc-parser.2.3.0/opam
+++ b/packages/odoc-parser/odoc-parser.2.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Parser for ocaml documentation comments"
+description: """
+Odoc_parser is a library for parsing the contents of OCaml documentation
+comments, formatted using 'odoc' syntax, an extension of the language
+understood by ocamldoc."""
+maintainer: ["Jon Ludlam <jon@recoil.org>"]
+authors: ["Anton Bachin <antonbachin@yahoo.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-doc/odoc-parser"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+doc: "https://ocaml-doc.github.io/odoc-parser/"
+depends: [
+  "dune" {>= "3.7.0"}
+  "ocaml" {>= "4.02.0"}
+  "astring"
+  "result"
+  "camlp-streams"
+  "ppx_expect" {with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/odoc/releases/download/v2.3.0/odoc-2.3.0.tbz"
+  checksum: [
+    "sha256=c46d2d9feffc389116b2dc80e7c9b8aefca8ce72b181b8cff816f4f53a748d6c"
+    "sha512=66bf5d68e9720756de0bc2b2e44fda684b732bcaa2225e77003f87c3eb0ebb13ef18f2271138441a26efd2f34e1fad13219428024c63f620cc40d25a2016f2a3"
+  ]
+}
+x-commit-hash: "5b0b056f7758f85cd49c756874aae874d375a0b7"
+

--- a/packages/odoc/odoc.2.2.0/opam
+++ b/packages/odoc/odoc.2.2.0/opam
@@ -23,7 +23,7 @@ delimited with `(** ... *)`, and outputs HTML.
 """
 
 depends: [
-  "odoc-parser" {>= "2.0.0"}
+  "odoc-parser" {>= "2.0.0" & < "2.3.0"}
   "astring"
   "cmdliner" {>= "1.0.0"}
   "cppo" {build & >= "1.1.0"}

--- a/packages/odoc/odoc.2.2.1/opam
+++ b/packages/odoc/odoc.2.2.1/opam
@@ -23,7 +23,7 @@ delimited with `(** ... *)`, and outputs HTML.
 """
 
 depends: [
-  "odoc-parser" {>= "2.0.0"}
+  "odoc-parser" {>= "2.0.0" & < "2.3.0"}
   "astring"
   "cmdliner" {>= "1.0.0"}
   "cppo" {build & >= "1.1.0"}

--- a/packages/odoc/odoc.2.3.0/opam
+++ b/packages/odoc/odoc.2.3.0/opam
@@ -1,0 +1,85 @@
+opam-version: "2.0"
+homepage: "http://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+maintainer: [
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+]
+authors: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Leo White <leo@lpw25.net>"
+  "Lubega Simon <lubegasimon73@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+  "Thomas Refis <trefis@janestreet.com>"
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml Documentation Generator"
+description: """
+**odoc** is a powerful and flexible documentation generator for OCaml. It reads *doc comments*, demarcated by `(** ... *)`, and transforms them into a variety of output formats, including HTML, LaTeX, and man pages.
+
+- **Output Formats:** Odoc generates HTML for web browsing, LaTeX for PDF generation, and man pages for use on Unix-like systems.
+- **Cross-References:** odoc uses the `ocamldoc` markup, which allows to create links for functions, types, modules, and documentation pages.
+- **Link to Source Code:** Documentation generated includes links to the source code of functions, providing an easy way to navigate from the docs to the actual implementation.
+- **Code Highlighting:** odoc automatically highlights syntax in code snippets for different languages.
+
+odoc is part of the [OCaml Platform](https://ocaml.org/docs/platform), the recommended set of tools for OCaml.
+"""
+
+
+depends: [
+  "odoc-parser" {= version}
+  "astring"
+  "cmdliner" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "3.7.0"}
+  "fpath"
+  "ocaml" {>= "4.02.0"}
+  "result"
+  "tyxml" {>= "4.3.0"}
+  "fmt"
+
+  "ocamlfind" {with-test}
+  "yojson" {>= "1.6.0" & with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+  "conf-jq" {with-test}
+
+  "ppx_expect" {with-test}
+  "bos" {with-test}
+  "crunch" {with-test}
+
+  ("ocaml" {< "4.07.0" & with-test} | "bisect_ppx" {with-test & > "2.5.0"})
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/odoc/releases/download/v2.3.0/odoc-2.3.0.tbz"
+  checksum: [
+    "sha256=c46d2d9feffc389116b2dc80e7c9b8aefca8ce72b181b8cff816f4f53a748d6c"
+    "sha512=66bf5d68e9720756de0bc2b2e44fda684b732bcaa2225e77003f87c3eb0ebb13ef18f2271138441a26efd2f34e1fad13219428024c63f620cc40d25a2016f2a3"
+  ]
+}
+x-commit-hash: "5b0b056f7758f85cd49c756874aae874d375a0b7"

--- a/packages/odoc/odoc.2.3.0/opam
+++ b/packages/odoc/odoc.2.3.0/opam
@@ -45,7 +45,7 @@ depends: [
   "fpath"
   "ocaml" {>= "4.02.0"}
   "result"
-  "tyxml" {>= "4.3.0"}
+  "tyxml" {>= "4.4.0"}
   "fmt"
 
   "ocamlfind" {with-test}


### PR DESCRIPTION
OCaml Documentation Generator

- Project page: <a href="http://github.com/ocaml/odoc">http://github.com/ocaml/odoc</a>
- Documentation: <a href="https://ocaml.github.io/odoc/">https://ocaml.github.io/odoc/</a>

##### CHANGES:


