### PR TITLE
fix old release tarballs for ocamlgraph

### DIFF
--- a/packages/ocamlgraph/ocamlgraph.1.8.1/opam
+++ b/packages/ocamlgraph/ocamlgraph.1.8.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: [
   "Sylvain Conchon"
   "Jean-Christophe Filliâtre"
@@ -21,6 +21,6 @@ synopsis: "A generic graph library for OCaml"
 flags: light-uninstall
 extra-files: ["ocamlgraph.install" "md5=e0b715868e84ec4df4d6cdda25843466"]
 url {
-  src: "http://ocamlgraph.lri.fr/download/ocamlgraph-1.8.1.tar.gz"
+  src: "https://github.com/backtracking/ocamlgraph/releases/download/v1.8.1/ocamlgraph-1.8.1.tar.gz"
   checksum: "md5=5aa256e9587a6d264d189418230af698"
 }

--- a/packages/ocamlgraph/ocamlgraph.1.8.2/opam
+++ b/packages/ocamlgraph/ocamlgraph.1.8.2/opam
@@ -1,11 +1,11 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: [
   "Sylvain Conchon"
   "Jean-Christophe Filliâtre"
   "Julien Signoles"
 ]
-homepage: "http://ocamlgraph.lri.fr/"
+homepage: "https://github.com/backtracking/ocamlgraph/"
 license: "LGPL-2.1-only"
 build: [
   ["./configure"]
@@ -21,6 +21,6 @@ synopsis: "A generic graph library for OCaml"
 flags: light-uninstall
 extra-files: ["ocamlgraph.install" "md5=e0b715868e84ec4df4d6cdda25843466"]
 url {
-  src: "http://ocamlgraph.lri.fr/download/ocamlgraph-1.8.2.tar.gz"
+  src: "https://github.com/backtracking/ocamlgraph/releases/download/v1.8.2/ocamlgraph-1.8.2.tar.gz"
   checksum: "md5=efa4394bc4651c90de443ff61c7477e6"
 }

--- a/packages/ocamlgraph/ocamlgraph.1.8.3/opam
+++ b/packages/ocamlgraph/ocamlgraph.1.8.3/opam
@@ -1,13 +1,12 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: [
   "Sylvain Conchon"
   "Jean-Christophe Filliâtre"
   "Julien Signoles"
 ]
-homepage: "http://ocamlgraph.lri.fr/"
+homepage: "https://github.com/backtracking/ocamlgraph/"
 license: "LGPL-2.1-only"
-doc: ["http://ocamlgraph.lri.fr/doc"]
 dev-repo: "git+https://github.com/backtracking/ocamlgraph.git"
 bug-reports: "https://github.com/backtracking/ocamlgraph/issues"
 
@@ -43,6 +42,6 @@ extra-files: [
   ["install-findlib-dgraph.patch" "md5=2e3851e1644a49c9152975a78637e479"]
 ]
 url {
-  src: "http://ocamlgraph.lri.fr/download/ocamlgraph-1.8.3.tar.gz"
+  src: "https://github.com/backtracking/ocamlgraph/releases/download/v1.8.3/ocamlgraph-1.8.3.tar.gz"
   checksum: "md5=ad2dc42f74c77dae9302c40cf2b5ff86"
 }

--- a/packages/ocamlgraph/ocamlgraph.1.8.5/opam
+++ b/packages/ocamlgraph/ocamlgraph.1.8.5/opam
@@ -1,13 +1,12 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: [
   "Sylvain Conchon"
   "Jean-Christophe Filliâtre"
   "Julien Signoles"
 ]
-homepage: "http://ocamlgraph.lri.fr/"
+homepage: "https://github.com/backtracking/ocamlgraph/"
 license: "LGPL-2.1-only"
-doc: ["http://ocamlgraph.lri.fr/doc"]
 dev-repo: "git+https://github.com/backtracking/ocamlgraph.git"
 bug-reports: "https://github.com/backtracking/ocamlgraph/issues"
 
@@ -40,6 +39,6 @@ synopsis: "A generic graph library for OCaml"
 flags: light-uninstall
 extra-files: ["ocamlgraph.install" "md5=e0b715868e84ec4df4d6cdda25843466"]
 url {
-  src: "http://ocamlgraph.lri.fr/download/ocamlgraph-1.8.5.tar.gz"
+  src: "https://github.com/backtracking/ocamlgraph/releases/download/v1.8.5/ocamlgraph-1.8.5.tar.gz"
   checksum: "md5=75dde65bfc3f9b07e795343d369aa84d"
 }

--- a/packages/ocamlgraph/ocamlgraph.1.8.6/opam
+++ b/packages/ocamlgraph/ocamlgraph.1.8.6/opam
@@ -1,13 +1,12 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: [
   "Sylvain Conchon"
   "Jean-Christophe Filliâtre"
   "Julien Signoles"
 ]
-homepage: "http://ocamlgraph.lri.fr/"
+homepage: "https://github.com/backtracking/ocamlgraph/"
 license: "LGPL-2.1-only"
-doc: ["http://ocamlgraph.lri.fr/doc"]
 dev-repo: "git+https://github.com/backtracking/ocamlgraph.git"
 bug-reports: "https://github.com/backtracking/ocamlgraph/issues"
 
@@ -39,6 +38,6 @@ depopts: [
 synopsis: "A generic graph library for OCaml"
 flags: light-uninstall
 url {
-  src: "http://ocamlgraph.lri.fr/download/ocamlgraph-1.8.6.tar.gz"
+  src: "https://github.com/backtracking/ocamlgraph/releases/download/v186/ocamlgraph-1.8.6.tar.gz"
   checksum: "md5=afbc24f0e0eb72c2d3eda64b68513e73"
 }

--- a/packages/ocamlgraph/ocamlgraph.1.8.7/opam
+++ b/packages/ocamlgraph/ocamlgraph.1.8.7/opam
@@ -1,13 +1,12 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: [
   "Sylvain Conchon"
   "Jean-Christophe Filliâtre"
   "Julien Signoles"
 ]
-homepage: "http://ocamlgraph.lri.fr/"
+homepage: "https://github.com/backtracking/ocamlgraph/"
 license: "LGPL-2.1-only"
-doc: ["http://ocamlgraph.lri.fr/doc"]
 dev-repo: "git+https://github.com/backtracking/ocamlgraph.git"
 bug-reports: "https://github.com/backtracking/ocamlgraph/issues"
 
@@ -39,6 +38,6 @@ depopts: [
 synopsis: "A generic graph library for OCaml"
 flags: light-uninstall
 url {
-  src: "http://ocamlgraph.lri.fr/download/ocamlgraph-1.8.7.tar.gz"
+  src: "https://github.com/backtracking/ocamlgraph/releases/download/v1.8.7/ocamlgraph-1.8.7.tar.gz"
   checksum: "md5=e733b8309b9374e89d96e907ecaf4f76"
 }

--- a/packages/ocamlgraph/ocamlgraph.1.8.8/opam
+++ b/packages/ocamlgraph/ocamlgraph.1.8.8/opam
@@ -1,13 +1,12 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: [
   "Sylvain Conchon"
   "Jean-Christophe Filliâtre"
   "Julien Signoles"
 ]
-homepage: "http://ocamlgraph.lri.fr/"
+homepage: "https://github.com/backtracking/ocamlgraph/"
 license: "LGPL-2.1-only"
-doc: ["http://ocamlgraph.lri.fr/doc"]
 dev-repo: "git+https://github.com/backtracking/ocamlgraph.git"
 bug-reports: "https://github.com/backtracking/ocamlgraph/issues"
 
@@ -39,6 +38,6 @@ depopts: [
 synopsis: "A generic graph library for OCaml"
 flags: light-uninstall
 url {
-  src: "http://ocamlgraph.lri.fr/download/ocamlgraph-1.8.8.tar.gz"
+  src: "https://github.com/backtracking/ocamlgraph/releases/download/v1.8.8/ocamlgraph-1.8.8.tar.gz"
   checksum: "md5=9d71ca69271055bd22d0dfe4e939831a"
 }

--- a/packages/ocamlgraph/ocamlgraph.2.0.0/opam
+++ b/packages/ocamlgraph/ocamlgraph.2.0.0/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "A generic graph library for OCaml"
 description: "Provides both graph data structures and graph algorithms"
-maintainer: ["filliatr@lri.fr"]
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: ["Sylvain Conchon" "Jean-Christophe Filliâtre" "Julien Signoles"]
 license: "LGPL-2.1-only"
 tags: [


### PR DESCRIPTION
the website ocamlgraph.lri.fr no longer exists
tarballs have been copied to github, and URLs updated in opam files

in the process, the maintainer email is updated (for the same reason)
and documentation URLs at ocamlgraph.lri.fr are removed