### PR TITLE
[new release] wayland (2.0)

### DIFF
--- a/packages/wayland/wayland.2.0/opam
+++ b/packages/wayland/wayland.2.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Pure OCaml Wayland protocol library"
+description:
+  "Wayland is a communications protocol intended for use between processes on a single computer. It is mainly used by graphical applications (clients) to talk to display servers, but nothing about the protocol is specific to graphics and it could be used for other things. This library can be used to write Wayland clients, servers and proxies."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "Apache-2.0 AND LicenseRef-various-licenses-for-the-schema-files"
+homepage: "https://github.com/talex5/ocaml-wayland"
+doc: "https://talex5.github.io/ocaml-wayland/"
+bug-reports: "https://github.com/talex5/ocaml-wayland/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "ocaml" {>= "5.0"}
+  "xmlm" {>= "1.3.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cstruct" {>= "6.0.0"}
+  "eio" {>= "0.12"}
+  "eio_main" {>= "0.12" & with-test}
+  "cmdliner" {>= "1.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/talex5/ocaml-wayland.git"
+url {
+  src:
+    "https://github.com/talex5/ocaml-wayland/releases/download/v2.0/wayland-2.0.tbz"
+  checksum: [
+    "sha256=8821b5ce4d6d03b81d186b7bf1cdec422d0d37d161dc7b023f8732ed8de9834b"
+    "sha512=d948ef44fefd3aed4c3a89cc2bea82e3e7ef6ef8584516645e763c2e5dbc31683c2f45fb002a1a22072ad7221972ad28f032973e9d40ae470b425c460c51ecdf"
+  ]
+}
+x-commit-hash: "a45afe264feb1f5733aee16b12968896844c90b7"


### PR DESCRIPTION
Pure OCaml Wayland protocol library

- Project page: <a href="https://github.com/talex5/ocaml-wayland">https://github.com/talex5/ocaml-wayland</a>
- Documentation: <a href="https://talex5.github.io/ocaml-wayland/">https://talex5.github.io/ocaml-wayland/</a>

##### CHANGES:

- Convert from Lwt to Eio (@talex5 talex5/ocaml-wayland#37).
  Remove `set_paused`, as it's no longer needed.

- Add `Client.stop` and `Server.stop` (@talex5 talex5/ocaml-wayland#37).
  These allow shutting down the connection without reporting an error.

- Update to latest versions of Wayland protocols (@talex5 talex5/ocaml-wayland#38).

- Add layer shell protocol (@yilinwei talex5/ocaml-wayland#36).
