### PR TITLE
Transition package tablecloth-native.transition

### DIFF
--- a/packages/tablecloth-native/tablecloth-native.transition/opam
+++ b/packages/tablecloth-native/tablecloth-native.transition/opam
@@ -1,0 +1,16 @@
+opam-version: "2.0"
+synopsis: "Transitional package for tablecloth-native (renaming)"
+maintainer: "Paul Biggar <paul@darklang.com>"
+authors: [
+  "Paul Biggar <paul@darklang.com>"
+  "Dean Merchant <deanmerchant@gmail.com>"
+  "Pomin Wu <pomin.wu@proton.me>"
+]
+license: "MIT"
+homepage: "https://github.com/darklang/tablecloth-ocaml-base"
+bug-reports: "https://github.com/darklang/tablecloth-ocaml-base/issues"
+dev-repo: "git://github.com/darklang/tablecloth-ocaml-base"
+depends: [ "ocaml" "tablecloth-base" ]
+post-messages: [
+  "tablecloth-native has been renamed and the tablecloth-native package is now a transition package.  Use the tablecloth-base package instead."
+]


### PR DESCRIPTION
- Rename tablecloth-native to tablecloth-base
- New package published in https://github.com/ocaml/opam-repository/pull/25032