### PR TITLE
orpie 1.6.1 is not compatible with ocaml 5

### DIFF
--- a/packages/orpie/orpie.1.6.1/opam
+++ b/packages/orpie/orpie.1.6.1/opam
@@ -7,7 +7,7 @@ license: "GPL-3.0-only"
 dev-repo: "git+https://github.com/pelzlpj/orpie.git"
 build: ["dune" "build" "-p" "orpie"]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "camlp5" {build}
   "dune" {>= "1.1"}
   "curses" {>= "1.0.3"}


### PR DESCRIPTION
Uses genlex 
```
#=== ERROR while compiling orpie.1.6.1 ========================================#
# context              2.2.0~alpha4~dev | linux/x86_64 | ocaml-base-compiler.5.1.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/orpie.1.6.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p orpie
# exit-code            1
# env-file             ~/.opam/log/orpie-7-ca382d.env
# output-file          ~/.opam/log/orpie-7-ca382d.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -w -27-35-52 -thread -g -bin-annot -I src/orpie/.main.eobjs/byte -I /home/opam/.opam/5.1/lib/curses -I /home/opam/.opam/5.1/lib/gsl -I /home/opam/.opam/5.1/lib/num -I /home/opam/.opam/5.1/lib/ocaml/str -I /home/opam/.opam/5.1/lib/ocaml/threads -I /home/opam/.opam/5.1/lib/ocaml/unix -no-alias-deps -o src/orpie/.main.eobjs/byte/rcfile.cmo -c -impl src/orpie/rcfile.pp.ml)
# File "_none_", line 1:
# Error: Unbound module Genlex
```