### PR TITLE
[new release] melange-testing-library (0.1.0)

### DIFF
--- a/packages/melange-testing-library/melange-testing-library.0.1.0/opam
+++ b/packages/melange-testing-library/melange-testing-library.0.1.0/opam
@@ -10,9 +10,6 @@ depends: [
   "ocaml"
   "melange" {>= "2.0.0"}
   "reason-react"
-  "melange-jest" {with-test}
-  "opam-check-npm-deps" {with-test}
-  "bisect_ppx" {with-test & >= "2.5.0"}
   "odoc" {with-doc}
 ]
 build: [
@@ -25,7 +22,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/melange-testing-library/melange-testing-library.0.1.0/opam
+++ b/packages/melange-testing-library/melange-testing-library.0.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Fetch API support for Melange"
+synopsis: "Melange bindings for testing-library (dom-testing-library and react-testing-library)"
 maintainer: ["David Sancho Moreno <dsnxmoreno@gmail.com>"]
 authors: ["David Sancho Moreno <dsnxmoreno@gmail.com>"]
 license: "MIT"

--- a/packages/melange-testing-library/melange-testing-library.0.1.0/opam
+++ b/packages/melange-testing-library/melange-testing-library.0.1.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Fetch API support for Melange"
+maintainer: ["David Sancho Moreno <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho Moreno <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/melange-community/melange-testing-library"
+bug-reports: "https://github.com/melange-community/melange-testing-library"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml"
+  "melange" {>= "2.0.0"}
+  "reason-react"
+  "melange-jest" {with-test}
+  "opam-check-npm-deps" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo:
+  "git+https://github.com/melange-community/melange-testing-library.git"
+depexts: [
+  ["@testing-library/react"] {npm-version = "^11.1.0"}
+  ["@testing-library/dom"] {npm-version = "^7.26.3"}
+]
+pin-depends: [
+  [ "bisect_ppx.dev"        "git+https://github.com/jchavarri/bisect_ppx.git#a14c5b5cd4564d2992dd1b14238922029bc1b1d7" ]
+]
+url {
+  src:
+    "https://github.com/melange-community/melange-testing-library/releases/download/0.1.0/melange-testing-library-0.1.0.tbz"
+  checksum: [
+    "sha256=43cce3297b23ef14e01631b615a5b34ea238d2ff8fde72d68beef28f4ac811d6"
+    "sha512=74b931034c62865c3e83171653d1157704f7660a3be3a36e9f12fd80677e1be1bf51c4fc76cc9e6c4e6b3691d4ee1351d3ef0177d064ca890ac5d134a7d2b7f6"
+  ]
+}
+x-commit-hash: "dd40bff6667ece78346d92c31527d2271e655a3b"


### PR DESCRIPTION
Fetch API support for Melange

- Project page: <a href="https://github.com/melange-community/melange-testing-library">https://github.com/melange-community/melange-testing-library</a>

##### CHANGES:

- Initial release
