### PR TITLE
[new release] ezcurl (2 packages) (0.2.4)

### DIFF
--- a/packages/ezcurl-lwt/ezcurl-lwt.0.2.4/opam
+++ b/packages/ezcurl-lwt/ezcurl-lwt.0.2.4/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Friendly wrapper around OCurl, Lwt version"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  #["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocurl" {>= "0.8.0"}
+  "ezcurl" { = version }
+  "lwt"
+  "dune" { >= "1.0" }
+  "odoc" {with-doc}
+  "mdx" {with-test}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "curl" "web" "http" "client" "lwt" ]
+homepage: "https://github.com/c-cube/ezcurl/"
+doc: "https://c-cube.github.io/ezcurl/doc/1.2"
+bug-reports: "https://github.com/c-cube/ezcurl/issues"
+dev-repo: "git+https://github.com/c-cube/ezcurl.git"
+url {
+  src:
+    "https://github.com/c-cube/ezcurl/releases/download/v0.2.4/ezcurl-0.2.4.tbz"
+  checksum: [
+    "sha256=26eda208be72d746eafbfe47f264850ae619e811b8c3165e7684d7a9295541a1"
+    "sha512=841d88cd4e7e6449cf17dc4626533856a13c81f96e81305be4773a0d2e5eba524950cd5280da6ff6390c386823c1bdbe671d946f643d26c2ea600b4b1cd66531"
+  ]
+}
+x-commit-hash: "ddf181fe83973a95b92399b3753583dea03ba32a"

--- a/packages/ezcurl/ezcurl.0.2.4/opam
+++ b/packages/ezcurl/ezcurl.0.2.4/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Friendly wrapper around OCurl"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  #["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocurl" {>= "0.8.0"}
+  "dune" { >= "1.0" }
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "curl" "web" "http" "client" ]
+homepage: "https://github.com/c-cube/ezcurl/"
+doc: "https://c-cube.github.io/ezcurl/doc/1.2"
+bug-reports: "https://github.com/c-cube/ezcurl/issues"
+dev-repo: "git+https://github.com/c-cube/ezcurl.git"
+url {
+  src:
+    "https://github.com/c-cube/ezcurl/releases/download/v0.2.4/ezcurl-0.2.4.tbz"
+  checksum: [
+    "sha256=26eda208be72d746eafbfe47f264850ae619e811b8c3165e7684d7a9295541a1"
+    "sha512=841d88cd4e7e6449cf17dc4626533856a13c81f96e81305be4773a0d2e5eba524950cd5280da6ff6390c386823c1bdbe671d946f643d26c2ea600b4b1cd66531"
+  ]
+}
+x-commit-hash: "ddf181fe83973a95b92399b3753583dea03ba32a"


### PR DESCRIPTION
Friendly wrapper around OCurl

- Project page: <a href="https://github.com/c-cube/ezcurl/">https://github.com/c-cube/ezcurl/</a>
- Documentation: <a href="https://c-cube.github.io/ezcurl/doc/1.2">https://c-cube.github.io/ezcurl/doc/1.2</a>

##### CHANGES:

- fix: global initialization logic is now hidden behind a mutex
  * depend on `thread`
