### PR TITLE
Move legacy Coq archives

### DIFF
--- a/packages/coq/coq.8.3/opam
+++ b/packages/coq/coq.8.3/opam
@@ -28,6 +28,6 @@ extra-files: [
   ["configure.patch" "md5=57538c85ccec8ae97e06ae3b6697cf0e"]
 ]
 url {
-  src: "http://coq.inria.fr/distrib/V8.3pl5/files/coq-8.3pl5.tar.gz"
+  src: "https://coq-distrib.s3.fr-par.scw.cloud/V8.3pl5/files/coq-8.3pl5.tar.gz"
   checksum: "md5=b16741e211e98a3a3870a105aa0cb9fe"
 }

--- a/packages/coq/coq.8.4.5/opam
+++ b/packages/coq/coq.8.4.5/opam
@@ -40,6 +40,6 @@ extra-files: [
   ["build_with_trunk.patch" "md5=c30af7766aced02aa12f9cb841add6cd"]
 ]
 url {
-  src: "http://coq.inria.fr/distrib/8.4pl5/files/coq-8.4pl5.tar.gz"
+  src: "https://coq-distrib.s3.fr-par.scw.cloud/8.4pl5/files/coq-8.4pl5.tar.gz"
   checksum: "md5=7839005b48527a85149da950bd2ac006"
 }

--- a/packages/coq/coq.8.4.6/opam
+++ b/packages/coq/coq.8.4.6/opam
@@ -38,6 +38,6 @@ synopsis: "Formal proof management system."
 flags: light-uninstall
 extra-files: ["coq.install" "md5=0bee75113a7888368e9e06ad9ac40aad"]
 url {
-  src: "https://coq.inria.fr/distrib/V8.4pl6/files/coq-8.4pl6.tar.gz"
+  src: "https://coq-distrib.s3.fr-par.scw.cloud/V8.4pl6/files/coq-8.4pl6.tar.gz"
   checksum: "md5=2334a98b64578cb81d2b4127e327b368"
 }

--- a/packages/coq/coq.8.4.6~camlp4/opam
+++ b/packages/coq/coq.8.4.6~camlp4/opam
@@ -40,6 +40,6 @@ description: "Version built using camlp4"
 flags: light-uninstall
 extra-files: ["coq.install" "md5=0bee75113a7888368e9e06ad9ac40aad"]
 url {
-  src: "https://coq.inria.fr/distrib/V8.4pl6/files/coq-8.4pl6.tar.gz"
+  src: "https://coq-distrib.s3.fr-par.scw.cloud/V8.4pl6/files/coq-8.4pl6.tar.gz"
   checksum: "md5=2334a98b64578cb81d2b4127e327b368"
 }

--- a/packages/coq/coq.8.4pl1/opam
+++ b/packages/coq/coq.8.4pl1/opam
@@ -39,6 +39,6 @@ extra-files: [
   ["CAML_LD_LIBRARY_PATH.patch" "md5=7ae1df6a74ae04bf1471e66c35145a1c"]
 ]
 url {
-  src: "http://coq.inria.fr/distrib/V8.4pl1/files/coq-8.4pl1.tar.gz"
+  src: "https://coq-distrib.s3.fr-par.scw.cloud/V8.4pl1/files/coq-8.4pl1.tar.gz"
   checksum: "md5=07e44e89fc99d6c414605dc96be37f12"
 }

--- a/packages/coq/coq.8.4pl2/opam
+++ b/packages/coq/coq.8.4pl2/opam
@@ -36,6 +36,6 @@ extra-files: [
   ["CAML_LD_LIBRARY_PATH.patch" "md5=e4ee7ff6d89c5bc32e8392faad13584e"]
 ]
 url {
-  src: "http://coq.inria.fr/distrib/V8.4pl2/files/coq-8.4pl2.tar.gz"
+  src: "https://coq-distrib.s3.fr-par.scw.cloud/V8.4pl2/files/coq-8.4pl2.tar.gz"
   checksum: "md5=7fd98da8db35a89b9718333a31af6153"
 }

--- a/packages/coq/coq.8.4pl4/opam
+++ b/packages/coq/coq.8.4pl4/opam
@@ -31,6 +31,6 @@ install: [make "install"]
 synopsis: "Formal proof management system"
 extra-files: ["coq.install" "md5=90aa43dcd6bdeb615b19364fe1c72dfb"]
 url {
-  src: "http://coq.inria.fr/distrib/V8.4pl4/files/coq-8.4pl4.tar.gz"
+  src: "https://coq-distrib.s3.fr-par.scw.cloud/V8.4pl4/files/coq-8.4pl4.tar.gz"
   checksum: "md5=6a9f61cf0ece644b170f722fbc8cf2a1"
 }

--- a/packages/coqide/coqide.8.4.5/opam
+++ b/packages/coqide/coqide.8.4.5/opam
@@ -38,6 +38,6 @@ extra-files: [
   "md5=478ed6e68fa46d00d0a6acfb53d39e52"
 ]
 url {
-  src: "http://coq.inria.fr/distrib/8.4pl5/files/coq-8.4pl5.tar.gz"
+  src: "https://coq-distrib.s3.fr-par.scw.cloud/8.4pl5/files/coq-8.4pl5.tar.gz"
   checksum: "md5=7839005b48527a85149da950bd2ac006"
 }

--- a/packages/coqide/coqide.8.4.6/opam
+++ b/packages/coqide/coqide.8.4.6/opam
@@ -38,6 +38,6 @@ extra-files: [
   "md5=cf7fa3750fa80405b1f117c3c3304c63"
 ]
 url {
-  src: "https://coq.inria.fr/distrib/V8.4pl6/files/coq-8.4pl6.tar.gz"
+  src: "https://coq-distrib.s3.fr-par.scw.cloud/V8.4pl6/files/coq-8.4pl6.tar.gz"
   checksum: "md5=2334a98b64578cb81d2b4127e327b368"
 }

--- a/packages/coqide/coqide.8.4pl2/opam
+++ b/packages/coqide/coqide.8.4pl2/opam
@@ -40,6 +40,6 @@ extra-files: [
   ["CAML_LD_LIBRARY_PATH.patch" "md5=cb40fd11d27c93a077f668a15e467e7a"]
 ]
 url {
-  src: "http://coq.inria.fr/distrib/V8.4pl2/files/coq-8.4pl2.tar.gz"
+  src: "https://coq-distrib.s3.fr-par.scw.cloud/V8.4pl2/files/coq-8.4pl2.tar.gz"
   checksum: "md5=7fd98da8db35a89b9718333a31af6153"
 }

--- a/packages/coqide/coqide.8.4pl4/opam
+++ b/packages/coqide/coqide.8.4pl4/opam
@@ -38,6 +38,6 @@ extra-files: [
   "md5=f17447834f0d663923b21e5c0c188a4a"
 ]
 url {
-  src: "http://coq.inria.fr/distrib/V8.4pl4/files/coq-8.4pl4.tar.gz"
+  src: "https://coq-distrib.s3.fr-par.scw.cloud/V8.4pl4/files/coq-8.4pl4.tar.gz"
   checksum: "md5=6a9f61cf0ece644b170f722fbc8cf2a1"
 }


### PR DESCRIPTION
The current URLs (https://coq.inria.fr/distrib/xxx) are going to break soon.