### PR TITLE
[new release] oseq (0.5.1)

### DIFF
--- a/packages/oseq/oseq.0.5.1/opam
+++ b/packages/oseq/oseq.0.5.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2-clause"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "1.0" }
+  "qcheck" {with-test}
+  "gen" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
+  "ocaml" { >= "4.08.0" }
+]
+tags: [ "sequence" "iterator" "seq" "pure" "list" ]
+homepage: "https://github.com/c-cube/oseq/"
+doc: "https://c-cube.github.io/oseq/"
+bug-reports: "https://github.com/c-cube/oseq/issues"
+dev-repo: "git+https://github.com/c-cube/oseq.git"
+synopsis: "Simple list of suspensions, as a composable lazy iterator that behaves like a value"
+description: "Extends the new standard library's `Seq` module with many useful combinators."
+authors: "Simon Cruanes"
+url {
+  src:
+    "https://github.com/c-cube/oseq/releases/download/v0.5.1/oseq-0.5.1.tbz"
+  checksum: [
+    "sha256=25426d5d7a9e8b99586a84dc509b887d5401168aff2083800d84fafe35a6feb5"
+    "sha512=945aaa093591b62f44f6e5e3c8b035bd7e17b08892f0337d5503bb7d2cf49c2caf90bd99143d86855b46f5ccbd38fa629386a0fcc7dda15ac4026def2b485b3c"
+  ]
+}
+x-commit-hash: "b44a72b18210d69a894672c955828db1a4feab9c"


### PR DESCRIPTION
Simple list of suspensions, as a composable lazy iterator that behaves like a value

- Project page: <a href="https://github.com/c-cube/oseq/">https://github.com/c-cube/oseq/</a>
- Documentation: <a href="https://c-cube.github.io/oseq/">https://c-cube.github.io/oseq/</a>

##### CHANGES:

- do not use qtest anymore
