### PR TITLE
ppx_minidebug.0.6.2: Upper bound `printbox-html` because of test expectations

### DIFF
--- a/packages/ppx_minidebug/ppx_minidebug.0.6.2/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.0.6.2/opam
@@ -18,7 +18,7 @@ depends: [
   "ppxlib" {>= "0.25.0"}
   "printbox" {>= "0.7"}
   "printbox-text"
-  "printbox-html" {>= "0.7"}
+  "printbox-html" {>= "0.7" & <= "0.8"}
   "ptime"
   "sexplib0"
   "ppx_expect" {with-test & >= "v0.9.0"}


### PR DESCRIPTION
Fixes a problem in the printbox.0.9 release.
Upcoming ppx_minidebug.1.0.0 will require printbox.0.9.
There's no technical reason for the upper bound, the change in the test is semantically equivalent,
but for simplicity the test expectation is exact.