### PR TITLE
Use clang on macOS for tsan support

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.1.0+tsan/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+tsan/opam
@@ -39,7 +39,8 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd")}
+    "CC=clang" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed}
     "--enable-tsan"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~rc3+tsan/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~rc3+tsan/opam
@@ -32,7 +32,8 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd")}
+    "CC=clang" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed}
     "--enable-tsan"

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+trunk/opam
@@ -43,6 +43,7 @@ build: [
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--enable-tsan" {ocaml-option-tsan:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed}
     "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}


### PR DESCRIPTION
Using the default cc on macOS does not provide ThreadSantizer support, I get this error on macOS Sonoma 14.1:
```
$ opam switch create 5.1.0+tsan --no-install

<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><>  🐫 
Switch invariant: ["ocaml-variants" {= "5.1.0+tsan"}]
Constructing initial basis...
Number of 0-1 knapsack inequalities = 9
Constructing conflict graph...
Conflict graph has 6 + 1 = 7 vertices

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫 
∗ installed base-bigarray.base
∗ installed base-threads.base
∗ installed base-unix.base
⬇ retrieved ocaml-variants.5.1.0+tsan  (cached)
∗ installed conf-pkg-config.3
∗ installed conf-unwind.0
[ERROR] The compilation of ocaml-variants.5.1.0+tsan failed at "./configure --prefix=/Users/tsmc/.opam/5.1.0+tsan
        --docdir=/Users/tsmc/.opam/5.1.0+tsan/doc/ocaml -C CC=cc --enable-tsan --disable-warn-error".

#=== ERROR while compiling ocaml-variants.5.1.0+tsan ==========================#
# context     2.1.5 | macos/x86_64 |  | https://opam.ocaml.org#2dcd8684
# path        ~/.opam/5.1.0+tsan/.opam-switch/build/ocaml-variants.5.1.0+tsan
# command     ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix=/Users/tsmc/.opam/5.1.0+tsan --docdir=/Users/tsmc/.opam/5.1.0+tsan/doc/ocaml -C CC=cc --enable-tsan --disable-warn-error
# exit-code   1
# env-file    ~/.opam/log/ocaml-variants-93286-9def9a.env
# output-file ~/.opam/log/ocaml-variants-93286-9def9a.out
### output ###
# [...]
# checking whether fma works... yes
# checking for cc options needed to detect all undeclared functions... none needed
# checking for unistd.h... (cached) yes
# checking whether getentropy is declared... no
# checking for getrusage... yes
# checking for times... yes
# checking for secure_getenv... no
# checking for __secure_getenv... no
# checking for issetugid... yes
# checking for mach_timebase_info... yes
# checking for mach_absolute_time... yes
# configure: error: thread sanitizer not supported with compiler cc"
```
With this patch I can create a tsan switch. I have tested on both Ventura and Sonoma (x86_64) but nothing previous to that. 