### PR TITLE
Package libbinaryen.115.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.115.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.115.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "6.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v115.0.0/libbinaryen-v115.0.0.tar.gz"
+  checksum: [
+    "md5=0079cc78b9a3f9eee566642f305d7086"
+    "sha512=fc826f141912edfe7a723cd1cb4786e0d176bd66c0394569a2e51fc692273aff83ee0e51266b6e0dda99a22bbb180ed496844f9e7e2ed63cd1b5773923f521eb"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.115.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [115.0.0](https://github.com/grain-lang/libbinaryen/compare/v114.0.0...v115.0.0) (2023-11-02)


### ⚠ BREAKING CHANGES

* Update to libbinaryen v115 ([#90](https://github.com/grain-lang/libbinaryen/issues/90))

### Features

* Update to libbinaryen v115 ([#90](https://github.com/grain-lang/libbinaryen/issues/90)) ([4f4a03c](https://github.com/grain-lang/libbinaryen/commit/4f4a03c8227ded32ab719daa6121a80bfbe2e640))

---
:camel: Pull-request generated by opam-publish v2.0.3