### PR TITLE
4 packages from c-cube/qcheck at 0.21.3

### DIFF
--- a/packages/qcheck-alcotest/qcheck-alcotest.0.21.3/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.21.3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+license: "BSD-2-Clause"
+synopsis: "Alcotest backend for qcheck"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "quickcheck"
+  "qcheck"
+  "alcotest"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "2.8.0" }
+  "base-unix"
+  "qcheck-core" { = version }
+  "alcotest" {>= "0.8.1"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+authors: "the qcheck contributors"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.21.3.tar.gz"
+  checksum: [
+    "md5=8930042156873aa8dfa433d7c1bf8463"
+    "sha512=89d8a8a1990cfa8cd839e732f4cc89d68811ae0cc04732668e1e2691e1eb6e3c525f75936bdb261aebdaa3a8845eb717128b0bf21884bbda80d64ba957d2e6e1"
+  ]
+}

--- a/packages/qcheck-core/qcheck-core.0.21.3/opam
+++ b/packages/qcheck-core/qcheck-core.0.21.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+license: "BSD-2-Clause"
+synopsis: "Core qcheck library"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "2.8.0" }
+  "base-unix"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]
+authors: "the qcheck contributors"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.21.3.tar.gz"
+  checksum: [
+    "md5=8930042156873aa8dfa433d7c1bf8463"
+    "sha512=89d8a8a1990cfa8cd839e732f4cc89d68811ae0cc04732668e1e2691e1eb6e3c525f75936bdb261aebdaa3a8845eb717128b0bf21884bbda80d64ba957d2e6e1"
+  ]
+}

--- a/packages/qcheck-ounit/qcheck-ounit.0.21.3/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.21.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/qcheck/"
+doc: ["http://c-cube.github.io/qcheck/"]
+synopsis: "OUnit backend for qcheck"
+tags: [
+  "qcheck"
+  "quickcheck"
+  "ounit"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "2.8.0" }
+  "base-unix"
+  "qcheck-core" { = version }
+  "ounit2"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+authors: "the qcheck contributors"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.21.3.tar.gz"
+  checksum: [
+    "md5=8930042156873aa8dfa433d7c1bf8463"
+    "sha512=89d8a8a1990cfa8cd839e732f4cc89d68811ae0cc04732668e1e2691e1eb6e3c525f75936bdb261aebdaa3a8845eb717128b0bf21884bbda80d64ba957d2e6e1"
+  ]
+}

--- a/packages/qcheck/qcheck.0.21.3/opam
+++ b/packages/qcheck/qcheck.0.21.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Compatibility package for qcheck"
+homepage: "https://github.com/c-cube/qcheck/"
+license: "BSD-2-Clause"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "2.8.0" }
+  "base-unix"
+  "qcheck-core" { = version }
+  "qcheck-ounit" { = version }
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]
+authors: "the qcheck contributors"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.21.3.tar.gz"
+  checksum: [
+    "md5=8930042156873aa8dfa433d7c1bf8463"
+    "sha512=89d8a8a1990cfa8cd839e732f4cc89d68811ae0cc04732668e1e2691e1eb6e3c525f75936bdb261aebdaa3a8845eb717128b0bf21884bbda80d64ba957d2e6e1"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `qcheck.0.21.3`: Compatibility package for qcheck
- `qcheck-alcotest.0.21.3`: Alcotest backend for qcheck
- `qcheck-core.0.21.3`: Core qcheck library
- `qcheck-ounit.0.21.3`: OUnit backend for qcheck



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: git+https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---
:camel: Pull-request generated by opam-publish v2.3.0