### PR TITLE
[new release] html_of_jsx (0.0.1)

### DIFF
--- a/packages/html_of_jsx/html_of_jsx.0.0.1/opam
+++ b/packages/html_of_jsx/html_of_jsx.0.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Render HTML writing JSX"
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/davesnx/html_of_jsx"
+bug-reports: "https://github.com/davesnx/html_of_jsx/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "5.0.0"}
+  "reason" {>= "3.10.0"}
+  "ppxlib" {> "0.23.0" & <= "0.31.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {= "0.26.1" & with-test}
+  "ocaml-lsp-server" {with-test}
+  "tiny_httpd" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/html_of_jsx.git"
+url {
+  src:
+    "https://github.com/davesnx/html_of_jsx/releases/download/0.0.1/html_of_jsx-0.0.1.tbz"
+  checksum: [
+    "sha256=d1a36abcbebd23adfaffe9eed27e69045c1e112da17bfebc385355d2a64f1fb7"
+    "sha512=bee674151f2ab6fba41acc1234118b5eca5379aedab2907da517bdeb604ddd02807519b9b29b4eea09595ced9936300b9a6ebf16c9edd92d959151daab4e7a96"
+  ]
+}
+x-commit-hash: "f0556edbd467d508f2cbea8eca98c7aaea717aed"


### PR DESCRIPTION
Render HTML writing JSX

- Project page: <a href="https://github.com/davesnx/html_of_jsx">https://github.com/davesnx/html_of_jsx</a>

##### CHANGES:

## 0.0.1

- First working version of the ppx and library
- Supports most of features from [JSX](https://reasonml.github.io/docs/en/jsx) (uppercase components, fragments, optional attributes, punning)
- but with a few improvements (lowercase components, no need to add annotations)
- No React idioms (no `className`, no `htmlFor`, no `onChange`, etc...)
- Type-safe, validates attributes and their types ([it can be better thought](https://github.com/davesnx/html_of_jsx/issues/2))
- Minimal
  - `Html_of_jsx.render` to render an element to HTML
  - `Jsx.*` to construct DOM Elements and DOM nodes (`Jsx.text`, `Jsx.int`, `Jsx.null`, `Jsx.list`)
- Works with [Reason](https://reasonml.github.io) and [mlx](https://github.com/andreypopp/mlx)
- Supports some htmx under the ppx (`html_of_jsx.ppx -htmx`)
