### PR TITLE
Package tablecloth-base.0.0.9

### DIFF
--- a/packages/tablecloth-base/tablecloth-base.0.0.9/opam
+++ b/packages/tablecloth-base/tablecloth-base.0.0.9/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml and Rescript"
+description: """
+Tablecloth is an ergonomic, cross-platform, standard library for use with OCaml and Rescript. It provides an easy-to-use, comprehensive and performant standard library, that has the same API on in OCaml and Rescript.
+"""
+maintainer: "Paul Biggar <paul@darklang.com>"
+authors: [
+  "Paul Biggar <paul@darklang.com>"
+  "Dean Merchant <deanmerchant@gmail.com>"
+  "Pomin Wu <pomin.wu@proton.me>"
+]
+license: "MIT"
+homepage: "https://github.com/darklang/tablecloth-ocaml-base"
+bug-reports: "https://github.com/darklang/tablecloth-ocaml-base/issues"
+dev-repo: "git://github.com/darklang/tablecloth-ocaml-base"
+depends: [ "ocaml" {>= "4.08" < "4.15" } "dune" {>= "2.4" } "base" { >= "v0.12.0" & < "v0.15.0" } ]
+build: ["dune" "build" "-p" name "-j" jobs]
+conflicts: [ "tablecloth-native" {!= "transition"} ]
+url {
+  src:
+    "https://github.com/darklang/tablecloth-ocaml-base/archive/refs/tags/0.0.9.tar.gz"
+  checksum: [
+    "md5=eef8da54ae2e373fc38a08bb761ea973"
+    "sha512=c74de7cf90798c6c2702a21f40d340da3fa2405f00ccc193568a04d6b0e08a41b47d5db35c0ed7662043f1fe223c2e82212e162a64f67c3577dece6660c08b20"
+  ]
+}


### PR DESCRIPTION
### `tablecloth-base.0.0.9`
Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml and Rescript
Tablecloth is an ergonomic, cross-platform, standard library for use with OCaml and Rescript. It provides an easy-to-use, comprehensive and performant standard library, that has the same API on in OCaml and Rescript.



---
* Homepage: https://github.com/darklang/tablecloth-ocaml-base
* Source repo: git://github.com/darklang/tablecloth-ocaml-base
* Bug tracker: https://github.com/darklang/tablecloth-ocaml-base/issues

---
:camel: Pull-request generated by opam-publish v2.2.0