### PR TITLE
[new release] odoc and odoc-parser (2.4.0)

### DIFF
--- a/packages/odoc-parser/odoc-parser.2.4.0/opam
+++ b/packages/odoc-parser/odoc-parser.2.4.0/opam
@@ -17,8 +17,6 @@ depends: [
   "astring"
   "result"
   "camlp-streams"
-  "ppx_expect" {with-test}
-  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -30,7 +28,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
   ]
 ]
 url {

--- a/packages/odoc-parser/odoc-parser.2.4.0/opam
+++ b/packages/odoc-parser/odoc-parser.2.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Parser for ocaml documentation comments"
+description: """
+Odoc_parser is a library for parsing the contents of OCaml documentation
+comments, formatted using 'odoc' syntax, an extension of the language
+understood by ocamldoc."""
+maintainer: ["Jon Ludlam <jon@recoil.org>"]
+authors: ["Anton Bachin <antonbachin@yahoo.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml/odoc"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+doc: "https://ocaml.github.io/odoc/odoc_parser"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.02.0"}
+  "astring"
+  "result"
+  "camlp-streams"
+  "ppx_expect" {with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/2.4.0/odoc-2.4.0.tbz"
+  checksum: [
+    "sha256=1be63699b761fe051df743fc77862559b17a1578a21c4d5098170c6f02503dce"
+    "sha512=ad5235765264e3117f8848b5982738573c8c967338e62fa9282baafd65b2b8a1b6f057fe0fc4ce7e40251ce381db5da23b62a27f3ceda1510b25407dc6c61a09"
+  ]
+}
+x-commit-hash: "74692c029b43dc379e6da04458e14a199c94d386"
+

--- a/packages/odoc/odoc.2.4.0/opam
+++ b/packages/odoc/odoc.2.4.0/opam
@@ -1,0 +1,84 @@
+opam-version: "2.0"
+homepage: "https://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+maintainer: [
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+]
+authors: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Leo White <leo@lpw25.net>"
+  "Lubega Simon <lubegasimon73@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+  "Thomas Refis <trefis@janestreet.com>"
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml Documentation Generator"
+description: """
+**odoc** is a powerful and flexible documentation generator for OCaml. It reads *doc comments*, demarcated by `(** ... *)`, and transforms them into a variety of output formats, including HTML, LaTeX, and man pages.
+
+- **Output Formats:** Odoc generates HTML for web browsing, LaTeX for PDF generation, and man pages for use on Unix-like systems.
+- **Cross-References:** odoc uses the `ocamldoc` markup, which allows to create links for functions, types, modules, and documentation pages.
+- **Link to Source Code:** Documentation generated includes links to the source code of functions, providing an easy way to navigate from the docs to the actual implementation.
+- **Code Highlighting:** odoc automatically highlights syntax in code snippets for different languages.
+
+odoc is part of the [OCaml Platform](https://ocaml.org/docs/platform), the recommended set of tools for OCaml.
+"""
+
+
+depends: [
+  "odoc-parser" {= version}
+  "astring"
+  "cmdliner" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "3.7.0"}
+  "fpath"
+  "ocaml" {>= "4.02.0"}
+  "result"
+  "tyxml" {>= "4.4.0"}
+  "fmt"
+
+  "ocamlfind" {with-test}
+  "yojson" {>= "1.6.0" & with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+  "conf-jq" {with-test}
+
+  "ppx_expect" {with-test}
+  "bos" {with-test}
+  "crunch"
+
+  ("ocaml" {< "4.07.0" & with-test} | "bisect_ppx" {with-test & > "2.5.0"})
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/2.4.0/odoc-2.4.0.tbz"
+  checksum: [
+    "sha256=1be63699b761fe051df743fc77862559b17a1578a21c4d5098170c6f02503dce"
+    "sha512=ad5235765264e3117f8848b5982738573c8c967338e62fa9282baafd65b2b8a1b6f057fe0fc4ce7e40251ce381db5da23b62a27f3ceda1510b25407dc6c61a09"
+  ]
+}
+x-commit-hash: "74692c029b43dc379e6da04458e14a199c94d386"


### PR DESCRIPTION
OCaml Documentation Generator

- Project page: <a href="https://github.com/ocaml/odoc">https://github.com/ocaml/odoc</a>
- Documentation: <a href="https://ocaml.github.io/odoc/">https://ocaml.github.io/odoc/</a>

##### CHANGES:

### Added

- Add support for external search engines (@panglesd, @EmileTrotignon, ocaml/odoc#972)
  This includes the generation of an index and the display of the results in
  the UI (HTML only).

- Display 'private' keyword for private type extensions (@gpetiot, ocaml/odoc#1019)
- Allow to omit parent type in constructor reference (@panglesd,
  @EmileTrotignon, ocaml/odoc#933)

### Fixed

- Warn and exit when table(s) is not closed (@lubegasimon, ocaml/odoc#1050)
- Hint when list(s) is not closed (@lubegasimon, ocaml/odoc#1050)
- Fix crash on functors returning an alias (@Julow, ocaml/odoc#1046)
- Fix rendering of polymorphic variants (@wikku, @panglesd, ocaml/odoc#971)
- Add references to extension declarations (@gpetiot, @panglesd, ocaml/odoc#949)

### Changed

- Style: Adjusted line height in the TOC to improve readability (@sorawee, ocaml/odoc#1045)
- Style: Remove font fallback to Helvetica, Arial (@Julow, ocaml/odoc#1028)
- Style: Preformatted elements fallback to UA monospace (@toastal, ocaml/odoc#967)
- Style: Sidebar is now stuck to the left of the content instead of the left of
  the viewport (@EmileTrotignon, ocaml/odoc#999)
