### PR TITLE
mybuild: conflicts with bytecode only compilers

### DIFF
--- a/packages/mybuild/mybuild.1/opam
+++ b/packages/mybuild/mybuild.1/opam
@@ -19,6 +19,9 @@ depends: [
   "ocamlbuild"
 ]
 synopsis: "Collection of ocamlbuild plugins"
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 flags: light-uninstall
 url {
   src: "https://github.com/ygrek/mybuild/archive/v1.tar.gz"

--- a/packages/mybuild/mybuild.2/opam
+++ b/packages/mybuild/mybuild.2/opam
@@ -21,6 +21,9 @@ depends: [
   "ocamlbuild"
 ]
 synopsis: "Collection of ocamlbuild plugins (extprot, atdgen, ragel, etc)"
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 flags: light-uninstall
 url {
   src: "https://github.com/ygrek/mybuild/archive/v2.tar.gz"

--- a/packages/mybuild/mybuild.3/opam
+++ b/packages/mybuild/mybuild.3/opam
@@ -21,6 +21,9 @@ depends: [
   "ocamlbuild"
 ]
 synopsis: "Collection of ocamlbuild plugins (extprot, atdgen, ragel, etc)"
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 flags: light-uninstall
 url {
   src: "https://github.com/ygrek/mybuild/archive/v3.tar.gz"

--- a/packages/mybuild/mybuild.5/opam
+++ b/packages/mybuild/mybuild.5/opam
@@ -21,6 +21,9 @@ depends: [
   "ocamlbuild"
 ]
 synopsis: "Collection of ocamlbuild plugins (extprot, atdgen, ragel, etc)"
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 flags: light-uninstall
 url {
   src: "https://github.com/ygrek/mybuild/archive/v5.tar.gz"

--- a/packages/mybuild/mybuild.6/opam
+++ b/packages/mybuild/mybuild.6/opam
@@ -18,6 +18,9 @@ depends: [
   "base-unix"
   "ocamlbuild"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 synopsis: "Collection of ocamlbuild plugins (extprot, atdgen, ragel, etc) and utility to generate version from VCS"
 extra-files: [ "mybuild.install" "md5=6fd20e1483f1350b71fdd00227bf3994" ]
 url {


### PR DESCRIPTION
Fails with:
```
#=== ERROR while compiling mybuild.6 ==========================================#
# context              2.2.0~alpha4~dev | linux/arm32 | ocaml-base-compiler.5.1.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/mybuild.6
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/mybuild-7-9481c4.env
# output-file          ~/.opam/log/mybuild-7-9481c4.out
### output ###
# fatal: not a git repository: '.git'
# ocamlbuild -use-ocamlfind -no-links -j 0  mybuild.cma mybuild.cmxa mybuild_write_version.native
# ocamlfind ocamldep -package ocamlbuild -modules mybuild.mli > mybuild.mli.depends
# ocamlfind ocamlc -c -package ocamlbuild -o mybuild.cmi mybuild.mli
# ocamlfind ocamldep -package ocamlbuild -modules mybuild.ml > mybuild.ml.depends
# ocamlfind ocamlc -c -package ocamlbuild -o mybuild.cmo mybuild.ml
# ocamlfind ocamlc -a -package ocamlbuild mybuild.cmo -o mybuild.cma
# ocamlfind ocamlopt -c -package ocamlbuild -o mybuild.cmx mybuild.ml
# + ocamlfind ocamlopt -c -package ocamlbuild -o mybuild.cmx mybuild.ml
# ocamlfind: Not supported in your configuration: ocamlopt
# Command exited with code 2.
# make: *** [Makefile:15: build] Error 10
```