### PR TITLE
add conf-bunjs.1

### DIFF
--- a/packages/conf-bunjs/conf-bunjs.1/opam
+++ b/packages/conf-bunjs/conf-bunjs.1/opam
@@ -9,6 +9,9 @@ build: [
   ["bun" "--version"]
   ["bunx" "bun" "--version"]
 ]
+depexts: [
+  [ "bun" ] {npm-version = "^1.0.0"}
+]
 post-messages: [
   """
 Command `bun` and/or `bunx` is not available on the system.

--- a/packages/conf-bunjs/conf-bunjs.1/opam
+++ b/packages/conf-bunjs/conf-bunjs.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "haochenx@acm.org"
+authors: ["Jarred Sumner" "Bun Developers and Contributors"]
+homepage: "https://github.com/oven-sh/bun"
+bug-reports: "https://github.com/oven-sh/bun/issues"
+dev-repo: "git+https://github.com/oven-sh/bun.git"
+license: "MIT"
+build: [
+  ["bun" "--version"]
+  ["bunx" "bun" "--version"]
+]
+post-messages: [
+  """
+Command `bun` and/or `bunx` is not available on the system.
+You can install them by running e.g. `npm install -g bun`
+or consult https://bun.sh/docs/installation for the official
+installation instructions for Bun (https://bun.sh).
+""" { failure }
+]
+synopsis: "Virtual package relying on Bun (https://bun.sh)"
+description: """
+Bun (https://bun.sh) is an all-in-one toolkit for JavaScript and TypeScript apps.
+It ships as a single executable called bun.
+
+At its core is the Bun runtime, a fast JavaScript runtime designed as a drop-in replacement for Node.js.
+It's written in Zig and powered by JavaScriptCore under the hood,
+dramatically reducing startup times and memory usage.
+
+Homepage: <https://github.com/oven-sh/bun>
+Release Notes: <https://api.github.com/repos/oven-sh/bun/releases/121316652>
+"""
+flags: conf


### PR DESCRIPTION
This PR adds the packages `conf-bunjs` that checks whether Bun (https://bun.sh) is installed on the system.

This is a rebake of https://github.com/ocaml/opam-repository/pull/24492 to instead of adding binary packages to opam-repository, add a conf package that only checks whether `bun` and `bunx` is already installed and available on the system.

Since currently there is no good way to install `bun` on the CI machines (as depexts cannot handle npm packages, nor does Bun has good system package manager support), this package will likely fail all the CI tests.