### PR TITLE
Package tablecloth-base.0.0.8

### DIFF
--- a/packages/tablecloth-base/tablecloth-base.0.0.8/opam
+++ b/packages/tablecloth-base/tablecloth-base.0.0.8/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml and Rescript"
+description: """
+Tablecloth is an ergonomic, cross-platform, standard library for use with OCaml and Rescript. It provides an easy-to-use, comprehensive and performant standard library, that has the same API on in OCaml and Rescript.
+"""
+maintainer: "Paul Biggar <paul@darklang.com>"
+authors: [
+  "Paul Biggar <paul@darklang.com>"
+  "Dean Merchant <deanmerchant@gmail.com>"
+  "Pomin Wu <pomin.wu@proton.me>"
+]
+license: "MIT with some exceptions"
+homepage: "hhttps://github.com/darklang/tablecloth-ocaml-base"
+bug-reports: "https://github.com/darklang/tablecloth-ocaml-base/issues"
+dev-repo: "git://github.com/darklang/tablecloth-ocaml-base"
+depends: [ "ocaml" {>= "4.08" < "4.15" } "dune" {build} "base" { >= "v0.12.0" & < "v0.15.0" } ]
+build: ["dune" "build" "-p" name "-j" jobs]
+conflicts: [ "tablecloth-native" {!= "transition"} ]
+url {
+  src:
+    "https://github.com/darklang/tablecloth-ocaml-base/archive/refs/tags/0.0.8.tar.gz"
+  checksum: [
+    "md5=bba3721fe7db606b594f3b45f97a0a41"
+    "sha512=e87b76355cb88a816c21a4f8ba086886a6897453c1ea3e24f52453cf87d019f3c8b03bb18703efbab852cf47aa495049da30deb1d4316b06bd70bb8e16d8ac4e"
+  ]
+}


### PR DESCRIPTION
### `tablecloth-base.0.0.8`
Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml and Rescript
Tablecloth is an ergonomic, cross-platform, standard library for use with OCaml and Rescript. It provides an easy-to-use, comprehensive and performant standard library, that has the same API on in OCaml and Rescript.



---
* Homepage: hhttps://github.com/darklang/tablecloth-ocaml-base
* Source repo: git://github.com/darklang/tablecloth-ocaml-base
* Bug tracker: https://github.com/darklang/tablecloth-ocaml-base/issues

---
:camel: Pull-request generated by opam-publish v2.2.0