### PR TITLE
mdx is not compatible with OCaml 5.2 (uses compiler-libs)

### DIFF
--- a/packages/mdx/mdx.2.3.1/opam
+++ b/packages/mdx/mdx.2.3.1/opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/realworldocaml/mdx"
 bug-reports: "https://github.com/realworldocaml/mdx/issues"
 depends: [
   "dune" {>= "3.5"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2"}
   "ocamlfind"
   "fmt" {>= "0.8.7"}
   "cppo" {build & >= "1.1.0"}


### PR DESCRIPTION
Reported upstream in https://github.com/realworldocaml/mdx/issues/447
```
#=== ERROR while compiling mdx.2.3.1 ==========================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/mdx.2.3.1
# command              ~/.opam/5.2/bin/dune build -p mdx -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/mdx-3916-cad682.env
# output-file          ~/.opam/log/mdx-3916-cad682.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/top/.mdx_top.objs/byte -I /home/opam/.opam/5.2/lib/astring -I /home/opam/.opam/5.2/lib/camlp-streams -I /home/opam/.opam/5.2/lib/csexp -I /home/opam/.opam/5.2/lib/findlib -I /home/opam/.opam/5.2/lib/fmt -I /home/opam/.opam/5.2/lib/logs -I /home/opam/.opam/5.2/lib/ocaml-version -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/ocaml/str -I /home/opam/.opam/5.2/lib/ocaml/threads -I /home/opam/.opam/5.2/lib/ocaml/unix -I /home/opam/.opam/5.2/lib/re -I /home/opam/.opam/5.2/lib/result -I /home/opam/.opam/5.2/lib/seq -I lib/.mdx.objs/byte -I vendor/odoc-parser/src/.odoc_parser.objs/byte -intf-suffix .ml -no-alias-deps -open Mdx_top__ -o lib/top/.mdx_top.objs/byte/mdx_top.cmo -c -impl lib/top/mdx_top.pp.ml)
# File "lib/top/mdx_top.ml", line 205, characters 29-37:
# Error: Unbound value "Exp.fun_"
```