### PR TITLE
opam-build: fix dependencies

### DIFF
--- a/packages/opam-build/opam-build.0.1.0/opam
+++ b/packages/opam-build/opam-build.0.1.0/opam
@@ -11,10 +11,10 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02"}
   "dune" {>= "2.0"}
-  "opam-client" {>= "2.1.0" & < "2.2" & opam-version >= "2.1" & opam-version < "2.2"}
+  "opam-client" {>= "2.1.0" & < "2.2"}
   "cmdliner" {>= "1.0"}
 ]
-available: opam-version >= "2.1" & opam-version < "2.3"
+available: opam-version >= "2.1" & opam-version < "2.2"
 url {
   src: "https://github.com/kit-ty-kate/opam-build/archive/v0.1.0.tar.gz"
   checksum: [


### PR DESCRIPTION
Fails with
```
#=== ERROR while compiling opam-build.0.1.0 ===================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/opam-build.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p opam-build -j 71
# exit-code            1
# env-file             ~/.opam/log/opam-build-7-63928b.env
# output-file          ~/.opam/log/opam-build-7-63928b.out
### output ###
# File "src/dune", line 4, characters 17-28:
# 4 |  (libraries unix opam-client))
#                      ^^^^^^^^^^^
# Error: Library "opam-client" not found.
# -> required by library "build_test_common" in _build/default/src
# -> required by executable opam_build in src/dune:7
# -> required by _build/default/src/opam_build.exe
# -> required by _build/install/default/bin/opam-build
# -> required by _build/default/opam-build.install
# -> required by alias install
```
because opam-client is ignored as dependency