### PR TITLE
Package binaryen.0.24.0

### DIFF
--- a/packages/binaryen/binaryen.0.24.0/opam
+++ b/packages/binaryen/binaryen.0.24.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "4.1.0" & < "6.0.0"}
+  "libbinaryen" {>= "114.0.0" & < "115.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.24.0/binaryen-archive-v0.24.0.tar.gz"
+  checksum: [
+    "md5=7983788fc30723512f95fa11b71a7d58"
+    "sha512=3e5d43c83d9db149e4b4accc390302838c545aca4ca5de8d0c9f84e1b2d482f4c75ed9942fbbab0d45331c6b4c7a87af78b68757852690028bbd67b784252b44"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.24.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.24.0](https://github.com/grain-lang/binaryen.ml/compare/v0.23.0...v0.24.0) (2023-10-30)


### ⚠ BREAKING CHANGES

* Update to libbinaryen v114 ([#198](https://github.com/grain-lang/binaryen.ml/issues/198))

### Features

* Update to libbinaryen v114 ([#198](https://github.com/grain-lang/binaryen.ml/issues/198)) ([d11b8e1](https://github.com/grain-lang/binaryen.ml/commit/d11b8e1fae530fe36439805576f8103aafc34583))

---
:camel: Pull-request generated by opam-publish v2.0.3