### PR TITLE
[new release] fit (1.2.0)

### DIFF
--- a/packages/fit/fit.1.2.0/opam
+++ b/packages/fit/fit.1.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A parser for Garmin FIT data files"
+description: """
+Fit is library for reading FIT files as they are produced by Garmin and
+other fitness devices. It comes with a small command-line tool to emit
+some of that information as JSON, mostly for debugging. Fit is not
+comprehensive but reads the most important records from a FIT file that
+contains the actual periodic measurements."""
+maintainer: ["Christian Lindig <lindig@gmail.com>"]
+authors: ["Christian Lindig <lindig@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/lindig/fit"
+bug-reports: "https://github.com/lindig/fit/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "cmdliner" {>= "1.1.0"}
+  "angstrom" {>= "0.15.0"}
+  "yojson" {>= "2.1.0"}
+  "rresult" {>= "0.6.0"}
+  "ptime" {>= "1.1.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lindig/fit.git"
+url {
+  src: "https://github.com/lindig/fit/releases/download/1.2.0/fit-1.2.0.tbz"
+  checksum: [
+    "sha256=171f88b6ee5fecfb8c0159da9f21692aba9881415a1e41a8a65392080516ff51"
+    "sha512=2826e072ad7fb5cc768c30c2f1ae64e9a7a8008b8b054690f9bbb281c5b833e6d521a4a44f7b8109f37edcf948dcdccb096b374d728cb9fe86298ee6b7df9311"
+  ]
+}
+x-commit-hash: "b137108cc40fa1695fda363baa8c8bd1db07075b"

--- a/packages/fit/fit.1.2.0/opam
+++ b/packages/fit/fit.1.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ptime" {>= "1.1.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/fit/fit.1.2.0/opam
+++ b/packages/fit/fit.1.2.0/opam
@@ -34,6 +34,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: arch != "x86_32" & arch != "arm32"
 dev-repo: "git+https://github.com/lindig/fit.git"
 url {
   src: "https://github.com/lindig/fit/releases/download/1.2.0/fit-1.2.0.tbz"


### PR DESCRIPTION
CHANGES:

* Replace Ezjsonm with Yojson, which is more widely used
* Replace ISO8601 with Ptime