### PR TITLE
Add Mint support to conf-autoconf

### DIFF
--- a/packages/conf-autoconf/conf-autoconf.0.1/opam
+++ b/packages/conf-autoconf/conf-autoconf.0.1/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depends: ["conf-which" {build}]
 depexts: [
-  ["autoconf"] {os-family = "debian"}
+  ["autoconf"] {os-family = "debian" | os-family = "ubuntu"}
   ["autoconf"] {os-distribution = "centos"}
   ["autoconf"] {os-distribution = "fedora"}
   ["autoconf"] {os-distribution = "arch"}


### PR DESCRIPTION
This little PR adds Linux Mint support to `conf-autoconf`