### PR TITLE
[new release] riot (0.0.5)

### DIFF
--- a/packages/riot/riot.0.0.5/opam
+++ b/packages/riot/riot.0.0.5/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "An actor-model multi-core scheduler for OCaml 5"
+description:
+  "Riot is an actor-model multi-core scheduler for OCaml 5. It brings Erlang-style concurrency to the language, where lighweight process communicate via message passing"
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: ["topics" "multicore" "erlang" "actor" "message-passing" "processes"]
+homepage: "https://github.com/leostera/riot"
+bug-reports: "https://github.com/leostera/riot/issues"
+depends: [
+  "ocaml" {>= "5.1"}
+  "dune" {>= "3.10"}
+  "ptime" {>= "1.1.0"}
+  "iomux" {>= "0.3"}
+  "bigstringaf" {>= "0.9.1"}
+  "uri" {>= "4.4.0"}
+  "telemetry" {>= "0.0.1"}
+  "odoc" {with-doc & >= "2.2.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/leostera/riot.git"
+url {
+  src:
+    "https://github.com/leostera/riot/releases/download/0.0.5/riot-0.0.5.tbz"
+  checksum: [
+    "sha256=01b7b82ccc656b12b7315960d9df17eb4682b8f1af68e9fee33171fee1f9cf88"
+    "sha512=d8831d8a75fe43a7e8d16d2c0bb7d27f6d975133e17c5dd89ef7e575039c59d27c1ab74fbadcca81ddfbc0c74d1e46c35baba35ef825b36ac6c4e49d7a41d0c2"
+  ]
+}
+x-commit-hash: "98855655048893413233afff6e7c47df2702041a"


### PR DESCRIPTION
An actor-model multi-core scheduler for OCaml 5

- Project page: <a href="https://github.com/leostera/riot">https://github.com/leostera/riot</a>

##### CHANGES:

## 0.0.5

* Add `register name pid`
* Add `unregister name`
* Add `send_by_name ~name msg`
* Fix timer wheel making it remove timers correctly
* Add better test for `Timer.send_after`