### PR TITLE
Fix conf-openblas on macOS arm64 hardware

### DIFF
--- a/packages/conf-openblas/conf-openblas.0.2.1/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.1/opam
@@ -10,7 +10,7 @@ build: [
   [
     "sh"
     "-exc"
-    "cc $CFLAGS $(pkg-config --cflags openblas) test.c $(pkg-config --libs openblas)"
+    "cc $CFLAGS $(PKG_CONFIG_PATH=\"$(brew --prefix openblas)/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --cflags openblas) test.c $(PKG_CONFIG_PATH=\"$(brew --prefix openblas)/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --libs openblas)"
   ] {os = "macos" & os-distribution = "homebrew"}
   ["sh" "-exc" "cc $CFLAGS test.c -lcblas"]
     {os-family = "arch"}
@@ -20,6 +20,9 @@ build: [
     {os = "win32" & os-distribution = "cygwinports"}
   ["sh" "-exc" "cc $CFLAGS test.c -lopenblas"]
     {os-distribution != "fedora" & os-distribution != "centos" & os-family != "suse" & os-family != "opensuse" & os != "macos" & os-family != "arch" & os != "freebsd" & os != "win32"}
+]
+depends: [
+  "conf-pkg-config" {os = "macos" & os-distribution = "homebrew"}
 ]
 depexts: [
   ["libc-dev" "openblas-dev" "lapack-dev"] {os-distribution = "alpine"}

--- a/packages/conf-openblas/conf-openblas.0.2.1/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.1/opam
@@ -10,6 +10,16 @@ build: [
   [
     "sh"
     "-exc"
+    "printf 'opam-version: \"2.0\"\\nvariables {\\n  pkg-config-homebrew: \"%s/lib/pkgconfig\"\\n}' \"$(brew --prefix openblas)\" > %{_:name}%.config"
+  ] {os = "macos" & os-distribution = "homebrew"}
+  [
+    "sh"
+    "-exc"
+    "printf 'opam-version: \"2.0\"\\nvariables {\\n  pkg-config-homebrew: \"\"\\n}' > %{_:name}%.config"
+  ] {os != "macos" | os-distribution != "homebrew"}
+  [
+    "sh"
+    "-exc"
     "cc $CFLAGS $(PKG_CONFIG_PATH=\"$(brew --prefix openblas)/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --cflags openblas) test.c $(PKG_CONFIG_PATH=\"$(brew --prefix openblas)/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --libs openblas)"
   ] {os = "macos" & os-distribution = "homebrew"}
   ["sh" "-exc" "cc $CFLAGS test.c -lcblas"]
@@ -37,6 +47,9 @@ depexts: [
 x-ci-accept-failures: [
   "oraclelinux-7"
   "oraclelinux-8"
+]
+setenv: [
+  PKG_CONFIG_PATH += "%{_:pkg-config-homebrew}%"
 ]
 synopsis: "Virtual package to install OpenBLAS and LAPACKE"
 description:


### PR DESCRIPTION
Possible fix for #25075 - working correctly on my M2 and didn't break a run in a Debian 12 opam container.

`pkg-config` requires additional configuration after installing the openblas package - it's detailed after installing the package that `PKG_CONFIG_PATH` must be updated for this to work.

The first commit fixes the test command to do exactly that; the second commit also adds the amendment to the output of `opam env`. Note that opam ignores `FOO += ""` in a `setenv`. The second commit is optional, but having installed openblas, it seems logical for opam to ensure that `pkg-config` then actually works.