### PR TITLE
Patch conf-pkg-config.3 for Windows

### DIFF
--- a/packages/conf-pkg-config/conf-pkg-config.1.0/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.0/opam
@@ -21,7 +21,7 @@ depexts: [
   ["pkgconf"] {os = "freebsd"}
   ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
 ]
-available: [ os != "openbsd" ]
+available: os != "openbsd" & (os != "win32" | os-distribution = "cygwinports")
 synopsis: "Virtual package relying on pkg-config installation"
 description: """
 This package can only install if the pkg-config package is installed

--- a/packages/conf-pkg-config/conf-pkg-config.1.1/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.1/opam
@@ -4,6 +4,7 @@ authors: ["Francois Berenger"]
 homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-1.0-or-later"
+available: os != "win32" | os-distribution = "cygwinports"
 build: [
   ["pkg-config" "--help"]
 ]

--- a/packages/conf-pkg-config/conf-pkg-config.1.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.2/opam
@@ -4,6 +4,7 @@ authors: ["Francois Berenger"]
 homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-1.0-or-later"
+available: os != "win32" | os-distribution = "cygwinports"
 build: [
   ["pkg-config" "--help"]
 ]

--- a/packages/conf-pkg-config/conf-pkg-config.1.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.3/opam
@@ -4,6 +4,7 @@ authors: ["Francois Berenger"]
 homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-1.0-or-later"
+available: os != "win32" | os-distribution = "cygwinports"
 build: [
   ["pkg-config" "--help"]
 ]

--- a/packages/conf-pkg-config/conf-pkg-config.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.2/opam
@@ -4,6 +4,7 @@ authors: ["Francois Berenger"]
 homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-1.0-or-later"
+available: os != "win32" | os-distribution = "cygwinports"
 setenv: [PKG_CONFIG_PATH += "%{lib}%/pkgconfig"]
 build: [
   ["pkg-config" "--help"] {os != "openbsd"}

--- a/packages/conf-pkg-config/conf-pkg-config.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.3/opam
@@ -5,7 +5,8 @@ homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-1.0-or-later"
 build: [
-  ["pkg-config" "--help"] {os != "openbsd"}
+  ["pkg-config" "--help"] {os != "openbsd" & os != "win32"}
+  ["pkgconf" "--version"] {os = "win32"}
 ]
 depexts: [
   ["pkg-config"] {os-family = "debian" | os-family = "ubuntu"}
@@ -24,6 +25,7 @@ depexts: [
   ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
   ["pkgconf-pkg-config"] {os-distribution = "ol" & os-version >= "8"}
   ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
+  ["pkgconf"] {os = "win32" & os-distribution = "cygwin"}
 ]
 synopsis: "Check if pkg-config is installed and create an opam switch local pkgconfig folder"
 description: """


### PR DESCRIPTION
Adapts conf-pkg-config.3 for opam 2.2's Windows depext support. The old versions remain available using "OCaml for Windows"'s depext-cygwinports plugin, but are otherwise unavailable.

depext-cygwinports installs a shim executable for pkg-config, which is why it didn't the extra build command, but it's fine to detect via pkgconf as well (i.e. it's OK that the filter on the command is `os = "win32"` not `os = "win32" & os-distribution != "cygwinports"`).