### PR TITLE
[new release] ppx_deriving_yaml (0.2.2)

### DIFF
--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.2/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Yaml PPX Deriver"
+description:
+  "Deriving conversion functions to and from yaml for your OCaml types."
+maintainer: ["patrick@sirref.org"]
+authors: ["Patrick Ferris"]
+license: "ISC"
+homepage: "https://github.com/patricoferris/ppx_deriving_yaml"
+bug-reports: "https://github.com/patricoferris/ppx_deriving_yaml/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yaml"
+  "ppx_deriving"
+  "alcotest" {with-test}
+  "mdx" {with-test & >= "2.0.0"}
+  "ocaml" {>= "4.08.1"}
+  "ppxlib" {>= "0.25.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/patricoferris/ppx_deriving_yaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v0.2.2/ppx_deriving_yaml-0.2.2.tbz"
+  checksum: [
+    "sha256=f71cb8de3682a4aa3f3a7e6c4d3b7c7f4332b728e3d4937642e14c7285984c16"
+    "sha512=1a7a09f48ba4c1d6397b4a772c6c3a7a2adb35ef3c5eb9371bf9fde4f59cc204478efebd7f2a679193dcc3e433e50c0da248a646c3273648a4646323c92918a1"
+  ]
+}
+x-commit-hash: "13f505a20f35651aa2d278bcd57ab3f9d356b12d"


### PR DESCRIPTION
Yaml PPX Deriver

- Project page: <a href="https://github.com/patricoferris/ppx_deriving_yaml">https://github.com/patricoferris/ppx_deriving_yaml</a>

##### CHANGES:

 - Embed errors in the AST (patricoferris/ppx_deriving_yaml#51, @patricoferris and special thanks to @panglesd
   for the detailed issue in patricoferris/ppx_deriving_yaml#48)
