### PR TITLE
Fix conf-openblas on macOS arm64 hardware, hopefully without breakages

### DIFF
--- a/packages/conf-openblas-macOS-env/conf-openblas-macOS-env.1/opam
+++ b/packages/conf-openblas-macOS-env/conf-openblas-macOS-env.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "David Allsopp"
+authors: [ "David Allsopp" ]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "ISC"
+build: [
+  "sh"
+  "-exc"
+  "printf 'opam-version: \"2.0\"\\nvariables {\\n  pkg-config-homebrew: \"%s/lib/pkgconfig\"\\n}' \"$(brew --prefix openblas)\" > %{_:name}%.config"
+]
+depends: [
+  "conf-openblas" {>= "0.2.2"}
+]
+setenv: [
+  PKG_CONFIG_PATH += "%{_:pkg-config-homebrew}%"
+]
+synopsis: "Virtual package to set the environment correctly for OpenBLAS in Homebrew"
+description: """
+Homebrew requires an update to PKG_CONFIG_PATH in order to detect the openblas
+package. opam 2.0.10 and earlier and 2.1.4 and earlier cannot handle a setenv
+update of "", and setenv updates cannot be filtered. This package exists to
+workaround these two limitations."""
+flags: conf
+available: os = "macos" & os-distribution = "homebrew"

--- a/packages/conf-openblas/conf-openblas.0.2.1/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.1/opam
@@ -40,3 +40,4 @@ description:
   "The package prepares OpenBLAS (CBLAS) and LAPACKE backend for Owl (OCaml numerical library). It can only be installed if OpenBLAS and LAPACKE are installed on the system."
 extra-files: ["test.c" "md5=8eb3463bce56366f0506721ca5c4e29c"]
 flags: conf
+available: os != "macos" | os-distribution != "homebrew"

--- a/packages/conf-openblas/conf-openblas.0.2.2/files/test.c
+++ b/packages/conf-openblas/conf-openblas.0.2.2/files/test.c
@@ -1,0 +1,12 @@
+#define _GNU_SOURCE
+#include <cblas.h>
+#include <lapacke.h>
+
+int main(int argc, char **argv)
+{
+  int N = 3;
+  double X[] = { 1, 2, 3 };
+  int INCX = 1;
+	double res = cblas_dnrm2(N, X, INCX);
+  return 0;
+}

--- a/packages/conf-openblas/conf-openblas.0.2.2/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Liang Wang <ryanrhymes@gmail.com>"
+authors: [ "Liang Wang" ]
+homepage: "https://github.com/xianyi/OpenBLAS"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "BSD-3-Clause"
+build: [
+  ["sh" "-exc" "cc $CFLAGS -I/usr/include/openblas test.c -lopenblas"]
+    {os-distribution = "fedora" | os-distribution = "centos" | os-family = "suse" | os-family = "opensuse"}
+  [
+    "sh"
+    "-exc"
+    "cc $CFLAGS $(PKG_CONFIG_PATH=\"$(brew --prefix openblas)/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --cflags openblas) test.c $(PKG_CONFIG_PATH=\"$(brew --prefix openblas)/lib/pkgconfig:$PKG_CONFIG_PATH\" pkg-config --libs openblas)"
+  ] {os = "macos" & os-distribution = "homebrew"}
+  ["sh" "-exc" "cc $CFLAGS test.c -lcblas"]
+    {os-family = "arch"}
+  ["sh" "-exc" "cc $CFLAGS -I/usr/local/include -L/usr/local/lib test.c -lopenblas"]
+    {os = "freebsd"}
+  ["sh" "-exc" "x86_64-w64-mingw32-gcc $CFLAGS test.c -lopenblas"]
+    {os = "win32" & os-distribution = "cygwinports"}
+  ["sh" "-exc" "cc $CFLAGS test.c -lopenblas"]
+    {os-distribution != "fedora" & os-distribution != "centos" & os-family != "suse" & os-family != "opensuse" & os != "macos" & os-family != "arch" & os != "freebsd" & os != "win32"}
+]
+depends: [
+  "conf-pkg-config" {os = "macos" & os-distribution = "homebrew"}
+]
+depexts: [
+  ["libc-dev" "openblas-dev" "lapack-dev"] {os-distribution = "alpine"}
+  ["epel-release" "openblas-devel"] {os-distribution = "centos"}
+  ["libopenblas-dev" "liblapacke-dev"] {os-family = "debian"}
+  ["openblas-devel"] {os-distribution = "fedora"}
+  ["openblas-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["openblas" "lapacke" "cblas"] {os-distribution = "arch"}
+  ["openblas"] {os = "macos" & os-distribution = "homebrew"}
+  ["openblas" "lapacke"] {os = "freebsd"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-7"
+  "oraclelinux-8"
+]
+synopsis: "Virtual package to install OpenBLAS and LAPACKE"
+description:
+  "The package prepares OpenBLAS (CBLAS) and LAPACKE backend for Owl (OCaml numerical library). It can only be installed if OpenBLAS and LAPACKE are installed on the system."
+extra-files: ["test.c" "md5=8eb3463bce56366f0506721ca5c4e29c"]
+flags: conf

--- a/packages/conf-openblas/conf-openblas.0.2.2/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.2/opam
@@ -23,6 +23,7 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {os = "macos" & os-distribution = "homebrew"}
+  "conf-openblas-macOS-env" {post & os = "macos" & os-distribution = "homebrew"}
 ]
 depexts: [
   ["libc-dev" "openblas-dev" "lapack-dev"] {os-distribution = "alpine"}


### PR DESCRIPTION
Re-attempt at #25076, following the needed revert of the second part in #25195.

First commit is the same as #25076 - it changes macOS only, introducing a missing dependency (the package already used pkg-config without depending on its conf- package) and amending the call to `pkg-config` for Homebrew only to match Homebrew's recommendation.

The second commit addresses the unintended breakage in #25194 (for which apologies again!). There are two issues at play: `setenv` doesn't support filters (ocaml/opam#5787) and empty updates to environment variables crash opam, which is fixed in 2.1.5, but not in earlier releases (ocaml/opam#5350).

The fix I propose is to put the `setenv` field in a package of its own, and have `conf-openblas` depend on that package only for macOS with Homebrew. Note that `conf-openblas-macOS-env` will only install if `conf-openblas` installed, which means that we know that the environment variable update will not be empty, hence there is no need to check for the opam-version itself.