### PR TITLE
Package lru_cache.0.4.0

### DIFF
--- a/packages/lru_cache/lru_cache.0.4.0/opam
+++ b/packages/lru_cache/lru_cache.0.4.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A simple implementation of a Least-Recently-Used cache"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-lru-cache/"
+doc: "https://zoggy.frama.io/ocaml-lru-cache/refdoc/lru_cache/"
+bug-reports: "https://framagit.org/zoggy/ocaml-lru-cache/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "lwt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-lru-cache.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-lru-cache/-/archive/0.4.0/ocaml-lru-cache-0.4.0.tar.bz2"
+  checksum: [
+    "md5=e8649edba630d6ba7178993f7da29752"
+    "sha512=50ae0647734a8ba1bfcac4f70b77bbd043e463e60bdad61c8b1e805f2b896bba0c8a3c8ebc5e2d8fba9b1b35f6fa34af110cb38a99fc41d83eda99c762166fff"
+  ]
+}


### PR DESCRIPTION
### `lru_cache.0.4.0`
A simple implementation of a Least-Recently-Used cache



---
* Homepage: https://zoggy.frama.io/ocaml-lru-cache/
* Source repo: git+https://framagit.org/zoggy/ocaml-lru-cache.git
* Bug tracker: https://framagit.org/zoggy/ocaml-lru-cache/issues

---
:camel: Pull-request generated by opam-publish v2.3.0