### PR TITLE
Minor corrections to compiler dev-repos

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
@@ -5,7 +5,7 @@ maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml.git#4.12"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.13"
 depends: [
   "ocaml" {= "4.13.0" & post}
   "base-unix" {post}

--- a/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
@@ -5,7 +5,7 @@ maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml.git#4.12"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.13"
 depends: [
   "ocaml" {= "4.13.1" & post}
   "base-unix" {post}

--- a/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
@@ -1,11 +1,11 @@
 opam-version: "2.0"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
-synopsis: "Latest 4.13 developmet"
+synopsis: "Latest 4.13 development"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.13"
 depends: [
   "ocaml" {= "4.13.2" & post}
   "base-unix" {post}

--- a/packages/ocaml-variants/ocaml-variants.4.14.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.2+trunk/opam
@@ -5,7 +5,7 @@ maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.14"
 depends: [
   "ocaml" {= "4.14.2" & post}
   "base-unix" {post}

--- a/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
@@ -5,7 +5,7 @@ maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.0"
 depends: [
   "ocaml" {= "5.0.1" & post}
   "base-unix" {post}

--- a/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
@@ -5,7 +5,7 @@ maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.1"
 depends: [
   "ocaml" {= "5.1.2" & post}
   "base-unix" {post}

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+trunk/opam
@@ -12,7 +12,7 @@ authors: [
 ]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.2"
 depends: [
   "ocaml" {= "5.2.0" & post}
   "base-unix" {post}


### PR DESCRIPTION
Spotted in passing while overhauling these (these things are basically typos) - given that they affect only 4.13's options packages (so an older release) and +trunk packages, I figure we can risk the switch churn of updating those separately?