### PR TITLE
containers-data < 3.11 is not compatible with ocaml 5.1

### DIFF
--- a/packages/containers-data/containers-data.3.10/opam
+++ b/packages/containers-data/containers-data.3.10/opam
@@ -8,7 +8,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
 ]
 depends: [
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "5.1" }
   "dune" { >= "2.0" }
   "containers" { = version }
   "seq"

--- a/packages/containers-data/containers-data.3.9/opam
+++ b/packages/containers-data/containers-data.3.9/opam
@@ -8,7 +8,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
 ]
 depends: [
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "5.1" }
   "dune" { >= "2.0" }
   "containers" { = version }
   "seq"


### PR DESCRIPTION
Fails with
```
\#=== ERROR while compiling containers-data.3.10 ===============================#
\# context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-base-compiler.5.1.0 | file:///home/opam/opam-repository
\# path                 ~/.opam/5.1/.opam-switch/build/containers-data.3.10
\# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p containers-data -j 31
\# exit-code            1
\# env-file             ~/.opam/log/containers-data-7-58bd8d.env
\# output-file          ~/.opam/log/containers-data-7-58bd8d.out
\### output ###
\# (cd _build/default && src/mdx_runner.exe)
\# warning: ocaml-mdx exited with code 127
\# sh: 1: ocaml-mdx: not found
\# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -strict-sequence -warn-error -a+8 -open CCShims_ -g -bin-annot -I tests/data/.t.eobjs/byte -I /home/opam/.opam/5.1/lib/bytes -I /home/opam/.opam/5.1/lib/containers -I /home/opam/.opam/5.1/lib/containers/monomorphic -I /home/opam/.opam/5.1/lib/either -I /home/opam/.opam/5.1/lib/gen -I /home/opam/.opam/5.1/lib/iter -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/qcheck-core -I /home/opam/.opam/5.1/lib/seq -I src/data/.containers_data.objs/byte -I src/testlib/.containers_testlib.objs/byte -no-alias-deps -open Dune__exe -o tests/data/.t.eobjs/byte/dune__exe__T_bitfield.cmo -c -impl tests/data/t_bitfield.ml)
\# File "tests/data/t_bitfield.ml", line 6, characters 15-33:
\# 6 | let module B = CCBitField.Make () in
\#                    ^^^^^^^^^^^^^^^^^^
\# Error: The functor was expected to be applicative at this position
```
Seen on https://github.com/ocaml/opam-repository/pull/24801