### PR TITLE
phylogenetics 0.2.0 requires yojson

### DIFF
--- a/packages/phylogenetics/phylogenetics.0.2.0/opam
+++ b/packages/phylogenetics/phylogenetics.0.2.0/opam
@@ -17,6 +17,7 @@ depends: [
   "lacaml" {>= "10.0.2"}
   "menhir"
   "ppx_deriving"
+  "yojson"
   "printbox" {>= "0.6.1"}
   "printbox-text"
   "odoc" {with-doc}


### PR DESCRIPTION
It was probably having it installed transitively