### PR TITLE
[new release] gitlab (4 packages) (0.1.8)

### DIFF
--- a/packages/current_gitlab/current_gitlab.0.6.1/opam
+++ b/packages/current_gitlab/current_gitlab.0.6.1/opam
@@ -21,7 +21,7 @@ depends: [
   "yojson"
   "cohttp-lwt-unix" {>= "4.0.0"}
   "dune" {>= "2.9"}
-  "gitlab-unix" {>= "0.1.3"}
+  "gitlab-unix" {>= "0.1.3" & < "0.1.8"}
   "cmdliner" {>= "1.1.0"}
   "logs" {>= "0.7.0"}
   "ppx_deriving_yojson" {>= "3.6.1"}

--- a/packages/current_gitlab/current_gitlab.0.6.2/opam
+++ b/packages/current_gitlab/current_gitlab.0.6.2/opam
@@ -22,7 +22,7 @@ depends: [
   "yojson"
   "cohttp-lwt-unix" {>= "4.0.0"}
   "dune" {>= "2.9"}
-  "gitlab-unix" {>= "0.1.4"}
+  "gitlab-unix" {>= "0.1.4" & < "0.1.8"}
   "cmdliner" {>= "1.1.0"}
   "logs" {>= "0.7.0"}
   "ppx_deriving_yojson" {>= "3.6.1"}

--- a/packages/current_gitlab/current_gitlab.0.6.4/opam
+++ b/packages/current_gitlab/current_gitlab.0.6.4/opam
@@ -22,7 +22,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "cohttp-lwt-unix" {>= "4.0.0"}
   "fmt" {>= "0.8.9"}
-  "gitlab-unix" {>= "0.1.4"}
+  "gitlab-unix" {>= "0.1.4" & < "0.1.8"}
   "logs" {>= "0.7.0"}
   "lwt" {>= "5.6.1"}
   "ppx_deriving_yojson" {>= "3.6.1"}

--- a/packages/gitlab-jsoo/gitlab-jsoo.0.1.8/opam
+++ b/packages/gitlab-jsoo/gitlab-jsoo.0.1.8/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Gitlab APIv4 OCaml library"
+description: """
+This library provides an OCaml interface to the
+[Gitlab APIv4](https://docs.gitlab.com/ee/api/) (JSON).
+This library installs the JavaScript version, which uses [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+maintainer: ["Tim McGilchrist <timmcgil@gmail.com>"]
+authors: ["Tim McGilchrist"]
+license: "BSD-3-clause"
+homepage: "https://github.com/tmcgilchrist/ocaml-gitlab"
+doc: "https://tmcgilchrist.github.io/ocaml-gitlab/"
+bug-reports: "https://github.com/tmcgilchrist/ocaml-gitlab/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "gitlab" {= version}
+  "cohttp" {>= "4.0"}
+  "cohttp-lwt-jsoo" {>= "4.0"}
+  "js_of_ocaml-lwt" {>= "3.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tmcgilchrist/ocaml-gitlab.git"
+available: [ arch != "x86_32" & arch != "arm32" & arch != "ppc32" ]
+url {
+  src:
+    "https://github.com/tmcgilchrist/ocaml-gitlab/releases/download/0.1.8/gitlab-0.1.8.tbz"
+  checksum: [
+    "sha256=06e430f4ab919c3417374d9628ce7ebfd49b6a901129a6e6fa1cdd53c2daae42"
+    "sha512=04c5c7131fa5a630edd0d2c605084fb37bb6a4d875b208450bf3b3fb70dc17da0f9ed8de04271e4eea62168d77dbcdda139aa7fe1a40f06f6c6cfb4407c47680"
+  ]
+}
+x-commit-hash: "7558a60a282f7d2a62b76fe1c79b9e45c8588c45"

--- a/packages/gitlab-unix/gitlab-unix.0.1.8/opam
+++ b/packages/gitlab-unix/gitlab-unix.0.1.8/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "GitLab APIv4 OCaml library"
+description: """
+This library provides an OCaml interface to the
+[Gitlab APIv4](https://docs.gitlab.com/ee/api/) (JSON).
+This package installs the Unix (Lwt) version."""
+maintainer: ["Tim McGilchrist <timmcgil@gmail.com>"]
+authors: ["Tim McGilchrist"]
+license: "BSD-3-clause"
+homepage: "https://github.com/tmcgilchrist/ocaml-gitlab"
+doc: "https://tmcgilchrist.github.io/ocaml-gitlab/"
+bug-reports: "https://github.com/tmcgilchrist/ocaml-gitlab/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "gitlab" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "cohttp" {>= "4.0"}
+  "cohttp-lwt-unix" {>= "4.0"}
+  "tls" {>= "0.11.0"}
+  "lwt" {>= "2.4.4"}
+  "stringext"
+  "base-unix"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/tmcgilchrist/ocaml-gitlab.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test & os != "macos"}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+
+available: [ arch != "x86_32" & arch != "arm32" & arch != "ppc32" ]
+url {
+  src:
+    "https://github.com/tmcgilchrist/ocaml-gitlab/releases/download/0.1.8/gitlab-0.1.8.tbz"
+  checksum: [
+    "sha256=06e430f4ab919c3417374d9628ce7ebfd49b6a901129a6e6fa1cdd53c2daae42"
+    "sha512=04c5c7131fa5a630edd0d2c605084fb37bb6a4d875b208450bf3b3fb70dc17da0f9ed8de04271e4eea62168d77dbcdda139aa7fe1a40f06f6c6cfb4407c47680"
+  ]
+}
+x-commit-hash: "7558a60a282f7d2a62b76fe1c79b9e45c8588c45"

--- a/packages/gitlab/gitlab.0.1.8/opam
+++ b/packages/gitlab/gitlab.0.1.8/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "GitLab APIv4 OCaml library"
+description: """
+This library provides an OCaml interface to the
+[GitLab APIv4](https://docs.gitlab.com/ee/api/) (JSON).
+
+It is compatible with [MirageOS](https://mirage.io) and also compiles to pure
+JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+maintainer: ["Tim McGilchrist <timmcgil@gmail.com>"]
+authors: ["Tim McGilchrist"]
+license: "BSD-3-clause"
+homepage: "https://github.com/tmcgilchrist/ocaml-gitlab"
+doc: "https://tmcgilchrist.github.io/ocaml-gitlab/"
+bug-reports: "https://github.com/tmcgilchrist/ocaml-gitlab/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "uri" {>= "1.9.0"}
+  "cohttp-lwt" {>= "4.0"}
+  "atdgen" {>= "2.8.0"}
+  "yojson" {>= "1.7.0"}
+  "ISO8601" {>= "0.2.6"}
+  "stringext"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tmcgilchrist/ocaml-gitlab.git"
+available: [ arch != "x86_32" & arch != "arm32" & arch != "ppc32" ]
+url {
+  src:
+    "https://github.com/tmcgilchrist/ocaml-gitlab/releases/download/0.1.8/gitlab-0.1.8.tbz"
+  checksum: [
+    "sha256=06e430f4ab919c3417374d9628ce7ebfd49b6a901129a6e6fa1cdd53c2daae42"
+    "sha512=04c5c7131fa5a630edd0d2c605084fb37bb6a4d875b208450bf3b3fb70dc17da0f9ed8de04271e4eea62168d77dbcdda139aa7fe1a40f06f6c6cfb4407c47680"
+  ]
+}
+x-commit-hash: "7558a60a282f7d2a62b76fe1c79b9e45c8588c45"

--- a/packages/lab/lab.0.1.4/opam
+++ b/packages/lab/lab.0.1.4/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.08.0"}
   "cmdliner" {>= "1.1.0"}
-  "gitlab-unix" {>= "0.1.4"}
+  "gitlab-unix" {>= "0.1.4" & < "0.1.8"}
   "cohttp-lwt-unix" {>= "4.0"}
   "otoml" {>= "0.9.0"}
   "fmt" {>= "0.9.0"}

--- a/packages/lab/lab.0.1.8/opam
+++ b/packages/lab/lab.0.1.8/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "GitLab cli"
+description:
+  "Experimental GitLab cli in the style of GitHub's gh and hub commands."
+maintainer: ["Tim McGilchrist <timmcgil@gmail.com>"]
+authors: ["Tim McGilchrist"]
+license: "BSD-3-clause"
+homepage: "https://github.com/tmcgilchrist/ocaml-gitlab"
+doc: "https://tmcgilchrist.github.io/ocaml-gitlab/"
+bug-reports: "https://github.com/tmcgilchrist/ocaml-gitlab/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "cmdliner" {>= "1.1.0"}
+  "gitlab-unix" {= version}
+  "cohttp-lwt-unix" {>= "4.0"}
+  "otoml" {>= "0.9.0"}
+  "fmt" {>= "0.9.0"}
+  "mdx" {>= "2.1" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tmcgilchrist/ocaml-gitlab.git"
+url {
+  src:
+    "https://github.com/tmcgilchrist/ocaml-gitlab/releases/download/0.1.8/gitlab-0.1.8.tbz"
+  checksum: [
+    "sha256=06e430f4ab919c3417374d9628ce7ebfd49b6a901129a6e6fa1cdd53c2daae42"
+    "sha512=04c5c7131fa5a630edd0d2c605084fb37bb6a4d875b208450bf3b3fb70dc17da0f9ed8de04271e4eea62168d77dbcdda139aa7fe1a40f06f6c6cfb4407c47680"
+  ]
+}
+x-commit-hash: "7558a60a282f7d2a62b76fe1c79b9e45c8588c45"


### PR DESCRIPTION
GitLab APIv4 OCaml library

- Project page: <a href="https://github.com/tmcgilchrist/ocaml-gitlab">https://github.com/tmcgilchrist/ocaml-gitlab</a>
- Documentation: <a href="https://tmcgilchrist.github.io/ocaml-gitlab/">https://tmcgilchrist.github.io/ocaml-gitlab/</a>

##### CHANGES:

## Added

 * `Project.merge_requests`: add parameter `wip`
 * `Project.merge_requests`: add parameter `target_branch`
 * `Project.merge_requests`: add parameter `per_page`
 * `Gitlab` module now exposes `Message` exception
 * `gitlab.atd`: add `user`, `duration`, `queued_duration`, `commit`,
   `pipeline` and `artifacts` to `pipeline_job`. Make `created_at`
   field mandatory (remove `nullable`).
 * `gitlab.atd`: add `tag`, `user`, `duration` and `queued_duration`
   to `pipeline_job`. Make `created_at` field mandatory (remove
   `nullable`).
 * `gitlab.atd`: add `event_action_type` type
 * `User.events`: add paging and `after` parameter. Return a stream
   instead of single list of events.

## Bug fixes

 * `gitlab.atd`: add `scheduler_failure` to `failure_reason`
 * `gitlab.atd`: add `data_integrity_failure` to `failure_reason`
 * `gitlab.atd`: make `merge_request.approvals_before_merge` integral
 * `gitlab.atd`: make `merge_request.sha` nullable
 * `gitlab.atd`: add failure reasons: `api_failure`,
   `missing_dependency_failure`, `runner_unsupported`,
   `stale_schedule`, `archived_failure`, `unmet_prerequisites`,
   `forward_deployment_failure`, `user_blocked`, `project_deleted`,
   `ci_quota_exceeded`, `pipeline_loop_detected`,
   `no_matching_runner`, `trace_size_exceeded`, `builds_disabled`,
   `environment_creation_failure`, `deployment_rejected`,
   `failed_outdated_deployment_job`, `protected_environment_failure`,
   `insufficient_bridge_permissions`,
   `downstream_bridge_project_not_found`, `invalid_bridge_trigger`,
   `upstream_bridge_project_not_found`,
   `insufficient_upstream_permissions`,
   `bridge_pipeline_is_child_pipeline`,
   `downstream_pipeline_creation_failed`,
   `secrets_provider_not_found`,
   `reached_max_descendant_pipelines_depth`, `ip_restriction_failure`,
   and `reached_max_pipeline_hierarchy_size`
 * the `action` param of `Events.all` takes an `event_action_type`,
   not an `event_action`

## Added

 * `Project.pipelines`: add parameter `scope`
