### PR TITLE
[new release] merlin and merlin-lib (4.13-500)

### DIFF
--- a/packages/merlin-lib/merlin-lib.4.13-500/opam
+++ b/packages/merlin-lib/merlin-lib.4.13-500/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.0" & < "5.1"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.13-500/merlin-4.13-500.tbz"
+  checksum: [
+    "sha256=8da3e933ba10a5d7c7857a6172dfede00d82f0d749ca7f01e6982043320f471c"
+    "sha512=7878c9f2f86f0438beb24226492674aea79d584aa9fc1e3bf8b725cd2611f70257aaec7ff3cdc73da26456e9ab27856ee9d5b4556757e683e820fd8f283c2b5e"
+  ]
+}
+x-commit-hash: "0fe8dd982a17ebebf0a0953d7f87cdb353ce771e"

--- a/packages/merlin/merlin.4.13-500/opam
+++ b/packages/merlin/merlin.4.13-500/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.0" & < "5.1"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.9"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.13-500/merlin-4.13-500.tbz"
+  checksum: [
+    "sha256=8da3e933ba10a5d7c7857a6172dfede00d82f0d749ca7f01e6982043320f471c"
+    "sha512=7878c9f2f86f0438beb24226492674aea79d584aa9fc1e3bf8b725cd2611f70257aaec7ff3cdc73da26456e9ab27856ee9d5b4556757e683e820fd8f283c2b5e"
+  ]
+}
+x-commit-hash: "0fe8dd982a17ebebf0a0953d7f87cdb353ce771e"


### PR DESCRIPTION
CHANGES:

Mon Dec 18 16:42:00 CET 2023

  + merlin binary 
    - Fix a follow-up issue to the preference of non-ghost nodes introduced in ocaml/merlin#1660 (ocaml/merlin#1690, fixes ocaml/merlin#1689) 
     - Add `-cache-lifespan` flag, that sets cache invalidation period. (ocaml/merlin#1698, ocaml/merlin#1705) 
     - Fix Merlin locate not fallbacking on the correct file in case of ambiguity (@goldfirere, ocaml/merlin#1699) 
     - Fix Merlin reporting errors provoked by the recovery itself (ocaml/merlin#1709, fixes ocaml/merlin#1704)
  + editor modes
    - vim: load merlin when Vim is compiled with +python3/dyn (e.g. MacVim)
    - emacs: highlight only first error line by default (ocaml/merlin#1693, fixes ocaml/merlin#1663)