### PR TITLE
Package jhupllib.0.3

### DIFF
--- a/packages/jhupllib/jhupllib.0.3/opam
+++ b/packages/jhupllib/jhupllib.0.3/opam
@@ -11,7 +11,7 @@ homepage: "http://pl.cs.jhu.edu/"
 doc: "https://github.com/JHU-PL-Lab/jhu-pl-lib/"
 bug-reports: "https://github.com/JHU-PL-Lab/jhu-pl-lib/issues"
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "base-threads"
   "batteries"
   "dune" {>= "1.0"}

--- a/packages/jhupllib/jhupllib.0.3/opam
+++ b/packages/jhupllib/jhupllib.0.3/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/JHU-PL-Lab/jhu-pl-lib/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "base-threads"
-  "batteries"
+  "batteries" {>="3.0.0"}
   "dune" {>= "1.0"}
   "ocaml-monadic" {>= "0.4.1"}
   "ounit" {with-test}

--- a/packages/jhupllib/jhupllib.0.3/opam
+++ b/packages/jhupllib/jhupllib.0.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A collection of OCaml utilities used by the JHU PL lab"
+description: """\
+A collection of OCaml utilities used by the JHU PL lab.  These are miscellaneous
+utilities which did not appear readily in standard libraries when they were
+written."""
+maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
+authors: "JHU PL Lab <pl.cs@jhu.edu>"
+license: "Apache-2.0"
+homepage: "http://pl.cs.jhu.edu/"
+doc: "https://github.com/JHU-PL-Lab/jhu-pl-lib/"
+bug-reports: "https://github.com/JHU-PL-Lab/jhu-pl-lib/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "base-threads"
+  "batteries"
+  "dune" {>= "1.0"}
+  "ocaml-monadic" {>= "0.4.1"}
+  "ounit" {with-test}
+  "ppx_deriving" {>= "2.0"}
+  "ppx_deriving_yojson"
+  "yojson" {>= "1.7.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/JHU-PL-Lab/jhu-pl-lib.git"
+url {
+  src:
+    "https://github.com/JHU-PL-Lab/jhupllib/archive/3edc6645cee5dd6d8f2a2e846c783b2d9ca362a8.zip"
+  checksum: [
+    "md5=e756ba2838cf3aee7382a3c1cfe01edb"
+    "sha512=06d420670ae2a2c4cf6de88c29f0f57ec12b53722afbfe14d574a16d16e3dd140d2a44bb504636a2678a55183eba1ae78e4047649248ff9b2e19dc9e5aa604db"
+  ]
+}


### PR DESCRIPTION
### `jhupllib.0.3`
A collection of OCaml utilities used by the JHU PL lab
A collection of OCaml utilities used by the JHU PL lab.  These are miscellaneous
utilities which did not appear readily in standard libraries when they were
written.



---
* Homepage: http://pl.cs.jhu.edu/
* Source repo: git+https://github.com/JHU-PL-Lab/jhu-pl-lib.git
* Bug tracker: https://github.com/JHU-PL-Lab/jhu-pl-lib/issues

---
:camel: Pull-request generated by opam-publish v2.2.0