### PR TITLE
[new release] multicore-bench (0.1.0)

### DIFF
--- a/packages/multicore-bench/multicore-bench.0.1.0/opam
+++ b/packages/multicore-bench/multicore-bench.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "Framework for writing multicore benchmark executables to run on current-bench"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-bench"
+bug-reports: "https://github.com/ocaml-multicore/multicore-bench/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.13.0"}
+  "domain-local-await" {>= "1.0.1"}
+  "multicore-magic" {>= "2.1.0"}
+  "mtime" {>= "2.0.0"}
+  "yojson" {>= "2.1.0"}
+  "domain_shims" {>= "0.1.0"}
+  "mdx" {>= "2.3.1" & with-test}
+  "odoc" {>= "2.2.0" & with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-bench.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-bench/releases/download/0.1.0/multicore-bench-0.1.0.tbz"
+  checksum: [
+    "sha256=11dd1cef2e1ac845464e2155ac6d03ff4d08e2bd4890aa1b0e6c82197342fb70"
+    "sha512=393da8f48330fae8151a9468f8cf1e51c1c323b954c9eb96f1f5b16cc66a7dd6a1674e8eacac9f265d9d7a1929e152d0bcf257191f57a48e2b41c3fab3c8758e"
+  ]
+}
+x-commit-hash: "213ea2a897c3e34e4c476f373d56afaa76d6dde9"


### PR DESCRIPTION
Framework for writing multicore benchmark executables to run on current-bench

- Project page: <a href="https://github.com/ocaml-multicore/multicore-bench">https://github.com/ocaml-multicore/multicore-bench</a>

## 0.1.0

- Initial version of multicore-bench (@polytypic)
