### PR TITLE
Package docker_hub.0.2.0

### DIFF
--- a/packages/docker_hub/docker_hub.0.2.0/opam
+++ b/packages/docker_hub/docker_hub.0.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Library aiming to provide data from hub.docker.com"
+maintainer: "Kate <kit-ty-kate@outlook.com>"
+authors: "Kate <kit-ty-kate@outlook.com>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/ocaml-docker-hub"
+doc: "https://kit-ty-kate.github.io/ocaml-docker-hub/"
+bug-reports: "https://github.com/kit-ty-kate/ocaml-docker-hub/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "2.0"}
+  "http-lwt-client" {>= "0.2.0"}
+  "lwt" {>= "2.0.0"}
+  "yojson" {>= "1.6.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/ocaml-docker-hub.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/ocaml-docker-hub/releases/download/v0.2.0/docker_hub-0.2.0.tar.gz"
+  checksum: [
+    "md5=4c3cef442a6801c8d8041a5a9ddfe92a"
+    "sha512=df09e2375670a177da2cc5539670223919edd70bb2b5b474e192d1d5a003f8d389f3195908e8398024397ff757f73b1aedb7b3e3b334a5ee818650caad199da6"
+  ]
+}

--- a/packages/docker_hub/docker_hub.0.2.0/opam
+++ b/packages/docker_hub/docker_hub.0.2.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/kit-ty-kate/ocaml-docker-hub"
 doc: "https://kit-ty-kate.github.io/ocaml-docker-hub/"
 bug-reports: "https://github.com/kit-ty-kate/ocaml-docker-hub/issues"
 depends: [
-  "ocaml" {>= "4.10"}
+  "ocaml" {>= "4.13"}
   "dune" {>= "2.0"}
   "http-lwt-client" {>= "0.2.0"}
   "lwt" {>= "2.0.0"}


### PR DESCRIPTION
### `docker_hub.0.2.0`
Library aiming to provide data from hub.docker.com



---
* Homepage: https://github.com/kit-ty-kate/ocaml-docker-hub
* Source repo: git+https://github.com/kit-ty-kate/ocaml-docker-hub.git
* Bug tracker: https://github.com/kit-ty-kate/ocaml-docker-hub/issues

---
:camel: Pull-request generated by opam-publish v2.3.0