### PR TITLE
Package ocsigen-toolkit.3.3.1

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.3.3.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.3.3.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "js_of_ocaml" {>= "4.1.0"}
+  "eliom" {>= "10.0.0"}
+  "calendar" {>= "2.0.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsigen-toolkit/archive/refs/tags/3.3.1.tar.gz"
+  checksum: [
+    "md5=3c90cb92bcf3b25347ae3f279fc5a7a0"
+    "sha512=c12fdd984752425a0bcced8324f4f699f4ec1d02fc97357b56d34d592a13c830e9367a4c0bb9e9f3aa8a56a15be3e8245c206868c86a4a1a4693912f7287aaf5"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.3.3.1`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.2.0