### PR TITLE
Add Mint support to conf-gtksourceview3

### DIFF
--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
@@ -10,7 +10,7 @@ depexts: [
   ["gtksourceview-dev"] {os-distribution = "alpine"}
   ["gtksourceview3"] {os-distribution = "arch"}
   ["epel-release" "gtksourceview3-devel"] {os-distribution = "centos"}
-  ["libgtksourceview-3.0-dev"] {os-family = "debian"}
+  ["libgtksourceview-3.0-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["gtksourceview3-devel"] {os-distribution = "fedora"}
   ["gtksourceview3"] {os = "freebsd"}
   ["gtksourceview3"] {os = "openbsd"}


### PR DESCRIPTION
This little PR adds Linux Mint support to `conf-gtksourceview3`