### PR TITLE
Update conf-lame opensuse depext

### DIFF
--- a/packages/conf-lame/conf-lame.1/opam
+++ b/packages/conf-lame/conf-lame.1/opam
@@ -6,8 +6,9 @@ authors: "lame dev team"
 license: "BSD-2-Clause"
 depexts: [
   ["lame-dev"] {os-distribution = "alpine"}
-  ["lame-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["lame-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse"}
   ["libmp3lame-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["libmp3lame-devel"] {os-family = "opensuse"}
   ["lame"] {os = "win32" & os-distribution = "cygwinports"}
   ["lame"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
 ]


### PR DESCRIPTION
According to this page: [https://software.opensuse.org/package/libmp3lame-devel](https://software.opensuse.org/package/libmp3lame-devel) and my experience with installing lame with opam, development package in opensuse should be: `libmp3lame-devel`