### PR TITLE
[new release] castore (0.0.1)

### DIFF
--- a/packages/castore/castore.0.0.1/opam
+++ b/packages/castore/castore.0.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A portable CA Store with a global .crt and .pem files"
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: ["https" "tls" "cert" "crt" "pem" "ca" "ca store"]
+homepage: "https://github.com/leostera/castore"
+bug-reports: "https://github.com/leostera/castore/issues"
+depends: [
+  "ocaml" {>= "5.1"}
+  "dune" {>= "3.11"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/leostera/castore.git"
+url {
+  src:
+    "https://github.com/leostera/castore/releases/download/0.0.1/castore-0.0.1.tbz"
+  checksum: [
+    "sha256=881ab402b92a8bcfe56d0c2083962e3a1ec8fd250ca18e60e9ce1ff2b19b67e1"
+    "sha512=2d6fecf03bcd2baf445e1b9d00dd7b957d32c73a5f2bd8377055f851a27c493fe1c5a02df03ffc23f1672f062dd7ce96998556bf662a98b3e820b2967a5bb8a0"
+  ]
+}
+x-commit-hash: "b825cdaad2178267c94a8d81eb74d57909b196ca"


### PR DESCRIPTION
A portable CA Store with a global .crt and .pem files

- Project page: <a href="https://github.com/leostera/castore">https://github.com/leostera/castore</a>

##### CHANGES:

## 0.0.1

Initial release of CAStore including a PEM file generated on Dec 12.
