### PR TITLE
[new release] dream-html (1.1.0)

### DIFF
--- a/packages/dream-html/dream-html.1.1.0/opam
+++ b/packages/dream-html/dream-html.1.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v1.1.0/dream-html-1.1.0.tbz"
+  checksum: [
+    "sha256=c6876dfac706b9e61d9a86637cf02c37557d40bc7f0dc89e4fdcf52e94d6eb18"
+    "sha512=4908c3152294242fcdd9cd6e6b4784b30bbe2977aa4a98ece60f1fb08778554627c30d80f5a3bc43b41ed84a789ad9ac1f1f50e7f287a6a1f1fb02261dd4a06b"
+  ]
+}
+x-commit-hash: "a0f269f419160cafd8af15bba93c64065b2dad7b"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
