### PR TITLE
Colibri2 0.3.3 is not compatible with ocaml 5.1

### DIFF
--- a/packages/colibri2/colibri2.0.3.3/opam
+++ b/packages/colibri2/colibri2.0.3.3/opam
@@ -34,7 +34,7 @@ depends: [
   "calcium"
   "farith"
   "ounit2" {>= "2.2.4" & with-test}
-  "ocaml" {>= "4.12"}
+  "ocaml" {>= "4.12" & < "5.1"}
   "ocplib-simplex" {>= "0.4" & < "0.5"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Fails with
```
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -w +a-4-42-44-48-50-58-60-40-9@8 -color always -open Containers -g -bin-annot -I src_colibri2/stdlib/.colibri2_stdlib.objs/byte -I /home/opam/.opam/5.1/lib/antic -I /home/opam/.opam/5.1/lib/arb -I /home/opam/.opam/5.1/lib/base -I /home/opam/.opam/5.1/lib/base/base_internalhash_types -I /home/opam/.opam/5.1/lib/base/caml -I /home/opam/.opam/5.1/lib/base/shadow_stdlib -I /home/opam/.opam/5.1/lib/bigarray-compat -I /home/opam/.opam/5.1/lib/bytes -I /home/opam/.opam/5.1/lib/calcium -I /home/opam/.opam/5.1/lib/containers -I /home/opam/.opam/5.1/lib/containers/monomorphic -I /home/opam/.opam/5.1/lib/ctypes -I /home/opam/.opam/5.1/lib/ctypes/stubs -I /home/opam/.opam/5.1/lib/either -I /home/opam/.opam/5.1/lib/flint -I /home/opam/.opam/5.1/lib/fmt -I /home/opam/.opam/5.1/lib/integers -I /home/opam/.opam/5.1/lib/ocaml/str -I /home/opam/.opam/5.1/lib/ocaml/threads -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_deriving/runtime -I /home/opam/.opam/5.1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.1/lib/qcheck-core -I /home/opam/.opam/5.1/lib/result -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/stdlib-shims -I /home/opam/.opam/5.1/lib/zarith -I src_colibri2/popop_lib/.colibri2_popop_lib.objs/byte -intf-suffix .ml -no-alias-deps -open Colibri2_stdlib -o src_colibri2/stdlib/.colibri2_stdlib.objs/byte/colibri2_stdlib__Comp_keys.cmo -c -impl src_colibri2/stdlib/comp_keys.pp.ml)
# File "src_colibri2/stdlib/comp_keys.ml", line 124, characters 13-29:
# 124 |   module K = Strings.Fresh ()
#                    ^^^^^^^^^^^^^^^^
# Error: The functor was expected to be applicative at this position
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -w +a-4-42-44-48-50-58-60-40-9@8 -color always -open Containers -open Colibri2_stdlib -open Std -g -bin-annot -I src_colibri2/core/.colibri2_core.objs/byte -I src_colibri2/core/.colibri2_core.objs/public_cmi -I /home/opam/.opam/5.1/lib/antic -I /home/opam/.opam/5.1/lib/arb -I /home/opam/.opam/5.1/lib/base -I /home/opam/.opam/5.1/lib/base/base_internalhash_types -I /home/opam/.opam/5.1/lib/base/caml -I /home/opam/.opam/5.1/lib/base/shadow_stdlib -I /home/opam/.opam/5.1/lib/bigarray-compat -I /home/opam/.opam/5.1/lib/bytes -I /home/opam/.opam/5.1/lib/calcium -I /home/opam/.opam/5.1/lib/cmdliner -I /home/opam/.opam/5.1/lib/containers -I /home/opam/.opam/5.1/lib/containers/monomorphic -I /home/opam/.opam/5.1/lib/ctypes -I /home/opam/.opam/5.1/lib/ctypes/stubs -I /home/opam/.opam/5.1/lib/dolmen -I /home/opam/.opam/5.1/lib/dolmen/ae -I /home/opam/.opam/5.1/lib/dolmen/class -I /home/opam/.opam/5.1/lib/dolmen/dimacs -I /home/opam/.opam/5.1/lib/dolmen/icnf -I /home/opam/.opam/5.1/lib/dolmen/intf -I /home/opam/.opam/5.1/lib/dolmen/line -I /home/opam/.opam/5.1/lib/dolmen/smtlib2 -I /home/opam/.opam/5.1/lib/dolmen/smtlib2/poly -I /home/opam/.opam/5.1/lib/dolmen/smtlib2/v6 -I /home/opam/.opam/5.1/lib/dolmen/std -I /home/opam/.opam/5.1/lib/dolmen/tptp -I /home/opam/.opam/5.1/lib/dolmen/tptp/v6_3_0 -I /home/opam/.opam/5.1/lib/dolmen/zf -I /home/opam/.opam/5.1/lib/dolmen_loop -I /home/opam/.opam/5.1/lib/dolmen_type -I /home/opam/.opam/5.1/lib/either -I /home/opam/.opam/5.1/lib/flint -I /home/opam/.opam/5.1/lib/fmt -I /home/opam/.opam/5.1/lib/gen -I /home/opam/.opam/5.1/lib/integers -I /home/opam/.opam/5.1/lib/menhirLib -I /home/opam/.opam/5.1/lib/ocaml/str -I /home/opam/.opam/5.1/lib/ocaml/threads -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/ocamlgraph -I /home/opam/.opam/5.1/lib/pp_loc -I /home/opam/.opam/5.1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_deriving/runtime -I /home/opam/.opam/5.1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.1/lib/qcheck-core -I /home/opam/.opam/5.1/lib/result -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/spelll -I /home/opam/.opam/5.1/lib/stdlib-shims -I /home/opam/.opam/5.1/lib/uutf -I /home/opam/.opam/5.1/lib/zarith -I src_colibri2/popop_lib/.colibri2_popop_lib.objs/byte -I src_colibri2/stdlib/.colibri2_stdlib.objs/byte -intf-suffix .ml -no-alias-deps -open Colibri2_core__ -o src_colibri2/core/.colibri2_core.objs/byte/colibri2_core__Nodes.cmo -c -impl src_colibri2/core/nodes.pp.ml)
# File "src_colibri2/core/nodes.ml", line 34, characters 20-37:
# 34 | module ThTermKind = Keys.Make_key2 ()
#                          ^^^^^^^^^^^^^^^^^
# Error: The functor was expected to be applicative at this position
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -w +a-4-42-44-48-50-58-60-40-9@8 -color always -open Containers -open Colibri2_stdlib -open Std -g -bin-annot -I src_colibri2/core/.colibri2_core.objs/byte -I src_colibri2/core/.colibri2_core.objs/public_cmi -I /home/opam/.opam/5.1/lib/antic -I /home/opam/.opam/5.1/lib/arb -I /home/opam/.opam/5.1/lib/base -I /home/opam/.opam/5.1/lib/base/base_internalhash_types -I /home/opam/.opam/5.1/lib/base/caml -I /home/opam/.opam/5.1/lib/base/shadow_stdlib -I /home/opam/.opam/5.1/lib/bigarray-compat -I /home/opam/.opam/5.1/lib/bytes -I /home/opam/.opam/5.1/lib/calcium -I /home/opam/.opam/5.1/lib/cmdliner -I /home/opam/.opam/5.1/lib/containers -I /home/opam/.opam/5.1/lib/containers/monomorphic -I /home/opam/.opam/5.1/lib/ctypes -I /home/opam/.opam/5.1/lib/ctypes/stubs -I /home/opam/.opam/5.1/lib/dolmen -I /home/opam/.opam/5.1/lib/dolmen/ae -I /home/opam/.opam/5.1/lib/dolmen/class -I /home/opam/.opam/5.1/lib/dolmen/dimacs -I /home/opam/.opam/5.1/lib/dolmen/icnf -I /home/opam/.opam/5.1/lib/dolmen/intf -I /home/opam/.opam/5.1/lib/dolmen/line -I /home/opam/.opam/5.1/lib/dolmen/smtlib2 -I /home/opam/.opam/5.1/lib/dolmen/smtlib2/poly -I /home/opam/.opam/5.1/lib/dolmen/smtlib2/v6 -I /home/opam/.opam/5.1/lib/dolmen/std -I /home/opam/.opam/5.1/lib/dolmen/tptp -I /home/opam/.opam/5.1/lib/dolmen/tptp/v6_3_0 -I /home/opam/.opam/5.1/lib/dolmen/zf -I /home/opam/.opam/5.1/lib/dolmen_loop -I /home/opam/.opam/5.1/lib/dolmen_type -I /home/opam/.opam/5.1/lib/either -I /home/opam/.opam/5.1/lib/flint -I /home/opam/.opam/5.1/lib/fmt -I /home/opam/.opam/5.1/lib/gen -I /home/opam/.opam/5.1/lib/integers -I /home/opam/.opam/5.1/lib/menhirLib -I /home/opam/.opam/5.1/lib/ocaml/str -I /home/opam/.opam/5.1/lib/ocaml/threads -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/ocamlgraph -I /home/opam/.opam/5.1/lib/pp_loc -I /home/opam/.opam/5.1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_deriving/runtime -I /home/opam/.opam/5.1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.1/lib/qcheck-core -I /home/opam/.opam/5.1/lib/result -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/spelll -I /home/opam/.opam/5.1/lib/stdlib-shims -I /home/opam/.opam/5.1/lib/uutf -I /home/opam/.opam/5.1/lib/zarith -I src_colibri2/popop_lib/.colibri2_popop_lib.objs/byte -I src_colibri2/stdlib/.colibri2_stdlib.objs/byte -intf-suffix .ml -no-alias-deps -open Colibri2_core__ -o src_colibri2/core/.colibri2_core.objs/byte/colibri2_core__Events.cmo -c -impl src_colibri2/core/events.pp.ml)
# File "src_colibri2/core/events.ml", line 23, characters 13-29:
# 23 | module Dem = Keys.Make_key ()
#                   ^^^^^^^^^^^^^^^^
# Error: The functor was expected to be applicative at this position
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -w +a-4-42-44-48-50-58-60-40-9@8 -color always -open Containers -open Colibri2_stdlib -open Std -g -bin-annot -I src_colibri2/core/.colibri2_core.objs/byte -I src_colibri2/core/.colibri2_core.objs/public_cmi -I /home/opam/.opam/5.1/lib/antic -I /home/opam/.opam/5.1/lib/arb -I /home/opam/.opam/5.1/lib/base -I /home/opam/.opam/5.1/lib/base/base_internalhash_types -I /home/opam/.opam/5.1/lib/base/caml -I /home/opam/.opam/5.1/lib/base/shadow_stdlib -I /home/opam/.opam/5.1/lib/bigarray-compat -I /home/opam/.opam/5.1/lib/bytes -I /home/opam/.opam/5.1/lib/calcium -I /home/opam/.opam/5.1/lib/cmdliner -I /home/opam/.opam/5.1/lib/containers -I /home/opam/.opam/5.1/lib/containers/monomorphic -I /home/opam/.opam/5.1/lib/ctypes -I /home/opam/.opam/5.1/lib/ctypes/stubs -I /home/opam/.opam/5.1/lib/dolmen -I /home/opam/.opam/5.1/lib/dolmen/ae -I /home/opam/.opam/5.1/lib/dolmen/class -I /home/opam/.opam/5.1/lib/dolmen/dimacs -I /home/opam/.opam/5.1/lib/dolmen/icnf -I /home/opam/.opam/5.1/lib/dolmen/intf -I /home/opam/.opam/5.1/lib/dolmen/line -I /home/opam/.opam/5.1/lib/dolmen/smtlib2 -I /home/opam/.opam/5.1/lib/dolmen/smtlib2/poly -I /home/opam/.opam/5.1/lib/dolmen/smtlib2/v6 -I /home/opam/.opam/5.1/lib/dolmen/std -I /home/opam/.opam/5.1/lib/dolmen/tptp -I /home/opam/.opam/5.1/lib/dolmen/tptp/v6_3_0 -I /home/opam/.opam/5.1/lib/dolmen/zf -I /home/opam/.opam/5.1/lib/dolmen_loop -I /home/opam/.opam/5.1/lib/dolmen_type -I /home/opam/.opam/5.1/lib/either -I /home/opam/.opam/5.1/lib/flint -I /home/opam/.opam/5.1/lib/fmt -I /home/opam/.opam/5.1/lib/gen -I /home/opam/.opam/5.1/lib/integers -I /home/opam/.opam/5.1/lib/menhirLib -I /home/opam/.opam/5.1/lib/ocaml/str -I /home/opam/.opam/5.1/lib/ocaml/threads -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/ocamlgraph -I /home/opam/.opam/5.1/lib/pp_loc -I /home/opam/.opam/5.1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_deriving/runtime -I /home/opam/.opam/5.1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.1/lib/qcheck-core -I /home/opam/.opam/5.1/lib/result -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/spelll -I /home/opam/.opam/5.1/lib/stdlib-shims -I /home/opam/.opam/5.1/lib/uutf -I /home/opam/.opam/5.1/lib/zarith -I src_colibri2/popop_lib/.colibri2_popop_lib.objs/byte -I src_colibri2/stdlib/.colibri2_stdlib.objs/byte -intf-suffix .ml -no-alias-deps -open Colibri2_core__ -o src_colibri2/core/.colibri2_core.objs/byte/colibri2_core__Options.cmo -c -impl src_colibri2/core/options.pp.ml)
# File "src_colibri2/core/options.ml", line 1, characters 11-27:
# 1 | module K = Keys.Make_key ()
#                ^^^^^^^^^^^^^^^^
# Error: The functor was expected to be applicative at this position
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -w +a-4-42-44-48-50-58-60-40-9@8 -color always -open Containers -open Colibri2_stdlib -open Std -g -bin-annot -I src_colibri2/core/.colibri2_core.objs/byte -I src_colibri2/core/.colibri2_core.objs/public_cmi -I /home/opam/.opam/5.1/lib/antic -I /home/opam/.opam/5.1/lib/arb -I /home/opam/.opam/5.1/lib/base -I /home/opam/.opam/5.1/lib/base/base_internalhash_types -I /home/opam/.opam/5.1/lib/base/caml -I /home/opam/.opam/5.1/lib/base/shadow_stdlib -I /home/opam/.opam/5.1/lib/bigarray-compat -I /home/opam/.opam/5.1/lib/bytes -I /home/opam/.opam/5.1/lib/calcium -I /home/opam/.opam/5.1/lib/cmdliner -I /home/opam/.opam/5.1/lib/containers -I /home/opam/.opam/5.1/lib/containers/monomorphic -I /home/opam/.opam/5.1/lib/ctypes -I /home/opam/.opam/5.1/lib/ctypes/stubs -I /home/opam/.opam/5.1/lib/dolmen -I /home/opam/.opam/5.1/lib/dolmen/ae -I /home/opam/.opam/5.1/lib/dolmen/class -I /home/opam/.opam/5.1/lib/dolmen/dimacs -I /home/opam/.opam/5.1/lib/dolmen/icnf -I /home/opam/.opam/5.1/lib/dolmen/intf -I /home/opam/.opam/5.1/lib/dolmen/line -I /home/opam/.opam/5.1/lib/dolmen/smtlib2 -I /home/opam/.opam/5.1/lib/dolmen/smtlib2/poly -I /home/opam/.opam/5.1/lib/dolmen/smtlib2/v6 -I /home/opam/.opam/5.1/lib/dolmen/std -I /home/opam/.opam/5.1/lib/dolmen/tptp -I /home/opam/.opam/5.1/lib/dolmen/tptp/v6_3_0 -I /home/opam/.opam/5.1/lib/dolmen/zf -I /home/opam/.opam/5.1/lib/dolmen_loop -I /home/opam/.opam/5.1/lib/dolmen_type -I /home/opam/.opam/5.1/lib/either -I /home/opam/.opam/5.1/lib/flint -I /home/opam/.opam/5.1/lib/fmt -I /home/opam/.opam/5.1/lib/gen -I /home/opam/.opam/5.1/lib/integers -I /home/opam/.opam/5.1/lib/menhirLib -I /home/opam/.opam/5.1/lib/ocaml/str -I /home/opam/.opam/5.1/lib/ocaml/threads -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/ocamlgraph -I /home/opam/.opam/5.1/lib/pp_loc -I /home/opam/.opam/5.1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_deriving/runtime -I /home/opam/.opam/5.1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.1/lib/qcheck-core -I /home/opam/.opam/5.1/lib/result -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/spelll -I /home/opam/.opam/5.1/lib/stdlib-shims -I /home/opam/.opam/5.1/lib/uutf -I /home/opam/.opam/5.1/lib/zarith -I src_colibri2/popop_lib/.colibri2_popop_lib.objs/byte -I src_colibri2/stdlib/.colibri2_stdlib.objs/byte -no-alias-deps -open Colibri2_core__ -o src_colibri2/core/.colibri2_core.objs/byte/colibri2_core__Expr.cmo -c -impl src_colibri2/core/expr.pp.ml)
# File "src_colibri2/core/expr.pp.ml", line 1:
# Warning 70 [missing-mli]: Cannot find interface file.
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlopt.opt -w -40 -w +a-4-42-44-48-50-58-60-40-9@8 -color always -open Containers -g -O3 -bin-annot -unbox-closures -unbox-closures-factor 20 -I src_colibri2/stdlib/.colibri2_stdlib.objs/byte -I src_colibri2/stdlib/.colibri2_stdlib.objs/native -I /home/opam/.opam/5.1/lib/antic -I /home/opam/.opam/5.1/lib/arb -I /home/opam/.opam/5.1/lib/base -I /home/opam/.opam/5.1/lib/base/base_internalhash_types -I /home/opam/.opam/5.1/lib/base/caml -I /home/opam/.opam/5.1/lib/base/shadow_stdlib -I /home/opam/.opam/5.1/lib/bigarray-compat -I /home/opam/.opam/5.1/lib/bytes -I /home/opam/.opam/5.1/lib/calcium -I /home/opam/.opam/5.1/lib/containers -I /home/opam/.opam/5.1/lib/containers/monomorphic -I /home/opam/.opam/5.1/lib/ctypes -I /home/opam/.opam/5.1/lib/ctypes/stubs -I /home/opam/.opam/5.1/lib/either -I /home/opam/.opam/5.1/lib/flint -I /home/opam/.opam/5.1/lib/fmt -I /home/opam/.opam/5.1/lib/integers -I /home/opam/.opam/5.1/lib/ocaml/str -I /home/opam/.opam/5.1/lib/ocaml/threads -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_deriving/runtime -I /home/opam/.opam/5.1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.1/lib/qcheck-core -I /home/opam/.opam/5.1/lib/result -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/stdlib-shims -I /home/opam/.opam/5.1/lib/zarith -I src_colibri2/popop_lib/.colibri2_popop_lib.objs/byte -I src_colibri2/popop_lib/.colibri2_popop_lib.objs/native -intf-suffix .ml -no-alias-deps -open Colibri2_stdlib -o src_colibri2/stdlib/.colibri2_stdlib.objs/native/colibri2_stdlib__Comp_keys.cmx -c -impl src_colibri2/stdlib/comp_keys.pp.ml)
# File "src_colibri2/stdlib/comp_keys.ml", line 124, characters 13-29:
# 124 |   module K = Strings.Fresh ()
#                    ^^^^^^^^^^^^^^^^
# Error: The functor was expected to be applicative at this position
```