### PR TITLE
[new release] bitwuzla-cxx (0.3.0)

### DIFF
--- a/packages/bitwuzla-cxx/bitwuzla-cxx.0.3.0/opam
+++ b/packages/bitwuzla-cxx/bitwuzla-cxx.0.3.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "SMT solver for AUFBVFP (C++ API)"
+description: """
+
+OCaml binding for the SMT solver Bitwuzla C++ API.
+
+Bitwuzla is a Satisfiability Modulo Theories (SMT) solver for the theories of fixed-size bit-vectors, arrays and uninterpreted functions and their combinations. Its name is derived from an Austrian dialect expression that can be translated as “someone who tinkers with bits”."""
+maintainer: ["Frédéric Recoules <frederic.recoules@cea.fr>"]
+authors: ["Frédéric Recoules"]
+license: "MIT"
+tags: ["SMT solver" "AUFBVFP"]
+homepage: "https://bitwuzla.github.io"
+doc: "https://bitwuzla.github.io/docs/ocaml/"
+bug-reports: "https://github.com/bitwuzla/ocaml-bitwuzla/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.12" & < "5"}
+  "conf-git" {build}
+  "conf-gcc" {build}
+  "conf-g++" {build}
+  "zarith"
+  "ppx_inline_test" {with-test & >= "v0.13"}
+  "ppx_expect" {with-test & >= "v0.13"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
+available: [ os = "linux" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) | os = "macos" & os-distribution = "homebrew" ]
+url {
+  src:
+    "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/0.3.0/bitwuzla-cxx-0.3.0.tbz"
+  checksum: [
+    "sha256=b5f4335ab0760bb76175e43e3bad04718620d39af1c5ff35863528cdf9bd2b59"
+    "sha512=55492d7b224263a5123449500d321f54dddfd0c66299cd60525c13f079d6cf9e8756329abf8bd54750f3b1d71f9774b30b3327cf358fb95a6a5b5ab226146979"
+  ]
+}
+x-commit-hash: "6bd3011be4244bd5891f5f43cc38a3cae2e62834"


### PR DESCRIPTION
SMT solver for AUFBVFP (C++ API)

- Project page: <a href="https://bitwuzla.github.io">https://bitwuzla.github.io</a>
- Documentation: <a href="https://bitwuzla.github.io/docs/ocaml/">https://bitwuzla.github.io/docs/ocaml/</a>

##### CHANGES:

Update [Bitwuzla](https://github.com/bitwuzla/bitwuzla/releases/tag/0.3.0) sources.

`Bitwuzla_cxx` can now be installed alongside `Bitwuzla_c`.

Vendor submodules:
- [Bitwuzla](https://github.com/bitwuzla/bitwuzla) tag:0.3.0
