### PR TITLE
[new release] obuilder (2 packages) (0.6.0)

### DIFF
--- a/packages/obuilder-spec/obuilder-spec.0.6.0/opam
+++ b/packages/obuilder-spec/obuilder-spec.0.6.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Build specification format"
+description:
+  "A library for constructing, reading and writing OBuilder build specification files."
+maintainer: [
+  "Tim McGilchrist <timmcgil@gmail.com>"
+  "Antonin Décimo <antonin@tarides.com>"
+]
+authors: [
+  "Antonin Décimo <antonin@tarides.com>"
+  "Arthur Wendling <art.wendling@gmail.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Patrick Ferris <pf341@patricoferris.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/obuilder"
+doc: "https://ocurrent.github.io/obuilder/"
+bug-reports: "https://github.com/ocurrent/obuilder/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "fmt" {>= "0.8.9"}
+  "sexplib"
+  "astring"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ocaml" {>= "4.14.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/obuilder.git"
+url {
+  src:
+    "https://github.com/ocurrent/obuilder/releases/download/v0.6.0/obuilder-0.6.0.tbz"
+  checksum: [
+    "sha256=07637b0d8010770b5ef89f07891dbc6155e4741582faf081ef7335ba123b3140"
+    "sha512=62ecd0a06d4b97f5288ecc0031b27a5588f7bdd44b8de4ff4293ba2228589de7b13d1c6d4e24c8c755bb3dea2e97eb6f8b9a7bbfb7d35c1e12ef6220632c9a4b"
+  ]
+}
+x-commit-hash: "d944aef9b04e0c45e584f73d3f49b821bc8421d8"

--- a/packages/obuilder-spec/obuilder-spec.0.6.0/opam
+++ b/packages/obuilder-spec/obuilder-spec.0.6.0/opam
@@ -31,8 +31,6 @@ depends: [
   "ppx_sexp_conv"
   "ocaml" {>= "4.14.1"}
   "odoc" {with-doc}
-  "conf-which" {with-test}
-  "conf-bash" {with-test}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/obuilder-spec/obuilder-spec.0.6.0/opam
+++ b/packages/obuilder-spec/obuilder-spec.0.6.0/opam
@@ -31,6 +31,8 @@ depends: [
   "ppx_sexp_conv"
   "ocaml" {>= "4.14.1"}
   "odoc" {with-doc}
+  "conf-which" {with-test}
+  "conf-bash" {with-test}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/obuilder/obuilder.0.6.0/opam
+++ b/packages/obuilder/obuilder.0.6.0/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "Run build scripts for CI"
+description:
+  "OBuilder takes a build script (similar to a Dockerfile) and performs the steps in it in a sandboxed environment."
+maintainer: [
+  "Tim McGilchrist <timmcgil@gmail.com>"
+  "Antonin Décimo <antonin@tarides.com>"
+]
+authors: [
+  "Antonin Décimo <antonin@tarides.com>"
+  "Arthur Wendling <art.wendling@gmail.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Patrick Ferris <pf341@patricoferris.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/obuilder"
+doc: "https://ocurrent.github.io/obuilder/"
+bug-reports: "https://github.com/ocurrent/obuilder/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "lwt" {>= "5.6.1"}
+  "astring"
+  "fmt" {>= "0.8.9"}
+  "logs"
+  "cmdliner" {>= "1.2.0"}
+  "tar-unix" {>= "2.4.0"}
+  "yojson" {>= "1.6.0"}
+  "sexplib"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "sha" {>= "1.15.4"}
+  "sqlite3"
+  "crunch" {>= "3.3.1" & build}
+  "obuilder-spec" {= version}
+  "fpath"
+  "extunix" {>= "0.4.0"}
+  "ocaml" {>= "4.14.1"}
+  "alcotest-lwt" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/obuilder.git"
+url {
+  src:
+    "https://github.com/ocurrent/obuilder/releases/download/v0.6.0/obuilder-0.6.0.tbz"
+  checksum: [
+    "sha256=07637b0d8010770b5ef89f07891dbc6155e4741582faf081ef7335ba123b3140"
+    "sha512=62ecd0a06d4b97f5288ecc0031b27a5588f7bdd44b8de4ff4293ba2228589de7b13d1c6d4e24c8c755bb3dea2e97eb6f8b9a7bbfb7d35c1e12ef6220632c9a4b"
+  ]
+}
+x-commit-hash: "d944aef9b04e0c45e584f73d3f49b821bc8421d8"

--- a/packages/obuilder/obuilder.0.6.0/opam
+++ b/packages/obuilder/obuilder.0.6.0/opam
@@ -43,6 +43,8 @@ depends: [
   "ocaml" {>= "4.14.1"}
   "alcotest-lwt" {>= "1.7.0" & with-test}
   "odoc" {with-doc}
+  "conf-which" {with-test}
+  "conf-bash" {with-test}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Run build scripts for CI

- Project page: <a href="https://github.com/ocurrent/obuilder">https://github.com/ocurrent/obuilder</a>
- Documentation: <a href="https://ocurrent.github.io/obuilder/">https://ocurrent.github.io/obuilder/</a>

##### CHANGES:

- Add a Docker backend for Windows and Linux jobs.
  (@MisterDA ocurrent/obuilder#127 ocurrent/obuilder#75, reviewed by @talex5 and @tmcgilchrist)
- Add FreeBSD sandbox backend using jail(8)
  (@dustanddreams ocurrent/obuilder#156 ocurrent/obuilder#174, reviewed by @tmcgilchrist, @MisterDA, and @mtelvers)
- Add Macos ZFS sandbox (@mtelvers ocurrent/obuilder#164, reviewed by @tmcgilchrist)
- Support XFS store (@mtelvers ocurrent/obuilder#170, reviewed by @tmcgilchrist)

- Search for bash rather than assume it lies in /bin (@dustanddreams ocurrent/obuilder#159, reviewed by @tmcgilchrist)
- Prune builds one at a time up to the limit (@mtelvers ocurrent/obuilder#157)
- Specify upper bound on number of items in the store (@mtelvers ocurrent/obuilder#158, reviewed by @MisterDA)
- Fix case where BTRFS is not fully allocated (@mtelvers ocurrent/obuilder#162)
- Avoid pruning parent cache objects (@mtelvers ocurrent/obuilder#176, reviewed by @tmcgilchrist)
