### PR TITLE
Add minivpt lower bounds

### DIFF
--- a/packages/minivpt/minivpt.1.0.0/opam
+++ b/packages/minivpt/minivpt.1.0.0/opam
@@ -18,7 +18,7 @@ remove: [
 depends: [
   "ocaml"
   "ocamlfind"
-  "obuild" {build}
+  "obuild" {build & >= "0.0.3"}
 ]
 synopsis: "Minimalist vantage point tree implementation in OCaml."
 description: """

--- a/packages/minivpt/minivpt.2.0.0/opam
+++ b/packages/minivpt/minivpt.2.0.0/opam
@@ -18,7 +18,7 @@ remove: [
 depends: [
   "ocaml"
   "ocamlfind"
-  "obuild" {build}
+  "obuild" {build & >= "0.0.3"}
 ]
 synopsis: "Minimalist vantage point tree implementation in OCaml."
 description: """


### PR DESCRIPTION
In #24677 there are lower bound failures in lower bound dependency... :sweat_smile: 
This causes:
```
#=== ERROR while compiling minivpt.2.0.0 ======================================#
# context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-base-compiler.4.03.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.03/.opam-switch/build/minivpt.2.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build obuild build lib-minivpt
# exit-code            2
# env-file             ~/.opam/log/minivpt-7-cd9550.env
# output-file          ~/.opam/log/minivpt-7-cd9550.out
### output ###
# uncaught exception
# Fatal error: exception Failure("unknown option: lib-minivpt")
```

After having checked locally, this PR therefore adds a lower bound requirement of `obuild.0.0.3`