### PR TITLE
[new release] melange-atdgen-codec-runtime (3.0.0)

### DIFF
--- a/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.3.0.0/opam
+++ b/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.3.0.0/opam
@@ -30,7 +30,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.3.0.0/opam
+++ b/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.3.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "A Melange runtime for atdgen"
+description: """A Melange runtime for atdgen, based on the Js.Json.t type
+provided by Melange and the combinators from melange-json
+"""
+maintainer: "Ahrefs"
+authors: "Ahrefs"
+license: "MIT"
+homepage: "https://github.com/ahrefs/melange-atdgen-codec-runtime"
+bug-reports: "https://github.com/ahrefs/melange-atdgen-codec-runtime/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml"
+  "melange" {>= "3.0.0"}
+  "atd"
+  "atdgen"
+  "melange-json"
+  "melange-jest" {with-test}
+  "reason" {with-test}
+  "opam-check-npm-deps" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/melange-atdgen-codec-runtime.git"
+url {
+  src:
+    "https://github.com/ahrefs/melange-atdgen-codec-runtime/releases/download/3.0.0/melange-atdgen-codec-runtime-3.0.0.tbz"
+  checksum: [
+    "sha256=56d49456f51cf057216275edca4d50843311c576ece3290d4ceed68fad0f7cba"
+    "sha512=1698e0727500e372a3c6a5de7e4d138a881542548256d01d5494c749d047fbc86742d8f7ecb5606ca8a40139762cfe70abcbe3049a87c6a02adbc531cd2146d9"
+  ]
+}
+x-commit-hash: "250fbf6c76bf49a6c69fc03d8b824d37a40c986b"


### PR DESCRIPTION
A Melange runtime for atdgen

- Project page: <a href="https://github.com/ahrefs/melange-atdgen-codec-runtime">https://github.com/ahrefs/melange-atdgen-codec-runtime</a>

##### CHANGES:

- Expose `DecodeErrorPath`, [ahrefs/melange-atdgen-codec-runtime#51](https://github.com/ahrefs/melange-atdgen-codec-runtime/pull/51)
- Migrated to Melange v3, [ahrefs/melange-atdgen-codec-runtime#50](https://github.com/ahrefs/melange-atdgen-codec-runtime/pull/50)
- Lifted version to v3 to avoid conflicts with previous `bs-atdgen-codec-runtime` versions / tags.
