### PR TITLE
Add: zipc.0.2.0

### DIFF
--- a/packages/zipc/zipc.0.2.0/opam
+++ b/packages/zipc/zipc.0.2.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "ZIP archive and deflate codec for OCaml"
+description: """\
+Zipc is an in-memory [ZIP archive] and [deflate] compression
+codec. Other compression formats in ZIP archives can be supported by
+using third-party libraries.
+
+Zipc has no dependencies and no C code. It is distributed under the
+ISC license.
+
+[ZIP archive]: https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
+[deflate]: https://www.rfc-editor.org/rfc/rfc1951
+
+Homepage: <https://erratique.ch/software/zipc>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The zipc programmers"
+license: "ISC"
+tags: ["codec" "zip" "deflate" "zlib" "org:erratique"]
+homepage: "https://erratique.ch/software/zipc"
+doc: "https://erratique.ch/software/zipc/doc"
+bug-reports: "https://github.com/dbuenzli/zipc/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "b0" {dev & with-test}
+]
+depopts: ["cmdliner"]
+conflicts: [
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/zipc.git"
+url {
+  src: "https://erratique.ch/software/zipc/releases/zipc-0.2.0.tbz"
+  checksum:
+    "sha512=ac1ff84abdc733e400c4bc3c56f09fe5792c96fc236d254ded97c40b2f2c9b521f34288e6c721a096e5acb0f15c73ec5852b57166985d3f48257b45e8587ab8a"
+}


### PR DESCRIPTION
* Add: `zipc.0.2.0` [home](https://erratique.ch/software/zipc), [doc](https://erratique.ch/software/zipc/doc), [issues](https://github.com/dbuenzli/zipc/issues)  
  *ZIP archive and deflate codec for OCaml*


---

#### `zipc` v0.2.0 2024-01-22 La Forclaz (VS)

- Decompression limits in `Zipc_deflate` (breaking change). When the
  `decompression_size` argument of decompression functions is
  specified, decompression errors as soon as the decompressed size
  exceeds that value. Previously it was only treated as a hint.

- `Zipc.File.to_binary_string`, error if the decompression size starts
  exceeding `File.decompressed_size` rather than ignoring this value.
  This allows clients to enforce limits on the decompression of
  untrusted zip file. Thanks to Valentin Gatien-Baron for suggesting ([#1](https://github.com/dbuenzli/zipc/issues/1)).

- `Zipc.File.make`: fix default value of `version_needed_to_extract`. It
  was the same as `version_made_by` which is wrong. Now defaults
  to `20`(PKZip 2.0). Thanks to Valentin Gatien-Baron for the report ([#3](https://github.com/dbuenzli/zipc/issues/3)).

- Fix encoding of `Zipc.File.gp_flags`. Bit 3 indicates presence of a
  data descriptor. Since we never write one, we clear the bit on
  encoding. Not doing this would result in interoperability issues
  when rewriting archives that originally had data descriptors. Thanks
  to Valentin Gatien-Baron for tracking this down ([#4](https://github.com/dbuenzli/zipc/issues/4)).

- Fix swapped date and time in the encoding of local file headers.
  Thanks to Valentin Gatien-Baron for the fix ([#5](https://github.com/dbuenzli/zipc/issues/5)).

- Write entries in the central directory in the same order as files
  are written in the archive. In particular this gives less
  surprising result on `unzip -l`. Thanks to Valentin Gatien-Baron
  for the patch ([#2](https://github.com/dbuenzli/zipc/issues/2)).

---

Use `b0 -- .opam publish zipc.0.2.0` to update the pull request.