### PR TITLE
Add mlgmpidl.1.3.0

### DIFF
--- a/packages/conf-mpfr-paths/conf-mpfr-paths.1/opam
+++ b/packages/conf-mpfr-paths/conf-mpfr-paths.1/opam
@@ -34,12 +34,15 @@ depexts: [
   ["mpfr-devel"] {os-distribution = "centos"}
   ["mpfr"] {os = "macos" & os-distribution = "homebrew"}
   ["mpfr"] {os = "macos" & os-distribution = "macports"}
-  ["mpfr"] {os = "freebsd"}
+  # ["mpfr"] {os = "freebsd"}
   ["mpfr"] {os = "openbsd"}
   ["mpfr"] {os-family = "arch"}
   ["mpfr-dev"] {os-family = "alpine"}
   ["mpfr-devel"] {os-family = "suse"}
   ["mpfr"] {os = "win32" & os-distribution = "cygwinports"}
+]
+available: [
+  os != "freebsd"
 ]
 extra-files: ["test-mpfr.c" "md5=60677273f1781840669e5a897df5d645"]
 flags: conf

--- a/packages/mlgmpidl/mlgmpidl.1.3.0/opam
+++ b/packages/mlgmpidl/mlgmpidl.1.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+authors: ["Bertrand Jeannet" "Nicolas Berthier"]
+maintainer: "Nicolas Berthier <m@nberth.space>"
+dev-repo: "git+https://github.com/nberth/mlgmpidl.git"
+bug-reports: "https://github.com/nberth/mlgmpidl/issues"
+homepage: "https://www.inrialpes.fr/pop-art/people/bjeannet/mlxxxidl-forge/mlgmpidl/"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [
+  ["sh" "./configure" "--absolute-dylibs" {os = "macos"}
+        "CPPFLAGS+=-I%{conf-gmp-paths:incdir}%"  { conf-gmp-paths:incdir != "" }
+        "CPPFLAGS+=-I%{conf-mpfr-paths:incdir}%" { conf-mpfr-paths:incdir != "" }
+        "LDFLAGS+=-L%{conf-gmp-paths:libdir}%"   { conf-gmp-paths:libdir != "" }
+        "LDFLAGS+=-L%{conf-mpfr-paths:libdir}%"  { conf-mpfr-paths:libdir != "" } ]
+  [make]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "3.12.1"}
+  "ocamlfind" {build & >= "1.5.6"}
+  "camlidl" {!= "1.10"}
+  "conf-gmp-paths"
+  "conf-mpfr-paths"
+  "conf-perl" {build}
+  "bigarray-compat"
+]
+conflicts: [
+  "mlgmp"
+  "apron" {= "20140725"}
+  "apron" {= "20150518"}
+]
+synopsis: "OCaml interface to the GMP library"
+url {
+  src: "https://github.com/nberth/mlgmpidl/archive/1.3.0.tar.gz"
+  checksum: "md5=527995e4bc37a57297d7f30495ea0cc2"
+}


### PR DESCRIPTION
Brings a version of `mlgmpidl` that makes use of `conf-gmp-paths` and `conf-mpfr-paths` to locate the respective libraries.