### PR TITLE
Package SZXX.4.1.2

### DIFF
--- a/packages/SZXX/SZXX.4.1.2/opam
+++ b/packages/SZXX/SZXX.4.1.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Asemio"
+authors: [
+  "Simon Grondin"
+]
+synopsis: "Streaming ZIP XML XLSX parser"
+description: """
+SZXX is a streaming and efficient XLSX, ZIP and XML parser built from the ground up for low and constant memory usage (<10Mb).
+SZXX is able to output XLSX rows while reading from a network socket without buffering any part of the file.
+It can also stream data (including network sockets) out of ZIP and XML files without buffering.
+"""
+license: "MIT"
+tags: ["XLSX" "Excel" "ZIP" "XML" "spreadsheet" "Stream" "Streaming"]
+homepage: "https://github.com/asemio/SZXX"
+dev-repo: "git://github.com/asemio/SZXX"
+doc: "https://github.com/asemio/SZXX"
+bug-reports: "https://github.com/asemio/SZXX/issues"
+depends: [
+  "ocaml" { >= "5.0.0" }
+  "dune" { >= "1.9.0" }
+
+  "angstrom" { >= "0.15.0" }
+  "base" { >= "v0.16.0" }
+  "ppx_sexp_conv" { >= "v0.16.0" }
+  "ppx_compare" { >= "v0.16.0" }
+  "ppx_custom_printf" { >= "v0.16.0" }
+  "decompress" { >= "1.4.1" }
+  "eio_main" { >= "0.12" }
+  "ptime" { >= "0.8.6" }
+
+  "alcotest" { with-test }
+  "yojson" { with-test }
+  "ppx_deriving_yojson" { >= "3.5.2" & with-test }
+  # "ocamlformat" { = "0.25.1" } # Development
+  # "ocaml-lsp-server" # Development
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/asemio/SZXX/archive/refs/tags/4.1.2.tar.gz"
+  checksum: [
+    "md5=c3955b2d1a41091789c87ff298797115"
+    "sha512=954855e8c31cbe5aa3650b5154578394bf33482ae4763be5ffef6d9821c72530c28735b835b51e1092e9640ccfe09beb04b3896619e0942cb226a00edfc0deaf"
+  ]
+}


### PR DESCRIPTION
### `SZXX.4.1.2`
Streaming ZIP XML XLSX parser
SZXX is a streaming and efficient XLSX, ZIP and XML parser built from the ground up for low and constant memory usage (<10Mb).
SZXX is able to output XLSX rows while reading from a network socket without buffering any part of the file.
It can also stream data (including network sockets) out of ZIP and XML files without buffering.



---
* Homepage: https://github.com/asemio/SZXX
* Source repo: git://github.com/asemio/SZXX
* Bug tracker: https://github.com/asemio/SZXX/issues

---
:camel: Pull-request generated by opam-publish v2.2.0