### PR TITLE
Package ocamleditor.1.15.1-ocaml414

### DIFF
--- a/packages/ocamleditor/ocamleditor.1.15.1-ocaml414/opam
+++ b/packages/ocamleditor/ocamleditor.1.15.1-ocaml414/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+
+synopsis:
+  "OCamlEditor is a GTK+ source code editor and build tool for OCaml"
+description:
+  """It provides many features to facilitate editing code, accessing API reference
+directly from the editor and compiling projects."""
+
+authors: ["OCamlEditor developers"]
+maintainer: ["OCamlEditor developers"]
+
+license: "LGPL-3.0-only"
+homepage: "https://github.com/ocamleditor/ocamleditor"
+bug-reports: "https://github.com/ocamleditor/ocamleditor/issues"
+dev-repo: "git+https://github.com/ocamleditor/ocamleditor.git"
+
+build: [["ocaml" "build.ml" "ocamleditor"]]
+install: [["ocaml" "tools/install.ml" "-prefix" prefix]]
+
+depends: [
+  "ocaml" {>= "4.14" & < "5"}
+  "ocamlfind" {>= "1.4.0"}
+  "lablgtk" {>= "2.18.0"}
+  "ocp-indent" { >= "1.8.0" }
+  "xml-light" {>= "2.2"}
+  "yojson" {>= "2.1"}
+  "atdgen" {>= "2.12"}
+  "ocamldiff" {>= "1.2"}
+  "merlin" {>= "4.9"}
+]
+depopts: [
+  "ocurl"
+]
+url {
+  src:
+    "https://github.com/ocamleditor/ocamleditor/archive/refs/tags/1.15.1-ocaml414.tar.gz"
+  checksum: [
+    "md5=25d21f40f2823fb385878dd94393a94a"
+    "sha512=aee3033c0c1ed60865cd701aa107668e74fbbf0074bbc109bf0d36079c36b07adb4824b77f79f9756d4e78841f862b4885d3ce28ef2f899dc884d10cffed86ea"
+  ]
+}

--- a/packages/ocamleditor/ocamleditor.1.15.1-ocaml414/opam
+++ b/packages/ocamleditor/ocamleditor.1.15.1-ocaml414/opam
@@ -14,7 +14,7 @@ homepage: "https://github.com/ocamleditor/ocamleditor"
 bug-reports: "https://github.com/ocamleditor/ocamleditor/issues"
 dev-repo: "git+https://github.com/ocamleditor/ocamleditor.git"
 
-build: [["ocaml" "build.ml" "ocamleditor"]]
+build: [["ocaml" "build.ml" "-verbose" "5" "ocamleditor"]]
 install: [["ocaml" "tools/install.ml" "-prefix" prefix]]
 
 depends: [

--- a/packages/ocamleditor/ocamleditor.1.15.1-ocaml414/opam
+++ b/packages/ocamleditor/ocamleditor.1.15.1-ocaml414/opam
@@ -31,6 +31,8 @@ depends: [
 depopts: [
   "ocurl"
 ]
+flags: verbose
+
 url {
   src:
     "https://github.com/ocamleditor/ocamleditor/archive/refs/tags/1.15.1-ocaml414.tar.gz"

--- a/packages/ocamleditor/ocamleditor.1.15.1-ocaml414/opam
+++ b/packages/ocamleditor/ocamleditor.1.15.1-ocaml414/opam
@@ -15,7 +15,10 @@ bug-reports: "https://github.com/ocamleditor/ocamleditor/issues"
 dev-repo: "git+https://github.com/ocamleditor/ocamleditor.git"
 
 build: [["ocaml" "build.ml" "-verbose" "5" "ocamleditor"]]
-install: [["ocaml" "tools/install.ml" "-prefix" prefix]]
+install: [
+  ["ocaml" "build.ml" "-verbose" "5" "ocamleditor"]
+  ["ocaml" "tools/install.ml" "-prefix" prefix]
+]
 
 depends: [
   "ocaml" {>= "4.14" & < "5"}


### PR DESCRIPTION
### `ocamleditor.1.15.1-ocaml414`
OCamlEditor is a GTK+ source code editor and build tool for OCaml
It provides many features to facilitate editing code, accessing API reference
directly from the editor and compiling projects.



---
* Homepage: https://github.com/ocamleditor/ocamleditor
* Source repo: git+https://github.com/ocamleditor/ocamleditor.git
* Bug tracker: https://github.com/ocamleditor/ocamleditor/issues

---
:camel: Pull-request generated by opam-publish v2.3.0