### PR TITLE
lower ocaml bound on hc

### DIFF
--- a/packages/hc/hc.0.2/opam
+++ b/packages/hc/hc.0.2/opam
@@ -10,7 +10,7 @@ doc: "https://doc.zapashcanon.fr/hc/"
 bug-reports: "https://git.zapashcanon.fr/zapashcanon/hc/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "5.0"}
+  "ocaml" {>= "4.14"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Hi,

I have been asked if the bound could be lowered to 4.14. I bumped it to 5.0 because I had to change the code after the removal of some functions in the Ephemeron API. But actually it should still be compatible with 4.14.

Sorry for the two PRs...

Thanks!