### PR TITLE
tezos-rpc-http-server 17.3 is not compatible with resto-cohttp-server 1.2

### DIFF
--- a/packages/tezos-rpc-http-server/tezos-rpc-http-server.17.3/opam
+++ b/packages/tezos-rpc-http-server/tezos-rpc-http-server.17.3/opam
@@ -11,7 +11,7 @@ depends: [
   "tezos-base" { = version }
   "tezos-stdlib-unix" { = version }
   "cohttp-lwt-unix" { >= "4.0.0" & != "5.1.0" }
-  "resto-cohttp-server" { >= "1.0" }
+  "resto-cohttp-server" { >= "1.0" & < "1.2" }
   "resto-acl" { >= "1.0" }
   "tezos-rpc" { = version }
   "tezos-rpc-http" { = version }


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/24811

Fails with
```
\#=== ERROR while compiling tezos-rpc-http-server.17.3 =========================#
\# context              2.2.0~alpha3 | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
\# path                 ~/.opam/4.14/.opam-switch/build/tezos-rpc-http-server.17.3
\# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p tezos-rpc-http-server -j 31
\# exit-code            1
\# env-file             ~/.opam/log/tezos-rpc-http-server-7-5a7e1b.env
\# output-file          ~/.opam/log/tezos-rpc-http-server-7-5a7e1b.out
\### output ###
\# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -open Tezos_base.TzPervasives -open Tezos_stdlib_unix -open Tezos_rpc_http -g -bin-annot -I src/lib_rpc_http/.tezos_rpc_http_server.objs/byte -I /home/opam/.opam/4.14/lib/aches -I /home/opam/.opam/4.14/lib/aches-lwt -I /home/opam/.opam/4.14/lib/aches-lwt/lache -I /home/opam/.opam/4.14/lib/aches/rache -I /home/opam/.opam/4.14/lib/aches/vache -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/asn1-combinators -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigarray-compat -I /home/opam/.opam/4.14/lib/bigstring -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bls12-381 -I /home/opam/.opam/4.14/lib/bos -I /home/opam/.opam/4.14/lib/ca-certs -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cohttp-lwt-unix -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-lwt-unix -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/ctypes -I /home/opam/.opam/4.14/lib/ctypes_stubs_js -I /home/opam/.opam/4.14/lib/data-encoding -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/either -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/eqaf/bigstring -I /home/opam/.opam/4.14/lib/eqaf/cstruct -I /home/opam/.opam/4.14/lib/ezjsonm -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/fpath -I /home/opam/.opam/4.14/lib/gmap -I /home/opam/.opam/4.14/lib/hacl-star -I /home/opam/.opam/4.14/lib/hacl-star-raw -I /home/opam/.opam/4.14/lib/hex -I /home/opam/.opam/4.14/lib/hkdf -I /home/opam/.opam/4.14/lib/integers -I /home/opam/.opam/4.14/lib/integers_stubs_js -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/json-data-encoding -I /home/opam/.opam/4.14/lib/json-data-encoding-bson -I /home/opam/.opam/4.14/lib/jsonm -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt-canceler -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/lwt_log -I /home/opam/.opam/4.14/lib/lwt_log/core -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/mirage-crypto -I /home/opam/.opam/4.14/lib/mirage-crypto-ec -I /home/opam/.opam/4.14/lib/mirage-crypto-pk -I /home/opam/.opam/4.14/lib/mirage-crypto-rng -I /home/opam/.opam/4.14/lib/mirage-crypto-rng-lwt -I /home/opam/.opam/4.14/lib/mirage-crypto-rng/unix -I /home/opam/.opam/4.14/lib/mtime -I /home/opam/.opam/4.14/lib/mtime/clock/os -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/octez-bls12-381-signature -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/pbkdf -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/ptime/clock/os -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/resto -I /home/opam/.opam/4.14/lib/resto-acl -I /home/opam/.opam/4.14/lib/resto-cohttp -I /home/opam/.opam/4.14/lib/resto-cohttp-server -I /home/opam/.opam/4.14/lib/resto-directory -I /home/opam/.opam/4.14/lib/ringo -I /home/opam/.opam/4.14/lib/rresult -I /home/opam/.opam/4.14/lib/secp256k1-internal -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/seqes -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/tezos-base -I /home/opam/.opam/4.14/lib/tezos-crypto -I /home/opam/.opam/4.14/lib/tezos-error-monad -I /home/opam/.opam/4.14/lib/tezos-event-logging -I /home/opam/.opam/4.14/lib/tezos-hacl -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/bare/functor-outputs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/bare/sigs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/bare/structs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/traced/functor-outputs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/traced/sigs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/traced/structs -I /home/opam/.opam/4.14/lib/tezos-micheline -I /home/opam/.opam/4.14/lib/tezos-rpc -I /home/opam/.opam/4.14/lib/tezos-rpc-http -I /home/opam/.opam/4.14/lib/tezos-stdlib -I /home/opam/.opam/4.14/lib/tezos-stdlib-unix -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/tls -I /home/opam/.opam/4.14/lib/tls-lwt -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/x509 -I /home/opam/.opam/4.14/lib/zarith -I /home/opam/.opam/4.14/lib/zarith_stubs_js -intf-suffix .ml -no-alias-deps -open Tezos_rpc_http_server -o src/lib_rpc_http/.tezos_rpc_http_server.objs/byte/tezos_rpc_http_server__RPC_server.cmo -c -impl src/lib_rpc_http/RPC_server.ml)
\# File "src/lib_rpc_http/RPC_server.ml", line 1:
\# Error: The implementation src/lib_rpc_http/RPC_server.ml
\#        does not match the interface src/lib_rpc_http/.tezos_rpc_http_server.objs/byte/tezos_rpc_http_server__RPC_server.cmi:
\#         Values do not match:
\#           val launch :
\#             ?host:string ->
\#             server ->
\#             ?conn_closed:(Cohttp_lwt_unix.Server.conn -> unit) ->
\#             ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
\#         is not included in
\#           val launch :
\#             ?host:string ->
\#             server ->
\#             ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
\#         The type
\#           ?host:string ->
\#           server ->
\#           ?conn_closed:(Cohttp_lwt_unix.Server.conn -> unit) ->
\#           ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
\#         is not compatible with the type
\#           ?host:string ->
\#           server ->
\#           ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
\#         Type
\#           ?conn_closed:(Cohttp_lwt_unix.Server.conn -> unit) ->
\#           ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
\#         is not compatible with type
\#           ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
\#         File "src/lib_rpc_http/RPC_server.mli", lines 51-56, characters 0-12:
\#           Expected declaration
\#         File "src/server.mli", lines 124-130, characters 2-14:
\#           Actual declaration
\# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -open Tezos_base.TzPervasives -open Tezos_stdlib_unix -open Tezos_rpc_http -g -O3 -I src/lib_rpc_http/.tezos_rpc_http_server.objs/byte -I src/lib_rpc_http/.tezos_rpc_http_server.objs/native -I /home/opam/.opam/4.14/lib/aches -I /home/opam/.opam/4.14/lib/aches-lwt -I /home/opam/.opam/4.14/lib/aches-lwt/lache -I /home/opam/.opam/4.14/lib/aches/rache -I /home/opam/.opam/4.14/lib/aches/vache -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/asn1-combinators -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigarray-compat -I /home/opam/.opam/4.14/lib/bigstring -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bls12-381 -I /home/opam/.opam/4.14/lib/bos -I /home/opam/.opam/4.14/lib/ca-certs -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cohttp-lwt-unix -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-lwt-unix -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/ctypes -I /home/opam/.opam/4.14/lib/ctypes_stubs_js -I /home/opam/.opam/4.14/lib/data-encoding -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/either -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/eqaf/bigstring -I /home/opam/.opam/4.14/lib/eqaf/cstruct -I /home/opam/.opam/4.14/lib/ezjsonm -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/fpath -I /home/opam/.opam/4.14/lib/gmap -I /home/opam/.opam/4.14/lib/hacl-star -I /home/opam/.opam/4.14/lib/hacl-star-raw -I /home/opam/.opam/4.14/lib/hex -I /home/opam/.opam/4.14/lib/hkdf -I /home/opam/.opam/4.14/lib/integers -I /home/opam/.opam/4.14/lib/integers_stubs_js -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/json-data-encoding -I /home/opam/.opam/4.14/lib/json-data-encoding-bson -I /home/opam/.opam/4.14/lib/jsonm -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt-canceler -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/lwt_log -I /home/opam/.opam/4.14/lib/lwt_log/core -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/mirage-crypto -I /home/opam/.opam/4.14/lib/mirage-crypto-ec -I /home/opam/.opam/4.14/lib/mirage-crypto-pk -I /home/opam/.opam/4.14/lib/mirage-crypto-rng -I /home/opam/.opam/4.14/lib/mirage-crypto-rng-lwt -I /home/opam/.opam/4.14/lib/mirage-crypto-rng/unix -I /home/opam/.opam/4.14/lib/mtime -I /home/opam/.opam/4.14/lib/mtime/clock/os -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/octez-bls12-381-signature -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/pbkdf -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/ptime/clock/os -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/resto -I /home/opam/.opam/4.14/lib/resto-acl -I /home/opam/.opam/4.14/lib/resto-cohttp -I /home/opam/.opam/4.14/lib/resto-cohttp-server -I /home/opam/.opam/4.14/lib/resto-directory -I /home/opam/.opam/4.14/lib/ringo -I /home/opam/.opam/4.14/lib/rresult -I /home/opam/.opam/4.14/lib/secp256k1-internal -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/seqes -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/tezos-base -I /home/opam/.opam/4.14/lib/tezos-crypto -I /home/opam/.opam/4.14/lib/tezos-error-monad -I /home/opam/.opam/4.14/lib/tezos-event-logging -I /home/opam/.opam/4.14/lib/tezos-hacl -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/bare/functor-outputs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/bare/sigs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/bare/structs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/traced/functor-outputs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/traced/sigs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/traced/structs -I /home/opam/.opam/4.14/lib/tezos-micheline -I /home/opam/.opam/4.14/lib/tezos-rpc -I /home/opam/.opam/4.14/lib/tezos-rpc-http -I /home/opam/.opam/4.14/lib/tezos-stdlib -I /home/opam/.opam/4.14/lib/tezos-stdlib-unix -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/tls -I /home/opam/.opam/4.14/lib/tls-lwt -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/x509 -I /home/opam/.opam/4.14/lib/zarith -I /home/opam/.opam/4.14/lib/zarith_stubs_js -intf-suffix .ml -no-alias-deps -open Tezos_rpc_http_server -o src/lib_rpc_http/.tezos_rpc_http_server.objs/native/tezos_rpc_http_server__RPC_server.cmx -c -impl src/lib_rpc_http/RPC_server.ml)
\# File "src/lib_rpc_http/RPC_server.ml", line 1:
\# Error: The implementation src/lib_rpc_http/RPC_server.ml
\#        does not match the interface src/lib_rpc_http/.tezos_rpc_http_server.objs/byte/tezos_rpc_http_server__RPC_server.cmi:
\#         Values do not match:
\#           val launch :
\#             ?host:string ->
\#             server ->
\#             ?conn_closed:(Cohttp_lwt_unix.Server.conn -> unit) ->
\#             ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
\#         is not included in
\#           val launch :
\#             ?host:string ->
\#             server ->
\#             ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
\#         The type
\#           ?host:string ->
\#           server ->
\#           ?conn_closed:(Cohttp_lwt_unix.Server.conn -> unit) ->
\#           ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
\#         is not compatible with the type
\#           ?host:string ->
\#           server ->
\#           ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
\#         Type
\#           ?conn_closed:(Cohttp_lwt_unix.Server.conn -> unit) ->
\#           ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
\#         is not compatible with type
\#           ?callback:callback -> Conduit_lwt_unix.server -> unit Lwt.t
\#         File "src/lib_rpc_http/RPC_server.mli", lines 51-56, characters 0-12:
\#           Expected declaration
\#         File "src/server.mli", lines 124-130, characters 2-14:
\#           Actual declaration
```
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>