### PR TITLE
Deprecate ocaml-migrate-parsetree

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.6/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.6/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -33,6 +34,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""
 url {

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.6/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.6/opam
@@ -35,6 +35,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.7/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.7/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -33,6 +34,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""
 url {

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.7/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.7/opam
@@ -35,6 +35,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.1/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.1/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -22,6 +23,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""
 url {

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.1/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.1/opam
@@ -24,6 +24,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.10/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.10/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.10/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.10/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""
 url {

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.11/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.11/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -23,6 +24,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""
 url {

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.11/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.11/opam
@@ -25,6 +25,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.2/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.2/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.2/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.2/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""
 url {

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.3/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.3/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.3/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.3/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""
 url {

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.4/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.4/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.4/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.4/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""
 url {

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.5/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.5/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.5/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.5/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""
 url {

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.6/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.6/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.6/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.6/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""
 url {

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.7/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.7/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.7/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.7/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""
 url {

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.8/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.8/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.8/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.8/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""
 url {

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.9/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.9/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.9/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.9/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""
 url {

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -33,6 +34,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""
 url {

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0/opam
@@ -35,6 +35,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
 High-level functions help making PPX rewriters independent of a compiler version."""

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions 
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.1.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions 
 
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.2.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.2.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.2.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.2.0/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0~4.08.0+beta2/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0~4.08.0+beta2/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -25,6 +26,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0~4.08.0+beta2/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0~4.08.0+beta2/opam
@@ -27,6 +27,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0~4.08.0+beta3/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0~4.08.0+beta3/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -25,6 +26,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0~4.08.0+beta3/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.0~4.08.0+beta3/opam
@@ -27,6 +27,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.1/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.1/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.1/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.3.1/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.4.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.4.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.4.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.4.0/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.5.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.5.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.5.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.5.0/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.6.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.6.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.6.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.6.0/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.1/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.1/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.1/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.1/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.2/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.2/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.2/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.2/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.3/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.3/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.3/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.7.3/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.8.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.8.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -24,6 +25,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.8.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.8.0/opam
@@ -26,6 +26,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.0.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.0.0/opam
@@ -24,6 +24,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.0.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.0.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -22,6 +23,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.1.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.1.0/opam
@@ -24,6 +24,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.1.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.1.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -22,6 +23,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.2.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.2.0/opam
@@ -24,6 +24,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.2.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.2.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -22,6 +23,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.3.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.3.0/opam
@@ -24,6 +24,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.3.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.3.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -22,6 +23,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.4.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.4.0/opam
@@ -24,6 +24,7 @@ conflicts: [
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
 Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
 
 Convert OCaml parsetrees between different versions
 

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.4.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.4.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -22,6 +23,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between


### PR DESCRIPTION
Hello :wave:

I'm deprecating ocaml-migrate-parsetree. I think this time, the whole community is behind it. I wrote a [discuss post](https://discuss.ocaml.org/t/rfc-deprecating-ocaml-migrate-parsetree-in-favor-of-ppxlib-also-as-a-platform-tool/13240) about deprecating it and nobody has commented on it.

I've added `flags: deprecated` and a note in the description in all opam packages. If you'd like me to do something else, such as a `post-message`, please let me know.