### PR TITLE
[new release] gemini (0.3.0)

### DIFF
--- a/packages/gemini/gemini.0.3.0/opam
+++ b/packages/gemini/gemini.0.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Carmelo Piccione <carmelo.piccione@gmail.com>"
+synopsis: "OCaml bindings for Gemini Trading Exchange API"
+description: "This library implements the Gemini exchange v1 REST, Market
+Data, and Order events websockets services. It is backed by yojson, cohttp-async
+and cohttp_async_websocket to do the heavy lifting. A provisional console interface
+is also provided using s-expressions to encode request parameters."
+authors: "Carmelo Piccione"
+homepage: "https://github.com/struktured/ocaml-gemini"
+license: "MIT"
+bug-reports: "https://github.com/struktured/ocaml-gemini/issues"
+dev-repo: "git+https://github.com/struktured/ocaml-gemini.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+doc: "https://struktured.github.io/ocaml-gemini/"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "async" {>= "v0.16.0"}
+  "core" {>= "v0.16.2"}
+  "async_ssl"
+  "cohttp-async"
+  "dune" {>= "1.2"}
+  "ppx_jane"
+  "uri"
+  "hex"
+  "yojson" {>= "2.1.0"}
+  "zarith"
+  "nocrypto"
+  "ppx_deriving_yojson" {>= "3.7.0"}
+  "ppx_csv_conv"
+  "csvfields"
+  "cohttp_async_websocket"
+  "expect_test_helpers_core" {>= "v0.16.0"}
+]
+url {
+  src:
+    "https://github.com/struktured/ocaml-gemini/releases/download/0.3.0/gemini-0.3.0.tbz"
+  checksum: [
+    "sha256=272dee4881951e559c66dc65d524373132d592af70c5612ae6ce9845956a4b77"
+    "sha512=2f6e73ee03d688d7b6f0fd3ec97c67d9bdfee03868ec45c28acb58a7cf71f50f070020f335531c476b11354dff0393cb2d8084e28747d0d5bd8e1ce2a603f0ea"
+  ]
+}
+x-commit-hash: "eae7fbd616235baf8d432cc6eae09ddc50c9930e"


### PR DESCRIPTION
OCaml bindings for Gemini Trading Exchange API

- Project page: <a href="https://github.com/struktured/ocaml-gemini">https://github.com/struktured/ocaml-gemini</a>
- Documentation: <a href="https://struktured.github.io/ocaml-gemini/">https://struktured.github.io/ocaml-gemini/</a>

##### CHANGES:

 - Update to OCaml 5.
 - Add support for many more symbols and currencies.
 - Gracefully handle unknown currencies using new `Enum_or_string` abstraction.
 - Websocket pipes now retain result types when processing json rather than raising
   exceptions inside the pipe (breaking change).
 - Switch from `websockets-async` to simpler, better supported `cohttp_async_websocket`.
 - Fix various parse errors due to new gemini fields.
 - Format the codebase with ocamlformat.
 - Added --no-csv option to disable csv generation from command line.
 - Introduced `Poly_ok` utility module for unwrapping polymorphic variant result types.
