### PR TITLE
oseq 0.4.1+ tests not compatible with containers 3.13

### DIFF
--- a/packages/oseq/oseq.0.4.1/opam
+++ b/packages/oseq/oseq.0.4.1/opam
@@ -11,7 +11,7 @@ depends: [
   "qcheck" {with-test & >= "0.9"}
   "qtest" {with-test}
   "gen" {with-test}
-  "containers" {with-test & >= "2.6"}
+  "containers" {with-test & >= "2.6" & < "3.13"}
   "odoc" {with-doc}
   "seq"
   "ocaml" { >= "4.03.0" }

--- a/packages/oseq/oseq.0.5/opam
+++ b/packages/oseq/oseq.0.5/opam
@@ -11,7 +11,7 @@ depends: [
   "qcheck" {with-test & >= "0.9"}
   "qtest" {with-test}
   "gen" {with-test}
-  "containers" {with-test}
+  "containers" {with-test & < "3.13"}
   "odoc" {with-doc}
   "ocaml" { >= "4.08.0" }
 ]


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/24899

Failure:
```
#=== ERROR while compiling oseq.0.5 ===========================================#
# context              2.2.0~alpha4~dev | linux/x86_64 | ocaml-base-compiler.5.1.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/oseq.0.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p oseq -j 31
# exit-code            1
# env-file             ~/.opam/log/oseq-7-b4a093.env
# output-file          ~/.opam/log/oseq-7-b4a093.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -warn-error -a+8 -w -3-33-35-27-39-50 -g -bin-annot -I qtest/.run_qtest.eobjs/byte -I /home/opam/.opam/5.1/lib/bytes -I /home/opam/.opam/5.1/lib/containers -I /home/opam/.opam/5.1/lib/containers/monomorphic -I /home/opam/.opam/5.1/lib/either -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/ounit2 -I /home/opam/.opam/5.1/lib/ounit2/advanced -I /home/opam/.opam/5.1/lib/qcheck -I /home/opam/.opam/5.1/lib/qcheck-core -I /home/opam/.opam/5.1/lib/qcheck-core/runner -I /home/opam/.opam/5.1/lib/qcheck-ounit -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/stdlib-shims -I src/.oseq.objs/byte -no-alias-deps -o qtest/.run_qtest.eobjs/byte/run_qtest.cmo -c -impl qtest/run_qtest.ml)
# File "../src/OSeq.ml", line 5, characters 7-15:
# Error: Unbound module CCShims_

(cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -warn-error -a+8 -w -3-33-35-27-39-50 -g -bin-annot -I qtest/.run_qtest.eobjs/byte -I /home/opam/.opam/5.1/lib/bytes -I /home/opam/.opam/5.1/lib/containers -I /home/opam/.opam/5.1/lib/containers/monomorphic -I /home/opam/.opam/5.1/lib/either -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/ounit2 -I /home/opam/.opam/5.1/lib/ounit2/advanced -I /home/opam/.opam/5.1/lib/qcheck -I /home/opam/.opam/5.1/lib/qcheck-core -I /home/opam/.opam/5.1/lib/qcheck-core/runner -I /home/opam/.opam/5.1/lib/qcheck-ounit -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/stdlib-shims -I src/.oseq.objs/byte -no-alias-deps -o qtest/.run_qtest.eobjs/byte/run_qtest.cmo -c -impl qtest/run_qtest.ml)
File "../src/OSeq.ml", line 5, characters 7-15:
Error: Unbound module CCShims_
- ```