### PR TITLE
Broaden conf-gnutls support

### DIFF
--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["gnutls-devel" "nettle-devel"] {os-distribution = "fedora"}
   ["gnutls"] {os = "macos" & os-distribution = "homebrew"}
   ["gnutls"] {os = "win32" & os-distribution = "cygwinports"}
+  ["gnutls"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a gnutls system installation"
 description:

--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -7,6 +7,7 @@ depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libgnutls28-dev" "nettle-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["gnutls-dev"] {os-distribution = "alpine"}
+  ["gnutls"] {os-distribution = "arch"}
   ["gnutls-devel" "nettle-devel"] {os-distribution = "fedora"}
   ["gnutls"] {os = "macos" & os-distribution = "homebrew"}
   ["gnutls"] {os = "win32" & os-distribution = "cygwinports"}

--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["gnutls-devel" "nettle-devel"] {os-distribution = "fedora"}
   ["gnutls"] {os = "macos" & os-distribution = "homebrew"}
   ["gnutls"] {os = "win32" & os-distribution = "cygwinports"}
-  ["gnutls"] {os-distribution = "ol"}
+  ["gnutls-devel"] {os-distribution = "ol"}
   ["gnutls"] {os-distribution = "homebrew" & os = "macos"}
   ["gnutls"] {os = "freebsd"}
 ]

--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -8,6 +8,7 @@ depexts: [
   ["libgnutls28-dev" "nettle-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["gnutls-dev"] {os-distribution = "alpine"}
   ["gnutls"] {os-distribution = "arch"}
+  ["gnutls"] {os-family = "suse" | os-family = "opensuse"}
   ["gnutls-devel" "nettle-devel"] {os-distribution = "fedora"}
   ["gnutls"] {os = "macos" & os-distribution = "homebrew"}
   ["gnutls"] {os = "win32" & os-distribution = "cygwinports"}

--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 maintainer: "vb@luminar.eu.org"
 homepage: "https://www.gnutls.org"
 authors: ["Nikos Mavrogiannopoulos" "Simon Josefsson"]
+license: "LGPL-2.1-or-later"
 build: [["pkg-config" "gnutls" "nettle"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [

--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["gnutls-devel" "nettle-devel"] {os-distribution = "fedora"}
   ["gnutls"] {os = "macos" & os-distribution = "homebrew"}
   ["gnutls"] {os = "win32" & os-distribution = "cygwinports"}
+  ["gnutls"] {os-distribution = "homebrew" & os = "macos"}
   ["gnutls"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a gnutls system installation"

--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -8,7 +8,7 @@ depexts: [
   ["libgnutls28-dev" "nettle-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["gnutls-dev"] {os-distribution = "alpine"}
   ["gnutls"] {os-distribution = "arch"}
-  ["gnutls"] {os-family = "suse" | os-family = "opensuse"}
+  ["libgnutls-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gnutls-devel" "nettle-devel"] {os-distribution = "fedora"}
   ["gnutls"] {os = "macos" & os-distribution = "homebrew"}
   ["gnutls"] {os = "win32" & os-distribution = "cygwinports"}

--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -5,7 +5,7 @@ authors: ["Nikos Mavrogiannopoulos" "Simon Josefsson"]
 build: [["pkg-config" "gnutls" "nettle"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libgnutls28-dev" "nettle-dev"] {os-family = "debian"}
+  ["libgnutls28-dev" "nettle-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["gnutls-dev"] {os-distribution = "alpine"}
   ["gnutls-devel" "nettle-devel"] {os-distribution = "fedora"}
   ["gnutls"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["gnutls-devel" "nettle-devel"] {os-distribution = "fedora"}
   ["gnutls"] {os = "macos" & os-distribution = "homebrew"}
   ["gnutls"] {os = "win32" & os-distribution = "cygwinports"}
+  ["gnutls"] {os-distribution = "ol"}
   ["gnutls"] {os-distribution = "homebrew" & os = "macos"}
   ["gnutls"] {os = "freebsd"}
 ]


### PR DESCRIPTION
This PR broadens `conf-gnutls` support to FreeBSD, macOS homebrew, and Linux-wise: Mint, Arch, OpenSuse, Oracle.

I probably messed up a couple of names - or have left out a `nettle` package install... :popcorn: :nerd_face: 