### PR TITLE
odoc is not compatible with OCaml 5.2 (uses compiler-libs)

### DIFF
--- a/packages/odoc/odoc.2.2.1/opam
+++ b/packages/odoc/odoc.2.2.1/opam
@@ -29,7 +29,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.0.2"}
   "fpath"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.2"}
   "result"
   "tyxml" {>= "4.3.0"}
   "fmt"

--- a/packages/odoc/odoc.2.2.2/opam
+++ b/packages/odoc/odoc.2.2.2/opam
@@ -29,7 +29,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.0.2"}
   "fpath"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.2"}
   "result"
   "tyxml" {>= "4.3.0"}
   "fmt"

--- a/packages/odoc/odoc.2.3.0/opam
+++ b/packages/odoc/odoc.2.3.0/opam
@@ -43,7 +43,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.7.0"}
   "fpath"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.2"}
   "result"
   "tyxml" {>= "4.4.0"}
   "fmt"

--- a/packages/odoc/odoc.2.3.1/opam
+++ b/packages/odoc/odoc.2.3.1/opam
@@ -43,7 +43,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.7.0"}
   "fpath"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.2"}
   "result"
   "tyxml" {>= "4.4.0"}
   "fmt"

--- a/packages/odoc/odoc.2.4.0/opam
+++ b/packages/odoc/odoc.2.4.0/opam
@@ -43,7 +43,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.7.0"}
   "fpath"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.2"}
   "result"
   "tyxml" {>= "4.4.0"}
   "fmt"

--- a/packages/odoc/odoc.2.4.1/opam
+++ b/packages/odoc/odoc.2.4.1/opam
@@ -43,7 +43,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.7.0"}
   "fpath"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.2"}
   "result"
   "tyxml" {>= "4.4.0"}
   "fmt"


### PR DESCRIPTION
Reported upstream in https://github.com/ocaml/odoc/issues/1080
```
#=== ERROR while compiling odoc.2.4.1 =========================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/odoc.2.4.1
# command              ~/.opam/5.2/bin/dune build -p odoc -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/odoc-19-2b40e9.env
# output-file          ~/.opam/log/odoc-19-2b40e9.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlopt.opt -w -40 -g -w -18-53 -g -I src/xref2/.odoc_xref2.objs/byte -I src/xref2/.odoc_xref2.objs/native -I /home/opam/.opam/5.2/lib/astring -I /home/opam/.opam/5.2/lib/camlp-streams -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/odoc-parser -I /home/opam/.opam/5.2/lib/result -I src/model/.odoc_model.objs/byte -I src/model/.odoc_model.objs/native -intf-suffix .ml -no-alias-deps -open Odoc_xref2 -o src/xref2/.odoc_xref2.objs/native/odoc_xref2__Shape_tools.cmx -c -impl src/xref2/shape_tools.ml)
# File "shape_tools.cppo.ml", line 70, characters 22-39:
# Error: Unbound module "Shape.Make_reduce"
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlopt.opt -w -40 -g -w -18-53 -g -I src/loader/.odoc_loader.objs/byte -I src/loader/.odoc_loader.objs/native -I /home/opam/.opam/5.2/lib/astring -I /home/opam/.opam/5.2/lib/camlp-streams -I /home/opam/.opam/5.2/lib/fpath -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/odoc-parser -I /home/opam/.opam/5.2/lib/result -I src/document/.odoc_document.objs/byte -I src/document/.odoc_document.objs/native -I src/model/.odoc_model.objs/byte -I src/model/.odoc_model.objs/native -I src/syntax_highlighter/.syntax_highlighter.objs/byte -I src/syntax_highlighter/.syntax_highlighter.objs/native -intf-suffix .ml -no-alias-deps -open Odoc_loader__ -o src/loader/.odoc_loader.objs/native/odoc_loader__Ident_env.cmx -c -impl src/loader/ident_env.pp.ml)
# File "src/loader/ident_env.cppo.ml", line 98, characters 12-31:
# Error: The constructor "Types.Type_abstract" expects 1 argument(s),
#        but is applied here to 0 argument(s)
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -w -18-53 -g -bin-annot -I src/loader/.odoc_loader.objs/byte -I /home/opam/.opam/5.2/lib/astring -I /home/opam/.opam/5.2/lib/camlp-streams -I /home/opam/.opam/5.2/lib/fpath -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/odoc-parser -I /home/opam/.opam/5.2/lib/result -I src/document/.odoc_document.objs/byte -I src/model/.odoc_model.objs/byte -I src/syntax_highlighter/.syntax_highlighter.objs/byte -no-alias-deps -open Odoc_loader__ -o src/loader/.odoc_loader.objs/byte/odoc_loader__Typedtree_traverse.cmo -c -impl src/loader/typedtree_traverse.pp.ml)
# File "src/loader/typedtree_traverse.ml", line 36, characters 12-30:
# Error: The constructor "Tpat_var" expects 3 argument(s),
#        but is applied here to 2 argument(s)
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -w -18-53 -g -bin-annot -I src/loader/.odoc_loader.objs/byte -I /home/opam/.opam/5.2/lib/astring -I /home/opam/.opam/5.2/lib/camlp-streams -I /home/opam/.opam/5.2/lib/fpath -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/odoc-parser -I /home/opam/.opam/5.2/lib/result -I src/document/.odoc_document.objs/byte -I src/model/.odoc_model.objs/byte -I src/syntax_highlighter/.syntax_highlighter.objs/byte -intf-suffix .ml -no-alias-deps -open Odoc_loader__ -o src/loader/.odoc_loader.objs/byte/odoc_loader__Cmi.cmo -c -impl src/loader/cmi.pp.ml)
# File "src/loader/cmi.ml", line 319, characters 4-17:
# Error: The constructor "Type_abstract" expects 1 argument(s),
#        but is applied here to 0 argument(s)
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -w -18-53 -g -bin-annot -I src/loader/.odoc_loader.objs/byte -I /home/opam/.opam/5.2/lib/astring -I /home/opam/.opam/5.2/lib/camlp-streams -I /home/opam/.opam/5.2/lib/fpath -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/odoc-parser -I /home/opam/.opam/5.2/lib/result -I src/document/.odoc_document.objs/byte -I src/model/.odoc_model.objs/byte -I src/syntax_highlighter/.syntax_highlighter.objs/byte -intf-suffix .ml -no-alias-deps -open Odoc_loader__ -o src/loader/.odoc_loader.objs/byte/odoc_loader__Cmt.cmo -c -impl src/loader/cmt.pp.ml)
# File "src/loader/cmt.ml", line 36, characters 6-21:
# Error: The constructor "Tpat_var" expects 3 argument(s),
#        but is applied here to 2 argument(s)
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -w -18-53 -g -bin-annot -I src/loader/.odoc_loader.objs/byte -I /home/opam/.opam/5.2/lib/astring -I /home/opam/.opam/5.2/lib/camlp-streams -I /home/opam/.opam/5.2/lib/fpath -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/odoc-parser -I /home/opam/.opam/5.2/lib/result -I src/document/.odoc_document.objs/byte -I src/model/.odoc_model.objs/byte -I src/syntax_highlighter/.syntax_highlighter.objs/byte -intf-suffix .ml -no-alias-deps -open Odoc_loader__ -o src/loader/.odoc_loader.objs/byte/odoc_loader__Cmti.cmo -c -impl src/loader/cmti.pp.ml)
# File "src/loader/cmti.ml", line 101, characters 21-24:
# Error: This expression has type "string Asttypes.loc" = "string Location.loc"
#        but an expression was expected of type "string"
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -w -18-53 -g -bin-annot -I src/loader/.odoc_loader.objs/byte -I /home/opam/.opam/5.2/lib/astring -I /home/opam/.opam/5.2/lib/camlp-streams -I /home/opam/.opam/5.2/lib/fpath -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/odoc-parser -I /home/opam/.opam/5.2/lib/result -I src/document/.odoc_document.objs/byte -I src/model/.odoc_model.objs/byte -I src/syntax_highlighter/.syntax_highlighter.objs/byte -intf-suffix .ml -no-alias-deps -open Odoc_loader__ -o src/loader/.odoc_loader.objs/byte/odoc_loader__Ident_env.cmo -c -impl src/loader/ident_env.pp.ml)
# File "src/loader/ident_env.cppo.ml", line 98, characters 12-31:
# Error: The constructor "Types.Type_abstract" expects 1 argument(s),
#        but is applied here to 0 argument(s)
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -w -18-53 -g -bin-annot -I src/xref2/.odoc_xref2.objs/byte -I /home/opam/.opam/5.2/lib/astring -I /home/opam/.opam/5.2/lib/camlp-streams -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/odoc-parser -I /home/opam/.opam/5.2/lib/result -I src/model/.odoc_model.objs/byte -intf-suffix .ml -no-alias-deps -open Odoc_xref2 -o src/xref2/.odoc_xref2.objs/byte/odoc_xref2__Shape_tools.cmo -c -impl src/xref2/shape_tools.ml)
# File "shape_tools.cppo.ml", line 70, characters 22-39:
# Error: Unbound module "Shape.Make_reduce"
```