### PR TITLE
[new release] saturn (2 packages) (0.4.1)

### DIFF
--- a/packages/saturn/saturn.0.4.1/opam
+++ b/packages/saturn/saturn.0.4.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Collection of parallelism-safe data structures for Multicore OCaml"
+maintainer: ["Carine Morel" "KC Sivaramakrishnan" "Sudha Parimala"]
+authors: ["KC Sivaramakrishnan"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/saturn"
+doc: "https://ocaml-multicore.github.io/saturn/"
+bug-reports: "https://github.com/ocaml-multicore/saturn/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.12"}
+  "domain_shims" {>= "0.1.0"}
+  "saturn_lockfree" {= version}
+  "qcheck" {>= "0.18.1" & with-test}
+  "qcheck-stm" {>= "0.2" & with-test}
+  "qcheck-alcotest" {>= "0.18.1" & with-test}
+  "yojson" {>= "2.0.2" & with-test}
+  "dscheck" {>= "0.1.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/saturn.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/saturn/releases/download/0.4.1/saturn-0.4.1.tbz"
+  checksum: [
+    "sha256=b4ed5aa911a872ea201ed13a3183c0331bf98f16e46230a9b6d1d1c545290ebd"
+    "sha512=575d58317c5d4b14abc0e4dfe781e396033f2381f5803eea8158b7c9fcd97e4d01546e9e827d60087bbd4fd1c045f9e24c0fb035f3733be9a7e6e7d2377cda61"
+  ]
+}
+x-commit-hash: "978b876ab512828ba36c068944dac64682784f9e"

--- a/packages/saturn_lockfree/saturn_lockfree.0.4.1/opam
+++ b/packages/saturn_lockfree/saturn_lockfree.0.4.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Collection of lock-free data structures for Multicore OCaml"
+maintainer: ["Carine Morel" "KC Sivaramakrishnan" "Sudha Parimala"]
+authors: ["KC Sivaramakrishnan"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/saturn"
+doc: "https://ocaml-multicore.github.io/saturn/"
+bug-reports: "https://github.com/ocaml-multicore/saturn/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.12"}
+  "domain_shims" {>= "0.1.0"}
+  "qcheck" {>= "0.18.1" & with-test}
+  "qcheck-stm" {>= "0.2" & with-test}
+  "qcheck-alcotest" {>= "0.18.1" & with-test}
+  "yojson" {>= "2.0.2" & with-test}
+  "dscheck" {>= "0.1.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/saturn.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/saturn/releases/download/0.4.1/saturn-0.4.1.tbz"
+  checksum: [
+    "sha256=b4ed5aa911a872ea201ed13a3183c0331bf98f16e46230a9b6d1d1c545290ebd"
+    "sha512=575d58317c5d4b14abc0e4dfe781e396033f2381f5803eea8158b7c9fcd97e4d01546e9e827d60087bbd4fd1c045f9e24c0fb035f3733be9a7e6e7d2377cda61"
+  ]
+}
+x-commit-hash: "978b876ab512828ba36c068944dac64682784f9e"


### PR DESCRIPTION
Collection of parallelism-safe data structures for Multicore OCaml

- Project page: <a href="https://github.com/ocaml-multicore/saturn">https://github.com/ocaml-multicore/saturn</a>
- Documentation: <a href="https://ocaml-multicore.github.io/saturn/">https://ocaml-multicore.github.io/saturn/</a>

##### CHANGES:

- pop_opt, peek, peek_opt functions for queue (@lyrm)
- Remove 'name' field from benchmark results (@Sudha247)
- Better README (@lyrm, @Sudha247, @polytypic, @art-w, @christinerose, @ILeandersson, @kayceesrk)
- Add .nojekyll (@lyrm)
- Add a barrier module in tests to replace the use of Semaphore (@lyrm, @polytypic)
- Remove .merlin and .ocp-indent files. (@lyrm)
- Correct issue caused by saturn_lockfree module beeing named Lockfree (@lyrm)
- Generate opam files automatically (@sudha247)
