### PR TITLE
Package cryptoverif.2.08pl1

### DIFF
--- a/packages/cryptoverif/cryptoverif.2.08pl1/opam
+++ b/packages/cryptoverif/cryptoverif.2.08pl1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "CryptoVerif: Cryptographic protocol verifier in the computational model"
+description: """
+CryptoVerif is an automatic protocol prover sound in the computational model. It can prove
+
+  - secrecy;
+  - correspondences, which include in particular authentication;
+  - indistinguishability between two games.
+
+It provides a generic mechanism for specifying the security assumptions on cryptographic primitives, which can handle in particular symmetric encryption, message authentication codes, public-key encryption, signatures, hash functions.
+
+The generated proofs are proofs by sequences of games, as used by cryptographers. These proofs are valid for a number of sessions polynomial in the security parameter, in the presence of an active adversary. CryptoVerif can also evaluate the probability of success of an attack against the protocol as a function of the probability of breaking each cryptographic primitive and of the number of sessions (exact security).
+
+This software is under development; please use it at your own risk. Comments and bug reports welcome. 
+"""
+maintainer: "Bruno Blanchet <Bruno.Blanchet@inria.fr>"
+authors: "Bruno Blanchet <Bruno.Blanchet@inria.fr>, Pierre Boutry <boutry.pierre@gmail.com>, David Cadé <David.Cade@normalesup.org>, Christian Doczkal <christian.doczkal@mpi-sp.org>, Charlie Jacomme <Charlie.Jacomme@inria.fr>, Benjamin Lipp <Benjamin.Lipp@mpi-sp.org>, and Pierre-Yves Strub <pierre-yves@strub.nu>"
+license: "CECILL-B"
+homepage: "https://cryptoverif.inria.fr"
+dev-repo: "git+https://gitlab.inria.fr/bblanche/CryptoVerif.git"
+bug-reports: "Bruno.Blanchet@inria.fr"
+depends: [ "ocaml" { >= "4.08" } "ocamlfind" { post } "cryptokit" { post } "conf-m4" { post } ]
+build: [
+       [ "./build" "byte" { !ocaml:native } ] 
+]
+install: [ "./build" "install" "%{prefix}%" ]
+url {
+  src: "https://cryptoverif.inria.fr/cryptoverif2.08pl1.tar.gz"
+  checksum: [
+    "md5=1729d3e3b356f3c6959beef5bb7a41f2"
+    "sha512=2625b9a244070b4525545a7f3d9b46490b750270e8e9dcf7bd42ee36828a87855c38a440d09804319a2ea375279ffbb6084966b0d7cc655341165c7bd347533c"
+  ]
+}


### PR DESCRIPTION
### `cryptoverif.2.08pl1`
CryptoVerif: Cryptographic protocol verifier in the computational model
CryptoVerif is an automatic protocol prover sound in the computational model. It can prove

  - secrecy;
  - correspondences, which include in particular authentication;
  - indistinguishability between two games.

It provides a generic mechanism for specifying the security assumptions on cryptographic primitives, which can handle in particular symmetric encryption, message authentication codes, public-key encryption, signatures, hash functions.

The generated proofs are proofs by sequences of games, as used by cryptographers. These proofs are valid for a number of sessions polynomial in the security parameter, in the presence of an active adversary. CryptoVerif can also evaluate the probability of success of an attack against the protocol as a function of the probability of breaking each cryptographic primitive and of the number of sessions (exact security).

This software is under development; please use it at your own risk. Comments and bug reports welcome.



---
* Homepage: https://cryptoverif.inria.fr
* Source repo: git+https://gitlab.inria.fr/bblanche/CryptoVerif.git
* Bug tracker: Bruno.Blanchet@inria.fr

---
:camel: Pull-request generated by opam-publish v2.2.0