### PR TITLE
[new release] hashcons (1.4.0)

### DIFF
--- a/packages/hashcons/hashcons.1.4.0/opam
+++ b/packages/hashcons/hashcons.1.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "OCaml hash-consing library"
+description: """
+The technique is described in this paper:
+*Sylvain Conchon and Jean-Christophe Filliâtre.* Type-Safe Modular Hash-Consing.
+In ACM SIGPLAN Workshop on ML, Portland, Oregon, September 2006.
+The PDF is available at
+<https://www.lri.fr/~filliatr/ftp/publis/hash-consing2.pdf>"""
+maintainer: ["Jean-Christophe Filliatre <Jean-Christophe.Filliatre@cnrs.fr>"]
+authors: ["Jean-Christophe Filliatre <Jean-Christophe.Filliatre@cnrs.fr>"]
+license: "LGPL-2.1"
+homepage: "https://github.com/backtracking/ocaml-hashcons"
+bug-reports: "https://github.com/backtracking/ocaml-hashcons/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/backtracking/ocaml-hashcons.git"
+url {
+  src:
+    "https://github.com/backtracking/ocaml-hashcons/releases/download/1.4.0/hashcons-1.4.0.tbz"
+  checksum: [
+    "sha256=73827f0a841f5aa2643263b88c2023d2d8668fda5dee0537de26f96d0f1ca3c2"
+    "sha512=4402d085679336985c6ab031fa7f58a6026279d22488f2c332314faccaee9ae12b33c42adab72eae533febd947061c10646ebb4fa78515fb721064e142860eb7"
+  ]
+}
+x-commit-hash: "9d6a7855e70ac59f8e434efdc301aa9c9bc81991"

--- a/packages/hashcons/hashcons.1.4.0/opam
+++ b/packages/hashcons/hashcons.1.4.0/opam
@@ -8,7 +8,7 @@ The PDF is available at
 <https://www.lri.fr/~filliatr/ftp/publis/hash-consing2.pdf>"""
 maintainer: ["Jean-Christophe Filliatre <Jean-Christophe.Filliatre@cnrs.fr>"]
 authors: ["Jean-Christophe Filliatre <Jean-Christophe.Filliatre@cnrs.fr>"]
-license: "LGPL-2.1"
+license: "LGPL-2.1-only"
 homepage: "https://github.com/backtracking/ocaml-hashcons"
 bug-reports: "https://github.com/backtracking/ocaml-hashcons/issues"
 depends: [


### PR DESCRIPTION
OCaml hash-consing library

- Project page: <a href="https://github.com/backtracking/ocaml-hashcons">https://github.com/backtracking/ocaml-hashcons</a>

##### CHANGES:

  - fixed performance bugs in weak hash tables implementation,
    by back porting some old fixes from OCaml's `Weak` module
    (reported by Edwin Török)
  - improved equality functions in Hset and Hmap
    (contributed by Dorian Lesbre)
  - a lot of missing functions in Hset and Hmap wrt OCaml's Set and Map,
    with the notable exception of `to_seq_rev`
    (contributed by Dorian Lesbre)
