### PR TITLE
[new release] multicore-magic (2.1.0)

### DIFF
--- a/packages/multicore-magic/multicore-magic.2.1.0/opam
+++ b/packages/multicore-magic/multicore-magic.2.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Low-level multicore utilities for OCaml"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-magic"
+bug-reports: "https://github.com/ocaml-multicore/multicore-magic/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.12.0"}
+  "domain_shims" {>= "0.1.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {>= "2.2.0" & with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-magic.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-magic/releases/download/2.1.0/multicore-magic-2.1.0.tbz"
+  checksum: [
+    "sha256=24ff4364730b403270f23407f7f6f9dc8111987ed468592e2ed70ad937705144"
+    "sha512=82f4a14d30c4b81304ba8bc5d7c7cb172c80fef765b96ea478c6a2258382c4e527777d9fc4b30e0254a7ffbe8d43f1d8ab807f4455baeecfc9de8d60c71ed27a"
+  ]
+}
+x-commit-hash: "a97296b82cee3f5a0f2f285e6542ffd565716a05"


### PR DESCRIPTION
Low-level multicore utilities for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/multicore-magic">https://github.com/ocaml-multicore/multicore-magic</a>

## 2.1.0

- Added `instantaneous_domain_index` for the implementation of contention
  avoiding data structures. (@polytypic)
- Added `Transparent_atomic` module as a workaround to CSE issues in OCaml 5.0
  and OCaml 5.1 and also to allow more efficient arrays of atomics. (@polytypic)
- Fixed `fenceless_get` to not be subject to CSE. (@polytypic)
