### PR TITLE
constrain octez-shell-libs to tezt < 4.0.0

### DIFF
--- a/packages/octez-shell-libs/octez-shell-libs.18.0/opam
+++ b/packages/octez-shell-libs/octez-shell-libs.18.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ringo" {>= "1.0.0"}
   "aches" {>= "1.0.0"}
   "prometheus" {>= "1.2"}
-  "tezt" {>= "3.1.1"}
+  "tezt" {>= "3.1.1" & < "4.0.0"}
   "tezt-tezos" {with-test & = version}
   "octez-alcotezt" {with-test & = version}
   "astring" {with-test}


### PR DESCRIPTION
https://github.com/ocaml/opam-repository/pull/24783 upgrades Tezt to version 4.0.0, but some revdeps failed in the CI:
- `octez-shell-libs` depends on features that changed in Tezt 4.0.0;
- `tezos-rpc-http-server` failed too for reasons that seem unrelated.

This MR should fix `octez-shell-libs`. I checked in Octez's codebase and this is the only library where the feature of Tezt that changed was used; and the feature was only used starting from v18.0 of Octez. So I think this is the only package that needs the `< 4.0.0` constraint.

Regarding `tezos-rpc-http-server`, I think the package is broken for reasons unrelated to Tezt. Looks like it is missing a version constraint on some package, maybe `cohttp`?