### PR TITLE
ocluster: add upper bound on obuilder

### DIFF
--- a/packages/ocluster-worker/ocluster-worker.0.2.1/opam
+++ b/packages/ocluster-worker/ocluster-worker.0.2.1/opam
@@ -18,7 +18,7 @@ depends: [
   "fpath"
   "logs"
   "lwt" {>= "5.6.1"}
-  "obuilder" {>= "0.5.1"}
+  "obuilder" {>= "0.5.1" & < "0.6.0"}
   "prometheus-app" {>= "1.2"}
   "odoc" {with-doc}
 ]

--- a/packages/ocluster/ocluster.0.2.1/opam
+++ b/packages/ocluster/ocluster.0.2.1/opam
@@ -34,7 +34,7 @@ depends: [
   "lwt" {>= "5.6.1"}
   "lwt-dllist"
   "mirage-crypto" {>= "0.8.5"}
-  "obuilder" {>= "0.5.1"}
+  "obuilder" {>= "0.5.1" & < "6.0.0"}
   "ppx_expect" {>= "v0.14.1"}
   "ppx_sexp_conv"
   "prometheus"


### PR DESCRIPTION
```
=== ERROR while compiling ocluster-worker.0.2.1 ==============================#
 context              2.2.0~beta1 | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
 path                 ~/.opam/4.14/.opam-switch/build/ocluster-worker.0.2.1
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ocluster-worker -j 255 @install
 exit-code            1
 env-file             ~/.opam/log/ocluster-worker-7-b47266.env
 output-file          ~/.opam/log/ocluster-worker-7-b47266.out
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I worker/.cluster_worker.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/asetmap -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/capnp -I /home/opam/.opam/4.14/lib/capnp-rpc -I /home/opam/.opam/4.14/lib/capnp-rpc-lwt -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cohttp-lwt-unix -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-lwt-unix -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/cstruct-lwt -I /home/opam/.opam/4.14/lib/digestif -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/extunix -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/fpath -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/obuilder -I /home/opam/.opam/4.14/lib/obuilder-spec -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocluster-api -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/prometheus -I /home/opam/.opam/4.14/lib/prometheus-app -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/res -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/sha -I /home/opam/.opam/4.14/lib/sqlite3 -I /home/opam/.opam/4.14/lib/stdint -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/tar -I /home/opam/.opam/4.14/lib/tar-unix -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -open Cluster_worker__ -o worker/.cluster_worker.objs/byte/cluster_worker__Obuilder_build.cmi -c -intf worker/obuilder_build.mli)
 File "worker/obuilder_build.mli", line 6, characters 10-33:
 6 |   val v : Obuilder.Sandbox.config -> Obuilder.Store_spec.t -> t
               ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Unbound module Obuilder.Sandbox
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I worker/.cluster_worker.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/asetmap -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/capnp -I /home/opam/.opam/4.14/lib/capnp-rpc -I /home/opam/.opam/4.14/lib/capnp-rpc-lwt -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cohttp-lwt-unix -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-lwt-unix -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/cstruct-lwt -I /home/opam/.opam/4.14/lib/digestif -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/extunix -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/fpath -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/obuilder -I /home/opam/.opam/4.14/lib/obuilder-spec -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocluster-api -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/prometheus -I /home/opam/.opam/4.14/lib/prometheus-app -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/res -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/sha -I /home/opam/.opam/4.14/lib/sqlite3 -I /home/opam/.opam/4.14/lib/stdint -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/tar -I /home/opam/.opam/4.14/lib/tar-unix -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/yojson -intf-suffix .ml -no-alias-deps -open Cluster_worker__ -o worker/.cluster_worker.objs/byte/cluster_worker__Fetcher.cmo -c -impl worker/fetcher.ml)
 File "worker/fetcher.ml", line 1:
 Error: The implementation worker/fetcher.ml
        does not match the interface worker/.cluster_worker.objs/byte/cluster_worker__Fetcher.cmi:
         The value `fetch' is required but not provided
        File "lib/s.ml", line 138, characters 2-76: Expected declaration
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I worker/.cluster_worker.objs/byte -I worker/.cluster_worker.objs/native -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/asetmap -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/capnp -I /home/opam/.opam/4.14/lib/capnp-rpc -I /home/opam/.opam/4.14/lib/capnp-rpc-lwt -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cohttp-lwt-unix -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-lwt-unix -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/cstruct-lwt -I /home/opam/.opam/4.14/lib/digestif -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/extunix -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/fpath -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/obuilder -I /home/opam/.opam/4.14/lib/obuilder-spec -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocluster-api -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/prometheus -I /home/opam/.opam/4.14/lib/prometheus-app -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/res -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/sha -I /home/opam/.opam/4.14/lib/sqlite3 -I /home/opam/.opam/4.14/lib/stdint -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/tar -I /home/opam/.opam/4.14/lib/tar-unix -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/yojson -intf-suffix .ml -no-alias-deps -open Cluster_worker__ -o worker/.cluster_worker.objs/native/cluster_worker__Fetcher.cmx -c -impl worker/fetcher.ml)
 File "worker/fetcher.ml", line 1:
 Error: The implementation worker/fetcher.ml
        does not match the interface worker/.cluster_worker.objs/byte/cluster_worker__Fetcher.cmi:
         The value `fetch' is required but not provided
        File "lib/s.ml", line 138, characters 2-76: Expected declaration
```