### PR TITLE
[new release] grenier (0.15)

### DIFF
--- a/packages/grenier/grenier.0.15/opam
+++ b/packages/grenier/grenier.0.15/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/grenier"
+bug-reports: "https://github.com/let-def/grenier"
+license: "ISC"
+dev-repo: "git+https://github.com/let-def/grenier.git"
+doc: "https://let-def.github.io/grenier/doc"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.0.0"}
+]
+synopsis: "A collection of various algorithms in OCaml"
+description: """
+This library implements various datastructures and algorithms:
+- automata minimization and transformation to regular expression
+- balanced trees
+- binpacking
+- cardinality estimation (hyperloglog)
+- immutable sequences
+- jump consistent hashing
+- solutions to the order maintenance problem
+- congruence closure
+- ...
+"""
+url {
+  src:
+    "https://github.com/let-def/grenier/releases/download/v0.15/grenier-0.15.tbz"
+  checksum: [
+    "sha256=dec7f84b9e93d5825f10c7dea84d5a74d7365ede45664ae63c26b5e8045c1c44"
+    "sha512=b8aa1569c2e24b89674d1b34de34cd1798896bb6a53aa5a1287f68cee880125e6b687f66ad73da9069a01cc3ece1f0684f48328b099d43529bff736b772c8fd8"
+  ]
+}
+x-commit-hash: "d598134cad00b0f1849164808c18f23625efb7ac"


### PR DESCRIPTION
A collection of various algorithms in OCaml

- Project page: <a href="https://github.com/let-def/grenier">https://github.com/let-def/grenier</a>
- Documentation: <a href="https://let-def.github.io/grenier/doc">https://let-def.github.io/grenier/doc</a>

##### CHANGES:

Fix compatibility with OCaml 5:
- balmap: missing functions (`add_to_list`, `to_list`, `of_list`) contributed by @kit-ty-kate
- physh: fix compilation with OCaml 5, contributed by @SquidDev

However physh is disabled for now when compiling with OCaml 5. Thorough reviewing is needed to ensure that the current design is safe with the multicore GC (see [let-def/grenier#10](https://github.com/let-def/grenier/pull/10)).

Add a new "Congre" library, a fast congruence closure algorithm with support for backtracking and interpretability of equivalence classes.
