### PR TITLE
2 packages from ocaml-sf/learn-ocaml at 1.0.0

### DIFF
--- a/packages/learn-ocaml-client/learn-ocaml-client.1.0.0/opam
+++ b/packages/learn-ocaml-client/learn-ocaml-client.1.0.0/opam
@@ -27,7 +27,7 @@ depends: [
   "cohttp-lwt-unix" {>= "2.0.0"}
   "cstruct" {>= "3.3.0"}
   "digestif" {>= "0.7.1"}
-  "dune" {>= "2.3.0"}
+  "dune" {>= "2.4.0"}
   "ezjsonm"
   "gg"
   "ipaddr" {= "2.9.0"}

--- a/packages/learn-ocaml-client/learn-ocaml-client.1.0.0/opam
+++ b/packages/learn-ocaml-client/learn-ocaml-client.1.0.0/opam
@@ -51,6 +51,9 @@ depends: [
 ]
 build: ["dune" "build" "@install" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+conflicts: [
+  "result" {< "1.5"}
+]
 url {
   src:
     "https://github.com/ocaml-sf/learn-ocaml/archive/refs/tags/v1.0.0.tar.gz"

--- a/packages/learn-ocaml-client/learn-ocaml-client.1.0.0/opam
+++ b/packages/learn-ocaml-client/learn-ocaml-client.1.0.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "The learn-ocaml client"
+description: """\
+This contains the binaries to interact with the learn-ocaml
+platform from the command line."""
+maintainer: [
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+  "Yann Régis-Gianas <yann.regis-gianas@nomadic-labs.com>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+]
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+depends: [
+  "asak" {>= "0.4"}
+  "base64"
+  "base" {>= "v0.9.4"}
+  "cmdliner" {>= "1.1.0"}
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "cstruct" {>= "3.3.0"}
+  "digestif" {>= "0.7.1"}
+  "dune" {>= "2.3.0"}
+  "ezjsonm"
+  "gg"
+  "ipaddr" {= "2.9.0"}
+  "lwt" {>= "4.0.0"}
+  "lwt_ssl"
+  "ocaml" {(>= "4.12") & (< "4.13~")}
+  "ocamlfind" {build}
+  "ocaml-migrate-parsetree" {= "1.8.0"}
+  "ocp-indent-nlfork"
+  "ocplib-json-typed" {>= "0.7"}
+  "ocp-ocamlres" {>= "0.4"}
+  "omd" {<= "1.3.1"}
+  "ppxlib"
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_fields_conv"
+  "ppx_sexp_conv"
+  "ppx_tools"
+  "ssl" {= "0.5.12"}
+  "vg"
+]
+build: ["dune" "build" "@install" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+url {
+  src:
+    "https://github.com/ocaml-sf/learn-ocaml/archive/refs/tags/v1.0.0.tar.gz"
+  checksum: [
+    "md5=3cca845f51a3e43147e4f2a3f152059b"
+    "sha512=71560941bc2696e360be748daeadf94f69ae21893f58374b3cae86b91a9ab98682c886b912598e1e562c46e099c1ee199edc206a444ab8d32ae9ee564b3d1ffb"
+  ]
+}

--- a/packages/learn-ocaml/learn-ocaml.1.0.0/opam
+++ b/packages/learn-ocaml/learn-ocaml.1.0.0/opam
@@ -31,7 +31,7 @@ depends: [
   "digestif" {>= "0.7.1"}
   "dune" {>= "2.3.0"}
   "easy-format" {>= "1.3.0"}
-  "ezjsonm" {>= 1.3.0}
+  "ezjsonm" {>= "1.3.0"}
   "ipaddr" {= "2.9.0"}
   "js_of_ocaml" {>= "3.3.0" & != "3.10.0"}
   "js_of_ocaml-compiler" {>= "3.3.0"}

--- a/packages/learn-ocaml/learn-ocaml.1.0.0/opam
+++ b/packages/learn-ocaml/learn-ocaml.1.0.0/opam
@@ -31,7 +31,7 @@ depends: [
   "digestif" {>= "0.7.1"}
   "dune" {>= "2.3.0"}
   "easy-format" {>= "1.3.0"}
-  "ezjsonm"
+  "ezjsonm" {>= 1.3.0}
   "ipaddr" {= "2.9.0"}
   "js_of_ocaml" {>= "3.3.0" & != "3.10.0"}
   "js_of_ocaml-compiler" {>= "3.3.0"}
@@ -79,6 +79,9 @@ install: [
   ["cp" "-r" "demo-repository" "%{_:share}%/repository"]
 ]
 dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+conflicts: [
+  "result" {< "1.5"}
+]
 url {
   src:
     "https://github.com/ocaml-sf/learn-ocaml/archive/refs/tags/v1.0.0.tar.gz"

--- a/packages/learn-ocaml/learn-ocaml.1.0.0/opam
+++ b/packages/learn-ocaml/learn-ocaml.1.0.0/opam
@@ -29,7 +29,7 @@ depends: [
   "conf-git"
   "decompress" {= "0.8.1"}
   "digestif" {>= "0.7.1"}
-  "dune" {>= "2.3.0"}
+  "dune" {>= "2.4.0"}
   "easy-format" {>= "1.3.0"}
   "ezjsonm" {>= "1.3.0"}
   "ipaddr" {= "2.9.0"}

--- a/packages/learn-ocaml/learn-ocaml.1.0.0/opam
+++ b/packages/learn-ocaml/learn-ocaml.1.0.0/opam
@@ -1,0 +1,89 @@
+opam-version: "2.0"
+synopsis: "The learn-ocaml online platform (engine)"
+description: """\
+This contains the binaries forming the engine for the learn-ocaml platform, and
+the common files. A demo exercise repository is also provided as example."""
+maintainer: [
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+  "Yann Régis-Gianas <yann.regis-gianas@nomadic-labs.com>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+]
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+depends: [
+  "asak" {>= "0.4"}
+  "base64"
+  "base" {>= "v0.9.4"}
+  "cmdliner" {>= "1.1.0"}
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt" {>= "2.0.0"}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "conf-git"
+  "decompress" {= "0.8.1"}
+  "digestif" {>= "0.7.1"}
+  "dune" {>= "2.3.0"}
+  "easy-format" {>= "1.3.0"}
+  "ezjsonm"
+  "ipaddr" {= "2.9.0"}
+  "js_of_ocaml" {>= "3.3.0" & != "3.10.0"}
+  "js_of_ocaml-compiler" {>= "3.3.0"}
+  "js_of_ocaml-lwt"
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-toplevel"
+  "js_of_ocaml-tyxml"
+  "lwt" {>= "4.0.0"}
+  "lwt_react"
+  "lwt_ssl"
+  "magic-mime"
+  "markup"
+  "markup-lwt"
+  "ocaml" {(>= "4.12") & (< "4.13~")}
+  "ocamlfind" {build}
+  "ocaml-migrate-parsetree" {= "1.8.0"}
+  "ocp-indent-nlfork"
+  "ocplib-json-typed" {>= "0.7"}
+  "ocplib-json-typed-browser" {>= "0.7"}
+  "ocp-ocamlres" {>= "0.4"}
+  "odoc" {build}
+  "omd" {<= "1.3.1"}
+  "pprint"
+  "ppxlib"
+  "ppx_cstruct"
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_sexp_conv"
+  "ppx_tools"
+  "ppx_tools_versioned"
+  "re"
+  "ssl" {= "0.5.12"}
+  "uutf" {>= "1.0"}
+  "vg"
+  "yojson" {>= "1.4.0"}
+]
+build: [
+  [make "static"]
+  ["dune" "build" "-p" name "-j" jobs]
+  [make "detect-libs"] {with-test}
+]
+run-test: [make "test"]
+install: [
+  ["mkdir" "-p" "%{_:share}%"]
+  ["cp" "-r" "demo-repository" "%{_:share}%/repository"]
+]
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+url {
+  src:
+    "https://github.com/ocaml-sf/learn-ocaml/archive/refs/tags/v1.0.0.tar.gz"
+  checksum: [
+    "md5=3cca845f51a3e43147e4f2a3f152059b"
+    "sha512=71560941bc2696e360be748daeadf94f69ae21893f58374b3cae86b91a9ab98682c886b912598e1e562c46e099c1ee199edc206a444ab8d32ae9ee564b3d1ffb"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `learn-ocaml.1.0.0`: The learn-ocaml online platform (engine)
- `learn-ocaml-client.1.0.0`: The learn-ocaml client



---
* Homepage: https://github.com/ocaml-sf/learn-ocaml
* Source repo: git+https://github.com/ocaml-sf/learn-ocaml
* Bug tracker: https://github.com/ocaml-sf/learn-ocaml/issues

---
Cc @erikmd @yurug @AltGr FYI

## [1.0.0](https://github.com/ocaml-sf/learn-ocaml/compare/v0.16.0...v1.0.0) (2024-02-12)


### ⚠ BREAKING CHANGES

* Implement pre-compilation of exercises and graders.  
  Prefix **pre-compilation** indicates the related commits below (sorted in chronological order).
* Remove doc tutorial on `depend.txt` (it will need rewriting; relying on the new server engine).


### Features

* **pre-compilation:** Implement pre-compilation of exercises and graders ([b03bdfe](https://github.com/ocaml-sf/learn-ocaml/commit/b03bdfe5a7c9ed5d4677b1ee2eb11d37e953cbe3))
* **pre-compilation:** Enable downloading for only the relevant artifacts (bc or js) ([47d5a06](https://github.com/ocaml-sf/learn-ocaml/commit/47d5a0614f82e313520c79739922616b99d8c868))
* **pre-compilation:** Include Prelude/Prepare and shadow them ([787840b](https://github.com/ocaml-sf/learn-ocaml/commit/787840bda9701ae932ce5f9d56c5929dbb889e17))
* **pre-compilation: ppx-metaquot:** Add transformation introducing the `register_sampler` calls ([3cd75f5](https://github.com/ocaml-sf/learn-ocaml/commit/3cd75f5fbf580ab7ec388ef36976a0b32ca118ce))
* **pre-compilation:** Restore compatibility with static deployment ([f0e8346](https://github.com/ocaml-sf/learn-ocaml/commit/f0e8346450a826a9955a71b69aa4504865d2d56a))
* **pre-compilation:** Add support for a `test_libs.txt` file in exercises ([d22a788](https://github.com/ocaml-sf/learn-ocaml/commit/d22a78822b007e92f576288713dfa5ed6be2b1de))
* **pre-compilation:** Preprocessing and typing of samplers and printers ([e768616](https://github.com/ocaml-sf/learn-ocaml/commit/e7686163f9b23acc6140cabd406f2999f228fb50))
* **pre-compilation:** Provide lib to compile grader helper libraries ([3fc41ca](https://github.com/ocaml-sf/learn-ocaml/commit/3fc41caf632ede074476d760b892ebd61b790b9e))
* **server:** add a `--replace` option ([82d9bea](https://github.com/ocaml-sf/learn-ocaml/commit/82d9bea4db4034857747b4da2e7b3121bd6c2b28))
* **grader:** Show a status line on what is being built ([995a79d](https://github.com/ocaml-sf/learn-ocaml/commit/995a79d5f02b787981eb29bffb012d6993e3c63f))
* **CI: static-binaries:** Deploy artifacts to GitHub Pages ([01eae90^..9cf5486](https://github.com/ocaml-sf/learn-ocaml/compare/6cee13c160aba5db8aba0968df16d069e02e8fda...9cf5486b02d098f556a72d5bd639196701bee633)), closes [#575](https://github.com/ocaml-sf/learn-ocaml/issues/575)
* **pre-compilation: CLI:** Add CLI option `learn-ocaml build --build-dir=[./_learn-ocaml-build]` to increase compatibility with existing workflows ([#585](https://github.com/ocaml-sf/learn-ocaml/issues/585)) ([6535692](https://github.com/ocaml-sf/learn-ocaml/commit/6535692bc77eba471a97bb671658b4db4c86b4f4))


### Bug Fixes

* **grading:** avoid failing on sampling arrays with unique elements ([6a3ce07](https://github.com/ocaml-sf/learn-ocaml/commit/6a3ce077e1ce0946e9e10324b5e1e1b51669e62c))
* **pre-compilation:** Fix a small race condition in builder ([87ee902](https://github.com/ocaml-sf/learn-ocaml/commit/87ee902e1c60fd3d5b6fcb40e68b563062b70662))
* **pre-compilation:** Properly type samplers ([a97f813](https://github.com/ocaml-sf/learn-ocaml/commit/a97f81367bcce970e6474f39d3f5940df77cb880))
* **pre-compilation:** Avoid double-printing of internal grader errors ([7422ca4](https://github.com/ocaml-sf/learn-ocaml/commit/7422ca439fb450af6dab362ccc95e094f4297b41))
* **pre-compilation:** Fix segfault on graders using samplers returning newly defined exceptions ([c61a4d0](https://github.com/ocaml-sf/learn-ocaml/commit/c61a4d06715180069e9c6625f9c9559af476054d))
* **pre-compilation:** Be more precise on the definition and lookup of samplers ([7825a6b](https://github.com/ocaml-sf/learn-ocaml/commit/7825a6b6d15b213b1297d7878e8fb36057ec7b81))
* **pre-compilation:** Fix printer registration in the grader ([7d27523](https://github.com/ocaml-sf/learn-ocaml/commit/7d2752392ec7bf74a21d1604e2f35a221377e3f1))
* **pre-compilation:** Do some cleanup & Fix `mutation_testing` test lib ([c432909](https://github.com/ocaml-sf/learn-ocaml/commit/c43290947491dc3e1de76a5df3581531971332aa))
* **pre-compilation:** Allow printer registration in prepare/prelude & Fix print callbacks' usage ([1ec3af6](https://github.com/ocaml-sf/learn-ocaml/commit/1ec3af6ebec857f79f440706779190541636ce68))
* **pre-compilation: dune:** Fix dune dependency glitch on recompilation of `mutation_test` ([32ad13e](https://github.com/ocaml-sf/learn-ocaml/commit/32ad13e1915239af563f88fa673b73649d685f28))
* **pre-compilation: docker:** Include jsoo in Dockerfile, which is now needed ([466e80c](https://github.com/ocaml-sf/learn-ocaml/commit/466e80ca8e5ea1ab99590d4795f7913188dd0333))
* **pre-compilation: CI:** Fix permission issues ([fa2cd23](https://github.com/ocaml-sf/learn-ocaml/commit/fa2cd23babafcea0ff7a2d685993a838af65eada))
* **pre-compilation:** Expose `prepare.ml` file ([365cbb7](https://github.com/ocaml-sf/learn-ocaml/commit/365cbb719a5048a6f422278fc986f822ad17770b))
* **pre-compilation: partition-view:** Reactivate the feature ([57ca10b](https://github.com/ocaml-sf/learn-ocaml/commit/57ca10b0a40157e6b97d974c76c9963a1e00a0aa))
* **pre-compilation: CLI:** Report JSON parse error origin and locations ([ee57ac1](https://github.com/ocaml-sf/learn-ocaml/commit/ee57ac18dc7d395108defaa38079affb13f6ccaf))
* **pre-compilation: grader:**: Add a safeguard against grading workers going haywire ([cb417d1](https://github.com/ocaml-sf/learn-ocaml/commit/cb417d186a32b2b0d11aea4228c264642b64bf34))
* **pre-compilation: grader:** allow exercises to use vg, gg ([ead187e](https://github.com/ocaml-sf/learn-ocaml/commit/ead187e387d5794d3f16bb420a77e643b95f4b5a))
* **pre-compilation: partition-view:** use newer asak compatible with precompilation ([942edc2](https://github.com/ocaml-sf/learn-ocaml/commit/942edc2fb1b30336f45caf9027d18f2bd5221ea9))
* **pre-compilation: build:** update lockfiles ([f1abb7d](https://github.com/ocaml-sf/learn-ocaml/commit/f1abb7d48e00e19edd3d922a043d309767b4c339))
* **pre-compilation: CI:** attempt to fix running the docker image on the corpus ([b94f053](https://github.com/ocaml-sf/learn-ocaml/commit/b94f05368a02038e5efb978976d8f7e20154fcc6))
* **pre-compilation: CI:** disable compat tests with 0.12, 0.13 ([91a418e](https://github.com/ocaml-sf/learn-ocaml/commit/91a418eeadf3be73e716a83ae16153332d7d19e7))
* **pre-compilation: docker:** install more libs in server image ([6ce797f](https://github.com/ocaml-sf/learn-ocaml/commit/6ce797f818766047c85d543188767fb4d3609352))
* **pre-compilation: grader:** avoid errors with too many open files on parallel builds ([6583af4](https://github.com/ocaml-sf/learn-ocaml/commit/6583af4bbb3547b302963922279e0516edd9d6b4))
* **server:** Avoid using `lsof -Q` which is only available from lsof 4.95.0 ([a242084](https://github.com/ocaml-sf/learn-ocaml/commit/a242084cde9eaf4ab25b205b71c244c23279704f)), closes [#580](https://github.com/ocaml-sf/learn-ocaml/issues/580)
* **UI:** Small CSS fix for exercise lists on small screens ([3c9c123](https://github.com/ocaml-sf/learn-ocaml/commit/3c9c1237f5e2565cc173e7f57b864866d190a83d)), closes [#574](https://github.com/ocaml-sf/learn-ocaml/issues/574)
* **server:** Do exercise recompilation correctly with `--replace` ([#584](https://github.com/ocaml-sf/learn-ocaml/issues/584)) ([fe2a806](https://github.com/ocaml-sf/learn-ocaml/commit/fe2a806fa306a46b1c978fe47fbd3c26170ee52c)), closes [#583](https://github.com/ocaml-sf/learn-ocaml/issues/583)


### Performance Improvements

* **pre-compilation:** Make `learn-ocaml build` parallel by default ([eaad14c](https://github.com/ocaml-sf/learn-ocaml/commit/eaad14cfe1d693081c43277c71dca8a74bd5a5a7))
* **pre-compilation:** Dump the cmis for grading only once ([e63359e](https://github.com/ocaml-sf/learn-ocaml/commit/e63359e38760ee052b62d6ccf3e46ad1db46e988))


### Code Refactoring

* **pre-compilation:** Get rid of the pseudo-cipher ([2792faf](https://github.com/ocaml-sf/learn-ocaml/commit/2792faf8f49b7b874ae9a854ccafb2c4a2922383))
* **pre-compilation:** Rename and generalise `recorder` to `ppx_autoregister` ([99e913d](https://github.com/ocaml-sf/learn-ocaml/commit/99e913d847c54e021669c7068ca991ae24de89f2))
* **pre-compilation:** Generalize sampler typing ([264db4c](https://github.com/ocaml-sf/learn-ocaml/commit/264db4c0436f581c5fc68f222305e8f8770fd674))
* **pre-compilation:** Disable debug flags ([54851dd](https://github.com/ocaml-sf/learn-ocaml/commit/54851dd368e1c8a5635a2a193751aec1e46f1d97))


### Build System

* **pre-compilation:** Make `make testrun` parallel ([46631d8](https://github.com/ocaml-sf/learn-ocaml/commit/46631d8e62385d934012ae16d756ce6f4bee4139))


### CI/CD

* **release.yml:** Replace `hub` (not installed anymore) with `gh` ([cad060f](https://github.com/ocaml-sf/learn-ocaml/commit/cad060f801dba21976cffc03f2fcb4119a3dec75))
* **release.yml:** Next release version will be 1.0.0 ([6e9cd2b](https://github.com/ocaml-sf/learn-ocaml/commit/6e9cd2bbdb4a695397a7eea0d2560bb8e694cf37))


### Documentation

* **pre-compilation: translations:** Update French translation ([f028b75](https://github.com/ocaml-sf/learn-ocaml/commit/f028b75b09676120669ea6f4b9e0beff686c9302))
* **pre-compilation:** Remove doc tutorial on `depend.txt` (it will need rewriting) ([9155145](https://github.com/ocaml-sf/learn-ocaml/commit/915514524c501317d79c6e40ee8a948f6a3e5af1))
* **pre-compilation:** Update doc for pre-compiled exercises + `test_libs.txt` ([2c89d9e](https://github.com/ocaml-sf/learn-ocaml/commit/2c89d9e0935cfce90031502c85cfb6ffa7ca000e))
* **pre-compilation:** Add/Update copyright headers ([5b4e0ab](https://github.com/ocaml-sf/learn-ocaml/commit/5b4e0abaf1c16c1f1964014ab0b4feecc6bcdef8))
* **pre-compilation:** Update index.md ([f572990](https://github.com/ocaml-sf/learn-ocaml/commit/f572990b4a25363da2b907f08b1f5aa0065273f4))


---
:camel: Pull-request generated by opam-publish v2.3.0