### PR TITLE
[new release] js_of_ocaml (7 packages) (5.5.2)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.5.2/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.5.2/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08" & < "5.2"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15.0"}
+  "re" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "sedlex" {>= "2.3"}
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.5.2/js_of_ocaml-5.5.2.tbz"
+  checksum: [
+    "sha256=97e68512114ff1d97436785f7fb9bb98c521811acc5cff32b104bc5c4a29ac33"
+    "sha512=b5c126a0cf3cfb1b894394519366fac69d8848eff14a48090e590252d0f8eaa5b7370e162969533db926cd9589e617fe023ebbf63c078f3af6324d2a2f73ae66"
+  ]
+}
+x-commit-hash: "ba5d826c5270baefe1bf80f27537d28b1bc7c1b4"

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.5.5.2/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.5.5.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "lwt" {>= "2.4.4"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["graphics" "lwt_log"]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.5.2/js_of_ocaml-5.5.2.tbz"
+  checksum: [
+    "sha256=97e68512114ff1d97436785f7fb9bb98c521811acc5cff32b104bc5c4a29ac33"
+    "sha512=b5c126a0cf3cfb1b894394519366fac69d8848eff14a48090e590252d0f8eaa5b7370e162969533db926cd9589e617fe023ebbf63c078f3af6324d2a2f73ae66"
+  ]
+}
+x-commit-hash: "ba5d826c5270baefe1bf80f27537d28b1bc7c1b4"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.5.5.2/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.5.5.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15.0"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.5.2/js_of_ocaml-5.5.2.tbz"
+  checksum: [
+    "sha256=97e68512114ff1d97436785f7fb9bb98c521811acc5cff32b104bc5c4a29ac33"
+    "sha512=b5c126a0cf3cfb1b894394519366fac69d8848eff14a48090e590252d0f8eaa5b7370e162969533db926cd9589e617fe023ebbf63c078f3af6324d2a2f73ae66"
+  ]
+}
+x-commit-hash: "ba5d826c5270baefe1bf80f27537d28b1bc7c1b4"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.5.5.2/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.5.5.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.5.2/js_of_ocaml-5.5.2.tbz"
+  checksum: [
+    "sha256=97e68512114ff1d97436785f7fb9bb98c521811acc5cff32b104bc5c4a29ac33"
+    "sha512=b5c126a0cf3cfb1b894394519366fac69d8848eff14a48090e590252d0f8eaa5b7370e162969533db926cd9589e617fe023ebbf63c078f3af6324d2a2f73ae66"
+  ]
+}
+x-commit-hash: "ba5d826c5270baefe1bf80f27537d28b1bc7c1b4"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.5.5.2/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.5.5.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml-compiler" {= version}
+  "ocamlfind" {>= "1.5.1"}
+  "cohttp-lwt-unix" {with-test}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.5.2/js_of_ocaml-5.5.2.tbz"
+  checksum: [
+    "sha256=97e68512114ff1d97436785f7fb9bb98c521811acc5cff32b104bc5c4a29ac33"
+    "sha512=b5c126a0cf3cfb1b894394519366fac69d8848eff14a48090e590252d0f8eaa5b7370e162969533db926cd9589e617fe023ebbf63c078f3af6324d2a2f73ae66"
+  ]
+}
+x-commit-hash: "ba5d826c5270baefe1bf80f27537d28b1bc7c1b4"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.5.5.2/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.5.5.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "react" {>= "1.2.1"}
+  "reactiveData" {>= "0.2"}
+  "tyxml" {>= "4.3"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.5.2/js_of_ocaml-5.5.2.tbz"
+  checksum: [
+    "sha256=97e68512114ff1d97436785f7fb9bb98c521811acc5cff32b104bc5c4a29ac33"
+    "sha512=b5c126a0cf3cfb1b894394519366fac69d8848eff14a48090e590252d0f8eaa5b7370e162969533db926cd9589e617fe023ebbf63c078f3af6324d2a2f73ae66"
+  ]
+}
+x-commit-hash: "ba5d826c5270baefe1bf80f27537d28b1bc7c1b4"

--- a/packages/js_of_ocaml/js_of_ocaml.5.5.2/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.5.5.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml-compiler" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.5.2/js_of_ocaml-5.5.2.tbz"
+  checksum: [
+    "sha256=97e68512114ff1d97436785f7fb9bb98c521811acc5cff32b104bc5c4a29ac33"
+    "sha512=b5c126a0cf3cfb1b894394519366fac69d8848eff14a48090e590252d0f8eaa5b7370e162969533db926cd9589e617fe023ebbf63c078f3af6324d2a2f73ae66"
+  ]
+}
+x-commit-hash: "ba5d826c5270baefe1bf80f27537d28b1bc7c1b4"


### PR DESCRIPTION
Compiler from OCaml bytecode to JavaScript

- Project page: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>
- Documentation: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>

##### CHANGES:

## Features/Changes
* Compiler: global dead code elimination (Micah Cantor, ocsigen/js_of_ocaml#1503)
* Compiler: change control-flow compilation strategy (ocsigen/js_of_ocaml#1496)
* Compiler: loop no longer absorb the whole continuation
* Compiler: Dead code elimination of unused references (ocsigen/js_of_ocaml#2076)
* Compiler: reduce memory consumption (ocsigen/js_of_ocaml#1516)
* Compiler: support for import and export construct in the js parser/printer
* Lib: add download attribute to anchor element
* Misc: switch CI to OCaml 5.1
* Misc: preliminary support for OCaml 5.2
* Misc: support for OCaml 5.1.1

## Bug fixes
* Runtime: fix Dom_html.onIE (ocsigen/js_of_ocaml#1493)
* Runtime: add conversion functions + strict equality for compatibility with Wasm_of_ocaml (ocsigen/js_of_ocaml#1492)
* Runtime: Dynlink should be able to find symbols in jsoo_runtime ocsigen/js_of_ocaml#1517
* Runtime: fix Unix.lstat, Unix.LargeFile.lstat (ocsigen/js_of_ocaml#1519)
* Compiler: fix global flow analysis (ocsigen/js_of_ocaml#1494)
* Compiler: fix js parser/printer wrt async functions (ocsigen/js_of_ocaml#1515)
* Compiler: fix free variables pass wrt parameters' default value (ocsigen/js_of_ocaml#1521)
* Compiler: fix free variables for classes
* Compiler: fix internal invariant (continuation)
* Compiler: fix variable renaming for let, const and classes
* Lib: Url.Current.set_fragment need not any urlencode (ocsigen/js_of_ocaml#1497)
