### PR TITLE
[new release] tty (0.0.2)

### DIFF
--- a/packages/tty/tty.0.0.2/opam
+++ b/packages/tty/tty.0.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A library for interacting with teletype and terminal emulators"
+description:
+  "TTY is a library for directly interacting with teletypes and terminal emulators, including escape sequences, colors, and consuming stdin"
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: ["terminal" "ansi" "tty" "teletype" "utf8"]
+homepage: "https://github.com/leostera/tty"
+bug-reports: "https://github.com/leostera/tty/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "5.1"}
+  "uutf" {>= "1.0.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/leostera/tty.git"
+url {
+  src:
+    "https://github.com/leostera/tty/releases/download/0.0.2/tty-0.0.2.tbz"
+  checksum: [
+    "sha256=387d437d3184ee21f3a5716a6e1e6e0737cb3b35aa95359b9748786ba03d1bf5"
+    "sha512=54a7938a4f71678ebd0801071f7dfda0cbc8d019bd43caa570767468310cfa9cae97339514bdae8583045c17f9bac21c4f02a475dbc5d23f5e4fa5ab56da5e46"
+  ]
+}
+x-commit-hash: "2a91614e7f4bc7843f8957f63af72c119efa6980"


### PR DESCRIPTION
A library for interacting with teletype and terminal emulators

- Project page: <a href="https://github.com/leostera/tty">https://github.com/leostera/tty</a>

##### CHANGES:

## 0.0.2

* fix: do not set stdin fd to non-blocking – this caused issues on Mint Tea's
  rendering of many emojis or colored symbols.

* chore: drop dune as a dependency to fix .opam files