### PR TITLE
[new release] ppxlib (0.32.0)

### DIFF
--- a/packages/ppxlib/ppxlib.0.32.0/opam
+++ b/packages/ppxlib/ppxlib.0.32.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Standard infrastructure for ppx rewriters"
+description: """
+Ppxlib is the standard infrastructure for ppx rewriters
+and other programs that manipulate the in-memory representation of
+OCaml programs, a.k.a the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04.1" & < "5.2.0" & != "5.1.0~alpha1"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0" {>= "v0.12"}
+  "sexplib0" {with-test & >= "v0.15"}
+  "stdlib-shims"
+  "ocamlfind" {with-test}
+  "re" {with-test & >= "1.9.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-migrate-parsetree" {< "2.0.0"}
+  "base-effects"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.32.0/ppxlib-0.32.0.tbz"
+  checksum: [
+    "sha256=507cc73ccf895f22eeb5257a2243838c18a38a09105fcff55eeef9148555422b"
+    "sha512=73fef8ab8761bfbfde6ae87cc51eaacc5a5c937f0d628a890f0abdb2bffbf073932c25287a9e3baa2a1947c37f3dfa7f83ddd33c440e2e800971015addc97cd2"
+  ]
+}
+x-commit-hash: "ad46a4c87f99a44dc70b2ec4c42caec2ccacc3c3"


### PR DESCRIPTION
Standard infrastructure for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Add an optional `embed_errors` argument to `Context_free.map_top_down` that
  controls how to deal with exceptions thrown by context-free rules.
  (ocaml-ppx/ppxlib#468, @NathanReb)

- Fix `Longident.parse` so it properly handles unparenthesized dotted operators
  such as `+.` or `*.`. (ocaml-ppx/ppxlib#111, @rgrinberg, @NathanReb)

- raising an exception does no longer cancel the whole context free phase(ocaml-ppx/ppxlib#453, @burnleydev1)

- Sort embedded errors that are appended to the AST by location so the compiler
  reports the one closer to the beginning of the file first. (ocaml-ppx/ppxlib#463, @NathanReb)

- Update `Attribute.get` to ignore `loc_ghost`. (ocaml-ppx/ppxlib#460, @ceastlund)

- Add API to manipulate attributes that are used as flags (ocaml-ppx/ppxlib#408, @dianaoigo)

- Update changelog to use ISO 8061 date format: YYYY-MM-DD. (ocaml-ppx/ppxlib#445, @ceastlund)

- Replace `Caml` with `Stdlib`. (ocaml-ppx/ppxlib#427, @ceastlund)

- When a transformation raises, the last valid AST is used as input to the upcoming
  transformations. All such errors are collected and appended as
  extension nodes to the final AST (ocaml-ppx/ppxlib#447, @burnleydev1)

- Fix a small mistake in the man pages: Embededding errors is done by default with
  `-as-pp`, not with `-dump-ast` (ocaml-ppx/ppxlib#464, @pitag-ha)

- Set appropriate binary mode when writing to `stdout` especially for Windows
  compatibility. (ocaml-ppx/ppxlib#466, @jonahbeckford)
