### PR TITLE
Package pds-reachability.0.2.3

### DIFF
--- a/packages/pds-reachability/pds-reachability.0.2.3/opam
+++ b/packages/pds-reachability/pds-reachability.0.2.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "A PDS reachability query library"
+description:
+  "This library performs efficient reachability queries on abstractly specified push-down systems."
+maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
+authors: "JHU PL Lab <pl.cs@jhu.edu>"
+license: "Apache-2.0"
+homepage: "https://github.com/JHU-PL-Lab/pds-reachability"
+bug-reports: "https://github.com/JHU-PL-Lab/pds-reachability/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "base-threads"
+  "batteries" {>= "3.0"}
+  "dune" {>= "1.4"}
+  "jhupllib" {>= "0.3"}
+  "ocaml-monadic" {>= "0.4.1"}
+  "ounit" {with-test}
+  "ppx_deriving" {>= "3.2"}
+  "ppx_deriving_yojson" {>= "2.1"}
+  "yojson" {>= "1.7.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/JHU-PL-Lab/pds-reachability.git"
+url {
+  src:
+    "http://github.com/JHU-PL-Lab/pds-reachability/archive/c13876200efddbfd4248c4b8137d9109f46cf8ae.zip"
+  checksum: [
+    "md5=e39c457a945cc4c42953502a1e56f14b"
+    "sha512=325e3e7f6eae417d4452e65360eeb756fc68f93bb4b842f2b2b5c9d02416e4e7c00f96b6f0ac051b287b7bf42a99cdab32188f64eaa7d9d424ade6567816d323"
+  ]
+}


### PR DESCRIPTION
### `pds-reachability.0.2.3`
A PDS reachability query library
This library performs efficient reachability queries on abstractly specified push-down systems.



---
* Homepage: https://github.com/JHU-PL-Lab/pds-reachability
* Source repo: git+https://github.com/JHU-PL-Lab/pds-reachability.git
* Bug tracker: https://github.com/JHU-PL-Lab/pds-reachability/issues

---
:camel: Pull-request generated by opam-publish v2.2.0