### PR TITLE
Restrict docker-api.0.2.2 to older OCaml

### DIFF
--- a/packages/docker-api/docker-api.0.2.1/opam
+++ b/packages/docker-api/docker-api.0.2.1/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5"}
   "dune" {>= "1.1"}
   "base-bytes"
   "base-unix"

--- a/packages/docker-api/docker-api.0.2.2/opam
+++ b/packages/docker-api/docker-api.0.2.2/opam
@@ -10,7 +10,7 @@ doc: "https://Chris00.github.io/ocaml-docker/doc"
 bug-reports: "https://github.com/Chris00/ocaml-docker/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.03" & < "5.1"}
+  "ocaml" {>= "4.03" & < "5"}
   "base-bytes"
   "base-unix"
   "yojson" {>= "1.6.0"}

--- a/packages/docker-api/docker-api.0.2.2/opam
+++ b/packages/docker-api/docker-api.0.2.2/opam
@@ -10,7 +10,7 @@ doc: "https://Chris00.github.io/ocaml-docker/doc"
 bug-reports: "https://github.com/Chris00/ocaml-docker/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.1"}
   "base-bytes"
   "base-unix"
   "yojson" {>= "1.6.0"}

--- a/packages/docker-api/docker-api.0.2/opam
+++ b/packages/docker-api/docker-api.0.2/opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5"}
   "dune" {>= "1.3"}
   "base-bytes"
   "base-unix"


### PR DESCRIPTION
#24832 has an unrelated revdep failure:
 
Fails on 5.1 (and most likely 5.0?) with

```
File "../compatibility.ml", line 39, characters 4-15:
39 |     output_file fname_out s
         ^^^^^^^^^^^
Warning 6 [labels-omitted]: label content was omitted in the application of this function.

File "../compatibility.ml", line 43, characters 4-15:
43 |     output_file fname_out (input_file fname_in)
         ^^^^^^^^^^^
Warning 6 [labels-omitted]: label content was omitted in the application of this function.

File "../compatibility.ml", line 55, characters 2-13:
55 |   output_file fname_out s
       ^^^^^^^^^^^
Warning 6 [labels-omitted]: label content was omitted in the application of this function.
(cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.docker.objs/byte -I /home/opam/.opam/5.1/lib/bytes -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/yojson -intf-suffix .ml -no-alias-deps -open Docker__ -o src/.docker.objs/byte/docker.cmo -c -impl src/docker.ml)
File "src/docker.ml", line 46, characters 32-33:
46 |         Buffer.add_subbytes buf b 0 r
                                     ^
Error: This expression has type bytes but an expression was expected of type
         string
(cd _build/default && /home/opam/.opam/5.1/bin/ocamlopt.opt -w -40 -g -I src/.docker.objs/byte -I src/.docker.objs/native -I /home/opam/.opam/5.1/lib/bytes -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/yojson -intf-suffix .ml -no-alias-deps -open Docker__ -o src/.docker.objs/native/docker.cmx -c -impl src/docker.ml)
File "src/docker.ml", line 46, characters 32-33:
46 |         Buffer.add_subbytes buf b 0 r
                                     ^
Error: This expression has type bytes but an expression was expected of type
         string
```

[Failure at CI](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/1bf8a8a232168bfebda5170ac014dc4c16872387/variant/compilers,5.1,yojson.2.1.2,revdeps,docker-api.0.2.2)