### PR TITLE
Package coq-waterproof.2.1.1+8.18

### DIFF
--- a/packages/coq-waterproof/coq-waterproof.2.1.1+8.18/opam
+++ b/packages/coq-waterproof/coq-waterproof.2.1.1+8.18/opam
@@ -28,11 +28,7 @@ depends: [
 ]
 
 build: [
-  ["dune" "build" "-p" "coq-waterproof" "@install"]
-]
-
-install: [
-  ["dune" "install" "-p" "coq-waterproof"]
+  ["dune" "build" "-p" name "-j" jobs "@install"]
 ]
 
 available: arch != "s390x"

--- a/packages/coq-waterproof/coq-waterproof.2.1.1+8.18/opam
+++ b/packages/coq-waterproof/coq-waterproof.2.1.1+8.18/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "Jim Portegies <j.w.portegies@tue.nl>"
+authors: [
+  "Jelle Wemmenhove"
+  "Balthazar Pathiachvili"
+  "Cosmin Manea"
+  "Lulof Pirée"
+  "Adrian Vrămuleţ"
+  "Tudor Voicu"
+  "Jim Portegies <j.w.portegies@tue.nl>"
+]
+
+synopsis: "Coq proofs in a style that resembles non-mechanized mathematical proofs"
+description: """
+The coq-waterproof library allows you to write Coq proofs in a style that resembles non-mechanized mathematical proofs.
+Mathematicians unfamiliar with the Coq syntax are able to read the resulting proof scripts.
+"""
+
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/impermeable/coq-waterproof"
+dev-repo: "git+https://github.com/impermeable/coq-waterproof.git"
+bug-reports: "https://github.com/impermeable/coq-waterproof/issues"
+
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "coq" {>= "8.18" & < "8.19"}
+  "dune" {>= "3.6."}
+]
+
+build: [
+  ["dune" "build" "-p" "coq-waterproof" "@install"]
+]
+
+install: [
+  ["dune" "install" "-p" "coq-waterproof"]
+]
+
+available: arch != "s390x"
+
+tags: [
+  "keyword:mathematics education"
+  "category:Mathematics/Education"
+  "date:2023-11-04"
+  "logpath:Waterproof"
+]
+url {
+  src:
+    "https://github.com/impermeable/coq-waterproof/archive/refs/tags/2.1.1+8.18.tar.gz"
+  checksum: [
+    "md5=a7d2922fb4ed7f0b8fe38074319890fe"
+    "sha512=3c511d066ba324cf19fc5620ae89ad09796f3a04576012739783100487dd8d50214edab9bdfc85d581d6538e601511f4563b90ad1dc3041e60a9702f4875e31d"
+  ]
+}


### PR DESCRIPTION
### `coq-waterproof.2.1.1+8.18`
Coq proofs in a style that resembles non-mechanized mathematical proofs
The coq-waterproof library allows you to write Coq proofs in a style that resembles non-mechanized mathematical proofs.
Mathematicians unfamiliar with the Coq syntax are able to read the resulting proof scripts.



---
* Homepage: https://github.com/impermeable/coq-waterproof
* Source repo: git+https://github.com/impermeable/coq-waterproof.git
* Bug tracker: https://github.com/impermeable/coq-waterproof/issues

---
:camel: Pull-request generated by opam-publish v2.2.0