### PR TITLE
merlin is not compatible with OCaml 5.1.1

### DIFF
--- a/packages/merlin/merlin.4.11-501/opam
+++ b/packages/merlin/merlin.4.11-501/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "5.1" & < "5.2"}
+  "ocaml" {>= "5.1" & < "5.1.1"}
   "dune" {>= "2.9.0"}
   "merlin-lib" {= version}
   "dot-merlin-reader" {>= "4.9"}

--- a/packages/merlin/merlin.4.12-501/opam
+++ b/packages/merlin/merlin.4.12-501/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "5.1" & < "5.2"}
+  "ocaml" {>= "5.1" & < "5.1.1"}
   "dune" {>= "2.9.0"}
   "merlin-lib" {= version}
   "dot-merlin-reader" {>= "4.9"}

--- a/packages/merlin/merlin.4.8~5.1preview/opam
+++ b/packages/merlin/merlin.4.8~5.1preview/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "5.1" & < "5.2"}
+  "ocaml" {>= "5.1" & < "5.1.1"}
   "dune" {>= "2.9.0"}
   "merlin-lib" {= version}
   "dot-merlin-reader" {>= "4.6"}

--- a/packages/merlin/merlin.4.9-501preview/opam
+++ b/packages/merlin/merlin.4.9-501preview/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "5.1" & < "5.2"}
+  "ocaml" {>= "5.1" & < "5.1.1"}
   "dune" {>= "2.9.0"}
   "merlin-lib" {= version}
   "dot-merlin-reader" {>= "4.9"}


### PR DESCRIPTION
(needs to implement the new Compression module)
```
$ ocamlmerlin single locate -position 2:13 -verbosity 0 < main.ml | jq '.value'
"input_value: compressed object, cannot decompress"
```
Being fixed upstream in https://github.com/ocaml/merlin/pull/1714