### PR TITLE
OCaml 5.1.1: first release candidate

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1~rc1/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1~rc1/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1~rc1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "First release candidate of OCaml 5.1.1"
+maintainer: "platform@lists.ocaml.org"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml#5.1"
+depends: [
+  "ocaml" {= "5.1.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "ocaml-options-vanilla" {post}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.1.1-rc1.tar.gz"
+  checksum: "sha256=abef810bbe0e8f10f56438d58f57e442e024bca724815c113f8c481ad518827b"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.5.1.1~rc1+options/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1~rc1+options/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.5.1.1~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1~rc1+options/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First release candidate of OCaml 5.1.1"
+maintainer: "platform@lists.ocaml.org"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.1"
+depends: [
+  "ocaml" {= "5.1.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build-env: [
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.1.1-rc1.tar.gz"
+  checksum: "sha256=abef810bbe0e8f10f56438d58f57e442e024bca724815c113f8c481ad518827b"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+]


### PR DESCRIPTION
This PR publishes the two opam packages for the release candidate for OCaml 5.1.1 .

This is an exceptionally heavy patch release, we have:
* the announced stdlib breaking change for compressed marshalling
*  two type system fixes
*  a fix for nested packs
*  a full package of performance fixes for the GC (to reduce an extreme performance regression on numerical code): 

----------------------

OCaml 5.1.1
-----------

### Standard library:

* 12562, 12734, 12783: Remove the `Marshal.Compression` flag to the
  `Marshal.to_*` functions introduced in 5.1 by 12006, as it cannot
  be implemented without risking to link -lzstd with all
  ocamlopt-generated executables.  The compilers are still able to use
  ZSTD compression for compilation artefacts.
  (Xavier Leroy and David Allsopp, report by Kate Deplaix, review by
   Nicolás Ojeda Bär, Kate Deplaix, and Damien Doligez).

### Type system bug fixes:

- 12623, fix the computation of variance composition
  (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)

- 12645, 12649 fix error messages for cyclic type definitions in presence of
  the `-short-paths` flag.
  (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)

### Build fix

- 12581, 12609: Fix error on uses of packed modules outside their pack
  to correctly handle nested packs
  (Vincent Laviron, report by Javier Chávarri, review by Pierre Chambart)

### OCamlnat

- 12757: Fix ocamlnat (native toplevel) by registering frametables correctly
  (Stephen Dolan, Nick Barnes and Mark Shinwell,
   review by Vincent Laviron and Sébastien Hinderer)

# GC performance package fix

- 12590, 12595: Move `caml_collect_gc_stats_sample` in
  `caml_empty_minor_heap_promote` before barrier arrival.
  (B. Szilvasy, review by Gabriel Scherer)

- 12318: GC: simplify the meaning of custom_minor_max_size: blocks with
  out-of-heap memory above this limit are now allocated directly in
  the major heap.
  (Damien Doligez, report by Stephen Dolan, review by Gabriel Scherer)

- 12439: Finalize and collect dead custom blocks during minor collection
  (Damien Doligez, review by Xavier Leroy, Gabriel Scherer and KC
  Sivaramakrishnan)

- 12491, 12493, 12500, 12754: Do not change GC pace when creating
  sub-arrays of bigarrays
  (Xavier Leroy, report by Ido Yariv, analysis by Gabriel Scherer,
   review by Gabriel Scherer and Fabrice Buoro)
