### PR TITLE
2 packages from ocaml-sf/learn-ocaml at 0.16.0

### DIFF
--- a/packages/learn-ocaml-client/learn-ocaml-client.0.16.0/opam
+++ b/packages/learn-ocaml-client/learn-ocaml-client.0.16.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "The learn-ocaml client"
+description: """\
+This contains the binaries to interact with the learn-ocaml
+platform from the command line."""
+maintainer: [
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+  "Yann Régis-Gianas <yann.regis-gianas@nomadic-labs.com>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+]
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+depends: [
+  "asak" {< "0.4"}
+  "base64"
+  "base" {>= "v0.9.4"}
+  "cmdliner" {>= "1.1.0"}
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "cstruct" {>= "3.3.0"}
+  "digestif" {>= "0.7.1"}
+  "dune" {>= "2.3.0"}
+  "ezjsonm"
+  "gg"
+  "ipaddr" {= "2.9.0"}
+  "lwt" {>= "4.0.0"}
+  "lwt_ssl"
+  "ocaml" {(>= "4.12") & (< "4.13~")}
+  "ocamlfind" {build}
+  "ocaml-migrate-parsetree" {= "1.8.0"}
+  "ocp-indent-nlfork"
+  "ocplib-json-typed" {>= "0.7"}
+  "ocp-ocamlres" {>= "0.4"}
+  "omd" {<= "1.3.1"}
+  "ppxlib"
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_fields_conv"
+  "ppx_sexp_conv"
+  "ppx_tools"
+  "ssl" {= "0.5.12"}
+  "vg"
+]
+build: ["dune" "build" "@install" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+url {
+  src:
+    "https://github.com/ocaml-sf/learn-ocaml/archive/refs/tags/v0.16.0.tar.gz"
+  checksum: [
+    "md5=23c47ac8ef2a9338cd41795d26566cf4"
+    "sha512=53d86304f0a6e2df8d372d80030cc1ed56887af6589a39253f53ef1e1a935cb4158c042c83c60c954c8ff70bea75bcdde9e74ee3a11cc6720f5562b9106a6088"
+  ]
+}

--- a/packages/learn-ocaml/learn-ocaml.0.16.0/opam
+++ b/packages/learn-ocaml/learn-ocaml.0.16.0/opam
@@ -1,0 +1,89 @@
+opam-version: "2.0"
+synopsis: "The learn-ocaml online platform (engine)"
+description: """\
+This contains the binaries forming the engine for the learn-ocaml platform, and
+the common files. A demo exercise repository is also provided as example."""
+maintainer: [
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+  "Yann Régis-Gianas <yann.regis-gianas@nomadic-labs.com>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+]
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+depends: [
+  "asak" {< "0.4"}
+  "base64"
+  "base" {>= "v0.9.4"}
+  "cmdliner" {>= "1.1.0"}
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt" {>= "2.0.0"}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "conf-git"
+  "decompress" {= "0.8.1"}
+  "digestif" {>= "0.7.1"}
+  "dune" {>= "2.3.0"}
+  "easy-format" {>= "1.3.0"}
+  "ezjsonm"
+  "ipaddr" {= "2.9.0"}
+  "js_of_ocaml" {>= "3.3.0" & != "3.10.0"}
+  "js_of_ocaml-compiler" {>= "3.3.0"}
+  "js_of_ocaml-lwt"
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-toplevel"
+  "js_of_ocaml-tyxml"
+  "lwt" {>= "4.0.0"}
+  "lwt_react"
+  "lwt_ssl"
+  "magic-mime"
+  "markup"
+  "markup-lwt"
+  "ocaml" {(>= "4.12") & (< "4.13~")}
+  "ocamlfind" {build}
+  "ocaml-migrate-parsetree" {= "1.8.0"}
+  "ocp-indent-nlfork"
+  "ocplib-json-typed" {>= "0.7"}
+  "ocplib-json-typed-browser" {>= "0.7"}
+  "ocp-ocamlres" {>= "0.4"}
+  "odoc" {build}
+  "omd" {<= "1.3.1"}
+  "pprint"
+  "ppxlib"
+  "ppx_cstruct"
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_sexp_conv"
+  "ppx_tools"
+  "ppx_tools_versioned"
+  "re"
+  "ssl" {= "0.5.12"}
+  "uutf" {>= "1.0"}
+  "vg"
+  "yojson" {>= "1.4.0"}
+]
+build: [
+  [make "static"]
+  ["dune" "build" "-p" name "-j" jobs]
+  [make "detect-libs"] {with-test}
+]
+run-test: [make "test"]
+install: [
+  ["mkdir" "-p" "%{_:share}%"]
+  ["cp" "-r" "demo-repository" "%{_:share}%/repository"]
+]
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+url {
+  src:
+    "https://github.com/ocaml-sf/learn-ocaml/archive/refs/tags/v0.16.0.tar.gz"
+  checksum: [
+    "md5=23c47ac8ef2a9338cd41795d26566cf4"
+    "sha512=53d86304f0a6e2df8d372d80030cc1ed56887af6589a39253f53ef1e1a935cb4158c042c83c60c954c8ff70bea75bcdde9e74ee3a11cc6720f5562b9106a6088"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `learn-ocaml.0.16.0`: The learn-ocaml online platform (engine)
- `learn-ocaml-client.0.16.0`: The learn-ocaml client



---
* Homepage: https://github.com/ocaml-sf/learn-ocaml
* Source repo: git+https://github.com/ocaml-sf/learn-ocaml
* Bug tracker: https://github.com/ocaml-sf/learn-ocaml/issues

---
Cc @erikmd @yurug @AltGr FYI

## [0.16.0](https://github.com/ocaml-sf/learn-ocaml/compare/v0.15.0...v0.16.0) (2023-11-03)


### Features

* **UI:** add exercise sorting by focus skill ([4f9766b](https://github.com/ocaml-sf/learn-ocaml/commit/4f9766ba0db73eacaef8f02b9562cd01a0a37e27))
* **UI:** Rework of the exercise index ([91f827b](https://github.com/ocaml-sf/learn-ocaml/commit/91f827b3b78b4466093da781d627db3979d11943))
* **UI:** Add possibility to choose exercise display order ([25780ba](https://github.com/ocaml-sf/learn-ocaml/commit/25780ba2ff2bbe50d7ad74d9ac6fb3097759ed03))


### Bug Fixes

* **translations:** Add missing fr.po.header ([f7ffc6f](https://github.com/ocaml-sf/learn-ocaml/commit/f7ffc6fd14c7a4618aba940cdb0003d24150083d)), closes [#555](https://github.com/ocaml-sf/learn-ocaml/issues/555)
* **teacher_tab:** Display (Open/Close)GloballyInconsistent exos and fix them ([10c9fc3](https://github.com/ocaml-sf/learn-ocaml/commit/10c9fc30e391036b0847e7d4ff2bc88e2be25e55))
* **teacher_tab:** partly fix Open/Close handling w.r.t. Assignments ([6c41457](https://github.com/ocaml-sf/learn-ocaml/commit/6c414578a70c5529387f7cb3266b9ea1e85cc97d)), closes [#534](https://github.com/ocaml-sf/learn-ocaml/issues/534) [#558](https://github.com/ocaml-sf/learn-ocaml/issues/558)
* **teacher_tab:** Fix Open/Closed handling for update_exercise_assignments ([49d82e4](https://github.com/ocaml-sf/learn-ocaml/commit/49d82e49c900000c9e04da845f1f47579f974332)), closes [#558](https://github.com/ocaml-sf/learn-ocaml/issues/558)


### Code Refactoring

* **translations:** gettext: Use CLI option `--no-wrap` ([ea4f2bc](https://github.com/ocaml-sf/learn-ocaml/commit/ea4f2bc3538ba1efaca3e388ab7fc5e65821081b))
* **teacher_tab:** Move critical code apart in update_exercise_assignments ([bf6a931](https://github.com/ocaml-sf/learn-ocaml/commit/bf6a931f122d41e8d6afb0a59ecc4a96a30d9b1a))


### Dependencies

* **opam:** learn-ocaml 0.x does not build with asak 0.4 ([#570](https://github.com/ocaml-sf/learn-ocaml/issues/570)) ([9176975](https://github.com/ocaml-sf/learn-ocaml/commit/9176975ab1df493ab0cecab8711223e1a692ab76))


### Tests

* **Learnocaml_data:** Add support for ppx_expect & ppx_inline_test ([3a0ceb4](https://github.com/ocaml-sf/learn-ocaml/commit/3a0ceb469d9f60979d15a889454fd2965c7fa72f))
* **Learnocaml_data:** Add ppx_expect tests for update_exercise_assignments ([c18da2a](https://github.com/ocaml-sf/learn-ocaml/commit/c18da2a89a88ebfdbed512f4dc813c63c0648d73))
* **Learnocaml_data:** Refactor ppx_expect tests to display more details in the trace ([569d536](https://github.com/ocaml-sf/learn-ocaml/commit/569d536d8ed5889bafa8bd88fa8d21b89f60810e))


### CI/CD

* ***.yml:** Move opam-publish in a separate workflow to enable testing ([#571](https://github.com/ocaml-sf/learn-ocaml/issues/571)) ([b84132e](https://github.com/ocaml-sf/learn-ocaml/commit/b84132ee7328fdf132743a17722c5e26b391b2e7))


### Documentation

* **opam:** Cite Louis Gesbert in the Learn-OCaml maintainers team ([c9a833b](https://github.com/ocaml-sf/learn-ocaml/commit/c9a833be624b8bda7d2f4a310ccf832fc10cae7f))


---
:camel: Pull-request generated by opam-publish v2.3.0