### PR TITLE
restrict more packages to mirage-flow < 4

### DIFF
--- a/packages/hvsock/hvsock.3.0.0/opam
+++ b/packages/hvsock/hvsock.3.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "base64" {>= "3.0.0"}
   "uuidm"
   "uutf"
-  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "cstruct" {>= "6.0.0"}

--- a/packages/hvsock/hvsock.3.0.1/opam
+++ b/packages/hvsock/hvsock.3.0.1/opam
@@ -26,7 +26,7 @@ depends: [
   "base64" {>= "3.0.0"}
   "uuidm"
   "uutf"
-  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "cstruct" {>= "6.0.0"}

--- a/packages/protocol-9p-unix/protocol-9p-unix.2.0.2/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.2.0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "sexplib" {> "113.00.00"}
   "prometheus"
   "rresult"
-  "mirage-flow" {>= "3.0.0"}
+  "mirage-flow" {>= "3.0.0" & < "4.0.0"}
   "mirage-channel" {with-test & >= "4.0.0"}
   "lwt" {>= "3.0.0"}
   "base-unix"

--- a/packages/spoke/spoke.0.0.1/opam
+++ b/packages/spoke/spoke.0.0.1/opam
@@ -24,7 +24,7 @@ depends: [
   "encore"        {>= "0.8"}
   "ke"
   "mirage-crypto" {>= "0.10.7" & < "0.11.0"}
-  "mirage-flow"   {>= "3.0.0"}
+  "mirage-flow"   {>= "3.0.0" & < "4.0.0"}
   "lwt"           {>= "5.6.1"}
   "result"        {>= "1.5"}
   "mimic"         {with-test}

--- a/packages/spoke/spoke.0.0.2/opam
+++ b/packages/spoke/spoke.0.0.2/opam
@@ -24,7 +24,7 @@ depends: [
   "encore"        {>= "0.8"}
   "ke"
   "mirage-crypto" {>= "0.11.0"}
-  "mirage-flow"   {>= "3.0.0"}
+  "mirage-flow"   {>= "3.0.0" & < "4.0.0"}
   "lwt"           {>= "5.6.1"}
   "result"        {>= "1.5"}
   "mimic"         {with-test}

--- a/packages/tcpip/tcpip.4.1.0/opam
+++ b/packages/tcpip/tcpip.4.1.0/opam
@@ -45,7 +45,7 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0" & < "3.0.0"}
-#  "mirage-flow" {with-test & >= "2.0.0" & < "4.0.0"}
+  "mirage-flow" {>= "2.0.0" & < "4.0.0"}
 #  "mirage-vnetif" {with-test & >= "0.5.0"}
 #  "alcotest" {with-test & >="0.7.0"}
 #  "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.5.0.0/opam
+++ b/packages/tcpip/tcpip.5.0.0/opam
@@ -44,7 +44,7 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0" & < "3.0.0"}
-#  "mirage-flow" {with-test & >= "2.0.0" & < "4.0.0"}
+  "mirage-flow" {>= "2.0.0" & < "4.0.0"}
 #  "mirage-vnetif" {with-test & >= "0.5.0"}
 #  "alcotest" {with-test & >="0.7.0"}
 #  "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.5.0.1/opam
+++ b/packages/tcpip/tcpip.5.0.1/opam
@@ -44,7 +44,7 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0" & < "3.0.0"}
-  "mirage-flow" {with-test & >= "2.0.0" & < "4.0.0"}
+  "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "alcotest" {with-test & >="0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.6.0.0/opam
+++ b/packages/tcpip/tcpip.6.0.0/opam
@@ -42,7 +42,7 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0" & < "3.0.0"}
-  "mirage-flow" {with-test & >= "2.0.0" & < "4.0.0"}
+  "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "alcotest" {with-test & >="0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.6.1.0/opam
+++ b/packages/tcpip/tcpip.6.1.0/opam
@@ -47,7 +47,7 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0" & < "3.0.0"}
-  "mirage-flow" {with-test & >= "2.0.0" & < "4.0.0"}
+  "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "alcotest" {with-test & >="0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.6.2.0/opam
+++ b/packages/tcpip/tcpip.6.2.0/opam
@@ -47,7 +47,7 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0" & < "3.0.0"}
-  "mirage-flow" {with-test & >= "2.0.0" & < "4.0.0"}
+  "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "alcotest" {with-test & >="0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.6.3.0/opam
+++ b/packages/tcpip/tcpip.6.3.0/opam
@@ -47,7 +47,7 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0" & < "3.0.0"}
-  "mirage-flow" {with-test & >= "2.0.0" & < "4.0.0"}
+  "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "alcotest" {with-test & >="0.7.0"}
   "pcap-format" {with-test}

--- a/packages/tcpip/tcpip.6.4.0/opam
+++ b/packages/tcpip/tcpip.6.4.0/opam
@@ -47,7 +47,7 @@ depends: [
   "duration"
   "randomconv"
   "ethernet" {>= "2.0.0" & < "3.0.0"}
-  "mirage-flow" {with-test & >= "2.0.0" & < "4.0.0"}
+  "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "alcotest" {with-test & >="0.7.0"}
   "pcap-format" {with-test}


### PR DESCRIPTION
The full list (combining #24952 with this PR):

- hvsock //cc @djs55 
- protocol-9p-unix //cc @djs55 
- spoke //cc @dinosaure 
- mimic //cc @dinosaure 
- tcpip (here, the `with-test` was clearly wrong) //cc @avsm 
- tls-mirage //cc @hannesm 
- awa-mirage //cc @hannesm @haesbaert 
- vchan //cc @jonludlam 
- mirage-console //cc @avsm 

Please keep in mind, that (a) there's now `shutdown` and (b) `close` semantics changed (see #24959 for the release and the details at https://mirage.github.io/mirage-flow/mirage-flow/Mirage_flow/module-type-S/index.html
