### PR TITLE
Disable all old alpha/beta/rc releases on Windows

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha1/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha3/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta1/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta2/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~rc1/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~alpha1/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~alpha2/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~beta1/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc1/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc2/opam
@@ -42,3 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~alpha1/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~alpha2/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~beta1/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~rc1/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~rc2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~rc2/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1~rc1/opam
@@ -43,3 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha0/opam
@@ -48,3 +48,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha1/opam
@@ -45,3 +45,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~beta1/opam
@@ -46,3 +46,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~beta2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~beta2/opam
@@ -46,3 +46,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~rc1/opam
@@ -46,3 +46,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha1/opam
@@ -46,3 +46,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha2/opam
@@ -46,3 +46,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~beta1/opam
@@ -46,3 +46,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~rc1/opam
@@ -46,3 +46,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~rc2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~rc2/opam
@@ -46,3 +46,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~rc3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~rc3/opam
@@ -46,3 +46,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1~rc1/opam
@@ -46,3 +46,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.02.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.0+rc1/opam
@@ -39,4 +39,4 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0+rc1.tar.gz"
   checksum: "md5=a18e89606d032a6442f68fc640541ab6"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.02.2+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.2+rc1/opam
@@ -39,4 +39,4 @@ url {
   src: "http://github.com/ocaml/ocaml/tarball/4.02.2+rc1"
   checksum: "md5=5444ee57d65d457d3524d293a51f3ae8"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta1+flambda/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta1-no-debug/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta1-no-debug/opam
@@ -40,4 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta1/opam
@@ -40,4 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta2+flambda/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta2-no-debug/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta2-no-debug/opam
@@ -40,4 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta2/opam
@@ -40,4 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4370afea8ee2dea768b0fcba52394a2f"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta1+flambda/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta1/opam
@@ -40,4 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta2+flambda/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta2/opam
@@ -40,4 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta1+flambda/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta1/opam
@@ -40,4 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta2+flambda/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta2/opam
@@ -40,4 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta3/opam
@@ -40,4 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+rc1+flambda/opam
@@ -39,4 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.05.0+rc1.tar.gz"
   checksum: "md5=83868514b06c3583cfe33f8ca4e8eb89"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+rc1/opam
@@ -38,4 +38,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.05.0+rc1.tar.gz"
   checksum: "md5=83868514b06c3583cfe33f8ca4e8eb89"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+afl/opam
@@ -40,4 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+default-unsafe-string/opam
@@ -46,4 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+flambda/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+force-safe-string/opam
@@ -39,4 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta1.tar.gz"
   checksum: "md5=150d27e8c053e1f2794be668895fcf1f"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1/opam
@@ -40,4 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+afl/opam
@@ -40,4 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+default-unsafe-string/opam
@@ -46,4 +46,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+flambda/opam
@@ -41,4 +41,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+force-safe-string/opam
@@ -39,4 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+beta2.tar.gz"
   checksum: "md5=d3beca2a7d12c42c6b2585557ba59c4a"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2/opam
@@ -40,4 +40,4 @@ url {
 }
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+afl/opam
@@ -38,4 +38,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
   checksum: "md5=4789f3147cbe82656459fea0f1b0b1a9"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+default-unsafe-string/opam
@@ -45,4 +45,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
   checksum: "md5=4789f3147cbe82656459fea0f1b0b1a9"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+flambda/opam
@@ -39,4 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
   checksum: "md5=4789f3147cbe82656459fea0f1b0b1a9"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+force-safe-string/opam
@@ -39,4 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
   checksum: "md5=4789f3147cbe82656459fea0f1b0b1a9"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1/opam
@@ -38,4 +38,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.0+rc1.tar.gz"
   checksum: "md5=4789f3147cbe82656459fea0f1b0b1a9"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+afl/opam
@@ -38,4 +38,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc1.tar.gz"
   checksum: "md5=7a8d77a43528224fa589e962604bd184"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+default-unsafe-string/opam
@@ -45,4 +45,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc1.tar.gz"
   checksum: "md5=7a8d77a43528224fa589e962604bd184"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+flambda/opam
@@ -39,4 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc1.tar.gz"
   checksum: "md5=7a8d77a43528224fa589e962604bd184"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+force-safe-string/opam
@@ -39,4 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc1.tar.gz"
   checksum: "md5=7a8d77a43528224fa589e962604bd184"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1/opam
@@ -38,4 +38,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc1.tar.gz"
   checksum: "md5=7a8d77a43528224fa589e962604bd184"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+afl/opam
@@ -39,4 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc2.tar.gz"
   checksum: "md5=8befb315cd6d4dbfad130061b5a34a66"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+default-unsafe-string/opam
@@ -45,4 +45,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc2.tar.gz"
   checksum: "md5=8befb315cd6d4dbfad130061b5a34a66"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+flambda/opam
@@ -39,4 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc2.tar.gz"
   checksum: "md5=8befb315cd6d4dbfad130061b5a34a66"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+force-safe-string/opam
@@ -39,4 +39,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc2.tar.gz"
   checksum: "md5=8befb315cd6d4dbfad130061b5a34a66"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2/opam
@@ -38,4 +38,4 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.1+rc2.tar.gz"
   checksum: "md5=8befb315cd6d4dbfad130061b5a34a66"
 }
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
@@ -49,4 +49,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
@@ -55,4 +55,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
@@ -50,4 +50,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
@@ -48,4 +48,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
@@ -49,4 +49,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
@@ -47,4 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
@@ -54,4 +54,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
@@ -48,4 +48,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
@@ -49,4 +49,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
@@ -47,4 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
@@ -47,4 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
@@ -54,4 +54,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
@@ -48,4 +48,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
@@ -49,4 +49,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
@@ -47,4 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
@@ -68,4 +68,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
@@ -49,4 +49,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
@@ -56,4 +56,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
@@ -58,4 +58,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
@@ -50,4 +50,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
@@ -51,4 +51,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
@@ -49,4 +49,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
@@ -41,4 +41,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
@@ -45,4 +45,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
@@ -40,4 +40,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
@@ -39,4 +39,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
@@ -41,4 +41,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
@@ -45,4 +45,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
@@ -40,4 +40,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
@@ -39,4 +39,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
@@ -40,4 +40,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
@@ -45,4 +45,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
@@ -40,4 +40,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
@@ -39,4 +39,4 @@ post-messages: [
 ]
 patches: ["fix-gcc10.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+afl/opam
@@ -39,4 +39,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+default-unsafe-string/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+flambda/opam
@@ -38,4 +38,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1/opam
@@ -37,4 +37,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+afl/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+default-unsafe-string/opam
@@ -47,4 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+flambda/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+afl/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+default-unsafe-string/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+flambda/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+force-safe-string/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+afl/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+default-unsafe-string/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+flambda/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+force-safe-string/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+afl/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+default-unsafe-string/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+flambda/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+force-safe-string/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+afl/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+default-unsafe-string/opam
@@ -47,4 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+flambda/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+afl/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+default-unsafe-string/opam
@@ -47,4 +47,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+flambda/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+afl/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+flambda/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+afl/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+flambda/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+afl/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+flambda/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+afl/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+flambda/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+afl/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+flambda/opam
@@ -40,4 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1/opam
@@ -39,4 +39,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+afl/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+flambda/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+afl/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+flambda/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+afl/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+flambda/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+afl/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+flambda/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+afl/opam
@@ -43,4 +43,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+flambda/opam
@@ -42,4 +42,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+afl/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+flambda/opam
@@ -40,4 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3/opam
@@ -39,4 +39,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+afl/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+flambda/opam
@@ -40,4 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1/opam
@@ -39,4 +39,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+afl/opam
@@ -41,4 +41,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+flambda/opam
@@ -40,4 +40,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2/opam
@@ -39,4 +39,4 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64" | os = "win32")

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha1+options/opam
@@ -74,3 +74,4 @@ depopts: [
   "ocaml-option-static"
   "ocaml-option-nnp"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
@@ -74,3 +74,4 @@ depopts: [
   "ocaml-option-static"
   "ocaml-option-nnp"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/opam
@@ -74,3 +74,4 @@ depopts: [
   "ocaml-option-static"
   "ocaml-option-nnp"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
@@ -76,3 +76,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/opam
@@ -76,3 +76,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~rc1+options/opam
@@ -76,3 +76,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~alpha1+options/opam
@@ -76,3 +76,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~alpha2+options/opam
@@ -76,3 +76,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~beta1+options/opam
@@ -76,3 +76,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~rc1+options/opam
@@ -76,3 +76,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~rc2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~rc2+options/opam
@@ -76,3 +76,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~alpha1+options/opam
@@ -77,3 +77,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~alpha2+options/opam
@@ -77,3 +77,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~beta1+options/opam
@@ -77,3 +77,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~rc1+options/opam
@@ -77,3 +77,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~rc2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~rc2+options/opam
@@ -77,3 +77,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.14.1~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1~rc1+options/opam
@@ -77,3 +77,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~alpha0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~alpha0+options/opam
@@ -87,3 +87,4 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~alpha1+options/opam
@@ -84,3 +84,4 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~beta1+options/opam
@@ -84,3 +84,4 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~beta2+options/opam
@@ -84,3 +84,4 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~rc1+options/opam
@@ -84,3 +84,4 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~alpha1+options/opam
@@ -84,3 +84,4 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/opam
@@ -84,3 +84,4 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~beta1+options/opam
@@ -84,3 +84,4 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~rc1+options/opam
@@ -84,3 +84,4 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~rc2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~rc2+options/opam
@@ -76,3 +76,4 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~rc3+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~rc3+options/opam
@@ -76,3 +76,4 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~rc3+tsan/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~rc3+tsan/opam
@@ -83,3 +83,4 @@ extra-source "check-tsan-distinguish-volatile.patch" {
   src: "https://github.com/ocaml-multicore/ocaml-tsan/commit/abb8fdb186773b2fc6e4e41b122d1df4c29b058c.patch?full_index=1"
   checksum: "sha256=efa4449d37c3843c488caffcd06f5ebd2a7569e06f9cf98f79458506c549bd2c"
 }
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.5.1.1~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1~rc1+options/opam
@@ -76,3 +76,4 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
+available: os != "win32"


### PR DESCRIPTION
Shedding weight from the Windows branch. It is just possible that when I finally switch the compiler packages over to being generated that it will be trivial to re-enable these, but even I don't really see the value in upgrading the alpha, beta & rc packages from old releases to work on native Windows.

It is, however, problematic if they get accidentally selected (e.g. from a solver which ignores avoid-version, etc.) so I propose marking them as unavailable on Windows.