### PR TITLE
spoke requires tcpip >= 6.0.0

### DIFF
--- a/packages/spoke/spoke.0.0.1/opam
+++ b/packages/spoke/spoke.0.0.1/opam
@@ -29,7 +29,7 @@ depends: [
   "result"        {>= "1.5"}
   "mimic"         {with-test}
   "rresult"       {with-test}
-  "tcpip"         {with-test}
+  "tcpip" {with-test & >= "6.0.0"}
 ]
 url {
   src:

--- a/packages/spoke/spoke.0.0.2/opam
+++ b/packages/spoke/spoke.0.0.2/opam
@@ -29,7 +29,7 @@ depends: [
   "result"        {>= "1.5"}
   "mimic"         {with-test}
   "rresult"       {with-test}
-  "tcpip"         {with-test}
+  "tcpip" {with-test & >= "6.0.0"}
 ]
 url {
   src:


### PR DESCRIPTION
Fails with
```
=== ERROR while compiling spoke.0.0.1 ========================================#
 context              2.2.0~alpha4~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
 path                 ~/.opam/4.14/.opam-switch/build/spoke.0.0.1
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p spoke -j 255
 exit-code            1
 env-file             ~/.opam/log/spoke-7-784fe2.env
 output-file          ~/.opam/log/spoke-7-784fe2.out
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I bin/.simulate.eobjs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigarray-compat -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/cstruct-lwt -I /home/opam/.opam/4.14/lib/digestif/c -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/encore -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/eqaf/bigstring -I /home/opam/.opam/4.14/lib/eqaf/cstruct -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/hxd/core -I /home/opam/.opam/4.14/lib/hxd/string -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/ke -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lru -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/macaddr-cstruct -I /home/opam/.opam/4.14/lib/mimic -I /home/opam/.opam/4.14/lib/mirage-clock -I /home/opam/.opam/4.14/lib/mirage-crypto -I /home/opam/.opam/4.14/lib/mirage-device -I /home/opam/.opam/4.14/lib/mirage-flow -I /home/opam/.opam/4.14/lib/mirage-profile -I /home/opam/.opam/4.14/lib/mirage-protocols -I /home/opam/.opam/4.14/lib/mirage-random -I /home/opam/.opam/4.14/lib/mirage-stack -I /home/opam/.opam/4.14/lib/mirage-time -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/psq -I /home/opam/.opam/4.14/lib/randomconv -I /home/opam/.opam/4.14/lib/rresult -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/tcpip -I /home/opam/.opam/4.14/lib/tcpip/icmpv4 -I /home/opam/.opam/4.14/lib/tcpip/ipv4 -I /home/opam/.opam/4.14/lib/tcpip/ipv6 -I /home/opam/.opam/4.14/lib/tcpip/stack-socket -I /home/opam/.opam/4.14/lib/tcpip/tcp_socket_options -I /home/opam/.opam/4.14/lib/tcpip/tcpv4-socket -I /home/opam/.opam/4.14/lib/tcpip/udp -I /home/opam/.opam/4.14/lib/tcpip/udpv4-socket -I /home/opam/.opam/4.14/lib/tcpip/unix -I lib/.flow.objs/byte -I lib/.spoke.objs/byte -no-alias-deps -o bin/.simulate.eobjs/byte/dune__exe__Simulate.cmo -c -impl bin/simulate.ml)
 File "bin/simulate.ml", line 192, characters 21-48:
 192 |   include Flow.Make (Tcpip_stack_socket.V4V6.TCP)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Unbound module Tcpip_stack_socket.V4V6
```
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>