### PR TITLE
batteries is not compatible with OCaml 5.1.1

### DIFF
--- a/packages/batteries/batteries.2.5.0/opam
+++ b/packages/batteries/batteries.2.5.0/opam
@@ -18,7 +18,7 @@ install: [
 remove: [["ocamlfind" "remove" "batteries"]]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.1.1"}
   "ocamlfind" {>= "1.5.3"}
   "ocamlbuild" {build}
   "qtest" {with-test & >= "2.0.0"}

--- a/packages/batteries/batteries.3.7.1/opam
+++ b/packages/batteries/batteries.3.7.1/opam
@@ -15,7 +15,7 @@ bug-reports:
   "https://github.com/ocaml-batteries-team/batteries-included/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.1.1"}
   "camlp-streams"
   "ocamlfind" {>= "1.5.3"}
   "qtest" {with-test & >= "2.5"}


### PR DESCRIPTION
expects Marshal.Compression on OCaml >= 5.1
```
#=== ERROR while compiling batteries.3.7.1 ====================================#
# context              2.2.0~alpha3 | linux/x86_64 | ocaml-variants.5.1.1+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.1.1/.opam-switch/build/batteries.3.7.1
# command              ~/.opam/5.1.1/bin/dune build -p batteries -j 1 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/batteries-465-7cced7.env
# output-file          ~/.opam/log/batteries-465-7cced7.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1.1/bin/ocamlc.opt -w -40 -w -3-32-50-52 -g -bin-annot -I src/.batteries_unthreaded.objs/byte -I /home/opam/.opam/5.1.1/lib/camlp-streams -I /home/opam/.opam/5.1.1/lib/num -I /home/opam/.opam/5.1.1/lib/ocaml/str -I /home/opam/.opam/5.1.1/lib/ocaml/unix -no-alias-deps -o src/.batteries_unthreaded.objs/byte/batMarshal.cmi -c -intf src/batMarshal.pp.mli)
# File "src/batMarshal.mli", lines 59-63, characters 0-15:
# Error: This variant or record definition does not match that of type
#          Marshal.extern_flags
#        A constructor, Compression, is missing in the original definition.
```
Fixed upstream in https://github.com/ocaml-batteries-team/batteries-included/pull/1124