### PR TITLE
[new release] dream-html (2.1.0)

### DIFF
--- a/packages/dream-html/dream-html.2.1.0/opam
+++ b/packages/dream-html/dream-html.2.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v2.1.0/dream-html-2.1.0.tbz"
+  checksum: [
+    "sha256=d0104fbfb19b640dec36008789ed8b0d8f2d1a5945eefbc97a8eb8c134f676c9"
+    "sha512=63db1d8578f2fbe5b7049ea73ef5fdc6083ad1f6f45d0e05f5934d24f644496097f7c71a97d4020a2ec48be6b095289bd31709969f1c80987014de4e48851130"
+  ]
+}
+x-commit-hash: "736c395880e770c971b5275f5ce119eef31f06d0"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
