### PR TITLE
add missing dependencies to ocaml in dkml-install-runner packages

### DIFF
--- a/packages/dkml-install-runner/dkml-install-runner.0.1.0/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.1.0/opam
@@ -8,7 +8,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-install-api"
 bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
 depends: [
-  "ocaml" {>= "4.09"}
+  "ocaml" {>= "4.09" & < "5.1"}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {>= "1.5.3" & with-doc}
   "dkml-install" {= version}

--- a/packages/dkml-install-runner/dkml-install-runner.0.1.0/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.1.0/opam
@@ -8,6 +8,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-install-api"
 bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
 depends: [
+  "ocaml" {>= "4.09"}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {>= "1.5.3" & with-doc}
   "dkml-install" {= version}

--- a/packages/dkml-install-runner/dkml-install-runner.0.2.0/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.2.0/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
 #   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/ocaml_abi.ml
 available: os = "win32" | os = "linux" | os = "macos"
 depends: [
-  "ocaml" {>= "4.09"}
+  "ocaml" {>= "4.09" & < "5.1"}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {>= "1.5.3" & with-doc}
   "dkml-install" {= version}

--- a/packages/dkml-install-runner/dkml-install-runner.0.2.0/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.2.0/opam
@@ -13,6 +13,7 @@ bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
 #   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/ocaml_abi.ml
 available: os = "win32" | os = "linux" | os = "macos"
 depends: [
+  "ocaml" {>= "4.09"}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {>= "1.5.3" & with-doc}
   "dkml-install" {= version}

--- a/packages/dkml-install-runner/dkml-install-runner.0.3.0/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.3.0/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
 #   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/ocaml_abi.ml
 available: os = "win32" | os = "linux" | os = "macos"
 depends: [
-  "ocaml" {>= "4.09"}
+  "ocaml" {>= "4.09" & < "5.1"}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {>= "1.5.3" & with-doc}
   "dkml-install" {= version}

--- a/packages/dkml-install-runner/dkml-install-runner.0.3.0/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.3.0/opam
@@ -13,6 +13,7 @@ bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
 #   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/ocaml_abi.ml
 available: os = "win32" | os = "linux" | os = "macos"
 depends: [
+  "ocaml" {>= "4.09"}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {>= "1.5.3" & with-doc}
   "dkml-install" {= version}

--- a/packages/dkml-install-runner/dkml-install-runner.0.3.1/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.3.1/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
 #   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/ocaml_abi.ml
 available: os = "win32" | os = "linux" | os = "macos"
 depends: [
-  "ocaml" {>= "4.10"}
+  "ocaml" {>= "4.10" & < "5.1"}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {>= "1.5.3" & with-doc}
   "dkml-install" {= version}

--- a/packages/dkml-install-runner/dkml-install-runner.0.3.1/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.3.1/opam
@@ -13,6 +13,7 @@ bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
 #   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/ocaml_abi.ml
 available: os = "win32" | os = "linux" | os = "macos"
 depends: [
+  "ocaml" {>= "4.10"}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {>= "1.5.3" & with-doc}
   "dkml-install" {= version}

--- a/packages/dkml-install-runner/dkml-install-runner.0.4.0/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.4.0/opam
@@ -8,6 +8,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-install-api"
 bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
 depends: [
+  "ocaml" {>= "4.10"}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {>= "1.5.3" & with-doc}
   "dkml-install" {= version}

--- a/packages/dkml-install-runner/dkml-install-runner.0.5.1/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.5.1/opam
@@ -8,6 +8,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-install-api"
 bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
 depends: [
+  "ocaml" {>= "4.10"}
   "dune" {>= "2.9"}
   "alcotest" {>= "1.4.0" & with-test}
   "dkml-install" {= version}


### PR DESCRIPTION
The lint job of PR #24542 shows the following errors:

```
2023-09-28 10:11.50: Error in dkml-install-runner.0.3.0:            warning 41: Some packages are mentioned in package scripts or features, but there is no dependency or depopt toward them: "ocaml"
2023-09-28 10:11.50: Error in dkml-install-runner.0.2.0:            warning 41: Some packages are mentioned in package scripts or features, but there is no dependency or depopt toward them: "ocaml"
2023-09-28 10:11.50: Error in dkml-install-runner.0.1.0:            warning 41: Some packages are mentioned in package scripts or features, but there is no dependency or depopt toward them: "ocaml"
2023-09-28 10:45.54: Job failed: 3 errors
```

This PR adds the OCaml dependencies. The version constraints are based on [opam-health-check results](https://check.ci.ocaml.org/?comp=4.08&comp=4.09&comp=4.10&comp=4.11&comp=4.12&comp=4.13&comp=4.14&comp=5.0&comp=5.1&available=4.08&available=4.09&available=4.10&available=4.11&available=4.12&available=4.13&available=4.14&available=5.0&available=5.1&show-only=good&show-only=partial&show-only=bad&show-only=not-available&show-only=internal-failure&maintainers=&logsearch=dkml-install-runner&logsearch_comp=4.14)