### PR TITLE
retry release of pa_ppx_parsetree (after prereqs have been released)

### DIFF
--- a/packages/pa_ppx_parsetree/pa_ppx_parsetree.0.02/opam
+++ b/packages/pa_ppx_parsetree/pa_ppx_parsetree.0.02/opam
@@ -1,0 +1,51 @@
+synopsis: "A Camlp5-based Quasi-Quotation ppx rewriter for OCaml's AST "
+description:
+"""
+This package provides quasi-quotations (like ppx_metaquot)
+for the OCaml AST, so you can write code that computes over
+OCaml's AST, using human-readable surface syntax for
+patterns and expressions.
+
+It provides them based on the official OCaml parser, but
+with anti-quotations at every point in the grammar where
+it's possible to have them.
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_parsetree"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_parsetree/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_parsetree.git"
+doc: "https://github.com/camlp5/pa_ppx_parsetree/doc"
+
+depends: [
+  "conf-perl"
+  "conf-diffutils" (* { >= "1.2" & with-test } *)
+  "ocaml"       { >= "4.10.0" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.00.04" }
+  "pa_ppx"      { >= "0.10" }
+  "pa_ppx_q_ast"      { >= "0.10" }
+  "pa_ppx_quotation2extension"
+  "not-ocamlfind" { >= "0.09" }
+  "ounit" { >= "2.2.7" & with-test}
+  "re" { >= "1.11.0" }
+  "fmt"
+  "conf-bash"
+  "cppo"
+  "mdx"{ >= "2.3.0" & with-test}
+]
+build: [
+  [make "tools"]
+  [make "setup"]
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_parsetree/archive/refs/tags/0.02.tar.gz"
+  checksum: [
+    "sha512=8ba0dcc0191c0e0c6fa8b492cd307d9aca29c6b63a43186ab4d24e46e320f8b8cde144ff0a86703556e691e7e28e10ea480d30aa170bb13aa7472691e753cf93"
+  ]
+}


### PR DESCRIPTION
second try, after switching from perl to ocaml for build-script