### PR TITLE
10 packages from savonet/liquidsoap-release-assets

### DIFF
--- a/packages/liquidsoap-core/liquidsoap-core.2.2.3/opam
+++ b/packages/liquidsoap-core/liquidsoap-core.2.2.3/opam
@@ -1,0 +1,138 @@
+opam-version: "2.0"
+synopsis: "Liquidsoap core library and binary"
+maintainer: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+license: "GPL-2.0-or-later"
+homepage: "https://github.com/savonet/liquidsoap"
+bug-reports: "https://github.com/savonet/liquidsoap/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.14.0"}
+  "dtools" {>= "0.4.5"}
+  "duppy" {>= "0.9.3"}
+  "mm" {>= "0.8.4"}
+  "pcre" {>= "7.5.0"}
+  "ocurl" {>= "0.9.2"}
+  "cry" {>= "1.0.0"}
+  "camomile" {>= "2.0.0"}
+  "uri"
+  "fileutils"
+  "menhirLib"
+  "metadata" {>= "0.2.0"}
+  "dune-build-info"
+  "liquidsoap-lang" {= version}
+  "ppx_string" {build}
+  "odoc" {with-doc}
+]
+depopts: [
+  "alsa"
+  "ao"
+  "bjack"
+  "camlimages"
+  "ctypes-foreign"
+  "dssi"
+  "faad"
+  "fdkaac"
+  "ffmpeg"
+  "flac"
+  "frei0r"
+  "gd"
+  "graphics"
+  "gstreamer"
+  "imagelib"
+  "inotify"
+  "irc-client-unix"
+  "jemalloc"
+  "ladspa"
+  "lame"
+  "lastfm"
+  "lilv"
+  "lo"
+  "mad"
+  "magic"
+  "memtrace"
+  "mem_usage"
+  "ogg"
+  "opus"
+  "osc-unix"
+  "portaudio"
+  "posix-time2"
+  "pulseaudio"
+  "prometheus-liquidsoap"
+  "samplerate"
+  "shine"
+  "soundtouch"
+  "speex"
+  "srt"
+  "ssl"
+  "taglib"
+  "tls-liquidsoap"
+  "theora"
+  "sdl-liquidsoap"
+  "vorbis"
+  "yaml"
+  "xmlplaylist"
+]
+conflicts: [
+  "alsa" {< "0.3.0"}
+  "ao" {< "0.2.0"}
+  "bjack" {< "0.1.3"}
+  "camomile" {< "1.0.0"}
+  "dssi" {< "0.1.3"}
+  "faad" {< "0.5.0"}
+  "fdkaac" {< "0.3.1"}
+  "ffmpeg" {< "1.1.8"}
+  "ffmpeg-avutil" {< "1.1.8"}
+  "flac" {< "0.3.0"}
+  "frei0r" {< "0.1.0"}
+  "gstreamer" {< "0.3.1"}
+  "inotify" {< "1.0"}
+  "ladspa" {< "0.2.0"}
+  "lame" {< "0.3.7"}
+  "lastfm" {< "0.3.0"}
+  "lo" {< "0.2.0"}
+  "mad" {< "0.5.0"}
+  "magic" {< "0.6"}
+  "mem_usage" {< "0.0.3"}
+  "ogg" {< "0.7.4"}
+  "opus" {< "0.2.0"}
+  "portaudio" {< "0.2.0"}
+  "posix-time2" {< "2.0.2"}
+  "pulseaudio" {< "0.1.4"}
+  "samplerate" {< "0.1.5"}
+  "shine" {< "0.2.0"}
+  "soundtouch" {< "0.1.9"}
+  "speex" {< "0.4.0"}
+  "srt" {< "0.3.0"}
+  "ssl" {< "0.7.0"}
+  "taglib" {< "0.3.10"}
+  "sdl-liquidsoap" {< "2"}
+  "theora" {< "0.4.0"}
+  "vorbis" {< "0.8.0"}
+  "xmlplaylist" {< "0.1.3"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/savonet/liquidsoap.git"
+url {
+  src:
+    "https://github.com/savonet/liquidsoap-release-assets/releases/download/v2.2.3/liquidsoap-2.2.3.tar.gz"
+  checksum: [
+    "md5=988ffcff06b32998c0810cc667247121"
+    "sha512=5e256f5413e933eecffa6a53ef17a0f586df1dcbb18de70c627b344f21d6f2c92ea770e4d9a416ac0a1aa4d21ce8872849cbe81c1ba6d9acfb973913a8dbb36c"
+  ]
+}

--- a/packages/liquidsoap-js/liquidsoap-js.2.2.3/opam
+++ b/packages/liquidsoap-js/liquidsoap-js.2.2.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Liquidsoap language - javascript wrapper"
+maintainer: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+license: "GPL-2.0-or-later"
+homepage: "https://github.com/savonet/liquidsoap"
+bug-reports: "https://github.com/savonet/liquidsoap/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.14.0"}
+  "liquidsoap-lang" {= version}
+  "js_of_ocaml-ppx"
+  "js_of_ocaml"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "liquidsoap" {!= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/savonet/liquidsoap.git"
+url {
+  src:
+    "https://github.com/savonet/liquidsoap-release-assets/releases/download/v2.2.3/liquidsoap-2.2.3.tar.gz"
+  checksum: [
+    "md5=988ffcff06b32998c0810cc667247121"
+    "sha512=5e256f5413e933eecffa6a53ef17a0f586df1dcbb18de70c627b344f21d6f2c92ea770e4d9a416ac0a1aa4d21ce8872849cbe81c1ba6d9acfb973913a8dbb36c"
+  ]
+}

--- a/packages/liquidsoap-lang/liquidsoap-lang.2.2.3/opam
+++ b/packages/liquidsoap-lang/liquidsoap-lang.2.2.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Liquidsoap language library"
+maintainer: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+license: "GPL-2.0-or-later"
+homepage: "https://github.com/savonet/liquidsoap"
+bug-reports: "https://github.com/savonet/liquidsoap/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.14.0"}
+  "dune-site"
+  "ppx_string" {build}
+  "sedlex" {>= "3.2"}
+  "menhir" {>= "20180703"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/savonet/liquidsoap.git"
+url {
+  src:
+    "https://github.com/savonet/liquidsoap-release-assets/releases/download/v2.2.3/liquidsoap-2.2.3.tar.gz"
+  checksum: [
+    "md5=988ffcff06b32998c0810cc667247121"
+    "sha512=5e256f5413e933eecffa6a53ef17a0f586df1dcbb18de70c627b344f21d6f2c92ea770e4d9a416ac0a1aa4d21ce8872849cbe81c1ba6d9acfb973913a8dbb36c"
+  ]
+}

--- a/packages/liquidsoap-libs-extra/liquidsoap-libs-extra.2.2.3/opam
+++ b/packages/liquidsoap-libs-extra/liquidsoap-libs-extra.2.2.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Liquidosap standard library -- extra functionalities"
+maintainer: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+license: "GPL-2.0-or-later"
+homepage: "https://github.com/savonet/liquidsoap"
+bug-reports: "https://github.com/savonet/liquidsoap/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "liquidsoap-libs" {= version}
+  "liquidsoap-lang" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/savonet/liquidsoap.git"
+url {
+  src:
+    "https://github.com/savonet/liquidsoap-release-assets/releases/download/v2.2.3/liquidsoap-2.2.3.tar.gz"
+  checksum: [
+    "md5=988ffcff06b32998c0810cc667247121"
+    "sha512=5e256f5413e933eecffa6a53ef17a0f586df1dcbb18de70c627b344f21d6f2c92ea770e4d9a416ac0a1aa4d21ce8872849cbe81c1ba6d9acfb973913a8dbb36c"
+  ]
+}

--- a/packages/liquidsoap-libs/liquidsoap-libs.2.2.3/opam
+++ b/packages/liquidsoap-libs/liquidsoap-libs.2.2.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Liquidosap standard library"
+maintainer: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+license: "GPL-2.0-or-later"
+homepage: "https://github.com/savonet/liquidsoap"
+bug-reports: "https://github.com/savonet/liquidsoap/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "liquidsoap-lang" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/savonet/liquidsoap.git"
+url {
+  src:
+    "https://github.com/savonet/liquidsoap-release-assets/releases/download/v2.2.3/liquidsoap-2.2.3.tar.gz"
+  checksum: [
+    "md5=988ffcff06b32998c0810cc667247121"
+    "sha512=5e256f5413e933eecffa6a53ef17a0f586df1dcbb18de70c627b344f21d6f2c92ea770e4d9a416ac0a1aa4d21ce8872849cbe81c1ba6d9acfb973913a8dbb36c"
+  ]
+}

--- a/packages/liquidsoap-mode/liquidsoap-mode.2.2.3/opam
+++ b/packages/liquidsoap-mode/liquidsoap-mode.2.2.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Liquidosap emacs mode"
+maintainer: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+license: "GPL-2.0-or-later"
+homepage: "https://github.com/savonet/liquidsoap"
+bug-reports: "https://github.com/savonet/liquidsoap/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "liquidsoap" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+post-messages:
+  """\
+This package requires additional configuration for use in editors. Install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path "%{share}%/emacs/site-lisp")
+  (require 'emacs-mode)"""
+    {success & !user-setup:installed}
+dev-repo: "git+https://github.com/savonet/liquidsoap.git"
+url {
+  src:
+    "https://github.com/savonet/liquidsoap-release-assets/releases/download/v2.2.3/liquidsoap-2.2.3.tar.gz"
+  checksum: [
+    "md5=988ffcff06b32998c0810cc667247121"
+    "sha512=5e256f5413e933eecffa6a53ef17a0f586df1dcbb18de70c627b344f21d6f2c92ea770e4d9a416ac0a1aa4d21ce8872849cbe81c1ba6d9acfb973913a8dbb36c"
+  ]
+}

--- a/packages/liquidsoap/liquidsoap.2.2.3/opam
+++ b/packages/liquidsoap/liquidsoap.2.2.3/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+synopsis: "Swiss-army knife for multimedia streaming"
+description: """\
+Liquidsoap is a powerful and flexible language for describing your
+streams. It offers a rich collection of operators that you can combine
+at will, giving you more power than you need for creating or
+transforming streams. But liquidsoap is still very light and easy to
+use, in the Unix tradition of simple strong components working
+together."""
+maintainer: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+license: "GPL-2.0-or-later"
+homepage: "https://github.com/savonet/liquidsoap"
+bug-reports: "https://github.com/savonet/liquidsoap/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "liquidsoap-core" {= version}
+  "liquidsoap-libs" {>= "2.2.3" & < "2.2.4"}
+  "liquidsoap-libs-extra" {>= "2.2.3" & < "2.2.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+post-messages: [
+  """\
+We're sorry that your liquidsoap install failed. Check out our installation
+instructions at: https://www.liquidsoap.info/doc-%{version}%/install.html#opam
+for more information."""
+    {failure}
+  "✨ Congratulations on installing liquidsoap! ✨" {success}
+  """\
+We noticed that you did not install the ffmpeg package. This package is
+highly recommended for most users and provides a lot of useful features,
+including decoding and encoding multiple media format, sending and
+receiving from various inputs and outputs and more."""
+    {success & !ffmpeg-enabled}
+  """\
+We noticed that you did not install any ssl or tls support. Liquidsoap won't
+be able to use SSL encryption in its input or output operators. You might want
+to install one of ssl or tls-liquidsoap package."""
+    {success & !ssl-enabled & !tls-enabled}
+  """\
+We noticed that your build includes GStreamer support. This support is DEPRECATED.
+We suggest you consider moving to FFmpeg, which should provide same the same level
+of functionalities."""
+    {success & gstreamer-enabled}
+]
+depexts: ["coreutils"] {os = "macos" & os-distribution = "homebrew"}
+dev-repo: "git+https://github.com/savonet/liquidsoap.git"
+url {
+  src:
+    "https://github.com/savonet/liquidsoap-release-assets/releases/download/v2.2.3/liquidsoap-2.2.3.tar.gz"
+  checksum: [
+    "md5=988ffcff06b32998c0810cc667247121"
+    "sha512=5e256f5413e933eecffa6a53ef17a0f586df1dcbb18de70c627b344f21d6f2c92ea770e4d9a416ac0a1aa4d21ce8872849cbe81c1ba6d9acfb973913a8dbb36c"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `liquidsoap.2.2.3`: Swiss-army knife for multimedia streaming
- `liquidsoap-core.2.2.3`: Liquidsoap core library and binary
- `liquidsoap-js.2.2.3`: Liquidsoap language - javascript wrapper
- `liquidsoap-lang.2.2.3`: Liquidsoap language library
- `liquidsoap-libs.2.2.3`: Liquidosap standard library
- `liquidsoap-libs-extra.2.2.3`: Liquidosap standard library -- extra functionalities
- `liquidsoap-mode.2.2.3`: Liquidosap emacs mode



---
* Homepage: https://github.com/savonet/liquidsoap
* Source repo: git+https://github.com/savonet/liquidsoap.git
* Bug tracker: https://github.com/savonet/liquidsoap/issues

---
:camel: Pull-request generated by opam-publish v2.2.0