### PR TITLE
Mark ocamlbuild.0.14.3 as not available on Windows

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.14.3/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.14.3/opam
@@ -30,6 +30,7 @@ build: [
   [make "check-if-preinstalled" "all" "opam-install"]
 ]
 dev-repo: "git+https://github.com/ocaml/ocamlbuild.git"
+available: os != "win32"
 url {
   src: "https://github.com/ocaml/ocamlbuild/archive/refs/tags/0.14.3.tar.gz"
   checksum: [


### PR DESCRIPTION
Not sure whether we should immediately update the Windows patched version, given that the fix in 0.14.3 is only for trunk/5.2, but regardless this package doesn't build on Windows.