### PR TITLE
[new release] riot (0.0.7)

### DIFF
--- a/packages/riot/riot.0.0.7/opam
+++ b/packages/riot/riot.0.0.7/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "An actor-model multi-core scheduler for OCaml 5"
+description:
+  "Riot is an actor-model multi-core scheduler for OCaml 5. It brings Erlang-style concurrency to the language, where lighweight process communicate via message passing"
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: ["multicore" "erlang" "actor" "message-passing" "processes"]
+homepage: "https://github.com/leostera/riot"
+bug-reports: "https://github.com/leostera/riot/issues"
+depends: [
+  "cstruct" {>= "6.2.0"}
+  "mdx" {with-test & >= "2.3.1"}
+  "ocaml" {>= "5.1"}
+  "odoc" {with-doc & >= "2.2.2"}
+  "poll" {>= "0.3.1"}
+  "ptime" {>= "1.1.0"}
+  "telemetry" {>= "0.0.1"}
+  "uri" {>= "4.4.0"}
+  "dune" {>= "3.11"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/leostera/riot.git"
+url {
+  src:
+    "https://github.com/leostera/riot/releases/download/0.0.7/riot-0.0.7.tbz"
+  checksum: [
+    "sha256=b7e3cc061e2b6578bcd9d5258efde72f3657e68d626a005b43d15f1a7aff769e"
+    "sha512=00dcd34cce21058137cca15229a81e0e2c898f9877f22db6903288c8f757847a65965cfe791f84fe251df342f90e7e4aefe04f2fbb6ba282ad45b1a3b979e6cf"
+  ]
+}
+x-commit-hash: "7dc78950b5dc172aef74bacee977abd2011005d2"


### PR DESCRIPTION
An actor-model multi-core scheduler for OCaml 5

- Project page: <a href="https://github.com/leostera/riot">https://github.com/leostera/riot</a>

##### CHANGES:

## 0.0.7

* Introduce IO module with low-level IO operations such as performing direct
  vectorized (or regular) reads/writes. New operations include:
  * `read`, `write`
  * `single_read`, `single_write` (vectorized)
  * `await_readable`, `await_writeable`, `await`
  * `write_all`
  * `copy` and `copy_buffered`

* Introduce Buffer module with support for converting from and to CStruct and
  String, including position tracking.

* Introduce Read/Reader interface for creating buffered and unbuffered readers
  of arbitrary sources.

* Introduce Write/Writer interfaces for creating unbuffered writers into
  arbitrary destinations/sinks.

* Introduce File module with Reader and Writer implementations

* Implment Reader and Writer interfaces for Net.Socket

* Dropped dependency on Bigstringaf and moved to Cstruct

* Fix max number of domains to always be under the recommended domain count

* Fix issue with tests where the runtime idled after the main would die. Now
  the main process finishing with an exception is considered reason enough to
  shutdown the system.

* Refactor tests to always output `test_name: OK` when everything is fine and
  all modules to end in `_test`.

* Add several IO tests.


## 0.0.6 (included since we didn't publish 0.0.6)

* Redo packaging to expose a single public library: `riot`
* Fix issue with schedulers busy-waiting
* Introduce separate IO Schedulers for polling
* Switch to `poll` to support kqueue on macOS
* Reuse read-buffers on Io.read loops
* Broaden IO socket types to file descriptors
* Improved polling with shorter poll timeouts and safety checks
* Add `Dashmap.iter` to iterate over a collection
* Add `net_test` with an echo tcp server/client
* Fix bugs with syscall suspension that was introduced with reduction counting