### PR TITLE
[new release] tiny_httpd (2 packages) (0.15)

### DIFF
--- a/packages/tiny_httpd/tiny_httpd.0.15/opam
+++ b/packages/tiny_httpd/tiny_httpd.0.15/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Minimal HTTP server using threads"
+maintainer: ["c-cube"]
+authors: ["c-cube"]
+license: "MIT"
+tags: [
+  "http" "thread" "server" "tiny_httpd" "http_of_dir" "simplehttpserver"
+]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "seq"
+  "base-threads"
+  "result"
+  "ocaml" {>= "4.05"}
+  "odoc" {with-doc}
+  "conf-libcurl" {with-test}
+  "ptime" {with-test}
+  "qcheck-core" {>= "0.9" & with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+url {
+  src:
+    "https://github.com/c-cube/tiny_httpd/releases/download/v0.15/tiny_httpd-0.15.tbz"
+  checksum: [
+    "sha256=feb311e52fafeccff8399f3c22addc641fed99001d87c63da3472313f9f71930"
+    "sha512=aaa2586b226c86a16cb8e38686644bb4603a8db12bfe4f46b625005b5babf0304a85900574f0b575dd1c3fb63f7e67ac5d6bcceb3f74f3ccff5f776a999e6bfd"
+  ]
+}
+x-commit-hash: "0766f15fe2658a5d82c116192d9b0ee603ee798e"

--- a/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.15/opam
+++ b/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.15/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Interface to camlzip for tiny_httpd"
+maintainer: ["c-cube"]
+authors: ["c-cube"]
+license: "MIT"
+homepage: "https://github.com/c-cube/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "tiny_httpd" {= version}
+  "camlzip" {>= "1.06"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+url {
+  src:
+    "https://github.com/c-cube/tiny_httpd/releases/download/v0.15/tiny_httpd-0.15.tbz"
+  checksum: [
+    "sha256=feb311e52fafeccff8399f3c22addc641fed99001d87c63da3472313f9f71930"
+    "sha512=aaa2586b226c86a16cb8e38686644bb4603a8db12bfe4f46b625005b5babf0304a85900574f0b575dd1c3fb63f7e67ac5d6bcceb3f74f3ccff5f776a999e6bfd"
+  ]
+}
+x-commit-hash: "0766f15fe2658a5d82c116192d9b0ee603ee798e"


### PR DESCRIPTION
Minimal HTTP server using threads

- Project page: <a href="https://github.com/c-cube/tiny_httpd/">https://github.com/c-cube/tiny_httpd/</a>

##### CHANGES:

- fix: do not block in `accept`, enabling more graceful shutdown
- improve help message for tiny-httpd-vfs-pack
- security: zero out buffers from pool before reusing them
