### PR TITLE
hts_shrink_301: correct opam file

### DIFF
--- a/packages/hts_shrink/hts_shrink.3.0.1/opam
+++ b/packages/hts_shrink/hts_shrink.3.0.1/opam
@@ -12,13 +12,9 @@ depends: [
   "cpm"
   "molenc" {>= "11.1.1"}
   "dolog" {>= "4.0.0"}
-  "parmap"
   "parany" {>= "11.0.2"}
   "minicli" {>= "5.0.0"}
-  "bitv"
   "bst"
-  "ocamlgraph"
-  "ptmap"
   "get_line" {with-test}
   "ocaml" {>= "4.03"}
 ]


### PR DESCRIPTION
does not depend on: parmap, bitv, ocamlgraph, ptmap