### PR TITLE
[new release] hdr_histogram (0.0.4)

### DIFF
--- a/packages/hdr_histogram/hdr_histogram.0.0.4/opam
+++ b/packages/hdr_histogram/hdr_histogram.0.0.4/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings to Hdr Histogram"
+description: "OCaml bindings to Hdr Histogram"
+maintainer: ["KC Sivaramakrishnan" "Christiano Haesbaert"]
+authors: ["KC Sivaramakrishnan"]
+license: "MIT"
+tags: ["histogram" "tail latency"]
+homepage: "https://github.com/ocaml-multicore/hdr_histogram_ocaml"
+doc: "https://ocaml-multicore.github.io/hdr_histogram_ocaml"
+bug-reports: "https://github.com/ocaml-multicore/hdr_histogram_ocaml/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.7"}
+  "ctypes" {>= "0.20.1"}
+  "ctypes-foreign" {>= "0.18.0"}
+  "conf-pkg-config" {build}
+  "conf-cmake" {build}
+  "conf-zlib"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+available: [
+  (arch = "x86_64" | arch = "arm64")
+]
+dev-repo: "git+https://github.com/ocaml-multicore/hdr_histogram_ocaml.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/hdr_histogram_ocaml/releases/download/0.0.4/hdr_histogram-0.0.4.tbz"
+  checksum: [
+    "sha256=4994fed083b40458990d40a1ebaa1556d28ca91da9b8245fb73e26073063e713"
+    "sha512=f1a757c993e96c369448495d6eeb6fa02e0729582cb33b90de3f6ab5f06e6d1bb43e892a7d937c9267b7f0b4fbc524bdbb6aacfec9ddf2a58a4de69915cab70d"
+  ]
+}
+x-commit-hash: "f7f40d6dbe23193ba22c53e3609dbad9a225c341"


### PR DESCRIPTION
OCaml bindings to Hdr Histogram

- Project page: <a href="https://github.com/ocaml-multicore/hdr_histogram_ocaml">https://github.com/ocaml-multicore/hdr_histogram_ocaml</a>
- Documentation: <a href="https://ocaml-multicore.github.io/hdr_histogram_ocaml">https://ocaml-multicore.github.io/hdr_histogram_ocaml</a>

##### CHANGES:

* Add FreeBSD support, fixes to endian includes for FreeBSD and DragonFly BSD (tmcgilchrist, ocaml-multicore/hdr_histogram_ocaml#7)
