### PR TITLE
Package ocamleditor.1.15.2-ocaml414

### DIFF
--- a/packages/ocamleditor/ocamleditor.1.15.2-ocaml414/opam
+++ b/packages/ocamleditor/ocamleditor.1.15.2-ocaml414/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlfind" {>= "1.4.0"}
   "lablgtk" {>= "2.18.0"}
   "ocp-indent" { >= "1.8.0" }
-  "xml-light" {>= "2.2"}
+  "xml-light" {>= "2.5"}
   "yojson" {>= "2.1"}
   "atdgen" {>= "2.12"}
   "ocamldiff" {>= "1.2"}

--- a/packages/ocamleditor/ocamleditor.1.15.2-ocaml414/opam
+++ b/packages/ocamleditor/ocamleditor.1.15.2-ocaml414/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+
+synopsis:
+  "OCamlEditor is a GTK+ source code editor and build tool for OCaml"
+description:
+  """It provides many features to facilitate editing code, accessing API reference
+directly from the editor and compiling projects."""
+
+authors: ["OCamlEditor developers"]
+maintainer: ["OCamlEditor developers"]
+
+license: "LGPL-3.0-only"
+homepage: "https://github.com/ocamleditor/ocamleditor"
+bug-reports: "https://github.com/ocamleditor/ocamleditor/issues"
+dev-repo: "git+https://github.com/ocamleditor/ocamleditor.git"
+
+build: [["ocaml" "build.ml" "ocamleditor"]]
+install: [["ocaml" "tools/install.ml" "-prefix" prefix]]
+
+depends: [
+  "ocaml" {>= "4.14" & < "5"}
+  "ocamlfind" {>= "1.4.0"}
+  "lablgtk" {>= "2.18.0"}
+  "ocp-indent" { >= "1.8.0" }
+  "xml-light" {>= "2.2"}
+  "yojson" {>= "2.1"}
+  "atdgen" {>= "2.12"}
+  "ocamldiff" {>= "1.2"}
+  "merlin" {>= "4.9"}
+]
+depopts: [
+  "ocurl"
+]
+url {
+  src:
+    "https://github.com/ocamleditor/ocamleditor/archive/refs/tags/1.15.2-ocaml414.tar.gz"
+  checksum: [
+    "md5=c9462ae362bb1060c334f55682de5526"
+    "sha512=8e1473f90d2d0e64c83784c19175da0b2aa284b8046d3360e18d76adaff82dc63aa5b0f92b90b6f6ca3ef91387e6cc98c3b4cbade334f07cd37f5e925ad8da93"
+  ]
+}


### PR DESCRIPTION
### `ocamleditor.1.15.2-ocaml414`
OCamlEditor is a GTK+ source code editor and build tool for OCaml
It provides many features to facilitate editing code, accessing API reference
directly from the editor and compiling projects.



---
* Homepage: https://github.com/ocamleditor/ocamleditor
* Source repo: git+https://github.com/ocamleditor/ocamleditor.git
* Bug tracker: https://github.com/ocamleditor/ocamleditor/issues

---
:camel: Pull-request generated by opam-publish v2.3.0