### PR TITLE
Package lru_cache.0.4.0

### DIFF
--- a/packages/lru_cache/lru_cache.0.4.0/opam
+++ b/packages/lru_cache/lru_cache.0.4.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A simple implementation of a Least-Recently-Used cache"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-lru-cache/"
+doc: "https://zoggy.frama.io/ocaml-lru-cache/refdoc/lru_cache/"
+bug-reports: "https://framagit.org/zoggy/ocaml-lru-cache/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "lwt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-lru-cache.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-lru-cache/-/archive/0.4.0/ocaml-lru-cache-0.4.0.tar.bz2"
+  checksum: [
+    "md5=700969587b907565f94d5bb434c7114b"
+    "sha512=a7ae4b7f5c0f33dfc686f32b277a8b1f0530c5990384a6eacfe2dc22cf5483c2303ffa090fd13d5d3449273500a005b70c5cda7ff9b90e7a6433d2c72974cf22"
+  ]
+}

--- a/packages/lru_cache/lru_cache.0.4.0/opam
+++ b/packages/lru_cache/lru_cache.0.4.0/opam
@@ -10,6 +10,7 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.12.0"}
   "lwt" {with-test}
+  "lwt_ppx" {with-test}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
### `lru_cache.0.4.0`
A simple implementation of a Least-Recently-Used cache



---
* Homepage: https://zoggy.frama.io/ocaml-lru-cache/
* Source repo: git+https://framagit.org/zoggy/ocaml-lru-cache.git
* Bug tracker: https://framagit.org/zoggy/ocaml-lru-cache/issues

---
:camel: Pull-request generated by opam-publish v2.3.0