### PR TITLE
4 packages from diskuv/dkml-install-api at 0.5.2

### DIFF
--- a/packages/dkml-install-installer/dkml-install-installer.0.5.2/opam
+++ b/packages/dkml-install-installer/dkml-install-installer.0.5.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Build tools for DkML installers"
+description:
+  "Build-time executables that can generate Dune include files which will compile essential end-user executables."
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "crunch" {>= "3.3.1"}
+  "odoc" {with-doc}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.5.2/dkml-install-0.5.2.tbz"
+  checksum: [
+    "md5=5b294da54e4474f8d260c7190fec8c85"
+    "sha512=33274eafb995b4ba9d1bdb05e63b466e621255155fe5c6df7f368b086e6658634eff07079a51c0501cd1ab6817ba637f3222a00e146b8c360e24b7488ca66b63"
+  ]
+}

--- a/packages/dkml-install-runner/dkml-install-runner.0.5.2/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.5.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Runner executable for DkML installation"
+description:
+  "The runner executable is responsible for loading and running all DkML installation components."
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "dkml-install" {= version}
+  "ppx_expect" {>= "v0.14.1"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.1"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "diskuvbox" {>= "0.1.1"}
+  "odoc" {with-doc}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.5.2/dkml-install-0.5.2.tbz"
+  checksum: [
+    "md5=5b294da54e4474f8d260c7190fec8c85"
+    "sha512=33274eafb995b4ba9d1bdb05e63b466e621255155fe5c6df7f368b086e6658634eff07079a51c0501cd1ab6817ba637f3222a00e146b8c360e24b7488ca66b63"
+  ]
+}

--- a/packages/dkml-install/dkml-install.0.5.2/opam
+++ b/packages/dkml-install/dkml-install.0.5.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "API and registry for DkML installation components"
+description:
+  "All DkML installation components implement the interfaces exposed in this API."
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "ppx_deriving" {>= "5.2.1"}
+  "result" {>= "1.5"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.1"}
+  "fmt" {>= "0.8.9"}
+  "tsort" {>= "2.1.0"}
+  "diskuvbox" {>= "0.1.1" & with-test}
+  "odoc" {with-doc}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.5.2/dkml-install-0.5.2.tbz"
+  checksum: [
+    "md5=5b294da54e4474f8d260c7190fec8c85"
+    "sha512=33274eafb995b4ba9d1bdb05e63b466e621255155fe5c6df7f368b086e6658634eff07079a51c0501cd1ab6817ba637f3222a00e146b8c360e24b7488ca66b63"
+  ]
+}

--- a/packages/dkml-package-console/dkml-package-console.0.5.2/opam
+++ b/packages/dkml-package-console/dkml-package-console.0.5.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Console setup and uninstall executables for DkML installation"
+description:
+  "The setup and uninstall executables are responsible for launching the DkML runners."
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "diskuvbox" {>= "0.1.1"}
+  "crunch" {>= "3.3.1"}
+  "dkml-component-xx-console" {>= "0.1.1"}
+  "odoc" {with-doc}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.5.2/dkml-install-0.5.2.tbz"
+  checksum: [
+    "md5=5b294da54e4474f8d260c7190fec8c85"
+    "sha512=33274eafb995b4ba9d1bdb05e63b466e621255155fe5c6df7f368b086e6658634eff07079a51c0501cd1ab6817ba637f3222a00e146b8c360e24b7488ca66b63"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`dkml-install.0.5.2`: API and registry for DkML installation components
-`dkml-install-installer.0.5.2`: Build tools for DkML installers
-`dkml-install-runner.0.5.2`: Runner executable for DkML installation
-`dkml-package-console.0.5.2`: Console setup and uninstall executables for DkML installation



---
* Homepage: https://github.com/diskuv/dkml-install-api
* Source repo: git+https://github.com/diskuv/dkml-install-api.git
* Bug tracker: https://github.com/diskuv/dkml-install-api/issues

---
:camel: Pull-request generated by opam-publish v2.1.0