### PR TITLE
Add libtorch 2.1.2+linux

### DIFF
--- a/packages/libtorch/libtorch.2.1.2+linux-x86_64/opam
+++ b/packages/libtorch/libtorch.2.1.2+linux-x86_64/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/torch"
+bug-reports: "https://github.com/janestreet/torch/issues"
+dev-repo: "git+https://github.com/janestreet/torch.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/torch/index.html"
+license: "MIT"
+available: arch = "x86_64" & os = "linux"
+synopsis: "CPU-only binaries for torch"
+description: "Downloads the CPU-only libtorch binaries, a requirement for using OCaml Torch."
+install: [
+  "sh"
+  "-c"
+  "test -d %{lib}%/libtorch/lib/libtorch.so || ( unzip libtorch-linux.zip && mv -f libtorch %{lib}%/ )"
+]
+extra-source "libtorch-linux.zip" {
+  src:
+    "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.1.2%2Bcpu.zip"
+  checksum: "md5=6395886cf4b2a9981306b78e15dad992"
+}


### PR DESCRIPTION
This is the first Jane Street-managed release of the OPAM libtorch package. We are taking maintenance responsibility, and this is backed by [Laurent's comment here](https://github.com/ocaml/opam-repository/pull/23742#discussion_r1183116185) and [the original repository's README](https://github.com/LaurentMazare/ocaml-torch).