### PR TITLE
omd archive link update

### DIFF
--- a/packages/omd/omd.0.5/opam
+++ b/packages/omd/omd.0.5/opam
@@ -26,6 +26,6 @@ markdown features."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-0.5.tar.gz"
-  checksum: "md5=d343deacc270674828260b0fdc55f74c"
+  src: "https://github.com/pw374/omd/archive/refs/tags/0.5.tar.gz"
+  checksum: "md5=64e40582aa879f37c9867f0e10b6268e"
 }

--- a/packages/omd/omd.0.5/opam
+++ b/packages/omd/omd.0.5/opam
@@ -26,6 +26,6 @@ markdown features."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "https://github.com/pw374/omd/archive/refs/tags/0.5.tar.gz"
-  checksum: "md5=64e40582aa879f37c9867f0e10b6268e"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/0.5.tar.gz"
+  checksum: "sha256=fc462bf7b8f896f924fef610da436d9152168676adca2d606233101eb67e9432"
 }

--- a/packages/omd/omd.1.2.0/opam
+++ b/packages/omd/omd.1.2.0/opam
@@ -34,6 +34,6 @@ with 0.9.x."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.2.0.tar.gz"
-  checksum: "md5=2a1aa5144466a466e33b34de855bcd1c"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.2.0.tar.gz"
+  checksum: "sha256=180465a930f27be1bf82bb4709f900cad0d7c69820c0c4efa98573242287637e"
 }

--- a/packages/omd/omd.1.2.1/opam
+++ b/packages/omd/omd.1.2.1/opam
@@ -34,6 +34,6 @@ with 0.9.x."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.2.1.tar.gz"
-  checksum: "md5=6784ba3dbdd9b56029a8ef0509d61690"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.2.1.tar.gz"
+  checksum: "sha256=fc1aaa6a1ec16edcc7ec41bdb43c85434e3863f9c576c4dd97faa30ab2d77942"
 }

--- a/packages/omd/omd.1.2.2/opam
+++ b/packages/omd/omd.1.2.2/opam
@@ -32,6 +32,6 @@ package installs both the OMD library and the command line tool `omd`."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.2.2.tar.gz"
-  checksum: "md5=3a3599c3c8241323d4ab30124deedab4"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.2.2.tar.gz"
+  checksum: "sha256=29dcda616e8c5a348e4b98729043c29b74fdedc2ffa2c6409b919bc09a979528"
 }

--- a/packages/omd/omd.1.2.3/opam
+++ b/packages/omd/omd.1.2.3/opam
@@ -32,6 +32,6 @@ package installs both the OMD library and the command line tool `omd`."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.2.3.tar.gz"
-  checksum: "md5=31ed60d39aa0aaa337818fd62b56706b"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.2.3.tar.gz"
+  checksum: "sha256=d212f5ee5d964e715749bbd2b44c640c056d769cc75e1b0d17307dc8823ddf25"
 }

--- a/packages/omd/omd.1.2.4/opam
+++ b/packages/omd/omd.1.2.4/opam
@@ -32,6 +32,6 @@ package installs both the OMD library and the command line tool `omd`."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.2.4.tar.gz"
-  checksum: "md5=083a56364a7046c4be868ccd8cc0f487"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.2.4.tar.gz"
+  checksum: "sha256=b8dae556b973cb1b4373aa42aba37bdf4028aec36d1f9c0bb2d6949f562415f6"
 }


### PR DESCRIPTION
- another take of https://github.com/ocaml/opam-repository/pull/23600 (which seems to be inactive)
- will proceed to replace all versions with available tarballs and use software heritage for the else
