### PR TITLE
[new release] ocaml-protoc (4 packages) (3.0.0)

### DIFF
--- a/packages/kinetic-client/kinetic-client.0.0.11/opam
+++ b/packages/kinetic-client/kinetic-client.0.0.11/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "dune" {>= "1.1.0"}
-  "ocaml-protoc" {>= "1.2.0"}
+  "ocaml-protoc" {>= "1.2.0" & < "3.0.0"}
   "lwt" {>= "3.2.0"}
   "lwt_log"
   "lwt_ssl"

--- a/packages/ocaml-protoc/ocaml-protoc.3.0.0/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.3.0.0/opam
@@ -28,6 +28,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: arch != "arm32" & arch != "x86_32"
 dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
 url {
   src:

--- a/packages/ocaml-protoc/ocaml-protoc.3.0.0/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.3.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Pure OCaml compiler for .proto files"
+maintainer: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+authors: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+license: "MIT"
+tags: ["protoc" "protobuf" "codegen"]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports: "https://github.com/mransan/ocaml-protoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "odoc" {with-doc}
+  "pbrt" {= version}
+  "pbrt_yojson" {= version & with-test}
+  "pbrt_services" {= version & with-test}
+  "ocaml" {>= "4.08"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
+url {
+  src:
+    "https://github.com/mransan/ocaml-protoc/releases/download/v3.0.0/ocaml-protoc-3.0.0.tbz"
+  checksum: [
+    "sha256=923b651cf0f400b5ee2fd1d05798a408b4c0a378aab655e4c2618bcce3fd7bff"
+    "sha512=5a1c80115e111f3d4e9384feb9a1a49375d06b11538cdfd388cb4d8a2cb1bb7ae6201d0555daf970be40a017cbb30819e7bec9875a418f5f316b0115999827df"
+  ]
+}
+x-commit-hash: "6f4bea038088774722ce17421758832c06b19890"

--- a/packages/ocaml-protoc/ocaml-protoc.3.0.0/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.3.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.08"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/ocaml-protoc/ocaml-protoc.3.0.0/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.3.0.0/opam
@@ -28,7 +28,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "arm32" & arch != "x86_32" & arch != "ppc32" & arch != "ppc64"
 dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
 url {
   src:

--- a/packages/opentelemetry/opentelemetry.0.2/opam
+++ b/packages/opentelemetry/opentelemetry.0.2/opam
@@ -13,8 +13,8 @@ depends: [
   "ocaml" {>= "4.08"}
   "ptime"
   "odoc" {with-doc}
-  "ocaml-protoc" {>= "2.2"}
-  "pbrt" {>= "2.2"}
+  "ocaml-protoc" {>= "2.2" & < "3.0.0"}
+  "pbrt" {>= "2.2" & < "3.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/opentelemetry/opentelemetry.0.3/opam
+++ b/packages/opentelemetry/opentelemetry.0.3/opam
@@ -13,8 +13,8 @@ depends: [
   "ocaml" {>= "4.08"}
   "ptime"
   "odoc" {with-doc}
-  "ocaml-protoc" {>= "2.2"}
-  "pbrt" {>= "2.2"}
+  "ocaml-protoc" {>= "2.2" & < "3.0.0"}
+  "pbrt" {>= "2.2" & < "3.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/opentelemetry/opentelemetry.0.4/opam
+++ b/packages/opentelemetry/opentelemetry.0.4/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "ptime"
   "odoc" {with-doc}
-  "pbrt" {>= "2.3"}
+  "pbrt" {>= "2.3" & < "3.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/opentelemetry/opentelemetry.0.5/opam
+++ b/packages/opentelemetry/opentelemetry.0.5/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "ptime"
   "odoc" {with-doc}
-  "pbrt" {>= "2.3"}
+  "pbrt" {>= "2.3" & < "3.0.0"}
 ]
 depopts: [
   "trace"

--- a/packages/opentelemetry/opentelemetry.0.6/opam
+++ b/packages/opentelemetry/opentelemetry.0.6/opam
@@ -19,7 +19,7 @@ depends: [
   "alcotest" {with-test}
   "opentelemetry-client-cohttp-lwt" {with-test & = version}
   "opentelemetry-client-ocurl" {with-test & = version}
-  "pbrt" {>= "2.3"}
+  "pbrt" {>= "2.3" & < "3.0.0"}
   "ocaml-lsp-server" {with-dev-setup}
   "ocamlformat" {with-dev-setup & >= "0.24" & < "0.25"}
 ]

--- a/packages/pbrt/pbrt.3.0.0/opam
+++ b/packages/pbrt/pbrt.3.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Runtime library for Protobuf tooling"
+maintainer: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+authors: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+license: "MIT"
+tags: ["protobuf" "encode" "decode"]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports: "https://github.com/mransan/ocaml-protoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "stdlib-shims"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
+url {
+  src:
+    "https://github.com/mransan/ocaml-protoc/releases/download/v3.0.0/ocaml-protoc-3.0.0.tbz"
+  checksum: [
+    "sha256=923b651cf0f400b5ee2fd1d05798a408b4c0a378aab655e4c2618bcce3fd7bff"
+    "sha512=5a1c80115e111f3d4e9384feb9a1a49375d06b11538cdfd388cb4d8a2cb1bb7ae6201d0555daf970be40a017cbb30819e7bec9875a418f5f316b0115999827df"
+  ]
+}
+x-commit-hash: "6f4bea038088774722ce17421758832c06b19890"

--- a/packages/pbrt/pbrt.3.0.0/opam
+++ b/packages/pbrt/pbrt.3.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.08"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pbrt_services/pbrt_services.3.0.0/opam
+++ b/packages/pbrt_services/pbrt_services.3.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Runtime library for ocaml-protoc to support RPC services"
+maintainer: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+authors: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+license: "MIT"
+tags: ["protobuf" "encode" "decode" "services" "rpc"]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports: "https://github.com/mransan/ocaml-protoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "pbrt" {= version}
+  "pbrt_yojson" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
+url {
+  src:
+    "https://github.com/mransan/ocaml-protoc/releases/download/v3.0.0/ocaml-protoc-3.0.0.tbz"
+  checksum: [
+    "sha256=923b651cf0f400b5ee2fd1d05798a408b4c0a378aab655e4c2618bcce3fd7bff"
+    "sha512=5a1c80115e111f3d4e9384feb9a1a49375d06b11538cdfd388cb4d8a2cb1bb7ae6201d0555daf970be40a017cbb30819e7bec9875a418f5f316b0115999827df"
+  ]
+}
+x-commit-hash: "6f4bea038088774722ce17421758832c06b19890"

--- a/packages/pbrt_services/pbrt_services.3.0.0/opam
+++ b/packages/pbrt_services/pbrt_services.3.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "pbrt_yojson" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pbrt_yojson/pbrt_yojson.3.0.0/opam
+++ b/packages/pbrt_yojson/pbrt_yojson.3.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "Runtime library for ocaml-protoc to support JSON encoding/decoding"
+maintainer: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+authors: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+license: "MIT"
+tags: ["protobuf" "encode" "decode"]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports: "https://github.com/mransan/ocaml-protoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+  "yojson" {>= "1.6"}
+  "base64" {>= "3.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
+url {
+  src:
+    "https://github.com/mransan/ocaml-protoc/releases/download/v3.0.0/ocaml-protoc-3.0.0.tbz"
+  checksum: [
+    "sha256=923b651cf0f400b5ee2fd1d05798a408b4c0a378aab655e4c2618bcce3fd7bff"
+    "sha512=5a1c80115e111f3d4e9384feb9a1a49375d06b11538cdfd388cb4d8a2cb1bb7ae6201d0555daf970be40a017cbb30819e7bec9875a418f5f316b0115999827df"
+  ]
+}
+x-commit-hash: "6f4bea038088774722ce17421758832c06b19890"

--- a/packages/pbrt_yojson/pbrt_yojson.3.0.0/opam
+++ b/packages/pbrt_yojson/pbrt_yojson.3.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "base64" {>= "3.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
Pure OCaml compiler for .proto files

- Project page: <a href="https://github.com/mransan/ocaml-protoc">https://github.com/mransan/ocaml-protoc</a>

##### CHANGES:

Major version that breaks code for every user. Sorry!

### Breaking

- Generated code now always fits into 2 files: code
    for `foo.proto` is produced in `foo.ml` and `foo.mli`.
    This follows a fairly large internal refactor that enables
    a plugin architecture internally (which facilitated codegen for
    services).
    All encoder/decoder functions also have a new name now,
    so that they don't collide inside the same file.
- CLI flags now use `--this-style` rather than `-this-style`
- Bump minimal OCaml version to 4.08

### Performance

- encode probotufs backward, which means we can write directly
    into a single buffer (which is not possible in a forward mode
    because sub-messages require an unknown amount of prefix space
    to write their size as a varint)
- add C stubs for pbrt
- use Bytes functions to read/write fixed size integers
- inlining annotations
- more benchmarks, helping optimization overall
- reduce allocations drastically, by having the generated code
    create fewer closures


### Services

- add `pbrt_services` runtime library
- generate code for `service` statements. This is a big feature
    for users who want to implement RPC systems using protobuf.
    The generated code is agnostic to whatever RPC implementation
    will use it, it only packs together RPC method names and path
    with the relevant encoders/decoders. Services require
    both JSON and binary encoders/decoders to be present.

### JSON

- migrate `pbrt_yojson` into the main ocaml-protoc repo
- JSON runtime support for empty messages
- Add support for bytes in JSON encoding
- Add support for encoding and decoding maps in JSON

### Other features and fixes

- add `--make` flag to generate `make` functions that take fewer
    optional arguments. This helps preventing the user from
    forgetting important arguments when they're encoding to protobuf.
    Arguments actually marked as `optional` in the .proto file
    are still optional.
- Support maps/lists in options
- add Pbrt.Decoder.of_substring
- Allow options to be named like `(validate.rules).message.required`
- support code generation for empty messages
- Empty proto file is a valid proto as well

### Testing

- expect-style tests for parser
- Tests for option parsing
- Test demonstrating parse error printing
