### PR TITLE
Add upper bound on ocaml 4.08 to result <1.5

### DIFF
--- a/packages/result/result.1.0/opam
+++ b/packages/result/result.1.0/opam
@@ -12,7 +12,7 @@ description: """
 Projects that want to use the new result type defined in OCaml >= 4.03
 while staying compatible with older version of OCaml should use the
 Result module defined in this library."""
-depends: ["ocaml" {< "4.14"}]
+depends: ["ocaml" {< "4.08"}]
 url {
   src: "https://github.com/janestreet/result/archive/1.0.tar.gz"
   checksum: "md5=01391a66385ab1a43f90455dfb5c6843"

--- a/packages/result/result.1.1/opam
+++ b/packages/result/result.1.1/opam
@@ -11,7 +11,7 @@ description: """
 Projects that want to use the new result type defined in OCaml >= 4.03
 while staying compatible with older version of OCaml should use the
 Result module defined in this library."""
-depends: ["ocaml" {< "4.14"}]
+depends: ["ocaml" {< "4.08"}]
 url {
   src: "https://github.com/janestreet/result/archive/1.1.tar.gz"
   checksum: "md5=1e0005783d4f70e1a9772723fa0e846b"

--- a/packages/result/result.1.2/opam
+++ b/packages/result/result.1.2/opam
@@ -14,7 +14,7 @@ description: """
 Projects that want to use the new result type defined in OCaml >= 4.03
 while staying compatible with older version of OCaml should use the
 Result module defined in this library."""
-depends: ["ocaml" {< "4.14"}]
+depends: ["ocaml" {< "4.08"}]
 url {
   src: "https://github.com/janestreet/result/archive/1.2.tar.gz"
   checksum: "md5=3d5b66c5526918f0f2ca9d6811ef09c8"

--- a/packages/result/result.1.3/opam
+++ b/packages/result/result.1.3/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/janestreet/result/issues"
 license: "BSD-3-Clause"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
-  "ocaml" {< "4.14"}
+  "ocaml" {< "4.08"}
   "jbuilder" {>= "1.0+beta11"}
 ]
 synopsis: "Compatibility Result module"

--- a/packages/result/result.1.4/opam
+++ b/packages/result/result.1.4/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/janestreet/result/issues"
 license: "BSD-3-Clause"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
-  "ocaml" {< "4.14"}
+  "ocaml" {< "4.08"}
   "dune" {>= "1.0"}
 ]
 synopsis: "Compatibility Result module"


### PR DESCRIPTION
This will make the constraints no longer necessary.
See https://github.com/ocaml/opam-repository/issues/24263