### PR TITLE
[new release] minttea (3 packages) (0.0.1)

### DIFF
--- a/packages/leaves/leaves.0.0.1/opam
+++ b/packages/leaves/leaves.0.0.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A collection of reusable components from Mint Tea"
+description:
+  "Leaves is a collection of reusable components for writing TUI applications with Mint Tea"
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: ["tui" "terminal-ui" "apps" "components" "component" "library"]
+homepage: "https://github.com/leostera/minttea"
+bug-reports: "https://github.com/leostera/minttea/issues"
+depends: [
+  "ocaml" {>= "5.1"}
+  "dune" {>= "3.11" & >= "3.11"}
+  "spices" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/leostera/minttea.git"
+url {
+  src:
+    "https://github.com/leostera/minttea/releases/download/0.0.1/minttea-0.0.1.tbz"
+  checksum: [
+    "sha256=fb89d57982b1d80da2da7965fcf6d2b5c11af83bf17744fb7bf2ac749a98e1b2"
+    "sha512=011460ee0ef0537c384378e25e05f31b5a083100b536b552ccec5890255167ac0e60c4cdb62e1015e048ff2910d411e6abdc50daa54b14db8dffb911aa358121"
+  ]
+}
+x-commit-hash: "90c72fe32831bab95790a7fb1ace1ffb5be168f1"

--- a/packages/minttea/minttea.0.0.1/opam
+++ b/packages/minttea/minttea.0.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "A fun, functional, and stateful way to build terminal apps in OCaml heavily inspired by Go's BubbleTea"
+description: "A longer description"
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: ["tui" "terminal-ui" "framework" "riot"]
+homepage: "https://github.com/leostera/minttea"
+bug-reports: "https://github.com/leostera/minttea/issues"
+depends: [
+  "ocaml" {>= "5.1"}
+  "dune" {>= "3.11" & >= "3.11"}
+  "riot" {>= "0.0.5"}
+  "tty" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/leostera/minttea.git"
+url {
+  src:
+    "https://github.com/leostera/minttea/releases/download/0.0.1/minttea-0.0.1.tbz"
+  checksum: [
+    "sha256=fb89d57982b1d80da2da7965fcf6d2b5c11af83bf17744fb7bf2ac749a98e1b2"
+    "sha512=011460ee0ef0537c384378e25e05f31b5a083100b536b552ccec5890255167ac0e60c4cdb62e1015e048ff2910d411e6abdc50daa54b14db8dffb911aa358121"
+  ]
+}
+x-commit-hash: "90c72fe32831bab95790a7fb1ace1ffb5be168f1"

--- a/packages/spices/spices.0.0.1/opam
+++ b/packages/spices/spices.0.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Declarative styles for TUI applications"
+description:
+  "Spices lets you create style definitions for TUIs and provide handy renderers for strings over them"
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: [
+  "styling" "styles" "declarative" "framework" "tui" "terminal-ui" "apps"
+]
+homepage: "https://github.com/leostera/minttea"
+bug-reports: "https://github.com/leostera/minttea/issues"
+depends: [
+  "ocaml" {>= "5.1"}
+  "dune" {>= "3.11" & >= "3.11"}
+  "tty" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/leostera/minttea.git"
+url {
+  src:
+    "https://github.com/leostera/minttea/releases/download/0.0.1/minttea-0.0.1.tbz"
+  checksum: [
+    "sha256=fb89d57982b1d80da2da7965fcf6d2b5c11af83bf17744fb7bf2ac749a98e1b2"
+    "sha512=011460ee0ef0537c384378e25e05f31b5a083100b536b552ccec5890255167ac0e60c4cdb62e1015e048ff2910d411e6abdc50daa54b14db8dffb911aa358121"
+  ]
+}
+x-commit-hash: "90c72fe32831bab95790a7fb1ace1ffb5be168f1"


### PR DESCRIPTION
A fun, functional, and stateful way to build terminal apps in OCaml heavily inspired by Go's BubbleTea

- Project page: <a href="https://github.com/leostera/minttea">https://github.com/leostera/minttea</a>

##### CHANGES:

## 0.0.1

Initial release for the 3 packages.

#### MintTea

* Let people create TUI apps using The-Elm-Architecture
* Introduce basic events for KeyDown, Frame, and Timers
* Introduce basic commands for setting timers, entering/exiting the AltScreen, exiting, and sequencing commands

#### Examples

* Add `views` example showcasing an application with multiples sections
* Add `altscreen-toggle` example to showcase the AltScreen
* Add `fullscreen` example with a timer
* Add `stopwatch` example
* Add `fps` counter example

#### Spices

* Introduce `color` and `style`
* Support basic styles (bold, italic, underscore, etc) and layouting (padding)

#### Leaves

* Add a Checkbox leaf
* Add a Progress bar leaf
