### PR TITLE
Add conf-boost support for Linux Mint

### DIFF
--- a/packages/conf-boost/conf-boost.1/opam
+++ b/packages/conf-boost/conf-boost.1/opam
@@ -5,7 +5,7 @@ authors: "Beman Dawes, David Abrahams, et al."
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "MIT"
 depexts: [
-  ["libboost-dev"] {os-family = "debian"}
+  ["libboost-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["boost"] {os-distribution = "nixos"}
   ["boost-dev"] {os-distribution = "alpine"}
   ["boost-devel"] {os-distribution = "fedora"}


### PR DESCRIPTION
This little PR add `conf-boost` support for Linux Mint.

Since this is enabling an existing `depexts` on a platform not currently tested by opam-ci, it should not trigger any different behaviour (read: I expect failures to be pre-existing).