### PR TITLE
Package iri.1.0.0

### DIFF
--- a/packages/iri/iri.1.0.0/opam
+++ b/packages/iri/iri.1.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Implementation of Internationalized Resource Identifiers (IRIs)"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["iri" "web" "rfc3987"]
+homepage: "https://framagit.org/zoggy/ocaml-iri/"
+doc: "https://zoggy.frama.io/ocaml-iri/refdoc/iri/IRI/index.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-iri/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "sedlex" {>= "2.3"}
+  "uunf" {>= "0.9.7"}
+  "uutf" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-iri.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-iri/-/archive/1.0.0/ocaml-iri-1.0.0.tar.bz2"
+  checksum: [
+    "md5=6ce4f0992e9f029e461af19fb232d50b"
+    "sha512=dad58975f1f601a56c113c5646a7b3c29ae5eb1c505e17c6120f492634d867d961f3f5cda8198b6e2a3cd84d23b04e4d230683a325c3935da1655c129a328eee"
+  ]
+}


### PR DESCRIPTION
### `iri.1.0.0`
Implementation of Internationalized Resource Identifiers (IRIs)



---
* Homepage: https://framagit.org/zoggy/ocaml-iri/
* Source repo: git+https://framagit.org/zoggy/ocaml-iri.git
* Bug tracker: https://framagit.org/zoggy/ocaml-iri/issues

---
:camel: Pull-request generated by opam-publish v2.3.0