### PR TITLE
Add ocaml-option-no-compression to 5.1.1+trunk

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.1.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+trunk/opam
@@ -34,6 +34,7 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--without-zstd" {ocaml-option-no-compression:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed}
@@ -78,6 +79,7 @@ depopts: [
   "ocaml-option-flambda"
   "ocaml-option-fp"
   "ocaml-option-musl"
+  "ocaml-option-no-compression"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"


### PR DESCRIPTION
Follow-up to https://github.com/ocaml/opam-repository/pull/24608 where this was suggested
