### PR TITLE
Point broken upstreams to opam-source-archives

### DIFF
--- a/packages/KaSim/KaSim.3.5.150925/opam
+++ b/packages/KaSim/KaSim.3.5.150925/opam
@@ -26,6 +26,7 @@ depends: [
 synopsis: "Command line stochastic simulator for kappa models."
 flags: light-uninstall
 url {
-  src: "https://github.com/Kappa-Dev/KaSim/archive/v3.5-250915.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/KaSim-3.5.150925.tar.gz"
   checksum: "md5=fa9998f9b31e033b16113e11deecc97b"
 }

--- a/packages/bsbnative/bsbnative.1.9.4/opam
+++ b/packages/bsbnative/bsbnative.1.9.4/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {= "4.02.3"}
 ]
 url {
-  src: "https://github.com/bsansouci/bsb-native/archive/1.9.4.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/bsbnative-1.9.4.tar.gz"
   checksum: "md5=90fa52709385f28cc80b15e6f0f537e6"
 }

--- a/packages/cairo/cairo.1.2.0/opam
+++ b/packages/cairo/cairo.1.2.0/opam
@@ -46,6 +46,6 @@ extra-files: [
 ]
 url {
   src:
-    "http://cgit.freedesktop.org/cairo-ocaml/snapshot/cairo-ocaml-1.2.0.tar.gz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/cairo-1.2.0.tar.gz"
   checksum: "md5=75bf7eb95045c1dba2733d7107b7b218"
 }

--- a/packages/dyntype/dyntype.0.8.2/opam
+++ b/packages/dyntype/dyntype.0.8.2/opam
@@ -18,6 +18,7 @@ synopsis:
   "syntax extension which makes OCaml types and values easier to manipulate programmatically"
 flags: light-uninstall
 url {
-  src: "https://github.com/mirage/dyntype/tarball/dyntype-0.8.2"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/dyntype-0.8.2.2"
   checksum: "md5=bcba157bb85737ce845147fac501e134"
 }

--- a/packages/dyntype/dyntype.0.8.3/opam
+++ b/packages/dyntype/dyntype.0.8.3/opam
@@ -18,6 +18,7 @@ synopsis:
   "syntax extension which makes OCaml types and values easier to manipulate programmatically"
 flags: light-uninstall
 url {
-  src: "https://github.com/mirage/dyntype/tarball/dyntype-0.8.3"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/dyntype-0.8.3.3"
   checksum: "md5=1eb647f02797d1d91b8674b38975cd1e"
 }

--- a/packages/dyntype/dyntype.0.8.4/opam
+++ b/packages/dyntype/dyntype.0.8.4/opam
@@ -18,6 +18,7 @@ synopsis:
   "syntax extension which makes OCaml types and values easier to manipulate programmatically"
 flags: light-uninstall
 url {
-  src: "https://github.com/mirage/dyntype/tarball/dyntype-0.8.4"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/dyntype-0.8.4.4"
   checksum: "md5=40b4d77c3288f65107410da629536c43"
 }

--- a/packages/dyntype/dyntype.0.8.5/opam
+++ b/packages/dyntype/dyntype.0.8.5/opam
@@ -18,6 +18,7 @@ synopsis:
   "syntax extension which makes OCaml types and values easier to manipulate programmatically"
 flags: light-uninstall
 url {
-  src: "https://github.com/mirage/dyntype/tarball/dyntype-0.8.5"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/dyntype-0.8.5.5"
   checksum: "md5=d1910c5dfd835a2315d84a30b6872b66"
 }

--- a/packages/elina/elina.1.3/opam
+++ b/packages/elina/elina.1.3/opam
@@ -44,7 +44,8 @@ significantly improve the performance of static analysis with the
 numerical domains."""
 
 url {
-  src: "https://github.com/eth-sri/ELINA/archive/1.3.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/elina-1.3.tar.gz"
   checksum: "md5=e0c78d7b0a7afaee871a057b83d06a76"
 }
 

--- a/packages/libres3/libres3.0.1/opam
+++ b/packages/libres3/libres3.0.1/opam
@@ -40,6 +40,7 @@ extra-files: [
   ["depfix.patch" "md5=0762983d6ea4096b67a9e38eef52ac6f"]
 ]
 url {
-  src: "http://cdn.skylable.com/source/libres3-0.1.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/libres3-0.1.tar.gz"
   checksum: "md5=1b1c9b4442f16aef9d210038798d1e5a"
 }

--- a/packages/libres3/libres3.0.2/opam
+++ b/packages/libres3/libres3.0.2/opam
@@ -42,6 +42,7 @@ It uses Skylable SX as the storage backend, which automatically
 provides data deduplication and replication."""
 extra-files: ["libres3.install" "md5=bad7ddd5db5cf6a53550e25af80bcaca"]
 url {
-  src: "http://cdn.skylable.com/source/libres3-0.2.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/libres3-0.2.tar.gz"
   checksum: "md5=ce3406cd3b8b73e4f31ea07d9b70b212"
 }

--- a/packages/libres3/libres3.0.3/opam
+++ b/packages/libres3/libres3.0.3/opam
@@ -44,6 +44,7 @@ It uses Skylable SX as the storage backend, which automatically
 provides data deduplication and replication."""
 extra-files: ["libres3.install" "md5=a47d2673184a7fa581069a513efe8b50"]
 url {
-  src: "http://cdn.skylable.com/source/libres3-0.3.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/libres3-0.3.tar.gz"
   checksum: "md5=edf532c3f8aee7e06897769a6c540e95"
 }

--- a/packages/libres3/libres3.0.9/opam
+++ b/packages/libres3/libres3.0.9/opam
@@ -45,6 +45,7 @@ It uses Skylable SX as the storage backend, which automatically
 provides data deduplication and replication."""
 extra-files: ["libres3.install" "md5=a47d2673184a7fa581069a513efe8b50"]
 url {
-  src: "http://cdn.skylable.com/source/libres3-0.9.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/libres3-0.9.tar.gz"
   checksum: "md5=b91bea21e3589de785317c2dccc6e0d0"
 }

--- a/packages/libres3/libres3.1.0/opam
+++ b/packages/libres3/libres3.1.0/opam
@@ -45,6 +45,7 @@ It uses Skylable SX as the storage backend, which automatically
 provides data deduplication and replication."""
 extra-files: ["libres3.install" "md5=150537f09471218057b533e1217ec1e3"]
 url {
-  src: "http://cdn.skylable.com/source/libres3-1.0.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/libres3-1.0.tar.gz"
   checksum: "md5=4f3170b670caa1b6369bc1bb623e922c"
 }

--- a/packages/libres3/libres3.1.1/opam
+++ b/packages/libres3/libres3.1.1/opam
@@ -46,6 +46,7 @@ It uses Skylable SX as the storage backend, which automatically
 provides data deduplication and replication."""
 extra-files: ["libres3.install" "md5=fe506a2c644b176b86ed22836ea395ee"]
 url {
-  src: "http://cdn.skylable.com/source/libres3-1.1.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/libres3-1.1.tar.gz"
   checksum: "md5=e4cb8001d8d435400b419fa95bacb6a6"
 }

--- a/packages/libres3/libres3.1.2/opam
+++ b/packages/libres3/libres3.1.2/opam
@@ -45,6 +45,7 @@ It uses Skylable SX as the storage backend, which automatically
 provides data deduplication and replication."""
 extra-files: ["libres3.install" "md5=fe506a2c644b176b86ed22836ea395ee"]
 url {
-  src: "http://cdn.skylable.com/source/libres3-1.2.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/libres3-1.2.tar.gz"
   checksum: "md5=d388eca12f6d648cb4d8e5e12e6946b8"
 }

--- a/packages/libres3/libres3.1.3/opam
+++ b/packages/libres3/libres3.1.3/opam
@@ -45,6 +45,7 @@ It uses Skylable SX as the storage backend, which automatically
 provides data deduplication and replication."""
 extra-files: ["libres3.install" "md5=fe506a2c644b176b86ed22836ea395ee"]
 url {
-  src: "http://cdn.skylable.com/source/libres3-1.3.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/libres3-1.3.tar.gz"
   checksum: "md5=2e5ddc5f9b1dfb83087077ab81f1a60d"
 }

--- a/packages/mirage-http-unix/mirage-http-unix.1.0.0/opam
+++ b/packages/mirage-http-unix/mirage-http-unix.1.0.0/opam
@@ -17,6 +17,7 @@ dev-repo: "git+https://github.com/mirage/mirage-http-unix"
 install: [make "install"]
 synopsis: "MirageOS HTTP client and server driver for Unix"
 url {
-  src: "https://github.com/mirage/mirage-http-unix/archive/v1.0.0.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/mirage-http-unix-1.0.0.tar.gz"
   checksum: "md5=ac773d4a74cf0e6e8d109d3eb86f296c"
 }

--- a/packages/ocaml-r/ocaml-r.0.0.1/opam
+++ b/packages/ocaml-r/ocaml-r.0.0.1/opam
@@ -36,6 +36,7 @@ description:
   "OCaml-R is still in development, is usable, but still has some syntactic idiosyncrasies and some performance bottlenecks."
 flags: light-uninstall
 url {
-  src: "https://github.com/pveber/OCaml-R/archive/pre-nyc-refactoring.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/ocaml-r-0.0.1.tar.gz"
   checksum: "md5=956f057af8871eb9f782ae75d45c2fda"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+trunk+forced_lto/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+trunk+forced_lto/opam
@@ -42,7 +42,8 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/chambart/ocaml-1/archive/lto.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/ocaml-variants-4.04.0+trunk+forced_lto.tar.gz"
   checksum: "md5=0bc3ded0fed30966a457c47f973e814e"
 }
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocamlregextkit/ocamlregextkit.1.0.0/opam
+++ b/packages/ocamlregextkit/ocamlregextkit.1.0.0/opam
@@ -40,7 +40,7 @@ build: [
 dev-repo: "git+https://github.com/toodom02/ocamlregextkit.git"
 url {
   src:
-    "https://github.com/toodom02/ocamlregextkit/releases/download/v1.0.0/ocamlregextkit-1.0.0.tbz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/ocamlregextkit-1.0.0.tbz"
   checksum: [
     "sha256=8edee54b513ce6320296e1f6723a4359a80c4fa759d2cd6c91594dd8a6b1c2a0"
     "sha512=f2a00da2dd7d6aa9b212b2dd252f2b09c407375884d19bc94512ea258281cee783b3716460f02ce550f779f7f19ddbf7dfec70577f3b93abae7ccfe0f9e29477"

--- a/packages/ocp-build/ocp-build.1.99.13-beta/opam
+++ b/packages/ocp-build/ocp-build.1.99.13-beta/opam
@@ -35,6 +35,7 @@ depends: [
 conflicts: [ "typerex"  {< "1.99.7"} ]
 synopsis: "Project manager for OCaml"
 url {
-  src: "http://github.com/OCamlPro/typerex-build/archive/1.99.13-beta.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/ocp-build-1.99.13-beta.tar.gz"
   checksum: "md5=46e876a35fd905df5be9b062e773b7f6"
 }

--- a/packages/ocp-build/ocp-build.1.99.14-beta/opam
+++ b/packages/ocp-build/ocp-build.1.99.14-beta/opam
@@ -35,6 +35,7 @@ depends: [
 conflicts: [ "typerex"  {< "1.99.7"} ]
 synopsis: "Project manager for OCaml"
 url {
-  src: "http://github.com/OCamlPro/typerex-build/archive/1.99.14-beta.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/ocp-build-1.99.14-beta.tar.gz"
   checksum: "md5=c626fd172939185a08aab6766cbb979c"
 }

--- a/packages/ocp-build/ocp-build.1.99.15-beta/opam
+++ b/packages/ocp-build/ocp-build.1.99.15-beta/opam
@@ -33,6 +33,7 @@ depends: [
 conflicts: [ "typerex"  {< "1.99.7"} ]
 synopsis: "Project manager for OCaml"
 url {
-  src: "http://github.com/OCamlPro/typerex-build/archive/1.99.15-beta.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/ocp-build-1.99.15-beta.tar.gz"
   checksum: "md5=863547bca8f1528b36034d736100b23e"
 }

--- a/packages/ocp-build/ocp-build.1.99.16-beta/opam
+++ b/packages/ocp-build/ocp-build.1.99.16-beta/opam
@@ -34,6 +34,7 @@ depends: [
 conflicts: [ "typerex"  {< "1.99.7"} ]
 synopsis: "Project manager for OCaml"
 url {
-  src: "http://github.com/OCamlPro/typerex-build/archive/1.99.16-beta.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/ocp-build-1.99.16-beta.tar.gz"
   checksum: "md5=bfd12f6e67e1db9b9fcf73f96cad71c8"
 }

--- a/packages/oqamldebug/oqamldebug.0.9.1/opam
+++ b/packages/oqamldebug/oqamldebug.0.9.1/opam
@@ -41,6 +41,7 @@ On MacOS it is necessary to set QMAKESPEC as follow to install the package
 export QMAKESPEC=macx-g++"""
 depends: ["ocaml"]
 url {
-  src: "http://oqamldebug.forge.ocamlcore.org/oqamldebug-0.9.1.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/oqamldebug-0.9.1.tar.gz"
   checksum: "md5=418d2292a6441bb974451a1351266cb0"
 }

--- a/packages/oqamldebug/oqamldebug.0.9.2/opam
+++ b/packages/oqamldebug/oqamldebug.0.9.2/opam
@@ -41,6 +41,7 @@ On MacOS it is necessary to set QMAKESPEC as follow to install the package
 export QMAKESPEC=macx-g++"""
 depends: ["ocaml"]
 url {
-  src: "http://oqamldebug.forge.ocamlcore.org/oqamldebug-0.9.2.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/oqamldebug-0.9.2.tar.gz"
   checksum: "md5=1037eefe46132300dd872ba6b0c25e58"
 }

--- a/packages/oqamldebug/oqamldebug.0.9.3/opam
+++ b/packages/oqamldebug/oqamldebug.0.9.3/opam
@@ -41,6 +41,7 @@ On MacOS it is necessary to set QMAKESPEC as follow to install the package
 export QMAKESPEC=macx-g++"""
 depends: ["ocaml"]
 url {
-  src: "http://oqamldebug.forge.ocamlcore.org/oqamldebug-0.9.3.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/oqamldebug-0.9.3.tar.gz"
   checksum: "md5=e7af5a5b24da9a0435e184628248c292"
 }

--- a/packages/oqamldebug/oqamldebug.0.9.4/opam
+++ b/packages/oqamldebug/oqamldebug.0.9.4/opam
@@ -41,6 +41,7 @@ On MacOS it is necessary to set QMAKESPEC as follow to install the package
 export QMAKESPEC=macx-g++"""
 depends: ["ocaml"]
 url {
-  src: "http://oqamldebug.forge.ocamlcore.org/oqamldebug-0.9.4.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/oqamldebug-0.9.4.tar.gz"
   checksum: "md5=57d9ae1b8e051f6dca2a10aaf50253b3"
 }

--- a/packages/oqamldebug/oqamldebug.0.9.5/opam
+++ b/packages/oqamldebug/oqamldebug.0.9.5/opam
@@ -36,6 +36,7 @@ export QMAKESPEC=macx-g++"""
 depends: ["ocaml"]
 extra-files: ["oqamldebug.install" "md5=75c25b7029fae5e7e4acc9b87d76026b"]
 url {
-  src: "http://oqamldebug.forge.ocamlcore.org/oqamldebug-0.9.5.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/oqamldebug-0.9.5.tar.gz"
   checksum: "md5=fd50ab57cfd3e48d8061a1c06b411ecd"
 }

--- a/packages/pa_ppx/pa_ppx.0.01/opam
+++ b/packages/pa_ppx/pa_ppx.0.01/opam
@@ -77,7 +77,8 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/chetmurthy/pa_ppx/archive/0.01.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/pa_ppx-0.01.tar.gz"
   checksum: [
     "md5=7212c459eff3ea17974b2d47998f2038"
     "sha512=f6e344a9ac8352c823d629e1c0cef9cf9aaf3bfa7800446f4087ed682c9e8ba3fbb834c83bc8276cdb5294951db559c0b19f364f2a7adf22bbd70313b7d0bd08"

--- a/packages/pancake/pancake.2.0.0/opam
+++ b/packages/pancake/pancake.2.0.0/opam
@@ -26,3 +26,4 @@ url {
     "sha512=708b5f7f3173839195352584da009f61d9dd6b69d0d85fe924dd539c2a33c8e0a6ba3f9fcc7bce6a697eb94349b646810849fbb9ed69cc4947b3ce5ba3b1f99f"
   ]
 }
+available: false # the upstream tarball has changed hash and it is not in the opam caches

--- a/packages/pancake/pancake.2.0.1/opam
+++ b/packages/pancake/pancake.2.0.1/opam
@@ -20,7 +20,7 @@ depends: [
 dev-repo: "git+https://github.com/rolandpeelen/bs-pancake.git"
 url {
   src:
-    "https://github.com/rolandpeelen/bs-pancake/archive/refs/tags/2.0.1.tar.gz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/pancake-2.0.1.tar.gz"
   checksum: [
     "md5=9923aa43c1dac021cb9c496f5ba1b707"
     "sha512=4f8b65d8c7f3482d6506adb5cd5f32187a238104a72ca2a7c6bde506cf00401f8e5646056e47f9a98c91ada754bee91c3fad177d54ed15a578dee483714aa3e6"

--- a/packages/rotor/rotor.0.1/opam
+++ b/packages/rotor/rotor.0.1/opam
@@ -33,8 +33,7 @@ depexts: [
 ]
 build: [ make ]
 url {
-  src:
-    "https://gitlab.com/trustworthy-refactoring/refactorer/-/archive/0.1/refactorer-0.1.zip"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/rotor-0.1.zip"
   checksum: [
     "md5=372ca9b6a7af2fdd99d5117d376870b4"
     "sha512=6f5473951437a48bf9ae7a5d22a4283c02bed6a6e5c7bc02fc5f28dc5c28720f3e2c69f32a2a0c5b9447c2bc8c83746bb4de5b67909a98cc8921527582727063"

--- a/packages/tls/tls.0.5.0/opam
+++ b/packages/tls/tls.0.5.0/opam
@@ -43,6 +43,7 @@ A clean-slate TLS implementation, with support for protocol versions 1.0-1.2.
 Includes the core library, as well as Lwt and MirageOS frontends."""
 flags: light-uninstall
 url {
-  src: "https://github.com/mirleft/ocaml-tls/archive/0.5.0.tar.gz"
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/tls-0.5.0.tar.gz"
   checksum: "md5=45a19a587179a65cf108d74c267c0692"
 }

--- a/packages/type_eq/type_eq.0.0.1/opam
+++ b/packages/type_eq/type_eq.0.0.1/opam
@@ -30,7 +30,7 @@ build: [
 dev-repo: "git+https://github.com/skolemlabs/type_eq.git"
 url {
   src:
-    "https://github.com/skolemlabs/type_eq/releases/download/0.0.1/type_eq-0.0.1.tbz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/type_eq-0.0.1.tbz"
   checksum: [
     "sha256=7855592497d4ea17dbf2f28d5ce64b67570772c0ddcc551eadb87645906dd199"
     "sha512=b54629c3eca93c820156d5d4cf1a71fdef3fba07321a8ac068869d7e900e056944d8a02770dd21e4c2bbdcb5376036ddb61b83b33afe7bb355ac59b9b4bb0d63"


### PR DESCRIPTION
From https://github.com/ocaml/opam-repository/issues/15298#issuecomment-1931475275 and https://github.com/ocaml/opam-repository/issues/12421#issuecomment-1931480130

I did omit the packages that have `available:false`