### PR TITLE
[new release] codept (0.12.0)

### DIFF
--- a/packages/codept/codept.0.12.0/opam
+++ b/packages/codept/codept.0.12.0/opam
@@ -17,6 +17,7 @@ license: "GPL-3.0-or-later"
 homepage: "https://github.com/Octachron/codept"
 bug-reports: "https://github.com/Octachron/codept/issues"
 depends: [
+  "ocaml" {>= "4.03"}
   "ocaml" {>= "4.02.0" & <= "5.2~" }
   "dune" {>= "2.5"}
   "menhir" {>= "20180523"}

--- a/packages/codept/codept.0.12.0/opam
+++ b/packages/codept/codept.0.12.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Alternative ocaml dependency analyzer"
+description: """
+Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep. Compared to ocamldep, codept major features are:
+
+ * whole project analysis
+ * exhaustive warning and error messages
+ * structured format (s-expression or json) for dependencies
+ * uniform handling of delayed alias dependencies
+ * (experimental) full dependencies,
+  when dependencies up to transitive closure are not enough
+
+Both ocamldep and codept computes an over-approximation of the dependencies graph of OCaml project. However, codept uses whole project analysis to reduce the number of fictitious dependencies inferred at the project scale, whereas ocamldep is, by design, limited to local file analysis."""
+maintainer: ["Florian Angeletti <octa@polychoron.fr>"]
+authors: ["Florian Angeletti <octa@polychoron.fr>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/Octachron/codept"
+bug-reports: "https://github.com/Octachron/codept/issues"
+depends: [
+  "dune"
+  "menhir" {>= "20180523"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Octachron/codept.git"
+url {
+  src:
+    "https://github.com/Octachron/codept/releases/download/0.12.0/codept-0.12.0.tbz"
+  checksum: [
+    "sha256=f0baad2f1ff352a5aadd02b5c971693c219bb1a1857e483a5700ecb2ba6d61b0"
+    "sha512=af74a4ff73a1f1bc5ee325d424351f8dab82a6b5f1cb044ad125286832bfbf7a51969e36f3f413541a0b42a2b752ca89224b77b71c55648861e93ddb47dceae1"
+  ]
+}
+x-commit-hash: "31aac3df3f7e03abcab6530b72ab4ddcd4686aed"

--- a/packages/codept/codept.0.12.0/opam
+++ b/packages/codept/codept.0.12.0/opam
@@ -17,8 +17,7 @@ license: "GPL-3.0-or-later"
 homepage: "https://github.com/Octachron/codept"
 bug-reports: "https://github.com/Octachron/codept/issues"
 depends: [
-  "ocaml" {>= "4.03"}
-  "ocaml" {>= "4.02.0" & <= "5.2~" }
+  "ocaml" {>= "4.03.0" & <= "5.2~" }
   "dune" {>= "2.5"}
   "menhir" {>= "20180523"}
 ]

--- a/packages/codept/codept.0.12.0/opam
+++ b/packages/codept/codept.0.12.0/opam
@@ -17,11 +17,12 @@ license: "GPL-3.0-or-later"
 homepage: "https://github.com/Octachron/codept"
 bug-reports: "https://github.com/Octachron/codept/issues"
 depends: [
-  "dune"
+  "ocaml" {>= "4.02.0" & <= "5.2~" }
+  "dune" {>= "2.5"}
   "menhir" {>= "20180523"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
This pull-request adds a new version for codept, an alternative ocaml dependency analyzer which adds the support for OCaml 5.1.0 and fix a bug with the `-sort` option while there is more internal clean-up ongoing before a probable change of name.

Changes
-------------
## Updates

   * Support 5.0.0 and 5.1.0 standard library in bundle
   * Support 5.1

## Bug fixes

   * Restore "-sort"

## Internal

  * cleaner library interfaces