### PR TITLE
[update] melange-numeral, remove unused dep

### DIFF
--- a/packages/melange-numeral/melange-numeral.0.0.1/opam
+++ b/packages/melange-numeral/melange-numeral.0.0.1/opam
@@ -18,7 +18,6 @@ depends: [
   "dune" {>= "3.8"}
   "melange" {>= "2.0.0"}
   "reason" {>= "3.10.0"}
-  "opam-check-npm-deps" {with-dev-setup}
   "ocaml-lsp-server" {with-dev-setup}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Turns out this package is not using this dep, thanks @haochenx for pointing it out in https://github.com/ocaml/opam-repository/pull/24656#discussion_r1368995319.