### PR TITLE
Package pratter.3.0.0

### DIFF
--- a/packages/pratter/pratter.3.0.0/opam
+++ b/packages/pratter/pratter.3.0.0/opam
@@ -17,9 +17,9 @@ depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
   "camlp-streams" {>= "5.0" & < "6"}
-  "alcotest" {with-test}
-  "qcheck" {with-test}
-  "qcheck-alcotest" {with-test}
+  "alcotest" {with-test >= "1.5.0" & < "2"}
+  "qcheck" {with-test >= "0.9"}
+  "qcheck-alcotest" {with-test >= "0.9"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/pratter/pratter.3.0.0/opam
+++ b/packages/pratter/pratter.3.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Parse strings of tokens and mixfix operators"
+description: """
+Pratter allows to transform strings of symbols and mixfix operators to full
+binary trees.
+Pratter is convenient for parsing languages made of terms with many mixfix
+operators with different associativities and precedences such as
+arithmetic or λ-calculi.
+In contrast to parser generators, parsing rules can be edited dynamically.
+"""
+maintainer: ["Gabriel Hondet <koizel#pratter@aleeas.com>"]
+authors: ["Gabriel Hondet <koizel#pratter@aleeas.com>"]
+license: "BSD-3-Clause"
+homepage: "https://forge.tedomum.net/koizel/pratter"
+bug-reports: "https://github.com/gabrielhdt/pratter/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.7"}
+  "camlp-streams" {>= "5.0" & < "6"}
+  "alcotest" {with-test}
+  "qcheck" {with-test}
+  "qcheck-alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://forge.tedomum.net/koizel/pratter"
+url {
+  src:
+    "https://forge.tedomum.net/koizel/pratter/-/archive/3.0.0/pratter-3.0.0.tar.gz"
+  checksum: [
+    "md5=f8ad3611d5702c0dd1ca869c2349663e"
+    "sha512=2dca78a5e2d1239c7aaa893c08eb612dad50ade092776ca02fd083209fca805e22520bff78309ef8435a4b900be2a272415efff3a81e1bb1f0a3dec8bcb3e1a4"
+  ]
+}


### PR DESCRIPTION
### `pratter.3.0.0`
Parse strings of tokens and mixfix operators
Pratter allows to transform strings of symbols and mixfix operators to full
binary trees.
Pratter is convenient for parsing languages made of terms with many mixfix
operators with different associativities and precedences such as
arithmetic or λ-calculi.
In contrast to parser generators, parsing rules can be edited dynamically.



---
* Homepage: https://forge.tedomum.net/koizel/pratter
* Source repo: git+https://forge.tedomum.net/koizel/pratter
* Bug tracker: https://github.com/gabrielhdt/pratter/issues

---
:camel: Pull-request generated by opam-publish v2.2.0