### PR TITLE
[new release] gemini (0.3.0-1-gb09bc23)

### DIFF
--- a/packages/gemini/gemini.0.3.0-1-gb09bc23/opam
+++ b/packages/gemini/gemini.0.3.0-1-gb09bc23/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Carmelo Piccione <carmelo.piccione@gmail.com>"
+synopsis: "OCaml bindings for Gemini Trading Exchange API"
+description: "This library implements the Gemini exchange v1 REST, Market
+Data, and Order events websockets services. It is backed by yojson, cohttp-async
+and cohttp_async_websocket to do the heavy lifting. A provisional console interface
+is also provided using s-expressions to encode request parameters."
+authors: "Carmelo Piccione"
+homepage: "https://github.com/struktured/ocaml-gemini"
+license: "MIT"
+bug-reports: "https://github.com/struktured/ocaml-gemini/issues"
+dev-repo: "git+https://github.com/struktured/ocaml-gemini.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+doc: "https://struktured.github.io/ocaml-gemini/"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "async" {>= "v0.16.0"}
+  "core" {>= "v0.16.2"}
+  "async_ssl"
+  "cohttp-async"
+  "dune" {build}
+  "ppx_jane"
+  "uri"
+  "hex"
+  "yojson" {>= "2.1.0"}
+  "zarith"
+  "nocrypto"
+  "ppx_deriving_yojson" {>= "3.7.0"}
+  "ppx_csv_conv"
+  "csvfields"
+  "cohttp_async_websocket"
+  "expect_test_helpers_core" {>= "v0.16.0"}
+]
+url {
+  src:
+    "https://github.com/struktured/ocaml-gemini/releases/download/0.3.0-1-gb09bc23/gemini-0.3.0-1-gb09bc23.tbz"
+  checksum: [
+    "sha256=b74b64a908074dd4beccdfe8fb18098370947ba75d84afc03a69345bc6508ae2"
+    "sha512=d0398f2cb94470dab1f593e3f7b1721ca3694c257e4f71c82923df71e220fe688c8fce29302c18ae13cf355319b9f825f036ca1b44181aa866552d32931aa5b9"
+  ]
+}
+x-commit-hash: "b09bc23a6281ce898a48e58ff24d4f617153a779"


### PR DESCRIPTION
OCaml bindings for Gemini Trading Exchange API

- Project page: <a href="https://github.com/struktured/ocaml-gemini">https://github.com/struktured/ocaml-gemini</a>
- Documentation: <a href="https://struktured.github.io/ocaml-gemini/">https://struktured.github.io/ocaml-gemini/</a>

##### CHANGES:

 - Update to OCaml 5.
 - Add support for many more symbols and currencies.
 - Gracefully handle unknown currencies using new `Enum_or_string` abstraction.
 - Websocket pipes now retain result types when processing json rather than raising
   exceptions inside the pipe (breaking change).
 - Switch from `websockets-async` to simpler, better supported `cohttp_async_websocket`.
 - Fix various parse errors due to new gemini fields.
 - Format the codebase with ocamlformat.
 - Added --no-csv option to disable csv generation from command line.
 - Introduced `Poly_ok` utility module for unwrapping polymorphic variant result types.
