### PR TITLE
[new release] hsluv (0.1.0)

### DIFF
--- a/packages/hsluv/hsluv.0.1.0/opam
+++ b/packages/hsluv/hsluv.0.1.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "HSLuv human-friendly color space implementation in OCaml"
+description: """
+This package implements the HSLuv color space model,
+providing a perceptually uniform alternative to traditional HSL.
+It includes functions for converting between HSLuv/HPLuv
+and other color spaces like RGB, XYZ, LCH, and LUV, as well as hexadecimal
+color representation."""
+maintainer: ["Sabine Schmaltz"]
+authors: ["Sabine Schmaltz"]
+license: "MIT"
+tags: [
+  "color"
+  "hsluv"
+  "hpluv"
+  "rgb"
+  "xyz"
+  "lch"
+  "luv"
+  "color space"
+  "color conversion"
+  "perceptually uniform colors"
+]
+homepage: "https://github.com/sabine/hsluv-ocaml"
+bug-reports: "https://github.com/sabine/hsluv-ocaml/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.7"}
+  "yojson" {with-test}
+  "ppx_yojson_conv" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sabine/hsluv-ocaml.git"
+url {
+  src:
+    "https://github.com/sabine/hsluv-ocaml/releases/download/0.1.0/hsluv-0.1.0.tbz"
+  checksum: [
+    "sha256=9eb31d2b6881d19a36d5ec41ccd12b146f9b313bbc44abcc24259ab0d73a314a"
+    "sha512=c1f444deb8566e18a1b000fec2033c64eaa32606d7c2a990654c6f651946b508fe730f21c64fd3380e1dced6ad374ae8f6700a0f55c193a2e646a3345a9a4e72"
+  ]
+}
+x-commit-hash: "7ede0394c9135445b2a611fb6c6a0e4de4ba7697"


### PR DESCRIPTION
First release.

Provides:
- record types for the different color spaces (HSLuv, HPLuv, RGB, XYZ, LCH, LUV)
- HSLuv and HPLuv color conversion functions
- color conversion functions between some of the other color spaces used to enable the HSLuv and HPluv conversions
- pretty printers for all provided color types
- a library `hsluv.float_conv` for conversions between float triples and the provided color types
- tests against the HSLuv reference (revision 4)