### PR TITLE
Package tablecloth-melange.0.0.9

### DIFF
--- a/packages/tablecloth-melange/tablecloth-melange.0.0.9/opam
+++ b/packages/tablecloth-melange/tablecloth-melange.0.0.9/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "A portable standard library enhancement for Reason"
+description: """
+Tablecloth is an ergonomic, cross-platform, standard library for use with OCaml, Rescript, F# and Reason.  It provides an easy-to-use, comprehensive and performant standard library, that has the same API on all platforms.
+"""
+maintainer: "Paul Biggar <paul@darklang.com>"
+authors: [
+  "Paul Biggar <paul@darklang.com>"
+  "Pomin Wu <pomin.wu@proton.me>"
+]
+license: "MIT"
+homepage: "https://github.com/tableclothdotdev/tablecloth-melange"
+bug-reports: "https://github.com/tableclothdotdev/tablecloth-melange/issues"
+dev-repo: "git://github.com/tableclothdotdev/tablecloth-melange"
+depends: [
+  "ocaml" {>= "5.1"}
+  "dune" {>= "3.8"}
+  "reason"
+  "melange"
+
+  "melange-jest" {withtest}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src:
+    "https://github.com/pm5/tablecloth-melange/archive/refs/tags/0.0.9.tar.gz"
+  checksum: [
+    "md5=99e20728399724bddbf077bac4351241"
+    "sha512=e43b2413efe3e03e8c872a98b9edf851812a758f1992bac30c56077e91a279b1c59d8b3d8f4c8f461ae3559fdf98bc8d4e5a151a4fb4e86b18e79fc6d2e5938f"
+  ]
+}


### PR DESCRIPTION
### `tablecloth-melange.0.0.9`
A portable standard library enhancement for Reason
Tablecloth is an ergonomic, cross-platform, standard library for use with OCaml, Rescript, F# and Reason.  It provides an easy-to-use, comprehensive and performant standard library, that has the same API on all platforms.



---
* Homepage: https://github.com/tableclothdotdev/tablecloth-melange
* Source repo: git://github.com/tableclothdotdev/tablecloth-melange
* Bug tracker: https://github.com/tableclothdotdev/tablecloth-melange/issues

---
:camel: Pull-request generated by opam-publish v2.3.0