### PR TITLE
tighten webauthn.0.1.0 dependencies

### DIFF
--- a/packages/webauthn/webauthn.0.1.0/opam
+++ b/packages/webauthn/webauthn.0.1.0/opam
@@ -20,7 +20,7 @@ conflicts: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7"}
-  "dream" {dev & >= "1.0.0~alpha2"}
+  "dream" {dev & >= "1.0.0~alpha2" & < "1.0.0~alpha4"}
   "ppx_blob" {dev}
   "cmdliner" {dev}
   "logs" {dev}


### PR DESCRIPTION
This package doesn't install in a switch which contains dream 1.0.0~alpha4 because an optional binary fails to compile.

cc @hannesm FYI