### PR TITLE
[new release] links, links-postgresql, links-sqlite3 and links-mysql (0.9.8)

### DIFF
--- a/packages/links-mysql/links-mysql.0.9.8/opam
+++ b/packages/links-mysql/links-mysql.0.9.8/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14.0"}
   "dune" {>= "2.7"}
   "conf-mysql"
   "mysql8"

--- a/packages/links-mysql/links-mysql.0.9.8/opam
+++ b/packages/links-mysql/links-mysql.0.9.8/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "James Cheney <jcheney@inf.ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "MySQL database driver for the Links Programming Language"
+description: "MySQL database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "conf-mysql"
+  "mysql8"
+  "links" {= version}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.8/links-0.9.8.tbz"
+  checksum: [
+    "sha256=1135cc3e53d4b30fd3d905c93c3f20b97635f8cf9a3532147e29c2362c9d8ff3"
+    "sha512=7dee3aa923eb49fc2c10208c609a6bddcdb57260f81917967b2fb9db01eee1267bb8e6b915b4722299b6ee14dcf04b0ba60127037a3a468b9955242401ac2db1"
+  ]
+}
+x-commit-hash: "a53a36f787599d549e370286099fbe518a047e74"

--- a/packages/links-postgresql/links-postgresql.0.9.8/opam
+++ b/packages/links-postgresql/links-postgresql.0.9.8/opam
@@ -15,7 +15,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14.0"}
   "dune" {>= "2.7"}
   "postgresql"
   "links" {= version}

--- a/packages/links-postgresql/links-postgresql.0.9.8/opam
+++ b/packages/links-postgresql/links-postgresql.0.9.8/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "Postgresql database driver for the Links Programming Language"
+description: "Postgresql database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "postgresql"
+  "links" {= version}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.8/links-0.9.8.tbz"
+  checksum: [
+    "sha256=1135cc3e53d4b30fd3d905c93c3f20b97635f8cf9a3532147e29c2362c9d8ff3"
+    "sha512=7dee3aa923eb49fc2c10208c609a6bddcdb57260f81917967b2fb9db01eee1267bb8e6b915b4722299b6ee14dcf04b0ba60127037a3a468b9955242401ac2db1"
+  ]
+}
+x-commit-hash: "a53a36f787599d549e370286099fbe518a047e74"

--- a/packages/links-sqlite3/links-sqlite3.0.9.8/opam
+++ b/packages/links-sqlite3/links-sqlite3.0.9.8/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14.0"}
   "dune" {>= "2.7"}
   "sqlite3"
   "links" {= version}

--- a/packages/links-sqlite3/links-sqlite3.0.9.8/opam
+++ b/packages/links-sqlite3/links-sqlite3.0.9.8/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "SQLite database driver for the Links Programming Language"
+description: "SQLite database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "sqlite3"
+  "links" {= version}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.8/links-0.9.8.tbz"
+  checksum: [
+    "sha256=1135cc3e53d4b30fd3d905c93c3f20b97635f8cf9a3532147e29c2362c9d8ff3"
+    "sha512=7dee3aa923eb49fc2c10208c609a6bddcdb57260f81917967b2fb9db01eee1267bb8e6b915b4722299b6ee14dcf04b0ba60127037a3a468b9955242401ac2db1"
+  ]
+}
+x-commit-hash: "a53a36f787599d549e370286099fbe518a047e74"

--- a/packages/links/links.0.9.8/opam
+++ b/packages/links/links.0.9.8/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "The Links Programming Language"
+description: "Links is a functional programming language designed to make web programming easier."
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+
+build: [
+  [ "dune" "exec" "preinstall/preinstall.exe" "--" "-libdir" _:lib ]
+  [ make "opam-build-links.opam" ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.3"}
+  "base64"
+  "linenoise"
+  "ANSITerminal"
+  "lwt" {>= "5.0.0"}
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "conduit-lwt-unix"
+  "uri"
+  "tls"
+  "websocket"
+  "websocket-lwt-unix"
+  "safepass"
+  "result"
+  "ocamlfind"
+  "menhir" {>= "20210419"}
+  "ppx_sexp_conv" {>= "v0.16.0"}
+  "calendar" {>= "2.0.4"}
+  "rdf_lwt" {>= "0.13.0"}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.8/links-0.9.8.tbz"
+  checksum: [
+    "sha256=1135cc3e53d4b30fd3d905c93c3f20b97635f8cf9a3532147e29c2362c9d8ff3"
+    "sha512=7dee3aa923eb49fc2c10208c609a6bddcdb57260f81917967b2fb9db01eee1267bb8e6b915b4722299b6ee14dcf04b0ba60127037a3a468b9955242401ac2db1"
+  ]
+}
+x-commit-hash: "a53a36f787599d549e370286099fbe518a047e74"

--- a/packages/links/links.0.9.8/opam
+++ b/packages/links/links.0.9.8/opam
@@ -15,7 +15,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14.0"}
   "dune" {>= "2.7"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}


### PR DESCRIPTION
The Links Programming Language

- Project page: <a href="https://github.com/links-lang/links">https://github.com/links-lang/links</a>

##### CHANGES:

This release includes minor bug fixes, improvements, and a breaking change regarding the syntax of handlers.

## Queries mixing set and bag semantics
Links now provides experimental support for SQL queries with grouping and
aggregation. These require the _mixing_ normaliser (`mixing_norm=on` in the
configuration file).

The result of grouping over a relation is represented as a finite map, which in
Links is treated as a list of (grouping key, associated subrelation) pairs.
Aggregation can then be applied groupwise to a finite map to obtain again a
relation. Such Links queries are translated to SQL queries using `group by` and
aggregates.

Further information on this feature is provided in the [Links GitHub
wiki](https://github.com/links-lang/links/wiki/Grouping-and-aggregation).


## New syntax for handlers

The syntax for handlers has changed. Instead of
```
handle (...) {
  case Op(params, resumption) -> ...
  case Return(x) -> x
}
```
we write
```
handle (...) {
  case <Op(params) => resumption> -> ...
  case x -> x
}
```

We can also write `case <Op(params) -> resumption> -> ...`.
For now, the semantics for `->` and `=>` are the same.

## Control-flow linearity
Links now tracks control-flow linearity when the flag `--control-flow-linearity`
is enabled. This extension fixes a long-standing soundness bug (see issue
[links-lang/links#544](https://github.com/links-lang/links/issues/544)) with the interaction
between exceptions, multi-shot effect handlers and session-typed channels. More
details about this extension can be found in the [wiki
page](https://github.com/links-lang/links/wiki/Control-flow-linearity).

## Other changes and fixes
* The package `links-mysql` now relies on the `mysql8` package as its underlying
  database driver.
* Links now supports OCaml 5.
* The `SessionFail` effect can now be supressed by disabling the
  `expose_session_fail` setting. When doing so, the `SessionFail` effect
  is included in the `wild` effect instead.
* The (incomplete) support for distributed session delegation has been removed.
* The standard library now provides functions for issuing SPARQL queries.

