### PR TITLE
[new release] domain-local-timeout (1.0.1)

### DIFF
--- a/packages/domain-local-timeout/domain-local-timeout.1.0.1/opam
+++ b/packages/domain-local-timeout/domain-local-timeout.1.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A scheduler independent timeout mechanism"
+description:
+  "A low level mechanism intended for writing higher level libraries that need to be able to have scheduler friendly timeouts."
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/domain-local-timeout"
+bug-reports: "https://github.com/ocaml-multicore/domain-local-timeout/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.12.0"}
+  "psq" {>= "0.2.1"}
+  "mtime" {>= "2.0.0"}
+  "thread-table" {>= "1.0.0"}
+  "domain-local-await" {>= "1.0.0" & with-test}
+  "mdx" {>= "2.3.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/domain-local-timeout.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/domain-local-timeout/releases/download/1.0.1/domain-local-timeout-1.0.1.tbz"
+  checksum: [
+    "sha256=eac0aa5243a337c13eece2d4c15427b64bf4beb4039060d5f0a36a0e1566d1df"
+    "sha512=32ecb0c41a10e3a68f5a8774c48d6b8598cbc81494dd1fb716c7d2d97ca14cbe2b59a02aa64d2ee6d53aa57b4e16c8992b6a592938bb3c70a2517273bde340f3"
+  ]
+}
+x-commit-hash: "70847fb897f52d7ede023058bb53be9e167f5e45"


### PR DESCRIPTION
A scheduler independent timeout mechanism

- Project page: <a href="https://github.com/ocaml-multicore/domain-local-timeout">https://github.com/ocaml-multicore/domain-local-timeout</a>

## 1.0.1

- Add `(implicit_transitive_deps false)` (@polytypic)
- Fix to not write to internal pipe after it has been closed (@polytypic)
