### PR TITLE
Release camlild 1.12

### DIFF
--- a/packages/camlidl/camlidl.1.11/opam
+++ b/packages/camlidl/camlidl.1.11/opam
@@ -20,7 +20,7 @@ generation of C stub code required for the Caml/C interface, based on
 an MIDL specification. Also provides some support for Microsoft's COM
 software components."""
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.05" & < "5.0"}
 ]
 extra-files: [
   ["camlidl.install" "md5=cf56e14faed046880b7c9d0f4cd737f1"]

--- a/packages/camlidl/camlidl.1.12/files/META
+++ b/packages/camlidl/camlidl.1.12/files/META
@@ -1,0 +1,5 @@
+description = "Stub generator from IDL description"
+version = "1.12"
+archive(byte) = "com.cma"
+archive(byte,plugin) = "com.cma"
+archive(native) = "com.cmxa"

--- a/packages/camlidl/camlidl.1.12/files/camlidl.install
+++ b/packages/camlidl/camlidl.1.12/files/camlidl.install
@@ -1,0 +1,21 @@
+bin: [
+ "?compiler/camlidl"
+ "?compiler/camlidl.exe"
+]
+lib: [
+  "META"
+  "lib/com.cma"
+  "lib/com.cmxa"
+  "lib/com.cmi"
+ "?lib/com.a"
+ "?lib/com.lib"
+ "?runtime/libcamlidl.a"
+ "?runtime/libcamlidl.lib"
+ "?runtime/cfactory.obj"
+ "?runtime/cfactory.o"
+ "runtime/camlidlruntime.h" { "caml/camlidlruntime.h" }
+]
+stublibs: [
+ "?runtime/dllcamlidl.so"
+ "?runtime/dllcamlidl.dll"
+]

--- a/packages/camlidl/camlidl.1.12/opam
+++ b/packages/camlidl/camlidl.1.12/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Nicolas Berthier <m@nberth.space>"
+authors: ["Xavier Leroy"]
+homepage: "https://github.com/xavierleroy/camlidl"
+dev-repo: "git+https://github.com/xavierleroy/camlidl.git"
+bug-reports: "https://github.com/xavierleroy/camlidl/issues"
+license: [
+  "QPL-1.0 WITH OCaml-LGPL-linking-exception"
+  "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
+]
+build: [
+  ["mv" "config/Makefile.unix" "config/Makefile"] {os != "win32"}
+  ["mv" "config/Makefile.mingw" "config/Makefile"] {os = "win32"}
+  [make "all"]
+]
+synopsis: "Stub code generator for OCaml"
+description: """
+CamlIDL is a stub code generator for OCaml. It automates the
+generation of C stub code required for the Caml/C interface, based on
+an MIDL specification. Also provides some support for Microsoft's COM
+software components."""
+depends: [
+  "ocaml" {>= "4.05"}
+]
+extra-files: [
+  ["camlidl.install" "md5=cf56e14faed046880b7c9d0f4cd737f1"]
+  ["META" "md5=2e2f78ac8c3e9f5581a28b2cec6d755b"]
+]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
+url {
+  src:
+    "https://github.com/xavierleroy/camlidl/archive/camlidl112.tar.gz"
+  checksum: "md5=6a33ac617bfbca2334f9c0fb8f9d3bb8"
+}

--- a/packages/camlidl/camlidl.1.12/opam
+++ b/packages/camlidl/camlidl.1.12/opam
@@ -24,7 +24,7 @@ depends: [
 ]
 extra-files: [
   ["camlidl.install" "md5=cf56e14faed046880b7c9d0f4cd737f1"]
-  ["META" "md5=2e2f78ac8c3e9f5581a28b2cec6d755b"]
+  ["META" "md5=ce109a486a026d3ad31cc68290da004b"]
 ]
 conflicts: [
   "ocaml-option-bytecode-only"


### PR DESCRIPTION
The release is on the upstream repository since July but was never sent to the opam-repository.

Should fix the issue in https://github.com/ocaml/opam-repository/pull/24745