### PR TITLE
new file:   packages/hts_shrink/hts_shrink.3.0.1/opam

### DIFF
--- a/packages/hts_shrink/hts_shrink.3.0.1/opam
+++ b/packages/hts_shrink/hts_shrink.3.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/hts_shrink"
+bug-reports: "https://github.com/UnixJunkie/hts_shrink/issues"
+dev-repo: "git+https://github.com/UnixJunkie/hts_shrink.git"
+license: "BSD-3-Clause"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "2.5"}
+  "batteries"
+  "dolog" {>= "4.0.0"}
+  "parmap"
+  "parany" {>= "11.0.2"}
+  "minicli" {>= "5.0.0"}
+  "bitv"
+  "bst"
+  "ocamlgraph"
+  "ptmap"
+  "get_line" {with-test}
+  "ocaml" {>= "4.03"}
+]
+synopsis:
+"Distance-Based Boolean Applicability Domain for High Throughput Screening data"
+description: """
+Reference implementation of the Distance-Based Boolean Applicability Domain.
+For more information, and if you use the software, please cite:
+"A Distance-Based Boolean Applicability Domain for Classification of
+High Throughput Screening Data"
+Francois Berenger and Yoshihiro Yamanishi.
+Journal of Chemical Information and Modeling:
+https://pubs.acs.org/doi/10.1021/acs.jcim.8b00499
+"""
+url {
+  src: "https://github.com/UnixJunkie/hts_shrink/archive/v3.0.1.tar.gz"
+  checksum: "md5=37e3ea3323a1a18f77d15259d378c94e"
+}

--- a/packages/hts_shrink/hts_shrink.3.0.1/opam
+++ b/packages/hts_shrink/hts_shrink.3.0.1/opam
@@ -10,6 +10,7 @@ depends: [
   "dune" {>= "2.5"}
   "batteries"
   "cpm"
+  "molenc"
   "dolog" {>= "4.0.0"}
   "parmap"
   "parany" {>= "11.0.2"}

--- a/packages/hts_shrink/hts_shrink.3.0.1/opam
+++ b/packages/hts_shrink/hts_shrink.3.0.1/opam
@@ -8,9 +8,9 @@ license: "BSD-3-Clause"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "batteries"
+  "batteries" {>= "3.0.0"}
   "cpm"
-  "molenc"
+  "molenc" {>= "11.1.1"}
   "dolog" {>= "4.0.0"}
   "parmap"
   "parany" {>= "11.0.2"}

--- a/packages/hts_shrink/hts_shrink.3.0.1/opam
+++ b/packages/hts_shrink/hts_shrink.3.0.1/opam
@@ -9,6 +9,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
   "batteries"
+  "cpm"
   "dolog" {>= "4.0.0"}
   "parmap"
   "parany" {>= "11.0.2"}


### PR DESCRIPTION
The software was updated long time ago, but the published opam package not.

Also, corrected the top-level test.sh file to work with this version.
