### PR TITLE
Package calli.0.2

### DIFF
--- a/packages/calli/calli.0.2/opam
+++ b/packages/calli/calli.0.2/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "CaLLi : OCaml Library for Static Analysis of LLVM bitcode"
+maintainer: ["Soyeon Baek <sy.baek28@gmail.com>"]
+authors: ["Soyeon Baek <sy.baek28@gmail.com>"]
+homepage: "https://github.com/cnu-ants/CaLLi"
+bug-reports: "https://github.com/cnu-ants/CaLLi/issues"
+dev-repo: "git+https://github.com/cnu-ants/CaLLi.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name]
+]
+depends: [
+  "ocaml" {>= "4.13"}
+  "dune" {>= "2.9"}
+  "llvm" 
+  "zarith"
+  "containers"
+]
+url {
+  src: "https://github.com/cnu-ants/CaLLi/archive/refs/tags/0.2.tar.gz"
+  checksum: [
+    "md5=bd68c856a1de7b742ba147275692e6e2"
+    "sha512=9e11baaee9056e4dfff45ddf898d1887840d9749dda82452ee2fce91dbabeeac377bc115dd0c35c55630c14d122c4f0cd065ecbc1baff8d36ef7033c06dbd27d"
+  ]
+}


### PR DESCRIPTION
### `calli.0.2`
CaLLi : OCaml Library for Static Analysis of LLVM bitcode



---
* Homepage: https://github.com/cnu-ants/CaLLi
* Source repo: git+https://github.com/cnu-ants/CaLLi.git
* Bug tracker: https://github.com/cnu-ants/CaLLi/issues

---
:camel: Pull-request generated by opam-publish v2.2.0