### PR TITLE
Add seq.base files to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,8 @@ packages/core/*/files/corebuild text eol=lf
 packages/bap-llvm/*/files/detect.travis text eol=lf
 packages/freetennis/*/files/freetennis text eol=lf
 packages/ocamlfind/*/files/ocaml-stub text eol=lf
+packages/seq/seq.base/files/seq.install text eol=lf
+packages/seq/seq.base/files/META.seq text eol=lf
 
 # Do not normalise patch files (opam will ensure that patch files are
 # appropriately normalised for the target files, but direct calls to patch


### PR DESCRIPTION
In a windows setup-ocaml job, I added this repository and `seq.base` files had a hash mismatch, adding them to gitattributes.