### PR TITLE
Luv 0.5.13: binding to libuv

### DIFF
--- a/packages/luv/luv.0.5.13/opam
+++ b/packages/luv/luv.0.5.13/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+
+synopsis: "Binding to libuv: cross-platform asynchronous I/O"
+
+license: "MIT"
+homepage: "https://github.com/aantron/luv"
+doc: "https://aantron.github.io/luv"
+bug-reports: "https://github.com/aantron/luv/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/luv.git"
+
+depends: [
+  "base-unix" {build}
+  "ctypes" {>= "0.14.0"}
+  "dune" {>= "2.7.0"}
+  "ocaml" {>= "4.03.0"}
+
+  "alcotest" {with-test & >= "0.8.1"}
+  "base-unix" {with-test}
+  "odoc" {with-doc & = "2.4.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "Luv is a binding to libuv, the cross-platform C library that does
+asynchronous I/O in Node.js and runs its main loop.
+
+Besides asynchronous I/O, libuv also supports multiprocessing and
+multithreading. Multiple event loops can be run in different threads. libuv also
+exposes a lot of other functionality, amounting to a full OS API, and an
+alternative to the standard module Unix."
+
+url {
+  src: "https://github.com/aantron/luv/releases/download/0.5.13/luv-0.5.13.tar.gz"
+  checksum: "md5=fa4875137341933d1308e432c652b2cd"
+}

--- a/packages/luv/luv.0.5.13/opam
+++ b/packages/luv/luv.0.5.13/opam
@@ -16,7 +16,8 @@ depends: [
   "ctypes" {>= "0.14.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.03.0"}
-
+  "integers" {>= "0.3.0"}
+  
   "alcotest" {with-test & >= "0.8.1"}
   "base-unix" {with-test}
   "odoc" {with-doc & = "2.4.0"}

--- a/packages/mel/mel.0.2.0/opam
+++ b/packages/mel/mel.0.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "melange" {= version}
   "cmdliner" {>= "1.1.0"}
-  "luv" {>= "0.5.11"}
+  "luv" {>= "0.5.11" & < "0.5.13"}
   "ounit" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/mel/mel.0.3.0/opam
+++ b/packages/mel/mel.0.3.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "melange" {= version}
   "cmdliner" {>= "1.1.0"}
-  "luv" {>= "0.5.11"}
+  "luv" {>= "0.5.11" & < "0.5.13"}
   "ocaml-migrate-parsetree" {>= "2.3.0"}
   "ounit" {with-test}
   "odoc" {with-doc}

--- a/packages/mel/mel.0.3.1/opam
+++ b/packages/mel/mel.0.3.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "melange" {= version}
   "cmdliner" {>= "1.1.0"}
-  "luv" {>= "0.5.11"}
+  "luv" {>= "0.5.11" & < "0.5.13"}
   "ocaml-migrate-parsetree" {>= "2.3.0"}
   "ounit" {with-test}
   "odoc" {with-doc}

--- a/packages/mel/mel.0.3.2/opam
+++ b/packages/mel/mel.0.3.2/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "melange" {= version}
   "cmdliner" {>= "1.1.0"}
-  "luv" {>= "0.5.11"}
+  "luv" {>= "0.5.11" & < "0.5.13"}
   "ocaml-migrate-parsetree" {>= "2.3.0"}
   "ounit" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
[Changelog](https://github.com/aantron/luv/releases/tag/0.5.13):

Breaking

- [`Luv.Resource.free_memory`](https://aantron.github.io/luv/luv/Luv/Resource/index.html#val-free_memory) and [`Luv.Resource.total_memory`](https://aantron.github.io/luv/luv/Luv/Resource/index.html#val-total_memory) now return options, in accordance with a [clarification](libuv/libuv#3817) in libuv (aantron/luv#153).
- Filename in callback of [`Luv.FS_event.start`](https://aantron.github.io/luv/luv/Luv/FS_event/index.html#val-start) can be `None`, in accordance with a [clarification](libuv/libuv#4177) in libuv (aantron/luv#155).
- Rename fields of [`Luv.Time.timeval`](https://aantron.github.io/luv/luv/Luv/Time/index.html#type-timeval) (aantron/luv@dbd4e43).

Additions

- Upgrade libuv to [1.48.0](https://github.com/libuv/libuv/commit/e9f29cb984231524e3931aa0ae2c5dae1a32884e), including [1.47.0](https://github.com/libuv/libuv/commit/be6b81a352d17513c95be153afcb3148f1a451cd), [1.46.0](https://github.com/libuv/libuv/commit/f0bb7e40f0508bedf6fad33769b3f87bb8aedfa6), [1.45.0](https://github.com/libuv/libuv/commit/96e05543f53b19d9642b4b0dd73b86ad3cea313e) and **io_uring support** (aantron/luv#153, aantron/luv#154, aantron/luv#155, aantron/luv#158).
- Expose [`uv_cpumask_size`](https://docs.libuv.org/en/v1.x/misc.html#c.uv_cpumask_size) as [`Luv.System_info.cpumask_size`](https://aantron.github.io/luv/luv/Luv/System_info/index.html#val-cpumask_size), [`uv_thread_setaffinity`](https://docs.libuv.org/en/v1.x/threading.html#c.uv_thread_setaffinity) as [`Luv.Thread.setaffinity`](https://aantron.github.io/luv/luv/Luv/Thread/index.html#val-setaffinity), [`uv_thread_getaffinity`](https://docs.libuv.org/en/v1.x/threading.html#c.uv_thread_getaffinity) as [`Luv.Thread.getaffinity`](https://aantron.github.io/luv/luv/Luv/Thread/index.html#val-getaffinity) (aantron/luv#153).
- Expose `UV_ENODATA` as [`` `ENODATA``](https://aantron.github.io/luv/luv/Luv/Error/index.html#type-t.ENODATA) (aantron/luv#153).
- Expose [`uv_metrics_info`](https://docs.libuv.org/en/v1.x/metrics.html#c.uv_metrics_info) as [`Luv.Metrics.info`](https://aantron.github.io/luv/luv/Luv/Metrics/index.html#val-info) (aantron/luv#153).
- Expose [`uv_thread_getcpu`](https://docs.libuv.org/en/v1.x/threading.html#c.uv_thread_getcpu) as [`Luv.Thread.getcpu`](https://aantron.github.io/luv/luv/Luv/Thread/index.html#val-getcpu) (aantron/luv#153).
- Expose [`uv_get_available_memory`](https://docs.libuv.org/en/v1.x/misc.html#c.uv_get_available_memory) as [`Luv.Resource.available_memory`](https://aantron.github.io/luv/luv/Luv/Resource/index.html#val-available_memory) (aantron/luv#153).
- Expose `uv_os_get_passwd2` as `?uid` parameter of [`Luv.Passwd.get_passwd`](https://aantron.github.io/luv/luv/Luv/Passwd/index.html#val-get_passwd) (aantron/luv#153).
- Expose `uv_os_get_group` as [`Luv.Passwd.get_group`](https://aantron.github.io/luv/luv/Luv/Passwd/index.html#val-get_group) (aantron/luv#153).
- Expose [`uv_clock_gettime`](https://docs.libuv.org/en/v1.x/misc.html#c.uv_clock_gettime) as [`Luv.Time.clock_gettime`](https://aantron.github.io/luv/luv/Luv/Time/index.html#val-clock_gettime) (aantron/luv#153).
- Expose [`uv_pipe_bind2`](https://docs.libuv.org/en/v1.x/pipe.html#c.uv_pipe_bind2) and [`uv_pipe_connect2`](https://docs.libuv.org/en/v1.x/pipe.html#c.uv_pipe_connect2) as `?no_truncate` parameters of [`Luv.Pipe.bind`](https://aantron.github.io/luv/luv/Luv/Pipe/index.html#val-bind) and [`Luv.Pipe.connect`](https://aantron.github.io/luv/luv/Luv/Pipe/index.html#val-connect) (aantron/luv#154).
- Expose [`EUNATCH`](https://docs.libuv.org/en/v1.x/errors.html#c.UV_EUNATCH) as [`` `EUNATCH``](https://aantron.github.io/luv/luv/Luv/Error/index.html#type-t.EUNATCH) (aantron/luv#154).
- Expose [UTF-16/WTF-8 conversion functions](https://docs.libuv.org/en/v1.x/misc.html#string-manipulation-functions) in new module [`Luv.String`](https://aantron.github.io/luv/luv/Luv/String/index.html) (aantron/luv#155).
- Expose [`uv_thread_setpriority`](https://docs.libuv.org/en/v1.x/threading.html#c.uv_thread_setpriority) as [`Luv.Thread.setpriority`](https://aantron.github.io/luv/luv/Luv/Thread/index.html#val-setpriority) and [`uv_thread_getpriority`](https://docs.libuv.org/en/v1.x/threading.html#c.uv_thread_getpriority) as [`Luv.Thread.getpriority`](https://aantron.github.io/luv/luv/Luv/Thread/index.html#val-getpriority) (aantron/luv#158).
- Expose `UV_PROCESS_WINDOWS_FILE_PATH_EXACT_NAME` as `?windows_file_path_exact_name` parameter of [`Luv.Process.spawn`](https://aantron.github.io/luv/luv/Luv/Process/index.html#val-spawn) (aantron/luv#158).
