### PR TITLE
Transition package ocaml-vdom.transition

### DIFF
--- a/packages/ocaml-vdom/ocaml-vdom.transition/opam
+++ b/packages/ocaml-vdom/ocaml-vdom.transition/opam
@@ -1,0 +1,14 @@
+opam-version: "2.0"
+version: "transition"
+synopsis: "This is a transition package, ocaml-vdom is now named vdom. Use the vdom package instead"
+post-messages:
+  "ocaml-vdom has been renamed and the ocaml-vdom package is now a transition package. Use the vdom package instead."
+maintainer: ["Alain Frisch <alain.frisch@lexifi.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Marc Lasson <marc.lasson@lexifi.com>"
+  "Aurélien Saue <aurelien.saue@lexifi.com>"
+]
+homepage: "https://github.com/LexiFi/ocaml-vdom"
+bug-reports: "https://github.com/LexiFi/ocaml-vdom/issues"
+depends: ["vdom"]

--- a/packages/ocaml-vdom/ocaml-vdom.transition/opam
+++ b/packages/ocaml-vdom/ocaml-vdom.transition/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "transition"
 synopsis: "This is a transition package, ocaml-vdom is now named vdom. Use the vdom package instead"
 post-messages:
   "ocaml-vdom has been renamed and the ocaml-vdom package is now a transition package. Use the vdom package instead."
@@ -12,3 +11,4 @@ authors: [
 homepage: "https://github.com/LexiFi/ocaml-vdom"
 bug-reports: "https://github.com/LexiFi/ocaml-vdom/issues"
 depends: ["vdom"]
+license: "MIT"


### PR DESCRIPTION
ocaml-vdom will now be named vdom (cf https://github.com/ocaml/opam-repository/pull/24609)