### PR TITLE
[new release] gluten (6 packages) (0.5.0)

### DIFF
--- a/packages/gluten-async/gluten-async.0.5.0/opam
+++ b/packages/gluten-async/gluten-async.0.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Async support for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "gluten" {= version}
+  "faraday-async" {>= "0.7.3"}
+  "async" {>= "v0.15.0"}
+  "core" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+depopts: ["async_ssl" "tls-async"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.0/gluten-0.5.0.tbz"
+  checksum: [
+    "sha256=98629b6d048f30eba6502b71ac076806de72d91ae401fe7cb29914ca64d88583"
+    "sha512=d60a4470f4de1c6e8163282d64b77db7cdf41ac605eb191d6bb3062f9375f6dc85b069bfaac6f6354ce4d199593b4914455a448a8d05e3cb22fa3551a0623715"
+  ]
+}
+x-commit-hash: "166e1e917710e1e43b04d33a368b6701a9f8b1f5"

--- a/packages/gluten-eio/gluten-eio.0.5.0/opam
+++ b/packages/gluten-eio/gluten-eio.0.5.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "EIO runtime for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "gluten" {= version}
+  "eio" {>= "0.12"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.0/gluten-0.5.0.tbz"
+  checksum: [
+    "sha256=98629b6d048f30eba6502b71ac076806de72d91ae401fe7cb29914ca64d88583"
+    "sha512=d60a4470f4de1c6e8163282d64b77db7cdf41ac605eb191d6bb3062f9375f6dc85b069bfaac6f6354ce4d199593b4914455a448a8d05e3cb22fa3551a0623715"
+  ]
+}
+x-commit-hash: "166e1e917710e1e43b04d33a368b6701a9f8b1f5"

--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.0/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Lwt + Unix support for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "gluten-lwt" {= version}
+  "faraday-lwt-unix" {>= "0.7.3"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "lwt_ssl" {>= "1.2.0"}
+  "tls-lwt"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.0/gluten-0.5.0.tbz"
+  checksum: [
+    "sha256=98629b6d048f30eba6502b71ac076806de72d91ae401fe7cb29914ca64d88583"
+    "sha512=d60a4470f4de1c6e8163282d64b77db7cdf41ac605eb191d6bb3062f9375f6dc85b069bfaac6f6354ce4d199593b4914455a448a8d05e3cb22fa3551a0623715"
+  ]
+}
+x-commit-hash: "166e1e917710e1e43b04d33a368b6701a9f8b1f5"

--- a/packages/gluten-lwt/gluten-lwt.0.5.0/opam
+++ b/packages/gluten-lwt/gluten-lwt.0.5.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Lwt-specific runtime for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "gluten" {= version}
+  "lwt" {>= "5.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.0/gluten-0.5.0.tbz"
+  checksum: [
+    "sha256=98629b6d048f30eba6502b71ac076806de72d91ae401fe7cb29914ca64d88583"
+    "sha512=d60a4470f4de1c6e8163282d64b77db7cdf41ac605eb191d6bb3062f9375f6dc85b069bfaac6f6354ce4d199593b4914455a448a8d05e3cb22fa3551a0623715"
+  ]
+}
+x-commit-hash: "166e1e917710e1e43b04d33a368b6701a9f8b1f5"

--- a/packages/gluten-mirage/gluten-mirage.0.5.0/opam
+++ b/packages/gluten-mirage/gluten-mirage.0.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Mirage support for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "gluten-lwt" {= version}
+  "faraday-lwt" {>= "0.7.3"}
+  "conduit-mirage" {>= "2.0.2"}
+  "mirage-flow" {>= "2.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.0/gluten-0.5.0.tbz"
+  checksum: [
+    "sha256=98629b6d048f30eba6502b71ac076806de72d91ae401fe7cb29914ca64d88583"
+    "sha512=d60a4470f4de1c6e8163282d64b77db7cdf41ac605eb191d6bb3062f9375f6dc85b069bfaac6f6354ce4d199593b4914455a448a8d05e3cb22fa3551a0623715"
+  ]
+}
+x-commit-hash: "166e1e917710e1e43b04d33a368b6701a9f8b1f5"

--- a/packages/gluten/gluten.0.5.0/opam
+++ b/packages/gluten/gluten.0.5.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A reusable runtime library for network protocols"
+description:
+  "gluten implements platform specific runtime code for driving network libraries based on state machines, such as http/af, h2 and websocketaf."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "bigstringaf" {>= "0.4.0"}
+  "faraday" {>= "0.7.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.0/gluten-0.5.0.tbz"
+  checksum: [
+    "sha256=98629b6d048f30eba6502b71ac076806de72d91ae401fe7cb29914ca64d88583"
+    "sha512=d60a4470f4de1c6e8163282d64b77db7cdf41ac605eb191d6bb3062f9375f6dc85b069bfaac6f6354ce4d199593b4914455a448a8d05e3cb22fa3551a0623715"
+  ]
+}
+x-commit-hash: "166e1e917710e1e43b04d33a368b6701a9f8b1f5"


### PR DESCRIPTION
A reusable runtime library for network protocols

- Project page: <a href="https://github.com/anmonteiro/gluten">https://github.com/anmonteiro/gluten</a>

##### CHANGES:

- gluten-eio: require `~sw:Eio.Switch.t` argument and fail the switch when loop
  raises an exception ([anmonteiro/gluten#61](https://github.com/anmonteiro/gluten/pull/61))
- gluten-eio: handle peer disconnects
  ([anmonteiro/gluten#60](https://github.com/anmonteiro/gluten/pull/60))
- gluten: replace `Gluten.Buffer` implementation and drop the `Ke` dependency
  ([anmonteiro/gluten#67](https://github.com/anmonteiro/gluten/pull/67))
- gluten-eio: adapt to Eio v0.12 ([anmonteiro/gluten#66](https://github.com/anmonteiro/gluten/pull/66)
- gluten-eio: don't fail switches in the I/O loop([anmonteiro/gluten#70](https://github.com/anmonteiro/gluten/pull/70)
- gluten-eio: open up #Eio.Flow.two_way ([anmonteiro/gluten#62](https://github.com/anmonteiro/gluten/pull/62)
- gluten-async: async-tls compilation error when using tls-async package ([anmonteiro/gluten#63](https://github.com/anmonteiro/gluten/pull/63))
- gluten-eio, gluten-async, gluten-lwt, gluten-lwt-unix: refactor: unwrap Gluten.Buffer.put in favor of exceptions ([anmonteiro/gluten#58](https://github.com/anmonteiro/gluten/pull/58))
