### PR TITLE
[new release] mirage-flow, mirage-flow-unix and mirage-flow-combinators (4.0.0)

### DIFF
--- a/packages/mirage-flow-combinators/mirage-flow-combinators.4.0.0/opam
+++ b/packages/mirage-flow-combinators/mirage-flow-combinators.4.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "logs"
+  "cstruct" {>= "6.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-flow" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS specialized to lwt"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v4.0.0/mirage-flow-4.0.0.tbz"
+  checksum: [
+    "sha256=6a80885761d12282ba4dd5bf0da24fb19dc50f4c80b8f5173784be4399beeb09"
+    "sha512=dbd870dcd9c39f7d83615e9a212d7899b10559a496fa62c06560fedfea9f1a4e6adc0627304142d9904473bd09c85c20d2201a5b021a946b80def3a86c6cf7c7"
+  ]
+}
+x-commit-hash: "8d7aeba29d359dc8f4b1abe75e169ca7058f39c4"

--- a/packages/mirage-flow-unix/mirage-flow-unix.4.0.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.4.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "mirage-flow" {= version}
+  "lwt" {>= "4.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "alcotest" {with-test}
+  "mirage-flow-combinators" {with-test & = version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS on Unix"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v4.0.0/mirage-flow-4.0.0.tbz"
+  checksum: [
+    "sha256=6a80885761d12282ba4dd5bf0da24fb19dc50f4c80b8f5173784be4399beeb09"
+    "sha512=dbd870dcd9c39f7d83615e9a212d7899b10559a496fa62c06560fedfea9f1a4e6adc0627304142d9904473bd09c85c20d2201a5b021a946b80def3a86c6cf7c7"
+  ]
+}
+x-commit-hash: "8d7aeba29d359dc8f4b1abe75e169ca7058f39c4"

--- a/packages/mirage-flow/mirage-flow.4.0.0/opam
+++ b/packages/mirage-flow/mirage-flow.4.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "4.0.0"}
+  "fmt"
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v4.0.0/mirage-flow-4.0.0.tbz"
+  checksum: [
+    "sha256=6a80885761d12282ba4dd5bf0da24fb19dc50f4c80b8f5173784be4399beeb09"
+    "sha512=dbd870dcd9c39f7d83615e9a212d7899b10559a496fa62c06560fedfea9f1a4e6adc0627304142d9904473bd09c85c20d2201a5b021a946b80def3a86c6cf7c7"
+  ]
+}
+x-commit-hash: "8d7aeba29d359dc8f4b1abe75e169ca7058f39c4"


### PR DESCRIPTION
Flow implementations and combinators for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-flow">https://github.com/mirage/mirage-flow</a>
- Documentation: <a href="https://mirage.github.io/mirage-flow/">https://mirage.github.io/mirage-flow/</a>

##### CHANGES:

- Add ``shutdown : flow -> [ `read | `write | `read_write ] -> unit Lwt.t``
  (@djs55 @hannesm mirage/mirage-flow#16 mirage/mirage-flow#18 mirage/mirage-flow#48)
- Remove SHUTDOWNABLE signature (@djs55 mirage/mirage-flow#17, rebased into mirage/mirage-flow#48)
