### PR TITLE
pandoc 0.1.0 requires yojson 2.0.0

### DIFF
--- a/packages/pandoc/pandoc.0.1.0/opam
+++ b/packages/pandoc/pandoc.0.1.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/smimram/ocaml-pandoc"
 bug-reports: "https://github.com/smimram/ocaml-pandoc/issues"
 depends: [
   "dune" {>= "2.0"}
-  "yojson" {>= "1.4.0"}
+  "yojson" {>= "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
This is where Yojson.Basic.t was introduced.
Seen on https://github.com/ocaml/opam-repository/pull/24774

Failure:
```
=== ERROR while compiling pandoc.0.1.0 =======================================#
 context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///home/opam/opam-repository
 path                 ~/.opam/4.08/.opam-switch/build/pandoc.0.1.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p pandoc -j 71 @install
 exit-code            1
 env-file             ~/.opam/log/pandoc-7-d4410c.env
 output-file          ~/.opam/log/pandoc-7-d4410c.out
 File "/home/opam/.opam/4.08/lib/biniou/biniou.dune", line 1, characters 0-0:
 Warning: .dune files are ignored since 2.0. Reinstall the library with dune
 >= 2.0 to get rid of this warning and enable support for the subsystem this
 library provides.
       ocamlc src/.pandoc.objs/byte/pandoc.{cmi,cmti} (exit 2)
 (cd _build/default && /home/opam/.opam/4.08/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.pandoc.objs/byte -I /home/opam/.opam/4.08/lib/biniou -I /home/opam/.opam/4.08/lib/easy-format -I /home/opam/.opam/4.08/lib/yojson -no-alias-deps -o src/.pandoc.objs/byte/pandoc.cmi -c -intf src/pandoc.mli)
 File "src/pandoc.mli", line 33, characters 23-37:
 33 |   | UnhandledInline of Yojson.Basic.t
                             ^^^^^^^^^^^^^^
 Error: Unbound type constructor Yojson.Basic.t
```