### PR TITLE
[new release] pretty_expressive (0.3)

### DIFF
--- a/packages/pretty_expressive/pretty_expressive.0.3/opam
+++ b/packages/pretty_expressive/pretty_expressive.0.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A pretty expressive printer"
+description:
+  "A pretty printer implementation of 'A Pretty Expressive Printer' (OOPSLA'23), with an emphasis on expressiveness and optimality."
+maintainer: ["Sorawee Porncharoenwase <sorawee.pwase@gmail.com>"]
+authors: ["Sorawee Porncharoenwase <sorawee.pwase@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/sorawee/pretty-expressive-ocaml"
+doc: "https://sorawee.github.io/pretty-expressive-ocaml/"
+bug-reports: "https://github.com/sorawee/pretty-expressive-ocaml/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "3.10"}
+  "mdx" {>= "2.3.0" & with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sorawee/pretty-expressive-ocaml.git"
+url {
+  src:
+    "https://github.com/sorawee/pretty-expressive-ocaml/releases/download/0.3/pretty_expressive-0.3.tbz"
+  checksum: [
+    "sha256=a62e254d8acb0d2c92eaa9685a86b9003b9f46ddc0fee4af68834cbcc0dd5dd1"
+    "sha512=173754e8ca9bcbe7485b0d578cdbd5b98bb38b21d92b391446f9057ee0c2539ccec80f4a536994ca91904cf5e61f4f345bbf2e30157ce989b831ff3295884b31"
+  ]
+}
+x-commit-hash: "d0d0e896ba383b85b3016f92cea097f07f068291"


### PR DESCRIPTION
A pretty expressive printer

- Project page: <a href="https://github.com/sorawee/pretty-expressive-ocaml">https://github.com/sorawee/pretty-expressive-ocaml</a>
- Documentation: <a href="https://sorawee.github.io/pretty-expressive-ocaml/">https://sorawee.github.io/pretty-expressive-ocaml/</a>

##### CHANGES:

* Add the `two_columns` construct
* Rename `CostFacory.debug` to `CostFactory.string_of_cost`
* Reorganize pretty printing functions:
  * Rename `Printer.Make.print` to `Printer.Make.pretty_format_info` (with slightly different signature)
  * Rename `Printer.Make.pretty_print` to `Printer.Make.pretty_format`
  * Add `Printer.Make.pretty_print`, `Printer.Make.pretty_print_info`, and `Printer.Make.pretty_format_debug`.
  * Essentially, `Printer.Make.pretty_print(*)` is suitable for printing to a channel.
    `Printer.Make.pretty_format(*)` is suitable for printing as a string.
    The suffix `_info` indicates that it returns debugging information.
