### PR TITLE
2 packages from mirage/ocaml-solo5 at 0.8.3

### DIFF
--- a/packages/ocaml-solo5-cross-aarch64/ocaml-solo5-cross-aarch64.0.8.3/opam
+++ b/packages/ocaml-solo5-cross-aarch64/ocaml-solo5-cross-aarch64.0.8.3/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Freestanding OCaml compiler"
+description:
+  "This package provides a OCaml cross-compiler for ARM64, suitable for linking with a Solo5 unikernel."
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+license: "MIT"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-solo5"
+bug-reports: "https://github.com/mirage/ocaml-solo5/issues/"
+depends: [
+  "conf-which" {build}
+  "ocamlfind" {build}
+  "ocaml-src" {build}
+  "ocaml" {>= "4.12.1" & < "4.15.0"}
+  "solo5" {>= "0.7.0"}
+  "solo5-cross-aarch64" {>= "0.7.0"}
+]
+conflicts: [
+  "ocaml-solo5"
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available:
+  os = "linux" & (arch = "x86_64" | arch = "arm64") |
+  os = "freebsd" & arch = "x86_64" |
+  os = "openbsd" & arch = "x86_64"
+build: [
+  [
+    "./configure.sh"
+    "--prefix=%{prefix}%"
+    "--target=aarch64-solo5-none-static"
+    "--ocaml-configure-option=--disable-flat-float-array"
+      {ocaml-option-no-flat-float-array:installed}
+    "--ocaml-configure-option=--enable-flambda"
+      {ocaml-option-flambda:installed}
+    "--ocaml-configure-option=--disable-naked-pointers"
+      {ocaml-option-nnp:installed}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-solo5/archive/refs/tags/v0.8.3.tar.gz"
+  checksum: [
+    "md5=82596c8e4e4960badbcb546901e59f5a"
+    "sha512=5ea10329ea9cb975d2ca47178c20b1ade0bc8c8886a2e8517918c43d184b16a65b334d60da03a11adcd5e2d4303a66a6ca52dcf98147cf20ac10d37b3da8d5b4"
+  ]
+}

--- a/packages/ocaml-solo5/ocaml-solo5.0.8.3/opam
+++ b/packages/ocaml-solo5/ocaml-solo5.0.8.3/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Freestanding OCaml compiler"
+description:
+  "This package provides a OCaml cross-compiler, suitable for linking with a Solo5 unikernel."
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+license: "MIT"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-solo5"
+bug-reports: "https://github.com/mirage/ocaml-solo5/issues/"
+depends: [
+  "conf-which" {build}
+  "ocamlfind" {build}
+  "ocaml-src" {build}
+  "ocaml" {>= "4.12.1" & < "4.15.0"}
+  "solo5" {>= "0.7.0"}
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available:
+  os = "linux" & (arch = "x86_64" | arch = "arm64") |
+  os = "freebsd" & arch = "x86_64" |
+  os = "openbsd" & arch = "x86_64"
+build: [
+  [
+    "./configure.sh"
+    "--prefix=%{prefix}%"
+    "--target=x86_64-solo5-none-static" {arch = "x86_64"}
+    "--target=aarch64-solo5-none-static" {arch = "arm64"}
+    "--ocaml-configure-option=--disable-flat-float-array"
+      {ocaml-option-no-flat-float-array:installed}
+    "--ocaml-configure-option=--enable-flambda"
+      {ocaml-option-flambda:installed}
+    "--ocaml-configure-option=--disable-naked-pointers"
+      {ocaml-option-nnp:installed}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-solo5/archive/refs/tags/v0.8.3.tar.gz"
+  checksum: [
+    "md5=82596c8e4e4960badbcb546901e59f5a"
+    "sha512=5ea10329ea9cb975d2ca47178c20b1ade0bc8c8886a2e8517918c43d184b16a65b334d60da03a11adcd5e2d4303a66a6ca52dcf98147cf20ac10d37b3da8d5b4"
+  ]
+}


### PR DESCRIPTION
Freestanding OCaml compiler

This pull-request concerns:
- `ocaml-solo5.0.8.3`
- `ocaml-solo5-cross-aarch64.0.8.3`



---
* Homepage: https://github.com/mirage/ocaml-solo5
* Source repo: git+https://github.com/mirage/ocaml-solo5.git
* Bug tracker: https://github.com/mirage/ocaml-solo5/issues/

---
:camel: Pull-request generated by opam-publish v2.3.0