### PR TITLE
Add upperbound on ctypes to more old tsdl releases

### DIFF
--- a/packages/tsdl/tsdl.0.9.1/opam
+++ b/packages/tsdl/tsdl.0.9.1/opam
@@ -15,7 +15,7 @@ depends: [
   "topkg" {build}
   "conf-sdl2"
   "result" {< "1.5"}
-  "ctypes" {>= "0.9.0"}
+  "ctypes" {>= "0.9.0" & < "0.21.0"}
   "ctypes-foreign"
 ]
 build: [[

--- a/packages/tsdl/tsdl.0.9.2/opam
+++ b/packages/tsdl/tsdl.0.9.2/opam
@@ -16,7 +16,7 @@ depends: [
   "ocb-stubblr" {build}
   "conf-sdl2"
   "result" {< "1.5"}
-  "ctypes" {>= "0.9.0"}
+  "ctypes" {>= "0.9.0" & < "0.21.0"}
   "ctypes-foreign"
 ]
 build: [[

--- a/packages/tsdl/tsdl.0.9.3/opam
+++ b/packages/tsdl/tsdl.0.9.3/opam
@@ -16,7 +16,7 @@ depends: [
   "ocb-stubblr" {build}
   "conf-sdl2"
   "result" {< "1.5"}
-  "ctypes" {>= "0.9.0"}
+  "ctypes" {>= "0.9.0" & < "0.21.0"}
   "ctypes-foreign"
 ]
 build: [[

--- a/packages/tsdl/tsdl.0.9.4/opam
+++ b/packages/tsdl/tsdl.0.9.4/opam
@@ -16,7 +16,7 @@ depends: [
   "ocb-stubblr" {build}
   "conf-sdl2"
   "result" {< "1.5"}
-  "ctypes" {>= "0.9.0"}
+  "ctypes" {>= "0.9.0" & < "0.21.0"}
   "ctypes-foreign"
 ]
 build: [[

--- a/packages/tsdl/tsdl.0.9.5/opam
+++ b/packages/tsdl/tsdl.0.9.5/opam
@@ -16,7 +16,7 @@ depends: [
   "ocb-stubblr" {build}
   "conf-sdl2"
   "result" {< "1.5"}
-  "ctypes" {>= "0.9.0"}
+  "ctypes" {>= "0.9.0" & < "0.21.0"}
   "ctypes-foreign"
 ]
 build: [[

--- a/packages/tsdl/tsdl.0.9.6/opam
+++ b/packages/tsdl/tsdl.0.9.6/opam
@@ -16,7 +16,7 @@ depends: [
   "ocb-stubblr" {build}
   "conf-sdl2"
   "result" {< "1.5"}
-  "ctypes" {>= "0.9.0"}
+  "ctypes" {>= "0.9.0" & < "0.21.0"}
   "ctypes-foreign"
 ]
 build: [[


### PR DESCRIPTION
Spotted while commenting on #24868 (see https://check.ocamllabs.io), possibly missed in #24101 because the lowerbound is different.