### PR TITLE
Package qiskit.0.44.0

### DIFF
--- a/packages/qiskit/qiskit.0.44.0/opam
+++ b/packages/qiskit/qiskit.0.44.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Qiskit for OCaml"
+description: """
+An OCaml wrapper for the Qiskit quantum computing toolkit
+"""
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: [
+  "Davide Gessa <gessadavide@gmail.com>"
+]
+
+homepage: "https://github.com/dakk/caml_qiskit"
+bug-reports: "https://github.com/dakk/caml_qiskit/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/dakk/caml_qiskit.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  
+  "dune" {>= "3.10.0"}
+  "pyml" {>= "20220905"}
+
+  "ounit" {with-test & >= "2.2.7"}
+
+  "odoc" {dev & >= "2.2.1"}
+  "bisect_ppx" {dev & >= "2.8.3"}
+]
+url {
+  src: "https://github.com/dakk/caml_qiskit/archive/refs/tags/v0.44.0.zip"
+  checksum: [
+    "md5=00c4df3973902e003c340e47d771df02"
+    "sha512=3dc5343bb529912bcccbb6b8b8e5cfaddb414258db35f9c6c56ea1c04174270d39a7dd92dd70da936b088e0b4008dcb36420f0082b77f94c46e19ce8be359015"
+  ]
+}


### PR DESCRIPTION
### `qiskit.0.44.0`
Qiskit for OCaml
An OCaml wrapper for the Qiskit quantum computing toolkit



---
* Homepage: https://github.com/dakk/caml_qiskit
* Source repo: git+https://github.com/dakk/caml_qiskit.git
* Bug tracker: https://github.com/dakk/caml_qiskit/issues

---
:camel: Pull-request generated by opam-publish v2.2.0