### PR TITLE
[new release] pyml.20231101

### DIFF
--- a/packages/pyml/pyml.20231101/opam
+++ b/packages/pyml/pyml.20231101/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "http://github.com/thierry-martinez/pyml"
+bug-reports: "http://github.com/thierry-martinez/pyml/issues"
+license: "BSD-2-Clause"
+dev-repo: "git+https://github.com/thierry-martinez/pyml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+synopsis: "OCaml bindings for Python"
+description: "OCaml bindings for Python 2 and Python 3"
+available: arch != "s390x"
+depends: [
+  "ocaml" {>= "3.12.1"}
+  "dune" {>= "2.8.0"}
+  "ocamlfind" {build}
+  "stdcompat" {>= "18"}
+  "conf-python-3-dev" {with-test}
+  "odoc" {with-doc}
+]
+depopts: ["utop"]
+url {
+  src: "https://github.com/thierry-martinez/pyml/releases/download/20231101/pyml.20231101.tar.gz"
+  checksum: "sha512=711cbb8fb14317a04780c4d27edc1897d8a5dd783edfd471fe16b8edfd0820f876507383526fe3b57c0046575982735504ca101ab26d96ad13363f14a2469fa1"
+}

--- a/packages/pyml/pyml.20231101/opam
+++ b/packages/pyml/pyml.20231101/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "3.12.1"}
   "dune" {>= "2.8.0"}
   "ocamlfind" {build}
-  "stdcompat" {>= "18"}
+  "stdcompat" {>= "19"}
   "conf-python-3-dev" {with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
This commit publishes the new release of pyml.20231101. https://github.com/thierry-martinez/pyml/releases/tag/20231101