### PR TITLE
Patch: Fix invisible character conf-unwind.0

### DIFF
--- a/packages/conf-unwind/conf-unwind.0/opam
+++ b/packages/conf-unwind/conf-unwind.0/opam
@@ -19,9 +19,9 @@ depexts: [
   ["libunwind"] {os = "freebsd"}
 ]
 x-ci-accept-failures: [
-￼ "oraclelinux-7"
-￼ "oraclelinux-8"
-￼ "oraclelinux-9"
+  "oraclelinux-7"
+  "oraclelinux-8"
+  "oraclelinux-9"
 ]
 synopsis: "Virtual package relying on libunwind"
 description:"


### PR DESCRIPTION
# Issue 
Package `conf-unwind.0` has an invisible character. This causes an error when building the package.
```
     At /.esy/opam-repository/packages/conf-unwind/conf-unwind.0/opam:22:0-22:1::
     '�' is not a valid token
```

# Screenshot
<img width="1361" alt="Screenshot 2023-10-04 at 1 11 49 PM" src="https://github.com/ocaml/opam-repository/assets/32528539/b0e897ea-1010-47f6-9735-dc614d4547fe">

# Solution
Replace with standard space ` ` character

# Pull Request
Please merge this pull request to solve this issue
https://github.com/ocaml/opam-repository/pull/24579