### PR TITLE
[new release] mirage-logs (2.1.0)

### DIFF
--- a/packages/mirage-logs/mirage-logs.2.1.0/opam
+++ b/packages/mirage-logs/mirage-logs.2.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "talex5@gmail.com"
+authors: [ "Thomas Leonard" ]
+license: "ISC"
+homepage: "https://github.com/mirage/mirage-logs"
+dev-repo: "git+https://github.com/mirage/mirage-logs.git"
+bug-reports: "https://github.com/mirage/mirage-logs/issues"
+doc: "https://mirage.github.io/mirage-logs/"
+tags: ["org:mirage"]
+depends: [
+  "ocaml" { >= "4.08.0" }
+  "dune" {>= "3.0"}
+  "logs" { >= "0.5.0" }
+  "fmt" { >= "0.9.0" }
+  "ptime" { >= "0.8.1" }
+  "mirage-clock" { >= "3.0.0" }
+  "cmdliner" { >= "1.1.0" }
+  "lwt" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+synopsis: "A reporter for the Logs library that writes log messages to stderr, using a Mirage `CLOCK` to add timestamps"
+description: """
+The Logs reporter prefixes each entry with a timestamp, and writes it to stderr.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-logs/releases/download/v2.1.0/mirage-logs-2.1.0.tbz"
+  checksum: [
+    "sha256=ae8ac2b20c3b4024268e8b6be3ae4a4a140659da1433cf1d8e9c20ab00469cbb"
+    "sha512=36d3d418d9ba9491a6145dfe5a550a2f8f997586355340700bfc4d975157e7a32dbc62509f120522b2aea84dccd3c2341a869742d91fd4da2368c3c0d36ad4b7"
+  ]
+}
+x-commit-hash: "37ac8d8bcc7e41f9bf232f6efbd7b931b9cd0403"


### PR DESCRIPTION
A reporter for the Logs library that writes log messages to stderr, using a Mirage `CLOCK` to add timestamps

- Project page: <a href="https://github.com/mirage/mirage-logs">https://github.com/mirage/mirage-logs</a>
- Documentation: <a href="https://mirage.github.io/mirage-logs/">https://mirage.github.io/mirage-logs/</a>

##### CHANGES:

- use Logs.pp_level instead of a custom string_of_level (mirage/mirage-logs#23 @hannesm)
- avoid global buffer, reuse Logs_fmt.pp_header for color (mirage/mirage-logs#25 @hannesm,
  fixes mirage/mirage-logs#24)
