### PR TITLE
melange is not compatible with OCaml 5.1.1

### DIFF
--- a/packages/melange/melange.1.0.0/opam
+++ b/packages/melange/melange.1.0.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/melange-re/melange"
 bug-reports: "https://github.com/melange-re/melange/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.13.0"}
+  "ocaml" {>= "4.13.0" & < "5.1.1"}
   "cmdliner" {>= "1.1.0"}
   "base64" {>= "3.1.0"}
   "dune-build-info"

--- a/packages/melange/melange.2.0.0/opam
+++ b/packages/melange/melange.2.0.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/melange-re/melange"
 bug-reports: "https://github.com/melange-re/melange/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "5.1"}
+  "ocaml" {>= "5.1" & < "5.1.1"}
   "cmdliner" {>= "1.1.0"}
   "dune-build-info"
   "cppo" {build}

--- a/packages/melange/melange.2.1.0/opam
+++ b/packages/melange/melange.2.1.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/melange-re/melange"
 bug-reports: "https://github.com/melange-re/melange/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "5.1"}
+  "ocaml" {>= "5.1" & < "5.1.1"}
   "cmdliner" {>= "1.1.0"}
   "dune-build-info"
   "cppo" {build}


### PR DESCRIPTION
required Marshal.compression_supported
```
#=== ERROR while compiling melange.2.1.0 ======================================#
# context              2.2.0~alpha3 | linux/x86_64 | ocaml-variants.5.1.1+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.1.1/.opam-switch/build/melange.2.1.0
# command              ~/.opam/5.1.1/bin/dune build -p melange -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/melange-274-532001.env
# output-file          ~/.opam/log/melange-274-532001.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1.1/bin/ocamlopt.opt -w -9 -g -O3 -unbox-closures -I vendor/melange-compiler-libs/lib/.melange_compiler_libs.objs/byte -I vendor/melange-compiler-libs/lib/.melange_compiler_libs.objs/native -I /home/opam/.opam/5.1.1/lib/menhirLib -I /home/opam/.opam/5.1.1/lib/ocaml/compiler-libs -I vendor/melange-compiler-libs/wrapper/.melange_wrapper.objs/byte -I vendor/melange-compiler-libs/wrapper/.melange_wrapper.objs/native -intf-suffix .ml -no-alias-deps -open Melange_compiler_libs__ -o vendor/melange-compiler-libs/lib/.melange_compiler_libs.objs/native/melange_compiler_libs__Config.cmx -c -impl vendor/melange-compiler-libs/lib/config.ml)
# File "utils/config.mlp", line 221, characters 34-63:
# Error: Unbound value Marshal.compression_supported
# (cd _build/default && /home/opam/.opam/5.1.1/bin/ocamlc.opt -w -9 -g -bin-annot -I vendor/melange-compiler-libs/lib/.melange_compiler_libs.objs/byte -I /home/opam/.opam/5.1.1/lib/menhirLib -I /home/opam/.opam/5.1.1/lib/ocaml/compiler-libs -I vendor/melange-compiler-libs/wrapper/.melange_wrapper.objs/byte -intf-suffix .ml -no-alias-deps -open Melange_compiler_libs__ -o vendor/melange-compiler-libs/lib/.melange_compiler_libs.objs/byte/melange_compiler_libs__Cmi_format.cmo -c -impl vendor/melange-compiler-libs/lib/cmi_format.ml)
# File "vendor/melange-compiler-libs/file_formats/cmi_format.ml", line 87, characters 66-77:
# Error: This variant expression is expected to have type Marshal.extern_flags
#        There is no constructor Compression within type Marshal.extern_flags
# (cd _build/default && /home/opam/.opam/5.1.1/bin/ocamlc.opt -w -9 -g -bin-annot -I vendor/melange-compiler-libs/lib/.melange_compiler_libs.objs/byte -I /home/opam/.opam/5.1.1/lib/menhirLib -I /home/opam/.opam/5.1.1/lib/ocaml/compiler-libs -I vendor/melange-compiler-libs/wrapper/.melange_wrapper.objs/byte -intf-suffix .ml -no-alias-deps -open Melange_compiler_libs__ -o vendor/melange-compiler-libs/lib/.melange_compiler_libs.objs/byte/melange_compiler_libs__Cmt_format.cmo -c -impl vendor/melange-compiler-libs/lib/cmt_format.ml)
# File "vendor/melange-compiler-libs/file_formats/cmt_format.ml", line 112, characters 44-55:
# Error: This variant expression is expected to have type Marshal.extern_flags
#        There is no constructor Compression within type Marshal.extern_flags
# (cd _build/default && /home/opam/.opam/5.1.1/bin/ocamlc.opt -w -9 -g -bin-annot -I vendor/melange-compiler-libs/lib/.melange_compiler_libs.objs/byte -I /home/opam/.opam/5.1.1/lib/menhirLib -I /home/opam/.opam/5.1.1/lib/ocaml/compiler-libs -I vendor/melange-compiler-libs/wrapper/.melange_wrapper.objs/byte -intf-suffix .ml -no-alias-deps -open Melange_compiler_libs__ -o vendor/melange-compiler-libs/lib/.melange_compiler_libs.objs/byte/melange_compiler_libs__Config.cmo -c -impl vendor/melange-compiler-libs/lib/config.ml)
# File "utils/config.mlp", line 221, characters 34-63:
# Error: Unbound value Marshal.compression_supported
```
Fixed upstream in https://github.com/melange-re/melange/pull/926