### PR TITLE
[new release] dream-html (2.0.0)

### DIFF
--- a/packages/dream-html/dream-html.2.0.0/opam
+++ b/packages/dream-html/dream-html.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v2.0.0/dream-html-2.0.0.tbz"
+  checksum: [
+    "sha256=655ea78590ded1978dca7b5a14690635d067a0295787ab099144b8c4b4b9e954"
+    "sha512=87dbbb5b8ad0351f481e904829676a3f43504b5b6c83683a40cf43e45ed4a0465012aada6b7008677c8634ea51038e91e2b99d535b6efc9dd9b9859e8a28703c"
+  ]
+}
+x-commit-hash: "a0102ff48bbfaba9cbcbec89e1c06c666daaa2ee"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
