### PR TITLE
Package ocsigen-toolkit.3.3.4

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.3.3.4/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.3.3.4/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "js_of_ocaml" {>= "4.1.0"}
+  "eliom" {>= "10.1.2"}
+  "calendar" {>= "2.0.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsigen-toolkit/archive/refs/tags/3.3.4.tar.gz"
+  checksum: [
+    "md5=9150259898e1abf5c5e507a4a4c1f819"
+    "sha512=f73427d1154a34ea6973e3639e019ce98e65d6862f61b740041c231a2b9d9cd04bc4aa86186fbf2d45288b9be1a97a7e5b57ddc9eb1434920d51fc3f76af47a7"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.3.3.4`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.2.0