### PR TITLE
[new release] containers (2 packages) (3.13)

### DIFF
--- a/packages/containers-data/containers-data.3.13/opam
+++ b/packages/containers-data/containers-data.3.13/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "A set of advanced datatypes for containers"
+maintainer: ["c-cube"]
+authors: ["c-cube"]
+license: "BSD-2-Clause"
+tags: ["containers" "RAL" "function" "vector" "okasaki"]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "containers" {= version}
+  "qcheck-core" {>= "0.18" & with-test}
+  "iter" {with-test}
+  "gen" {with-test}
+  "mdx" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+url {
+  src:
+    "https://github.com/c-cube/ocaml-containers/releases/download/v3.13/containers-3.13.tbz"
+  checksum: [
+    "sha256=372df86e2a41e86c959c28a3392eb2ffd89754d1e5af2aaa09537654af57b1da"
+    "sha512=7d87d44065612095fa0342a9c95a2c4cfdf73d5af47c6fce24262cf2870c36dee70ebecd056113aa9c1643256bc032c08530f5083061c44602c0da5a132c2d6c"
+  ]
+}
+x-commit-hash: "7c1ca1d82f3894bbfb634cbd421f696e854cafbc"

--- a/packages/containers/containers.3.13/opam
+++ b/packages/containers/containers.3.13/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "A modular, clean and powerful extension of the OCaml standard library"
+maintainer: ["c-cube"]
+authors: ["c-cube"]
+license: "BSD-2-Clause"
+tags: ["stdlib" "containers" "iterators" "list" "heap" "queue"]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "either"
+  "dune-configurator"
+  "qcheck-core" {>= "0.18" & with-test}
+  "yojson" {with-test}
+  "iter" {with-test}
+  "gen" {with-test}
+  "csexp" {with-test}
+  "uutf" {with-test}
+  "odoc" {with-doc}
+]
+depopts: ["base-unix" "base-threads"]
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+url {
+  src:
+    "https://github.com/c-cube/ocaml-containers/releases/download/v3.13/containers-3.13.tbz"
+  checksum: [
+    "sha256=372df86e2a41e86c959c28a3392eb2ffd89754d1e5af2aaa09537654af57b1da"
+    "sha512=7d87d44065612095fa0342a9c95a2c4cfdf73d5af47c6fce24262cf2870c36dee70ebecd056113aa9c1643256bc032c08530f5083061c44602c0da5a132c2d6c"
+  ]
+}
+x-commit-hash: "7c1ca1d82f3894bbfb634cbd421f696e854cafbc"


### PR DESCRIPTION
A modular, clean and powerful extension of the OCaml standard library

- Project page: <a href="https://github.com/c-cube/ocaml-containers/">https://github.com/c-cube/ocaml-containers/</a>

##### CHANGES:

- breaking: delete containers-thread (which was deprecated)
- breaking: pp: modify `Ext.t` so it takes surrounding value
- CCMultiMap: Rename functions find_left and find_right in the bidirectional multimap
    to find_left_iter and find_right_iter respectively to reflect their usage,
    and add new functions to replace the old find_left and find_right
    that return a list of values rather than an iterator,
    to make the signatures of CCMultiMap.S and CCMultiMap.BIDIR cohere.
    Additionally, change the return type of
    `S.find_iter` from `t -> key -> (value -> unit) -> unit` to `t -> key -> value iter`.

- CCList: add `unfold`
- CCBool: Add functions if_then and if_then_else
- CCList: remove some functions that are subsumed by the stdlib
- CCList: use TRMC for many functions on 5.1
- feat CCFunvec: add `fold_rev`
- add `Containers_pp.newline_or_spaces`
- cleanup: remove stubs for code always present on 4.08, rely on
    newer functions in 5.1
- remove last refs to `CCShims`

- perf: accelerate `List.append` and `List.flat_map` on 5.1

- more warnings, more tests, cleanup dead code
- change COC to ocaml-coc
