### PR TITLE
pretter 3.0.0: updated qcheck lower bound

### DIFF
--- a/packages/pratter/pratter.3.0.0/opam
+++ b/packages/pratter/pratter.3.0.0/opam
@@ -18,8 +18,8 @@ depends: [
   "dune" {>= "2.7"}
   "camlp-streams" {>= "5.0" & < "6"}
   "alcotest" {with-test >= "1.5.0" & < "2"}
-  "qcheck" {with-test >= "0.9"}
-  "qcheck-alcotest" {with-test >= "0.9"}
+  "qcheck" {with-test >= "0.12"}
+  "qcheck-alcotest" {with-test >= "0.12"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Requires `char_range`, see https://github.com/ocaml/opam-repository/pull/24703#issuecomment-1798066199