### PR TITLE
[new release] caisar (1.0)

### DIFF
--- a/packages/caisar/caisar.1.0/opam
+++ b/packages/caisar/caisar.1.0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis:
+  "A platform for characterizing the safety and robustness of artificial intelligence based software"
+maintainer: [
+  "LAISER team, Software Safety and Security Laboratory, CEA-List"
+]
+authors: ["LAISER team, Software Safety and Security Laboratory, CEA-List"]
+license: "LGPL-2.1-only"
+homepage: "https://git.frama-c.com/pub/caisar"
+doc: "https://git.frama-c.com/pub/caisar"
+bug-reports: "https://git.frama-c.com/pub/caisar/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.13"}
+  "dune-site" {>= "2.9.0"}
+  "piqi" {>= "0.7.6"}
+  "piqilib" {>= "0.6.14"}
+  "zarith" {>= "1.7"}
+  "ocplib-endian" {>= "1.0"}
+  "base" {>= "v0.15.1"}
+  "stdio" {>= "v0.14.0"}
+  "cmdliner" {>= "1.1.1"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "yojson" {>= "1.7.0"}
+  "menhirLib" {>= "20210310"}
+  "csv" {>= "2.4"}
+  "why3" {= "1.6.0"}
+  "re" {>= "1.10.4"}
+  "fpath" {>= "0.7.3"}
+  "yaml" {>= "3.1.0"}
+  "ocaml-protoc-plugin" {>= "4.2.0"}
+  "stdio" {>= "v0.14.0"}
+  "ocamlgraph" {>= "1.8.8"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_inline_test" {>= "0.12.0"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/caisar.git"
+url {
+  src:
+    "https://git.frama-c.com/api/v4/projects/1082/packages/generic/caisar/1.0/caisar-1.0.tbz"
+  checksum: [
+    "sha256=cd24b647565aaa4bb82d46c195c692d56ba0ad4b39bc86ef6baaf2d7a08c92a5"
+    "sha512=073761d95d6d8f6eb6f687643054297eb47db5d5bdc3a72ba42bf1509ab76415d485f536e5e42c11bd59c972ab7ad72e398d19af6e74c4f0778f28ef5bf4935e"
+  ]
+}
+x-commit-hash: "d9054057a969f5a254be71a4c4914c0db6a76a1c"


### PR DESCRIPTION
A platform for characterizing the safety and robustness of artificial intelligence based software

- Project page: <a href="https://git.frama-c.com/pub/caisar">https://git.frama-c.com/pub/caisar</a>
- Documentation: <a href="https://git.frama-c.com/pub/caisar">https://git.frama-c.com/pub/caisar</a>

##### CHANGES:

- [language] Extended WhyML for AI systems. It is now possible to model with
  CAISAR computations on vectors, datasets and the application of machine
  learning programs. Added an interpretation engine that allow direct evaluation
  on some predicates and functions related to those extensions.

- [doc] Update the documentation to cover the new interpretation language. Add
  contribution guide.

- [cmdline] Add command line option `--goal` (or, `-g`) to verify only the
  provided list of goals, either from all theories or from the specified ones.

- [cmdline] Add command line option `--theory` (or, `-T`) to verify only the
  provided list of theories (ie, all their goals).

- [cmdline] Add command line option `--define` (or `-D`) to define the value of
  a declared constant in any specification file to verify.

- [build] Make CAISAR available as a Nix Flake.

- [prover] Better integration of the AIMOS metamorphic testing prover.

- [docker] Add the $\alpha-\beta-$CROWN prover to the docker image.
