### PR TITLE
melange-atdgen-codec-runtime  needs Belt

### DIFF
--- a/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.1.0.0/opam
+++ b/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.1.0.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/ahrefs/melange-atdgen-codec-runtime/issues"
 depends: [
   "dune" {>= "3.8"}
   "ocaml"
-  "melange" {>= "2.0.0"}
+  "melange" {>= "2.0.0" & < "3.0.0"}
   "atd"
   "atdgen"
   "melange-json"


### PR DESCRIPTION
Ping @jchavarri to check if the fix is correct (I saw it on melange-json release revdeps)

Error
```
#=== ERROR while compiling melange-atdgen-codec-runtime.1.0.0 =================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/melange-atdgen-codec-runtime.1.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p melange-atdgen-codec-runtime -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/melange-atdgen-codec-runtime-7-518d82.env
# output-file          ~/.opam/log/melange-atdgen-codec-runtime-7-518d82.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/melc -w -40 -g -bin-annot -I src/.melange_atdgen_codec_runtime.objs/melange -I /home/opam/.opam/5.1/lib/melange-json/melange -intf-suffix .ml --bs-stop-after-cmj --bs-package-output . --bs-module-name atdgen_codec_decode --bs-package-name melange-atdgen-codec-runtime -no-alias-deps -o src/.melange_atdgen_codec_runtime.objs/melange/atdgen_codec_decode.cmj -c -impl src/atdgen_codec_decode.pp.ml)
# File "src/atdgen_codec_decode.ml", line 35, characters 17-51:
# 35 |     let target = Belt.Array.makeUninitializedUnsafe length in
#                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module Belt
```