### PR TITLE
[new release] printbox (3 packages) (0.7)

### DIFF
--- a/packages/printbox-html/printbox-html.0.7/opam
+++ b/packages/printbox-html/printbox-html.0.7/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Printbox unicode handling"
+description: """
+Adds html output handling to the printbox package.
+Printbox allows to print nested boxes, lists, arrays, tables in several formats
+"""
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "odoc" {with-doc}
+  "printbox" {= version}
+  "tyxml" {>="4.3"}
+  "mdx" {with-test & >= "1.4" }
+]
+license: "BSD-2-Clause"
+tags: [ "print" "box" "table" "tree" ]
+homepage: "https://github.com/c-cube/printbox/"
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+bug-reports: "https://github.com/c-cube/printbox/issues/"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.7/printbox-0.7.tbz"
+  checksum: [
+    "sha256=59271f9720bfe25e8bf884b38f1ba7fe161292faf6f895c89f71b615e5671737"
+    "sha512=77af5c0479a62f7e3df96267d0f5dc1315bdafcdaa2ded7bb2cbe4cab415c6310add696a45f8ae505f1ed51d509d4dd4d74000b5eae1f518c638afdaec95774d"
+  ]
+}
+x-commit-hash: "8a23ed1e54ca64183e2a47d96e6cdd02db3ffaaa"

--- a/packages/printbox-text/printbox-text.0.7/opam
+++ b/packages/printbox-text/printbox-text.0.7/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Text renderer for printbox, using unicode edges"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "base-bytes"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03" }
+  "printbox" { = version }
+  "uutf" { >= "1.0" }
+  "uucp" { >= "2.0" }
+  "mdx" {with-test & >= "1.4" }
+]
+license: "BSD-2-Clause"
+tags: [ "print" "box" "table" "tree" ]
+homepage: "https://github.com/c-cube/printbox/"
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+bug-reports: "https://github.com/c-cube/printbox/issues/"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.7/printbox-0.7.tbz"
+  checksum: [
+    "sha256=59271f9720bfe25e8bf884b38f1ba7fe161292faf6f895c89f71b615e5671737"
+    "sha512=77af5c0479a62f7e3df96267d0f5dc1315bdafcdaa2ded7bb2cbe4cab415c6310add696a45f8ae505f1ed51d509d4dd4d74000b5eae1f518c638afdaec95774d"
+  ]
+}
+x-commit-hash: "8a23ed1e54ca64183e2a47d96e6cdd02db3ffaaa"

--- a/packages/printbox-text/printbox-text.0.7/opam
+++ b/packages/printbox-text/printbox-text.0.7/opam
@@ -16,6 +16,7 @@ depends: [
   "uutf" { >= "1.0" }
   "uucp" { >= "2.0" }
   "mdx" {with-test & >= "1.4" }
+  "printbox-html" {with-test & post}
 ]
 license: "BSD-2-Clause"
 tags: [ "print" "box" "table" "tree" ]

--- a/packages/printbox/printbox.0.7/opam
+++ b/packages/printbox/printbox.0.7/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Allows to print nested boxes, lists, arrays, tables in several formats"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "base-bytes"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.08" }
+]
+license: "BSD-2-Clause"
+tags: [ "print" "box" "table" "tree" ]
+homepage: "https://github.com/c-cube/printbox/"
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+bug-reports: "https://github.com/c-cube/printbox/issues/"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.7/printbox-0.7.tbz"
+  checksum: [
+    "sha256=59271f9720bfe25e8bf884b38f1ba7fe161292faf6f895c89f71b615e5671737"
+    "sha512=77af5c0479a62f7e3df96267d0f5dc1315bdafcdaa2ded7bb2cbe4cab415c6310add696a45f8ae505f1ed51d509d4dd4d74000b5eae1f518c638afdaec95774d"
+  ]
+}
+x-commit-hash: "8a23ed1e54ca64183e2a47d96e6cdd02db3ffaaa"


### PR DESCRIPTION
Allows to print nested boxes, lists, arrays, tables in several formats

- Project page: <a href="https://github.com/c-cube/printbox/">https://github.com/c-cube/printbox/</a>

##### CHANGES:

## 0.7

- move to 4.08 as lower bound
- `preformatted` text style instead of global setting
- PrintBox_html:
  * Optionally wrap text with the `<pre>` HTML element
  * Output text consistently as `<span>`, not `<div>`
  * Use `<details><summary>` for collapsible trees

- fix: Tree connectors touching frames (c-cube/printbox#26)

## 0.6.1

- compat with dune 3

## 0.6

- move text rendering into a new printbox-text library
- Changing visuals for hlines and vlines connections, and tree structure
  using unicode characters for box borders

## 0.5

- reenable mdx for tests
- custom classes/attributes for html translation in `PrintBox_html`
- add `link` case
- examples: add lambda.ml

## 0.4

- remove `<p>` in rendering text to html
- add `grid_map_l` and `v_record`
- add another test

## 0.3

- improve code readability in text rendering
- add `align` and `center`
- add basic styling for text (ansi codes/html styles)
- add `printbox_unicode` for setting up proper unicode printing
- add `grid_l`, `grid_text_l`, and `record` helpers

- use a more accurate length estimate for unicode, add test
- remove mdx as a test dep
- fix rendering bugs related to align right, and padding

## 0.2

- make the box type opaque, with a view function
- require OCaml 4.03

- add `PrintBox_text.pp`
- expose a few new functions to build boxes
- change `Text` type, work on string slices when rendering

- automatic testing using dune and mdx
- migrate to dune and opam 2

## 0.1

initial release
