### PR TITLE
[new release] validate (1.0.0)

### DIFF
--- a/packages/validate/validate.1.0.0/opam
+++ b/packages/validate/validate.1.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "OCaml library enabling efficient data validation through PPX derivers and a suite of annotation-based validators"
+description:
+  "Validate is an OCaml library that focuses on data validation using PPX derivers and a range of annotations for different data types. It allows developers to apply annotations for various validation rules, such as string length, numeric values, and format constraints like URLs and UUIDs. This functionality makes it suitable for a wide array of applications in OCaml development where data integrity is crucial."
+maintainer: ["Mateusz Ledwoń <mateuszledwon@duck.com>"]
+authors: ["Mateusz Ledwoń <mateuszledwon@duck.com>"]
+license: "MIT"
+tags: ["validation" "ppx"]
+homepage: "https://github.com/Axot017/validate"
+doc: "https://axot017.github.io/validate/"
+bug-reports: "https://github.com/Axot017/validate/issues"
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.12"}
+  "alcotest" {with-test}
+  "ppx_deriving"
+  "re"
+  "uri"
+  "bisect_ppx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Axot017/validate.git"
+url {
+  src:
+    "https://github.com/Axot017/validate/releases/download/v1.0.0/validate-1.0.0.tbz"
+  checksum: [
+    "sha256=af5d77b4c0b861516f1499e5d4d5d55e8214f9871878bb801e579bf26ed5a089"
+    "sha512=349b65e41da8aa44da10d5b21da0f05fea4ffe75957f18d21d2140483dedefd04fa3f183fd60f1f75a3ac094f33510587eff551dc6b464b28b72eb916dad9461"
+  ]
+}
+x-commit-hash: "363c80235bbeef86eef95c82e8d0d42a09b92153"


### PR DESCRIPTION
OCaml library enabling efficient data validation through PPX derivers and a suite of annotation-based validators

- Project page: <a href="https://github.com/Axot017/validate">https://github.com/Axot017/validate</a>
- Documentation: <a href="https://axot017.github.io/validate/">https://axot017.github.io/validate/</a>

##### CHANGES:

- Added support for validating variants.
- Introduced support for recursive types, enabling the validation of nested self-referential data structures.
- Implemented support for circular recursive types, allowing for validation in complex interconnected data structures.
- API stabilization: The API can now be considered stable. Future changes will primarily focus on adding new validators without altering existing functionality.
