### PR TITLE
grpc-examples: add upper bound on eio

### DIFF
--- a/packages/grpc-examples/grpc-examples.0.2.0/opam
+++ b/packages/grpc-examples/grpc-examples.0.2.0/opam
@@ -31,7 +31,7 @@ depends: [
   "tls-async"
   "lwt_ssl" {>= "1.2.0"}
   "mdx" {>= "2.2.1" & with-test}
-  "eio_main" {>= "0.10"}
+  "eio_main" {>= "0.10" & < "0.12"}
   "stringext"
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
due to Eio.Flow.two_way object use, and interface change in eio.0.12

fixes revdeps in #24687 