### PR TITLE
Bump minivpt lower bound further

### DIFF
--- a/packages/minivpt/minivpt.1.0.0/opam
+++ b/packages/minivpt/minivpt.1.0.0/opam
@@ -18,7 +18,7 @@ remove: [
 depends: [
   "ocaml"
   "ocamlfind"
-  "obuild" {build & >= "0.0.3"}
+  "obuild" {build & >= "0.1.0"}
 ]
 synopsis: "Minimalist vantage point tree implementation in OCaml"
 description: """

--- a/packages/minivpt/minivpt.1.0.0/opam
+++ b/packages/minivpt/minivpt.1.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind"
   "obuild" {build & >= "0.0.3"}
 ]
-synopsis: "Minimalist vantage point tree implementation in OCaml."
+synopsis: "Minimalist vantage point tree implementation in OCaml"
 description: """
 A vantage point tree allows to do fast but exact nearest neighbor searches
 in any space provided that you have a distance function to measure the

--- a/packages/minivpt/minivpt.2.0.0/opam
+++ b/packages/minivpt/minivpt.2.0.0/opam
@@ -18,7 +18,7 @@ remove: [
 depends: [
   "ocaml"
   "ocamlfind"
-  "obuild" {build & >= "0.0.3"}
+  "obuild" {build & >= "0.1.0"}
 ]
 synopsis: "Minimalist vantage point tree implementation in OCaml"
 description: """

--- a/packages/minivpt/minivpt.2.0.0/opam
+++ b/packages/minivpt/minivpt.2.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind"
   "obuild" {build & >= "0.0.3"}
 ]
-synopsis: "Minimalist vantage point tree implementation in OCaml."
+synopsis: "Minimalist vantage point tree implementation in OCaml"
 description: """
 A vantage point tree allows to do fast but exact nearest neighbor searches
 in any space provided that you have a distance function to measure the


### PR DESCRIPTION
`minivpt` is a dependency in #24677 which is now causing `lbvs_consent` compilation to fail with:
```
[ERROR] The compilation of lbvs_consent.2.1.1 failed at "dune build -p lbvs_consent -j 255".

#=== ERROR while compiling lbvs_consent.2.1.1 =================================#
# context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-base-compiler.4.03.0 | pinned(https://github.com/UnixJunkie/consent/archive/v2.1.1.tar.gz)
# path                 ~/.opam/4.03/.opam-switch/build/lbvs_consent.2.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p lbvs_consent -j 255
# exit-code            1
# env-file             ~/.opam/log/lbvs_consent-7-697f60.env
# output-file          ~/.opam/log/lbvs_consent-7-697f60.out
### output ###
# File "src/dune", line 6, characters 49-56:
# 6 |   (libraries dolog batteries bitv parmap str zip minivpt cpm))
#                                                      ^^^^^^^
# Error: Library "minivpt" not found.
```

I believe this is an issue with the `obuild` version, not making the name `minivpt` visible to `dune`.
Locally I can reproduce the issue - and bumping the `obuild` requirement to 0.1.0 solved it.
The change should benefit other packages that use `dune` and would want to depend on `minivpt`.

For context, #24680 added the first `obuild` lower bound.

While I was at it, I removed a period in the synopsis to make the opam files lint cleanly.