### PR TITLE
[new release] mustache (2 packages) (3.3.0)

### DIFF
--- a/packages/mustache-cli/mustache-cli.3.3.0/opam
+++ b/packages/mustache-cli/mustache-cli.3.3.0/opam
@@ -16,11 +16,13 @@ homepage: "https://github.com/rgrinberg/ocaml-mustache"
 bug-reports: "https://github.com/rgrinberg/ocaml-mustache/issues"
 depends: [
   "dune" {>= "2.7"}
+  "ezjsonm" {with-test}
   "jsonm" {>= "1.0.1"}
   "mustache" {= version}
   "cmdliner" {>= "1.1.0"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
+  "ounit2" {with-test}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/mustache-cli/mustache-cli.3.3.0/opam
+++ b/packages/mustache-cli/mustache-cli.3.3.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "CLI for Mustache logic-less templates"
+description: """
+
+Command line utility `mustache-ocaml` for driving logic-less templates.
+Read and write mustache templates, and render them by providing a json object.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Armaël Guéneau <armael.gueneau@ens-lyon.fr>"
+  "Gabriel Scherer <gabriel.scherer@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/rgrinberg/ocaml-mustache"
+bug-reports: "https://github.com/rgrinberg/ocaml-mustache/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "jsonm" {>= "1.0.1"}
+  "mustache" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/rgrinberg/ocaml-mustache.git"
+url {
+  src:
+    "https://github.com/rgrinberg/ocaml-mustache/releases/download/v3.3.0/mustache-3.3.0.tbz"
+  checksum: [
+    "sha256=370b7eae6315f24d457d85c393aafe4a448a2b9c41d00ac0fa0dd1ac7728adfc"
+    "sha512=64795b0a0a2644961619cfdf43d9b5904181eb783ac1e5dc2a44c7bfb9ebf6fe9fb03bc1f31aa53a760b3ca6676b93d494e17b3f89f07c3cb3e4a85927cfbca2"
+  ]
+}
+x-commit-hash: "1d12af8eb7e60f7b84e20adfc39974ce8b672961"

--- a/packages/mustache/mustache.3.3.0/opam
+++ b/packages/mustache/mustache.3.3.0/opam
@@ -15,8 +15,6 @@ homepage: "https://github.com/rgrinberg/ocaml-mustache"
 bug-reports: "https://github.com/rgrinberg/ocaml-mustache/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ounit2" {with-test}
-  "ezjsonm" {with-test}
   "menhir" {>= "20180703"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
@@ -31,7 +29,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mustache/mustache.3.3.0/opam
+++ b/packages/mustache/mustache.3.3.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Mustache logic-less templates in OCaml"
+description: """
+
+Read and write mustache templates, and render them.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Armaël Guéneau <armael.gueneau@ens-lyon.fr>"
+  "Gabriel Scherer <gabriel.scherer@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/rgrinberg/ocaml-mustache"
+bug-reports: "https://github.com/rgrinberg/ocaml-mustache/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ounit2" {with-test}
+  "ezjsonm" {with-test}
+  "menhir" {>= "20180703"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/rgrinberg/ocaml-mustache.git"
+url {
+  src:
+    "https://github.com/rgrinberg/ocaml-mustache/releases/download/v3.3.0/mustache-3.3.0.tbz"
+  checksum: [
+    "sha256=370b7eae6315f24d457d85c393aafe4a448a2b9c41d00ac0fa0dd1ac7728adfc"
+    "sha512=64795b0a0a2644961619cfdf43d9b5904181eb783ac1e5dc2a44c7bfb9ebf6fe9fb03bc1f31aa53a760b3ca6676b93d494e17b3f89f07c3cb3e4a85927cfbca2"
+  ]
+}
+x-commit-hash: "1d12af8eb7e60f7b84e20adfc39974ce8b672961"


### PR DESCRIPTION
Mustache logic-less templates in OCaml

- Project page: <a href="https://github.com/rgrinberg/ocaml-mustache">https://github.com/rgrinberg/ocaml-mustache</a>

##### CHANGES:

* Rename the CLI tool to `mustache-ocaml`. It's now part of the new opam
  package `mustache-cli` (@psafont, rgrinberg/ocaml-mustache#71)
