### PR TITLE
Add new version 3.0 for the E-prover automatic theorem prover

### DIFF
--- a/packages/eprover/eprover.3.0/opam
+++ b/packages/eprover/eprover.3.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+authors: [ "Stephan Schulz" "Simon Cruanes" "Petar Vukmirovic" "Mohamed Bassem" "Martin Moehrmann" ]
+homepage: "https://www.eprover.org"
+license: ["LGPL-2.1-or-later OR GPL-2.0-or-later"]
+dev-repo: "git+https://github.com/eprover/eprover.git"
+bug-reports: "Stephan Schulz (see homepage for email)"
+build: [
+  [ "./configure" "--bindir=%{bin}%" ]
+  [ make "-j" "%{jobs}%" ]
+]
+install: [
+  [ make "install" ]
+]
+depends: [
+  "conf-gcc"
+]
+synopsis: "E Theorem Prover"
+description: "E is a theorem prover for first-order and higher-order logic with equality. It accepts a problem specification, typically consisting of a number of first-order clauses or formulas, and a conjecture, in clausal or full first-order/higher-order form. The system will then try to find a formal proof for the conjecture, assuming the axioms."
+url {
+  # Note: the main author prefers this download link over the also available github tag tarball download and expects that the link is stable over time
+  src: "http://wwwlehre.dhbw-stuttgart.de/~sschulz/WORK/E_DOWNLOAD/V_3.0/E.tgz"
+  checksum: "sha512=a4d90080c400579beb0a1b43ffbcb6d9b1435abb72807b1a51acd6311f975f37204368bdfee1a1c15ea46111cbe7497f9b25a5bf2eed6032b8d47e29455c31e3"
+}


### PR DESCRIPTION
This PR adds the new version 3.0 of the E-prover automatic theorem prover.

The main difference to version 2.6 is the support for higher order logic (2.6 was first order logic only).

E-prover is written in C++, but used by software written in OCaml, notably automation plugins for the Coq theorem prover.