### PR TITLE
[new release] ezjsonm-encoding (1.0.0)

### DIFF
--- a/packages/ezjsonm-encoding/ezjsonm-encoding.1.0.0/opam
+++ b/packages/ezjsonm-encoding/ezjsonm-encoding.1.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Encoding combinators a la Data_encoding for Ezjsonm"
+maintainer: ["Thomas Letan <lthms@soap.coffee>"]
+authors: ["Thomas Letan <lthms@soap.coffee>"]
+license: "mpl-2.0"
+homepage: "https://github.com/lthms/ezjsonm-encoding"
+bug-reports: "https://github.com/lthms/ezjsonm-encoding/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.8.0"}
+  "ezjsonm" {>= "1.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lthms/ezjsonm-encoding.git"
+url {
+  src:
+    "https://github.com/lthms/ezjsonm-encoding/releases/download/1.0.0/ezjsonm-encoding-1.0.0.tbz"
+  checksum: [
+    "sha256=6d998916ff393d8cf36b00d1603c1088cb54b35b80b1a6e4e1e6edcbc474911a"
+    "sha512=74f8bf558898e43d3f29395b004aeee16c8f348bfe2be7c20ff3efbfdcc3d3bda8938154240a07ccc9ab24cd6d10feabdb46ff9954cf191baffbaad36ff77b43"
+  ]
+}
+x-commit-hash: "567a0d853ec1622155e9ce444ec0e0273ea3b29e"


### PR DESCRIPTION
Encoding combinators a la Data_encoding for Ezjsonm

- Project page: <a href="https://github.com/lthms/ezjsonm-encoding">https://github.com/lthms/ezjsonm-encoding</a>

##### CHANGES:

Extract the `jsoner` private library from the [Spatial Shell
repository](https://github.com/lthms/spatial-shell) and turn it into
a standalone library named `ezjsonm-encoding`.
