### PR TITLE
[new release] dream-html (1.2.0)

### DIFF
--- a/packages/dream-html/dream-html.1.2.0/opam
+++ b/packages/dream-html/dream-html.1.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v1.2.0/dream-html-1.2.0.tbz"
+  checksum: [
+    "sha256=f5145f4ad6b3a03126466630784afac01ac5e9b1cf5e89be39d91cac57dd831a"
+    "sha512=bf637974c4dcc2feba314f937b7ebb8b402dec0f96bd8bab441a4d676916af75dcd2176cba9ee8a8c276fbe9e99f4e70ceabe0a1a02553e6bb21a1cab1f13193"
+  ]
+}
+x-commit-hash: "37f3cc27b1b778cc9197a1ca39b5c4200ae0237f"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
