### PR TITLE
Fix missing ocaml-option-no-compression

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.2.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+trunk/opam
@@ -72,6 +72,7 @@ depopts: [
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"
+  "ocaml-option-no-compression"
   "ocaml-option-musl"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-address-sanitizer"

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~alpha1+options/opam
@@ -74,6 +74,7 @@ depopts: [
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"
+  "ocaml-option-no-compression"
   "ocaml-option-musl"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-address-sanitizer"

--- a/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
@@ -41,6 +41,7 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--without-zstd" {ocaml-option-no-compression:installed}
     "--enable-tsan" {ocaml-option-tsan:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
     "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
@@ -71,6 +72,7 @@ depopts: [
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"
+  "ocaml-option-no-compression"
   "ocaml-option-musl"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-address-sanitizer"


### PR DESCRIPTION
I think we need to update this in ocaml/ocaml as well, but offloading this commit from my Windows compiler branch. I haven't double-checked this against the 5.1.x packages as well, although I _think_ they're all correct.

cc @Octachron 