### PR TITLE
[new release] mirage-flow (3 packages) (4.0.1)

### DIFF
--- a/packages/mirage-flow-combinators/mirage-flow-combinators.4.0.0/opam
+++ b/packages/mirage-flow-combinators/mirage-flow-combinators.4.0.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+available: false
 maintainer: "thomas@gazagnaire.org"
 authors: ["Thomas Gazagnaire" "Dave Scott"]
 license: "ISC"

--- a/packages/mirage-flow-combinators/mirage-flow-combinators.4.0.1/opam
+++ b/packages/mirage-flow-combinators/mirage-flow-combinators.4.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "logs"
+  "cstruct" {>= "6.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-flow" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS specialized to lwt"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v4.0.1/mirage-flow-4.0.1.tbz"
+  checksum: [
+    "sha256=ab3c6014d311b03cddc7525e53f03d17a12593e87f36e0fd505185d33fe2b952"
+    "sha512=3bcdd4c80f7f69547b63c1d05b0f1f6088940a4793ce5b7c5d8595ef58ffc90d02e80b08149c71267daf7049f6013afdfa21ee061e604852a4b68071a225b68b"
+  ]
+}
+x-commit-hash: "94fd331c81411cb12aa38c04f95a9f5252dc1193"

--- a/packages/mirage-flow-unix/mirage-flow-unix.4.0.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.4.0.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+available: false
 maintainer: "thomas@gazagnaire.org"
 authors: ["Thomas Gazagnaire" "Dave Scott"]
 license: "ISC"

--- a/packages/mirage-flow-unix/mirage-flow-unix.4.0.1/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.4.0.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "mirage-flow" {= version}
+  "lwt" {>= "4.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "alcotest" {with-test}
+  "mirage-flow-combinators" {with-test & = version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS on Unix"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v4.0.1/mirage-flow-4.0.1.tbz"
+  checksum: [
+    "sha256=ab3c6014d311b03cddc7525e53f03d17a12593e87f36e0fd505185d33fe2b952"
+    "sha512=3bcdd4c80f7f69547b63c1d05b0f1f6088940a4793ce5b7c5d8595ef58ffc90d02e80b08149c71267daf7049f6013afdfa21ee061e604852a4b68071a225b68b"
+  ]
+}
+x-commit-hash: "94fd331c81411cb12aa38c04f95a9f5252dc1193"

--- a/packages/mirage-flow/mirage-flow.4.0.0/opam
+++ b/packages/mirage-flow/mirage-flow.4.0.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+available: false
 maintainer: "thomas@gazagnaire.org"
 authors: ["Thomas Gazagnaire" "Dave Scott"]
 license: "ISC"

--- a/packages/mirage-flow/mirage-flow.4.0.1/opam
+++ b/packages/mirage-flow/mirage-flow.4.0.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "4.0.0"}
+  "fmt"
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v4.0.1/mirage-flow-4.0.1.tbz"
+  checksum: [
+    "sha256=ab3c6014d311b03cddc7525e53f03d17a12593e87f36e0fd505185d33fe2b952"
+    "sha512=3bcdd4c80f7f69547b63c1d05b0f1f6088940a4793ce5b7c5d8595ef58ffc90d02e80b08149c71267daf7049f6013afdfa21ee061e604852a4b68071a225b68b"
+  ]
+}
+x-commit-hash: "94fd331c81411cb12aa38c04f95a9f5252dc1193"


### PR DESCRIPTION
Flow implementations and combinators for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-flow">https://github.com/mirage/mirage-flow</a>
- Documentation: <a href="https://mirage.github.io/mirage-flow/">https://mirage.github.io/mirage-flow/</a>

##### CHANGES:

- move Mirage_flow.stats and pp_stats to Mirage_flow_combinators (mirage/mirage-flow#51 @hannesm)
- improve documentation of expected semantics (when write promise is resolved,
  what is done to the underlying flow - addresses mirage/mirage-flow#4 @samoht),
  (mirage/mirage-flow#51 @reynir @dinosaure @hannesm)
- add < coercion to shutdown:
  ``shutdown : flow -> [< `read | `write | `read_write ] -> unit Lwt.t``
  (requested mirage/mirage-flow#50 @reynir, mirage/mirage-flow#52 @hannesm)
