### PR TITLE
Package SZXX.3.0.4

### DIFF
--- a/packages/SZXX/SZXX.3.0.4/opam
+++ b/packages/SZXX/SZXX.3.0.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Asemio"
+authors: [
+  "Simon Grondin"
+]
+synopsis: "Streaming ZIP XML XLSX parser"
+description: """
+SZXX is a streaming, non-seeking and efficient XLSX parser built from ground up for low memory usage.
+SZXX is able to output XLSX rows while a file is being read from the file descriptor without buffering any part of the file.
+It can also stream data out of ZIP files and XML files without buffering.
+"""
+license: "MIT"
+tags: ["Stream" "ZIP" "XML" "XLSX"]
+homepage: "https://github.com/asemio/SZXX"
+dev-repo: "git://github.com/asemio/SZXX"
+doc: "https://github.com/asemio/SZXX"
+bug-reports: "https://github.com/asemio/SZXX/issues"
+depends: [
+  "ocaml" { >= "4.10.0" }
+  "dune" { >= "1.9.0" }
+
+  "angstrom" { >= "0.15.0" }
+  "core" { >= "v0.15.0" & < "v0.17.0" }
+  "decompress" { >= "1.4.1" }
+  "lwt" { >= "5.3.0" }
+
+  "alcotest-lwt" { with-test }
+  "angstrom-lwt-unix" { >= "0.15.0" & with-test }
+  "yojson" { with-test }
+  "ppx_deriving_yojson" { >= "3.5.2" & with-test }
+  # "ocamlformat" { = "0.21.0" } # Development
+  # "ocaml-lsp-server" # Development
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/asemio/SZXX/archive/refs/tags/3.0.4.tar.gz"
+  checksum: [
+    "md5=a8b188f651be284331cdacef2f203807"
+    "sha512=5a2bc3b9a727c297fd11c28f1642da9a94e1200f01cf72b8fc2d0ad3efbc1ffd655f5a4e07dd572e8a1860fc3afd36c079ece9b534ef97fb54d80d2c004887ec"
+  ]
+}


### PR DESCRIPTION
### `SZXX.3.0.4`
Streaming ZIP XML XLSX parser
SZXX is a streaming, non-seeking and efficient XLSX parser built from ground up for low memory usage.
SZXX is able to output XLSX rows while a file is being read from the file descriptor without buffering any part of the file.
It can also stream data out of ZIP files and XML files without buffering.



---
* Homepage: https://github.com/asemio/SZXX
* Source repo: git://github.com/asemio/SZXX
* Bug tracker: https://github.com/asemio/SZXX/issues

---
:camel: Pull-request generated by opam-publish v2.2.0