### PR TITLE
dune-release.2.0.0 requires dune < 3.14 for tests

### DIFF
--- a/packages/dune-release/dune-release.2.0.0/opam
+++ b/packages/dune-release/dune-release.2.0.0/opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/tarides/dune-release/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7"}
-  "dune" {>= "3.8" & with-test}
+  "dune" {>= "3.8" & < "3.14" & with-test}
   "curly" {>= "0.3.0"}
   "fmt" {>= "0.8.7"}
   "fpath" {>= "0.7.3"}


### PR DESCRIPTION
ocaml/dune#9851 adds a loc which is visible in the test suite.
