### PR TITLE
[new release] castore (0.0.2)

### DIFF
--- a/packages/castore/castore.0.0.2/opam
+++ b/packages/castore/castore.0.0.2/opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/leostera/castore/issues"
 depends: [
   "ocaml" {>= "5.1"}
   "dune" {>= "3.11"}
+  "x509" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/castore/castore.0.0.2/opam
+++ b/packages/castore/castore.0.0.2/opam
@@ -10,6 +10,7 @@ depends: [
   "ocaml" {>= "5.1"}
   "dune" {>= "3.11"}
   "x509" {with-test}
+  "mdx" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/castore/castore.0.0.2/opam
+++ b/packages/castore/castore.0.0.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A portable CA Store with a global .crt and .pem files"
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: ["https" "tls" "cert" "crt" "pem" "ca" "ca store"]
+homepage: "https://github.com/leostera/castore"
+bug-reports: "https://github.com/leostera/castore/issues"
+depends: [
+  "ocaml" {>= "5.1"}
+  "dune" {>= "3.11"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/leostera/castore.git"
+url {
+  src:
+    "https://github.com/leostera/castore/releases/download/0.0.2/castore-0.0.2.tbz"
+  checksum: [
+    "sha256=8d1d399085f733b6b822a8bc059bae6d72459377cbfce4d1a6c8bb1001258b3e"
+    "sha512=2c92e6e1ed62dcd872f3ec48d247e987e81d6b39600e6901e2300410dc7df8a0395d8c7d8ad803f5733f1333ae61299d30cb42bdad3ec86910dc651013ec1ddc"
+  ]
+}
+x-commit-hash: "0fa5d9e364c40a830642dbf0ad27da1db66e004e"


### PR DESCRIPTION
A portable CA Store with a global .crt and .pem files

- Project page: <a href="https://github.com/leostera/castore">https://github.com/leostera/castore</a>

##### CHANGES:

## 0.0.2

This release pre-processes the .pem file into a list of pem certificate strings
that can be easily parsed with `X509` to build chains of trust.

You can access the whole pem file on `Ca_store.pem` and the individual
certificates in the `Ca_store.certificates` list.
