### PR TITLE
[new release] travesty (0.8.0)

### DIFF
--- a/packages/travesty/travesty.0.8.0/opam
+++ b/packages/travesty/travesty.0.8.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Traversable containers, monad extensions, and more"
+description: """
+'Travesty' is a library for defining containers with applicative
+or monadic traversals, inspired by Haskell's Traversable typeclass; it also
+contains various helpers for monadic code, such as state transformers and
+extension functions for common monads and containers.  It sits on top of Jane
+Street's Base library and ecosystem."""
+maintainer: ["Matt Windsor <mattwindsor91@gmail.com>"]
+authors: ["Matt Windsor <mattwindsor91@gmail.com>"]
+license: "MIT"
+homepage: "https://MattWindsor91.github.io/travesty/"
+doc: "https://MattWindsor91.github.io/travesty/"
+bug-reports: "https://github.com/MattWindsor91/travesty/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.1"}
+  "ppx_jane" {>= "v0.16.0"}
+  "ppx_expect" {with-test & >= "v0.16.0"}
+  "base" {>= "v0.16.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/MattWindsor91/travesty.git"
+url {
+  src:
+    "https://github.com/MattWindsor91/travesty/releases/download/v0.8.0/travesty-0.8.0.tbz"
+  checksum: [
+    "sha256=216c920c872cef2d52fa58e3c49826766a2cf6f2233e64937f18c46c0c5c5388"
+    "sha512=3b4f76794666aa3fb16c3639479790df3478a79e6f582b3e66b144e57df26a76580499961dd374f4fb6f3bd2dd7506e2725ed1242bada9deb14eb1916cacd18f"
+  ]
+}
+x-commit-hash: "b310f87034d4162e0f6f92cabd252314a314bc6e"


### PR DESCRIPTION
Traversable containers, monad extensions, and more

- Project page: <a href="https://MattWindsor91.github.io/travesty/">https://MattWindsor91.github.io/travesty/</a>
- Documentation: <a href="https://MattWindsor91.github.io/travesty/">https://MattWindsor91.github.io/travesty/</a>

##### CHANGES:

- Depends on OCaml 5.1+, Dune 3.6+, and Base 0.16+.
- Generic containers now have a phantom type parameter in compliance with Base
  0.16.  There are currently no functors or signatures that make use of this
  phantom type.  This may change if client code needs it.
