### PR TITLE
Restrict pkcs11-driver to older OCaml

### DIFF
--- a/packages/pkcs11-driver/pkcs11-driver.1.0.0/opam
+++ b/packages/pkcs11-driver/pkcs11-driver.1.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_deriving" { >= "4.0" }
   "ppx_deriving_yojson" { >= "3.0" }
   "yojson" {>= "1.6.0"}
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.1"}
   "ounit" {with-test}
 ]
 conflicts: [

--- a/packages/pkcs11-driver/pkcs11-driver.1.0.1/opam
+++ b/packages/pkcs11-driver/pkcs11-driver.1.0.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ctypes-foreign"
   "dune" {>= "2.0.0"}
   "pkcs11" {>= "0.18.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.1"}
   "ounit" {with-test}
   "ppx_deriving" { >= "4.0" }
   "ppx_deriving_yojson" { >= "3.0" }


### PR DESCRIPTION
If fails on 5.1 (and possibly 5.0), while it builds just fine on 4.14:

```
#=== ERROR while compiling pkcs11-driver.1.0.1 ================================#
# context              2.2.0~alpha3 | linux/x86_64 | ocaml-base-compiler.5.1.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/pkcs11-driver.1.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p pkcs11-driver -j 255
# exit-code            1
# env-file             ~/.opam/log/pkcs11-driver-7-01b512.env
# output-file          ~/.opam/log/pkcs11-driver-7-01b512.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -w -39-32 -g -bin-annot -I driver/.pkcs11_driver.objs/byte -I /home/opam/.opam/5.1/lib/base -I /home/opam/.opam/5.1/lib/base/base_internalhash_types -I /home/opam/.opam/5.1/lib/base/caml -I /home/opam/.opam/5.1/lib/base/shadow_stdlib -I /home/opam/.opam/5.1/lib/bigarray-compat -I /home/opam/.opam/5.1/lib/cstruct -I /home/opam/.opam/5.1/lib/ctypes -I /home/opam/.opam/5.1/lib/ctypes-foreign -I /home/opam/.opam/5.1/lib/ctypes/stubs -I /home/opam/.opam/5.1/lib/hex -I /home/opam/.opam/5.1/lib/integers -I /home/opam/.opam/5.1/lib/ocaml/str -I /home/opam/.opam/5.1/lib/ocaml/threads -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/pkcs11 -I /home/opam/.opam/5.1/lib/ppx_deriving/runtime -I /home/opam/.opam/5.1/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.1/lib/result -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/stdlib-shims -I /home/opam/.opam/5.1/lib/variantslib -I /home/opam/.opam/5.1/lib/yojson -I /home/opam/.opam/5.1/lib/zarith -intf-suffix .ml -no-alias-deps -o driver/.pkcs11_driver.objs/byte/pkcs11.cmo -c -impl driver/pkcs11.pp.ml)
# File "driver/pkcs11.ml", line 1421, characters 12-19:
# 1421 |     (module Fake () : LOW_LEVEL_BINDINGS)
#                    ^^^^^^^
# Error: The functor was expected to be applicative at this position
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlopt.opt -w -40 -w -39-32 -g -I driver/.pkcs11_driver.objs/byte -I driver/.pkcs11_driver.objs/native -I /home/opam/.opam/5.1/lib/base -I /home/opam/.opam/5.1/lib/base/base_internalhash_types -I /home/opam/.opam/5.1/lib/base/caml -I /home/opam/.opam/5.1/lib/base/shadow_stdlib -I /home/opam/.opam/5.1/lib/bigarray-compat -I /home/opam/.opam/5.1/lib/cstruct -I /home/opam/.opam/5.1/lib/ctypes -I /home/opam/.opam/5.1/lib/ctypes-foreign -I /home/opam/.opam/5.1/lib/ctypes/stubs -I /home/opam/.opam/5.1/lib/hex -I /home/opam/.opam/5.1/lib/integers -I /home/opam/.opam/5.1/lib/ocaml/str -I /home/opam/.opam/5.1/lib/ocaml/threads -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/pkcs11 -I /home/opam/.opam/5.1/lib/ppx_deriving/runtime -I /home/opam/.opam/5.1/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.1/lib/result -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/stdlib-shims -I /home/opam/.opam/5.1/lib/variantslib -I /home/opam/.opam/5.1/lib/yojson -I /home/opam/.opam/5.1/lib/zarith -intf-suffix .ml -no-alias-deps -o driver/.pkcs11_driver.objs/native/pkcs11.cmx -c -impl driver/pkcs11.pp.ml)
# File "driver/pkcs11.ml", line 1421, characters 12-19:
# 1421 |     (module Fake () : LOW_LEVEL_BINDINGS)
#                    ^^^^^^^
# Error: The functor was expected to be applicative at this position
```

[Link to CI](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/1bf8a8a232168bfebda5170ac014dc4c16872387/variant/compilers,5.1,yojson.2.1.2,revdeps,pkcs11-driver.1.0.1). The same line of code exists in 1.0.0, so I've restricted it too. 0.18 looks a bit different, did not test whether it builds.