### PR TITLE
Add conf-python-3 support for Linux Mint

### DIFF
--- a/packages/conf-python-3/conf-python-3.9.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.9.0.0/opam
@@ -6,7 +6,7 @@ license: "PSF-2.0"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: ["python3" "test.py"]
 depexts: [
-  ["python3"] {os-family = "debian"}
+  ["python3"] {os-family = "debian" | os-family = "ubuntu"}
   ["python3"] {os-distribution = "nixos"}
   ["python3"] {os-distribution = "alpine"}
   ["python39" "epel-release"] {os-distribution = "centos"}


### PR DESCRIPTION
This little PR adds conf-python-3 support for Linux Mint.

Locally, I can see the opam file is not `opam lint`ing cleanly:
```
$ opam lint packages/conf-python-3/conf-python-3.9.0.0/opam
/home/jmi/software/opam-repository/packages/conf-python-3/conf-python-3.9.0.0/opam: Warnings.
  warning 62: License doesn't adhere to the SPDX standard, see https://spdx.org/licenses/: "PSF-2.0"
```
despite that being a valid license ID: https://github.com/kit-ty-kate/spdx_licenses/blob/main/src/licenseIDs.ml#L363

I suspect it is just a consequence of me running an older `opam` though (2.1.2)