### PR TITLE
[new release] mustache (3.2.0)

### DIFF
--- a/packages/mustache/mustache.3.2.0/opam
+++ b/packages/mustache/mustache.3.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Mustache logic-less templates in OCaml"
+description: """
+Read and write mustache templates, and render them by providing a json object.
+Contains the `mustache` command line utility for driving logic-less templates.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Armaël Guéneau <armael.gueneau@ens-lyon.fr>"
+  "Gabriel Scherer <gabriel.scherer@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/rgrinberg/ocaml-mustache"
+bug-reports: "https://github.com/rgrinberg/ocaml-mustache/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "jsonm" {>= "1.0.1"}
+  "ounit2" {with-test}
+  "ezjsonm" {with-test}
+  "menhir" {>= "20180703"}
+  "cmdliner" {>= "1.0.4" & < "1.1.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/rgrinberg/ocaml-mustache.git"
+url {
+  src:
+    "https://github.com/rgrinberg/ocaml-mustache/releases/download/v3.2.0/mustache-3.2.0.tbz"
+  checksum: [
+    "sha256=080b6852ce81f2604134348e19d7b1c8d2ea311519be854ad4517729508c4d4c"
+    "sha512=80bf68ab0547002290254979cb60ad0962ac526551f9a7a0337c4f0426128b2974ca1d9efbac345613d73b340d7027e1331a0baad0d3743256dbd1b2d97f1eb0"
+  ]
+}
+x-commit-hash: "a86cab0ceb8d77d5045b4d6464b68affafb80e2e"

--- a/packages/soupault/soupault.1.10.0/opam
+++ b/packages/soupault/soupault.1.10.0/opam
@@ -32,7 +32,7 @@ depends: [
   "stringext"
   "calendar" {>= "2.00"}
   "spelll" {>= "0.3"}
-  "mustache"
+  "mustache" {< "3.2.0"}
   "tsort" {< "2.0.0"}
   "lua-ml" {>= "0.9.1"}
 ]

--- a/packages/soupault/soupault.1.11.0/opam
+++ b/packages/soupault/soupault.1.11.0/opam
@@ -32,7 +32,7 @@ depends: [
   "stringext"
   "calendar" {>= "2.00"}
   "spelll" {>= "0.3"}
-  "mustache"
+  "mustache" {< "3.2.0"}
   "tsort" {< "2.0.0"}
   "lua-ml" {>= "0.9.1"}
 ]

--- a/packages/soupault/soupault.1.12.0/opam
+++ b/packages/soupault/soupault.1.12.0/opam
@@ -32,7 +32,7 @@ depends: [
   "stringext"
   "calendar" {>= "2.00"}
   "spelll" {>= "0.3"}
-  "mustache"
+  "mustache" {< "3.2.0"}
   "tsort" {>= "2.0.0"}
   "lua-ml" {>= "0.9.1"}
 ]

--- a/packages/soupault/soupault.1.13.0/opam
+++ b/packages/soupault/soupault.1.13.0/opam
@@ -32,7 +32,7 @@ depends: [
   "stringext"
   "calendar" {>= "2.00"}
   "spelll" {>= "0.3"}
-  "mustache"
+  "mustache" {< "3.2.0"}
   "tsort" {>= "2.0.0"}
   "lua-ml" {>= "0.9.1"}
 ]

--- a/packages/soupault/soupault.1.6/opam
+++ b/packages/soupault/soupault.1.6/opam
@@ -32,7 +32,7 @@ depends: [
   "stringext"
   "calendar" {>= "2.00"}
   "spelll" {>= "0.3"}
-  "mustache"
+  "mustache" {< "3.2.0"}
   "tsort" {< "2.0.0"}
   "lua-ml"
 ]

--- a/packages/soupault/soupault.1.7.0/opam
+++ b/packages/soupault/soupault.1.7.0/opam
@@ -32,7 +32,7 @@ depends: [
   "stringext"
   "calendar" {>= "2.00"}
   "spelll" {>= "0.3"}
-  "mustache"
+  "mustache" {< "3.2.0"}
   "tsort" {< "2.0.0"}
   "lua-ml"
 ]

--- a/packages/soupault/soupault.1.8.0/opam
+++ b/packages/soupault/soupault.1.8.0/opam
@@ -38,7 +38,7 @@ depends: [
   "stringext"
   "calendar" {>= "2.00"}
   "spelll" {>= "0.3"}
-  "mustache"
+  "mustache" {< "3.2.0"}
   "tsort" {< "2.0.0"}
   "lua-ml" {>= "0.9.1"}
 ]

--- a/packages/soupault/soupault.1.9.0/opam
+++ b/packages/soupault/soupault.1.9.0/opam
@@ -38,7 +38,7 @@ depends: [
   "stringext"
   "calendar" {>= "2.00"}
   "spelll" {>= "0.3"}
-  "mustache"
+  "mustache" {< "3.2.0"}
   "tsort" {< "2.0.0"}
   "lua-ml" {>= "0.9.1"}
 ]


### PR DESCRIPTION
Mustache logic-less templates in OCaml

- Project page: <a href="https://github.com/rgrinberg/ocaml-mustache">https://github.com/rgrinberg/ocaml-mustache</a>

##### CHANGES:

* Remove the AST without locations: now all functions build an AST with locations;
  in particular, parsing always provide located error messages.
  To ease backward-compatibility, the smart constructors still use the
  same interface, using dummy locations by default, with
  a With_locations module for users who wish to explicitly provide
  locations.
  (@gasche, rgrinberg/ocaml-mustache#65)
* Support for "template inheritance" (partials with parameters)
  `{{<foo}} {{$param1}}...{{/param1}} {{$param2}}...{{/param2}} {{/foo}`
  following the widely-implemented semi-official specification
    https://github.com/mustache/spec/pull/75
  (@gasche, 58)
* Partials are now supported in the `mustache` command-line tool (@gasche, rgrinberg/ocaml-mustache#57)
  They are interpreted as template inclusion: "{{>foo/bar}}" will include
  "foo/bar.mustache", relative to the current working directory.
* Improve error messages (@gasche, rgrinberg/ocaml-mustache#47, rgrinberg/ocaml-mustache#51, rgrinberg/ocaml-mustache#56)
  Note: the exceptions raised by Mustache have changed, this breaks
  compatibility for users that would catch and deconstruct existing
  exceptions.
* Add `render_buf` to render templates directly to buffers (@gasche, rgrinberg/ocaml-mustache#48)
* When a lookup fails in the current context, lookup in parents contexts.
  This should fix errors when using "{{#foo}}" for a scalar variable
  'foo' to check that the variable exists.
  (@gasche, rgrinberg/ocaml-mustache#49)
