### PR TITLE
ocurl 0.7.6 is not compatible with ocaml 5

### DIFF
--- a/packages/ocurl/ocurl.0.7.6/opam
+++ b/packages/ocurl/ocurl.0.7.6/opam
@@ -17,7 +17,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "curl"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "base-unix"
   "conf-libcurl"


### PR DESCRIPTION
Fails linking on revdeps due to using older C calls without the 'caml_' prefix.
This was fixed in 0.7.7: https://github.com/ygrek/ocurl/commit/96c989ed57854209e8002c9a76a8f5b52e66b71c

Seen on https://github.com/ocaml/opam-repository/pull/24745