### PR TITLE
[new release] validate (1.1.0)

### DIFF
--- a/packages/validate/validate.1.1.0/opam
+++ b/packages/validate/validate.1.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "OCaml library enabling efficient data validation through PPX derivers and a suite of annotation-based validators"
+description:
+  "Validate is an OCaml library that focuses on data validation using PPX derivers and a range of annotations for different data types. It allows developers to apply annotations for various validation rules, such as string length, numeric values, and format constraints like URLs and UUIDs. This functionality makes it suitable for a wide array of applications in OCaml development where data integrity is crucial."
+maintainer: ["Mateusz Ledwoń <mateuszledwon@duck.com>"]
+authors: ["Mateusz Ledwoń <mateuszledwon@duck.com>"]
+license: "MIT"
+tags: ["validation" "ppx"]
+homepage: "https://github.com/Axot017/validate"
+doc: "https://axot017.github.io/validate/"
+bug-reports: "https://github.com/Axot017/validate/issues"
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.12"}
+  "alcotest" {with-test}
+  "ppx_deriving"
+  "re"
+  "uri"
+  "bisect_ppx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Axot017/validate.git"
+url {
+  src:
+    "https://github.com/Axot017/validate/releases/download/v1.1.0/validate-1.1.0.tbz"
+  checksum: [
+    "sha256=830d3b1ac8cdacfca2877030dd0377e46115527e7963359537daa5897e563da4"
+    "sha512=3d681eff0948af42b0b9a7bcab789d00d45066c4efdc2a426925e15c16ad8568afd0024e98afe9320d41619813464aaf9a448712d7722955385f2cd3379c6cf5"
+  ]
+}
+x-commit-hash: "be8bb80a0cc8c7600dcdb60adbb0700a9fd45e39"


### PR DESCRIPTION
OCaml library enabling efficient data validation through PPX derivers and a suite of annotation-based validators

- Project page: <a href="https://github.com/Axot017/validate">https://github.com/Axot017/validate</a>
- Documentation: <a href="https://axot017.github.io/validate/">https://axot017.github.io/validate/</a>

##### CHANGES:

- Added new string annotations:
  - `@ulid`: Ensures a string is a valid ULID.
  - `@ipv4`: Validates that a string is a valid IPv4 address.
  - `@ipv6`: Ensures a string is a valid IPv6 address.
  - `@phone`: Validates that a string conforms to the E.164 phone number format.
  - `@mac_address`: Ensures a string is a valid MAC address.
- Introduced new option type annotations:
  - `@some`: Ensures an option type is `Some`.
  - `@none`: Ensures an option type is `None`.
- Implemented `@custom` annotation for custom validation logic.
- Added `@ignore_if` annotation for conditional validation.
- Introduced `@some_if` and `@none_if` annotations for conditional requirements on option types.
