### PR TITLE
[new release] http-lwt-client (0.2.6)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.2.6/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.2.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/http-lwt-client"
+dev-repo: "git+https://github.com/robur-coop/http-lwt-client.git"
+bug-reports: "https://github.com/robur-coop/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "lwt"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "0.16.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.10.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/robur-coop/http-lwt-client/releases/download/v0.2.6/http-lwt-client-0.2.6.tbz"
+  checksum: [
+    "sha256=ea07cb15e0e8720906edf4477a6d6221faa437a9cffe7a9400d76bb9041a9459"
+    "sha512=b98ca0ee6af3e2f25bbb1e12473f0351a0c7e307c8ff1c3c02060a33fd8eb357231c6150e3e7c2e92d8e8df3f22c6c23c532d456759eda96ce7b0d7928a46422"
+  ]
+}
+x-commit-hash: "b870b269d5e2050bf08dab2fcbee5c621957825f"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/robur-coop/http-lwt-client">https://github.com/robur-coop/http-lwt-client</a>

##### CHANGES:

* Call shutdown in h2 to properly close http2 connections. This fixes a file
  descriptor leak reported in robur-coop/http-lwt-client#22 (robur-coop/http-lwt-client#23, @reynir @hannesm)
