### PR TITLE
Package camlimages.5.0.5

### DIFF
--- a/packages/camlimages/camlimages.5.0.5/opam
+++ b/packages/camlimages/camlimages.5.0.5/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Image processing library"
+description:
+  "An image processing library, which provides loading and saving various image formats with an interface for the Caml graphics library. It has also an interface with the freetype library to draw texts using truetype fonts."
+maintainer: "Jun FURUSE <jun.furuse@gmail.com>"
+authors: "Jun FURUSE <jun.furuse@gmail.com>"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://gitlab.com/camlspotter/camlimages"
+bug-reports: "https://gitlab.com/camlspotter/camlimages/-/issues"
+depends: [
+  "ocaml" {>= "4.12.1"}
+  "dune" {>= "3.2"}
+  "base" {build}
+  "stdio" {build}
+  "cppo" {build}
+  "dune-configurator" {build & >= "2.0.0"}
+  "ocamlfind" {build}
+  "odoc" {with-doc}
+]
+depopts: [
+  "lablgtk"
+  "graphics"
+  "conf-libpng"
+  "conf-libjpeg"
+  "conf-freetype"
+  "conf-libgif"
+  "conf-ghostscript"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/camlspotter/camlimages.git"
+url {
+  src:
+    "https://gitlab.com/camlspotter/camlimages/-/archive/5.0.5/camlimages-5.0.5.tar.gz"
+  checksum: [
+    "md5=84929b30257aa8e493dc84303768f400"
+    "sha512=b3774d2287e4a97082f0289766f5a79d3e75454a194d2d6400cee9cf926f7676d8eba4cb27221a98314461b7a81b4386b253f1d706a94447423394be89d2ed49"
+  ]
+}

--- a/packages/liquidsoap/liquidsoap.1.4.0/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.0/opam
@@ -135,6 +135,7 @@ conflicts: [
   "theora" {< "0.3.1"}
   "vorbis" {< "0.7.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"
 dev-repo: "git+https://github.com/savonet/liquidsoap.git"

--- a/packages/liquidsoap/liquidsoap.1.4.1-1/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1-1/opam
@@ -146,6 +146,7 @@ conflicts: [
   "theora" {< "0.3.1"}
   "vorbis" {< "0.7.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"
 dev-repo: "git+https://github.com/savonet/liquidsoap.git"

--- a/packages/liquidsoap/liquidsoap.1.4.1-2/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1-2/opam
@@ -149,6 +149,7 @@ conflicts: [
   "theora" {< "0.3.1"}
   "vorbis" {< "0.7.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 extra-files: ["ignore-bash-completion-install-errors.patch" "md5=b43419de6e3225f59a42f330f557e877"]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"

--- a/packages/liquidsoap/liquidsoap.1.4.1/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1/opam
@@ -135,6 +135,7 @@ conflicts: [
   "theora" {< "0.3.1"}
   "vorbis" {< "0.7.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"
 dev-repo: "git+https://github.com/savonet/liquidsoap.git"

--- a/packages/liquidsoap/liquidsoap.1.4.2/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.2/opam
@@ -147,6 +147,7 @@ conflicts: [
   "theora" {< "0.3.1"}
   "vorbis" {< "0.7.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"
 dev-repo: "git+https://github.com/savonet/liquidsoap.git"

--- a/packages/liquidsoap/liquidsoap.1.4.3/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.3/opam
@@ -146,6 +146,7 @@ conflicts: [
   "theora" {< "0.3.1"}
   "vorbis" {< "0.7.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"
 dev-repo: "git+https://github.com/savonet/liquidsoap.git"

--- a/packages/liquidsoap/liquidsoap.1.4.4/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.4/opam
@@ -141,6 +141,7 @@ conflicts: [
   "theora" {< "0.3.1"}
   "vorbis" {< "0.7.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"
 dev-repo: "git+https://github.com/savonet/liquidsoap.git"

--- a/packages/liquidsoap/liquidsoap.2.0.0/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.0/opam
@@ -132,6 +132,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.0~rc1/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.0~rc1/opam
@@ -132,6 +132,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.1/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.1/opam
@@ -132,6 +132,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.2-1/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.2-1/opam
@@ -131,6 +131,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.2/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.2/opam
@@ -125,6 +125,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.3-1/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.3-1/opam
@@ -128,6 +128,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.3/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.3/opam
@@ -128,6 +128,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.4-1/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.4-1/opam
@@ -129,6 +129,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.4-2/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.4-2/opam
@@ -129,6 +129,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.4/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.4/opam
@@ -129,6 +129,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.5/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.5/opam
@@ -129,6 +129,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.6/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.6/opam
@@ -129,6 +129,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.7/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.7/opam
@@ -129,6 +129,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}


### PR DESCRIPTION
### `camlimages.5.0.5`
Image processing library
An image processing library, which provides loading and saving various image formats with an interface for the Caml graphics library. It has also an interface with the freetype library to draw texts using truetype fonts.



---
* Homepage: https://gitlab.com/camlspotter/camlimages
* Source repo: git+https://gitlab.com/camlspotter/camlimages.git
* Bug tracker: https://gitlab.com/camlspotter/camlimages/-/issues

---
:camel: Pull-request generated by opam-publish v2.3.0