### PR TITLE
new file:   packages/molenc/molenc.16.23.0/opam

### DIFF
--- a/packages/molenc/molenc.16.23.0/opam
+++ b/packages/molenc/molenc.16.23.0/opam
@@ -1,0 +1,90 @@
+opam-version: "2.0"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/molenc"
+bug-reports: "https://github.com/UnixJunkie/molenc/issues"
+dev-repo: "git+https://github.com/UnixJunkie/molenc.git"
+license: "BSD-3-Clause"
+build: ["dune" "build" "-p" name "-j" jobs]
+install: [
+  ["cp" "bin/molenc_diam.py" "%{bin}%/molenc_diam.py"]
+  ["cp" "bin/molenc_ph4.py" "%{bin}%/molenc_ph4.py"]
+  ["cp" "bin/molenc.sh" "%{bin}%/molenc.sh"]
+  ["cp" "bin/molenc_ligprep.sh" "%{bin}%/molenc_ligprep.sh"]
+  ["cp" "bin/molenc_common.py" "%{bin}%/molenc_common.py"]
+  ["cp" "bin/molenc_lean.py" "%{bin}%/molenc_lean.py"]
+  ["cp" "bin/molenc_lizard.py" "%{bin}%/molenc_lizard.py"]
+  ["cp" "bin/molenc_scan.py" "%{bin}%/molenc_scan.py"]
+  ["cp" "bin/molenc_scan.sh" "%{bin}%/molenc_scan.sh"]
+  ["cp" "bin/molenc_type_atoms.py" "%{bin}%/molenc_type_atoms.py"]
+  ["cp" "bin/smi2png.py" "%{bin}%/molenc_smi2png.py"]
+  ["cp" "bin/molenc_smisur.py" "%{bin}%/molenc_smisur.py"]
+  ["cp" "bin/molenc_panascan.py" "%{bin}%/molenc_panascan.py"]
+  ["cp" "bin/molenc_scaffold.py" "%{bin}%/molenc_scaffold.py"]
+  ["cp" "bin/molenc_deepsmi.py" "%{bin}%/molenc_deepsmi.py"]
+  ["cp" "bin/molenc_lead.py" "%{bin}%/molenc_lead.py"]
+  ["cp" "bin/molenc_drug.py" "%{bin}%/molenc_drug.py"]
+  ["cp" "bin/molenc_smi2cansmi.py" "%{bin}%/molenc_smi2cansmi.py"]
+  ["cp" "bin/molenc_std.py" "%{bin}%/molenc_std.py"]
+  ["cp" "bin/molenc_padel.py" "%{bin}%/molenc_padel.py"]
+  ["cp" "bin/molenc_rotbond.py" "%{bin}%/molenc_rotbond.py"]
+  ["cp" "bin/molenc_mview.py" "%{bin}%/molenc_mview.py"]
+  ["cp" "bin/molenc_HA.py" "%{bin}%/molenc_HA.py"]
+  ["cp" "bin/molenc_sdf2smi.py" "%{bin}%/molenc_sdf2smi.py"]
+  ["cp" "bin/molenc_atoms_filter.py" "%{bin}%/molenc_atoms_filter.py"]
+]
+depends: [
+  "batteries" {>= "3.5.0"}
+  "bst" {>= "2.0.0"}
+  "conf-graphviz"
+  "conf-python-3"
+  "conf-rdkit"
+  "cpm" {>= "9.0.0"}
+  "dokeysto"
+  "dolog" {>= "5.0.0"}
+  "dune" {>= "1.11"}
+  "line_oriented"
+  "minicli" {>= "5.0.0"}
+  "ocaml" {>= "5.1.0"}
+  "ocamlgraph"
+  "parany" {>= "12.1.1"}
+  "vector3"
+  "pyml" {>= "20211015"}
+]
+synopsis: "Molecular encoder/featurizer using rdkit and OCaml"
+description: """Chemical fingerprints are lossy encodings of molecules.
+molenc allows to encode molecules using unfolded-counted fingerprints
+(i.e. a potentially very long but sparse vector of positive integers).
+
+Currently, Faulon fingerprints and atom pairs are supported.
+
+Currently, atom types are the quadruplet
+(#pi-electrons, element symbol, #HA neighbors, formal charge).
+In the future, pharmacophore features might be supported (a more abstract/fuzzy
+atom typing scheme).
+
+Bibliography:
+=============
+
+Faulon, J. L., Visco, D. P., & Pophale, R. S. (2003).
+The signature molecular descriptor.
+1. Using extended valence sequences in QSAR and QSPR studies.
+Journal of chemical information and computer sciences, 43(3), 707-720.
+
+Carhart, R. E., Smith, D. H., & Venkataraghavan, R. (1985).
+Atom pairs as molecular features in structure-activity studies:
+definition and applications.
+Journal of Chemical Information and Computer Sciences, 25(2), 64-73.
+
+Kearsley, S. K., Sallamack, S., Fluder, E. M., Andose, J. D., Mosley, R. T., &
+Sheridan, R. P. (1996).
+Chemical similarity using physiochemical property descriptors.
+Journal of Chemical Information and Computer Sciences, 36(1), 118-127.
+
+OpenSMILES specification. Craig A. James et. al. v1.0 2016-05-15.
+http://opensmiles.org/opensmiles.html
+"""
+url {
+  src: "https://github.com/UnixJunkie/molenc/archive/refs/tags/v16.23.0.tar.gz"
+  checksum: "md5=cab545a0a8b78f78d54c33750349022c"
+}


### PR DESCRIPTION
Latest, and greatest, version of molenc.

New scripts:
- molenc_mview.py, molenc_HA.py, molenc_sdf2smi.py, molenc_atoms_filter.py

New exe: molenc_AP
- more precise atom typing compared to previous versions

Removed old script:
- molenc_standardize.py; molenc_std.py is the new way

