### PR TITLE
[new release] logs-async (2 packages) (1.3)

### DIFF
--- a/packages/logs-async-reporter/logs-async-reporter.1.3/opam
+++ b/packages/logs-async-reporter/logs-async-reporter.1.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Logs reporter compatible with Async"
+description: "Logs reporter that will play nice with Async's runtime."
+maintainer: ["Vincent Bernardoff <vb@luminar.eu.org>"]
+authors: ["Vincent Bernardoff <vb@luminar.eu.org>"]
+license: "ISC"
+tags: ["async" "logs"]
+homepage: "https://github.com/vbmithr/logs-async"
+doc: "https://vbmithr.github.io/logs-async"
+bug-reports: "https://github.com/vbmithr/logs-async/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.10"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.9.0"}
+  "core" {>= "v0.16"}
+  "async" {>= "v0.16"}
+  "zstandard" {>= "v0.16"}
+  "yojson" {>= "2.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/vbmithr/logs-async.git"
+url {
+  src:
+    "https://github.com/vbmithr/logs-async/releases/download/1.3/logs-async-1.3.tbz"
+  checksum: [
+    "sha256=12aff8081de966ee5f6db129d73e60463846fe91e60345c9b05254be7681fe36"
+    "sha512=8dc77450b1cac25d163165b82013488ef253d572f36cdcde126a113a4609a6489d6a6ddbbbb1c5d1754f76532b291d82fde31619d202e62ae72dc6aed15bcbe4"
+  ]
+}
+x-commit-hash: "ebe64b2265c1889d5a7a3db1491892cdda5b7557"

--- a/packages/logs-async/logs-async.1.3/opam
+++ b/packages/logs-async/logs-async.1.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Jane Street Async logging with Logs"
+description: """
+This is analogous to the Logs_lwt module in the logs package.
+The log functions of this module return Async threads that proceed only
+when the log operation is over, as defined by the current
+Logs.reporter."""
+maintainer: ["Vincent Bernardoff <vb@luminar.eu.org>"]
+authors: ["Vincent Bernardoff <vb@luminar.eu.org>"]
+license: "ISC"
+tags: ["async" "logs"]
+homepage: "https://github.com/vbmithr/logs-async"
+doc: "https://vbmithr.github.io/logs-async"
+bug-reports: "https://github.com/vbmithr/logs-async/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.10"}
+  "logs" {>= "0.7.0"}
+  "async_kernel" {>= "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/vbmithr/logs-async.git"
+url {
+  src:
+    "https://github.com/vbmithr/logs-async/releases/download/1.3/logs-async-1.3.tbz"
+  checksum: [
+    "sha256=12aff8081de966ee5f6db129d73e60463846fe91e60345c9b05254be7681fe36"
+    "sha512=8dc77450b1cac25d163165b82013488ef253d572f36cdcde126a113a4609a6489d6a6ddbbbb1c5d1754f76532b291d82fde31619d202e62ae72dc6aed15bcbe4"
+  ]
+}
+x-commit-hash: "ebe64b2265c1889d5a7a3db1491892cdda5b7557"


### PR DESCRIPTION
Jane Street Async logging with Logs

- Project page: <a href="https://github.com/vbmithr/logs-async">https://github.com/vbmithr/logs-async</a>
- Documentation: <a href="https://vbmithr.github.io/logs-async">https://vbmithr.github.io/logs-async</a>

##### CHANGES:

- Use latest dune-project format and opam file autogeneration
- ocamlformat Janestreet style formatting
- Remove OVH logger
