### PR TITLE
Mark proverif.1.98 and proverif.1.98pl1 as unavailable

### DIFF
--- a/packages/proverif/proverif.1.98/opam
+++ b/packages/proverif/proverif.1.98/opam
@@ -52,3 +52,4 @@ url {
   src: "http://proverif.inria.fr/proverif1.98.tar.gz"
   checksum: "md5=409506301341da28c429f2fb79f94c63"
 }
+available: false

--- a/packages/proverif/proverif.1.98pl1/opam
+++ b/packages/proverif/proverif.1.98pl1/opam
@@ -52,3 +52,4 @@ url {
   src: "http://proverif.inria.fr/proverif1.98pl1.tar.gz"
   checksum: "md5=1d3a4d63fcc2e0c2f0924df9d21b5f09"
 }
+available: false


### PR DESCRIPTION
Fetching the source code yields a 404 from curl in #24700:
```
proverif.1.98 (failed: Failed to get sources of proverif.1.98: curl error code 404)
proverif.1.98pl1 (failed: Failed to get sources of proverif.1.98pl1: curl error code 404)
```

Looking some more, 1.98 is fetched from http://proverif.inria.fr/proverif1.98.tar.gz
with http://proverif.inria.fr/ forwarded to https://bblanche.gitlabpages.inria.fr/proverif/

The source code for the gitlab page can be seen here where 1.98 and 1.98pl1 are clearly missing tar.gz entries:
https://gitlab.inria.fr/bblanche/proverif/-/tree/master/website/copy?ref_type=heads

This PR therefore marks the two versions as unavailable.