### PR TITLE
[new release] dream-html (3.0.0)

### DIFF
--- a/packages/dream-html/dream-html.3.0.0/opam
+++ b/packages/dream-html/dream-html.3.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.0.0/dream-html-3.0.0.tbz"
+  checksum: [
+    "sha256=c1762f8bcf9fa5284b2942e5dc20370965daad35bd97ff4fad28053c471969e1"
+    "sha512=8058aafc8b364ffc71c71ec73b23cbd094e2afd037e9ce22414427b568a04972fcbd0603d24c5d127bd97439f611feb96699da19667623df1472f39990a29827"
+  ]
+}
+x-commit-hash: "36c716b7f226b8f7b7d62810825a00dc8170204f"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
