### PR TITLE
ocamlformat is not compatible with OCaml 5.2 (uses compiler-libs)

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.13.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.13.0/opam
@@ -20,7 +20,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06" & < "4.11"}
-  "ocaml" {with-test & >= "4.08"}
+  "ocaml" {with-test & >= "4.08" & < "5.2"}
   "alcotest" {with-test}
   "base" {>= "v0.12.0" & < "v0.14"}
   "base-unix"

--- a/packages/ocamlformat/ocamlformat.0.2/opam
+++ b/packages/ocamlformat/ocamlformat.0.2/opam
@@ -10,7 +10,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.2"}
   "base" {< "v0.10.0"}
   "base-unix"
   "cmdliner"

--- a/packages/ocamlformat/ocamlformat.0.23.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.23.0/opam
@@ -7,7 +7,7 @@ authors: ["Josh Berdine <jjb@fb.com>"]
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.2"}
   "alcotest" {with-test}
   "base" {>= "v0.12.0"}
   "cmdliner" {>= "1.1.0"}

--- a/packages/ocamlformat/ocamlformat.0.24.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.24.1/opam
@@ -7,7 +7,7 @@ authors: ["Josh Berdine <jjb@fb.com>"]
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.2"}
   "alcotest" {with-test}
   "base" {>= "v0.12.0"}
   "cmdliner" {>= "1.1.0"}

--- a/packages/ocamlformat/ocamlformat.0.25.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.25.1/opam
@@ -7,7 +7,7 @@ authors: ["Josh Berdine <jjb@fb.com>"]
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.2"}
   "cmdliner" {>= "1.1.0"}
   "dune" {>= "2.8"}
   "ocamlformat-lib" {= version}

--- a/packages/ocamlformat/ocamlformat.0.26.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.26.0/opam
@@ -7,7 +7,7 @@ authors: ["Josh Berdine <jjb@fb.com>"]
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.2"}
   "cmdliner" {with-test = "false" & >= "1.1.0" | with-test & >= "1.2.0"}
   "dune" {>= "2.8"}
   "ocamlformat-lib" {= version}

--- a/packages/ocamlformat/ocamlformat.0.26.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.26.1/opam
@@ -22,7 +22,7 @@ authors: [
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.2"}
   "cmdliner" {with-test = "false" & >= "1.1.0" | with-test & >= "1.2.0"}
   "dune" {>= "2.8"}
   "ocamlformat-lib" {= version}

--- a/packages/ocamlformat/ocamlformat.0.3/opam
+++ b/packages/ocamlformat/ocamlformat.0.3/opam
@@ -10,7 +10,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.2"}
   "base" {= "v0.10.0"}
   "base-unix"
   "cmdliner"

--- a/packages/ocamlformat/ocamlformat.0.4/opam
+++ b/packages/ocamlformat/ocamlformat.0.4/opam
@@ -10,7 +10,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.2"}
   "base" {= "v0.10.0"}
   "base-unix"
   "cmdliner"

--- a/packages/ocamlformat/ocamlformat.0.6/opam
+++ b/packages/ocamlformat/ocamlformat.0.6/opam
@@ -10,7 +10,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.2"}
   "base" {>= "v0.11.0" & < "v0.12"}
   "base-unix"
   "cmdliner"

--- a/packages/ocamlformat/ocamlformat.0.7/opam
+++ b/packages/ocamlformat/ocamlformat.0.7/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" "ocamlformat_support,ocamlformat" "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.2"}
   "base" {>= "v0.11.0" & < "v0.12"}
   "base-unix"
   "cmdliner"

--- a/packages/ocamlformat/ocamlformat.0.8/opam
+++ b/packages/ocamlformat/ocamlformat.0.8/opam
@@ -17,7 +17,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.05" & < "5.2"}
   "base" {>= "v0.11.0" & < "v0.12"}
   "base-unix"
   "cmdliner"


### PR DESCRIPTION
Reported upstream in https://github.com/ocaml-ppx/ocamlformat/issues/2524
```
#=== ERROR while compiling ocamlformat.0.24.1 =================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/ocamlformat.0.24.1
# command              ~/.opam/5.2/bin/dune build -p ocamlformat -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/ocamlformat-20-f28b05.env
# output-file          ~/.opam/log/ocamlformat-20-f28b05.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -noassert -g -bin-annot -I vendor/parser-shims/.parser_shims.objs/byte -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -no-alias-deps -o vendor/parser-shims/.parser_shims.objs/byte/parser_shims.cmi -c -intf vendor/parser-shims/parser_shims.mli)
# File "vendor/parser-shims/parser_shims.mli", line 21, characters 9-14:
# 21 |   module Color : sig
#               ^^^^^
# Error: Illegal shadowing of included module "Color/2" by "Color".
# File "vendor/parser-shims/parser_shims.mli", line 19, characters 2-29:
# 19 |   include module type of Misc
#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
#   Module "Color/2" came from this include.
# File "utils/misc.mli", lines 473-522, characters 0-3:
#   The module "Style" has no valid type if "Color/2" is shadowed.
```