### PR TITLE
[new release] gmp (6.2.1-5)

### DIFF
--- a/packages/gmp/gmp.6.2.1-5/opam
+++ b/packages/gmp/gmp.6.2.1-5/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Lucas Pluvinage <lucas@tarides.com>"
+license: ["LGPL-3.0-only" "LGPL-2.0-only"]
+authors: "Torbjörn Granlund and contributors"
+homepage: "https://github.com/mirage/ocaml-gmp"
+bug-reports: "https://github.com/mirage/ocaml-gmp/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-gmp.git"
+substs: [ "src/build.sh" ]
+build: [
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.6"}
+  "conf-m4"
+]
+synopsis: "The GNU Multiple Precision Arithmetic Library"
+description: """Dune packaging of the GMP library, suitable for 
+cross-compilation."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-gmp/releases/download/6.2.1-5/gmp-6.2.1-5.tbz"
+  checksum: [
+    "sha256=26b24412e18b511f1b8af6f9bf891452e214e32773fdf2f68004310dc9f016f5"
+    "sha512=d3f7cb9043bb387c95d2f95fa82d832dc00287a8ba039ac82b573c849943c181045d61af32b3f47ae48d43c85ab52ab23570a8c4095a7d84c854f26aa38a0844"
+  ]
+}
+x-commit-hash: "e15e2024d31973f39d0552b1b306db682e3ddaab"

--- a/packages/gmp/gmp.6.2.1-5/opam
+++ b/packages/gmp/gmp.6.2.1-5/opam
@@ -15,6 +15,9 @@ depends: [
   "dune" {>= "2.6"}
   "conf-m4"
 ]
+depexts: [
+  "xz" {os = "macos" & os-distribution = "homebrew"}
+]
 synopsis: "The GNU Multiple Precision Arithmetic Library"
 description: """Dune packaging of the GMP library, suitable for 
 cross-compilation."""

--- a/packages/gmp/gmp.6.2.1-5/opam
+++ b/packages/gmp/gmp.6.2.1-5/opam
@@ -16,7 +16,7 @@ depends: [
   "conf-m4"
 ]
 depexts: [
-  "xz" {os = "macos" & os-distribution = "homebrew"}
+  [ "xz" ] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "The GNU Multiple Precision Arithmetic Library"
 description: """Dune packaging of the GMP library, suitable for 


### PR DESCRIPTION
The GNU Multiple Precision Arithmetic Library

- Project page: <a href="https://github.com/mirage/ocaml-gmp">https://github.com/mirage/ocaml-gmp</a>

##### CHANGES:

- Fix the cross-compilation for `aarch64` (@dinosaure, @shym, mirage/ocaml-gmp#22)
- Fix the compilation on OpenBSD (@kit-ty-kate, mirage/ocaml-gmp#22)
