### PR TITLE
Package ocaml-compiler-libs.v0.17.0

### DIFF
--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.10.0/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.10.0/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.2.0"}
   "jbuilder" {>= "1.0+beta12"}
 ]
 synopsis: "OCaml compiler libraries repackaged"

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.11.0/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.11.0/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.2.0"}
   "jbuilder" {>= "1.0+beta12"}
 ]
 synopsis: "OCaml compiler libraries repackaged"

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.0/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.0/opam
@@ -9,7 +9,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.2.0"}
   "dune" {>= "1.0"}
 ]
 synopsis: "OCaml compiler libraries repackaged"

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.1/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.1/opam
@@ -9,7 +9,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.2.0"}
   "dune" {>= "1.5.1"}
 ]
 synopsis: "OCaml compiler libraries repackaged"

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.3/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.3/opam
@@ -9,7 +9,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.2.0"}
   "dune" {>= "1.5.1"}
 ]
 synopsis: """OCaml compiler libraries repackaged"""

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.4/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/janestreet/ocaml-compiler-libs"
 bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.2.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.17.0/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.17.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ocaml-compiler-libs"
+bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
+dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2.0"}
+  "dune" {>= "1.5.1"}
+]
+synopsis: """OCaml compiler libraries repackaged"""
+description: """
+
+This packages exposes the OCaml compiler libraries repackages under
+the toplevel names Ocaml_common, Ocaml_bytecomp, Ocaml_optcomp, ...
+"""
+url {
+  src:
+    "https://github.com/janestreet/ocaml-compiler-libs/archive/refs/tags/v0.17.0.tar.gz"
+  checksum: [
+    "md5=aaf66efea8752475c25a942443579b41"
+    "sha512=c5cd418b0eb74e00c3f63235754bbdb3a3328ac743d6ae885424d8c50b4edaa7068572e689cb3456d222793283927f2984a1ff840b1bc3817f810b5314faf897"
+  ]
+}


### PR DESCRIPTION
### `ocaml-compiler-libs.v0.17.0`
OCaml compiler libraries repackaged
This packages exposes the OCaml compiler libraries repackages under
the toplevel names Ocaml_common, Ocaml_bytecomp, Ocaml_optcomp, ...



---
* Homepage: https://github.com/janestreet/ocaml-compiler-libs
* Source repo: git+https://github.com/janestreet/ocaml-compiler-libs.git
* Bug tracker: https://github.com/janestreet/ocaml-compiler-libs/issues

---
:camel: Pull-request generated by opam-publish v2.3.0