### PR TITLE
Package algaeff.1.1.0

### DIFF
--- a/packages/algaeff/algaeff.1.1.0/opam
+++ b/packages/algaeff/algaeff.1.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Reusable Effects-Based Components"
+description: """
+This OCaml library collects reusable effects-based components we have identified while developing our proof assistants based on algebraic effects.
+"""
+maintainer: "favonia <favonia@gmail.com>"
+authors: "The RedPRL Development Team"
+license: "Apache-2.0"
+homepage: "https://github.com/RedPRL/algaeff"
+bug-reports: "https://github.com/RedPRL/algaeff/issues"
+dev-repo: "git+https://github.com/RedPRL/algaeff.git"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "5.0"}
+  "alcotest" {>= "1.5" & with-test}
+  "qcheck-core" {>= "0.18" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
+url {
+  src: "https://github.com/RedPRL/algaeff/archive/refs/tags/1.1.0.tar.gz"
+  checksum: [
+    "md5=b8bafd5ed5f2ab222a327b038929d6b6"
+    "sha512=c58a9497d9f97a138ea3de99b33ea4ef8c8a5ab5ad4d501482fad2ea35894032b2fab65397881bd21a20cd2c0d5a4305782d81673ba3a7e4b7a3fe7273a22d1a"
+  ]
+}


### PR DESCRIPTION
### `algaeff.1.1.0`
Reusable Effects-Based Components
This OCaml library collects reusable effects-based components we have identified while developing our proof assistants based on algebraic effects.



---
* Homepage: https://github.com/RedPRL/algaeff
* Source repo: git+https://github.com/RedPRL/algaeff.git
* Bug tracker: https://github.com/RedPRL/algaeff/issues

---
:camel: Pull-request generated by opam-publish v2.2.0