### PR TITLE
Package vscoq-language-server.2.1.0+coq8.19

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.1.0+coq8.19/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.1.0+coq8.19/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/coq-community/vscoq"
+bug-reports: "https://github.com/coq-community/vscoq/issues"
+dev-repo: "git+https://github.com/coq-community/vscoq"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { >= "4.13.1" }
+  "dune" { >= "3.5" }
+  "coq-core" { >= "8.18" < "8.20" }
+  "coq-stdlib" { >= "8.18" < "8.20" }
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_yojson_conv" {< "v0.16.0"}
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "ppx_optcomp"
+  "result" { >= "1.5" }
+  "lsp" { >= "1.15"}
+  "sel" {>= "0.4.0"}
+]
+synopsis: "VSCoq language server"
+description: """
+LSP based language server for Coq and its VSCoq user interface
+"""
+url {
+  src:
+    "https://github.com/coq-community/vscoq/releases/download/v2.1.0+coq8.19/vscoq-language-server-2.1.0-coq8.19.tar.gz"
+  checksum: [
+    "md5=7bdc4ae44d8d6ab21d586e20835a1b79"
+    "sha512=7ab8ddae303a9b9ec2d62338edbf4176ca1146ed29e34eb02cf41fc91bf21d507c6e571ba30b73e45869d25a750d7915e79b915d962629cb9aed1598e0b68795"
+  ]
+}


### PR DESCRIPTION
### `vscoq-language-server.2.1.0+coq8.19`
VSCoq language server
LSP based language server for Coq and its VSCoq user interface



---
* Homepage: https://github.com/coq-community/vscoq
* Source repo: git+https://github.com/coq-community/vscoq
* Bug tracker: https://github.com/coq-community/vscoq/issues

---
:camel: Pull-request generated by opam-publish v2.0.3