### PR TITLE
[new release] riot (0.0.2)

### DIFF
--- a/packages/riot/riot.0.0.2/opam
+++ b/packages/riot/riot.0.0.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "An actor-model multi-core scheduler for OCaml 5"
+description: """
+Riot is an actor-model multi-core scheduler for OCaml 5. It
+              brings Erlang-style concurrency to the language, where
+              lighweight process communicate via message passing"""
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: ["topics" "multicore" "erlang" "actor" "message-passing" "processes"]
+homepage: "https://github.com/leostera/riot"
+bug-reports: "https://github.com/leostera/riot/issues"
+depends: [
+  "ocaml" {>= "5.1"}
+  "dune" {>= "3.10"}
+  "ptime" {>= "1.1.0"}
+  "iomux" {>= "0.3"}
+  "bigstringaf" {>= "0.9.1"}
+  "uri" {>= "4.4.0"}
+  "odoc" {with-doc & >= "2.2.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/leostera/riot.git"
+url {
+  src:
+    "https://github.com/leostera/riot/releases/download/0.0.2/riot-0.0.2.tbz"
+  checksum: [
+    "sha256=724fedaf9a349ca17858d8233ce0c7835fed95a2afd49b6e620a987c8219efc4"
+    "sha512=c83a6c51f89583d0b171901618d81894b38376b8ad2bea901de4d9ab4511b8008cca76302278a69a202157e9c379f2802392c4e17046d0ec2843052dc0610b3e"
+  ]
+}
+x-commit-hash: "3a46b02dab5953c8003826306b4ca0048a64f054"


### PR DESCRIPTION
An actor-model multi-core scheduler for OCaml 5

- Project page: <a href="https://github.com/leostera/riot">https://github.com/leostera/riot</a>

##### CHANGES:

## 0.0.2

* New `Riot.random ()` API to expose current scheduler's random state
* Better logging in the `Net` module
* Fix a bug where `Net.Socket` operations where hanging on I/O polling when they could have been eager

## 0.0.1

First release, including:

* First working version of the scheduler
* Support for process spawning, message passing, monitoring, and linking
* Rudimentary supervisors
* Basic (and incomplete) GenServer
* Scheduling-aware I/O primitives
* Scheduling-aware Logger
* Timers
