### PR TITLE
camlidl 1.10: add missing ocaml 5 upper bound

### DIFF
--- a/packages/camlidl/camlidl.1.10/opam
+++ b/packages/camlidl/camlidl.1.10/opam
@@ -20,7 +20,7 @@ generation of C stub code required for the Caml/C interface, based on
 an MIDL specification. Also provides some support for Microsoft's COM
 software components."""
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.05" & < "5.0"}
 ]
 extra-files: [
   ["camlidl.install" "md5=cf56e14faed046880b7c9d0f4cd737f1"]


### PR DESCRIPTION
camlidl 1.12 is the first release compatible with ocaml 5