### PR TITLE
[new release] melange-webapi (0.21.0)

### DIFF
--- a/packages/melange-webapi/melange-webapi.0.21.0/opam
+++ b/packages/melange-webapi/melange-webapi.0.21.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Melange bindings to the DOM"
+description: "Melange bindings to the DOM and other Web APIs."
+maintainer: [
+  "Javier Chávarri <javier.chavarri@gmail.com>"
+  "David Sancho <dsnxmoreno@gmail.com>"
+]
+authors: ["Cheng Lou <chenglou@users.noreply.github.com>"]
+license: "MIT"
+homepage: "https://github.com/melange-community/melange-webapi"
+bug-reports: "https://github.com/melange-community/melange-webapi/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml"
+  "melange" {>= "2.0.0"}
+  "melange-fetch"
+  "reason" {>= "3.10"}
+  "ocaml-lsp-server" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-community/melange-webapi.git"
+url {
+  src:
+    "https://github.com/melange-community/melange-webapi/releases/download/0.21.0/melange-webapi-0.21.0.tbz"
+  checksum: [
+    "sha256=13005ea0d9f1d688389cc3abf4154fc61da60aaaf541c9d3ee508366bc1b12c1"
+    "sha512=33a05a521a546bb21dc6372c8d196d39da164d2352c26985169e9045f68147dae6c092b6e4249fa8cc6198223b90e1d29bdd581c00cc46e0dce7c1144dd48b18"
+  ]
+}
+x-commit-hash: "adbca8879d81acddd06e397e23d702cf50ffd207"


### PR DESCRIPTION
Melange bindings to the DOM

- Project page: <a href="https://github.com/melange-community/melange-webapi">https://github.com/melange-community/melange-webapi</a>

##### CHANGES:

* feat: bind to new FormData(HtmlFormElement) by @andreypopp (melange-community/melange-webapi#13)
* fix: compatibilty with Melange v3 by @anmonteiro (melange-community/melange-webapi#16)
