### PR TITLE
[new release] yaml (2 packages) (3.2.0)

### DIFF
--- a/packages/yaml-sexp/yaml-sexp.3.2.0/opam
+++ b/packages/yaml-sexp/yaml-sexp.3.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Parse and generate YAML 1.1 files"
+description: "ocaml-yaml with sexp support"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Rizo Isrof <rizo@odis.io>"
+  "Patrick Ferris"
+  "favonia@gmail.com"
+  "Alan J Hu <alanh@ccs.neu.edu>"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-yaml"
+doc: "https://avsm.github.io/ocaml-yaml/"
+bug-reports: "https://github.com/avsm/ocaml-yaml/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "yaml" {= version}
+  "mdx" {with-test & >= "2.1.0"}
+  "alcotest" {with-test}
+  "crowbar" {with-test}
+  "junit_alcotest" {with-test}
+  "ezjsonm" {with-test}
+  "bos" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/avsm/ocaml-yaml.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-yaml/releases/download/v3.2.0/yaml-3.2.0.tbz"
+  checksum: [
+    "sha256=c50d2aca28b9f966792b71e1603351e5d24eda4dfd3e4453fbd50366a3a08227"
+    "sha512=e87ae73f3e376800a09e4359d5c7090ef5107807f540b51fbdee9017bcbacb2414ec12255b37caead115ea1562303436cac2c91c60814c2ba44bdd3d677fc0d1"
+  ]
+}
+x-commit-hash: "d126d9417d85096e421dd3c4cf3550e18ffc3c4e"

--- a/packages/yaml/yaml.3.2.0/opam
+++ b/packages/yaml/yaml.3.2.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Parse and generate YAML 1.1/1.2 files"
+description: """\
+This is an OCaml library to parse and generate the YAML file
+format.  It is intended to interoperable with the [Ezjsonm](https://github.com/mirage/ezjsonm)
+JSON handling library, if the simple common subset of Yaml
+is used.  Anchors and other advanced Yaml features are not
+implemented in the JSON compatibility layer.
+
+The [Yaml module docs](http://anil-code.recoil.org/ocaml-yaml/yaml/Yaml/index.html) are browseable online."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Rizo Isrof <rizo@odis.io>"
+  "Patrick Ferris"
+  "favonia@gmail.com"
+  "Alan J Hu <alanh@ccs.neu.edu>"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-yaml"
+doc: "https://avsm.github.io/ocaml-yaml/"
+bug-reports: "https://github.com/avsm/ocaml-yaml/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "dune-configurator"
+  "ctypes" {>= "0.14.0"}
+  "bos"
+  "fmt" {with-test}
+  "logs" {with-test}
+  "mdx" {with-test & >= "2.1.0"}
+  "alcotest" {>="1.5.0" & with-test}
+  "crowbar" {with-test}
+  "junit_alcotest" {>= "2.0.2" & with-test}
+  "ezjsonm" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/avsm/ocaml-yaml.git"
+conflicts:[
+  "result" {< "1.5"}
+]
+url {
+  src:
+    "https://github.com/avsm/ocaml-yaml/releases/download/v3.2.0/yaml-3.2.0.tbz"
+  checksum: [
+    "sha256=c50d2aca28b9f966792b71e1603351e5d24eda4dfd3e4453fbd50366a3a08227"
+    "sha512=e87ae73f3e376800a09e4359d5c7090ef5107807f540b51fbdee9017bcbacb2414ec12255b37caead115ea1562303436cac2c91c60814c2ba44bdd3d677fc0d1"
+  ]
+}
+x-commit-hash: "d126d9417d85096e421dd3c4cf3550e18ffc3c4e"


### PR DESCRIPTION
Parse and generate YAML 1.1/1.2 files

- Project page: <a href="https://github.com/avsm/ocaml-yaml">https://github.com/avsm/ocaml-yaml</a>
- Documentation: <a href="https://avsm.github.io/ocaml-yaml/">https://avsm.github.io/ocaml-yaml/</a>

##### CHANGES:

* Fix potential GC corruption when serialising large Yaml
  buffers (avsm/ocaml-yaml#75 @hhugo)

* Add missing `?len` argument to `yaml_of_string` to specify
  buffer size (avsm/ocaml-yaml#74 @hhugo)

* Remove remaining references to Rresult in tests and
  documentation (avsm/ocaml-yaml#62 @sim642)
