### PR TITLE
Package mem_usage.0.1.0

### DIFF
--- a/packages/mem_usage/mem_usage.0.1.0/opam
+++ b/packages/mem_usage/mem_usage.0.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Cross-platform stats about memory usage"
+maintainer: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+authors: "Romain Beauxis <toots@rastageeks.org>"
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-mem_usage"
+bug-reports: "https://github.com/savonet/ocaml-mem_usage/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-mem_usage.git"
+url {
+  src:
+    "https://github.com/savonet/ocaml-mem_usage/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=efa6847db6884a2cd26b064f6431ad86"
+    "sha512=19a2772e0fdb55c6dd0cd01df2fba7ff8c8cf63dd3cd4361d4964464fe2acea664db75a0c97c5fd47b7b1a662cc23bdce61ae0d5298fcfc93b60a99d8ebab3a2"
+  ]
+}


### PR DESCRIPTION
### `mem_usage.0.1.0`
Cross-platform stats about memory usage



---
* Homepage: https://github.com/savonet/ocaml-mem_usage
* Source repo: git+https://github.com/savonet/ocaml-mem_usage.git
* Bug tracker: https://github.com/savonet/ocaml-mem_usage/issues

---
:camel: Pull-request generated by opam-publish v2.3.0