### PR TITLE
Disable tsdl-ttf's < 0.5 tests (infinit loop)

### DIFF
--- a/packages/tsdl-ttf/tsdl-ttf.0.2/opam
+++ b/packages/tsdl-ttf/tsdl-ttf.0.2/opam
@@ -10,8 +10,9 @@ build: [
   ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure"]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"] {with-test}
-  ["ocaml" "setup.ml" "-test"] {with-test}
+# Tests disabled (infinit loops)
+#  ["ocaml" "setup.ml" "-configure" "--enable-tests"] {with-test}
+#  ["ocaml" "setup.ml" "-test"] {with-test}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "tsdl_ttf"]

--- a/packages/tsdl-ttf/tsdl-ttf.0.3.2/opam
+++ b/packages/tsdl-ttf/tsdl-ttf.0.3.2/opam
@@ -29,7 +29,8 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+# Tests disabled (infinit loops)
+#    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/tsdl-ttf/tsdl-ttf.0.3/opam
+++ b/packages/tsdl-ttf/tsdl-ttf.0.3/opam
@@ -28,7 +28,8 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+# Tests disabled (infinit loops)
+#    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/tsdl-ttf/tsdl-ttf.0.4/opam
+++ b/packages/tsdl-ttf/tsdl-ttf.0.4/opam
@@ -29,7 +29,8 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+# Tests disabled (infinit loops)
+#    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
```
/home/opam: (run (network host)
                 (shell "(opam reinstall --with-test tsdl-ttf.0.4) || true"))
The following actions will be performed:
=== recompile 1 package
  - recompile tsdl-ttf 0.4

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-> retrieved tsdl-ttf.0.4  (https://github.com/sanette/tsdl-ttf/archive/0.4.tar.gz)
2023-11-29 18:35.05: Cancelling: Timeout (120.0 minutes)
Job cancelled
2023-11-29 18:35.22: Timeout (120.0 minutes)
```
See for example:
* https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/2f1b7c959e9fed25c6af6710301f2a4c52dd0302/variant/compilers,4.14,dune-configurator.3.12.1,revdeps,tsdl-ttf.0.4
* as well as the rest of the run https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/2f1b7c959e9fed25c6af6710301f2a4c52dd0302