### PR TITLE
Package ocamldiff.1.2

### DIFF
--- a/packages/ocamldiff/ocamldiff.1.2/opam
+++ b/packages/ocamldiff/ocamldiff.1.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "OCamldiff is a small OCaml library providing functions to parse and display diff results"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocamldiff/"
+doc: "https://zoggy.frama.io/ocamldiff/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocamldiff/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocamldiff.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocamldiff/-/archive/1.2/ocamldiff-1.2.tar.bz2"
+  checksum: [
+    "md5=a7944e8628a72a6d3a22aa2e1e9abde3"
+    "sha512=edbc495be519b22c42e97140b756d831c71cb761efe38aabd599659954adee86404722c43d831c5ab72e65a43ce69d4973aa5072ce1f0b6abab90b87420c06cc"
+  ]
+}


### PR DESCRIPTION
### `ocamldiff.1.2`
OCamldiff is a small OCaml library providing functions to parse and display diff results



---
* Homepage: https://zoggy.frama.io/ocamldiff/
* Source repo: git+https://framagit.org/zoggy/ocamldiff.git
* Bug tracker: https://framagit.org/zoggy/ocamldiff/issues

---
:camel: Pull-request generated by opam-publish v2.3.0