### PR TITLE
[new release] hidapi/hidapi-lwt (1.2.1)

### DIFF
--- a/packages/hidapi-lwt/hidapi-lwt.1.2.1/opam
+++ b/packages/hidapi-lwt/hidapi-lwt.1.2.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+authors: "Vincent Botbol <vincent.botbol@nomadic-labs.com>"
+maintainer: "Vincent Botbol <vincent.botbol@nomadic-labs.com>"
+homepage: "https://github.com/vbmithr/ocaml-hidapi"
+bug-reports: "https://github.com/vbmithr/ocaml-hidapi/issues"
+dev-repo: "git+https://github.com/vbmithr/ocaml-hidapi"
+doc: "https://vbmithr.github.io/ocaml-hidapi/doc"
+license: "MIT"
+build: [ "dune" "build" "-p" name "-j" jobs ]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.8.2"}
+  "conf-hidapi" {build}
+  "hidapi" {= version}
+  "lwt" {>= "5.7.0"}
+]
+synopsis: "Lwt-wrappers for hidapi library"
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-hidapi/archive/refs/tags/1.2.1.tar.gz"
+    checksum: [
+  "sha256=750d03623fe39a5ff13f206a182163a18a65d529f9ea4431d3daab9ccf438f1a"
+  "sha512=d352e7d75f702b1a36db858ac7117fcb928a11a100b231fbd8c4e1f4dd7219cf496cb6f4184236d87a4eb22b208df389e43e29946ac3681aab7486faf519f749"
+  ]
+}

--- a/packages/hidapi/hidapi.1.2.1/opam
+++ b/packages/hidapi/hidapi.1.2.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://github.com/vbmithr/ocaml-hidapi"
+bug-reports: "https://github.com/vbmithr/ocaml-hidapi/issues"
+dev-repo: "git+https://github.com/vbmithr/ocaml-hidapi"
+doc: "https://vbmithr.github.io/ocaml-hidapi/doc"
+license: "MIT"
+build: [ "dune" "build" "-p" name "-j" jobs ]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.8.2"}
+  "dune-configurator"
+  "conf-hidapi" {build}
+  "bigstring" {>= "0.2"}
+]
+synopsis: "Bindings to Signal11's hidapi library"
+description: """
+A Simple library for communicating with USB and Bluetooth HID devices
+on Linux, Mac, and Windows."""
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-hidapi/archive/refs/tags/1.2.1.tar.gz"
+    checksum: [
+  "sha256=750d03623fe39a5ff13f206a182163a18a65d529f9ea4431d3daab9ccf438f1a"
+  "sha512=d352e7d75f702b1a36db858ac7117fcb928a11a100b231fbd8c4e1f4dd7219cf496cb6f4184236d87a4eb22b208df389e43e29946ac3681aab7486faf519f749"
+  ]
+}

--- a/packages/ledgerwallet/ledgerwallet.0.4.0/opam
+++ b/packages/ledgerwallet/ledgerwallet.0.4.0/opam
@@ -7,13 +7,12 @@ bug-reports: "https://github.com/vbmithr/ocaml-ledger-wallet/issues"
 dev-repo: "git+https://github.com/vbmithr/ocaml-ledger-wallet"
 doc: "https://vbmithr.github.io/ocaml-ledger-wallet/doc"
 build:    [ "dune" "build"   "-p" name "-j" jobs ]
-# run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.4.0"}
   "rresult" {>= "0.6.0"}
   "cstruct" {>= "6.0.0"}
-  "hidapi-lwt"
+  "hidapi-lwt" {>= "1.2.1"}
   "lwt" {>= "5.7.0"}
 ]
 synopsis: "Ledger wallet library for OCaml"


### PR DESCRIPTION
This PR adds the `hidapi.1.2.1` and `hidapi-lwt.1.2.1` packages which contain a bug fix. It also constrains `ledgerwallet.0.4.0` to use this new version.