### PR TITLE
[new release] moonpool (0.5.1)

### DIFF
--- a/packages/moonpool/moonpool.0.5.1/opam
+++ b/packages/moonpool/moonpool.0.5.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Pools of threads supported by a pool of domains"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["thread" "pool" "domain" "futures" "fork-join"]
+homepage: "https://github.com/c-cube/moonpool"
+bug-reports: "https://github.com/c-cube/moonpool/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.0"}
+  "either" {>= "1.0"}
+  "trace" {with-test}
+  "trace-tef" {with-test}
+  "qcheck-core" {with-test & >= "0.19"}
+  "odoc" {with-doc}
+  "mdx" {>= "1.9.0" & with-test}
+]
+depopts: [
+  "thread-local-storage"
+  "domain-local-await" {>= "0.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/moonpool.git"
+url {
+  src:
+    "https://github.com/c-cube/moonpool/releases/download/v0.5.1/moonpool-0.5.1.tbz"
+  checksum: [
+    "sha256=749b193c63588227346e8484227b3587e80b6fa27f7e6de055187018b99192b0"
+    "sha512=28012bbb96c77607139c28eb908c89e85bf25ca7a1a68eedd1955178ba5b0c41ef6efce44e2f9e39331d7fff4de4a7dc6ce9be176d258218e85a6cf6bdad7672"
+  ]
+}
+x-commit-hash: "019cea2d5cb5b3096b6b86b08d0dca80e3661d29"


### PR DESCRIPTION
Pools of threads supported by a pool of domains

- Project page: <a href="https://github.com/c-cube/moonpool">https://github.com/c-cube/moonpool</a>

##### CHANGES:

- fix `Ws_pool`: workers would exit before processing
    all remaining tasks upon shutdown
