### PR TITLE
Package abella.2.0.8

### DIFF
--- a/packages/abella/abella.2.0.8/opam
+++ b/packages/abella/abella.2.0.8/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Interactive theorem prover based on lambda-tree syntax"
+maintainer: "kaustuv@chaudhuri.info"
+authors: [
+  "Andrew Gacek"
+  "Yuting Wang"
+  "Kaustuv Chaudhuri"
+]
+homepage: "https://abella-prover.org"
+license: "GPL-3.0-only"
+build: [
+  [make "all-release" "abella.install"]
+]
+depends: [
+  "ocaml"    { >= "4.12.0" }
+  "cmdliner" { >= "1.2.0" }
+  "menhir"   { >= "20211012" }
+  "yojson"   { >= "2.1.1" }
+  "dune"     { >= "3.11" }
+  "crunch"   { >= "3.3.0" & build }
+  "ounit2"   { with-test }
+]
+bug-reports: "https://github.com/abella-prover/abella/issues"
+dev-repo: "git+https://github.com/abella-prover/abella.git"
+url {
+  src:
+    "https://github.com/abella-prover/abella/archive/refs/tags/v2.0.8.tar.gz"
+  checksum: [
+    "md5=91d1ed5ad95aab58c410e76e2e5516eb"
+    "sha512=a8e0e661e299f6c4dc16b9f040839cd6bdcc50705c2ddc95e69da47e1aaaed55ba6724afeb0d08639071e73a1161ee06ff71c06f170f660b07103ba54518db78"
+  ]
+}


### PR DESCRIPTION
### `abella.2.0.8`
Interactive theorem prover based on lambda-tree syntax



---
* Homepage: https://abella-prover.org
* Source repo: git+https://github.com/abella-prover/abella.git
* Bug tracker: https://github.com/abella-prover/abella/issues

---
:camel: Pull-request generated by opam-publish v2.2.0