### PR TITLE
domainslib 0.5.1 is not compatible with saturn 0.4.1

### DIFF
--- a/packages/domainslib/domainslib.0.5.1/opam
+++ b/packages/domainslib/domainslib.0.5.1/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "5.0"}
-  "saturn" {>= "0.4.0"}
+  "saturn" {>= "0.4.0" & < "0.4.1"}
   "domain-local-await" {>= "0.1.0"}
   "kcas" {>= "0.3.0" & with-test}
   "mirage-clock-unix" {with-test & >= "4.2.0"}


### PR DESCRIPTION
Fails with
```
#=== ERROR while compiling domainslib.0.5.1 ===================================#
# context              2.2.0~alpha3~dev | linux/x86_64 | ocaml-base-compiler.5.1.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/domainslib.0.5.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p domainslib -j 71 @install
# exit-code            1
# env-file             ~/.opam/log/domainslib-7-2e874f.env
# output-file          ~/.opam/log/domainslib-7-2e874f.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.domainslib.objs/byte -I /home/opam/.opam/5.1/lib/domain-local-await -I /home/opam/.opam/5.1/lib/domain_shims -I /home/opam/.opam/5.1/lib/ocaml/threads -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/saturn -I /home/opam/.opam/5.1/lib/saturn_lockfree -I /home/opam/.opam/5.1/lib/thread-table -no-alias-deps -open Domainslib__ -o lib/.domainslib.objs/byte/domainslib__Multi_channel.cmo -c -impl lib/multi_channel.ml)
# File "lib/multi_channel.ml", line 152, characters 18-19:
# 152 |       | Some v -> v
#                         ^
# Error: This expression has type 'a but an expression was expected of type
#          'a option
#        The type variable 'a occurs inside 'a option
```
See #24788