### PR TITLE
ppx_cstubs is not compatible with ocaml 5.1

### DIFF
--- a/packages/ppx_cstubs/ppx_cstubs.0.7.0/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.7.0/opam
@@ -17,7 +17,7 @@ depends: [
   "result"
   "containers" {>= "2.2"}
   "cppo" {build & >= "1.3"}
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.04.2" & < "5.1"}
   "ppxlib" {>= "0.22.0"}
   "ocamlfind" {>= "1.7.2"} # not only a build dependency, it depends on findlib.top
   "dune" {>= "1.6"}


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/24899

Failure:
```
#=== ERROR while compiling ppx_cstubs.0.7.0 ===================================#
# context              2.2.0~alpha4~dev | linux/x86_64 | ocaml-base-compiler.5.1.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/ppx_cstubs.0.7.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ppx_cstubs -j 47
# exit-code            1
# env-file             ~/.opam/log/ppx_cstubs-7-1e17bd.env
# output-file          ~/.opam/log/ppx_cstubs-7-1e17bd.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I src/internal/.ppxc__script.objs/byte -I src/internal/.ppxc__script.objs/public_cmi -I /home/opam/.opam/5.1/lib/bigarray-compat -I /home/opam/.opam/5.1/lib/containers -I /home/opam/.opam/5.1/lib/containers/monomorphic -I /home/opam/.opam/5.1/lib/ctypes -I /home/opam/.opam/5.1/lib/either -I /home/opam/.opam/5.1/lib/findlib -I /home/opam/.opam/5.1/lib/integers -I /home/opam/.opam/5.1/lib/num -I /home/opam/.opam/5.1/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.1/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.1/lib/ocaml/compiler-libs -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/ppx_derivers -I /home/opam/.opam/5.1/lib/ppxlib -I /home/opam/.opam/5.1/lib/ppxlib/ast -I /home/opam/.opam/5.1/lib/ppxlib/astlib -I /home/opam/.opam/5.1/lib/ppxlib/print_diff -I /home/opam/.opam/5.1/lib/ppxlib/stdppx -I /home/opam/.opam/5.1/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.1/lib/re -I /home/opam/.opam/5.1/lib/re/perl -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/stdlib-shims -I src/runtime/.ppx_cstubs.objs/byte -intf-suffix .ml -no-alias-deps -open Ppxc__script__ -o src/internal/.ppxc__script.objs/byte/ppxc__script__Ppxc__script_real.cmo -c -impl src/internal/ppxc__script_real.pp.ml)
# File "src/internal/ppxc__script_real.ml", line 171, characters 26-43:
# 171 | module C_content_phase0 = C_content_make ()
#                                 ^^^^^^^^^^^^^^^^^
# Error: The functor was expected to be applicative at this position
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlopt.opt -w -40 -g -I src/internal/.ppxc__script.objs/byte -I src/internal/.ppxc__script.objs/native -I src/internal/.ppxc__script.objs/public_cmi -I /home/opam/.opam/5.1/lib/bigarray-compat -I /home/opam/.opam/5.1/lib/containers -I /home/opam/.opam/5.1/lib/containers/monomorphic -I /home/opam/.opam/5.1/lib/ctypes -I /home/opam/.opam/5.1/lib/either -I /home/opam/.opam/5.1/lib/findlib -I /home/opam/.opam/5.1/lib/integers -I /home/opam/.opam/5.1/lib/num -I /home/opam/.opam/5.1/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.1/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.1/lib/ocaml/compiler-libs -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/ppx_derivers -I /home/opam/.opam/5.1/lib/ppxlib -I /home/opam/.opam/5.1/lib/ppxlib/ast -I /home/opam/.opam/5.1/lib/ppxlib/astlib -I /home/opam/.opam/5.1/lib/ppxlib/print_diff -I /home/opam/.opam/5.1/lib/ppxlib/stdppx -I /home/opam/.opam/5.1/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.1/lib/re -I /home/opam/.opam/5.1/lib/re/perl -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/stdlib-shims -I src/runtime/.ppx_cstubs.objs/byte -I src/runtime/.ppx_cstubs.objs/native -intf-suffix .ml -no-alias-deps -open Ppxc__script__ -o src/internal/.ppxc__script.objs/native/ppxc__script__Ppxc__script_real.cmx -c -impl src/internal/ppxc__script_real.pp.ml)
# File "src/internal/ppxc__script_real.ml", line 171, characters 26-43:
# 171 | module C_content_phase0 = C_content_make ()
#                                 ^^^^^^^^^^^^^^^^^
# Error: The functor was expected to be applicative at this position
```