### PR TITLE
Package zarith_stubs_js.v0.16.1

### DIFF
--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.16.1/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.16.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/zarith_stubs_js"
+bug-reports: "https://github.com/janestreet/zarith_stubs_js/issues"
+dev-repo: "git+https://github.com/janestreet/zarith_stubs_js.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/zarith_stubs_js/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune"  {>= "2.0.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Javascripts stubs for the Zarith library"
+description: "
+This library contains no ocaml code, but instead implements
+all of the Zarith C stubs in Javascript for use in Js_of_ocaml
+"
+url {
+  src:
+    "https://github.com/janestreet/zarith_stubs_js/archive/refs/tags/v0.16.1.tar.gz"
+  checksum: [
+    "md5=e6e748e14c7699ad2c3baa8dff6907fa"
+    "sha512=7ab808431ff5c5ab235911431e9afcf208f4f6bd7b552c1b3421e4dd1c1a02b23ba84c880c8a69856533e9221292351740f50a62d8e72c78a30be6372f5f2a20"
+  ]
+}


### PR DESCRIPTION
### `zarith_stubs_js.v0.16.1`
Javascripts stubs for the Zarith library
This library contains no ocaml code, but instead implements
all of the Zarith C stubs in Javascript for use in Js_of_ocaml



---
* Homepage: https://github.com/janestreet/zarith_stubs_js
* Source repo: git+https://github.com/janestreet/zarith_stubs_js.git
* Bug tracker: https://github.com/janestreet/zarith_stubs_js/issues

---
:camel: Pull-request generated by opam-publish v2.3.0