### PR TITLE
Add Linux Mint support to conf-pkg-config

### DIFF
--- a/packages/conf-pkg-config/conf-pkg-config.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.3/opam
@@ -8,7 +8,7 @@ build: [
   ["pkg-config" "--help"] {os != "openbsd"}
 ]
 depexts: [
-  ["pkg-config"] {os-family = "debian"}
+  ["pkg-config"] {os-family = "debian" | os-family = "ubuntu"}
   ["pkgconf"] {os-distribution = "arch"}
   ["pkgconf-pkg-config"] {os-distribution = "fedora"}
   ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}


### PR DESCRIPTION
This little PR adds Linux Mint support to `conf-pkg-config` 