### PR TITLE
atacama 0.0.1 is not compatible with riot 0.0.3

### DIFF
--- a/packages/atacama/atacama.0.0.1/opam
+++ b/packages/atacama/atacama.0.0.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/leostera/atacama"
 bug-reports: "https://github.com/leostera/atacama/issues"
 depends: [
   "ocaml" {>= "5.1"}
-  "riot" {>= "0.0.1"}
+  "riot" {>= "0.0.1" & < "0.0.3"}
   "telemetry" {>= "0.0.1"}
   "dune" {>= "3.10"}
   "odoc" {with-doc}


### PR DESCRIPTION
Fails with
```
\#=== ERROR while compiling atacama.0.0.1 ======================================#
\# context              2.2.0~alpha3 | linux/x86_64 | ocaml-base-compiler.5.1.0 | file:///home/opam/opam-repository
\# path                 ~/.opam/5.1/.opam-switch/build/atacama.0.0.1
\# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p atacama -j 255 @install
\# exit-code            1
\# env-file             ~/.opam/log/atacama-7-703553.env
\# output-file          ~/.opam/log/atacama-7-703553.out
\### output ###
\# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I atacama/.atacama.objs/byte -I /home/opam/.opam/5.1/lib/angstrom -I /home/opam/.opam/5.1/lib/bigstringaf -I /home/opam/.opam/5.1/lib/iomux -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/ptime -I /home/opam/.opam/5.1/lib/ptime/clock/os -I /home/opam/.opam/5.1/lib/riot -I /home/opam/.opam/5.1/lib/riot/core -I /home/opam/.opam/5.1/lib/riot/lib -I /home/opam/.opam/5.1/lib/riot/lib/logger -I /home/opam/.opam/5.1/lib/riot/lib/net -I /home/opam/.opam/5.1/lib/riot/log -I /home/opam/.opam/5.1/lib/riot/net -I /home/opam/.opam/5.1/lib/riot/runtime -I /home/opam/.opam/5.1/lib/riot/runtime/time -I /home/opam/.opam/5.1/lib/riot/scheduler -I /home/opam/.opam/5.1/lib/riot/util -I /home/opam/.opam/5.1/lib/stringext -I /home/opam/.opam/5.1/lib/telemetry -I /home/opam/.opam/5.1/lib/uri -no-alias-deps -open Atacama__ -o atacama/.atacama.objs/byte/atacama__Telemetry_.cmo -c -impl atacama/telemetry_.ml)
\# File "atacama/telemetry_.ml", line 6, characters 28-45:
\# 6 |   | Listening of { socket : Net.listen_socket }
\#                                 ^^^^^^^^^^^^^^^^^
\# Error: Unbound type constructor Net.listen_socket
\# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I atacama/.atacama.objs/byte -I /home/opam/.opam/5.1/lib/angstrom -I /home/opam/.opam/5.1/lib/bigstringaf -I /home/opam/.opam/5.1/lib/iomux -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/ptime -I /home/opam/.opam/5.1/lib/ptime/clock/os -I /home/opam/.opam/5.1/lib/riot -I /home/opam/.opam/5.1/lib/riot/core -I /home/opam/.opam/5.1/lib/riot/lib -I /home/opam/.opam/5.1/lib/riot/lib/logger -I /home/opam/.opam/5.1/lib/riot/lib/net -I /home/opam/.opam/5.1/lib/riot/log -I /home/opam/.opam/5.1/lib/riot/net -I /home/opam/.opam/5.1/lib/riot/runtime -I /home/opam/.opam/5.1/lib/riot/runtime/time -I /home/opam/.opam/5.1/lib/riot/scheduler -I /home/opam/.opam/5.1/lib/riot/util -I /home/opam/.opam/5.1/lib/stringext -I /home/opam/.opam/5.1/lib/telemetry -I /home/opam/.opam/5.1/lib/uri -no-alias-deps -open Atacama__ -o atacama/.atacama.objs/byte/atacama.cmi -c -intf atacama/atacama.mli)
\# File "atacama/atacama.mli", line 97, characters 7-24:
\# 97 |       (Net.listen_socket, [> `System_limit | `Unix_error of Unix.error ]) result
\#             ^^^^^^^^^^^^^^^^^
\# Error: Unbound type constructor Net.listen_socket
\# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I atacama/.atacama.objs/byte -I /home/opam/.opam/5.1/lib/angstrom -I /home/opam/.opam/5.1/lib/bigstringaf -I /home/opam/.opam/5.1/lib/iomux -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/ptime -I /home/opam/.opam/5.1/lib/ptime/clock/os -I /home/opam/.opam/5.1/lib/riot -I /home/opam/.opam/5.1/lib/riot/core -I /home/opam/.opam/5.1/lib/riot/lib -I /home/opam/.opam/5.1/lib/riot/lib/logger -I /home/opam/.opam/5.1/lib/riot/lib/net -I /home/opam/.opam/5.1/lib/riot/log -I /home/opam/.opam/5.1/lib/riot/net -I /home/opam/.opam/5.1/lib/riot/runtime -I /home/opam/.opam/5.1/lib/riot/runtime/time -I /home/opam/.opam/5.1/lib/riot/scheduler -I /home/opam/.opam/5.1/lib/riot/util -I /home/opam/.opam/5.1/lib/stringext -I /home/opam/.opam/5.1/lib/telemetry -I /home/opam/.opam/5.1/lib/uri -no-alias-deps -open Atacama__ -o atacama/.atacama.objs/byte/atacama__Transport.cmo -c -impl atacama/transport.ml)
\# File "atacama/transport.ml", line 8, characters 5-22:
\# 8 |     (Net.listen_socket, [> `System_limit ]) Net.Socket.result
\#          ^^^^^^^^^^^^^^^^^
\# Error: Unbound type constructor Net.listen_socket
```

Seen on https://github.com/ocaml/opam-repository/pull/24814