### PR TITLE
Before renaming lru-cache to lru_cache

### DIFF
--- a/packages/erssical/erssical.1.1.0/opam
+++ b/packages/erssical/erssical.1.1.0/opam
@@ -17,6 +17,9 @@ depends: [
   "xtmpl" {>= "0.19.0"}
   "lwt_ppx"
 ]
+conflicts: [
+  "lru_cache" {= "v0.16.0"}
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/lru-cache/lru-cache.0.1.0/opam
+++ b/packages/lru-cache/lru-cache.0.1.0/opam
@@ -19,7 +19,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind"
 ]
-synopsis: "A simple implementation of a LRU cache."
+post-messages: [ "This library has been renamed to lru_cache since version 0.4.0" ]
+synopsis: "A simple implementation of a LRU cache"
 description: """
 ocaml-lru-cache is a simple OCaml implementation of a cache using
 the [Least Recently Used (LRU)](https://en.wikipedia.org/wiki/Cache_algorithms)

--- a/packages/lru-cache/lru-cache.0.2.0/opam
+++ b/packages/lru-cache/lru-cache.0.2.0/opam
@@ -19,7 +19,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind"
 ]
-synopsis: "A simple implementation of a LRU cache."
+post-messages: [ "This library has been renamed to lru_cache since version 0.4.0" ]
+synopsis: "A simple implementation of a LRU cache"
 description: """
 ocaml-lru-cache is a simple OCaml implementation of a cache using
 the [Least Recently Used (LRU)](https://en.wikipedia.org/wiki/Cache_algorithms)

--- a/packages/lru-cache/lru-cache.0.3.0/opam
+++ b/packages/lru-cache/lru-cache.0.3.0/opam
@@ -14,7 +14,8 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind"
 ]
-synopsis: "A simple implementation of a LRU cache."
+post-messages: [ "This library has been renamed to lru_cache since version 0.4.0" ]
+synopsis: "A simple implementation of a LRU cache"
 description: """
 ocaml-lru-cache is a simple OCaml implementation of a cache using
 the [Least Recently Used (LRU)](https://en.wikipedia.org/wiki/Cache_algorithms)


### PR DESCRIPTION
Add warning in lru-cache that it is renamed to lru_cache since version 0.4.0.
Add conflits in erssical with lru_cache v0.16.0.