### PR TITLE
[new release] melange-recharts (4.0.0)

### DIFF
--- a/packages/melange-recharts/melange-recharts.4.0.0/opam
+++ b/packages/melange-recharts/melange-recharts.4.0.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Melange bindings for recharts"
+description: "Melange bindings for recharts JavaScript library."
+maintainer: [
+  "Liubomyr Mykhalchenko <liubomyr.mykhalchenko@ahrefs.com>"
+]
+authors: [
+  "Liubomyr Mykhalchenko <liubomyr.mykhalchenko@ahrefs.com>"
+]
+license: "MIT"
+tags: ["melange" "org:ahrefs"]
+homepage: "https://github.com/ahrefs/melange-recharts/"
+bug-reports: "https://github.com/ahrefs/melange-recharts/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml"
+  "melange" {>= "2.0.0"}
+  "reason" {>= "3.10.0"}
+  "reason-react"
+  "reason-react-ppx"
+  "ocaml-lsp-server" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/melange-recharts.git"
+depexts: [
+  ["recharts"] {npm-version = "^2.1.12"}
+]
+url {
+  src:
+    "https://github.com/ahrefs/melange-recharts/releases/download/4.0.0/melange-recharts-4.0.0.tbz"
+  checksum: [
+    "sha256=644be0eb66ad09460efaf6e045034276b7a8f5c0714c3e6a82e8067ebcefeb50"
+    "sha512=8469cccee493f590df6b6450c496527581d4206bb4aac5a9715ec9532808b4d1cdce0f36539b4592ed5040c3ebfd03e75952c37410e89f4c4eb6480d950875ab"
+  ]
+}
+x-commit-hash: "bfef1a21bd9e11b1c39493f435e6332fca2d09a5"


### PR DESCRIPTION
Melange bindings for recharts

- Project page: <a href="https://github.com/ahrefs/melange-recharts/">https://github.com/ahrefs/melange-recharts/</a>

##### CHANGES:

- Migrate to Melange v2.
