### PR TITLE
WIP: TEST ONLY: run CI tests for FreeBSD compatibility

### DIFF
--- a/packages/frama-c/frama-c.28.0~beta/opam
+++ b/packages/frama-c/frama-c.28.0~beta/opam
@@ -182,6 +182,6 @@ Finalization also requires Node v16 and Yarn:
 ]
 
 url {
-  src: "https://www.frama-c.com/download/frama-c-28.0-beta-Nickel.tar.gz"
-  checksum: "sha256=0c80dae8074fcb3f6a33d7a41faf9939a2a336478a8d2c79e20e2d7bab953735"
+  src: "https://github.com/maroneze/Frama-C-snapshot/raw/test-freebsd/frama-c-28.0~beta-Nickel.tar.gz"
+  checksum: "sha256=8f2436db49b3db5afa4923c86a36a1e2ce209cf5c8c1a3cefb54e4c8bdd6cd99"
 }


### PR DESCRIPTION
This is a test branch, to get the opam CI to run and test FreeBSD compatibility.

It must NOT be merged. It will be erased when I succeed in making FreeBSD tests pass.