### PR TITLE
lwt_eio: don't run tests with Eio 0.13

### DIFF
--- a/packages/lwt_eio/lwt_eio.0.5/opam
+++ b/packages/lwt_eio/lwt_eio.0.5/opam
@@ -13,7 +13,7 @@ depends: [
   "eio" {>= "0.12"}
   "lwt" {>= "5.7.0"}
   "mdx" {>= "1.10.0" & with-test}
-  "eio_main" {with-test}
+  "eio_main" {< "0.13" & with-test}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
The MDX output changed slightly, breaking the tests (see https://github.com/ocaml/opam-repository/pull/24736#issuecomment-1792089061).