### PR TITLE
[new release] lsp (3 packages) (1.17.0)

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.17.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.17.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.17.0/lsp-1.17.0.tbz"
+  checksum: [
+    "sha256=8fb8bbd717eefd2608b4d83458105b660e0de3a1134dc8fc216ae659d4d19600"
+    "sha512=6876df760dbcb51f85e7fd9d08cc8498c69ede38a52f4e12407187da3fbd9657c71f3223f9490ad97edd5259cfdeb2819d943db65bb9ce3c2a18dace3b65ffa8"
+  ]
+}
+x-commit-hash: "d3d8de5a4213c2a16e43ac4f87cbbe88a894d05f"

--- a/packages/lsp/lsp.1.17.0/opam
+++ b/packages/lsp/lsp.1.17.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "jsonrpc" {= version}
+  "yojson"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "cinaps" {with-test}
+  "ppx_expect" {>= "v0.15.0" & with-test}
+  "uutf" {>= "1.0.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.14"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.17.0/lsp-1.17.0.tbz"
+  checksum: [
+    "sha256=8fb8bbd717eefd2608b4d83458105b660e0de3a1134dc8fc216ae659d4d19600"
+    "sha512=6876df760dbcb51f85e7fd9d08cc8498c69ede38a52f4e12407187da3fbd9657c71f3223f9490ad97edd5259cfdeb2819d943db65bb9ce3c2a18dace3b65ffa8"
+  ]
+}
+x-commit-hash: "d3d8de5a4213c2a16e43ac4f87cbbe88a894d05f"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.17.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.17.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson"
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc" {>= "3.4.0"}
+  "chrome-trace" {>= "3.3.0"}
+  "dyn"
+  "stdune"
+  "fiber" {>= "3.1.1" & < "4.0.0"}
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "astring"
+  "camlp-streams"
+  "ppx_expect" {>= "v0.15.0" & with-test}
+  "ocamlformat" {with-test & = "0.24.1"}
+  "ocamlc-loc" {>= "3.7.0"}
+  "uutf" {>= "1.0.2"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.14" & < "5.2"}
+  "merlin-lib" {>= "4.9" & < "5.0"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-j"
+    jobs
+    "ocaml-lsp-server.install"
+    "--release"
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.17.0/lsp-1.17.0.tbz"
+  checksum: [
+    "sha256=8fb8bbd717eefd2608b4d83458105b660e0de3a1134dc8fc216ae659d4d19600"
+    "sha512=6876df760dbcb51f85e7fd9d08cc8498c69ede38a52f4e12407187da3fbd9657c71f3223f9490ad97edd5259cfdeb2819d943db65bb9ce3c2a18dace3b65ffa8"
+  ]
+}
+x-commit-hash: "d3d8de5a4213c2a16e43ac4f87cbbe88a894d05f"


### PR DESCRIPTION
LSP protocol implementation in OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-lsp">https://github.com/ocaml/ocaml-lsp</a>

##### CHANGES:

## Fixes

- Fix missing super & subscripts in markdown documentation. (ocaml/ocaml-lsp#1170)

- Do not invoke dune at all if `--fallback-read-dot-merlin` flag is on. (ocaml/ocaml-lsp#1173)

- Fix semantic highlighting of infix operators that contain '.'. (ocaml/ocaml-lsp#1186)

- Disable highlighting unit as an enum member to fix comment highlighting bug. (ocaml/ocaml-lsp#1185)

- Improve type-on-hover and type-annotate efficiency by only formatting the type
  of the first enclosing. (ocaml/ocaml-lsp#1191, ocaml/ocaml-lsp#1196)

- Fix the encoding of URI's to match how vscode does it (ocaml/ocaml-lsp#1197)

- Fix parsing of completion prefixes (ocaml/ocaml-lsp#1181)

## Features

- Compatibility with Odoc 2.3.0, with support for the introduced syntax: tables,
  and "codeblock output" (ocaml/ocaml-lsp#1184)

- Display text of references in doc strings (ocaml/ocaml-lsp#1166)

- Add mark/remove unused actions for open, types, for loop indexes, modules,
  match cases, rec, and constructors (ocaml/ocaml-lsp#1141)

- Offer auto-completion for the keyword `in` (ocaml/ocaml-lsp#1217)
