### PR TITLE
[new release] riot (0.0.3)

### DIFF
--- a/packages/riot/riot.0.0.3/opam
+++ b/packages/riot/riot.0.0.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "An actor-model multi-core scheduler for OCaml 5"
+description:
+  "Riot is an actor-model multi-core scheduler for OCaml 5. It brings Erlang-style concurrency to the language, where lighweight process communicate via message passing"
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: ["topics" "multicore" "erlang" "actor" "message-passing" "processes"]
+homepage: "https://github.com/leostera/riot"
+bug-reports: "https://github.com/leostera/riot/issues"
+depends: [
+  "ocaml" {>= "5.1"}
+  "dune" {>= "3.10"}
+  "ptime" {>= "1.1.0"}
+  "iomux" {>= "0.3"}
+  "bigstringaf" {>= "0.9.1"}
+  "uri" {>= "4.4.0"}
+  "telemetry" {>= "0.0.1"}
+  "odoc" {with-doc & >= "2.2.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/leostera/riot.git"
+url {
+  src:
+    "https://github.com/leostera/riot/releases/download/0.0.3/riot-0.0.3.tbz"
+  checksum: [
+    "sha256=6201ce27997ec1c4b4509782c6be2fa2bf102b804b11dcbf9ebdb49a123c19c3"
+    "sha512=ad70a67601a892700e461efe57484d109b1d08e30d15464ad8611e71dd568c934d3f948afd645e096e4f97ad1935aaeaf5d9b6d9d59c52a82eeb5c4995421646"
+  ]
+}
+x-commit-hash: "8f6c100541ca46a7a42ef0ff0d5ec2e6ff6afc6e"


### PR DESCRIPTION
An actor-model multi-core scheduler for OCaml 5

- Project page: <a href="https://github.com/leostera/riot">https://github.com/leostera/riot</a>

##### CHANGES:

## 0.0.3

* Big namespace refactor. `Riot.Runtime` includes the lower-level runtime
  blocks, and everything else that is more user-friendly lives at the `Riot.*`
level.
* Introduce reduction counting, so processes will run up to N iterations unless
  they finish, or they execute an unhandled effect.
* Introduce the `Application` interface for managing the lifecycle of the system
* Fix `Riot.Logger` to fit the `Application` interface
* Add a new `Riot.Telemetry` backend for doing async telemetry
