### PR TITLE
[new release] mirage-flow (3 packages) (4.0.2)

### DIFF
--- a/packages/mirage-flow-combinators/mirage-flow-combinators.4.0.2/opam
+++ b/packages/mirage-flow-combinators/mirage-flow-combinators.4.0.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "logs"
+  "cstruct" {>= "6.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-flow" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS specialized to lwt"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v4.0.2/mirage-flow-4.0.2.tbz"
+  checksum: [
+    "sha256=4865e3dd2e1be773bd24435416e325dc8f90a22674412ad8bbbcd37adeeafb5a"
+    "sha512=833a8a4e048d9e3206926e46617824f8d6719fd28c7c29e520b34d2776182439b36a668262a7fa3696d4b22bf15ea5517e7da63a9b813d8bb3dd88f683bb3a7e"
+  ]
+}
+x-commit-hash: "e69813887e494b82e04909eeafb2f996d7e6f263"

--- a/packages/mirage-flow-unix/mirage-flow-unix.4.0.2/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.4.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "mirage-flow" {= version}
+  "lwt" {>= "4.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "alcotest" {with-test}
+  "mirage-flow-combinators" {with-test & = version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS on Unix"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v4.0.2/mirage-flow-4.0.2.tbz"
+  checksum: [
+    "sha256=4865e3dd2e1be773bd24435416e325dc8f90a22674412ad8bbbcd37adeeafb5a"
+    "sha512=833a8a4e048d9e3206926e46617824f8d6719fd28c7c29e520b34d2776182439b36a668262a7fa3696d4b22bf15ea5517e7da63a9b813d8bb3dd88f683bb3a7e"
+  ]
+}
+x-commit-hash: "e69813887e494b82e04909eeafb2f996d7e6f263"

--- a/packages/mirage-flow/mirage-flow.4.0.2/opam
+++ b/packages/mirage-flow/mirage-flow.4.0.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "4.0.0"}
+  "fmt"
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v4.0.2/mirage-flow-4.0.2.tbz"
+  checksum: [
+    "sha256=4865e3dd2e1be773bd24435416e325dc8f90a22674412ad8bbbcd37adeeafb5a"
+    "sha512=833a8a4e048d9e3206926e46617824f8d6719fd28c7c29e520b34d2776182439b36a668262a7fa3696d4b22bf15ea5517e7da63a9b813d8bb3dd88f683bb3a7e"
+  ]
+}
+x-commit-hash: "e69813887e494b82e04909eeafb2f996d7e6f263"


### PR DESCRIPTION
Flow implementations and combinators for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-flow">https://github.com/mirage/mirage-flow</a>
- Documentation: <a href="https://mirage.github.io/mirage-flow/">https://mirage.github.io/mirage-flow/</a>

##### CHANGES:

- move Mirage_flow.stats and pp_stats to Mirage_flow_combinators (mirage/mirage-flow#51 @hannesm)
- improve documentation of expected semantics (when write promise is resolved,
  what is done to the underlying flow - addresses mirage/mirage-flow#4 @samoht),
  (mirage/mirage-flow#51 @reynir @dinosaure @hannesm)
- revert < coercion, shutdown is again
  ``shutdown : flow -> [ `read | `write | `read_write ] -> unit Lwt.t``
  (@reynir @hannesm)
