### PR TITLE
Add upper OCaml bound for extunix.0.1.5-0.1.6

### DIFF
--- a/packages/extunix/extunix.0.1.5/opam
+++ b/packages/extunix/extunix.0.1.5/opam
@@ -42,7 +42,7 @@ remove: [
   ["ocamlfind" "remove" "extunix"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "camlp4" {build}
   "ounit" {with-test & >= "1.0.3"}

--- a/packages/extunix/extunix.0.1.6/opam
+++ b/packages/extunix/extunix.0.1.6/opam
@@ -44,7 +44,7 @@ remove: [
   ["ocamlfind" "remove" "extunix"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "camlp4" {build}
   "ounit" {with-test & >= "1.0.3"}


### PR DESCRIPTION
`extunix.0.1.5` and `extunix-0.1.6` depend on the `Stream` module which was removed in OCaml 5.
I'm seeing a lower bound test CI failure in #24677 because of it:
```
[ERROR] The compilation of extunix.0.1.5 failed at "ocaml setup.ml -configure --disable-tests --prefix /home/opam/.opam/5.0".

#=== ERROR while compiling extunix.0.1.5 ======================================#
# context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/extunix.0.1.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --disable-tests --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/extunix-7-6bbbc0.env
# output-file          ~/.opam/log/extunix-7-6bbbc0.out
### output ###
# File "./setup.ml", line 581, characters 4-15:
# 581 |     Stream.from next
#           ^^^^^^^^^^^
# Error: Unbound module Stream
```

This PR takes the "easy road" of diabling `extunix.0.1.5-0.1.6` on OCaml 5 rather than patching with a conditional dependency on an external package offering a `Stream` module. I've chosen that since
- these are old versions which I don't want to spend too much energy on
- the following `extunix.0.2.0` requires an `ocaml-migrate-parsetree` incompatible with OCaml 5, which would create "holes of OCaml5 support"