### PR TITLE
Frama-C: fix minimal version of dune-site

### DIFF
--- a/packages/frama-c/frama-c.26.0/opam
+++ b/packages/frama-c/frama-c.26.0/opam
@@ -110,7 +110,7 @@ depends: [
   "dune" { (>= "3.2.0" & os!="macos") | (>= "3.5.0" & os="macos") }
   "dune-configurator"
   "dune-private-libs"
-  "dune-site"
+  "dune-site" { >= "3.2.0" }
 
   ( "alt-ergo-free" | "alt-ergo" )
   "conf-graphviz" { post }

--- a/packages/frama-c/frama-c.26.0~beta/opam
+++ b/packages/frama-c/frama-c.26.0~beta/opam
@@ -112,7 +112,7 @@ depends: [
   "dune" { (>= "3.2.0" & os!="macos") | (>= "3.5.0" & os="macos") }
   "dune-configurator"
   "dune-private-libs"
-  "dune-site"
+  "dune-site" { >= "3.2.0" }
 
   ( "alt-ergo-free" | "alt-ergo" )
   "conf-graphviz" { post }

--- a/packages/frama-c/frama-c.26.1/opam
+++ b/packages/frama-c/frama-c.26.1/opam
@@ -111,7 +111,7 @@ depends: [
   "dune" { (>= "3.2.0" & os!="macos") | (>= "3.5.0" & os="macos") }
   "dune-configurator"
   "dune-private-libs"
-  "dune-site"
+  "dune-site" { >= "3.2.0" }
 
   ( "alt-ergo-free" | "alt-ergo" )
   "conf-graphviz" { post }

--- a/packages/frama-c/frama-c.27.0/opam
+++ b/packages/frama-c/frama-c.27.0/opam
@@ -117,7 +117,7 @@ run-test: [
 depends: [
   "dune" { >= "3.2.0" | (>= "3.5.0" & os="macos") }
   "dune-configurator"
-  "dune-site"
+  "dune-site" { >= "3.2.0" }
 
   ( "alt-ergo-free" | "alt-ergo" )
   "conf-graphviz" { post }

--- a/packages/frama-c/frama-c.27.0~beta/opam
+++ b/packages/frama-c/frama-c.27.0~beta/opam
@@ -113,7 +113,7 @@ run-test: [
 depends: [
   "dune" { >= "3.2.0" | (>= "3.5.0" & os="macos") }
   "dune-configurator"
-  "dune-site"
+  "dune-site" { >= "3.2.0" }
 
   ( "alt-ergo-free" | "alt-ergo" )
   "conf-graphviz" { post }

--- a/packages/frama-c/frama-c.27.1/opam
+++ b/packages/frama-c/frama-c.27.1/opam
@@ -116,7 +116,7 @@ run-test: [
 depends: [
   "dune" { >= "3.2.0" | (>= "3.5.0" & os="macos") }
   "dune-configurator"
-  "dune-site"
+  "dune-site" { >= "3.2.0" }
 
   ( "alt-ergo-free" | "alt-ergo" )
   "conf-graphviz" { post }

--- a/packages/frama-c/frama-c.28.0~beta/opam
+++ b/packages/frama-c/frama-c.28.0~beta/opam
@@ -121,7 +121,7 @@ run-test: [
 depends: [
   "dune" { >= "3.7.0" }
   "dune-configurator"
-  "dune-site"
+  "dune-site" { >= "3.7.0" }
 
   ( "alt-ergo-free" | "alt-ergo" )
   "conf-graphviz" { post }


### PR DESCRIPTION
We discovered that while the compilation of Frama-C succeeds with `dune-site` 2.x, the installed Frama-C crashes when plug-ins are loaded. We are sure that with a `dune-site` with version >= to the minimal version it works, thus we choose to use this constraint.

Note that on 26.x and 27.x, we have a lower bound `3.5.0` on macOS, but the version of `dune-site` does not need this version, we only need `3.5` for binary signature.

The issue remained unnoticed for a long time because to detect the problem, one has to run Frama-C with options that guarantee that plug-ins are loaded. Thus, I don't know whether the CI process could be improved to detect this kind of problems since running the tests is obviously not a solution (since tests might have different version constraints).