### PR TITLE
[new release] flint (4 packages) (0.3.2)

### DIFF
--- a/packages/antic/antic.0.3.2/opam
+++ b/packages/antic/antic.0.3.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Stub of the C library Antic. Algebraic number"
+maintainer: ["François Bobot"]
+authors: ["François Bobot"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/bobot/ocaml-flint"
+bug-reports: "https://github.com/bobot/ocaml-flint/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "conf-antic"
+  "flint" {= version}
+  "ctypes" {>= "0.20.1"}
+  "conf-mpfr" {>= "3"}
+  "ocaml" {>= "4.10"}
+  "conf-pkg-config" {>= "2"}
+  "dune-configurator"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bobot/ocaml-flint.git"
+conflicts: [ "ocaml-option-bytecode-only" ]
+messages: [ "Problem with the installation of the external
+             libraries can be fixed using version 0.3 which
+             compile them locally" { failure } ]
+url {
+  src:
+    "https://github.com/bobot/ocaml-flint/releases/download/0.3.2/flint-0.3.2.tbz"
+  checksum: [
+    "sha256=1a8a1278631602a7d17d0fe665f6e6194520c894caf26162a0eff85a545d466c"
+    "sha512=b179c3c953b47e7495201631c38d906332306d51d8b2243083ddbb2ec971d735cc842b77385655c22a1e724bb3fe635ec541c3a31ed7da2c3d6559d440a2fd21"
+  ]
+}
+x-commit-hash: "32db5b129980a0a5b95aad260bfd57a2ed1142b1"

--- a/packages/arb/arb.0.3.2/opam
+++ b/packages/arb/arb.0.3.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Stub of the C library Arb. Ball approximation"
+maintainer: ["François Bobot"]
+authors: ["François Bobot"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/bobot/ocaml-flint"
+bug-reports: "https://github.com/bobot/ocaml-flint/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "conf-arb"
+  "flint" {= version}
+  "ctypes" {>= "0.20.1"}
+  "conf-mpfr" {>= "3"}
+  "ocaml" {>= "4.10"}
+  "conf-pkg-config" {>= "2"}
+  "dune-configurator"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bobot/ocaml-flint.git"
+conflicts: [ "ocaml-option-bytecode-only" ]
+messages: [ "Problem with the installation of the external
+             libraries can be fixed using version 0.3 which
+             compile them locally" { failure } ]
+url {
+  src:
+    "https://github.com/bobot/ocaml-flint/releases/download/0.3.2/flint-0.3.2.tbz"
+  checksum: [
+    "sha256=1a8a1278631602a7d17d0fe665f6e6194520c894caf26162a0eff85a545d466c"
+    "sha512=b179c3c953b47e7495201631c38d906332306d51d8b2243083ddbb2ec971d735cc842b77385655c22a1e724bb3fe635ec541c3a31ed7da2c3d6559d440a2fd21"
+  ]
+}
+x-commit-hash: "32db5b129980a0a5b95aad260bfd57a2ed1142b1"

--- a/packages/calcium/calcium.0.3.2/opam
+++ b/packages/calcium/calcium.0.3.2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis:
+  "Stub of the C library Antic. For exact computation with real and complex numbers, presently in early development"
+maintainer: ["François Bobot"]
+authors: ["François Bobot"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/bobot/ocaml-flint"
+bug-reports: "https://github.com/bobot/ocaml-flint/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "conf-calcium"
+  "zarith" {>= "1.12"}
+  "flint" {= version}
+  "arb" {= version}
+  "antic" {= version}
+  "ctypes" {>= "0.20.1"}
+  "conf-mpfr" {>= "3"}
+  "dune-site" {with-test}
+  "ocaml" {>= "4.10"}
+  "conf-pkg-config" {>= "2"}
+  "dune-configurator"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bobot/ocaml-flint.git"
+conflicts: [ "ocaml-option-bytecode-only" ]
+messages: [ "Problem with the installation of the external
+             libraries can be fixed using version 0.3 which
+             compile them locally" { failure } ]
+url {
+  src:
+    "https://github.com/bobot/ocaml-flint/releases/download/0.3.2/flint-0.3.2.tbz"
+  checksum: [
+    "sha256=1a8a1278631602a7d17d0fe665f6e6194520c894caf26162a0eff85a545d466c"
+    "sha512=b179c3c953b47e7495201631c38d906332306d51d8b2243083ddbb2ec971d735cc842b77385655c22a1e724bb3fe635ec541c3a31ed7da2c3d6559d440a2fd21"
+  ]
+}
+x-commit-hash: "32db5b129980a0a5b95aad260bfd57a2ed1142b1"

--- a/packages/flint/flint.0.3.2/opam
+++ b/packages/flint/flint.0.3.2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Stub of the C library Flint2"
+maintainer: ["François Bobot"]
+authors: ["François Bobot"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/bobot/ocaml-flint"
+bug-reports: "https://github.com/bobot/ocaml-flint/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "conf-flint"
+  "zarith" {>= "1.12"}
+  "ctypes" {>= "0.20.1"}
+  "conf-mpfr" {>= "3"}
+  "dune-site" {with-test}
+  "ocaml" {>= "4.10"}
+  "conf-pkg-config" {>= "2"}
+  "dune-configurator"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bobot/ocaml-flint.git"
+conflicts: [ "ocaml-option-bytecode-only" ]
+messages: [ "Problem with the installation of the external
+             libraries can be fixed using version 0.3 which
+             compile them locally" { failure } ]
+url {
+  src:
+    "https://github.com/bobot/ocaml-flint/releases/download/0.3.2/flint-0.3.2.tbz"
+  checksum: [
+    "sha256=1a8a1278631602a7d17d0fe665f6e6194520c894caf26162a0eff85a545d466c"
+    "sha512=b179c3c953b47e7495201631c38d906332306d51d8b2243083ddbb2ec971d735cc842b77385655c22a1e724bb3fe635ec541c3a31ed7da2c3d6559d440a2fd21"
+  ]
+}
+x-commit-hash: "32db5b129980a0a5b95aad260bfd57a2ed1142b1"


### PR DESCRIPTION
Stub of the C library Flint2

- Project page: <a href="https://github.com/bobot/ocaml-flint">https://github.com/bobot/ocaml-flint</a>

##### CHANGES:

  - Bump to dune 3.7 using ctypes stanza 0.3
