### PR TITLE
Release three Ortac packages 0.1.0

### DIFF
--- a/packages/ortac-core/ortac-core.0.1.0/opam
+++ b/packages/ortac-core/ortac-core.0.1.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis:
+  "Ortac (OCaml Runtime Assertion Checking) core tool and library based on Gospel"
+description: """\
+Ortac (OCaml Runtime Assertion Checking) is a tool to turn
+executable Gospel specifications into code to test they hold.
+
+Ortac Core provides:
+- a library to turn Gospel terms and types into OCaml expressions
+  and types,
+- and a command-line tool.
+You will need at least one of the Ortac plugins to actually
+generate test code."""
+maintainer: "Clément Pascutto <clement@pascutto.fr>"
+authors: [
+  "Clément Pascutto <clement@pascutto.fr>"
+  "Nicolas Osborne <nicolas.osborne@tarides.com>"
+  "Samuel Hym <samuel.hym@rustyne.lautre.net>"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-gospel/ortac"
+doc: "https://ocaml-gospel.github.io/ortac/ortac-core/"
+bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "3.8"}
+  "dune-site"
+  "cmdliner" {>= "1.1.0"}
+  "fmt"
+  "ppxlib" {>= "0.26.0"}
+  "gospel" {>= "0.2.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "ortac-runtime" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-gospel/ortac.git"
+url {
+  src: "https://github.com/ocaml-gospel/ortac/archive/refs/tags/0.1.0.tar.gz"
+  checksum: [
+    "md5=665760e43919a9da2b33bb896033b011"
+    "sha512=f1f45cd3534ca040eb7e0f0f86c6c905a972d5ff7918946f1a8f04fa7c9947def46b3ede68fa0c2297706832a807389c2964f9bfd8d40bcd06acdf5e3004d57f"
+  ]
+}

--- a/packages/ortac-qcheck-stm/ortac-qcheck-stm.0.1.0/opam
+++ b/packages/ortac-qcheck-stm/ortac-qcheck-stm.0.1.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "QCheck-STM plugin for Ortac"
+description: """\
+The QCheck-STM plugin for the Ortac command-line tool (provided by
+the ortac-core package) can generate model-based tests for a module
+with Gospel specifications. The generated code will test that the
+function specifications hold by using the QCheck-STM library to
+create random test cases.
+
+Ortac (OCaml Runtime Assertion Checking) is a tool to turn
+executable Gospel specifications into code to test they hold."""
+maintainer: "Nicolas Osborne <nicolas.osborne@tarides.com>"
+authors: [
+  "Nicolas Osborne <nicolas.osborne@tarides.com>"
+  "Samuel Hym <samuel.hym@rustyne.lautre.net>"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-gospel/ortac"
+doc: "https://ocaml-gospel.github.io/ortac/ortac-qcheck-stm/"
+bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "3.8"}
+  "cmdliner" {>= "1.1.0"}
+  "fmt"
+  "ppxlib" {>= "0.26.0"}
+  "mdx" {with-test}
+  "gospel" {>= "0.2.0"}
+  "qcheck-core" {with-test}
+  "qcheck-stm" {with-test}
+  "qcheck-multicoretests-util" {with-test}
+  "ortac-core"
+  "ortac-runtime" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-gospel/ortac.git"
+conflicts: [
+  "result" { < "1.5" }
+]
+url {
+  src: "https://github.com/ocaml-gospel/ortac/archive/refs/tags/0.1.0.tar.gz"
+  checksum: [
+    "md5=665760e43919a9da2b33bb896033b011"
+    "sha512=f1f45cd3534ca040eb7e0f0f86c6c905a972d5ff7918946f1a8f04fa7c9947def46b3ede68fa0c2297706832a807389c2964f9bfd8d40bcd06acdf5e3004d57f"
+  ]
+}

--- a/packages/ortac-runtime/ortac-runtime.0.1.0/opam
+++ b/packages/ortac-runtime/ortac-runtime.0.1.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Runtime support library for Ortac-generated code"
+description: """\
+The ortac-runtime library provides support for the code generated
+by the various Ortac plugins.
+
+Ortac (OCaml Runtime Assertion Checking) is a tool to turn
+executable Gospel specifications into code to test they hold."""
+maintainer: "Clément Pascutto <clement@pascutto.fr>"
+authors: [
+  "Clément Pascutto <clement@pascutto.fr>"
+  "Nicolas Osborne <nicolas.osborne@tarides.com>"
+  "Samuel Hym <samuel.hym@rustyne.lautre.net>"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-gospel/ortac"
+doc: "https://ocaml-gospel.github.io/ortac/ortac-runtime/"
+bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.8"}
+  "fmt" {>= "0.8.7"}
+  "zarith"
+  "monolith" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-gospel/ortac.git"
+url {
+  src: "https://github.com/ocaml-gospel/ortac/archive/refs/tags/0.1.0.tar.gz"
+  checksum: [
+    "md5=665760e43919a9da2b33bb896033b011"
+    "sha512=f1f45cd3534ca040eb7e0f0f86c6c905a972d5ff7918946f1a8f04fa7c9947def46b3ede68fa0c2297706832a807389c2964f9bfd8d40bcd06acdf5e3004d57f"
+  ]
+}


### PR DESCRIPTION
The initial opam release of `ortac-core`, `ortac-runtime` and `ortac-qcheck-stm`.

Co-authored-by: Samuel Hym <samuel.hym@rustyne.lautre.net>
