### PR TITLE
Fix conf-gstreamer

### DIFF
--- a/packages/conf-gstreamer/conf-gstreamer.1/opam
+++ b/packages/conf-gstreamer/conf-gstreamer.1/opam
@@ -21,7 +21,7 @@ depexts: [
   ["gstreamer1" "gstreamer1-plugins-core"] {os = "freebsd"}
   ["gstreamer1.0" "gstreamer1.0-plugins-base"]
     {os = "win32" & os-distribution = "cygwinports"}
-  ["gstreamer" "gst-plugins-base"]
+  ["gstreamer"]
     {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on libgstreamer"


### PR DESCRIPTION
On macos: `gst-plugins-base` package does not exist anymore.