### PR TITLE
[new release] libctrl (1.0.0-alpha.1)

### DIFF
--- a/packages/libctrl/libctrl.1.0.0-alpha.1/opam
+++ b/packages/libctrl/libctrl.1.0.0-alpha.1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "A playground library for programming with first-class control"
+description:
+  "A collection of first-class control operators from the literature. The operators are encoded on top of OCaml's effect handlers."
+maintainer: ["Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"]
+authors: ["Daniel Hillerström"]
+license: "MIT"
+tags: [
+  "first-class control operators"
+  "effect handlers"
+  "shift/reset"
+  "control/prompt"
+  "fcontrol/run"
+  "callcc"
+  "C"
+  "delimited continuations"
+  "undelimited continuations"
+  "monadic reflection"
+]
+homepage: "https://github.com/dhil/ocaml-libctrl"
+bug-reports: "https://github.com/dhil/ocaml-libctrl/issues"
+depends: [
+  "ocaml" { >= "5.0.0"}
+  "dune" {>= "3.10"}
+  "multicont" { >= "1.0.1"}
+  "ounit2" {with-test}
+  "qcheck" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dhil/ocaml-libctrl.git"
+url {
+  src:
+    "https://github.com/dhil/ocaml-libctrl/releases/download/1.0.0-alpha.1/libctrl-1.0.0-alpha.1.tbz"
+  checksum: [
+    "sha256=eff5a02f3fef3bdede7699a74e69754d9fd2903ec9eaeabf71a36969a715b08a"
+    "sha512=991474bc9aa43635e62b3ab1f6bff9f4fc01a6d755d934c961dae1cec961b8a38002e525ec95b3195c996c521b1fcb7bd2d248fb1cc7a5b9d497ab6f48fbddb4"
+  ]
+}
+x-commit-hash: "ed7ca52dd5c55c49f272556956c2fee16f9e4e44"


### PR DESCRIPTION
A playground library for programming with first-class control

- Project page: <a href="https://github.com/dhil/ocaml-libctrl">https://github.com/dhil/ocaml-libctrl</a>

##### CHANGES:

This is an initial prerelease. This version includes the following
operators:

* McCarthy's `amb`.
* Scheme's `call/cc` (aka. Reynolds' `escape`).
* Filinski's monadic reflection for any monad.
* Kiselyov's interface for programming with typed multi-prompt continuations.
* Danvy and Filinski's `shift` and `reset` (and some of their variations).
* Felleisen's `control` and `prompt`.
* Felleisen'c `C` operator.
