### PR TITLE
[new release] ppx_deriving_yaml (0.2.2)

### DIFF
--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.2/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Yaml PPX Deriver"
+description:
+  "Deriving conversion functions to and from yaml for your OCaml types."
+maintainer: ["patrick@sirref.org"]
+authors: ["Patrick Ferris"]
+license: "ISC"
+homepage: "https://github.com/patricoferris/ppx_deriving_yaml"
+bug-reports: "https://github.com/patricoferris/ppx_deriving_yaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "yaml"
+  "ppx_deriving"
+  "alcotest" {with-test}
+  "mdx" {with-test & >= "2.0.0"}
+  "ocaml" {>= "4.08.1"}
+  "ppxlib" {>= "0.25.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/patricoferris/ppx_deriving_yaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v0.2.2/ppx_deriving_yaml-0.2.2.tbz"
+  checksum: [
+    "sha256=ac08d3aebdc8e70f461c77ded83a634c55b28d577fd3b1fbdd4f5a5759ccc3ca"
+    "sha512=0589620d5f510975be766ef65a0b8bf2c2b5f6332f4c743f24f5d9ff6555b78554e858747bdc5ed62e0f2a3b152791adbc52b22dd2f91d1afcb0a172443c1046"
+  ]
+}
+x-commit-hash: "201143eba1f7bae53340ea05cd9eed23524d1fe5"


### PR DESCRIPTION
Yaml PPX Deriver

- Project page: <a href="https://github.com/patricoferris/ppx_deriving_yaml">https://github.com/patricoferris/ppx_deriving_yaml</a>

##### CHANGES:

 - Embed errors in the AST (patricoferris/ppx_deriving_yaml#51, @patricoferris and special thanks to @panglesd
   for the detailed issue in patricoferris/ppx_deriving_yaml#48)
