### PR TITLE
[new release] hol2dk (0.0.1)

### DIFF
--- a/packages/hol2dk/hol2dk.0.0.1/opam
+++ b/packages/hol2dk/hol2dk.0.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "HOL-Light to Dedukti/Lambdapi translator"
+description: "HOL-Light to Dedukti/Lambdapi translator"
+maintainer: ["Frédéric Blanqui"]
+authors: ["Frédéric Blanqui"]
+license: "CeCILL-2.1"
+homepage: "https://github.com/Deducteam/hol2dk"
+doc: "https://github.com/Deducteam/hol2dk/blob/master/README.md"
+bug-reports: "https://github.com/Deducteam/hol2dk/issues"
+depends: [
+  "ocaml" {>= "4.13"}
+  "dune" {>= "3.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Deducteam/hol2dk.git"
+url {
+  src:
+    "https://github.com/Deducteam/hol2dk/releases/download/0.0.1/hol2dk-0.0.1.tbz"
+  checksum: [
+    "sha256=e1d729676f01c0fdfcffaa06be212caa80316dcdccdea77fe3c0973c14fe641d"
+    "sha512=7be0c83ef0356ce18889f447a1183c4ec5373c2a47291ceb9c75d426fe159cd824db95b01285f8da805fbd002fdcb91cb59666e31535c3c84cac92075feefd63"
+  ]
+}
+x-commit-hash: "adf49ef619beb9670c41e86eb2cfe8bf809aeb6a"


### PR DESCRIPTION
HOL-Light to Dedukti/Lambdapi translator

- Project page: <a href="https://github.com/Deducteam/hol2dk">https://github.com/Deducteam/hol2dk</a>
- Documentation: <a href="https://github.com/Deducteam/hol2dk/blob/master/README.md">https://github.com/Deducteam/hol2dk/blob/master/README.md</a>

##### CHANGES:

### Added

- add command dump-use for dumping a file without including "hol.ml"

### Modified

- rename mk-part command into mk
- the dump command now includes "hol.ml"
- do not print ocaml warnings while dumping proofs
- do not export unused proofs (about 7%)
- make hol2dk stat give the number of unused proofs

### Fixed

- README.md
- output of hol2dk axm
- output of hol2dk mk
