### PR TITLE
Stog 0.20.0: Update opam

### DIFF
--- a/packages/stog/stog.0.20.0/opam
+++ b/packages/stog/stog.0.20.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dune-build-info" {>= "2.9.1"}
   "dune-site" {>= "2.9.1"}
   "fmt" {>= "0.9.0"}
-  "higlo" {>= "0.8"}
+  "higlo" {= "0.8" }
   "logs" {>= "0.7.0"}
   "lwt" {>= "5.4.0"}
   "lwt_ppx" {>= "2.0.2"}


### PR DESCRIPTION
Fix dependency to higlo, as stog 0.20.0 is not compatible with higlo 0.9.