### PR TITLE
Package patdiff.v0.16.1

### DIFF
--- a/packages/patdiff/patdiff.v0.16.1/opam
+++ b/packages/patdiff/patdiff.v0.16.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/patdiff"
+bug-reports: "https://github.com/janestreet/patdiff/issues"
+dev-repo: "git+https://github.com/janestreet/patdiff.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/patdiff/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"                    {>= "4.14.0"}
+  "core"                     {>= "v0.16" & < "v0.17"}
+  "core_kernel"              {>= "v0.16" & < "v0.17"}
+  "core_unix"                {>= "v0.16" & < "v0.17"}
+  "expect_test_helpers_core" {>= "v0.16" & < "v0.17"}
+  "patience_diff"            {>= "v0.16" & < "v0.17"}
+  "ppx_jane"                 {>= "v0.16" & < "v0.17"}
+  "dune"                     {>= "2.0.0"}
+  "re"                       {>= "1.8.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "File Diff using the Patience Diff algorithm"
+url {
+  src:
+    "https://github.com/janestreet/patdiff/archive/refs/tags/v0.16.1.tar.gz"
+  checksum: [
+    "md5=ed1fd8166e2e99774432c1e28515f37e"
+    "sha512=7833f95ce42eeb17ecbef514eab13a37a0ab125b3c6e7e8af09c5b0efa3be6b971c6c4a40f3d809f1c254c8bc720ddaa46b54ff0514ddb9db0f5be03d99f5fd0"
+  ]
+}


### PR DESCRIPTION
### `patdiff.v0.16.1`
File Diff using the Patience Diff algorithm



---
* Homepage: https://github.com/janestreet/patdiff
* Source repo: git+https://github.com/janestreet/patdiff.git
* Bug tracker: https://github.com/janestreet/patdiff/issues

---
:camel: Pull-request generated by opam-publish v2.3.0