### PR TITLE
Package ocsigen-toolkit.3.3.3

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.3.3.3/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.3.3.3/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "js_of_ocaml" {>= "4.1.0"}
+  "eliom" {>= "10.0.0"}
+  "calendar" {>= "2.0.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsigen-toolkit/archive/refs/tags/3.3.3.tar.gz"
+  checksum: [
+    "md5=a6d5e06ed0ff363f56f82f0466eafa61"
+    "sha512=32013eede25db617b7004de209440d32ddc4627c9f7786383ae00ecdb7fe2ec4818560b2bc78ba9805676c36a3b6c061300e382723f6d46441e2a9736640dd21"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.3.3.3`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.2.0