### PR TITLE
Add ocaml upper bounds for lablgtk.2.18.11-2.18.13

### DIFF
--- a/packages/lablgtk/lablgtk.2.18.11/opam
+++ b/packages/lablgtk/lablgtk.2.18.11/opam
@@ -13,7 +13,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.05" & < "5.0.0"}
   "ocamlfind" {>= "1.2.1"}
   "conf-gtk2" {build}
 ]

--- a/packages/lablgtk/lablgtk.2.18.12/opam
+++ b/packages/lablgtk/lablgtk.2.18.12/opam
@@ -13,7 +13,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0.0"}
   "ocamlfind" {>= "1.2.1"}
   "conf-gtk2" {build}
 ]

--- a/packages/lablgtk/lablgtk.2.18.13/opam
+++ b/packages/lablgtk/lablgtk.2.18.13/opam
@@ -13,7 +13,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0.0"}
   "ocamlfind" {>= "1.2.1"}
   "conf-gtk2" {build}
   "camlp-streams" {build}


### PR DESCRIPTION
lablgtk.2.18.11-2.18.13 use `String.create` which was first deprecated and then removed in OCaml 5.
This causes errors (as seen in #24682):
```
# ocamlc.opt -I +unix  -w s-3-6+52 -c  lablgladecc.ml
# File "lablgladecc.ml", line 355, characters 16-29:
# 355 |       let buf = String.create 1024 in
#                       ^^^^^^^^^^^^^
# Error: Unbound value String.create
```

The PR therefore adds upper bounds for lablgtk.2.18.11-2.18.13.
For earlier versions (lower) upper bounds are already present.