### PR TITLE
[new release] tty (0.0.2)

### DIFF
--- a/packages/tty/tty.0.0.2/opam
+++ b/packages/tty/tty.0.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A library for interacting with teletype and terminal emulators"
+description:
+  "TTY is a library for directly interacting with teletypes and terminal emulators, including escape sequences, colors, and consuming stdin"
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: ["terminal" "ansi" "tty" "teletype" "utf8"]
+homepage: "https://github.com/leostera/tty"
+bug-reports: "https://github.com/leostera/tty/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "5.1"}
+  "uutf" {>= "1.0.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/leostera/tty.git"
+url {
+  src:
+    "https://github.com/leostera/tty/releases/download/0.0.2/tty-0.0.2.tbz"
+  checksum: [
+    "sha256=79e0f963efd05d9cc5a041ef392663d90ef857c04ae63dcbbb766cae3d98514b"
+    "sha512=40667f04fe390da339e1b2e818379e0e477486d083a278903a5005d67f406d06d9d65ed4836fe8c69a9e6c1ca9de83f197ba85e2ec53e675e1c2105024268fb3"
+  ]
+}
+x-commit-hash: "d64f98e1ba761b3ac14672a9081da9936ac52931"


### PR DESCRIPTION
A library for interacting with teletype and terminal emulators

- Project page: <a href="https://github.com/leostera/tty">https://github.com/leostera/tty</a>

##### CHANGES:

## 0.0.2

* fix: use select to check for reads, instead of setting the stdin fd to
  non-blocking. This caused issues on Mint Tea's rendering of many emojis or
  colored symbols.

* chore: drop dune as a dependency to fix .opam files