### PR TITLE
[new release] printbox (4 packages) (0.9)

### DIFF
--- a/packages/printbox-html/printbox-html.0.9/opam
+++ b/packages/printbox-html/printbox-html.0.9/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Printbox unicode handling"
+description: """
+
+Adds html output handling to the printbox package.
+Printbox allows to print nested boxes, lists, arrays, tables in several formats"""
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "printbox" {= version}
+  "printbox-text" {= version & with-test}
+  "odoc" {with-test}
+  "tyxml" {>= "4.3"}
+  "mdx" {>= "1.4" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.9/printbox-0.9.tbz"
+  checksum: [
+    "sha256=40f9920bdedc5c2537ab61e90fd246ca24a78883ed234935ad4fda38367b5760"
+    "sha512=0d643a7b238bb1bf472b1bf1401b6401e802ee4c6c016b319f5c161b3546bc2b8fcc3224dc9879c433d7944566e9ffcce703f040f3f217d17cdc8149a4bed449"
+  ]
+}
+x-commit-hash: "5adaf7e166f8925df8781f639f5e470e15782243"

--- a/packages/printbox-md/printbox-md.0.9/opam
+++ b/packages/printbox-md/printbox-md.0.9/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Printbox Markdown rendering"
+description: """
+
+Adds Markdown output handling to the printbox package, with fallback to text and simplified HTML.
+Printbox allows to print nested boxes, lists, arrays, tables in several formats"""
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "printbox" {= version}
+  "printbox-text" {= version}
+  "printbox-html" {= version}
+  "odoc" {with-test}
+  "mdx" {>= "1.4" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.9/printbox-0.9.tbz"
+  checksum: [
+    "sha256=40f9920bdedc5c2537ab61e90fd246ca24a78883ed234935ad4fda38367b5760"
+    "sha512=0d643a7b238bb1bf472b1bf1401b6401e802ee4c6c016b319f5c161b3546bc2b8fcc3224dc9879c433d7944566e9ffcce703f040f3f217d17cdc8149a4bed449"
+  ]
+}
+x-commit-hash: "5adaf7e166f8925df8781f639f5e470e15782243"

--- a/packages/printbox-text/printbox-text.0.9/opam
+++ b/packages/printbox-text/printbox-text.0.9/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Text renderer for printbox, using unicode edges"
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "printbox" {= version}
+  "uutf" {>= "1.0"}
+  "uucp" {>= "2.0"}
+  "odoc" {with-test}
+  "mdx" {>= "1.4" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.9/printbox-0.9.tbz"
+  checksum: [
+    "sha256=40f9920bdedc5c2537ab61e90fd246ca24a78883ed234935ad4fda38367b5760"
+    "sha512=0d643a7b238bb1bf472b1bf1401b6401e802ee4c6c016b319f5c161b3546bc2b8fcc3224dc9879c433d7944566e9ffcce703f040f3f217d17cdc8149a4bed449"
+  ]
+}
+x-commit-hash: "5adaf7e166f8925df8781f639f5e470e15782243"

--- a/packages/printbox/printbox.0.9/opam
+++ b/packages/printbox/printbox.0.9/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Allows to print nested boxes, lists, arrays, tables in several formats"
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+tags: ["print" "box" "table" "tree"]
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.9/printbox-0.9.tbz"
+  checksum: [
+    "sha256=40f9920bdedc5c2537ab61e90fd246ca24a78883ed234935ad4fda38367b5760"
+    "sha512=0d643a7b238bb1bf472b1bf1401b6401e802ee4c6c016b319f5c161b3546bc2b8fcc3224dc9879c433d7944566e9ffcce703f040f3f217d17cdc8149a4bed449"
+  ]
+}
+x-commit-hash: "5adaf7e166f8925df8781f639f5e470e15782243"


### PR DESCRIPTION
Allows to print nested boxes, lists, arrays, tables in several formats

- Project page: <a href="https://github.com/c-cube/printbox">https://github.com/c-cube/printbox</a>

##### CHANGES:

## 0.9

- fix `PrintBox.text` will correctly handle newlines
- new `printbox-md` backend, generating markdown (by @lukstafi)

## 0.8

- require dune 3.0
- Fixes c-cube/printbox#28: no misleading uptick for empty tree nodes
- HTML: Allow frames in the summary / tree header
- Output frames as div borders in HTML

## 0.7

- move to 4.08 as lower bound
- `preformatted` text style instead of global setting
- PrintBox_html:
  * Optionally wrap text with the `<pre>` HTML element
  * Output text consistently as `<span>`, not `<div>`
  * Use `<details><summary>` for collapsible trees

- fix: Tree connectors touching frames (c-cube/printbox#26)

## 0.6.1

- compat with dune 3

## 0.6

- move text rendering into a new printbox-text library
- Changing visuals for hlines and vlines connections, and tree structure
  using unicode characters for box borders

## 0.5

- reenable mdx for tests
- custom classes/attributes for html translation in `PrintBox_html`
- add `link` case
- examples: add lambda.ml

## 0.4

- remove `<p>` in rendering text to html
- add `grid_map_l` and `v_record`
- add another test

## 0.3

- improve code readability in text rendering
- add `align` and `center`
- add basic styling for text (ansi codes/html styles)
- add `printbox_unicode` for setting up proper unicode printing
- add `grid_l`, `grid_text_l`, and `record` helpers

- use a more accurate length estimate for unicode, add test
- remove mdx as a test dep
- fix rendering bugs related to align right, and padding

## 0.2

- make the box type opaque, with a view function
- require OCaml 4.03

- add `PrintBox_text.pp`
- expose a few new functions to build boxes
- change `Text` type, work on string slices when rendering

- automatic testing using dune and mdx
- migrate to dune and opam 2

## 0.1

initial release
