### PR TITLE
Package jsonschema2atd.0.0.1

### DIFF
--- a/packages/jsonschema2atd/jsonschema2atd.0.0.1/opam
+++ b/packages/jsonschema2atd/jsonschema2atd.0.0.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Generate ATD types out of JSON Schema and OpenAPI document"
+description: "Generate ATD types out of JSON Schema and OpenAPI document"
+maintainer: "Egor Chemokhonenko <egor.chemohonenko@ahrefs.com>"
+authors: "Ahrefs"
+license: "MIT"
+homepage: "https://github.com/ahrefs/jsonschema2atd"
+bug-reports: "https://github.com/ahrefs/jsonschema2atd/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.10"}
+  "atdgen" {>= "2.7"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup & = "0.24.1"}
+  "odoc" {with-doc}
+  "ounit2" {with-test}
+  "yojson"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/jsonschema2atd.git"
+url {
+  src:
+    "https://github.com/ahrefs/jsonschema2atd/archive/refs/tags/0.0.1.tar.gz"
+  checksum: [
+    "md5=dcdbf453fbfab9a1fe41966b69823c3b"
+    "sha512=b6ab5b78fee8fb41a7da867bcd11b54d92228e4798572aa7714aa59fc983a79998ddb176153755b6ca772ae5b38efef2e2f8a76459d165298455688bf55c6f83"
+  ]
+}


### PR DESCRIPTION
### `jsonschema2atd.0.0.1`
Generate ATD types out of JSON Schema and OpenAPI document
Generate ATD types out of JSON Schema and OpenAPI document



---
* Homepage: https://github.com/ahrefs/jsonschema2atd
* Source repo: git+https://github.com/ahrefs/jsonschema2atd.git
* Bug tracker: https://github.com/ahrefs/jsonschema2atd/issues

---
:camel: Pull-request generated by opam-publish v2.3.0