### PR TITLE
pareto 0.3 is not compatible with ocaml 5

### DIFF
--- a/packages/pareto/pareto.0.3/opam
+++ b/packages/pareto/pareto.0.3/opam
@@ -10,7 +10,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "pareto"]
 
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "gsl" {>= "1.13.0"}


### PR DESCRIPTION
Fails with
```
#=== ERROR while compiling pareto.0.3 =========================================#
# context              2.2.0~alpha4~dev | linux/x86_64 | ocaml-base-compiler.5.1.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/pareto.0.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix /home/opam/.opam/5.1
# exit-code            2
# env-file             ~/.opam/log/pareto-7-572e9b.env
# output-file          ~/.opam/log/pareto-7-572e9b.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```