### PR TITLE
Fix Ortac 0.1.0 packages

### DIFF
--- a/packages/ortac-core/ortac-core.0.1.0/opam
+++ b/packages/ortac-core/ortac-core.0.1.0/opam
@@ -41,10 +41,12 @@ build: [
     name
     "-j"
     jobs
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/ocaml-gospel/ortac.git"
 url {

--- a/packages/ortac-qcheck-stm/ortac-qcheck-stm.0.1.0/opam
+++ b/packages/ortac-qcheck-stm/ortac-qcheck-stm.0.1.0/opam
@@ -41,10 +41,12 @@ build: [
     name
     "-j"
     jobs
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/ocaml-gospel/ortac.git"
 conflicts: [

--- a/packages/ortac-runtime/ortac-runtime.0.1.0/opam
+++ b/packages/ortac-runtime/ortac-runtime.0.1.0/opam
@@ -32,10 +32,12 @@ build: [
     name
     "-j"
     jobs
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/ocaml-gospel/ortac.git"
 url {


### PR DESCRIPTION
This PR fixes the packages introduced by #24666. Those packages use plugins as set up by `dune-site` but were not calling `dune install` during the `build`; as a consequence, the command-line executable can’t find its plugins directory.