### PR TITLE
Ppxlib: disable tests for 0.30.0 on OCaml 5.1

### DIFF
--- a/packages/ppxlib/ppxlib.0.30.0/opam
+++ b/packages/ppxlib/ppxlib.0.30.0/opam
@@ -21,6 +21,7 @@ bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.04.1" & < "5.2.0" & != "5.1.0~alpha1"}
+  "ocaml" {with-test & ( < "5.1.0" | >= "5.2.0" ) }
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ppx_derivers" {>= "1.0"}
   "sexplib0" {>= "v0.12"}

--- a/packages/ppxlib/ppxlib.0.30.0/opam
+++ b/packages/ppxlib/ppxlib.0.30.0/opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.04.1" & < "5.2.0" & != "5.1.0~alpha1"}
-  "ocaml" {with-test & ( < "5.1.0" | >= "5.2.0" ) }
+  "ocaml" {with-test & < "5.1.0~alpha2"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ppx_derivers" {>= "1.0"}
   "sexplib0" {>= "v0.12"}


### PR DESCRIPTION
There is a formatting reproducibility problem with those `ppxlib.0.30.0` tests, that test the behavior on OCaml 5.1. The `ppxlib.0.30.0` tests need therefore be disabled on 5.1, which is what this PR does. Funnily, the test conditions were written in a way that the tests don't run on OCaml 5.1.0, but do run on OCaml 5.1.1, so this has been noticed only now. See https://github.com/ocaml-ppx/ppxlib/issues/459.