### PR TITLE
ulex is not compatible with ocaml 5

### DIFF
--- a/packages/ulex/ulex.1.2/opam
+++ b/packages/ulex/ulex.1.2/opam
@@ -9,7 +9,7 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "ulex"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bytes"
   "ocamlfind"
   "camlp4"


### PR DESCRIPTION
Uses Stream
```
#=== ERROR while compiling ulex.1.2 ===========================================#
# context              2.2.0~alpha3 | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ulex.1.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/ulex-7-cff87a.env
# output-file          ~/.opam/log/ulex-7-cff87a.out
### output ###
# ocamlbuild -byte-plugin pa_ulex.cma ulexing.cma
# /home/opam/.opam/5.0/bin/ocamlc.opt unix.cma -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cma myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmo -o myocamlbuild
# /home/opam/.opam/5.0/bin/ocamldep.opt -pp camlp4orf -modules pa_ulex.ml > pa_ulex.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules cset.ml > cset.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules ulex.mli > ulex.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -o cset.cmo cset.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -o ulex.cmi ulex.mli
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -I /home/opam/.opam/5.0/lib/ocaml/camlp4 -pp camlp4orf -o pa_ulex.cmo pa_ulex.ml
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules ulex.ml > ulex.ml.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -o ulex.cmo ulex.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -a cset.cmo ulex.cmo pa_ulex.cmo -o pa_ulex.cma
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules ulexing.mli > ulexing.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -o ulexing.cmi ulexing.mli
# + /home/opam/.opam/5.0/bin/ocamlc.opt -c -o ulexing.cmi ulexing.mli
# File "ulexing.mli", line 50, characters 21-29:
# 50 | val from_stream: int Stream.t -> lexbuf
#                           ^^^^^^^^
# Error: Unbound module Stream
# Command exited with code 2.
# + /home/opam/.opam/5.0/bin/ocamlc.opt unix.cma -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cma myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmo -o myocamlbuild
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# make: *** [Makefile:5: all] Error 10
```