### PR TITLE
Revert "Fix conf-openblas on macOS arm64 hardware"

### DIFF
--- a/packages/conf-openblas/conf-openblas.0.2.1/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.1/opam
@@ -10,17 +10,7 @@ build: [
   [
     "sh"
     "-exc"
-    "printf 'opam-version: \"2.0\"\\nvariables {\\n  pkg-config-homebrew: \"%s/lib/pkgconfig\"\\n}' \"$(brew --prefix openblas)\" > %{_:name}%.config"
-  ] {os = "macos" & os-distribution = "homebrew"}
-  [
-    "sh"
-    "-exc"
-    "printf 'opam-version: \"2.0\"\\nvariables {\\n  pkg-config-homebrew: \"\"\\n}' > %{_:name}%.config"
-  ] {os != "macos" | os-distribution != "homebrew"}
-  [
-    "sh"
-    "-exc"
-    "cc $CFLAGS $(PKG_CONFIG_PATH=\"$(brew --prefix openblas)/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --cflags openblas) test.c $(PKG_CONFIG_PATH=\"$(brew --prefix openblas)/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --libs openblas)"
+    "cc $CFLAGS $(pkg-config --cflags openblas) test.c $(pkg-config --libs openblas)"
   ] {os = "macos" & os-distribution = "homebrew"}
   ["sh" "-exc" "cc $CFLAGS test.c -lcblas"]
     {os-family = "arch"}
@@ -30,9 +20,6 @@ build: [
     {os = "win32" & os-distribution = "cygwinports"}
   ["sh" "-exc" "cc $CFLAGS test.c -lopenblas"]
     {os-distribution != "fedora" & os-distribution != "centos" & os-family != "suse" & os-family != "opensuse" & os != "macos" & os-family != "arch" & os != "freebsd" & os != "win32"}
-]
-depends: [
-  "conf-pkg-config" {os = "macos" & os-distribution = "homebrew"}
 ]
 depexts: [
   ["libc-dev" "openblas-dev" "lapack-dev"] {os-distribution = "alpine"}
@@ -47,9 +34,6 @@ depexts: [
 x-ci-accept-failures: [
   "oraclelinux-7"
   "oraclelinux-8"
-]
-setenv: [
-  PKG_CONFIG_PATH += "%{_:pkg-config-homebrew}%"
 ]
 synopsis: "Virtual package to install OpenBLAS and LAPACKE"
 description:


### PR DESCRIPTION
Reverts ocaml/opam-repository#25076

it breaks with some opam versions, maybe < 2.1.5 (as spotted by @pklehre in https://github.com/ocaml/opam-repository/pull/25076#issuecomment-1931923608 https://github.com/ocaml/opam-repository/issues/25194 https://discuss.ocaml.org/t/opam-error-invalid-argument-opamenv-unzip-to/14012)