### PR TITLE
Package frama-c-metacsl.0.5

### DIFF
--- a/packages/frama-c-metacsl/frama-c-metacsl.0.5/opam
+++ b/packages/frama-c-metacsl/frama-c-metacsl.0.5/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "MetAcsl plugin of Frama-C for writing pervasives properties"
+description: """\
+MetAcsl let users write properties that need to be checked at particular
+contexts (e.g. each time a location is written to inside a given set
+of functions). It will then generate all the corresponding ACSL
+annotations, leaving it to analysis plug-ins (e.g. WP) to prove the
+resulting clauses."""
+maintainer: "Virgile.Prevosto@cea.fr"
+authors: ["Virgile Robles" "Téo Bernier" "Nikolai Kosmatov"]
+license: "LGPL-2.1-only"
+tags: [
+  "program verification"
+  "formal specification"
+  "C"
+  "plugins"
+  "ACSL"
+  "MetACSL"
+]
+homepage: "https://frama-c.com/"
+bug-reports: "https://git.frama-c.com/pub/meta/-/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.11.1"}
+  "frama-c" {>= "27.0~" & < "28.0~"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "conf-swi-prolog"
+  "why3" {>= "1.3.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+messages:
+  "Note that if you wish to use the deduction features of MetAcsl, you must install the conf-swi-prolog package (and swi-prolog itself)"
+    {!conf-swi-prolog:installed}
+dev-repo: "git+https://git.frama-c.com/pub/meta.git"
+url {
+  src: "https://git.frama-c.com/pub/meta/-/archive/0.5/meta-0.5.tar.bz2"
+  checksum: [
+    "md5=c2f0fd2ae9b412e16c58a5391410183f"
+    "sha512=7c738ac097a5cea1010b9dff993d40573746d85e430e9c93409c4aea7e171a7b31fec7f580c9a168dce281c9159662a7dd61fc1179f4d94f76795adc28c68ef1"
+  ]
+}


### PR DESCRIPTION
### `frama-c-metacsl.0.5`
MetAcsl plugin of Frama-C for writing pervasives properties
MetAcsl let users write properties that need to be checked at particular
contexts (e.g. each time a location is written to inside a given set
of functions). It will then generate all the corresponding ACSL
annotations, leaving it to analysis plug-ins (e.g. WP) to prove the
resulting clauses.



---
* Homepage: https://frama-c.com/
* Source repo: git+https://git.frama-c.com/pub/meta.git
* Bug tracker: https://git.frama-c.com/pub/meta/-/issues

---
:camel: Pull-request generated by opam-publish v2.2.0