### PR TITLE
[new release] libctrl (1.0.0-alpha.2)

### DIFF
--- a/packages/libctrl/libctrl.1.0.0-alpha.2/opam
+++ b/packages/libctrl/libctrl.1.0.0-alpha.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "A playground library for programming with first-class control"
+description:
+  "A collection of first-class control operators from the literature. The operators are encoded on top of OCaml's effect handlers."
+maintainer: ["Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"]
+authors: ["Daniel Hillerström"]
+license: "MIT"
+tags: [
+  "first-class control operators"
+  "effect handlers"
+  "shift/reset"
+  "control/prompt"
+  "fcontrol/run"
+  "callcc"
+  "C"
+  "delimited continuations"
+  "undelimited continuations"
+  "monadic reflection"
+]
+homepage: "https://github.com/dhil/ocaml-libctrl"
+bug-reports: "https://github.com/dhil/ocaml-libctrl/issues"
+depends: [
+  "ocaml" { >= "5.0.0"}
+  "dune" {>= "3.10"}
+  "multicont" { >= "1.0.1"}
+  "ounit2" {with-test}
+  "qcheck" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dhil/ocaml-libctrl.git"
+url {
+  src:
+    "https://github.com/dhil/ocaml-libctrl/releases/download/1.0.0-alpha.2/libctrl-1.0.0-alpha.2.tbz"
+  checksum: [
+    "sha256=0e56fb7569c239ed001d3db50574472577e9e3f41f15188919f6dc71279d9316"
+    "sha512=c36c466791ecb1999e1603ff84a5ca3c849be9c5a5795c5cc728f544105085000c845d141ba221d5dfe3e19cbcd49d90a6bd069198562cd24c29b0776525feb7"
+  ]
+}
+x-commit-hash: "1eb5ac805119807bba4c94c7b0097d771fd0ac76"


### PR DESCRIPTION
A playground library for programming with first-class control

- Project page: <a href="https://github.com/dhil/ocaml-libctrl">https://github.com/dhil/ocaml-libctrl</a>

##### CHANGES:

This prerelease includes some bug fixes:

* Plugged a memory leak in the implementation of `callcc`.
* Fixed a bug in the implementation of `callcc` which would occur
  whenever the capture continuation would escape the scope of its
  binding occurrence without being invoked at least once.
* Renamed the `C` operator `resume` to `throw`.
* Slightly generalised the type of `C`'s `throw` operator.
