### PR TITLE
Package opam-publish.2.3.0

### DIFF
--- a/packages/opam-publish/opam-publish.2.3.0/opam
+++ b/packages/opam-publish/opam-publish.2.3.0/opam
@@ -18,9 +18,9 @@ depends: [
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.03.0"}
-  "opam-core" {>= "2.1.0~rc"}
-  "opam-format" {>= "2.1.0~rc"}
-  "opam-state" {>= "2.1.0~rc"}
+  "opam-core" {>= "2.1.0~rc" & < "2.2.0~~"}
+  "opam-format" {>= "2.1.0~rc" & < "2.2.0~~"}
+  "opam-state" {>= "2.1.0~rc" & < "2.2.0~~"}
   "github" {>= "4.3.2"}
   "github-unix" {>= "4.3.2"}
 ]

--- a/packages/opam-publish/opam-publish.2.3.0/opam
+++ b/packages/opam-publish/opam-publish.2.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A tool to ease contributions to opam repositories"
+description: """\
+opam-publish automates publishing packages to package repositories: it checks that the
+opam file is complete using `opam lint`, verifies and adds the archive URL and its
+checksum and files a GitHub pull request for merging it."""
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+depends: [
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "1.0"}
+  "lwt_ssl"
+  "ocaml" {>= "4.03.0"}
+  "opam-core" {>= "2.1.0~rc"}
+  "opam-format" {>= "2.1.0~rc"}
+  "opam-state" {>= "2.1.0~rc"}
+  "github" {>= "4.3.2"}
+  "github-unix" {>= "4.3.2"}
+]
+conflicts: [
+  "ssl" {= "0.5.6"}
+]
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+url {
+  src:
+    "https://github.com/ocaml/opam-publish/releases/download/2.3.0/opam-publish-2.3.0.tar.gz"
+  checksum: [
+    "md5=1ed118cf985f418736c9a5cfd6be60cf"
+    "sha512=ba0014adae5e0fce5116d333c4839e8c70d309c6eab15aac47ab5527a7ee232d0cf4e80133d552a774305323512da83845fe03a2a48970d471ab383ecbf178bb"
+  ]
+}


### PR DESCRIPTION
### `opam-publish.2.3.0`
A tool to ease contributions to opam repositories
opam-publish automates publishing packages to package repositories: it checks that the
opam file is complete using `opam lint`, verifies and adds the archive URL and its
checksum and files a GitHub pull request for merging it.



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v2.3.0