### PR TITLE
[new release] ezjsonm-encoding (2.0.0)

### DIFF
--- a/packages/ezjsonm-encoding/ezjsonm-encoding.2.0.0/opam
+++ b/packages/ezjsonm-encoding/ezjsonm-encoding.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Encoding combinators a la Data_encoding for Ezjsonm"
+maintainer: ["Thomas Letan <lthms@soap.coffee>"]
+authors: ["Thomas Letan <lthms@soap.coffee>"]
+license: "mpl-2.0"
+homepage: "https://github.com/lthms/ezjsonm-encoding"
+bug-reports: "https://github.com/lthms/ezjsonm-encoding/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.8.0"}
+  "ezjsonm" {>= "1.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lthms/ezjsonm-encoding.git"
+url {
+  src:
+    "https://github.com/lthms/ezjsonm-encoding/releases/download/2.0.0/ezjsonm-encoding-2.0.0.tbz"
+  checksum: [
+    "sha256=7b938f71b6d02ebd7a00d14d6798b5d0b8e51e0c1c453098872bce855936db22"
+    "sha512=6ed40eabfc335e4619873dae832c5ce0e35acd425014adc13f47e39d980c5972a2490c3781d4edfb4e4ed829f64a7831890a296ae13c8d0c208f5972e44a48d5"
+  ]
+}
+x-commit-hash: "e9f9a6d242a1970db3a3262659af1dd1649519c5"


### PR DESCRIPTION
Encoding combinators a la Data_encoding for Ezjsonm

- Project page: <a href="https://github.com/lthms/ezjsonm-encoding">https://github.com/lthms/ezjsonm-encoding</a>

##### CHANGES:

- Rename `Decoding.of_string` into `Decoding.from_string` for consistency with
  top-module.
- Rename `Decoding.of_string_exn` into `Decoding.from_string_exn` for
  consistency with top-module.
- Add `Decoding.from_value_exn` and `Decoding.from_value`.
- Add `from_value_exn` and `from_value`.
