### PR TITLE
Add upper OCaml bound for extunix.0.1.4

### DIFF
--- a/packages/extunix/extunix.0.1.4/opam
+++ b/packages/extunix/extunix.0.1.4/opam
@@ -42,7 +42,7 @@ remove: [
   ["ocamlfind" "remove" "extunix"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocaml" {with-test & < "4.06"}
   "ocamlfind" {build}
   "camlp4" {build}


### PR DESCRIPTION
`extunix.0.1.4` uses `Pervasives` and hence requires ocaml < 5.0.0

Specifically, it runs a `setup.ml` file during installation which contains it resulting in the following error (spotted in #24677):
```
#=== ERROR while compiling extunix.0.1.4 ======================================#
# context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/extunix.0.1.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/extunix-7-b45b1c.env
# output-file          ~/.opam/log/extunix-7-b45b1c.out
### output ###
# File "./setup.ml", line 1404, characters 23-41:
# 1404 |          let compare = Pervasives.compare
#                               ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```