### PR TITLE
ocaml: dev packages for OCaml 5.3

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
-synopsis: "Latest 5.2 development"
+synopsis: "Current trunk"
 maintainer: "platform@lists.ocaml.org"
 authors: [
   "Xavier Leroy"
@@ -14,7 +14,7 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
 depends: [
-  "ocaml" {= "5.2.0" & post}
+  "ocaml" {= "5.3.0" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
@@ -41,7 +41,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--without-zstd" {ocaml-option-no-compression:installed}
     "--enable-tsan" {ocaml-option-tsan:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
     "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
@@ -63,7 +62,7 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/5.2.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 }
 depopts: [
   "ocaml-option-32bit"

--- a/packages/ocaml/ocaml.5.3.0/opam
+++ b/packages/ocaml/ocaml.5.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml-config" {>= "3"}
+  "ocaml-base-compiler" {= "5.3.0"} |
+  "ocaml-variants" {>= "5.3.0~" & < "5.3.1~"} |
+  "ocaml-system" {>= "5.3.0~" & < "5.3.1~"} |
+  "dkml-base-compiler" {>= "5.3.0~" & < "5.3.1~"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build-env: [
+  [CAML_LD_LIBRARY_PATH = ""]
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+flags: conf


### PR DESCRIPTION
With OCaml 5.2 in feature freeze/bug fixing mode, the development package for compiler developers need to switch to version 5.3. Thus this PR creates two packages:

- ocaml.5.3.0 (the metapackage for OCaml 5.3)
- ocaml-variants.5.3.0+trunk (the new latest development package)

and update the package

- ocaml-variants.5.2.0+trunk

to point towards the new 5.2 branch.

