### PR TITLE
archimedes 0.4.19: relax upper bound on oasis

### DIFF
--- a/packages/archimedes/archimedes.0.4.19/opam
+++ b/packages/archimedes/archimedes.0.4.19/opam
@@ -33,7 +33,7 @@ depends: [
   "ocaml"
   "base-bigarray"
   "camlp4"
-  "oasis" {build & >= "0.3" & < "0.4.7"}
+  "oasis" {build & >= "0.3" & != "0.4.7"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
 ]


### PR DESCRIPTION
archimedes.0.4.19 builds with any oasis > 0.4.7 currently in the repo.

Hard upper bound makes archimedes.0.4.19 non-installable on a recent compiler (oasis.0.4.6 needs ocaml < 4.06.0), and jupyter-archimedes non-installable totally (jupyter in addition needs ocaml >= 4.10.0). 