### PR TITLE
Release of Esperanto (v0.0.5)

### DIFF
--- a/packages/aarch64-esperanto/aarch64-esperanto.0.0.5/opam
+++ b/packages/aarch64-esperanto/aarch64-esperanto.0.0.5/opam
@@ -23,5 +23,5 @@ description:
   "An OCaml compiler (toolchain) with Cosmopolitan as the C library"
 url {
   src: "https://github.com/dinosaure/esperanto/releases/download/v0.0.5/esperanto-v0.0.5.tar.gz"
-  checksum: "sha512=477e11c143fd97f8de7246cba8319d8d5113a3f71d0ff6c521f318a1a92c9367d7f63baaa502f01d3796e8f696aa4dcace65097c00c8842da8dcf098fb742691"
+  checksum: "sha512=c1b409de5c7ff4f33d3b280318386060ee8b3d6aa340ec2c3269b1f59e32d9caa395541ebc056d57d888da1445cde800ccf0ba8bb4b0e64950f3cca418bce888"
 }

--- a/packages/aarch64-esperanto/aarch64-esperanto.0.0.5/opam
+++ b/packages/aarch64-esperanto/aarch64-esperanto.0.0.5/opam
@@ -15,7 +15,7 @@ install: ["sh" "-c" "make -C caml install" ]
 depends: [
   "conf-which" {build}
   "ocaml-src" {build}
-  "esperanto-cosmopolitan" {build}
+  "esperanto-cosmopolitan" {= version & build}
   "ocaml" {>= "4.13.0" & < "4.15.0"}
 ]
 synopsis: "An OCaml compiler with Cosmopolitan"

--- a/packages/aarch64-esperanto/aarch64-esperanto.0.0.5/opam
+++ b/packages/aarch64-esperanto/aarch64-esperanto.0.0.5/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage: "https://github.com/dinosaure/esperanto"
+bug-reports: "https://github.com/dinosaure/esperanto/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/dinosaure/esperanto.git"
+build: [
+  ["sh" "-c" "cd caml && ./configure.sh --prefix=%{prefix}% \
+              --target=aarch64-unknown-cosmo" ]
+  ["sh" "-c" "make -C caml -j%{jobs}%"]
+]
+install: ["sh" "-c" "make -C caml install" ]
+depends: [
+  "conf-which" {build}
+  "ocaml-src" {build}
+  "esperanto-cosmopolitan" {build}
+  "ocaml" {>= "4.13.0" & < "4.15.0"}
+]
+synopsis: "An OCaml compiler with Cosmopolitan"
+description:
+  "An OCaml compiler (toolchain) with Cosmopolitan as the C library"
+url {
+  src: "https://github.com/dinosaure/esperanto/releases/download/v0.0.5/esperanto-v0.0.5.tar.gz"
+  checksum: "sha512=477e11c143fd97f8de7246cba8319d8d5113a3f71d0ff6c521f318a1a92c9367d7f63baaa502f01d3796e8f696aa4dcace65097c00c8842da8dcf098fb742691"
+}

--- a/packages/aarch64-esperanto/aarch64-esperanto.0.0.5/opam
+++ b/packages/aarch64-esperanto/aarch64-esperanto.0.0.5/opam
@@ -12,6 +12,7 @@ build: [
   ["sh" "-c" "make -C caml -j%{jobs}%"]
 ]
 install: ["sh" "-c" "make -C caml install" ]
+available: opam-version >= "2.1.0"
 depends: [
   "conf-which" {build}
   "ocaml-src" {build}

--- a/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.5/opam
+++ b/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.5/opam
@@ -22,7 +22,7 @@ depends: [
 ]
 synopsis: "Cosmopolitan toolchain for OCaml compiler"
 description: "A little toolchain for OCaml with Cosmopolitan"
-available: [ arch = "x86_64" & (os = "linux" | os = "freebsd" | os = "openbsd") ]
+available: [ opam-version >= "2.1.0" & arch = "x86_64" & (os = "linux" | os = "freebsd" | os = "openbsd") ]
 url {
   src: "https://github.com/dinosaure/esperanto/releases/download/v0.0.5/esperanto-v0.0.5.tar.gz"
   checksum: "sha512=c1b409de5c7ff4f33d3b280318386060ee8b3d6aa340ec2c3269b1f59e32d9caa395541ebc056d57d888da1445cde800ccf0ba8bb4b0e64950f3cca418bce888"

--- a/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.5/opam
+++ b/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.5/opam
@@ -13,6 +13,7 @@ install: [
   [ make "-C" "toolchain" "PREFIX=%{prefix}%" "install" ]
 ]
 depends: [
+  "ocaml" {>= "4.12.0"}
   "dune"
   "decompress"
   "checkseum"

--- a/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.5/opam
+++ b/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.5/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "decompress" {>= "1.5.3"}
   "checkseum"
-  "digestif"
+  "digestif" {>= "1.0.0"}
 # "conf-binutils"
 ]
 synopsis: "Cosmopolitan toolchain for OCaml compiler"
@@ -25,5 +25,5 @@ description: "A little toolchain for OCaml with Cosmopolitan"
 available: [ arch = "x86_64" & (os = "linux" | os = "freebsd" | os = "openbsd") ]
 url {
   src: "https://github.com/dinosaure/esperanto/releases/download/v0.0.5/esperanto-v0.0.5.tar.gz"
-  checksum: "sha512=477e11c143fd97f8de7246cba8319d8d5113a3f71d0ff6c521f318a1a92c9367d7f63baaa502f01d3796e8f696aa4dcace65097c00c8842da8dcf098fb742691"
+  checksum: "sha512=c1b409de5c7ff4f33d3b280318386060ee8b3d6aa340ec2c3269b1f59e32d9caa395541ebc056d57d888da1445cde800ccf0ba8bb4b0e64950f3cca418bce888"
 }

--- a/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.5/opam
+++ b/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.5/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage: "https://github.com/dinosaure/esperanto"
+bug-reports: "https://github.com/dinosaure/esperanto/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/dinosaure/esperanto.git"
+build: [
+  [ make "-C" "toolchain" ]
+]
+install: [
+  [ make "-C" "toolchain" "PREFIX=%{prefix}%" "install" ]
+]
+depends: [
+  "dune"
+  "decompress"
+  "checkseum"
+  "digestif"
+# "conf-binutils"
+]
+synopsis: "Cosmopolitan toolchain for OCaml compiler"
+description: "A little toolchain for OCaml with Cosmopolitan"
+available: [ arch = "x86_64" & (os = "linux" | os = "freebsd" | os = "openbsd") ]
+url {
+  src: "https://github.com/dinosaure/esperanto/releases/download/v0.0.5/esperanto-v0.0.5.tar.gz"
+  checksum: "sha512=477e11c143fd97f8de7246cba8319d8d5113a3f71d0ff6c521f318a1a92c9367d7f63baaa502f01d3796e8f696aa4dcace65097c00c8842da8dcf098fb742691"
+}

--- a/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.5/opam
+++ b/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.5/opam
@@ -13,9 +13,9 @@ install: [
   [ make "-C" "toolchain" "PREFIX=%{prefix}%" "install" ]
 ]
 depends: [
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.13.0"}
   "dune"
-  "decompress"
+  "decompress" {>= "1.5.3"}
   "checkseum"
   "digestif"
 # "conf-binutils"

--- a/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.5/opam
+++ b/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.5/opam
@@ -14,7 +14,7 @@ install: [
 ]
 depends: [
   "ocaml" {>= "4.13.0"}
-  "dune"
+  "dune" {>= "2.6"}
   "decompress" {>= "1.5.3"}
   "checkseum"
   "digestif" {>= "1.0.0"}

--- a/packages/esperanto/esperanto.0.0.1/opam
+++ b/packages/esperanto/esperanto.0.0.1/opam
@@ -11,6 +11,7 @@ build: [
   [make "-C" "caml" "-j%{jobs}%"]
 ]
 install: [make "-C" "caml" "install"]
+available: os = "linux"
 depends: [
   "conf-which" {build}
   "ocaml-src" {build}

--- a/packages/esperanto/esperanto.0.0.2/opam
+++ b/packages/esperanto/esperanto.0.0.2/opam
@@ -14,7 +14,7 @@ install: [make "-C" "caml" "install" ]
 depends: [
   "conf-which" {build}
   "ocaml-src" {build}
-  "esperanto-cosmopolitan" {build}
+  "esperanto-cosmopolitan" {build & < "0.0.5"}
 #  "cosmopolitan-pth" {build}
   "ocaml" {>= "4.13.0" & < "4.15.0"}
 ]

--- a/packages/esperanto/esperanto.0.0.2/opam
+++ b/packages/esperanto/esperanto.0.0.2/opam
@@ -11,6 +11,7 @@ build: [
   [make "-C" "caml" "-j%{jobs}%"]
 ]
 install: [make "-C" "caml" "install" ]
+available: os = "linux"
 depends: [
   "conf-which" {build}
   "ocaml-src" {build}

--- a/packages/esperanto/esperanto.0.0.3/opam
+++ b/packages/esperanto/esperanto.0.0.3/opam
@@ -14,7 +14,7 @@ install: [make "-C" "caml" "install" ]
 depends: [
   "conf-which" {build}
   "ocaml-src" {build}
-  "esperanto-cosmopolitan" {build}
+  "esperanto-cosmopolitan" {build & < "0.0.5"}
 #  "cosmopolitan-pth" {build}
   "ocaml" {>= "4.13.0" & < "4.15.0"}
 ]

--- a/packages/esperanto/esperanto.0.0.3/opam
+++ b/packages/esperanto/esperanto.0.0.3/opam
@@ -11,6 +11,7 @@ build: [
   [make "-C" "caml" "-j%{jobs}%"]
 ]
 install: [make "-C" "caml" "install" ]
+available: os = "linux"
 depends: [
   "conf-which" {build}
   "ocaml-src" {build}

--- a/packages/esperanto/esperanto.0.0.4/opam
+++ b/packages/esperanto/esperanto.0.0.4/opam
@@ -14,7 +14,7 @@ install: [make "-C" "caml" "install" ]
 depends: [
   "conf-which" {build}
   "ocaml-src" {build}
-  "esperanto-cosmopolitan" {build}
+  "esperanto-cosmopolitan" {build & < "0.0.5"}
 #  "cosmopolitan-pth" {build}
   "ocaml" {>= "4.13.0" & < "4.15.0"}
 ]

--- a/packages/esperanto/esperanto.0.0.4/opam
+++ b/packages/esperanto/esperanto.0.0.4/opam
@@ -11,6 +11,7 @@ build: [
   [make "-C" "caml" "-j%{jobs}%"]
 ]
 install: [make "-C" "caml" "install" ]
+available: os = "linux"
 depends: [
   "conf-which" {build}
   "ocaml-src" {build}

--- a/packages/x86_64-esperanto/x86_64-esperanto.0.0.5/opam
+++ b/packages/x86_64-esperanto/x86_64-esperanto.0.0.5/opam
@@ -23,5 +23,5 @@ description:
   "An OCaml compiler (toolchain) with Cosmopolitan as the C library"
 url {
   src: "https://github.com/dinosaure/esperanto/releases/download/v0.0.5/esperanto-v0.0.5.tar.gz"
-  checksum: "sha512=477e11c143fd97f8de7246cba8319d8d5113a3f71d0ff6c521f318a1a92c9367d7f63baaa502f01d3796e8f696aa4dcace65097c00c8842da8dcf098fb742691"
+  checksum: "sha512=c1b409de5c7ff4f33d3b280318386060ee8b3d6aa340ec2c3269b1f59e32d9caa395541ebc056d57d888da1445cde800ccf0ba8bb4b0e64950f3cca418bce888"
 }

--- a/packages/x86_64-esperanto/x86_64-esperanto.0.0.5/opam
+++ b/packages/x86_64-esperanto/x86_64-esperanto.0.0.5/opam
@@ -15,7 +15,7 @@ install: ["sh" "-c" "make -C caml install" ]
 depends: [
   "conf-which" {build}
   "ocaml-src" {build}
-  "esperanto-cosmopolitan" {build}
+  "esperanto-cosmopolitan" {= version & build}
   "ocaml" {>= "4.13.0" & < "4.15.0"}
 ]
 synopsis: "An OCaml compiler with Cosmopolitan"

--- a/packages/x86_64-esperanto/x86_64-esperanto.0.0.5/opam
+++ b/packages/x86_64-esperanto/x86_64-esperanto.0.0.5/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage: "https://github.com/dinosaure/esperanto"
+bug-reports: "https://github.com/dinosaure/esperanto/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/dinosaure/esperanto.git"
+build: [
+  ["sh" "-c" "cd caml && ./configure.sh --prefix=%{prefix}% \
+              --target=x86_64-unknown-cosmo" ]
+  ["sh" "-c" "make -C caml -j%{jobs}%"]
+]
+install: ["sh" "-c" "make -C caml install" ]
+depends: [
+  "conf-which" {build}
+  "ocaml-src" {build}
+  "esperanto-cosmopolitan" {build}
+  "ocaml" {>= "4.13.0" & < "4.15.0"}
+]
+synopsis: "An OCaml compiler with Cosmopolitan"
+description:
+  "An OCaml compiler (toolchain) with Cosmopolitan as the C library"
+url {
+  src: "https://github.com/dinosaure/esperanto/releases/download/v0.0.5/esperanto-v0.0.5.tar.gz"
+  checksum: "sha512=477e11c143fd97f8de7246cba8319d8d5113a3f71d0ff6c521f318a1a92c9367d7f63baaa502f01d3796e8f696aa4dcace65097c00c8842da8dcf098fb742691"
+}

--- a/packages/x86_64-esperanto/x86_64-esperanto.0.0.5/opam
+++ b/packages/x86_64-esperanto/x86_64-esperanto.0.0.5/opam
@@ -12,6 +12,7 @@ build: [
   ["sh" "-c" "make -C caml -j%{jobs}%"]
 ]
 install: ["sh" "-c" "make -C caml install" ]
+available: opam-version >= "2.1.0"
 depends: [
   "conf-which" {build}
   "ocaml-src" {build}


### PR DESCRIPTION
- Support Cosmopolitan 3.1 (dinosaure/esperanto#43, @dinosaure)
- Fix the compilation of esperanto with setup-ocaml and GitHub CI (dinosaure/esperanto#44, @dinosaure)
- Extend the support of Esperanto to 4.13 (dinosaure/esperanto#45, @dinosaure)