### PR TITLE
fix broken tarball URLs from lri.fr

### DIFF
--- a/packages/bibtex2html/bibtex2html.1.97/opam
+++ b/packages/bibtex2html/bibtex2html.1.97/opam
@@ -1,10 +1,10 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: [
   "Jean-Christophe Filliâtre"
   "Claude Marché"
 ]
-homepage: "https://www.lri.fr/~filliatr/bibtex2html/"
+homepage: "https://github.com/backtracking/bibtex2html"
 dev-repo: "git+https://github.com/backtracking/bibtex2html.git"
 bug-reports: "https://github.com/backtracking/bibtex2html/issues"
 license: "GPL-2.0-only"
@@ -24,6 +24,6 @@ patches: [
 synopsis: "BibTeX to HTML translator"
 extra-files: ["make-uninstall.patch" "md5=9b4962f579a48817413af55901dc1db1"]
 url {
-  src: "http://www.lri.fr/~filliatr/ftp/bibtex2html/bibtex2html-1.97.tar.gz"
+  src: "https://github.com/backtracking/bibtex2html/releases/download/v1.97/bibtex2html-1.97.tar.gz"
   checksum: "md5=d20d0d607be3f6aa770554f3eee0dde1"
 }

--- a/packages/bibtex2html/bibtex2html.1.98/opam
+++ b/packages/bibtex2html/bibtex2html.1.98/opam
@@ -1,10 +1,10 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: [
   "Jean-Christophe Filliâtre"
   "Claude Marché"
 ]
-homepage: "https://www.lri.fr/~filliatr/bibtex2html/"
+homepage: "https://github.com/backtracking/bibtex2html"
 dev-repo: "git+https://github.com/backtracking/bibtex2html.git"
 bug-reports: "https://github.com/backtracking/bibtex2html/issues"
 license: "GPL-2.0-only"
@@ -24,6 +24,6 @@ patches: [
 synopsis: "BibTeX to HTML translator"
 extra-files: ["make-uninstall.patch" "md5=9b4962f579a48817413af55901dc1db1"]
 url {
-  src: "http://www.lri.fr/~filliatr/ftp/bibtex2html/bibtex2html-1.98.tar.gz"
+  src: "https://github.com/backtracking/bibtex2html/releases/download/v1.98/bibtex2html-1.98.tar.gz"
   checksum: "md5=33a96d32d6ca870163855573253aa720"
 }

--- a/packages/bibtex2html/bibtex2html.1.99-1/opam
+++ b/packages/bibtex2html/bibtex2html.1.99-1/opam
@@ -1,10 +1,10 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: [
   "Jean-Christophe Filliâtre"
   "Claude Marché"
 ]
-homepage: "https://www.lri.fr/~filliatr/bibtex2html/"
+homepage: "https://github.com/backtracking/bibtex2html"
 dev-repo: "git+https://github.com/backtracking/bibtex2html.git"
 bug-reports: "https://github.com/backtracking/bibtex2html/issues"
 license: "GPL-2.0-only"
@@ -19,6 +19,6 @@ depends: [
 install: [make "install"]
 synopsis: "BibTeX to HTML translator"
 url {
-  src: "http://www.lri.fr/~filliatr/ftp/bibtex2html/bibtex2html-1.99.tar.gz"
+  src: "https://github.com/backtracking/bibtex2html/releases/download/v-1-99/bibtex2html-1.99.tar.gz"
   checksum: "md5=85f8d617b13d34a552261b3fbb406a0f"
 }

--- a/packages/bibtex2html/bibtex2html.1.99/opam
+++ b/packages/bibtex2html/bibtex2html.1.99/opam
@@ -1,10 +1,10 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: [
   "Jean-Christophe Filliâtre"
   "Claude Marché"
 ]
-homepage: "https://www.lri.fr/~filliatr/bibtex2html/"
+homepage: "https://github.com/backtracking/bibtex2html"
 dev-repo: "git+https://github.com/backtracking/bibtex2html.git"
 bug-reports: "https://github.com/backtracking/bibtex2html/issues"
 license: "GPL-2.0-only"
@@ -27,6 +27,6 @@ extra-files: [
   ["0001-make-uninstall.patch" "md5=9b4962f579a48817413af55901dc1db1"]
 ]
 url {
-  src: "http://www.lri.fr/~filliatr/ftp/bibtex2html/bibtex2html-1.99.tar.gz"
+  src: "https://github.com/backtracking/bibtex2html/releases/download/v-1-99/bibtex2html-1.99.tar.gz"
   checksum: "md5=85f8d617b13d34a552261b3fbb406a0f"
 }

--- a/packages/combine/combine.0.42/opam
+++ b/packages/combine/combine.0.42/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: [
   "Remy El Sibaie"
   "Jean-Christophe Filliâtre"

--- a/packages/combine/combine.0.55/opam
+++ b/packages/combine/combine.0.55/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: [
   "Remy El Sibaie"
   "Jean-Christophe Filliâtre"

--- a/packages/combine/combine.0.6/opam
+++ b/packages/combine/combine.0.6/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 license: "LGPL-2.1-only"
-maintainer: "Jean-Christophe Filliâtre <jean-christophe.filliatre@lri.fr>"
-authors: ["Jean-Christophe Filliâtre <jean-christophe.filliatre@lri.fr>" "Rémy El Sibaie <remy.el-sibaie@lip6.fr>"]
-homepage: "https://www.lri.fr/~filliatr/combine/"
+maintainer: "Jean-Christophe Filliâtre <jean-christophe.filliatre@cnrs.fr>"
+authors: ["Jean-Christophe Filliâtre <jean-christophe.filliatre@cnrs.fr>" "Rémy El Sibaie <remy.el-sibaie@lip6.fr>"]
+homepage: "https://github.com/backtracking/combine"
 bug-reports: "http://github.com/backtracking/combine/issues"
 dev-repo: "git+https://github.com/backtracking/combine.git"
 build: [

--- a/packages/flex-array/flex-array.1.0.0/opam
+++ b/packages/flex-array/flex-array.1.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jean-Christophe.Filliatre@lri.fr"
+maintainer: "Jean-Christophe.Filliatre@cnrs.fr"
 authors: "Jean-Christophe Filliâtre"
 synopsis: "Flexible arrays"
 description: "Flexible arrays are arrays whose size can be changed by adding or

--- a/packages/flex-array/flex-array.1.1.0/opam
+++ b/packages/flex-array/flex-array.1.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jean-Christophe.Filliatre@lri.fr"
+maintainer: "Jean-Christophe.Filliatre@cnrs.fr"
 authors: "Jean-Christophe Filliâtre"
 synopsis: "Flexible arrays"
 description: "Flexible arrays are arrays whose size can be changed by adding or

--- a/packages/flex-array/flex-array.1.2.0/opam
+++ b/packages/flex-array/flex-array.1.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jean-Christophe.Filliatre@lri.fr"
+maintainer: "Jean-Christophe.Filliatre@cnrs.fr"
 authors: "Jean-Christophe Filliâtre"
 synopsis: "Flexible arrays"
 description: "Flexible arrays are arrays whose size can be changed by adding or

--- a/packages/functory/functory.0.5/opam
+++ b/packages/functory/functory.0.5/opam
@@ -4,7 +4,7 @@ authors: [
   "Jean-Christophe Filliâtre"
   "Kalyan Krishnamani"
 ]
-homepage: "http://functory.lri.fr/"
+homepage: "https://github.com/backtracking/functory"
 dev-repo: "git+https://github.com/backtracking/functory.git"
 license: "LGPL-2.1-only"
 build: [
@@ -20,6 +20,6 @@ install: [make "ocamlfind-install"]
 synopsis: "Distributed computing library."
 flags: light-uninstall
 url {
-  src: "https://www.lri.fr/~filliatr/functory/download/functory-0.5.tar.gz"
+  src: "https://github.com/backtracking/functory/releases/download/v-0-5/functory-0.5.tar.gz"
   checksum: "md5=c7e6576c3e6b3a7e247eab530d7e4de8"
 }

--- a/packages/functory/functory.0.6/opam
+++ b/packages/functory/functory.0.6/opam
@@ -4,7 +4,7 @@ authors: [
   "Jean-Christophe Filliâtre"
   "Kalyan Krishnamani"
 ]
-homepage: "http://functory.lri.fr/"
+homepage: "https://github.com/backtracking/functory"
 dev-repo: "git+https://github.com/backtracking/functory.git"
 license: "LGPL-2.1-only"
 build: [
@@ -20,6 +20,6 @@ install: [make "ocamlfind-install"]
 synopsis: "Distributed computing library."
 flags: light-uninstall
 url {
-  src: "https://www.lri.fr/~filliatr/functory/download/functory-0.6.tar.gz"
+  src: "https://github.com/backtracking/functory/releases/download/v-0-6/functory-0.6.tar.gz"
   checksum: "md5=0dd4a8ce7f2c8f293686a7df5c307477"
 }

--- a/packages/mlpost/mlpost.0.9/opam
+++ b/packages/mlpost/mlpost.0.9/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: [
   "Romain Bardou"
   "Francois Bobot"

--- a/packages/ocamlwc/ocamlwc.0.3/opam
+++ b/packages/ocamlwc/ocamlwc.0.3/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: ["Jean-Christophe Filliâtre"]
 license: "GPL-2.0-only"
 build: [
@@ -10,6 +10,6 @@ install: [make "install"]
 synopsis: "Count lines in OCaml source code"
 depends: ["ocaml"]
 url {
-  src: "http://www.lri.fr/~filliatr/ftp/ocaml/misc/ocamlwc-0.3.tar.gz"
+  src: "https://github.com/backtracking/ocamlwc/releases/download/V-0-3/ocamlwc-0.3.tar.gz"
   checksum: "md5=72bb9e8c0dad08735b62dabe216967d6"
 }

--- a/packages/ocamlweb/ocamlweb.1.38/opam
+++ b/packages/ocamlweb/ocamlweb.1.38/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: ["Jean-Christophe Filliâtre"]
 license: "LGPL-2.1-only"
 build: [
@@ -25,6 +25,6 @@ depends: [
 ]
 extra-files: ["ocamlweb.install" "md5=8190c722de440e2f113fd8c332c29be6"]
 url {
-  src: "http://www.lri.fr/~filliatr/ftp/ocamlweb/ocamlweb-1.38.tar.gz"
+  src: "https://github.com/backtracking/ocamlweb/releases/download/v1.38/ocamlweb-1.38.tar.gz"
   checksum: "md5=8b4d446a0a6cfc0925c60647d424510e"
 }

--- a/packages/ocamlweb/ocamlweb.1.39/opam
+++ b/packages/ocamlweb/ocamlweb.1.39/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "filliatr@lri.fr"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
 authors: ["Jean-Christophe Filliâtre"]
 license: "LGPL-2.1-only"
 build: [
@@ -25,6 +25,6 @@ depends: [
 ]
 extra-files: ["ocamlweb.install" "md5=8190c722de440e2f113fd8c332c29be6"]
 url {
-  src: "http://www.lri.fr/~filliatr/ftp/ocamlweb/ocamlweb-1.39.tar.gz"
+  src: "https://github.com/backtracking/ocamlweb/releases/download/v1.39/ocamlweb-1.39.tar.gz"
   checksum: "md5=d6038bba8c67a36abe156c172637be24"
 }


### PR DESCRIPTION
The websites at lri.fr no longer exist, or will be discontinued very soon.
This PR updates several URLs of tarballs that have been moved to github. In the process, it also updates contact emails and homepages of various packages.