### PR TITLE
add tezt.4.0.0

### DIFF
--- a/packages/tezt/tezt.4.0.0/opam
+++ b/packages/tezt/tezt.4.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://gitlab.com/nomadic-labs/tezt/"
+bug-reports: "https://gitlab.com/nomadic-labs/tezt/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/tezt.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "ocaml" { >= "4.12" }
+  "re" { >= "1.7.2" }
+  "lwt" { >= "5.6.0" }
+  "base-unix"
+  "ezjsonm" { >= "1.1.0" }
+  "clap" { >= "0.3.0" }
+  "conf-npm" { with-test }
+  "js_of_ocaml" { with-test }
+  "js_of_ocaml-lwt" { with-test }
+  "ocamlformat" { with-test & = "0.21.0" }
+]
+depopts: [
+  "js_of_ocaml"
+  "js_of_ocaml-lwt"
+]
+conflicts: [
+  "js_of_ocaml" { < "4.0.0" }
+  "js_of_ocaml-lwt" { < "4.0.0" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Test framework for unit tests, integration tests, and regression tests"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/tezt/-/archive/4.0.0/tezt-4.0.0.tar.bz2"
+  checksum: [
+    "md5=643f48378265ae18b7aab4675a1e836e"
+    "sha512=f399d4d8b935fc3dcb4354596c2b7fa26a019f99c83cb4c1d48b0e26c5bc6da13b2cad9792dd50420a88b777d3b8a1d67c7ddd0457322e65d311b859be03879f"
+  ]
+}


### PR DESCRIPTION
Version 4.0.0 of [Tezt](https://gitlab.com/nomadic-labs/tezt) has been released.