### PR TITLE
lambdapi: add upper bound on pratter

### DIFF
--- a/packages/lambdapi/lambdapi.2.2.1/opam
+++ b/packages/lambdapi/lambdapi.2.2.1/opam
@@ -52,7 +52,7 @@ depends: [
   "sedlex" {>= "2.2"}
   "alcotest" {with-test}
   "dedukti" {with-test & >= "2.7"}
-  "bindlib" {>= "5.0.1"}
+  "bindlib" {>= "6.0.0"}
   "timed" {>= "1.0"}
   "pratter" {>= "2.0.0" & < "3"}
   "camlp-streams" {>= "5.0"}

--- a/packages/lambdapi/lambdapi.2.2.1/opam
+++ b/packages/lambdapi/lambdapi.2.2.1/opam
@@ -54,7 +54,7 @@ depends: [
   "dedukti" {with-test & >= "2.7"}
   "bindlib" {>= "5.0.1"}
   "timed" {>= "1.0"}
-  "pratter" {>= "2.0.0"}
+  "pratter" {>= "2.0.0" & < "3"}
   "camlp-streams" {>= "5.0"}
   "why3" {>= "1.5.0" & < "1.6~"}
   "yojson" {>= "1.6.0"}

--- a/packages/lambdapi/lambdapi.2.3.0/opam
+++ b/packages/lambdapi/lambdapi.2.3.0/opam
@@ -54,7 +54,7 @@ depends: [
   "dedukti" {with-test & >= "2.7"}
   "bindlib" {>= "6.0.0"}
   "timed" {>= "1.0"}
-  "pratter" {>= "2.0.0"}
+  "pratter" {>= "2.0.0" & < "3"}
   "camlp-streams" {>= "5.0"}
   "why3" {>= "1.5.0" & < "1.6~"}
   "yojson" {>= "1.6.0"}

--- a/packages/lambdapi/lambdapi.2.3.1/opam
+++ b/packages/lambdapi/lambdapi.2.3.1/opam
@@ -54,7 +54,7 @@ depends: [
   "dedukti" {with-test & >= "2.7"}
   "bindlib" {>= "6.0.0"}
   "timed" {>= "1.0"}
-  "pratter" {>= "2.0.0"}
+  "pratter" {>= "2.0.0" & < "3"}
   "camlp-streams" {>= "5.0"}
   "why3" {>= "1.6.0" & < "1.7~"}
   "yojson" {>= "1.6.0"}

--- a/packages/lambdapi/lambdapi.2.4.0/opam
+++ b/packages/lambdapi/lambdapi.2.4.0/opam
@@ -54,7 +54,7 @@ depends: [
   "dedukti" {with-test & >= "2.7"}
   "bindlib" {>= "6.0.0"}
   "timed" {>= "1.0"}
-  "pratter" {>= "2.0.0"}
+  "pratter" {>= "2.0.0" & < "3"}
   "camlp-streams" {>= "5.0"}
   "why3" {>= "1.6.0" & < "1.7~"}
   "yojson" {>= "1.6.0"}


### PR DESCRIPTION
required by coming new version of pratter (https://github.com/ocaml/opam-repository/pull/24746)