### PR TITLE
[new release] magic-mime (1.3.1)

### DIFF
--- a/packages/magic-mime/magic-mime.1.3.1/opam
+++ b/packages/magic-mime/magic-mime.1.3.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Map filenames to common MIME types"
+description: """
+This library contains a database of MIME types that maps filename extensions
+into MIME types suitable for use in many Internet protocols such as HTTP or
+e-mail.  It is generated from the `mime.types` file found in Unix systems, but
+has no dependency on a filesystem since it includes the contents of the
+database as an ML datastructure.
+
+For example, here's how to lookup MIME types in the [utop] REPL:
+
+    #require "magic-mime";;
+    Magic_mime.lookup "/foo/bar.txt";;
+    - : bytes = "text/plain"
+    Magic_mime.lookup "bar.css";;
+    - : bytes = "text/css"
+"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy" "Maxence Guesdon"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-magic-mime"
+doc: "https://mirage.github.io/ocaml-magic-mime/"
+bug-reports: "https://github.com/mirage/ocaml-magic-mime/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-magic-mime.git"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-magic-mime/releases/download/v1.3.1/magic-mime-1.3.1.tbz"
+  checksum: [
+    "sha256=e0234d03625dba1efac58e57e387672d75a5e9a621ff49acfe0f609c00f13b08"
+    "sha512=607f7469caa2e800a92e3c5248125108fad5e0513f4230a37ed774c86112eacdae0ee533c5c78ec2752e939e83e2201dd4ee02cbbff92ae32e25683710d7b365"
+  ]
+}
+x-commit-hash: "605338f0e3684425d99d853c15d5ea9a1478b5ee"


### PR DESCRIPTION
Map filenames to common MIME types

- Project page: <a href="https://github.com/mirage/ocaml-magic-mime">https://github.com/mirage/ocaml-magic-mime</a>
- Documentation: <a href="https://mirage.github.io/ocaml-magic-mime/">https://mirage.github.io/ocaml-magic-mime/</a>

##### CHANGES:

* Add WebAssembly (wasm) mime type (@vouillon mirage/ocaml-magic-mime#28, fixes mirage/ocaml-magic-mime#27 reported by @glondu)
