### PR TITLE
Mark conflict in zarith_js_stubs

### DIFF
--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.12.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.12.0/opam
@@ -12,6 +12,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.5.1"}
 ]
+conflicts: [ "zarith" { >= "1.13" } ]
 synopsis: "Javascripts stubs for the Zarith library"
 description: "
 This library contains no ocaml code, but instead implements

--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.12.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.12.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "1.5.1"}
 ]
 # The conflict is a run-time failure (extract_small) when versions do not match:
-conflicts: [ "zarith" { >= "1.13" } ]
+conflicts: [ "zarith" {< "1.12" | >= "1.13" } ]
 synopsis: "Javascripts stubs for the Zarith library"
 description: "
 This library contains no ocaml code, but instead implements

--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.12.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.12.0/opam
@@ -12,6 +12,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.5.1"}
 ]
+# The conflict is a run-time failure (extract_small) when versions do not match:
 conflicts: [ "zarith" { >= "1.13" } ]
 synopsis: "Javascripts stubs for the Zarith library"
 description: "

--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.13.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.13.0/opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune"  {>= "1.5.1"}
 ]
+# The conflict is a run-time failure (extract_small) when versions do not match:
 conflicts: [ "zarith" { >= "1.13" } ]
 synopsis: "Javascripts stubs for the Zarith library"
 description: "

--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.13.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.13.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dune"  {>= "1.5.1"}
 ]
 # The conflict is a run-time failure (extract_small) when versions do not match:
-conflicts: [ "zarith" { >= "1.13" } ]
+conflicts: [ "zarith" {< "1.12" | >= "1.13" } ]
 synopsis: "Javascripts stubs for the Zarith library"
 description: "
 This library contains no ocaml code, but instead implements

--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.13.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.13.0/opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune"  {>= "1.5.1"}
 ]
+conflicts: [ "zarith" { >= "1.13" } ]
 synopsis: "Javascripts stubs for the Zarith library"
 description: "
 This library contains no ocaml code, but instead implements

--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.15.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.15.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dune"  {>= "2.0.0"}
 ]
 # The conflict is a run-time failure when versions do not match:
-conflicts: "zarith" {< "1.12"}
+conflicts: [ "zarith" {< "1.12" | >= "1.13" } ]
 synopsis: "Javascripts stubs for the Zarith library"
 description: "
 This library contains no ocaml code, but instead implements

--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.15.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.15.0/opam
@@ -15,7 +15,7 @@ depends: [
 ]
 # The conflict is a run-time failure when versions do not match:
 # There are two separate failures for <1.12 and >1.12
-conflicts: [ "zarith" {!= "1.12" } ]
+conflicts: [ "zarith" {< "1.12" | >= "1.13" } ]
 synopsis: "Javascripts stubs for the Zarith library"
 description: "
 This library contains no ocaml code, but instead implements

--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.15.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.15.0/opam
@@ -14,7 +14,8 @@ depends: [
   "dune"  {>= "2.0.0"}
 ]
 # The conflict is a run-time failure when versions do not match:
-conflicts: [ "zarith" {< "1.12" | >= "1.13" } ]
+# There are two separate failures for <1.12 and >1.12
+conflicts: [ "zarith" {!= "1.12" } ]
 synopsis: "Javascripts stubs for the Zarith library"
 description: "
 This library contains no ocaml code, but instead implements

--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.16.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.16.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dune"  {>= "2.0.0"}
 ]
 # The conflict is a run-time failure (extract_small) when versions do not match:
-conflicts: [ "zarith" { >= "1.13" } ]
+conflicts: [ "zarith" {< "1.12" | >= "1.13" } ]
 synopsis: "Javascripts stubs for the Zarith library"
 description: "
 This library contains no ocaml code, but instead implements

--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.16.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.16.0/opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml" {>= "4.14.0"}
   "dune"  {>= "2.0.0"}
 ]
+conflicts: [ "zarith" { >= "1.13" } ]
 synopsis: "Javascripts stubs for the Zarith library"
 description: "
 This library contains no ocaml code, but instead implements

--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.16.0/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.16.0/opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml" {>= "4.14.0"}
   "dune"  {>= "2.0.0"}
 ]
+# The conflict is a run-time failure (extract_small) when versions do not match:
 conflicts: [ "zarith" { >= "1.13" } ]
 synopsis: "Javascripts stubs for the Zarith library"
 description: "


### PR DESCRIPTION
Calling the extract function makes a runtime failure: `[failure] ml_z_extract_small not implemented`

See also https://github.com/janestreet/zarith_stubs_js/issues/10

Note that the error is only triggered when calling the missing function, so it's not necessarily a strict conflict, but there is precedent in the other zarith version for similar issues.