### PR TITLE
frama-c: add constraints for upcoming why3 version

### DIFF
--- a/packages/frama-c/frama-c.27.0/opam
+++ b/packages/frama-c/frama-c.27.0/opam
@@ -128,7 +128,7 @@ depends: [
   "ocamlgraph" { >= "1.8.8" }
   "ocamlgraph" { with-test & < "2.1.0" }
   "odoc" { with-doc }
-  "why3" { >= "1.6.0" }
+  "why3" { >= "1.6.0" & < "1.7.0" }
   "yaml" { >= "3.0.0" }
   "yojson" {>= "1.6.0" & (>= "2.0.1" | !with-test)}
   "zarith" { >= "1.5" }

--- a/packages/frama-c/frama-c.27.0~beta/opam
+++ b/packages/frama-c/frama-c.27.0~beta/opam
@@ -123,7 +123,7 @@ depends: [
   "ocamlfind" # needed beyond build stage, used by -load-module
   "ocamlgraph" { >= "1.8.8" }
   "ocamlgraph" { with-test & < "2.1.0" }
-  "why3" { >= "1.6.0" }
+  "why3" { >= "1.6.0" & < "1.7.0" }
   "yaml" { >= "3.0.0" }
   "yojson" {>= "1.6.0" & (>= "2.0.1" | !with-test)}
   "zarith" { >= "1.5" }

--- a/packages/frama-c/frama-c.27.1/opam
+++ b/packages/frama-c/frama-c.27.1/opam
@@ -127,7 +127,7 @@ depends: [
   "ocamlgraph" { >= "1.8.8" }
   "ocamlgraph" { with-test & < "2.1.0" }
   "odoc" { with-doc }
-  "why3" { >= "1.6.0" }
+  "why3" { >= "1.6.0" & < "1.7.0" }
   "yaml" { >= "3.0.0" }
   "yojson" {>= "1.6.0" & (>= "2.0.1" | !with-test)}
   "zarith" { >= "1.5" }

--- a/packages/frama-c/frama-c.28.0~beta/opam
+++ b/packages/frama-c/frama-c.28.0~beta/opam
@@ -132,7 +132,7 @@ depends: [
   "ocamlgraph" { with-test & >= "2.1.0" }
   "odoc" { with-doc }
   "unionFind" { >= "20220107" }
-  "why3" { >= "1.6.0" }
+  "why3" { >= "1.6.0" & < "1.7.0" }
   "yaml" { >= "3.0.0" }
   "yojson" {>= "1.6.0" & (>= "2.0.1" | !with-test)}
   "zarith" { >= "1.5" }


### PR DESCRIPTION
The upcoming why3 1.7.0 version has some incompatibilities with Frama-C, so we must add these version constraints.