### PR TITLE
js_of_ocaml-compiler is not compatible with OCaml 5.1.1

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.4.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.4.0/opam
@@ -12,7 +12,7 @@ doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
   "dune" {>= "3.7"}
-  "ocaml" {>= "4.08" & < "5.2"}
+  "ocaml" {>= "4.08" & < "5.1.1"}
   "num" {with-test}
   "ppx_expect" {>= "v0.14.2" & with-test}
   "ppxlib" {>= "0.15.0"}


### PR DESCRIPTION
requires caml_zstd_initialize to be implemented in javascript.
Any usage of js_of_ocaml with OCaml 5.1.1 will fail
```
#=== ERROR while compiling jsonoo.0.1.0 =======================================#
# context              2.2.0~alpha3 | linux/x86_64 | ocaml-variants.5.1.1+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.1.1/.opam-switch/build/jsonoo.0.1.0
# command              ~/.opam/5.1.1/bin/dune build -p jsonoo -j 1 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/jsonoo-354-c54ecb.env
# output-file          ~/.opam/log/jsonoo-354-c54ecb.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1.1/bin/ocamlc.opt -w -40 -g -bin-annot -I test/.test_jsonoo.eobjs/byte -I /home/opam/.opam/5.1.1/lib/js_of_ocaml -I /home/opam/.opam/5.1.1/lib/webtest -I /home/opam/.opam/5.1.1/lib/webtest-js -I .jsonoo.objs/byte -no-alias-deps -o test/.test_jsonoo.eobjs/byte/dune__exe__Test_jsonoo.cmo -c -impl test/test_jsonoo.ml)
# File "test/test_jsonoo.ml", line 528, characters 27-38:
# 528 |       (fun () -> ignore @@ (at []) int);
#                                  ^^^^^^^^^^^
# Warning 5 [ignored-partial-application]: this function application is partial,
# maybe some arguments are missing.
# (cd _build/default/test && /home/opam/.opam/5.1.1/bin/js_of_ocaml -o test_jsonoo.bc.js /home/opam/.opam/5.1.1/lib/ojs/ojs_runtime.js test_jsonoo.bc-for-jsoo)
# There are some missing primitives
# Dummy implementations (raising 'Failure' exception) will be used if they are not available at runtime.
# You can prevent the generation of dummy implementations with the commandline option '--disable genprim'
# Missing primitives:
#   caml_zstd_initialize
# File "test/dune", line 6, characters 0-90:
#  6 | (rule
#  7 |  (alias runtest)
#  8 |  (deps test_jsonoo.bc.js)
#  9 |  (action
# 10 |   (run node test_jsonoo.bc.js)))
# (cd _build/default/test && /usr/bin/node test_jsonoo.bc.js)
# Fatal error: exception Failure("caml_zstd_initialize not implemented")
```
Fixed upstream in https://github.com/ocsigen/js_of_ocaml/pull/1535