### PR TITLE
[new release] elpi (1.18.2)

### DIFF
--- a/packages/elpi/elpi.1.18.2/opam
+++ b/packages/elpi/elpi.1.18.2/opam
@@ -1,0 +1,89 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Claudio Sacerdoti Coen" "Enrico Tassi" ]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/LPCIC/elpi"
+doc: "https://LPCIC.github.io/elpi/"
+dev-repo: "git+https://github.com/LPCIC/elpi.git"
+bug-reports: "https://github.com/LPCIC/elpi/issues"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  [make "tests" "DUNE_OPTS=-p %{name}%" "SKIP=performance_HO" "SKIP+=performance_FO" "SKIP+=elpi_api_performance"] {with-test & os != "macos" & os-distribution != "alpine" & os-distribution != "freebsd"}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "stdlib-shims"
+  "ppxlib" {>= "0.12.0" }
+  "menhir" {>= "20211230" }
+  "re" {>= "1.7.2"}
+  "ppx_deriving" {>= "4.3"}
+  "ANSITerminal" {with-test}
+  "cmdliner" {with-test}
+  "dune" {>= "2.8.0"}
+  "conf-time" {with-test}
+  "atdgen" {>= "2.10.0"}
+  "atdts" {>= "2.10.0"}
+  "odoc" {with-doc}
+]
+synopsis: "ELPI - Embeddable λProlog Interpreter"
+description: """
+ELPI implements a variant of λProlog enriched with Constraint Handling Rules,
+a programming language well suited to manipulate syntax trees with binders.
+
+ELPI is designed to be embedded into larger applications written in OCaml as
+an extension language. It comes with an API to drive the interpreter and 
+with an FFI for defining built-in predicates and data types, as well as
+quotations and similar goodies that are handy to adapt the language to the host
+application.
+
+This package provides both a command line interpreter (elpi) and a library to
+be linked in other applications (eg by passing -package elpi to ocamlfind).
+
+The ELPI programming language has the following features:
+
+- Native support for variable binding and substitution, via an Higher Order
+  Abstract Syntax (HOAS) embedding of the object language. The programmer
+  does not need to care about technical devices to handle bound variables,
+  like De Bruijn indices.
+
+- Native support for hypothetical context. When moving under a binder one can
+  attach to the bound variable extra information that is collected when the
+  variable gets out of scope. For example when writing a type-checker the
+  programmer needs not to care about managing the typing context.
+
+- Native support for higher order unification variables, again via HOAS.
+  Unification variables of the meta-language (λProlog) can be reused to
+  represent the unification variables of the object language. The programmer
+  does not need to care about the unification-variable assignment map and
+  cannot assign to a unification variable a term containing variables out of
+  scope, or build a circular assignment.
+
+- Native support for syntactic constraints and their meta-level handling rules.
+  The generative semantics of Prolog can be disabled by turning a goal into a
+  syntactic constraint (suspended goal). A syntactic constraint is resumed as
+  soon as relevant variables gets assigned. Syntactic constraints can be
+  manipulated by constraint handling rules (CHR).
+
+- Native support for backtracking. To ease implementation of search.
+
+- The constraint store is extensible.  The host application can declare
+  non-syntactic constraints and use custom constraint solvers to check their
+  consistency.
+
+- Clauses are graftable. The user is free to extend an existing program by
+  inserting/removing clauses, both at runtime (using implication) and at
+  "compilation" time by accumulating files.
+
+ELPI is free software released under the terms of LGPL 2.1 or above."""
+url {
+  src:
+    "https://github.com/LPCIC/elpi/releases/download/v1.18.2/elpi-1.18.2.tbz"
+  checksum: [
+    "sha256=bac398ba41d0fe1e1807196162b024313563366f7b86ae0802b23d6ef0f3cbf9"
+    "sha512=e9e9e14adf6ef929cd28516ddffdc67faafc7dbe683dce42818329fedc9d1a22992333d8948cb427fec5f5e442d9440c0f450d81a76c9c1e87050c434441cd74"
+  ]
+}
+x-commit-hash: "e067f064dd955046b5912abdf63833a6989df9e6"


### PR DESCRIPTION
ELPI - Embeddable λProlog Interpreter

- Project page: <a href="https://github.com/LPCIC/elpi">https://github.com/LPCIC/elpi</a>
- Documentation: <a href="https://LPCIC.github.io/elpi/">https://LPCIC.github.io/elpi/</a>

##### CHANGES:

Requires Menhir 20211230 and OCaml 4.08 or above.

Language:
  - Change indexing for multiple arguments is now based on discrimination trees
  - Change `:index` acecpts an optional string to force `"Hash"` based indexing

API:
  - Change `clause_of_term` accepts a ``` `Replace ``` grafting directive
