### PR TITLE
Jasmin 2023.06.1 is not compatible with OCaml 5

### DIFF
--- a/packages/jasmin/jasmin.2023.06.1/opam
+++ b/packages/jasmin/jasmin.2023.06.1/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/jasmin-lang/jasmin/issues"
 dev-repo: "git+https://github.com/jasmin-lang/jasmin.git"
 
 depends: [
-  "ocaml" {>= "4.11" & build}
+  "ocaml" {>= "4.11" & < "5.0" & build}
   "batteries" {>= "3.4.0"}
   "menhir" {>= "20160825" & build}
   "menhirLib"


### PR DESCRIPTION
Cf. https://github.com/ocaml/opam-repository/pull/24231

jasmin.2023.06.1 is not compatible either.