### PR TITLE
Add missing quotes in ppx_rapper from a54638e028

### DIFF
--- a/packages/ppx_rapper/ppx_rapper.1.0.1/opam
+++ b/packages/ppx_rapper/ppx_rapper.1.0.1/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
-  "ppxlib" {with-test & < 0.31.1}
+  "ppxlib" {with-test & < "0.31.1"}
   "base"
   "caqti" {< "2.0.0~"}
   "caqti-lwt" {< "2.0.0~"}

--- a/packages/ppx_rapper/ppx_rapper.1.0.2/opam
+++ b/packages/ppx_rapper/ppx_rapper.1.0.2/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
-  "ppxlib" {with-test & < 0.31.1}
+  "ppxlib" {with-test & < "0.31.1"}
   "base"
   "caqti" {< "2.0.0~"}
   "caqti-lwt" {< "2.0.0~"}

--- a/packages/ppx_rapper/ppx_rapper.1.1.0/opam
+++ b/packages/ppx_rapper/ppx_rapper.1.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
-  "ppxlib" {with-test & < 0.31.1}
+  "ppxlib" {with-test & < "0.31.1"}
   "base"
   "caqti" {< "2.0.0~"}
   "caqti-lwt" {< "2.0.0~"}

--- a/packages/ppx_rapper/ppx_rapper.1.1.1/opam
+++ b/packages/ppx_rapper/ppx_rapper.1.1.1/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
-  "ppxlib" {with-test & < 0.31.1}
+  "ppxlib" {with-test & < "0.31.1"}
   "base"
   "caqti" {< "2.0.0~"}
   "caqti-lwt" {< "2.0.0~"}

--- a/packages/ppx_rapper/ppx_rapper.1.2.0/opam
+++ b/packages/ppx_rapper/ppx_rapper.1.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
-  "ppxlib" {with-test & < 0.31.1}
+  "ppxlib" {with-test & < "0.31.1"}
   "base"
   "caqti" {< "2.0.0~"}
   "caqti-lwt" {< "2.0.0~"}

--- a/packages/ppx_rapper/ppx_rapper.2.0.0/opam
+++ b/packages/ppx_rapper/ppx_rapper.2.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.0.1"}
   "pg_query"
   "ppxlib"
-  "ppxlib" {with-test & < 0.31.1}
+  "ppxlib" {with-test & < "0.31.1"}
   "base"
   "caqti" {< "2.0.0~"}
   "caqti-lwt" {< "2.0.0~"}

--- a/packages/ppx_rapper/ppx_rapper.3.0.0/opam
+++ b/packages/ppx_rapper/ppx_rapper.3.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.07"}
   "pg_query"
   "ppxlib" {>= "0.3.1"}
-  "ppxlib" {with-test & < 0.31.1}
+  "ppxlib" {with-test & < "0.31.1"}
   "base" {>= "v0.11.1"}
   "caqti" {>= "1.2.0" & < "2.0.0~"}
 ]

--- a/packages/ppx_rapper/ppx_rapper.3.1.0/opam
+++ b/packages/ppx_rapper/ppx_rapper.3.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.07"}
   "pg_query" {>= "0.9.6"}
   "ppxlib" {>= "0.3.1"}
-  "ppxlib" {with-test & < 0.31.1}
+  "ppxlib" {with-test & < "0.31.1"}
   "base" {>= "v0.11.1"}
   "caqti" {>= "1.7.0" & < "2.0.0~"}
 ]


### PR DESCRIPTION
a54638e028 was missing quotes which cause CI errors:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/a15fc84310d5e04d5c0c41549ab60638f4f8f32b/variant/compilers,4.02,conf-openbabel.0.1
```
[ERROR] At /home/opam/.opam/repo/default/packages/ppx_rapper/ppx_rapper.3.1.0/opam:15:27-15:28::
        '.' is not a valid token
```

I also confirmed locally:
```
$ opam lint ../ppx_rapper/ppx_rapper.3.1.0/opam
/home/jmi/software/opam-repository/packages/ppx_rapper/ppx_rapper.3.1.0/opam: Errors.
    error  2: File format error at line 15, column 27: '.' is not a valid token
```

With this PR all affected opam files from a54638e028 pass linting again:
```
$ opam lint ../ppx_rapper/ppx_rapper.*/opam
/home/jmi/software/opam-repository/packages/ppx_rapper/ppx_rapper.0.9.2/opam: Passed.
/home/jmi/software/opam-repository/packages/ppx_rapper/ppx_rapper.1.0.1/opam: Passed.
/home/jmi/software/opam-repository/packages/ppx_rapper/ppx_rapper.1.0.2/opam: Passed.
/home/jmi/software/opam-repository/packages/ppx_rapper/ppx_rapper.1.1.0/opam: Passed.
/home/jmi/software/opam-repository/packages/ppx_rapper/ppx_rapper.1.1.1/opam: Passed.
/home/jmi/software/opam-repository/packages/ppx_rapper/ppx_rapper.1.2.0/opam: Passed.
/home/jmi/software/opam-repository/packages/ppx_rapper/ppx_rapper.2.0.0/opam: Passed.
/home/jmi/software/opam-repository/packages/ppx_rapper/ppx_rapper.3.0.0/opam: Passed.
/home/jmi/software/opam-repository/packages/ppx_rapper/ppx_rapper.3.1.0/opam: Passed.
```

CC: @pitag-ha 