### PR TITLE
stdcompat is not compatible with OCaml 5.2

### DIFF
--- a/packages/stdcompat/stdcompat.0/opam
+++ b/packages/stdcompat/stdcompat.0/opam
@@ -9,7 +9,7 @@ build: [make "all" "PREFIX=%{prefix}%"]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.2"}
   "ocamlfind" {build}
   "cppo" {build}
 ]

--- a/packages/stdcompat/stdcompat.1/opam
+++ b/packages/stdcompat/stdcompat.1/opam
@@ -9,7 +9,7 @@ build: [make "all" "PREFIX=%{prefix}%"]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.2"}
   "ocamlfind" {build}
   "cppo" {build}
 ]

--- a/packages/stdcompat/stdcompat.19/opam
+++ b/packages/stdcompat/stdcompat.19/opam
@@ -8,7 +8,7 @@ license: "BSD-2-Clause"
 homepage: "https://github.com/thierry-martinez/stdcompat"
 bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
-  "ocaml" {>= "3.07"}
+  "ocaml" {>= "3.07" & < "5.2"}
   "dune" {>= "2.0"}
   "conf-autoconf"
 ]


### PR DESCRIPTION
Reported upstream in https://github.com/thierry-martinez/stdcompat/issues/32
```
#=== ERROR while compiling stdcompat.19 =======================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/stdcompat.19
# command              ~/.opam/5.2/bin/dune build -p stdcompat -j 1
# exit-code            1
# env-file             ~/.opam/log/stdcompat-20-752b66.env
# output-file          ~/.opam/log/stdcompat-20-752b66.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -nolabels -w -3 -g -bin-annot -I .stdcompat.objs/byte -no-alias-deps -o .stdcompat.objs/byte/stdcompat__printexc_s.cmi -c -intf stdcompat__printexc_s.mli)
# File "stdcompat__printexc_s.mli", lines 57-62, characters 0-17:
# 57 | type location = Printexc.location =
# 58 |   {
# 59 |   filename: string ;
# 60 |   line_number: int ;
# 61 |   start_char: int ;
# 62 |   end_char: int }
# Error: This variant or record definition does not match that of type
#          "Printexc.location"
#        5. An extra field, "end_line", is provided in the original definition.
#        6. An extra field, "end_col", is provided in the original definition.
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -nolabels -w -3 -g -bin-annot -I .stdcompat.objs/byte -intf-suffix .ml -no-alias-deps -o .stdcompat.objs/byte/stdcompat__digest.cmo -c -impl stdcompat__digest.ml)
# File "stdcompat__digest.ml", line 1:
# Error: The implementation "stdcompat__digest.ml"
#        does not match the interface "stdcompat__digest.ml": 
#        Values do not match:
#          val channel : in_channel -> int -> t
#        is not included in
#          external channel : in_channel -> int -> t = "caml_md5_chan"
#        The implementation is not a primitive.
#        File "stdcompat__digest_s.mli", line 39, characters 0-59:
#          Expected declaration
#        File "digest.mli", line 60, characters 0-36: Actual declaration
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlopt.opt -w -40 -nolabels -w -3 -g -I .stdcompat.objs/byte -I .stdcompat.objs/native -intf-suffix .ml -no-alias-deps -o .stdcompat.objs/native/stdcompat__digest.cmx -c -impl stdcompat__digest.ml)
# File "stdcompat__digest.ml", line 1:
# Error: The implementation "stdcompat__digest.ml"
#        does not match the interface "stdcompat__digest.ml": 
#        Values do not match:
#          val channel : in_channel -> int -> t
#        is not included in
#          external channel : in_channel -> int -> t = "caml_md5_chan"
#        The implementation is not a primitive.
#        File "stdcompat__digest_s.mli", line 39, characters 0-59:
#          Expected declaration
#        File "digest.mli", line 60, characters 0-36: Actual declaration
```