### PR TITLE
Package SZXX.3.0.3

### DIFF
--- a/packages/SZXX/SZXX.3.0.3/opam
+++ b/packages/SZXX/SZXX.3.0.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Asemio"
+authors: [
+  "Simon Grondin"
+]
+synopsis: "Streaming ZIP XML XLSX parser"
+description: """
+SZXX is a streaming, non-seeking and efficient XLSX parser built from ground up for low memory usage.
+SZXX is able to output XLSX rows while a file is being read from the file descriptor without buffering any part of the file.
+It can also stream data out of ZIP files and XML files without buffering.
+"""
+license: "MIT"
+tags: ["Stream" "ZIP" "XML" "XLSX"]
+homepage: "https://github.com/asemio/SZXX"
+dev-repo: "git://github.com/asemio/SZXX"
+doc: "https://github.com/asemio/SZXX"
+bug-reports: "https://github.com/asemio/SZXX/issues"
+depends: [
+  "ocaml" { >= "4.10.0" }
+  "dune" { >= "1.9.0" }
+
+  "angstrom" { >= "0.15.0" }
+  "core" { >= "v0.15.0" & < "v0.17.0" }
+  "decompress" { >= "1.4.1" }
+  "lwt" { >= "5.3.0" }
+
+  "alcotest-lwt" { with-test }
+  "angstrom-lwt-unix" { >= "0.15.0" & with-test }
+  "yojson" { with-test }
+  "ppx_deriving_yojson" { >= "3.5.2" & with-test }
+  # "ocamlformat" { = "0.21.0" } # Development
+  # "ocaml-lsp-server" # Development
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/asemio/SZXX/archive/refs/tags/3.0.3.tar.gz"
+  checksum: [
+    "md5=154e31d6d022768eb30f051f8f4dd2df"
+    "sha512=61b16a91f19cdced8ef04f483b2f51bea488a88dec6c1d40d8a9f0bc5372103be0c58fe757d84b27aa3bd096ba79982dd936242f7a72497a762a732dd0107082"
+  ]
+}


### PR DESCRIPTION
### `SZXX.3.0.3`
Streaming ZIP XML XLSX parser
SZXX is a streaming, non-seeking and efficient XLSX parser built from ground up for low memory usage.
SZXX is able to output XLSX rows while a file is being read from the file descriptor without buffering any part of the file.
It can also stream data out of ZIP files and XML files without buffering.



---
* Homepage: https://github.com/asemio/SZXX
* Source repo: git://github.com/asemio/SZXX
* Bug tracker: https://github.com/asemio/SZXX/issues

---
:camel: Pull-request generated by opam-publish v2.2.0