### PR TITLE
[new release] trace (4 packages) (0.6)

### DIFF
--- a/packages/ppx_trace/ppx_trace.0.6/opam
+++ b/packages/ppx_trace/ppx_trace.0.6/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A ppx-based preprocessor for trace"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "ppx"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "ppxlib" {>= "0.28"}
+  "trace" {= version}
+  "trace-tef" {= version & with-test}
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.6/trace-0.6.tbz"
+  checksum: [
+    "sha256=97cc4159b96429adc01a84bff1ed34b8f06746bc56a40a214a6306036be2df38"
+    "sha512=6a67ea9ddeebb4b93a0b8dba9ed26d95e786722d08fd9ca7d8e2db7651a9b9d6ccc63cc437b4eb71c28b3ec51838716a84707a8d366abb595f32a5e65035e28b"
+  ]
+}
+x-commit-hash: "659ce2e403386c167294487900d988e90ec669e2"

--- a/packages/trace-fuchsia/trace-fuchsia.0.6/opam
+++ b/packages/trace-fuchsia/trace-fuchsia.0.6/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "A high-performance backend for trace, emitting a Fuchsia trace into a file"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "tracing" "fuchsia"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "trace" {= version}
+  "mtime" {>= "2.0"}
+  "thread-local-storage"
+  "base-bigarray"
+  "base-unix"
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+available: arch != "s390x"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.6/trace-0.6.tbz"
+  checksum: [
+    "sha256=97cc4159b96429adc01a84bff1ed34b8f06746bc56a40a214a6306036be2df38"
+    "sha512=6a67ea9ddeebb4b93a0b8dba9ed26d95e786722d08fd9ca7d8e2db7651a9b9d6ccc63cc437b4eb71c28b3ec51838716a84707a8d366abb595f32a5e65035e28b"
+  ]
+}
+x-commit-hash: "659ce2e403386c167294487900d988e90ec669e2"

--- a/packages/trace-tef/trace-tef.0.6/opam
+++ b/packages/trace-tef/trace-tef.0.6/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "A simple backend for trace, emitting Catapult/TEF JSON into a file"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "tracing" "catapult" "TEF" "chrome-format"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "trace" {= version}
+  "mtime" {>= "2.0"}
+  "base-unix"
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.6/trace-0.6.tbz"
+  checksum: [
+    "sha256=97cc4159b96429adc01a84bff1ed34b8f06746bc56a40a214a6306036be2df38"
+    "sha512=6a67ea9ddeebb4b93a0b8dba9ed26d95e786722d08fd9ca7d8e2db7651a9b9d6ccc63cc437b4eb71c28b3ec51838716a84707a8d366abb595f32a5e65035e28b"
+  ]
+}
+x-commit-hash: "659ce2e403386c167294487900d988e90ec669e2"

--- a/packages/trace/trace.0.6/opam
+++ b/packages/trace/trace.0.6/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "A stub for tracing/observability, agnostic in how data is collected"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "tracing" "observability" "profiling"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "mtime" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.6/trace-0.6.tbz"
+  checksum: [
+    "sha256=97cc4159b96429adc01a84bff1ed34b8f06746bc56a40a214a6306036be2df38"
+    "sha512=6a67ea9ddeebb4b93a0b8dba9ed26d95e786722d08fd9ca7d8e2db7651a9b9d6ccc63cc437b4eb71c28b3ec51838716a84707a8d366abb595f32a5e65035e28b"
+  ]
+}
+x-commit-hash: "659ce2e403386c167294487900d988e90ec669e2"


### PR DESCRIPTION
A stub for tracing/observability, agnostic in how data is collected

- Project page: <a href="https://github.com/c-cube/ocaml-trace">https://github.com/c-cube/ocaml-trace</a>

##### CHANGES:

- add `ppx_trace` for easier instrumentation.
  * `let%trace span = "foo" in …` will enter a scope `span` named "foo"
  * `let%trace () = "foo" in …` will enter a scope named "foo" with a hidden name
- add `trace-fuchsia` backend, which produces traces in the binary format
    of [fuchsia](https://fuchsia.dev/fuchsia-src/reference/tracing/trace-format).
    These traces are reasonably efficient to produce (~60ns per span on my machines)
    and reasonably compact on disk, at least compared to the TEF backend.
