### PR TITLE
[new release] eio (5 packages) (0.13)

### DIFF
--- a/packages/eio/eio.0.13/opam
+++ b/packages/eio/eio.0.13/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "5.1.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "hmap" {>= "0.8.1"}
+  "domain-local-await" {>= "0.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "2.0.0"}
+  "mdx" {>= "2.2.0" & with-test}
+  "dscheck" {>= "0.1.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "seq" {< "0.3"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.13/eio-0.13.tbz"
+  checksum: [
+    "sha256=82537ee1c5b1829fde8207614a4e39f560bd582332841290ed5ef76691f3af70"
+    "sha512=69fc509e5ed34da64c3c26fa22558ce7f0cb42afa65c864c57dbb05948e12c0f4f6ab7b77a07f8b292ea3a18748ed46deb9da6af74852115da5e938177b3bf18"
+  ]
+}
+x-commit-hash: "bc1e231b64a69af5226d998d3286d235b61b0f5f"

--- a/packages/eio_linux/eio_linux.0.13/opam
+++ b/packages/eio_linux/eio_linux.0.13/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An Eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "eio" {= version}
+  "mdx" {>= "2.2.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "0.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+available: [os = "linux"]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.13/eio-0.13.tbz"
+  checksum: [
+    "sha256=82537ee1c5b1829fde8207614a4e39f560bd582332841290ed5ef76691f3af70"
+    "sha512=69fc509e5ed34da64c3c26fa22558ce7f0cb42afa65c864c57dbb05948e12c0f4f6ab7b77a07f8b292ea3a18748ed46deb9da6af74852115da5e938177b3bf18"
+  ]
+}
+x-commit-hash: "bc1e231b64a69af5226d998d3286d235b61b0f5f"

--- a/packages/eio_main/eio_main.0.13/opam
+++ b/packages/eio_main/eio_main.0.13/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "mdx" {>= "2.2.0" & with-test}
+  "kcas" {>= "0.3.0" & with-test}
+  "yojson" {>= "2.0.2" & with-test}
+  "eio_linux"
+    {= version & os = "linux" &
+     (os-distribution != "centos" | os-version > "7")}
+  "eio_posix" {= version & os != "win32"}
+  "eio_windows" {= version & os = "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.13/eio-0.13.tbz"
+  checksum: [
+    "sha256=82537ee1c5b1829fde8207614a4e39f560bd582332841290ed5ef76691f3af70"
+    "sha512=69fc509e5ed34da64c3c26fa22558ce7f0cb42afa65c864c57dbb05948e12c0f4f6ab7b77a07f8b292ea3a18748ed46deb9da6af74852115da5e938177b3bf18"
+  ]
+}
+x-commit-hash: "bc1e231b64a69af5226d998d3286d235b61b0f5f"
+x-ci-accept-failures: ["macos-homebrew"]

--- a/packages/eio_posix/eio_posix.0.13/opam
+++ b/packages/eio_posix/eio_posix.0.13/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for POSIX systems"
+description: "An Eio implementation for most Unix-like platforms"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "iomux" {>= "0.2"}
+  "mdx" {>= "2.2.0" & with-test}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.13/eio-0.13.tbz"
+  checksum: [
+    "sha256=82537ee1c5b1829fde8207614a4e39f560bd582332841290ed5ef76691f3af70"
+    "sha512=69fc509e5ed34da64c3c26fa22558ce7f0cb42afa65c864c57dbb05948e12c0f4f6ab7b77a07f8b292ea3a18748ed46deb9da6af74852115da5e938177b3bf18"
+  ]
+}
+x-commit-hash: "bc1e231b64a69af5226d998d3286d235b61b0f5f"

--- a/packages/eio_windows/eio_windows.0.13/opam
+++ b/packages/eio_windows/eio_windows.0.13/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Windows"
+description: "An Eio implementation using OCaml's Unix.select"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "kcas" {>= "0.3.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.13/eio-0.13.tbz"
+  checksum: [
+    "sha256=82537ee1c5b1829fde8207614a4e39f560bd582332841290ed5ef76691f3af70"
+    "sha512=69fc509e5ed34da64c3c26fa22558ce7f0cb42afa65c864c57dbb05948e12c0f4f6ab7b77a07f8b292ea3a18748ed46deb9da6af74852115da5e938177b3bf18"
+  ]
+}
+x-commit-hash: "bc1e231b64a69af5226d998d3286d235b61b0f5f"
+available: [os = "win32"]


### PR DESCRIPTION
Effect-based direct-style IO API for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/eio">https://github.com/ocaml-multicore/eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/eio/">https://ocaml-multicore.github.io/eio/</a>

##### CHANGES:

New features / API changes:

- Add `Flow.read_all` (@SGrondin ocaml-multicore/eio#596, reviewed by @talex5 @rbjorklin).

- Add `Path.stat` (@patricoferris @talex5 @avsm ocaml-multicore/eio#617 ocaml-multicore/eio#618 ocaml-multicore/eio#624 ocaml-multicore/eio#620, reviewed by @SGrondin).

- Add `Path.rmtree` (@talex5 ocaml-multicore/eio#627 ocaml-multicore/eio#628, reviewed by @SGrondin).

- Add `Path.mkdirs` and `Path.split` (@patricoferris @talex5 ocaml-multicore/eio#625).

- Add `Eio.File.{seek,sync,truncate}` (@talex5 ocaml-multicore/eio#626).

- Add `Eio.Path.{kind,is_file,is_directory}` (@patricoferris @talex5 ocaml-multicore/eio#623, reviewed by @avsm).

- Switch from CTF to OCaml 5.1 runtime events (@TheLortex @patricoferris @talex5 ocaml-multicore/eio#634 ocaml-multicore/eio#635, reviewed by @avsm).
  This is a minimal initial version.

Documentation:

- Document `File.Stat` record fields (@avsm @talex5 ocaml-multicore/eio#621).

- Update README section about `env` (@talex5 ocaml-multicore/eio#614, reported by @jonsterling).

Build and test changes:

- Add `File.stat` benchmark (@talex5 ocaml-multicore/eio#616).

- Add `Path.stat` benchmark (@patricoferris @talex5 ocaml-multicore/eio#630).

- eio_linux: mark as only available on Linux (@talex5 ocaml-multicore/eio#629).

- Make MDX tests idempotent (@SGrondin ocaml-multicore/eio#601, reviewed by @talex5).

- Allow trailing whitespace in CHANGES.md (@talex5 ocaml-multicore/eio#632).

- Update minimum OCaml version to 5.1 (@talex5 ocaml-multicore/eio#631).

- Generate prototypes for C stubs from ml files (@talex5 ocaml-multicore/eio#615).

- Don't try to compile uring support on centos 7 (@talex5 ocaml-multicore/eio#638, reported by @zenfey).
