### PR TITLE
conf-python-3 - update freebsd python packages

### DIFF
--- a/packages/conf-python-3/conf-python-3.1.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.1.0.0/opam
@@ -17,7 +17,7 @@ depexts: [
   ["dev-lang/python:3.6"] {os-distribution = "gentoo"}
   ["python3"] {os = "openbsd"}
   ["lang/python36"] {os = "netbsd"}
-  ["lang/python36"] {os = "freebsd"}
+  ["python3"] {os = "freebsd"}
   ["python36"] {os-distribution = "macports" & os = "macos"}
   ["python@3"] {os-distribution = "homebrew" & os = "macos"}
   ["system:python3"] {os-distribution = "cygwinports"}

--- a/packages/conf-python-3/conf-python-3.9.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.9.0.0/opam
@@ -17,7 +17,7 @@ depexts: [
   ["dev-lang/python:3.6"] {os-distribution = "gentoo"}
   ["python3"] {os = "openbsd"}
   ["lang/python39"] {os = "netbsd"}
-  ["lang/python39"] {os = "freebsd"}
+  ["python39"] {os = "freebsd"}
   ["python39"] {os-distribution = "macports" & os = "macos"}
   ["python@3"] {os-distribution = "homebrew" & os = "macos"}
   ["system:python3"] {os-distribution = "cygwinports"}

--- a/packages/conf-python-3/conf-python-3.9.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.9.0.0/opam
@@ -4,7 +4,10 @@ homepage: "https://www.python.org/downloads/release/python-3910/"
 authors: "Python Software Foundation"
 license: "PSF-2.0"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-build: ["python3" "test.py"]
+build: [
+  ["python3" "test.py"] {os != "freebsd"}
+  ["python3" "test.py"] {os = "freebsd"}
+]
 depexts: [
   ["python3"] {os-family = "debian"}
   ["python3"] {os-distribution = "nixos"}
@@ -31,4 +34,3 @@ python-3.9 will be used.
 """
 extra-files: ["test.py" "md5=db8829ab1f4aa1fc15f380afba9d01f5"]
 flags: conf
-available: os != "freebsd" # conf-python-3.1.0.0 will be used instead

--- a/packages/conf-python-3/conf-python-3.9.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.9.0.0/opam
@@ -4,11 +4,7 @@ homepage: "https://www.python.org/downloads/release/python-3910/"
 authors: "Python Software Foundation"
 license: "PSF-2.0"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-build: [
-  ["python3" "test.py"] {os != "freebsd"}
-  ["python3.9" "test.py"] {os = "freebsd"}
-]
-available: os != "freebsd" # conf-python-3.1.0.0 will be used instead
+build: ["python3" "test.py"]
 depexts: [
   ["python3"] {os-family = "debian"}
   ["python3"] {os-distribution = "nixos"}
@@ -21,8 +17,8 @@ depexts: [
   ["dev-lang/python:3.6"] {os-distribution = "gentoo"}
   ["python3"] {os = "openbsd"}
   ["lang/python39"] {os = "netbsd"}
-  ["lang/python39"] {os = "freebsd"} # this will not result in a python3 command but only a python3.9 command
-  ["python39"] {os-distribution = "macports" & os = "macos"}
+  ["python3"] {os = "freebsd"}
+  ["python39"] {os-distribution = "macports" & os = "macos"}  # this will not result in a python3 command but only a python3.9 command
   ["python@3"] {os-distribution = "homebrew" & os = "macos"}
   ["system:python3"] {os-distribution = "cygwinports"}
 ]

--- a/packages/conf-python-3/conf-python-3.9.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.9.0.0/opam
@@ -6,7 +6,7 @@ license: "PSF-2.0"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
   ["python3" "test.py"] {os != "freebsd"}
-  ["python3" "test.py"] {os = "freebsd"}
+  ["python3.9" "test.py"] {os = "freebsd"}
 ]
 depexts: [
   ["python3"] {os-family = "debian"}

--- a/packages/conf-python-3/conf-python-3.9.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.9.0.0/opam
@@ -17,7 +17,7 @@ depexts: [
   ["dev-lang/python:3.6"] {os-distribution = "gentoo"}
   ["python3"] {os = "openbsd"}
   ["lang/python39"] {os = "netbsd"}
-  ["python39"] {os = "freebsd"}
+  ["lang/python39"] {os = "freebsd"} # this will not result in a python3 command but only a python3.9 command
   ["python39"] {os-distribution = "macports" & os = "macos"}
   ["python@3"] {os-distribution = "homebrew" & os = "macos"}
   ["system:python3"] {os-distribution = "cygwinports"}
@@ -31,3 +31,4 @@ python-3.9 will be used.
 """
 extra-files: ["test.py" "md5=db8829ab1f4aa1fc15f380afba9d01f5"]
 flags: conf
+available: os != "freebsd" # conf-python-3.1.0.0 will be used instead

--- a/packages/conf-python-3/conf-python-3.9.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.9.0.0/opam
@@ -8,6 +8,7 @@ build: [
   ["python3" "test.py"] {os != "freebsd"}
   ["python3.9" "test.py"] {os = "freebsd"}
 ]
+available: os != "freebsd" # conf-python-3.1.0.0 will be used instead
 depexts: [
   ["python3"] {os-family = "debian"}
   ["python3"] {os-distribution = "nixos"}


### PR DESCRIPTION
- package conf-python-3.1.0.0: change freebsd python package to python3 from lang/python36
  - lang/python36 is no longer available in freebsd ports
- package conf-python-3.9.0.0: change freebsd python package to python39 from lang/python39
  - to trigger CI rebuild to see why ↓failed
- this PR is prompted by a recent CI failure: https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/2af04d7e6e57970975fc614d724f3c44bdb59683/variant/freebsd,freebsd-ocaml-4.14-amd64,atdpy.2.14.1,tests
  - `tests (failed: conf-python-3.9.0.0 failed to build)`
  - (for PR https://github.com/ocaml/opam-repository/pull/24651)

```
The following actions will be performed:
=== recompile 1 package
  ↻ atdpy              2.14.1 (pinned)
=== install 10 packages
  ∗ alcotest           1.7.0           [required by atdpy]
  ∗ astring            0.8.5           [required by alcotest]
  ∗ conf-python-3      9.0.0           [required by atdpy]
  ∗ fmt                0.9.0           [required by alcotest]
  ∗ ocaml-syntax-shims 1.0.0           [required by alcotest]
  ∗ ocamlbuild         0.14.2          [required by fmt, astring, uutf]
  ∗ ocamlfind          1.9.6           [required by fmt, astring, uutf]
  ∗ stdlib-shims       0.3.0           [required by alcotest]
  ∗ topkg              1.0.7           [required by fmt, astring, uutf]
  ∗ uutf               1.0.3           [required by alcotest]

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
⬇ retrieved alcotest.1.7.0  (https://github.com/mirage/alcotest/releases/download/1.7.0/alcotest-1.7.0.tbz)
⬇ retrieved astring.0.8.5  (https://erratique.ch/software/astring/releases/astring-0.8.5.tbz)

#=== ERROR while compiling conf-python-3.9.0.0 ================================#
"python3": command not found.


<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
┌─ The following actions failed
│ ⬇ fetch fmt           0.9.0
│ λ build conf-python-3 9.0.0
└─ 
╶─ No changes have been performed
```