### PR TITLE
Package vscoq-language-server.2.0.3+coq8.18

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.0.3+coq8.18/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.0.3+coq8.18/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/coq-community/vscoq"
+bug-reports: "https://github.com/coq-community/vscoq/issues"
+dev-repo: "git+https://github.com/coq-community/vscoq"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { >= "4.13.1" }
+  "dune" { >= "3.2" }
+  "coq-core" { >= "8.18" < "8.19" }
+  "coq-stdlib" { >= "8.18" < "8.19" }
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_yojson_conv" {< "v0.16.0"}
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "result" { >= "1.5" }
+  "lsp" { >= "1.15"}
+  "sel" {>= "0.4.0"}
+]
+synopsis: "VSCoq language server"
+description: """
+LSP based language server for Coq and its VSCoq user interface
+"""
+url {
+  src:
+    "https://github.com/coq-community/vscoq/releases/download/v2.0.3+coq8.18/vscoq-language-server-2.0.3-coq8.18.tar.gz"
+  checksum: [
+    "md5=37688b8df4ccfc920a57552d0ebc0d3a"
+    "sha512=0db05bdfc4409cf8e5a43d191220b4ebd47978bcbb6fd41075ee745dd448b75e98677c81657809c30627c875e5fd54fbef180e6d30cb0a8e56ca26cbf8c5adb8"
+  ]
+}


### PR DESCRIPTION
### `vscoq-language-server.2.0.3+coq8.18`
VSCoq language server
LSP based language server for Coq and its VSCoq user interface



---
* Homepage: https://github.com/coq-community/vscoq
* Source repo: git+https://github.com/coq-community/vscoq
* Bug tracker: https://github.com/coq-community/vscoq/issues

---
:camel: Pull-request generated by opam-publish v2.0.3