### PR TITLE
Package calli.0.1

### DIFF
--- a/packages/calli/calli.0.1/opam
+++ b/packages/calli/calli.0.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "CaLLi : OCaml Library for Static Analysis of LLVM bitcode"
+maintainer: ["Soyeon Baek <sy.baek28@gmail.com>"]
+authors: ["Soyeon Baek <sy.baek28@gmail.com>"]
+homepage: "https://github.com/cnu-ants/CaLLi"
+bug-reports: "https://github.com/cnu-ants/CaLLi/issues"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name]
+]
+depends: [
+  "ocaml"
+  "dune"
+  "llvm" 
+  "zarith"
+  "containers"
+]
+url {
+  src:
+    "https://github.com/cnu-ants/CaLLi_analyzer/archive/refs/tags/0.1.tar.gz"
+  checksum: [
+    "md5=a8a2a047d4abec1277375276ee601432"
+    "sha512=c7d56afaed8aa6d6ca19aa515340fcbd7dccfd3308628030c5e53a3ed2a17e0c44c9f7496778a15b5dbc807c14db068f388585bca89f2c3f5cf433909fc942fa"
+  ]
+}


### PR DESCRIPTION
### `calli.0.1`
CaLLi : OCaml Library for Static Analysis of LLVM bitcode



---
* Homepage: https://github.com/cnu-ants/CaLLi
* Bug tracker: https://github.com/cnu-ants/CaLLi/issues

---
:camel: Pull-request generated by opam-publish v2.2.0