### PR TITLE
conf-glade support on Linux Mint, Arch, Alpine, OpenSuse, and FreeBSD

### DIFF
--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "LGPL-2.1-or-later"
 build: [["pkg-config" "libglade-2.0"]]
 depexts: [
-  ["libglade2-dev"] {os-family = "debian"}
+  ["libglade2-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libglade2.0"] {os = "win32" & os-distribution = "cygwinports"}
   ["libglade2-devel"] {os-distribution = "fedora"}
   ["gnome2.libglade"] {os-distribution = "nixos"}

--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -15,6 +15,11 @@ depexts: [
   ["libglade2"] {os-family = "suse" | os-family = "opensuse"}
   ["libglade2"] {os = "freebsd"}
 ]
+x-ci-accept-failures: [
+  "oraclelinux-7"
+  "oraclelinux-8"
+  "oraclelinux-9"
+]
 synopsis: "Virtual package relying on a libglade system installation"
 description:
   "This package can only install if libglade2-dev is installed on the system."

--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -10,7 +10,7 @@ depexts: [
   ["libglade2.0"] {os = "win32" & os-distribution = "cygwinports"}
   ["libglade2-devel"] {os-distribution = "fedora"}
   ["gnome2.libglade"] {os-distribution = "nixos"}
-  ["glade-dev"] {os-distribution = "alpine"}
+  ["libglade-dev"] {os-distribution = "alpine"}
   ["libglade2"] {os-family = "suse" | os-family = "opensuse"}
   ["libglade2"] {os = "freebsd"}
 ]

--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -10,6 +10,7 @@ depexts: [
   ["libglade2.0"] {os = "win32" & os-distribution = "cygwinports"}
   ["libglade2-devel"] {os-distribution = "fedora"}
   ["gnome2.libglade"] {os-distribution = "nixos"}
+  ["libglade2"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a libglade system installation"
 description:

--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -19,6 +19,7 @@ x-ci-accept-failures: [
   "oraclelinux-7"
   "oraclelinux-8"
   "oraclelinux-9"
+  "macos-homebrew"
 ]
 synopsis: "Virtual package relying on a libglade system installation"
 description:

--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -10,6 +10,7 @@ depexts: [
   ["libglade2.0"] {os = "win32" & os-distribution = "cygwinports"}
   ["libglade2-devel"] {os-distribution = "fedora"}
   ["gnome2.libglade"] {os-distribution = "nixos"}
+  ["glade-dev"] {os-distribution = "alpine"}
   ["libglade2"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a libglade system installation"

--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -11,6 +11,7 @@ depexts: [
   ["libglade2-devel"] {os-distribution = "fedora"}
   ["gnome2.libglade"] {os-distribution = "nixos"}
   ["libglade-dev"] {os-distribution = "alpine"}
+  ["libglade"] {os-distribution = "arch"}
   ["libglade2"] {os-family = "suse" | os-family = "opensuse"}
   ["libglade2"] {os = "freebsd"}
 ]

--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -11,6 +11,7 @@ depexts: [
   ["libglade2-devel"] {os-distribution = "fedora"}
   ["gnome2.libglade"] {os-distribution = "nixos"}
   ["glade-dev"] {os-distribution = "alpine"}
+  ["libglade2"] {os-family = "suse" | os-family = "opensuse"}
   ["libglade2"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a libglade system installation"


### PR DESCRIPTION
This little PR adds `conf-glade` support on Linux Mint and FreeBSD

I can see support is also missing for Arch, OpenSuse, Oracle, and macOS and expect the CI to fail on those as a result.