### PR TITLE
[new release] melange-react-dates (1.4.0)

### DIFF
--- a/packages/melange-react-dates/melange-react-dates.1.4.0/opam
+++ b/packages/melange-react-dates/melange-react-dates.1.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Melange bindings for react-dates"
+maintainer: "Ahrefs"
+authors: "Ahrefs"
+license: "MIT"
+tags: ["melange" "react-js" "org:ahrefs"]
+homepage: "https://github.com/ahrefs/melange-react-dates"
+bug-reports: "https://github.com/ahrefs/melange-react-dates"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml"
+  "melange" {>= "2.0.0"}
+  "reason"
+  "melange-moment"
+  "reason-react"
+  "reason-react-ppx"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/melange-react-dates.git"
+depexts: [
+  ["react-dates"] {npm-version = "^21.8.0"}
+]
+url {
+  src:
+    "https://github.com/ahrefs/melange-react-dates/releases/download/1.4.0/melange-react-dates-1.4.0.tbz"
+  checksum: [
+    "sha256=f9ddf931b80f0618cddedd2b7334390fa74adf5d0f0b4f0429c95ce1a07db2cd"
+    "sha512=a277a81d7a95995ee1b4a5d7eced8b47b84acae9168a3fcf35880aed99610526cb849fb571faab25042c94c99bdde8dea6ca371c2e8398a1088051aa3e3ee365"
+  ]
+}
+x-commit-hash: "9cc13597a054ed3a5f657e4c090dc648c6d7087f"


### PR DESCRIPTION
Melange bindings for react-dates

- Project page: <a href="https://github.com/ahrefs/melange-react-dates">https://github.com/ahrefs/melange-react-dates</a>

##### CHANGES:

- Migrate to Melange v2
