### PR TITLE
[new release] jekyll-format (0.3.3)

### DIFF
--- a/packages/jekyll-format/jekyll-format.0.3.3/opam
+++ b/packages/jekyll-format/jekyll-format.0.3.3/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Jekyll post parsing library"
+description: """
+This library provides an OCaml interface to parsing
+posts in the Jekyll format."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: ["Anil Madhavapeddy" "Patrick Ferris"]
+license: "MIT"
+homepage: "https://github.com/avsm/jekyll-format"
+bug-reports: "https://github.com/avsm/jekyll-format/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "yaml-sexp" {>= "3.0.0"}
+  "yaml" {>= "3.0.0"}
+  "sexplib"
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "rresult"
+  "ptime"
+  "fpath"
+  "ezjsonm" {>= "1.1.0"}
+  "alcotest" {with-test}
+  "bos" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/avsm/jekyll-format.git"
+url {
+  src:
+    "https://github.com/avsm/jekyll-format/releases/download/v0.3.3/jekyll-format-0.3.3.tbz"
+  checksum: [
+    "sha256=c197b6dcff4f0f85fea2405fa8ef7629745c4e59da80ad42bd50d9e9b0a92fc5"
+    "sha512=f3a0c971f64d942f46e87d9472a5d98a8d6c8c908c2631930c199685d1d358d5aec846e36ebe8a15306178dec6fc3518e405aae66aaf63556a9631e745886f25"
+  ]
+}
+x-commit-hash: "80794bb11bba15e50fc6a5f98467871fc6a362ba"


### PR DESCRIPTION
Jekyll post parsing library

- Project page: <a href="https://github.com/avsm/jekyll-format">https://github.com/avsm/jekyll-format</a>

##### CHANGES:

- Remove unnecessary dependency on `omd`.
