### PR TITLE
ott: fix for building on Windows (without symlink)

### DIFF
--- a/packages/ott/ott.0.32/opam
+++ b/packages/ott/ott.0.32/opam
@@ -14,6 +14,8 @@ depends: [
 build: [
   [make "world"]
   [make "ott.install"]
+  ["rm" "src/ott"] { os = "win32" }
+  ["cp" "src/ott.opt" "src/ott"] { os = "win32" }
 ]
 run-test: [
   [make "-C" "tests/menhir_tests/test_if"]

--- a/packages/ott/ott.0.33/opam
+++ b/packages/ott/ott.0.33/opam
@@ -15,6 +15,9 @@ depends: [
 build: [
   [make "world"] { ocaml:native }
   [make "world.byt"] { !ocaml:native }
+  ["rm" "src/ott"] {os = "win32"}
+  ["cp" "src/ott.opt" "src/ott"] {os = "win32" & ocaml:native}
+  ["cp" "src/ott.byte" "src/ott"] {os = "win32" & !ocaml:native}
   [make "ott.install"]
 ]
 run-test: [


### PR DESCRIPTION
This PR merges the Windows fix from the Opam MinGW repo:

https://github.com/ocaml-opam/opam-repository-mingw/tree/sunset/packages/ott/ott.0.32

and adds a correspnding fix for ott.0.33.

For older versions of ott the MinGW repo has no patches - not sure if these work or not, I didn't test it.

The change does not influence builds on other systems, so I did not change the version numbers.