### PR TITLE
Dune opam name checking

### DIFF
--- a/packages/archetype/archetype.1.0.0/opam
+++ b/packages/archetype/archetype.1.0.0/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "1.10.0" & < "3.13"}
   "menhir"
   "digestif" {>= "0.7.2" }
   "num"

--- a/packages/archetype/archetype.1.0.0/opam
+++ b/packages/archetype/archetype.1.0.0/opam
@@ -28,7 +28,7 @@ depends: [
   "digestif" {>= "0.7.2" }
   "num"
   "yojson"
-  "ppx_deriving"
+  "ppx_deriving" {>= "4.2"}
   "ppx_deriving_yojson"
   "visitors"
 ]

--- a/packages/archetype/archetype.1.0.0/opam
+++ b/packages/archetype/archetype.1.0.0/opam
@@ -24,7 +24,7 @@ on the Tezos blockchain, with a specific focus on contract security
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.10.0" & < "3.13"}
-  "menhir"
+  "menhir" {>= "20180528"}
   "digestif" {>= "0.7.2" }
   "num"
   "yojson"

--- a/packages/archetype/archetype.1.1.0/opam
+++ b/packages/archetype/archetype.1.1.0/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "1.10.0" & < "3.13"}
   "menhir"
   "digestif" {>= "0.7.2" }
   "num"

--- a/packages/archetype/archetype.1.1.0/opam
+++ b/packages/archetype/archetype.1.1.0/opam
@@ -28,7 +28,7 @@ depends: [
   "digestif" {>= "0.7.2" }
   "num"
   "yojson"
-  "ppx_deriving"
+  "ppx_deriving" {>= "4.2"}
   "ppx_deriving_yojson"
   "visitors"
 ]

--- a/packages/archetype/archetype.1.1.0/opam
+++ b/packages/archetype/archetype.1.1.0/opam
@@ -24,7 +24,7 @@ on the Tezos blockchain, with a specific focus on contract security
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.10.0" & < "3.13"}
-  "menhir"
+  "menhir" {>= "20180528"}
   "digestif" {>= "0.7.2" }
   "num"
   "yojson"

--- a/packages/archetype/archetype.1.1.1/opam
+++ b/packages/archetype/archetype.1.1.1/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "1.10.0" & < "3.13"}
   "menhir"
   "digestif" {>= "0.7.2"}
   "num"

--- a/packages/archetype/archetype.1.1.1/opam
+++ b/packages/archetype/archetype.1.1.1/opam
@@ -28,7 +28,7 @@ depends: [
   "digestif" {>= "0.7.2"}
   "num"
   "yojson"
-  "ppx_deriving"
+  "ppx_deriving" {>= "4.2"}
   "ppx_deriving_yojson"
   "visitors"
 ]

--- a/packages/archetype/archetype.1.1.1/opam
+++ b/packages/archetype/archetype.1.1.1/opam
@@ -24,7 +24,7 @@ on the Tezos blockchain, with a specific focus on contract security
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.10.0" & < "3.13"}
-  "menhir"
+  "menhir" {>= "20180528"}
   "digestif" {>= "0.7.2"}
   "num"
   "yojson"

--- a/packages/archetype/archetype.1.1.2/opam
+++ b/packages/archetype/archetype.1.1.2/opam
@@ -28,7 +28,7 @@ depends: [
   "menhir" {>= "20180528"}
   "num"
   "yojson"
-  "ppx_deriving"
+  "ppx_deriving" {>= "4.2"}
   "ppx_deriving_yojson"
   "visitors"
 ]

--- a/packages/archetype/archetype.1.1.2/opam
+++ b/packages/archetype/archetype.1.1.2/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.10.0" & < "3.13"}
   "digestif" {>= "0.7.2"}
-  "menhir"
+  "menhir" {>= "20180528"}
   "num"
   "yojson"
   "ppx_deriving"

--- a/packages/archetype/archetype.1.1.2/opam
+++ b/packages/archetype/archetype.1.1.2/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "1.10.0" & < "3.13"}
   "digestif" {>= "0.7.2"}
   "menhir"
   "num"

--- a/packages/archetype/archetype.1.2.0/opam
+++ b/packages/archetype/archetype.1.2.0/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "1.10.0" & < "3.13"}
   "menhir"
   "digestif" {>= "0.7.2"}
   "num"

--- a/packages/archetype/archetype.1.2.0/opam
+++ b/packages/archetype/archetype.1.2.0/opam
@@ -28,7 +28,7 @@ depends: [
   "digestif" {>= "0.7.2"}
   "num"
   "yojson"
-  "ppx_deriving"
+  "ppx_deriving" {>= "4.2"}
   "ppx_deriving_yojson"
   "visitors"
 ]

--- a/packages/archetype/archetype.1.2.0/opam
+++ b/packages/archetype/archetype.1.2.0/opam
@@ -24,7 +24,7 @@ on the Tezos blockchain, with a specific focus on contract security
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.10.0" & < "3.13"}
-  "menhir"
+  "menhir" {>= "20180528"}
   "digestif" {>= "0.7.2"}
   "num"
   "yojson"

--- a/packages/baguette_sharp/baguette_sharp.2.0.4/opam
+++ b/packages/baguette_sharp/baguette_sharp.2.0.4/opam
@@ -10,7 +10,7 @@ doc: "https://github.com/coco33920/ocaml-baguettesharp-interpreter/wiki"
 bug-reports:
   "https://github.com/coco33920/ocaml-baguettesharp-interpreter/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.0" & < "3.13"}
   "ocaml" {>="4.13.1"}
   "fmt" {>="0.7.0"}
   "linenoise" {>="1.3.1"}

--- a/packages/baguette_sharp/baguette_sharp.2.1.1/opam
+++ b/packages/baguette_sharp/baguette_sharp.2.1.1/opam
@@ -10,7 +10,7 @@ doc: "https://github.com/coco33920/ocaml-baguettesharp-interpreter/wiki"
 bug-reports:
   "https://github.com/coco33920/ocaml-baguettesharp-interpreter/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.0" & < "3.13"}
   "ocaml" {>="4.13.1"}
   "fmt" {>="0.7.0"}
   "linenoise" {>="1.4.0"}

--- a/packages/baguette_sharp/baguette_sharp.2.2.1/opam
+++ b/packages/baguette_sharp/baguette_sharp.2.2.1/opam
@@ -10,7 +10,7 @@ doc: "https://github.com/coco33920/ocaml-baguettesharp-interpreter/wiki"
 bug-reports:
   "https://github.com/coco33920/ocaml-baguettesharp-interpreter/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.0" & < "3.13"}
   "ocaml" {>="4.13.1"}
   "fmt" {>="0.7.0"}
   "linenoise" {>="1.4.0"}

--- a/packages/codept/codept.0.11.1/opam
+++ b/packages/codept/codept.0.11.1/opam
@@ -11,7 +11,7 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs]
 ]
 depends: [
-  "dune" {>= "2.5"}
+  "dune" {>= "2.5" & < "3.13"}
   "menhir" {build & >= "20180523"}
   "ocaml" {>= "4.03" & < "5.1~"}
 ]

--- a/packages/comby/comby.1.2.2/opam
+++ b/packages/comby/comby.1.2.2/opam
@@ -18,7 +18,7 @@ build: [
     ]
 ]
 depends: [
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.7.0" & < "3.13"}
   "ocaml" {>= "4.08.1"}
   "angstrom" {>= "0.15.0"}
   "conf-autoconf"

--- a/packages/comby/comby.1.2.2/opam
+++ b/packages/comby/comby.1.2.2/opam
@@ -36,7 +36,7 @@ depends: [
   "lwt_react"
   "opium" {>= "0.19.0"}
   "cohttp-lwt-unix"
-  "parany"
+  "parany" {>= "11"}
   "patience_diff" {>= "v0.14"}
   "ppxlib"
   "ppx_deriving"

--- a/packages/comby/comby.1.2.2/opam
+++ b/packages/comby/comby.1.2.2/opam
@@ -62,3 +62,4 @@ url {
     "sha512=63af340d65f4ca37f00bee2a67c7a87822ef15c86051e6486c6eeb5d7fe310c845d4fff15625a72b48ceea89e14aff52dc678da1d43d2029f58b435885d568d8"
   ]
 }
+available: [ arch != "arm64" ]

--- a/packages/comby/comby.1.3.0/opam
+++ b/packages/comby/comby.1.3.0/opam
@@ -38,7 +38,7 @@ depends: [
   "mparser-pcre"
   "opium" {>= "0.19.0"}
   "cohttp-lwt-unix"
-  "parany"
+  "parany" {>= "11"}
   "patience_diff" {>= "v0.14"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.6.0"}

--- a/packages/comby/comby.1.3.0/opam
+++ b/packages/comby/comby.1.3.0/opam
@@ -63,3 +63,4 @@ url {
     "sha512=2f8f82c119210ae0efd7f3eefdd992d6b52655575233dfab74662d9a9854ce4aafcd4fe01dad17ba310e38f28ee1437be2f3c4af4f6952a97bb19e1400fc709a"
   ]
 }
+available: [ arch != "arm64" ]

--- a/packages/comby/comby.1.3.0/opam
+++ b/packages/comby/comby.1.3.0/opam
@@ -18,7 +18,7 @@ build: [
     ]
 ]
 depends: [
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.7.0" < "3.13"}
   "ocaml" {>= "4.08.1"}
   "angstrom" {>= "0.15.0"}
   "conf-autoconf"

--- a/packages/ip2locationio/ip2locationio.1.0.0/opam
+++ b/packages/ip2locationio/ip2locationio.1.0.0/opam
@@ -12,7 +12,7 @@ doc: "https://github.com/ip2location/ip2location-io-ocaml"
 bug-reports: "https://github.com/ip2location/ip2location-io-ocaml/issues"
 depends: [
   "ocaml" {>= "4.13"}
-  "dune" {>= "3.4"}
+  "dune" {>= "3.4" & < "3.13"}
   "lwt"
   "cohttp"
   "cohttp-lwt-unix"

--- a/packages/mparser-pcre/mparser-pcre.1.3/opam
+++ b/packages/mparser-pcre/mparser-pcre.1.3/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/murmour/mparser/issues"
 depends: [
   "dune" {>= "1.11"}
   "ocaml" {>= "4.02"}
-  "mparser"
+  "mparser" {>= "1.3"}
   "pcre"
 ]
 build: [


### PR DESCRIPTION
The upcoming Dune 3.13 includes stricter checking for OPAM package names in the `depends` field of `dune-project` files. It will now reject packages with dots (only valid as findlib names, not opam names, thus these never pointed to valid dependencies) as well as OPAM style dependency filters (`{`, which dune has never supported using angle bracket syntax, only s-expression syntax). More details to be found in https://github.com/ocaml/dune/pull/9472.

It turns out this breaks a small amount packages (that for the most part already have been fixed or where fixes have already been submitted and/or merged upstream), so this PR adds version constraints to the affected older releases.

Each commit takes care of one particular project, the commits have links to the failing OPAM-repository CI builds of the Dune 3.13~alpha1 test run in #25067.

cc @ElectreAAS