### PR TITLE
utop is not compatible with OCaml 5.2 (uses compiler-libs)

### DIFF
--- a/packages/utop/utop.2.12.0/opam
+++ b/packages/utop/utop.2.12.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/ocaml-community/utop"
 bug-reports: "https://github.com/ocaml-community/utop/issues"
 doc: "https://ocaml-community.github.io/utop/"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2"}
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}

--- a/packages/utop/utop.2.12.1/opam
+++ b/packages/utop/utop.2.12.1/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/ocaml-community/utop"
 bug-reports: "https://github.com/ocaml-community/utop/issues"
 doc: "https://ocaml-community.github.io/utop/"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2"}
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}

--- a/packages/utop/utop.2.13.0/opam
+++ b/packages/utop/utop.2.13.0/opam
@@ -10,7 +10,7 @@ doc: "https://ocaml-community.github.io/utop/"
 bug-reports: "https://github.com/ocaml-community/utop/issues"
 depends: [
   "dune" {>= "2.0"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.11.0" & < "5.2"}
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}

--- a/packages/utop/utop.2.13.1/opam
+++ b/packages/utop/utop.2.13.1/opam
@@ -10,7 +10,7 @@ doc: "https://ocaml-community.github.io/utop/"
 bug-reports: "https://github.com/ocaml-community/utop/issues"
 depends: [
   "dune" {>= "2.0"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.11.0" & < "5.2"}
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}

--- a/packages/utop/utop.2.9.0/opam
+++ b/packages/utop/utop.2.9.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/ocaml-community/utop"
 bug-reports: "https://github.com/ocaml-community/utop/issues"
 doc: "https://ocaml-community.github.io/utop/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.2"}
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}

--- a/packages/utop/utop.2.9.1/opam
+++ b/packages/utop/utop.2.9.1/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/ocaml-community/utop"
 doc: "https://ocaml-community.github.io/utop/"
 bug-reports: "https://github.com/ocaml-community/utop/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.2"}
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}

--- a/packages/utop/utop.2.9.2/opam
+++ b/packages/utop/utop.2.9.2/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/ocaml-community/utop"
 doc: "https://ocaml-community.github.io/utop/"
 bug-reports: "https://github.com/ocaml-community/utop/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.2"}
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}


### PR DESCRIPTION
Fixed upstream in https://github.com/ocaml-community/utop
```
#=== ERROR while compiling utop.2.13.1 ========================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/utop.2.13.1
# command              ~/.opam/5.2/bin/dune build -p utop -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/utop-20-6d9f79.env
# output-file          ~/.opam/log/utop-20-6d9f79.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I src/lib/.uTop.objs/byte -I /home/opam/.opam/5.2/lib/bytes -I /home/opam/.opam/5.2/lib/findlib -I /home/opam/.opam/5.2/lib/lambda-term -I /home/opam/.opam/5.2/lib/logs -I /home/opam/.opam/5.2/lib/lwt -I /home/opam/.opam/5.2/lib/lwt/unix -I /home/opam/.opam/5.2/lib/lwt_react -I /home/opam/.opam/5.2/lib/mew -I /home/opam/.opam/5.2/lib/mew_vi -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/ocaml/threads -I /home/opam/.opam/5.2/lib/ocaml/unix -I /home/opam/.opam/5.2/lib/ocplib-endian -I /home/opam/.opam/5.2/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.2/lib/react -I /home/opam/.opam/5.2/lib/result -I /home/opam/.opam/5.2/lib/trie -I /home/opam/.opam/5.2/lib/uchar -I /home/opam/.opam/5.2/lib/uucp -I /home/opam/.opam/5.2/lib/uuseg -I /home/opam/.opam/5.2/lib/uutf -I /home/opam/.opam/5.2/lib/xdg -I /home/opam/.opam/5.2/lib/zed -no-alias-deps -o src/lib/.uTop.objs/byte/uTop_compat.cmo -c -impl src/lib/uTop_compat.pp.ml)
# File "src/lib/uTop_compat.ml", line 24, characters 17-21:
# Error: The function applied to this argument has type
#          visible:string list -> hidden:string list -> unit
# This argument cannot be applied without label
```