### PR TITLE
[new release] riot (0.0.4)

### DIFF
--- a/packages/riot/riot.0.0.4/opam
+++ b/packages/riot/riot.0.0.4/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "An actor-model multi-core scheduler for OCaml 5"
+description:
+  "Riot is an actor-model multi-core scheduler for OCaml 5. It brings Erlang-style concurrency to the language, where lighweight process communicate via message passing"
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: ["topics" "multicore" "erlang" "actor" "message-passing" "processes"]
+homepage: "https://github.com/leostera/riot"
+bug-reports: "https://github.com/leostera/riot/issues"
+depends: [
+  "ocaml" {>= "5.1"}
+  "dune" {>= "3.10"}
+  "ptime" {>= "1.1.0"}
+  "iomux" {>= "0.3"}
+  "bigstringaf" {>= "0.9.1"}
+  "uri" {>= "4.4.0"}
+  "telemetry" {>= "0.0.1"}
+  "odoc" {with-doc & >= "2.2.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/leostera/riot.git"
+url {
+  src:
+    "https://github.com/leostera/riot/releases/download/0.0.4/riot-0.0.4.tbz"
+  checksum: [
+    "sha256=bd196369f74bbc42f23d262030d5fa04c03f5f00c46bf944f0dcbc193745976f"
+    "sha512=f1ca69e05b57e83a1bd173efe51b745d331355a83381e6068743a7626e45dcf515cdd8947180051bddfe9f5727c2732aa0f01a093b04cf33fa4081d32f24fd65"
+  ]
+}
+x-commit-hash: "6c862bf5376f9ea465faec6a7ba6bebf1e6d791d"


### PR DESCRIPTION
An actor-model multi-core scheduler for OCaml 5

- Project page: <a href="https://github.com/leostera/riot">https://github.com/leostera/riot</a>

##### CHANGES:

## 0.0.4

* Internally immediately suspend (bypassing reduction counts) when on a receive expression
* Fix reads from closed Unix sockets
* Fix writes to closed Unix sockets
* Ignore SIGPIPEs on setup
* Fix always mark connected sockets as nonblocking
* Fix GC i/o process table
* Surface pretty-printing of socket values