### PR TITLE
[new release] melange-atdgen-codec-runtime (1.0.0)

### DIFF
--- a/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.1.0.0/opam
+++ b/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.1.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "A Melange runtime for atdgen"
+description: """A Melange runtime for atdgen, based on the Js.Json.t type
+provided by Melange and the combinators from melange-json
+"""
+maintainer: "Ahrefs"
+authors: "Ahrefs"
+license: "MIT"
+homepage: "https://github.com/ahrefs/melange-atdgen-codec-runtime"
+bug-reports: "https://github.com/ahrefs/melange-atdgen-codec-runtime/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml"
+  "melange" {>= "2.0.0"}
+  "atd"
+  "atdgen"
+  "melange-json"
+  "melange-jest" {with-test}
+  "reason" {with-test}
+  "opam-check-npm-deps" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/melange-atdgen-codec-runtime.git"
+url {
+  src:
+    "https://github.com/ahrefs/melange-atdgen-codec-runtime/releases/download/1.0.0/melange-atdgen-codec-runtime-1.0.0.tbz"
+  checksum: [
+    "sha256=bc922594a417889050d18cb53401e15f684572c8a3984a2931b74d3894789fe6"
+    "sha512=a8198aafd146217739c7e27a711c9d29c87c19dd64fcf46554714be23e45c6a6d87f8e98e5227133d3be77c6e6dadc512989f615b82009921209341553a1116b"
+  ]
+}
+x-commit-hash: "3ce0d2bd7c5b03f6240257a25a78e9dc05246cc3"

--- a/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.1.0.0/opam
+++ b/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.1.0.0/opam
@@ -30,7 +30,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
A Melange runtime for atdgen

- Project page: <a href="https://github.com/ahrefs/melange-atdgen-codec-runtime">https://github.com/ahrefs/melange-atdgen-codec-runtime</a>

##### CHANGES:

Initial release.

Migrated to Melange v2.
