### PR TITLE
Add conf-scdoc package

### DIFF
--- a/packages/conf-scdoc/conf-scdoc.1/opam
+++ b/packages/conf-scdoc/conf-scdoc.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+authors: "lthms@soap.coffee"
+maintainer: "lthms@soap.coffee"
+homepage: "https://git.sr.ht/~sircmpwn/scdoc"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "MIT"
+build: ["scdoc" "-v"]
+depexts: [
+  ["scdoc"] {os-family = "arch" | os-family = "archlinux"}
+  ["scdoc"] {os-family = "debian"}
+  ["scdoc"] {os-family = "ubuntu"}
+  ["scdoc"] {os-distribution = "fedora"}
+  ["scdoc"] {os-distribution = "nixos"}
+  ["scdoc"] {os-distribution = "alpine"}
+  ["scdoc"] {os-family = "suse" | os-family = "opensuse"}
+  ["scdoc"] {os = "macos" & os-distribution = "homebrew"}
+  ["scdoc"] {os = "macos" & os-distribution = "macports"}
+]
+synopsis: "Virtual package to install scdoc"
+description:
+  "This package will install a system scdoc if invoked via `opam depext`"
+flags: conf


### PR DESCRIPTION
Hi, dear opam-repository maintainers!

In preparation for adding [Spatial Shell](/lthms/spatial-shell) to Opam, I’d like to propose to add a conf package for [scdoc](https://git.sr.ht/~sircmpwn/scdoc). scdoc is a very convenient way to write man pages (basically, it’s a ad-hoc markdown specifically for this purpose). I’m using it for the man pages of Spatial Shell (and it’s called by `dune`).

Links to the packages:

- [Archlinux](https://archlinux.org/packages/extra/x86_64/scdoc/)
- [Debian](https://packages.debian.org/source/scdoc)
- [Ubunta](https://packages.ubuntu.com/search?keywords=scdoc)
- [Fedora](https://packages.fedoraproject.org/pkgs/scdoc/)
- [NixOS](https://search.nixos.org/packages?channel=23.11&show=scdoc&from=0&size=50&sort=relevance&type=packages&query=scdoc)
- [Alpine](https://pkgs.alpinelinux.org/package/edge/main/armv7/scdoc)
- [OpenSUSE](https://software.opensuse.org/package/scdoc)
- [Homebrew](https://formulae.brew.sh/formula/scdoc)
- [MacPorts](https://ports.macports.org/port/scdoc/details/)

Let me know what you think! :)