### PR TITLE
Add missing algorithms in the description of `digestif`

### DIFF
--- a/packages/digestif/digestif.0.7.1/opam
+++ b/packages/digestif/digestif.0.7.1/opam
@@ -28,7 +28,7 @@ We provides implementation of:
 """
 
 build: [
-  [ "dune" "subst"]
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
   [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]

--- a/packages/digestif/digestif.0.7.1/opam
+++ b/packages/digestif/digestif.0.7.1/opam
@@ -21,6 +21,7 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160

--- a/packages/digestif/digestif.0.7.2/opam
+++ b/packages/digestif/digestif.0.7.2/opam
@@ -21,6 +21,7 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160

--- a/packages/digestif/digestif.0.7.3/opam
+++ b/packages/digestif/digestif.0.7.3/opam
@@ -21,6 +21,7 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160

--- a/packages/digestif/digestif.0.7.4/opam
+++ b/packages/digestif/digestif.0.7.4/opam
@@ -21,6 +21,7 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160

--- a/packages/digestif/digestif.0.8.0-1/opam
+++ b/packages/digestif/digestif.0.8.0-1/opam
@@ -21,6 +21,7 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160

--- a/packages/digestif/digestif.0.8.0/opam
+++ b/packages/digestif/digestif.0.8.0/opam
@@ -21,6 +21,7 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160

--- a/packages/digestif/digestif.0.8.1/opam
+++ b/packages/digestif/digestif.0.8.1/opam
@@ -21,6 +21,7 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160

--- a/packages/digestif/digestif.0.9.0/opam
+++ b/packages/digestif/digestif.0.9.0/opam
@@ -21,6 +21,8 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * SHA3
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160

--- a/packages/digestif/digestif.1.0.0/opam
+++ b/packages/digestif/digestif.1.0.0/opam
@@ -21,6 +21,8 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * SHA3
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160

--- a/packages/digestif/digestif.1.0.1/opam
+++ b/packages/digestif/digestif.1.0.1/opam
@@ -21,6 +21,8 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * SHA3
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160

--- a/packages/digestif/digestif.1.1.0/opam
+++ b/packages/digestif/digestif.1.1.0/opam
@@ -21,6 +21,9 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * SHA3
+ * Keccak-256
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160

--- a/packages/digestif/digestif.1.1.1/opam
+++ b/packages/digestif/digestif.1.1.1/opam
@@ -21,6 +21,9 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * SHA3
+ * Keccak-256
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160

--- a/packages/digestif/digestif.1.1.2/opam
+++ b/packages/digestif/digestif.1.1.2/opam
@@ -21,6 +21,9 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * SHA3
+ * Keccak-256
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160

--- a/packages/digestif/digestif.1.1.3/opam
+++ b/packages/digestif/digestif.1.1.3/opam
@@ -21,6 +21,9 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * SHA3
+ * Keccak-256
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160

--- a/packages/digestif/digestif.1.1.4/opam
+++ b/packages/digestif/digestif.1.1.4/opam
@@ -21,6 +21,9 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * SHA3
+ * Keccak-256
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160


### PR DESCRIPTION
It added WHIRLPOOL in 0.7.1, SHA3 in 0.9.0 and Keccak-256 in 1.1.0, so now searching in the opam-repository for an SHA3 implementation it should turn up.

Change submitted upstream: https://github.com/mirage/digestif/pull/146