### PR TITLE
[new release] lablgtk3 (5 packages) (3.1.4)

### DIFF
--- a/packages/lablgtk3-goocanvas2/lablgtk3-goocanvas2.3.1.4/opam
+++ b/packages/lablgtk3-goocanvas2/lablgtk3-goocanvas2.3.1.4/opam
@@ -31,8 +31,8 @@ url {
   src:
     "https://github.com/garrigue/lablgtk/releases/download/3.1.4/lablgtk3-3.1.4.tbz"
   checksum: [
-    "sha256=b86794ab84cc2c835bc20eca78c7e35a674cf015961e43493b06bc5fd52c7d14"
-    "sha512=e08a167da2b741efb4d64cc54e7827fa774f82a95abb8141f46c456437aa2e2f0eaade1d755241f51cfd025ed7dad0feb425f8a7a448b9fe8e611fc8238e38fe"
+    "sha256=6f11153337e7687e721d5c409a27cd60ecbc1a74a2bcb2e0484ffdfb5cb1048e"
+    "sha512=a667c4e93555c7b98f0597694929f94c5e2513b944d99ebcc8a66030c95e5923b34765378a813dece986b8ad447f3d3dd9d157267ce4d766fbe53afd14a4e01e"
   ]
 }
 x-commit-hash: "7601748ad7949a1ac2b20851ccc0a7e38d5d73b1"

--- a/packages/lablgtk3-goocanvas2/lablgtk3-goocanvas2.3.1.4/opam
+++ b/packages/lablgtk3-goocanvas2/lablgtk3-goocanvas2.3.1.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+ GooCanvas library"
+description: """
+OCaml interface to GTK+3, goocanvas library.
+
+See https://garrigue.github.io/lablgtk/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3/lablgtk3-goocanvas2"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+
+depends: [
+  "ocaml"                {         >= "4.09.0" }
+  "dune"                 {         >= "1.8.0"  }
+  "lablgtk3"             {          = version  }
+  "conf-goocanvas2"      { build & >= "0"      }
+  "camlp-streams"        { build               }
+]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.1.4/lablgtk3-3.1.4.tbz"
+  checksum: [
+    "sha256=b86794ab84cc2c835bc20eca78c7e35a674cf015961e43493b06bc5fd52c7d14"
+    "sha512=e08a167da2b741efb4d64cc54e7827fa774f82a95abb8141f46c456437aa2e2f0eaade1d755241f51cfd025ed7dad0feb425f8a7a448b9fe8e611fc8238e38fe"
+  ]
+}
+x-commit-hash: "7601748ad7949a1ac2b20851ccc0a7e38d5d73b1"

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.4/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.4/opam
@@ -35,7 +35,7 @@ depexts: [
 ]
 
 build: [
-  [ "dune" "subst" ] {pinned}
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 url {

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.4/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.4/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+3"
+description: """
+OCaml interface to GTK+3, gtkspell library
+
+See https://garrigue.github.io/lablgtk/ for more information.
+
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3/lablgtk3-gtkspell3"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+
+depends: [
+  "ocaml"                { >= "4.09.0" }
+  "dune"                 { >= "1.8.0"  }
+  "lablgtk3"             {  = version  }
+]
+depexts: [
+  ["gtkspell3-dev"] {os-distribution = "alpine"}
+  ["gtkspell3"] {os-distribution = "archlinux"}
+  ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
+  ["libgtkspell3-3-dev"] {os-distribution = "debian"}
+  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3"] {os = "freebsd"}
+  ["gtkspell3"] {os = "openbsd"}
+  ["gtkspell3-devel"] {os-family = "suse"}
+  ["libgtkspell3-3-dev"] {os-distribution = "ubuntu"}
+  ["gtkspell3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
+]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.1.4/lablgtk3-3.1.4.tbz"
+  checksum: [
+    "sha256=b86794ab84cc2c835bc20eca78c7e35a674cf015961e43493b06bc5fd52c7d14"
+    "sha512=e08a167da2b741efb4d64cc54e7827fa774f82a95abb8141f46c456437aa2e2f0eaade1d755241f51cfd025ed7dad0feb425f8a7a448b9fe8e611fc8238e38fe"
+  ]
+}
+x-commit-hash: "7601748ad7949a1ac2b20851ccc0a7e38d5d73b1"

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.4/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.4/opam
@@ -42,8 +42,8 @@ url {
   src:
     "https://github.com/garrigue/lablgtk/releases/download/3.1.4/lablgtk3-3.1.4.tbz"
   checksum: [
-    "sha256=b86794ab84cc2c835bc20eca78c7e35a674cf015961e43493b06bc5fd52c7d14"
-    "sha512=e08a167da2b741efb4d64cc54e7827fa774f82a95abb8141f46c456437aa2e2f0eaade1d755241f51cfd025ed7dad0feb425f8a7a448b9fe8e611fc8238e38fe"
+    "sha256=6f11153337e7687e721d5c409a27cd60ecbc1a74a2bcb2e0484ffdfb5cb1048e"
+    "sha512=a667c4e93555c7b98f0597694929f94c5e2513b944d99ebcc8a66030c95e5923b34765378a813dece986b8ad447f3d3dd9d157267ce4d766fbe53afd14a4e01e"
   ]
 }
 x-commit-hash: "7601748ad7949a1ac2b20851ccc0a7e38d5d73b1"

--- a/packages/lablgtk3-rsvg2/lablgtk3-rsvg2.3.1.4/opam
+++ b/packages/lablgtk3-rsvg2/lablgtk3-rsvg2.3.1.4/opam
@@ -23,7 +23,7 @@ depends: [
 ]
 
 build: [
-  [ "dune" "subst" ] {pinned}
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 url {

--- a/packages/lablgtk3-rsvg2/lablgtk3-rsvg2.3.1.4/opam
+++ b/packages/lablgtk3-rsvg2/lablgtk3-rsvg2.3.1.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to Gnome rsvg2 library"
+description: """
+OCaml interface to Gnome rsvg2 library.
+
+See https://garrigue.github.io/lablgtk/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-sourceview3"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                {         >= "4.12.0" }
+  "dune"                 {         >= "1.8.0"  }
+  "lablgtk3"             {          = version  }
+  "conf-librsvg2"        { build & >= "0"      }
+]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.1.4/lablgtk3-3.1.4.tbz"
+  checksum: [
+    "sha256=b86794ab84cc2c835bc20eca78c7e35a674cf015961e43493b06bc5fd52c7d14"
+    "sha512=e08a167da2b741efb4d64cc54e7827fa774f82a95abb8141f46c456437aa2e2f0eaade1d755241f51cfd025ed7dad0feb425f8a7a448b9fe8e611fc8238e38fe"
+  ]
+}
+x-commit-hash: "7601748ad7949a1ac2b20851ccc0a7e38d5d73b1"

--- a/packages/lablgtk3-rsvg2/lablgtk3-rsvg2.3.1.4/opam
+++ b/packages/lablgtk3-rsvg2/lablgtk3-rsvg2.3.1.4/opam
@@ -12,8 +12,8 @@ authors: ["Jacques Garrigue et al., Nagoya University"]
 homepage: "https://github.com/garrigue/lablgtk"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
-doc: "https://garrigue.github.io/lablgtk/lablgtk3-rsvg2"
-license: "LGPL with linking exception"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3/lablgtk3-rsvg2"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 
 depends: [
   "ocaml"                {         >= "4.12.0" }

--- a/packages/lablgtk3-rsvg2/lablgtk3-rsvg2.3.1.4/opam
+++ b/packages/lablgtk3-rsvg2/lablgtk3-rsvg2.3.1.4/opam
@@ -12,7 +12,7 @@ authors: ["Jacques Garrigue et al., Nagoya University"]
 homepage: "https://github.com/garrigue/lablgtk"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
-doc: "https://garrigue.github.io/lablgtk/lablgtk3-sourceview3"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-rsvg2"
 license: "LGPL with linking exception"
 
 depends: [
@@ -30,8 +30,8 @@ url {
   src:
     "https://github.com/garrigue/lablgtk/releases/download/3.1.4/lablgtk3-3.1.4.tbz"
   checksum: [
-    "sha256=b86794ab84cc2c835bc20eca78c7e35a674cf015961e43493b06bc5fd52c7d14"
-    "sha512=e08a167da2b741efb4d64cc54e7827fa774f82a95abb8141f46c456437aa2e2f0eaade1d755241f51cfd025ed7dad0feb425f8a7a448b9fe8e611fc8238e38fe"
+    "sha256=6f11153337e7687e721d5c409a27cd60ecbc1a74a2bcb2e0484ffdfb5cb1048e"
+    "sha512=a667c4e93555c7b98f0597694929f94c5e2513b944d99ebcc8a66030c95e5923b34765378a813dece986b8ad447f3d3dd9d157267ce4d766fbe53afd14a4e01e"
   ]
 }
 x-commit-hash: "7601748ad7949a1ac2b20851ccc0a7e38d5d73b1"

--- a/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.1.4/opam
+++ b/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.1.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+ gtksourceview library"
+description: """
+OCaml interface to GTK+3, gtksourceview3 library.
+
+See https://garrigue.github.io/lablgtk/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3/lablgtk3-sourceview3"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+
+depends: [
+  "ocaml"                {         >= "4.09.0" }
+  "dune"                 {         >= "1.8.0"  }
+  "lablgtk3"             {          = version  }
+  "conf-gtksourceview3"  { build & >= "0"      }
+  "camlp-streams"        { build               }
+]
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.1.4/lablgtk3-3.1.4.tbz"
+  checksum: [
+    "sha256=b86794ab84cc2c835bc20eca78c7e35a674cf015961e43493b06bc5fd52c7d14"
+    "sha512=e08a167da2b741efb4d64cc54e7827fa774f82a95abb8141f46c456437aa2e2f0eaade1d755241f51cfd025ed7dad0feb425f8a7a448b9fe8e611fc8238e38fe"
+  ]
+}
+x-commit-hash: "7601748ad7949a1ac2b20851ccc0a7e38d5d73b1"

--- a/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.1.4/opam
+++ b/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.1.4/opam
@@ -24,7 +24,7 @@ depends: [
 ]
 
 build: [
-  [ "dune" "subst"] {pinned}
+  [ "dune" "subst"] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 url {

--- a/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.1.4/opam
+++ b/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.1.4/opam
@@ -31,8 +31,8 @@ url {
   src:
     "https://github.com/garrigue/lablgtk/releases/download/3.1.4/lablgtk3-3.1.4.tbz"
   checksum: [
-    "sha256=b86794ab84cc2c835bc20eca78c7e35a674cf015961e43493b06bc5fd52c7d14"
-    "sha512=e08a167da2b741efb4d64cc54e7827fa774f82a95abb8141f46c456437aa2e2f0eaade1d755241f51cfd025ed7dad0feb425f8a7a448b9fe8e611fc8238e38fe"
+    "sha256=6f11153337e7687e721d5c409a27cd60ecbc1a74a2bcb2e0484ffdfb5cb1048e"
+    "sha512=a667c4e93555c7b98f0597694929f94c5e2513b944d99ebcc8a66030c95e5923b34765378a813dece986b8ad447f3d3dd9d157267ce4d766fbe53afd14a4e01e"
   ]
 }
 x-commit-hash: "7601748ad7949a1ac2b20851ccc0a7e38d5d73b1"

--- a/packages/lablgtk3/lablgtk3.3.1.4/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.4/opam
@@ -26,7 +26,7 @@ depends: [
 ]
 
 build: [
-  [ "dune" "subst"] {pinned}
+  [ "dune" "subst"] {dev}```
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 run-test: [

--- a/packages/lablgtk3/lablgtk3.3.1.4/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.4/opam
@@ -36,8 +36,8 @@ url {
   src:
     "https://github.com/garrigue/lablgtk/releases/download/3.1.4/lablgtk3-3.1.4.tbz"
   checksum: [
-    "sha256=b86794ab84cc2c835bc20eca78c7e35a674cf015961e43493b06bc5fd52c7d14"
-    "sha512=e08a167da2b741efb4d64cc54e7827fa774f82a95abb8141f46c456437aa2e2f0eaade1d755241f51cfd025ed7dad0feb425f8a7a448b9fe8e611fc8238e38fe"
+    "sha256=6f11153337e7687e721d5c409a27cd60ecbc1a74a2bcb2e0484ffdfb5cb1048e"
+    "sha512=a667c4e93555c7b98f0597694929f94c5e2513b944d99ebcc8a66030c95e5923b34765378a813dece986b8ad447f3d3dd9d157267ce4d766fbe53afd14a4e01e"
   ]
 }
 x-commit-hash: "7601748ad7949a1ac2b20851ccc0a7e38d5d73b1"

--- a/packages/lablgtk3/lablgtk3.3.1.4/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+3"
+description: """
+OCaml interface to GTK+3
+
+See https://garrigue.github.io/lablgtk/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3/lablgtk3"
+
+depends: [
+  "ocaml"     {         >= "4.09.0" }
+  "camlp-streams" {     >= "5.0" & build }
+  "dune"      {         >= "1.8.0"  }
+  "cairo2"    {         >= "0.6"    }
+  "conf-gtk3" {         >= "18"     }
+  "ocamlfind" { dev                 }
+  "camlp5"    { dev                 }
+]
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "build" "-p" name "-j" jobs "examples/buttons.exe" ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.1.4/lablgtk3-3.1.4.tbz"
+  checksum: [
+    "sha256=b86794ab84cc2c835bc20eca78c7e35a674cf015961e43493b06bc5fd52c7d14"
+    "sha512=e08a167da2b741efb4d64cc54e7827fa774f82a95abb8141f46c456437aa2e2f0eaade1d755241f51cfd025ed7dad0feb425f8a7a448b9fe8e611fc8238e38fe"
+  ]
+}
+x-commit-hash: "7601748ad7949a1ac2b20851ccc0a7e38d5d73b1"

--- a/packages/lablgtk3/lablgtk3.3.1.4/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.4/opam
@@ -26,7 +26,7 @@ depends: [
 ]
 
 build: [
-  [ "dune" "subst"] {dev}```
+  [ "dune" "subst"] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 run-test: [


### PR DESCRIPTION
OCaml interface to GTK+3

- Project page: <a href="https://github.com/garrigue/lablgtk">https://github.com/garrigue/lablgtk</a>
- Documentation: <a href="https://garrigue.github.io/lablgtk/lablgtk3/lablgtk3">https://garrigue.github.io/lablgtk/lablgtk3/lablgtk3</a>

##### CHANGES:

2024.01.31 [Jacques]
  * use Bytes rather than String
  * Various missing bindings, including lablgtk3-rsvg2 (garrigue/lablgtk#128)
  * GtkStyleContext: Add missing class and provider functions (garrigue/lablgtk#163)
  * Add GdkEvent.Scroll.delta_{x,y} (garrigue/lablgtk#173) [Thomas Leonard]
