### PR TITLE
[new release] opentelemetry (5 packages) (0.7)

### DIFF
--- a/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.7/opam
+++ b/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.7/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Collector client for opentelemetry, using cohttp + lwt"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team and contributors"]
+license: "MIT"
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "mtime" {>= "1.4"}
+  "opentelemetry" {= version}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "lwt_ppx" {>= "2.0"}
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.7/opentelemetry-0.7.tbz"
+  checksum: [
+    "sha256=a5de04aa33f5b66e4a63377fd868a839814a4ee229c98c84a04bd49926a38e1d"
+    "sha512=f0f9956cb6a605826018794a8fa866b5bda622d2aaa82c4cca5e10262ae163a99512ee22ed4ef0c3af0bb4eeabc7aee736fe7830c585879b029b5ef6d4ef2b05"
+  ]
+}
+x-commit-hash: "5a78805addcc09f08e374a4d7b37a4128bcabe69"

--- a/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.7/opam
+++ b/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.7/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Collector client for opentelemetry, using http + ezcurl"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team and contributors"]
+license: "MIT"
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "mtime" {>= "1.4"}
+  "opentelemetry" {= version}
+  "odoc" {with-doc}
+  "ezcurl" {>= "0.2.3"}
+  "ocurl"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.7/opentelemetry-0.7.tbz"
+  checksum: [
+    "sha256=a5de04aa33f5b66e4a63377fd868a839814a4ee229c98c84a04bd49926a38e1d"
+    "sha512=f0f9956cb6a605826018794a8fa866b5bda622d2aaa82c4cca5e10262ae163a99512ee22ed4ef0c3af0bb4eeabc7aee736fe7830c585879b029b5ef6d4ef2b05"
+  ]
+}
+x-commit-hash: "5a78805addcc09f08e374a4d7b37a4128bcabe69"

--- a/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.7/opam
+++ b/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.7/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Opentelemetry tracing for Cohttp HTTP servers"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team and contributors"]
+license: "MIT"
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "opentelemetry" {= version}
+  "opentelemetry-lwt" {= version}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "cohttp-lwt" {>= "4.0.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.7/opentelemetry-0.7.tbz"
+  checksum: [
+    "sha256=a5de04aa33f5b66e4a63377fd868a839814a4ee229c98c84a04bd49926a38e1d"
+    "sha512=f0f9956cb6a605826018794a8fa866b5bda622d2aaa82c4cca5e10262ae163a99512ee22ed4ef0c3af0bb4eeabc7aee736fe7830c585879b029b5ef6d4ef2b05"
+  ]
+}
+x-commit-hash: "5a78805addcc09f08e374a4d7b37a4128bcabe69"

--- a/packages/opentelemetry-lwt/opentelemetry-lwt.0.7/opam
+++ b/packages/opentelemetry-lwt/opentelemetry-lwt.0.7/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Lwt-compatible instrumentation for https://opentelemetry.io"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team and contributors"]
+license: "MIT"
+tags: ["instrumentation" "tracing" "opentelemetry" "datadog" "lwt"]
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "ambient-context"
+  "opentelemetry" {= version}
+  "cohttp-lwt-unix" {with-test}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "lwt_ppx" {>= "2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.7/opentelemetry-0.7.tbz"
+  checksum: [
+    "sha256=a5de04aa33f5b66e4a63377fd868a839814a4ee229c98c84a04bd49926a38e1d"
+    "sha512=f0f9956cb6a605826018794a8fa866b5bda622d2aaa82c4cca5e10262ae163a99512ee22ed4ef0c3af0bb4eeabc7aee736fe7830c585879b029b5ef6d4ef2b05"
+  ]
+}
+x-commit-hash: "5a78805addcc09f08e374a4d7b37a4128bcabe69"

--- a/packages/opentelemetry/opentelemetry.0.7/opam
+++ b/packages/opentelemetry/opentelemetry.0.7/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Instrumentation for https://opentelemetry.io"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team and contributors"]
+license: "MIT"
+tags: ["instrumentation" "tracing" "opentelemetry" "datadog" "jaeger"]
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "ptime"
+  "ambient-context"
+  "odoc" {with-doc}
+  "alcotest" {with-test}
+  "pbrt" {>= "3.0" & < "4.0"}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup & >= "0.24" & < "0.25"}
+]
+depopts: ["trace"]
+conflicts: [
+  "trace" {< "0.4" | >= "0.7"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.7/opentelemetry-0.7.tbz"
+  checksum: [
+    "sha256=a5de04aa33f5b66e4a63377fd868a839814a4ee229c98c84a04bd49926a38e1d"
+    "sha512=f0f9956cb6a605826018794a8fa866b5bda622d2aaa82c4cca5e10262ae163a99512ee22ed4ef0c3af0bb4eeabc7aee736fe7830c585879b029b5ef6d4ef2b05"
+  ]
+}
+x-commit-hash: "5a78805addcc09f08e374a4d7b37a4128bcabe69"


### PR DESCRIPTION
Instrumentation for https://opentelemetry.io

- Project page: <a href="https://github.com/imandra-ai/ocaml-opentelemetry">https://github.com/imandra-ai/ocaml-opentelemetry</a>

##### CHANGES:

- add Span_link.of_span_ctx, Scope.to_span_ctx, dummy values
- feat: add Span_context, as required by OTEL API guidelines
- feat: record backtraces in error spans
- compat with trace 0.6
- ocurl: add ticker_interval_ms config
- ocurl: do some self-tracing optionally
- move protobuf code to opentelemetry.proto

- perf: rewrite parsing+printing for span ctx as w3c trace ctx
- perf: when we get multiple messages, check batches only once
- perf: use ocaml-protoc 3.0.1 for codegen, with faster pbrt
