### PR TITLE
change build command of `ocaml` to support compilation in a path with spaces

### DIFF
--- a/packages/ocaml/ocaml.5.1.0/opam
+++ b/packages/ocaml/ocaml.5.1.0/opam
@@ -17,7 +17,7 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
-build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build: ["ocamlrun" "%{bin}/ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [
   [CAML_LD_LIBRARY_PATH = ""]
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]


### PR DESCRIPTION
Related to https://github.com/ocaml/opam/issues/5679

This is a naive proposal to be able to compile the `ocaml` package with a version of ocaml that has been compiled in a folder with spaces in its name.