### PR TITLE
[new release] mjson (0.2.1)

### DIFF
--- a/packages/mjson/mjson.0.2.1/opam
+++ b/packages/mjson/mjson.0.2.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis:
+  "Composable, applicative and monadic DSL for decoding Yojson values"
+description:
+  "Composable, applicative and monadic DSL for decoding Yojson values"
+maintainer: ["Marco Schneider <marco.schneider@posteo.de>"]
+authors: ["Marco Schneider <marco.schneider@posteo.de"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/neshtea/mjson"
+bug-reports: "https://github.com/neshtea/mjson/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.11" & >= "3.11"}
+  "yojson" {>= "2.0.0"}
+  "alcotest"
+  "ppx_deriving"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/neshtea/mjson.git"
+url {
+  src:
+    "https://github.com/neshtea/mjson/releases/download/0.2.1/mjson-0.2.1.tbz"
+  checksum: [
+    "sha256=894754a6d9e144bdae088db09d4d8b6d5e534c3b567fdf1f2ddf56f0c398d236"
+    "sha512=9fd065c037049d21161d19b7fe7350e1495e834263a55e0a0c727ae47733d22a88f55fb8377c9a5385ba82a326b0b55d4ea48bc2bf3d707ff3c36983f8224099"
+  ]
+}
+x-commit-hash: "31aac6947d0ff50bf6bdf9e3347e182c52ccf3c6"


### PR DESCRIPTION
Composable, applicative and monadic DSL for decoding Yojson values

- Project page: <a href="https://github.com/neshtea/mjson">https://github.com/neshtea/mjson</a>

##### CHANGES:

### Changed
- added a lower version bound (>= 4.14.0) on the ocaml version
