### PR TITLE
Add FreeBSD conf-rdkit support

### DIFF
--- a/packages/conf-rdkit/conf-rdkit.1/opam
+++ b/packages/conf-rdkit/conf-rdkit.1/opam
@@ -27,6 +27,7 @@ x-ci-accept-failures: [ # RDKit does not exist by default on these distributions
   "opensuse-15.2"
   "oraclelinux-7"
   "oraclelinux-8"
+  "oraclelinux-9"
 ]
 post-messages:
     "This package requires rdkit to be installed. You might want to try:

--- a/packages/conf-rdkit/conf-rdkit.1/opam
+++ b/packages/conf-rdkit/conf-rdkit.1/opam
@@ -25,6 +25,7 @@ x-ci-accept-failures: [ # RDKit does not exist by default on these distributions
   "archlinux"
   "centos-7"
   "centos-8"
+  "fedora-37"
   "opensuse-15.2"
   "oraclelinux-7"
   "oraclelinux-8"

--- a/packages/conf-rdkit/conf-rdkit.1/opam
+++ b/packages/conf-rdkit/conf-rdkit.1/opam
@@ -5,8 +5,8 @@ maintainer: "unixjunkie@sdf.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "BSD-3-Clause"
 build: [
-  ["sh" "-c" "c++ test.cpp -o test -I/usr/local/include/rdkit -L/usr/local/lib -lRDKitRDGeneral -DSWIG"] {os = "macos"}
-  ["sh" "-c" "c++ test.cpp -o test -I/usr/include/rdkit -lRDKitRDGeneral -DSWIG || c++ test.cpp -o test -I/usr/include/rdkit -lRDGeneral -DSWIG"] {os = "linux" | os = "freebsd"}
+  ["sh" "-c" "c++ test.cpp -o test -I/usr/local/include/rdkit -L/usr/local/lib -lRDKitRDGeneral -DSWIG"] {os = "macos" | os = "freebsd"}
+  ["sh" "-c" "c++ test.cpp -o test -I/usr/include/rdkit -lRDKitRDGeneral -DSWIG || c++ test.cpp -o test -I/usr/include/rdkit -lRDGeneral -DSWIG"] {os = "linux"}
   ["./test"]
 ]
 depexts: [

--- a/packages/conf-rdkit/conf-rdkit.1/opam
+++ b/packages/conf-rdkit/conf-rdkit.1/opam
@@ -27,6 +27,7 @@ x-ci-accept-failures: [ # RDKit does not exist by default on these distributions
   "centos-8"
   "fedora-37"
   "opensuse-15.2"
+  "opensuse-15.5"
   "oraclelinux-7"
   "oraclelinux-8"
   "oraclelinux-9"

--- a/packages/conf-rdkit/conf-rdkit.1/opam
+++ b/packages/conf-rdkit/conf-rdkit.1/opam
@@ -7,7 +7,7 @@ license: "BSD-3-Clause"
 build: [
   ["sh" "-c" "c++ test.cpp -o test -I/usr/local/include/rdkit -L/usr/local/lib -lRDKitRDGeneral -DSWIG"] {os = "macos"}
   ["sh" "-c" "c++ test.cpp -o test -I/usr/include/rdkit -lRDKitRDGeneral -DSWIG || c++ test.cpp -o test -I/usr/include/rdkit -lRDGeneral -DSWIG"] {os = "linux"}
-  ["sh" "-c" "c++ test.cpp -o test -I/usr/local/include -L/usr/local/lib -lRDKitRDGeneral -DSWIG"] {os = "freebsd"}
+  ["sh" "-c" "c++ test.cpp -o test -I/usr/local/include -I/usr/local/include/rdkit -L/usr/local/lib -lRDKitRDGeneral -DSWIG"] {os = "freebsd"}
   ["./test"]
 ]
 depexts: [

--- a/packages/conf-rdkit/conf-rdkit.1/opam
+++ b/packages/conf-rdkit/conf-rdkit.1/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "BSD-3-Clause"
 build: [
   ["sh" "-c" "c++ test.cpp -o test -I/usr/local/include/rdkit -L/usr/local/lib -lRDKitRDGeneral -DSWIG"] {os = "macos"}
-  ["sh" "-c" "c++ test.cpp -o test -I/usr/include/rdkit -lRDKitRDGeneral -DSWIG || c++ test.cpp -o test -I/usr/include/rdkit -lRDGeneral -DSWIG"] {os = "linux"}
+  ["sh" "-c" "c++ test.cpp -o test -I/usr/include/rdkit -lRDKitRDGeneral -DSWIG || c++ test.cpp -o test -I/usr/include/rdkit -lRDGeneral -DSWIG"] {os = "linux" | os = "freebsd"}
   ["./test"]
 ]
 depexts: [
@@ -16,6 +16,7 @@ depexts: [
   ["librdkit-dev" "python3-rdkit"] {os-distribution = "ubuntu" & os-version >= "20.04"}
   ["librdkit-dev" "python3-rdkit"] {(os-family = "debian" | os-family = "ubuntu") & os-distribution != "debian" & os-distribution != "ubuntu"}
   ["rdkit-devel" "python3-rdkit"] {os-distribution = "fedora"}
+  ["rdkit"] {os = "freebsd"}
 ]
 x-ci-accept-failures: [ # RDKit does not exist by default on these distributions
   "alpine-3.12"

--- a/packages/conf-rdkit/conf-rdkit.1/opam
+++ b/packages/conf-rdkit/conf-rdkit.1/opam
@@ -5,8 +5,9 @@ maintainer: "unixjunkie@sdf.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "BSD-3-Clause"
 build: [
-  ["sh" "-c" "c++ test.cpp -o test -I/usr/local/include/rdkit -L/usr/local/lib -lRDKitRDGeneral -DSWIG"] {os = "macos" | os = "freebsd"}
+  ["sh" "-c" "c++ test.cpp -o test -I/usr/local/include/rdkit -L/usr/local/lib -lRDKitRDGeneral -DSWIG"] {os = "macos"}
   ["sh" "-c" "c++ test.cpp -o test -I/usr/include/rdkit -lRDKitRDGeneral -DSWIG || c++ test.cpp -o test -I/usr/include/rdkit -lRDGeneral -DSWIG"] {os = "linux"}
+  ["sh" "-c" "c++ test.cpp -o test -I/usr/local/include -L/usr/local/lib -lRDKitRDGeneral -DSWIG"] {os = "freebsd"}
   ["./test"]
 ]
 depexts: [

--- a/packages/conf-rdkit/conf-rdkit.1/opam
+++ b/packages/conf-rdkit/conf-rdkit.1/opam
@@ -26,6 +26,7 @@ x-ci-accept-failures: [ # RDKit does not exist by default on these distributions
   "centos-7"
   "centos-8"
   "fedora-37"
+  "fedora-38"
   "opensuse-15.2"
   "opensuse-15.5"
   "oraclelinux-7"

--- a/packages/conf-rdkit/conf-rdkit.1/opam
+++ b/packages/conf-rdkit/conf-rdkit.1/opam
@@ -21,6 +21,7 @@ depexts: [
 ]
 x-ci-accept-failures: [ # RDKit does not exist by default on these distributions
   "alpine-3.12"
+  "alpine-3.18"
   "archlinux"
   "centos-7"
   "centos-8"


### PR DESCRIPTION
This PR adds conf-rdkit support for FreeBSD.

I'm unsure of the right include dir and compile flags on FreeBSD and so mimic the Linux ones for a start. 