### PR TITLE
alcotest's tests are not compatible with OCaml 5.2

### DIFF
--- a/packages/alcotest/alcotest.1.5.0/opam
+++ b/packages/alcotest/alcotest.1.5.0/opam
@@ -43,7 +43,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version < "5.2"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/alcotest/alcotest.1.6.0/opam
+++ b/packages/alcotest/alcotest.1.6.0/opam
@@ -42,7 +42,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version < "5.2"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/alcotest/alcotest.1.7.0/opam
+++ b/packages/alcotest/alcotest.1.7.0/opam
@@ -43,7 +43,8 @@ build: [
     jobs
     "@install"
     "@runtest" {with-test & arch != "arm32" & arch != "x86_32"
-                          & arch != "s390x" & arch != "ppc64"}
+                          & arch != "s390x" & arch != "ppc64"
+                          & ocaml:version < "5.2"}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
Fixed upstream in https://github.com/mirage/alcotest/pull/402
```
#=== ERROR while compiling alcotest.1.7.0 =====================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/alcotest.1.7.0
# command              ~/.opam/5.2/bin/dune build -p alcotest -j 1 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/alcotest-1572-265f5d.env
# output-file          ~/.opam/log/alcotest-1572-265f5d.out
### output ###
# (cd _build/default/examples && ./floats.exe)
# Testing `Float tests'.
# This run has ID `0GQT2QHE'.
# 
#   [OK]          Edge cases            0   NaN.
#   [OK]          Edge cases            1   ∞.
#   [OK]          Other floats          0   others.
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/alcotest.1.7.0/_build/default/examples/_build/_tests/Float tests'.
# Test Successful in 0.000s. 3 tests run.
# (cd _build/default/examples && ./simple.exe)
# Testing `Utils'.
# This run has ID `9SIA8X8A'.
# 
#   [OK]          string-case            0   Lower case.
#   [OK]          string-case            1   Capitalization.
#   [OK]          string-concat          0   String mashing.
#   [OK]          list-concat            0   List mashing.
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/alcotest.1.7.0/_build/default/examples/_build/_tests/Utils'.
# Test Successful in 0.000s. 4 tests run.
# File "test/e2e/alcotest/source_code_position/with-position.expected", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/e2e/alcotest/source_code_position/with-position.expected _build/default/test/e2e/alcotest/source_code_position/with-position.processed
# diff --git a/_build/default/test/e2e/alcotest/source_code_position/with-position.expected b/_build/default/test/e2e/alcotest/source_code_position/with-position.processed
# index 34697b9..0bb5731 100644
# --- a/_build/default/test/e2e/alcotest/source_code_position/with-position.expected
# +++ b/_build/default/test/e2e/alcotest/source_code_position/with-position.processed
# @@ -14,7 +14,7 @@ FAIL strings
#     Expected: `"A"'
#     Received: `"B"'
#  
# -<stacktrace>
# +Raised at Alcotest_engine__Test.check in file "src/alcotest-engine/test.ml", lines 200-210, characters 4-19
```