### PR TITLE
[new release] producer (0.2.0)

### DIFF
--- a/packages/producer/producer.0.2.0/opam
+++ b/packages/producer/producer.0.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Accumulate results using monadic dependency graphs"
+maintainer: ["sixstring982@gmail.com"]
+authors: ["Trent Small"]
+license: "BSD-3-Clause"
+tags: ["dependency injection" "graph" "node" "producer"]
+homepage: "https://github.com/sixstring982/producer"
+doc: "https://sixstring982.github.io/producer"
+bug-reports: "https://github.com/sixstring982/producer/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.7" & >= "3.7"}
+  "alcotest" {"1.7.0" >= with-test}
+  "hmap" {>= "0.8.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sixstring982/producer.git"
+url {
+  src:
+    "https://github.com/Sixstring982/producer/releases/download/v0.2.0/producer-0.2.0.tbz"
+  checksum: [
+    "sha256=05670c2f5010c96418ffacc95da87d302798f00c68a996f136d0f68bb6072934"
+    "sha512=7435250398df0f37c4c34d209fa574312ffe79a8b62b9efe82abeb67dab344acf7ece8bc695812da6147bce5dcd1b3dc807115285a2a49d663665ead376ec54b"
+  ]
+}
+x-commit-hash: "ca562d552549be808fc6a049b5b425f90a6ffc55"

--- a/packages/producer/producer.0.2.0/opam
+++ b/packages/producer/producer.0.2.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/sixstring982/producer/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "3.7" & >= "3.7"}
-  "alcotest" {"1.7.0" >= with-test}
+  "alcotest" {>="1.7.0" & with-test}
   "hmap" {>= "0.8.1"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Accumulate results using monadic dependency graphs

- Project page: <a href="https://github.com/sixstring982/producer">https://github.com/sixstring982/producer</a>
- Documentation: <a href="https://sixstring982.github.io/producer">https://sixstring982.github.io/producer</a>

##### CHANGES:

* Pin dependency versions in `producer.opam` and `dune-project`
* Add support for monads with two type parameters (e.g. `Result`)
