### PR TITLE
[new release] hol2dk (0.0.0)

### DIFF
--- a/packages/hol2dk/hol2dk.0.0.0/opam
+++ b/packages/hol2dk/hol2dk.0.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "HOL-Light to Dedukti/Lambdapi translator"
+description: "HOL-Light to Dedukti/Lambdapi translator"
+maintainer: ["Frédéric Blanqui"]
+authors: ["Frédéric Blanqui"]
+license: "CeCILL-2.1"
+homepage: "https://github.com/Deducteam/hol2dk"
+doc: "https://github.com/Deducteam/hol2dk/blob/master/README.md"
+bug-reports: "https://github.com/Deducteam/hol2dk/issues"
+depends: [
+  "ocaml" {>= "4.13"}
+  "dune" {>= "3.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Deducteam/hol2dk.git"
+url {
+  src:
+    "https://github.com/Deducteam/hol2dk/releases/download/0.0.0/hol2dk-0.0.0.tbz"
+  checksum: [
+    "sha256=17aaba571153eb188524225c4a491a15e749935a38ebf190a5162f9f6563407c"
+    "sha512=aaf26a8d0c6545b655ae18ffdaa65ab11c133e362103677dbc733ad9fa0b60092e05819c15b45bb7b1bda2235c5ec3b869f842c465613688882f961e7a2b7b04"
+  ]
+}
+x-commit-hash: "855a531994c37de0ea3d9cfd00d7b16d1f95920d"


### PR DESCRIPTION
HOL-Light to Dedukti/Lambdapi translator

- Project page: <a href="https://github.com/Deducteam/hol2dk">https://github.com/Deducteam/hol2dk</a>
- Documentation: <a href="https://github.com/Deducteam/hol2dk/blob/master/README.md">https://github.com/Deducteam/hol2dk/blob/master/README.md</a>

##### CHANGES:

First release.
