### PR TITLE
Package ninja_utils.0.9.0

### DIFF
--- a/packages/ninja_utils/ninja_utils.0.9.0/opam
+++ b/packages/ninja_utils/ninja_utils.0.9.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Small library used to generate Ninja build files"
+description:
+  "This library contains the implementations of utility functions used to generate Ninja build files -- see https://ninja-build.org. It's currently used by the Catala build system (see https://github.com/CatalaLang/catala/tree/master/build_system)"
+maintainer: ["contact@catala-lang.org"]
+authors: ["Emile Rolley"]
+license: "Apache-2.0"
+homepage: "https://github.com/CatalaLang/ninja_utils"
+bug-reports: "https://github.com/CatalaLang/ninja_utils/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.12.0"}
+  "re" {>= "1.10.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CatalaLang/ninja_utils.git"
+url {
+  src:
+    "https://github.com/CatalaLang/ninja_utils/archive/refs/tags/0.9.0.tar.gz"
+  checksum: [
+    "md5=5ff92d56b3ad2e34fd0f23e0fedeb470"
+    "sha512=a0c113a68aacf9cbf8f9570ec4c9ab9263902d34a0b16ff78e67632903a114855d0d2daf48a0ebc1e725ba4d7a49b44111df23ae61840dc47ae9fe2948071818"
+  ]
+}


### PR DESCRIPTION
### `ninja_utils.0.9.0`
Small library used to generate Ninja build files
This library contains the implementations of utility functions used to generate Ninja build files -- see https://ninja-build.org. It's currently used by the Catala build system (see https://github.com/CatalaLang/catala/tree/master/build_system)



---
* Homepage: https://github.com/CatalaLang/ninja_utils
* Source repo: git+https://github.com/CatalaLang/ninja_utils.git
* Bug tracker: https://github.com/CatalaLang/ninja_utils/issues

---
:camel: Pull-request generated by opam-publish v2.2.0