### PR TITLE
[new release] sail_sv_backend, sail_smt_backend, sail_output, sail_ocaml_backend, sail_manifest, sail_lem_backend, sail_latex_backend, sail_doc_backend, sail_coq_backend, sail_c_backend, sail and libsail (0.17)

### DIFF
--- a/packages/libsail/libsail.0.17/opam
+++ b/packages/libsail/libsail.0.17/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis:
+  "Sail is a language for describing the instruction semantics of processors"
+description: """
+Sail is a language for describing the instruction-set
+architecture (ISA) semantics of processors. Sail aims to provide a
+engineer-friendly, vendor-pseudocode-like language for describing
+instruction semantics. It is essentially a first-order imperative
+language, but with lightweight dependent typing for numeric types and
+bitvector lengths, which are automatically checked using Z3. It has
+been used for several papers, available from
+http://www.cl.cam.ac.uk/~pes20/sail/.
+"""
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "dune-site" {>= "3.0.2"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "menhir" {>= "20180523" & build}
+  "ott" {>= "0.28" & build}
+  "lem" {>= "2018-12-14"}
+  "linksem" {>= "0.3"}
+  "conf-gmp"
+  "conf-zlib"
+  "yojson" {>= "1.6.0"}
+  "pprint" {>= "20220103"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.17/sail-0.17.tbz"
+  checksum: [
+    "sha256=115a7bb139d9694af901f4deb638cd1622d2987ff1d2bafab7e802a038850f3f"
+    "sha512=ec54691ca2bf53bfb9879fb603c17c6fd270ca61c5880c07cbf5ba457c58fc2e49ff12ed9c988a3a4285d69a3759fb848c2a701a606e83f5db8b304067b2986d"
+  ]
+}
+x-commit-hash: "4437a673e8144576ddd594c0b98a1038ee54374a"

--- a/packages/sail/sail.0.17/opam
+++ b/packages/sail/sail.0.17/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+synopsis:
+  "Sail is a language for describing the instruction semantics of processors"
+description: """
+Sail is a language for describing the instruction-set
+architecture (ISA) semantics of processors. Sail aims to provide a
+engineer-friendly, vendor-pseudocode-like language for describing
+instruction semantics. It is essentially a first-order imperative
+language, but with lightweight dependent typing for numeric types and
+bitvector lengths, which are automatically checked using Z3. It has
+been used for several papers, available from
+http://www.cl.cam.ac.uk/~pes20/sail/.
+"""
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "sail_manifest" {= version & build}
+  "sail_ocaml_backend" {= version & post}
+  "sail_c_backend" {= version & post}
+  "sail_smt_backend" {= version & post}
+  "sail_sv_backend" {= version & post}
+  "sail_lem_backend" {= version & post}
+  "sail_coq_backend" {= version & post}
+  "sail_latex_backend" {= version & post}
+  "sail_doc_backend" {= version & post}
+  "sail_output" {= version & post}
+  "linenoise" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+substs: [ "src/bin/manifest.ml" ]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.17/sail-0.17.tbz"
+  checksum: [
+    "sha256=115a7bb139d9694af901f4deb638cd1622d2987ff1d2bafab7e802a038850f3f"
+    "sha512=ec54691ca2bf53bfb9879fb603c17c6fd270ca61c5880c07cbf5ba457c58fc2e49ff12ed9c988a3a4285d69a3759fb848c2a701a606e83f5db8b304067b2986d"
+  ]
+}
+x-commit-hash: "4437a673e8144576ddd594c0b98a1038ee54374a"

--- a/packages/sail_c_backend/sail_c_backend.0.17/opam
+++ b/packages/sail_c_backend/sail_c_backend.0.17/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to C translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.17/sail-0.17.tbz"
+  checksum: [
+    "sha256=115a7bb139d9694af901f4deb638cd1622d2987ff1d2bafab7e802a038850f3f"
+    "sha512=ec54691ca2bf53bfb9879fb603c17c6fd270ca61c5880c07cbf5ba457c58fc2e49ff12ed9c988a3a4285d69a3759fb848c2a701a606e83f5db8b304067b2986d"
+  ]
+}
+x-commit-hash: "4437a673e8144576ddd594c0b98a1038ee54374a"

--- a/packages/sail_coq_backend/sail_coq_backend.0.17/opam
+++ b/packages/sail_coq_backend/sail_coq_backend.0.17/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Coq translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.17/sail-0.17.tbz"
+  checksum: [
+    "sha256=115a7bb139d9694af901f4deb638cd1622d2987ff1d2bafab7e802a038850f3f"
+    "sha512=ec54691ca2bf53bfb9879fb603c17c6fd270ca61c5880c07cbf5ba457c58fc2e49ff12ed9c988a3a4285d69a3759fb848c2a701a606e83f5db8b304067b2986d"
+  ]
+}
+x-commit-hash: "4437a673e8144576ddd594c0b98a1038ee54374a"

--- a/packages/sail_doc_backend/sail_doc_backend.0.17/opam
+++ b/packages/sail_doc_backend/sail_doc_backend.0.17/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Sail documentation generator"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "base64" {>= "3.1.0"}
+  "omd" {>= "1.3.1" & < "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.17/sail-0.17.tbz"
+  checksum: [
+    "sha256=115a7bb139d9694af901f4deb638cd1622d2987ff1d2bafab7e802a038850f3f"
+    "sha512=ec54691ca2bf53bfb9879fb603c17c6fd270ca61c5880c07cbf5ba457c58fc2e49ff12ed9c988a3a4285d69a3759fb848c2a701a606e83f5db8b304067b2986d"
+  ]
+}
+x-commit-hash: "4437a673e8144576ddd594c0b98a1038ee54374a"

--- a/packages/sail_latex_backend/sail_latex_backend.0.17/opam
+++ b/packages/sail_latex_backend/sail_latex_backend.0.17/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to LaTeX formatting"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "omd" {>= "1.3.1" & < "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.17/sail-0.17.tbz"
+  checksum: [
+    "sha256=115a7bb139d9694af901f4deb638cd1622d2987ff1d2bafab7e802a038850f3f"
+    "sha512=ec54691ca2bf53bfb9879fb603c17c6fd270ca61c5880c07cbf5ba457c58fc2e49ff12ed9c988a3a4285d69a3759fb848c2a701a606e83f5db8b304067b2986d"
+  ]
+}
+x-commit-hash: "4437a673e8144576ddd594c0b98a1038ee54374a"

--- a/packages/sail_lem_backend/sail_lem_backend.0.17/opam
+++ b/packages/sail_lem_backend/sail_lem_backend.0.17/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Lem translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.17/sail-0.17.tbz"
+  checksum: [
+    "sha256=115a7bb139d9694af901f4deb638cd1622d2987ff1d2bafab7e802a038850f3f"
+    "sha512=ec54691ca2bf53bfb9879fb603c17c6fd270ca61c5880c07cbf5ba457c58fc2e49ff12ed9c988a3a4285d69a3759fb848c2a701a606e83f5db8b304067b2986d"
+  ]
+}
+x-commit-hash: "4437a673e8144576ddd594c0b98a1038ee54374a"

--- a/packages/sail_manifest/sail_manifest.0.17/opam
+++ b/packages/sail_manifest/sail_manifest.0.17/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Helper tool for compiling Sail"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.17/sail-0.17.tbz"
+  checksum: [
+    "sha256=115a7bb139d9694af901f4deb638cd1622d2987ff1d2bafab7e802a038850f3f"
+    "sha512=ec54691ca2bf53bfb9879fb603c17c6fd270ca61c5880c07cbf5ba457c58fc2e49ff12ed9c988a3a4285d69a3759fb848c2a701a606e83f5db8b304067b2986d"
+  ]
+}
+x-commit-hash: "4437a673e8144576ddd594c0b98a1038ee54374a"

--- a/packages/sail_ocaml_backend/sail_ocaml_backend.0.17/opam
+++ b/packages/sail_ocaml_backend/sail_ocaml_backend.0.17/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to OCaml translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "base64" {>= "3.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.17/sail-0.17.tbz"
+  checksum: [
+    "sha256=115a7bb139d9694af901f4deb638cd1622d2987ff1d2bafab7e802a038850f3f"
+    "sha512=ec54691ca2bf53bfb9879fb603c17c6fd270ca61c5880c07cbf5ba457c58fc2e49ff12ed9c988a3a4285d69a3759fb848c2a701a606e83f5db8b304067b2986d"
+  ]
+}
+x-commit-hash: "4437a673e8144576ddd594c0b98a1038ee54374a"

--- a/packages/sail_output/sail_output.0.17/opam
+++ b/packages/sail_output/sail_output.0.17/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Example Sail output plugin"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.17/sail-0.17.tbz"
+  checksum: [
+    "sha256=115a7bb139d9694af901f4deb638cd1622d2987ff1d2bafab7e802a038850f3f"
+    "sha512=ec54691ca2bf53bfb9879fb603c17c6fd270ca61c5880c07cbf5ba457c58fc2e49ff12ed9c988a3a4285d69a3759fb848c2a701a606e83f5db8b304067b2986d"
+  ]
+}
+x-commit-hash: "4437a673e8144576ddd594c0b98a1038ee54374a"

--- a/packages/sail_smt_backend/sail_smt_backend.0.17/opam
+++ b/packages/sail_smt_backend/sail_smt_backend.0.17/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to C translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.17/sail-0.17.tbz"
+  checksum: [
+    "sha256=115a7bb139d9694af901f4deb638cd1622d2987ff1d2bafab7e802a038850f3f"
+    "sha512=ec54691ca2bf53bfb9879fb603c17c6fd270ca61c5880c07cbf5ba457c58fc2e49ff12ed9c988a3a4285d69a3759fb848c2a701a606e83f5db8b304067b2986d"
+  ]
+}
+x-commit-hash: "4437a673e8144576ddd594c0b98a1038ee54374a"

--- a/packages/sail_sv_backend/sail_sv_backend.0.17/opam
+++ b/packages/sail_sv_backend/sail_sv_backend.0.17/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Systemverilog translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.17/sail-0.17.tbz"
+  checksum: [
+    "sha256=115a7bb139d9694af901f4deb638cd1622d2987ff1d2bafab7e802a038850f3f"
+    "sha512=ec54691ca2bf53bfb9879fb603c17c6fd270ca61c5880c07cbf5ba457c58fc2e49ff12ed9c988a3a4285d69a3759fb848c2a701a606e83f5db8b304067b2986d"
+  ]
+}
+x-commit-hash: "4437a673e8144576ddd594c0b98a1038ee54374a"


### PR DESCRIPTION
Project page: <a href="https://github.com/rems-project/sail">https://github.com/rems-project/sail</a>

##### CHANGES:

##### Performance improvements

This release is primarily intended to fix performance issues. Overall
the Sail to C compilation can be almost 10x faster, and consumes
significantly less memory.

##### Order parameters deprecated

The order parameter on the bitvector and vector types no longer does
anything. The `default Order <ord>` statement now sets the bitvector
and vector ordering globally. In practice only POWER uses increasing
bit order, and there is never a valid reason to mix them in a
specification. Overall they added significant complexity to the
language for no real gain. Over subsequent releases a warning will be
added before they are eventually removed from the syntax.

##### String append pattern rework

For a while string append patterns `x ^ y` have been marked with a
special non-executable effect that forbids them from being used. Now
the implementation has been removed due to the deleterious effect
the generated code has on performance. Such clauses are now eagerly
removed from the syntax tree during rewriting pending a revised
implementation.

##### SystemVerilog backend (EXPERIMENTAL)

Sail can now produce SystemVerilog output using the -sv flag. Note
that this is not intended to be human readable or produce a
synthesizable design, but is instead intended to be used with
SystemVerilog verification tools like JasperGold.
