### PR TITLE
Package vscoq-language-server.2.0.2+coq8.18

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.0.2+coq8.18/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.0.2+coq8.18/opam
@@ -25,6 +25,7 @@ depends: [
   "sexplib"
   "ppx_yojson_conv"
   "ppx_import"
+  "result" { >= "1.5" }
   "lsp" { >= "1.15"}
   "sel" {>= "0.4.0"}
 ]

--- a/packages/vscoq-language-server/vscoq-language-server.2.0.2+coq8.18/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.0.2+coq8.18/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/coq-community/vscoq"
+bug-reports: "https://github.com/coq-community/vscoq/issues"
+dev-repo: "git+https://github.com/coq-community/vscoq"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { >= "4.13.1" }
+  "dune" { >= "3.2" }
+  "coq-core" { >= "8.18" < "8.19" }
+  "coq-stdlib" { >= "8.18" < "8.19" }
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_yojson_conv" {< "v0.16.0"}
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "lsp" { >= "1.15"}
+  "sel" {>= "0.4.0"}
+]
+synopsis: "VSCoq language server"
+description: """
+LSP based language server for Coq and its VSCoq user interface
+"""
+url {
+  src:
+    "https://github.com/coq-community/vscoq/releases/download/v2.0.2+coq8.18/vscoq-language-server-2.0.2-coq8.18.tar.gz"
+  checksum: [
+    "md5=8a4ff41372c157688170f0174e58d646"
+    "sha512=852f4e8cc7e687805e0707368a5625ef3c226d1373f677a731d32a04f8d0cb2f5d64ffdf350b0a5e446ff5075982dc36f2bc9d533d3862009f73fc22fd04fcc0"
+  ]
+}


### PR DESCRIPTION
### `vscoq-language-server.2.0.2+coq8.18`
VSCoq language server
LSP based language server for Coq and its VSCoq user interface



---
* Homepage: https://github.com/coq-community/vscoq
* Source repo: git+https://github.com/coq-community/vscoq
* Bug tracker: https://github.com/coq-community/vscoq/issues

---
:camel: Pull-request generated by opam-publish v2.0.3