### PR TITLE
Package abella.2.0.8

### DIFF
--- a/packages/abella/abella.2.0.8/opam
+++ b/packages/abella/abella.2.0.8/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Interactive theorem prover based on lambda-tree syntax"
+maintainer: "kaustuv@chaudhuri.info"
+authors: [
+  "Andrew Gacek"
+  "Yuting Wang"
+  "Kaustuv Chaudhuri"
+]
+homepage: "https://abella-prover.org"
+license: "GPL-3.0-only"
+build: [
+  [make "all-release" "abella.install"]
+]
+depends: [
+  "ocaml"    { >= "4.12.0" }
+  "cmdliner" { >= "1.2.0" }
+  "yojson"   { >= "2.1.1" }
+  "menhir"   { >= "20211012" & build }
+  "dune"     { >= "3.11"     & build }
+  "crunch"   { >= "3.3.0"    & build }
+  "ounit2"   { with-test }
+]
+bug-reports: "https://github.com/abella-prover/abella/issues"
+dev-repo: "git+https://github.com/abella-prover/abella.git"
+url {
+  src:
+    "https://github.com/abella-prover/abella/archive/refs/tags/v2.0.8.tar.gz"
+  checksum: [
+    "md5=fa1fd789aa26de6287ba6608625c8313"
+    "sha512=467898f0c03bbf902a0f32dcad197a699d68109908a544bf2d31e87ef6fa5cb88182356d4c97b148d00f4897b570c79ff9e5bfa2f5326c9474fa86f0209d75df"
+  ]
+}

--- a/packages/abella/abella.2.0.8/opam
+++ b/packages/abella/abella.2.0.8/opam
@@ -15,9 +15,10 @@ depends: [
   "ocaml"    { >= "4.12.0" }
   "cmdliner" { >= "1.2.0" }
   "yojson"   { >= "2.1.1" }
-  "menhir"   { >= "20211012" & build }
-  "dune"     { >= "3.11"     & build }
+  "dune"     { >= "3.11" }
+  "menhir"   { >= "20211012" }
   "crunch"   { >= "3.3.0"    & build }
+  "conf-npm" { >= "1"        & build }
   "ounit2"   { with-test }
 ]
 bug-reports: "https://github.com/abella-prover/abella/issues"


### PR DESCRIPTION
### `abella.2.0.8`
Interactive theorem prover based on lambda-tree syntax



---
* Homepage: https://abella-prover.org
* Source repo: git+https://github.com/abella-prover/abella.git
* Bug tracker: https://github.com/abella-prover/abella/issues

---
:camel: Pull-request generated by opam-publish v2.2.0