### PR TITLE
Fix conf-python-3 on homebrew

### DIFF
--- a/packages/conf-python-3/conf-python-3.9.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.9.0.0/opam
@@ -19,7 +19,7 @@ depexts: [
   ["lang/python39"] {os = "netbsd"}
   ["python3"] {os = "freebsd"}
   ["python39"] {os-distribution = "macports" & os = "macos"}  # this will not result in a python3 command but only a python3.9 command
-  ["python@3"] {os-distribution = "homebrew" & os = "macos"}
+  ["python@3.9"] {os-distribution = "homebrew" & os = "macos"}
   ["system:python3"] {os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on Python-3 installation"


### PR DESCRIPTION
Maybe opam can work with python@3.x since it cannot see python@3. This is a known issue: https://github.com/ocaml/opam/issues/5023
See #24741 