### PR TITLE
[new release] dream-html (1.2.0)

### DIFF
--- a/packages/dream-html/dream-html.1.2.0/opam
+++ b/packages/dream-html/dream-html.1.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v1.2.0/dream-html-1.2.0.tbz"
+  checksum: [
+    "sha256=9eb28815a6c10cb92d705965f7a2d999348e45f4f6453db12e3780e9b94598a9"
+    "sha512=d4b4a840d439dc57e9844e9c8595129a22212afaf4f217719083bd6fe0fb481c28db1974ea5920b38a31994a64a6a90ca263ca54d96cf866f9308df433a4ef0c"
+  ]
+}
+x-commit-hash: "bb2cc683df93a79dc8533273208becc69ba22c82"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
