### PR TITLE
4 packages from gitlab.com/nomadic-labs/data-encoding/-/archive/v1.0.1/data-encoding-v1.0.1.tar.gz

### DIFF
--- a/packages/data-encoding/data-encoding.1.0.1/opam
+++ b/packages/data-encoding/data-encoding.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/data-encoding/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/data-encoding.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "3.0" }
+  "ezjsonm" { >= "1.1.0" }
+  "zarith" {>= "1.4"}
+  "zarith_stubs_js" { >= "v0.16.1" }
+  "hex" {>= "1.3.0"}
+  "json-data-encoding" { = version }
+  "json-data-encoding-bson" { = version }
+  "alcotest" { >= "1.0.0" & with-test }
+  "crowbar" { >= "0.2" & with-test }
+  "ppx_expect"
+  "either"
+  "bigstringaf" { >= "0.6.1" }
+  "ppx_hash"
+  "ocamlformat" { = "0.24.1" & with-doc } # not technically a doc dep; modify when with-dev becomes available
+  "odoc" { with-doc }
+  "md2mld" { with-test } # not technically a test dep; modify when https://github.com/ocurrent/ocaml-ci/issues/264 is fixed
+  "js_of_ocaml-compiler" { with-test }
+  "conf-npm" { with-test }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Library of JSON and binary encoding combinators"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/data-encoding/-/archive/v1.0.1/data-encoding-v1.0.1.tar.gz"
+  checksum: [
+    "md5=82d6e7783274595c82cff4562e2b06a2"
+    "sha512=df5d00dfef8afeada8a6aee2a97d491a2ce20cfe90aed203848f6098ba05ba60e2ee9d1afc0c6c07cf32dad3f8e34c0b55cf900ef1f2e7a72d704f07fd32e651"
+  ]
+}

--- a/packages/data-encoding/data-encoding.1.0.1/opam
+++ b/packages/data-encoding/data-encoding.1.0.1/opam
@@ -39,3 +39,4 @@ url {
     "sha512=df5d00dfef8afeada8a6aee2a97d491a2ce20cfe90aed203848f6098ba05ba60e2ee9d1afc0c6c07cf32dad3f8e34c0b55cf900ef1f2e7a72d704f07fd32e651"
   ]
 }
+available: [ arch != "s390x" | "ocaml-version" < "5.0" ]

--- a/packages/json-data-encoding-browser/json-data-encoding-browser.1.0.1/opam
+++ b/packages/json-data-encoding-browser/json-data-encoding-browser.1.0.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (browser support)"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "MIT"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+]
+
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "3.0"}
+  "json-data-encoding" {= version }
+  "js_of_ocaml" {>= "3.3.0"}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/data-encoding/-/archive/v1.0.1/data-encoding-v1.0.1.tar.gz"
+  checksum: [
+    "md5=82d6e7783274595c82cff4562e2b06a2"
+    "sha512=df5d00dfef8afeada8a6aee2a97d491a2ce20cfe90aed203848f6098ba05ba60e2ee9d1afc0c6c07cf32dad3f8e34c0b55cf900ef1f2e7a72d704f07fd32e651"
+  ]
+}

--- a/packages/json-data-encoding-bson/json-data-encoding-bson.1.0.1/opam
+++ b/packages/json-data-encoding-bson/json-data-encoding-bson.1.0.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (bson support)"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "MIT"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+]
+
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "3.0"}
+  "json-data-encoding" {= version }
+  "ocplib-endian" {>= "1.0"}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/data-encoding/-/archive/v1.0.1/data-encoding-v1.0.1.tar.gz"
+  checksum: [
+    "md5=82d6e7783274595c82cff4562e2b06a2"
+    "sha512=df5d00dfef8afeada8a6aee2a97d491a2ce20cfe90aed203848f6098ba05ba60e2ee9d1afc0c6c07cf32dad3f8e34c0b55cf900ef1f2e7a72d704f07fd32e651"
+  ]
+}

--- a/packages/json-data-encoding/json-data-encoding.1.0.1/opam
+++ b/packages/json-data-encoding/json-data-encoding.1.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "MIT"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "3.0"}
+  "uri" {>= "1.9.0" }
+  "hex" {>= "1.3.0"}
+  "crowbar" { with-test }
+  "alcotest" { with-test }
+  "ocamlformat" { = "0.24.1" & with-doc } # not technically a doc dep; modify when with-dev becomes available
+  "odoc" { with-doc }
+  "js_of_ocaml-compiler" { with-test }
+  "conf-npm" { with-test }
+]
+conflicts: [
+  "data-encoding" {!= version}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/data-encoding/-/archive/v1.0.1/data-encoding-v1.0.1.tar.gz"
+  checksum: [
+    "md5=82d6e7783274595c82cff4562e2b06a2"
+    "sha512=df5d00dfef8afeada8a6aee2a97d491a2ce20cfe90aed203848f6098ba05ba60e2ee9d1afc0c6c07cf32dad3f8e34c0b55cf900ef1f2e7a72d704f07fd32e651"
+  ]
+}

--- a/packages/json-data-encoding/json-data-encoding.1.0.1/opam
+++ b/packages/json-data-encoding/json-data-encoding.1.0.1/opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
 
 build: [
   ["dune" "build" "-j" jobs "-p" name]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & !ocaml-option-bytecode-only:installed}
 ]
 
 depends: [


### PR DESCRIPTION
This pull-request concerns:
-`data-encoding.1.0.1`: Library of JSON and binary encoding combinators
-`json-data-encoding.1.0.1`: Type-safe encoding to and decoding from JSON
-`json-data-encoding-browser.1.0.1`: Type-safe encoding to and decoding from JSON (browser support)
-`json-data-encoding-bson.1.0.1`: Type-safe encoding to and decoding from JSON (bson support)



---

---
:camel: Pull-request generated by opam-publish v2.1.0