### PR TITLE
[new release] h2 (7 packages) (0.11.0)

### DIFF
--- a/packages/h2-async/h2-async.0.11.0/opam
+++ b/packages/h2-async/h2-async.0.11.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Async support for h2"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-async provides an Async runtime implementation for h2."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "h2" {= version}
+  "faraday-async"
+  "gluten-async" {>= "0.4.0"}
+  "odoc" {with-doc}
+]
+depopts: ["async_ssl" "tls-async"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.11.0/h2-0.11.0.tbz"
+  checksum: [
+    "sha256=19d5f06b39600eeae3cf2ede90ba6e3240a28bc5be17f8e5fc806ffd64c78053"
+    "sha512=aafcb9df5dc76aa4050613696303fc0581e40c28707265672d378f0128fbb717fbbb9214a7557c124c8196e41cfaba4bb190755a7a94afcadd4ae15a64ae01fc"
+  ]
+}
+x-commit-hash: "c694398c1b429db622638e94f9a6f8fbce2a208a"

--- a/packages/h2-async/h2-async.0.11.0/opam
+++ b/packages/h2-async/h2-async.0.11.0/opam
@@ -26,7 +26,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/h2-eio/h2-eio.0.11.0/opam
+++ b/packages/h2-eio/h2-eio.0.11.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
   "h2" {= version}
-  "gluten-eio" {>= "0.4.1"}
+  "gluten-eio" {>= "0.5.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/h2-eio/h2-eio.0.11.0/opam
+++ b/packages/h2-eio/h2-eio.0.11.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "EIO support for h2"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-eio provides an EIO runtime implementation for h2."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "h2" {= version}
+  "gluten-eio" {>= "0.4.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.11.0/h2-0.11.0.tbz"
+  checksum: [
+    "sha256=19d5f06b39600eeae3cf2ede90ba6e3240a28bc5be17f8e5fc806ffd64c78053"
+    "sha512=aafcb9df5dc76aa4050613696303fc0581e40c28707265672d378f0128fbb717fbbb9214a7557c124c8196e41cfaba4bb190755a7a94afcadd4ae15a64ae01fc"
+  ]
+}
+x-commit-hash: "c694398c1b429db622638e94f9a6f8fbce2a208a"

--- a/packages/h2-eio/h2-eio.0.11.0/opam
+++ b/packages/h2-eio/h2-eio.0.11.0/opam
@@ -24,7 +24,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.11.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.11.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Lwt + UNIX support for h2"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-lwt-unix provides an Lwt runtime implementation for h2 that targets UNIX binaries."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "h2-lwt" {= version}
+  "faraday-lwt-unix"
+  "gluten-lwt-unix" {>= "0.2.1"}
+  "odoc" {with-doc}
+]
+depopts: ["tls-lwt" "lwt_ssl"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.11.0/h2-0.11.0.tbz"
+  checksum: [
+    "sha256=19d5f06b39600eeae3cf2ede90ba6e3240a28bc5be17f8e5fc806ffd64c78053"
+    "sha512=aafcb9df5dc76aa4050613696303fc0581e40c28707265672d378f0128fbb717fbbb9214a7557c124c8196e41cfaba4bb190755a7a94afcadd4ae15a64ae01fc"
+  ]
+}
+x-commit-hash: "c694398c1b429db622638e94f9a6f8fbce2a208a"

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.11.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.11.0/opam
@@ -26,7 +26,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/h2-lwt/h2-lwt.0.11.0/opam
+++ b/packages/h2-lwt/h2-lwt.0.11.0/opam
@@ -25,7 +25,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/h2-lwt/h2-lwt.0.11.0/opam
+++ b/packages/h2-lwt/h2-lwt.0.11.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Lwt support for h2"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-lwt provides an Lwt runtime implementation for h2."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "h2" {= version}
+  "lwt" {>= "5.1.1"}
+  "gluten-lwt" {>= "0.2.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.11.0/h2-0.11.0.tbz"
+  checksum: [
+    "sha256=19d5f06b39600eeae3cf2ede90ba6e3240a28bc5be17f8e5fc806ffd64c78053"
+    "sha512=aafcb9df5dc76aa4050613696303fc0581e40c28707265672d378f0128fbb717fbbb9214a7557c124c8196e41cfaba4bb190755a7a94afcadd4ae15a64ae01fc"
+  ]
+}
+x-commit-hash: "c694398c1b429db622638e94f9a6f8fbce2a208a"

--- a/packages/h2-mirage/h2-mirage.0.11.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.11.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Lwt support for h2"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-mirage provides an Lwt runtime implementation for h2 that targets MirageOS unikernels."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "h2-lwt" {= version}
+  "faraday-lwt"
+  "lwt"
+  "gluten-mirage" {>= "0.3.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "cstruct"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.11.0/h2-0.11.0.tbz"
+  checksum: [
+    "sha256=19d5f06b39600eeae3cf2ede90ba6e3240a28bc5be17f8e5fc806ffd64c78053"
+    "sha512=aafcb9df5dc76aa4050613696303fc0581e40c28707265672d378f0128fbb717fbbb9214a7557c124c8196e41cfaba4bb190755a7a94afcadd4ae15a64ae01fc"
+  ]
+}
+x-commit-hash: "c694398c1b429db622638e94f9a6f8fbce2a208a"

--- a/packages/h2-mirage/h2-mirage.0.11.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.11.0/opam
@@ -28,7 +28,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/h2/h2.0.11.0/opam
+++ b/packages/h2/h2.0.11.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "A high-performance, memory-efficient, and scalable HTTP/2 library for OCaml"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. It is based on the concepts in http/af, and therefore uses the Angstrom and Faraday libraries to implement the parsing and serialization layers of the HTTP/2 standard as a state machine that is agnostic to the underlying I/O specifics. It also preserves the same API as http/af wherever possible."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "base64" {>= "3.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "faraday" {>= "0.7.3"}
+  "bigstringaf" {>= "0.5.0"}
+  "psq"
+  "hpack" {= version}
+  "httpaf"
+  "alcotest" {with-test}
+  "yojson" {with-test}
+  "hex" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.11.0/h2-0.11.0.tbz"
+  checksum: [
+    "sha256=19d5f06b39600eeae3cf2ede90ba6e3240a28bc5be17f8e5fc806ffd64c78053"
+    "sha512=aafcb9df5dc76aa4050613696303fc0581e40c28707265672d378f0128fbb717fbbb9214a7557c124c8196e41cfaba4bb190755a7a94afcadd4ae15a64ae01fc"
+  ]
+}
+x-commit-hash: "c694398c1b429db622638e94f9a6f8fbce2a208a"

--- a/packages/h2/h2.0.11.0/opam
+++ b/packages/h2/h2.0.11.0/opam
@@ -33,7 +33,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/hpack/hpack.0.11.0/opam
+++ b/packages/hpack/hpack.0.11.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "An HPACK (Header Compression for HTTP/2) implementation in OCaml"
+description:
+  "hpack is an implementation of the HPACK: Header Compression for HTTP/2 specification (RFC7541) written in OCaml. It uses Angstrom and Faraday for parsing and serialization, respectively."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "angstrom"
+  "faraday" {>= "0.7.3"}
+  "yojson" {with-test}
+  "hex" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.11.0/h2-0.11.0.tbz"
+  checksum: [
+    "sha256=19d5f06b39600eeae3cf2ede90ba6e3240a28bc5be17f8e5fc806ffd64c78053"
+    "sha512=aafcb9df5dc76aa4050613696303fc0581e40c28707265672d378f0128fbb717fbbb9214a7557c124c8196e41cfaba4bb190755a7a94afcadd4ae15a64ae01fc"
+  ]
+}
+x-commit-hash: "c694398c1b429db622638e94f9a6f8fbce2a208a"

--- a/packages/hpack/hpack.0.11.0/opam
+++ b/packages/hpack/hpack.0.11.0/opam
@@ -26,7 +26,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
A high-performance, memory-efficient, and scalable HTTP/2 library for OCaml

- Project page: <a href="https://github.com/anmonteiro/ocaml-h2">https://github.com/anmonteiro/ocaml-h2</a>

##### CHANGES:

- h2-eio: adapt to Eio v0.12
  ([anmonteiro/ocaml-h2#225](https://github.com/anmonteiro/ocaml-h2/pull/225))
- h2-eio: track sw for gluten
  ([anmonteiro/ocaml-h2#215](https://github.com/anmonteiro/ocaml-h2/pull/215))
- h2: Add hpack {= version} constraint
  ([anmonteiro/ocaml-h2#214](https://github.com/anmonteiro/ocaml-h2/pull/214))
- h2, hpack, h2-async: Add opam constraints for angstrom and gluten-async
  ([anmonteiro/ocaml-h2#212](https://github.com/anmonteiro/ocaml-h2/pull/212))
