### PR TITLE
[new release] melange-webapi (0.20.0)

### DIFF
--- a/packages/melange-webapi/melange-webapi.0.20.0/opam
+++ b/packages/melange-webapi/melange-webapi.0.20.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Melange bindings to the DOM"
+description: "Melange bindings to the DOM and other Web APIs."
+maintainer: [
+  "Javier Chávarri <javier.chavarri@gmail.com>"
+  "David Sancho <dsnxmoreno@gmail.com>"
+]
+authors: ["Cheng Lou <chenglou@users.noreply.github.com>"]
+license: "MIT"
+homepage: "https://github.com/melange-community/melange-webapi"
+bug-reports: "https://github.com/melange-community/melange-webapi/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "5.1"}
+  "melange" {>= "2.0.0"}
+  "melange-fetch"
+  "reason" {>= "3.10"}
+  "ocaml-lsp-server" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-community/melange-webapi.git"
+url {
+  src:
+    "https://github.com/melange-community/melange-webapi/releases/download/0.20.0/melange-webapi-0.20.0.tbz"
+  checksum: [
+    "sha256=eea28fba52c856cbd9a4b8f8cb429d3a2741e2fa402b0cde290a50566b318143"
+    "sha512=0cf2cecca9ce9666acded365e7a7e638b0dc5ff0e5079df90ec509a627a1b0f0c0f5ce9d7b0cfafda30c461f05b8329c800a16b5e21fa77b97051b7a4d3da915"
+  ]
+}
+x-commit-hash: "b7aed17a2e306350d718c6bbd0d6eb928eba60bd"


### PR DESCRIPTION
Melange bindings to the DOM

- Project page: <a href="https://github.com/melange-community/melange-webapi">https://github.com/melange-community/melange-webapi</a>

##### CHANGES:

* Migrate to Melange
* Remove bsdoc
