### PR TITLE
vdom 0.3 does not depend on odoc

### DIFF
--- a/packages/vdom/vdom.0.3/opam
+++ b/packages/vdom/vdom.0.3/opam
@@ -20,7 +20,7 @@ depends: [
   "gen_js_api" {>= "1.0.7"}
   "ojs"
   "js_of_ocaml-compiler"
-  "odoc"
+  "odoc" {with-doc}
 ]
 conflicts: [
   "ocaml-vdom" {!= "transition"}


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/24609