### PR TITLE
Package tablecloth-base.0.0.8

### DIFF
--- a/packages/tablecloth-base/tablecloth-base.0.0.8/opam
+++ b/packages/tablecloth-base/tablecloth-base.0.0.8/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml and Rescript"
+description: """
+Tablecloth is an ergonomic, cross-platform, standard library for use with OCaml and Rescript. It provides an easy-to-use, comprehensive and performant standard library, that has the same API on in OCaml and Rescript.
+"""
+maintainer: "Paul Biggar <paul@darklang.com>"
+authors: [
+  "Paul Biggar <paul@darklang.com>"
+  "Dean Merchant <deanmerchant@gmail.com>"
+  "Pomin Wu <pomin.wu@proton.me>"
+]
+license: "MIT with some exceptions"
+homepage: "hhttps://github.com/darklang/tablecloth-ocaml-base"
+bug-reports: "https://github.com/darklang/tablecloth-ocaml-base/issues"
+dev-repo: "git://github.com/darklang/tablecloth-ocaml-base"
+depends: [ "ocaml" {>= "4.08" < "4.15" } "dune" {build} "base" { >= "v0.12.0" & < "v0.15.0" } ]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src:
+    "https://github.com/darklang/tablecloth-ocaml-base/archive/refs/tags/0.0.8.tar.gz"
+  checksum: [
+    "md5=203760cdb3cb1ab7f7506b9eb6f91925"
+    "sha512=78692915001b44189b201c24524960254bfb5c8c39de677e8737ad29300577bad0f5a47936d67da62df856565cb300d586259597feaf256c418a52a2944421ec"
+  ]
+}


### PR DESCRIPTION
### `tablecloth-base.0.0.8`
Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml and Rescript
Tablecloth is an ergonomic, cross-platform, standard library for use with OCaml and Rescript. It provides an easy-to-use, comprehensive and performant standard library, that has the same API on in OCaml and Rescript.



---
* Homepage: hhttps://github.com/darklang/tablecloth-ocaml-base
* Source repo: git://github.com/darklang/tablecloth-ocaml-base
* Bug tracker: https://github.com/darklang/tablecloth-ocaml-base/issues

---
:camel: Pull-request generated by opam-publish v2.2.0