### PR TITLE
Add an `ocaml-option-no-compression` to disable compressed Marshalling

### DIFF
--- a/packages/ocaml-option-no-compression/ocaml-option-no-compression.1/opam
+++ b/packages/ocaml-option-no-compression/ocaml-option-no-compression.1/opam
@@ -1,0 +1,7 @@
+opam-version: "2.0"
+synopsis: "Set OCaml to be compiled with --without-zstd"
+depends: [
+  "ocaml-variants" {post & >= "5.1.0~"}
+]
+maintainer: "platform@lists.ocaml.org"
+flags: compiler

--- a/packages/ocaml-options-only-afl/ocaml-options-only-afl.1/opam
+++ b/packages/ocaml-options-only-afl/ocaml-options-only-afl.1/opam
@@ -9,6 +9,7 @@ conflicts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-no-flat-float-array"
+  "ocaml-option-no-compression"
   "ocaml-option-spacetime"
   "ocaml-option-static"
   "ocaml-option-nnp"

--- a/packages/ocaml-options-only-flambda-fp/ocaml-options-only-flambda-fp.1/opam
+++ b/packages/ocaml-options-only-flambda-fp/ocaml-options-only-flambda-fp.1/opam
@@ -8,6 +8,7 @@ conflicts: [
   "ocaml-option-default-unsafe-string"
   "ocaml-option-musl"
   "ocaml-option-no-flat-float-array"
+  "ocaml-option-no-compression"
   "ocaml-option-spacetime"
   "ocaml-option-static"
   "ocaml-option-nnp"

--- a/packages/ocaml-options-only-flambda/ocaml-options-only-flambda.1/opam
+++ b/packages/ocaml-options-only-flambda/ocaml-options-only-flambda.1/opam
@@ -9,6 +9,7 @@ conflicts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-no-flat-float-array"
+  "ocaml-option-no-compression"
   "ocaml-option-spacetime"
   "ocaml-option-static"
   "ocaml-option-nnp"

--- a/packages/ocaml-options-only-fp/ocaml-options-only-fp.1/opam
+++ b/packages/ocaml-options-only-fp/ocaml-options-only-fp.1/opam
@@ -9,6 +9,7 @@ conflicts: [
   "ocaml-option-flambda"
   "ocaml-option-musl"
   "ocaml-option-no-flat-float-array"
+  "ocaml-option-no-compression"
   "ocaml-option-spacetime"
   "ocaml-option-static"
   "ocaml-option-nnp"

--- a/packages/ocaml-options-only-nnp/ocaml-options-only-nnp.1/opam
+++ b/packages/ocaml-options-only-nnp/ocaml-options-only-nnp.1/opam
@@ -10,6 +10,7 @@ conflicts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-no-flat-float-array"
+  "ocaml-option-no-compression"
   "ocaml-option-spacetime"
   "ocaml-option-static"
   "ocaml-option-nnpchecker"

--- a/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1+bytecode-only/opam
+++ b/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1+bytecode-only/opam
@@ -11,6 +11,7 @@ conflicts: [
   "ocaml-option-default-unsafe-string"
   "ocaml-option-flambda"
   "ocaml-option-fp"
+  "ocaml-option-no-compression"
   "ocaml-option-musl"
   "ocaml-option-spacetime"
   "ocaml-option-static"

--- a/packages/ocaml-options-only-tsan/ocaml-options-only-tsan.1/opam
+++ b/packages/ocaml-options-only-tsan/ocaml-options-only-tsan.1/opam
@@ -10,6 +10,7 @@ conflicts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-no-flat-float-array"
+  "ocaml-option-no-compression"
   "ocaml-option-spacetime"
   "ocaml-option-static"
   "ocaml-option-nnp"

--- a/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
+++ b/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
@@ -14,6 +14,7 @@ conflicts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-no-flat-float-array"
+  "ocaml-option-no-compression"
   "ocaml-option-spacetime"
   "ocaml-option-static"
   "ocaml-option-nnp"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
@@ -40,6 +40,7 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--without-zstd"  {ocaml-option-no-compression:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed}
@@ -70,6 +71,7 @@ depopts: [
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"
+  "ocaml-option-no-compression"
   "ocaml-option-musl"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-address-sanitizer"


### PR DESCRIPTION
Compression support within the compiler introduces a dependency to zstd, this option removes this dependency to make it easier to package independent executables without a dependency on zstd.