### PR TITLE
[new release] xapi-stdext (7 packages) (4.23.0)

### DIFF
--- a/packages/xapi-stdext-date/xapi-stdext-date.4.23.0/opam
+++ b/packages/xapi-stdext-date/xapi-stdext-date.4.23.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Dates"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "alcotest" {with-test}
+  "astring"
+  "base-unix"
+  "ptime"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.23.0/xapi-stdext-4.23.0.tbz"
+  checksum: [
+    "sha256=3908ba667aeefa5c771179596b511f04da5cfeef42bbfcbb7872c7c248b6be3e"
+    "sha512=fcc494a523fa843183d75a5288c9b3b0d012e260f131c40793f59253cf2140e8bbf953e204b23d98d1ca68fbc8ba37352a4f1a674fd3f3bd91cf94c61aa07a55"
+  ]
+}
+x-commit-hash: "4404d5b0c1c248f5e74fa587b5b16ef17f733857"

--- a/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.23.0/opam
+++ b/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.23.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Encodings"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.13.0"}
+  "alcotest" {>= "0.6.0" & with-test}
+  "odoc" {with-doc}
+  "bechamel" {with-test}
+  "bechamel-notty" {with-test}
+  "notty" {with-test}
+]
+available: arch != "arm32" & arch != "x86_32"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.23.0/xapi-stdext-4.23.0.tbz"
+  checksum: [
+    "sha256=3908ba667aeefa5c771179596b511f04da5cfeef42bbfcbb7872c7c248b6be3e"
+    "sha512=fcc494a523fa843183d75a5288c9b3b0d012e260f131c40793f59253cf2140e8bbf953e204b23d98d1ca68fbc8ba37352a4f1a674fd3f3bd91cf94c61aa07a55"
+  ]
+}
+x-commit-hash: "4404d5b0c1c248f5e74fa587b5b16ef17f733857"

--- a/packages/xapi-stdext-pervasives/xapi-stdext-pervasives.4.23.0/opam
+++ b/packages/xapi-stdext-pervasives/xapi-stdext-pervasives.4.23.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Pervasives"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "logs"
+  "odoc" {with-doc}
+  "xapi-backtrace"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.23.0/xapi-stdext-4.23.0.tbz"
+  checksum: [
+    "sha256=3908ba667aeefa5c771179596b511f04da5cfeef42bbfcbb7872c7c248b6be3e"
+    "sha512=fcc494a523fa843183d75a5288c9b3b0d012e260f131c40793f59253cf2140e8bbf953e204b23d98d1ca68fbc8ba37352a4f1a674fd3f3bd91cf94c61aa07a55"
+  ]
+}
+x-commit-hash: "4404d5b0c1c248f5e74fa587b5b16ef17f733857"

--- a/packages/xapi-stdext-std/xapi-stdext-std.4.23.0/opam
+++ b/packages/xapi-stdext-std/xapi-stdext-std.4.23.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Stdlib"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.23.0/xapi-stdext-4.23.0.tbz"
+  checksum: [
+    "sha256=3908ba667aeefa5c771179596b511f04da5cfeef42bbfcbb7872c7c248b6be3e"
+    "sha512=fcc494a523fa843183d75a5288c9b3b0d012e260f131c40793f59253cf2140e8bbf953e204b23d98d1ca68fbc8ba37352a4f1a674fd3f3bd91cf94c61aa07a55"
+  ]
+}
+x-commit-hash: "4404d5b0c1c248f5e74fa587b5b16ef17f733857"

--- a/packages/xapi-stdext-threads/xapi-stdext-threads.4.23.0/opam
+++ b/packages/xapi-stdext-threads/xapi-stdext-threads.4.23.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Threads"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml"
+  "base-threads"
+  "base-unix"
+  "odoc" {with-doc}
+  "xapi-stdext-pervasives" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.23.0/xapi-stdext-4.23.0.tbz"
+  checksum: [
+    "sha256=3908ba667aeefa5c771179596b511f04da5cfeef42bbfcbb7872c7c248b6be3e"
+    "sha512=fcc494a523fa843183d75a5288c9b3b0d012e260f131c40793f59253cf2140e8bbf953e204b23d98d1ca68fbc8ba37352a4f1a674fd3f3bd91cf94c61aa07a55"
+  ]
+}
+x-commit-hash: "4404d5b0c1c248f5e74fa587b5b16ef17f733857"

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.23.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.23.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Unix"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12.0"}
+  "base-unix"
+  "fd-send-recv" {>= "2.0.0"}
+  "odoc" {with-doc}
+  "xapi-stdext-pervasives" {= version}
+]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+available: [ os = "macos" | os = "linux" ]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.23.0/xapi-stdext-4.23.0.tbz"
+  checksum: [
+    "sha256=3908ba667aeefa5c771179596b511f04da5cfeef42bbfcbb7872c7c248b6be3e"
+    "sha512=fcc494a523fa843183d75a5288c9b3b0d012e260f131c40793f59253cf2140e8bbf953e204b23d98d1ca68fbc8ba37352a4f1a674fd3f3bd91cf94c61aa07a55"
+  ]
+}
+x-commit-hash: "4404d5b0c1c248f5e74fa587b5b16ef17f733857"

--- a/packages/xapi-stdext-zerocheck/xapi-stdext-zerocheck.4.23.0/opam
+++ b/packages/xapi-stdext-zerocheck/xapi-stdext-zerocheck.4.23.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Zerocheck"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.23.0/xapi-stdext-4.23.0.tbz"
+  checksum: [
+    "sha256=3908ba667aeefa5c771179596b511f04da5cfeef42bbfcbb7872c7c248b6be3e"
+    "sha512=fcc494a523fa843183d75a5288c9b3b0d012e260f131c40793f59253cf2140e8bbf953e204b23d98d1ca68fbc8ba37352a4f1a674fd3f3bd91cf94c61aa07a55"
+  ]
+}
+x-commit-hash: "4404d5b0c1c248f5e74fa587b5b16ef17f733857"


### PR DESCRIPTION
Xapi's standard library extension

- Project page: <a href="https://github.com/xapi-project/stdext">https://github.com/xapi-project/stdext</a>

## What's Changed
* CA-382014: Fix blkgetsize return type mismatch by @edwintorok in https://github.com/xapi-project/stdext/pull/74
* Create a function to recursively remove files by @snwoods in https://github.com/xapi-project/stdext/pull/76
