### PR TITLE
Package catala.0.9.0

### DIFF
--- a/packages/catala/catala.0.9.0/opam
+++ b/packages/catala/catala.0.9.0/opam
@@ -36,7 +36,7 @@ depends: [
   "sedlex" {>= "2.4"}
   "uutf" {>= "1.0.3"}
   "ubase" {>= "0.05"}
-  "unionFind" {>= "20200320"}
+  "unionFind" {>= "20220109"}
   "visitors" {>= "20200210"}
   "zarith" {>= "1.12"}
   "zarith_stubs_js" {>= "v0.14.1"}

--- a/packages/catala/catala.0.9.0/opam
+++ b/packages/catala/catala.0.9.0/opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/CatalaLang/catala/issues"
 depends: [
   "ocolor" {>= "1.3.0"}
   "benchmark" {>= "1.6"}
-  "bindlib" {>= "5.0.1"}
+  "bindlib" {>= "6.0.0"}
   "cmdliner" {>= "1.1.0"}
   "cppo" {>= "1"}
   "dates_calc" {>= "0.0.4"}

--- a/packages/catala/catala.0.9.0/opam
+++ b/packages/catala/catala.0.9.0/opam
@@ -1,0 +1,86 @@
+opam-version: "2.0"
+synopsis:
+  "Compiler and library for the literate programming language for tax code specification"
+description:
+  "Catala is a domain-specific language for deriving faithful-by-construction algorithms from legislative texts. See https://catala-lang.org for more information"
+maintainer: ["contact@catala-lang.org"]
+authors: [
+  "Denis Merigoux"
+  "Nicolas Chataing"
+  "Emile Rolley"
+  "Louis Gesbert"
+  "Aymeric Fromherz"
+  "Alain Delaët-Tixeuil"
+  "Raphaël Monat"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/CatalaLang/catala"
+bug-reports: "https://github.com/CatalaLang/catala/issues"
+depends: [
+  "ocolor" {>= "1.3.0"}
+  "benchmark" {>= "1.6"}
+  "bindlib" {>= "5.0.1"}
+  "cmdliner" {>= "1.1.0"}
+  "cppo" {>= "1"}
+  "dates_calc" {>= "0.0.4"}
+  "dune" {>= "3.11"}
+  "js_of_ocaml-ppx" {= "4.1.0"}
+  "menhir" {>= "20200211"}
+  "menhirLib" {>= "20200211"}
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {!= "1.9.5"}
+  "ocamlgraph" {>= "1.8.8"}
+  "yojson" {>= "2.0" }
+  "ppx_yojson_conv" {>= "0.14.0"}
+  "re" {>= "1.9.0"}
+  "sedlex" {>= "2.4"}
+  "uutf" {>= "1.0.3"}
+  "ubase" {>= "0.05"}
+  "unionFind" {>= "20200320"}
+  "visitors" {>= "20200210"}
+  "zarith" {>= "1.12"}
+  "zarith_stubs_js" {>= "v0.14.1"}
+  "crunch" {>= "3.0.0"}
+  "alcotest" {>= "1.5.0"}
+  "ninja_utils" {= "0.9.0"}
+  "odoc" {with-doc}
+  "conf-ninja"
+  "ocamlformat" {with-dev-setup & = "0.26.0"}
+  "obelisk" {with-dev-setup}
+  "conf-npm" {with-dev-setup}
+  "conf-python-3-dev" {with-dev-setup}
+  "cpdf" {with-dev-setup}
+  "conf-diffutils" {with-dev-setup}
+  "conf-texlive" {with-dev-setup}
+  "conf-pandoc" {with-dev-setup}
+]
+depopts: ["z3"]
+conflicts: [
+  "z3" {< "4.8.11"}
+  "base" {>= "v0.16.0"}
+  "ocaml-option-bytecode-only"
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CatalaLang/catala.git"
+depexts: [
+  ["groff"] { with-doc }
+]
+url {
+  src: "https://github.com/CatalaLang/catala/archive/refs/tags/0.9.0.tar.gz"
+  checksum: [
+    "md5=8f891209d18b6540df9c34b2d1a6a783"
+    "sha512=737770b87a057674bceefe77e8526720732552f51f424afcebcb6a628267eab522c4fd993caca1ae8ed7ace65a4a87e485af10c1676e51ca5939509a1b841ac2"
+  ]
+}


### PR DESCRIPTION
### `catala.0.9.0`
Compiler and library for the literate programming language for tax code specification
Catala is a domain-specific language for deriving faithful-by-construction algorithms from legislative texts. See https://catala-lang.org for more information



---
* Homepage: https://github.com/CatalaLang/catala
* Source repo: git+https://github.com/CatalaLang/catala.git
* Bug tracker: https://github.com/CatalaLang/catala/issues

---
:camel: Pull-request generated by opam-publish v2.2.0