### PR TITLE
lablgtk 2.18.13 is compatible with ocaml 5.0

### DIFF
--- a/packages/lablgtk/lablgtk.2.18.13/opam
+++ b/packages/lablgtk/lablgtk.2.18.13/opam
@@ -13,7 +13,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.06" & < "5.0.0"}
+  "ocaml" {>= "4.06"} 
   "ocamlfind" {>= "1.2.1"}
   "conf-gtk2" {build}
   "camlp-streams" {build}
@@ -23,6 +23,9 @@ depopts: [
   "conf-gnomecanvas"
   "conf-glade"
   "lablgl"
+]
+conflicts: [
+  "conf-glade" {ocaml:version >= "5.0"}
 ]
 patches: ["lablgldir.patch"]
 post-messages: [


### PR DESCRIPTION
unless conf-glade is installed.

Ping @garrigue 
