### PR TITLE
[new release] moonpool (0.5)

### DIFF
--- a/packages/moonpool/moonpool.0.5/opam
+++ b/packages/moonpool/moonpool.0.5/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Pools of threads supported by a pool of domains"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["thread" "pool" "domain" "futures" "fork-join"]
+homepage: "https://github.com/c-cube/moonpool"
+bug-reports: "https://github.com/c-cube/moonpool/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.0"}
+  "either" {>= "1.0"}
+  "trace" {with-test}
+  "trace-tef" {with-test}
+  "qcheck-core" {with-test & >= "0.19"}
+  "odoc" {with-doc}
+  "mdx" {>= "1.9.0" & with-test}
+]
+depopts: [
+  "thread-local-storage"
+  "domain-local-await" {>= "0.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/moonpool.git"
+url {
+  src:
+    "https://github.com/c-cube/moonpool/releases/download/v0.5/moonpool-0.5.tbz"
+  checksum: [
+    "sha256=bd1ab7a02532bc515fa43b6ed3ef7e206d318bd393a4256ed9084255c364ac86"
+    "sha512=4385fb57dde586b229b00c28c00c23b140ac41d8300c5b5f6fc812167d29b277c0c22a41c35d697bcb3ecefd20b1cbb22c115d4586e6421808469efa8f9bf6c3"
+  ]
+}
+x-commit-hash: "fd2102c7fe4fc936de93fe179b3e59758d18f992"


### PR DESCRIPTION
Pools of threads supported by a pool of domains

- Project page: <a href="https://github.com/c-cube/moonpool">https://github.com/c-cube/moonpool</a>

##### CHANGES:

## features

- add `Bb_queue.transfer`
 -add `Bb_queue.to_{iter,gen,seq}`
- add `Fifo_pool`, a simple pool with a single blocking queue for
    workloads with coarse granularity tasks that value
    latency (e.g. a web server)
- add a work-stealing pool for heavy compute workloads that
    feature a lot of await/fork-join, with a lot of help
    from Vesa Karvonen (@polytypic)
- add `Fut.spawn_on_current_runner`
- add `Runner.{spawn_on_current_runner, await}`
- add a few more toplevel aliases in `Moonpool` itself
- add `No_runner`: a runner that runs tasks synchronously in the caller
- on shutdown, pools will finish running all present tasks before
    closing. New tasks are immediately rejected.

- use an optional dependency on `thread-local-storage` to
    implement work stealing and `spawn_on_current_runner`

## optimizations

- use the main domain to spawn threads on it. This means we can really
    use all cores, not all but one.
- in `Fork_join.both`, only one of the two sides schedules a task,
    the other runs in the current thread. This reduces scheduling overhead.
- compare to domainslib in benchmarks. With the WS pool we're now slightly
    ahead in terms of overhead on the recursive fib benchmark.

## breaking

- deprecate `Pool`, now an alias to `Fifo_pool`
