### PR TITLE
Package zenon_modulo.0.5.0

### DIFF
--- a/packages/zenon_modulo/zenon_modulo.0.5.0/opam
+++ b/packages/zenon_modulo/zenon_modulo.0.5.0/opam
@@ -20,6 +20,7 @@ build: [
   [make]
 ]
 install: [[make "install"]]
+conflicts: ["ocaml-option-bytecode-only"]
 synopsis: "Zenon Modulo Theory"
 description: """
 Automated theorem prover for first order classical logic (with

--- a/packages/zenon_modulo/zenon_modulo.0.5.0/opam
+++ b/packages/zenon_modulo/zenon_modulo.0.5.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+homepage: "https://github.com/Deducteam/zenon_modulo"
+dev-repo: "git+https://github.com/Deducteam/zenon_modulo.git"
+maintainer: "Guillaume Burel <guillaume.burel@ensiie.fr>"
+authors: [ "INRIA and contributors" ]
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/Deducteam/zenon_modulo/issues"
+tags: [ "automated theorem prover" ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "zarith" {>= "1.11"}
+]
+depopts: [
+  "coq"
+]
+build: [
+  ["./configure"
+   "--prefix" prefix
+   "--libdir" lib]
+  [make]
+]
+install: [[make "install"]]
+synopsis: "Zenon Modulo Theory"
+description: """
+Automated theorem prover for first order classical logic (with
+equality), based on the tableau method. Zenon_modulo handles first-order
+logic with equality. Its most important feature is that it outputs the
+proofs of the theorems, in Coq-checkable form."""
+url {
+  src:
+    "https://github.com/Deducteam/zenon_modulo/archive/refs/tags/0.5.0.tar.gz"
+  checksum: [
+    "md5=3e0a13775df0546b02d8d77d3834d777"
+    "sha512=9b70eddb40404011c4b593604c9974c3f81ffeac119ad190be3aa2964f98c60ee166aeff07eee62d51f26df9663e65eea4e181812ef0077892a421b50f1bc4f6"
+  ]
+}


### PR DESCRIPTION
### `zenon_modulo.0.5.0`
Zenon Modulo Theory
Automated theorem prover for first order classical logic (with
equality), based on the tableau method. Zenon_modulo handles first-order
logic with equality. Its most important feature is that it outputs the
proofs of the theorems, in Coq-checkable form.



---
* Homepage: https://github.com/Deducteam/zenon_modulo
* Source repo: git+https://github.com/Deducteam/zenon_modulo.git
* Bug tracker: https://github.com/Deducteam/zenon_modulo/issues

---
:camel: Pull-request generated by opam-publish v2.3.0