### PR TITLE
[new release] linol (2 packages) (0.5)

### DIFF
--- a/packages/linol-lwt/linol-lwt.0.5/opam
+++ b/packages/linol-lwt/linol-lwt.0.5/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+license: "MIT"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/linol"
+synopsis: "LSP server library (with Lwt for concurrency)"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "linol" { = version }
+  "lwt" { >= "5.1" & < "6.0" }
+  "base-unix"
+  "yojson" { >= "1.6" }
+  "ocaml" { >= "4.08" }
+  "odoc" { with-doc }
+]
+tags: [ "lsp" "server" "lwt" "linol" ]
+bug-reports: "https://github.com/c-cube/linol/issues"
+dev-repo: "git+https://github.com/c-cube/linol.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/linol/releases/download/v0.5/linol-0.5.tbz"
+  checksum: [
+    "sha256=467ea7ec23c2c9fd3685d404fecd3915ffcd088215db342d0b6f7879982d8d9e"
+    "sha512=8b4d5c5a85e77d557b2d3e906ed923cd7bb295dd1fe43bdb2d727c544b8dc0dedc76aa42618518f51c3074128aa5b4874cd925ef610661431791709c4a02d3e7"
+  ]
+}
+x-commit-hash: "68525aa24be3753247b8bed43dec47fe20926ae9"
+
+

--- a/packages/linol/linol.0.5/opam
+++ b/packages/linol/linol.0.5/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+homepage: "https://github.com/c-cube/linol"
+synopsis: "LSP server library"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "yojson" { >= "1.6" }
+  "logs"
+  "atomic"
+  "trace" { >= "0.4" }
+  "lsp" { >= "1.17" & < "1.18" }
+  "jsonrpc" { >= "1.17" & < "1.18" }
+  "ocaml" { >= "4.14" }
+  "odoc" { with-doc }
+]
+tags: [ "lsp" "server" "lwt" ]
+bug-reports: "https://github.com/c-cube/linol/issues"
+dev-repo: "git+https://github.com/c-cube/linol.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/linol/releases/download/v0.5/linol-0.5.tbz"
+  checksum: [
+    "sha256=467ea7ec23c2c9fd3685d404fecd3915ffcd088215db342d0b6f7879982d8d9e"
+    "sha512=8b4d5c5a85e77d557b2d3e906ed923cd7bb295dd1fe43bdb2d727c544b8dc0dedc76aa42618518f51c3074128aa5b4874cd925ef610661431791709c4a02d3e7"
+  ]
+}
+x-commit-hash: "68525aa24be3753247b8bed43dec47fe20926ae9"
+
+


### PR DESCRIPTION
LSP server library

- Project page: <a href="https://github.com/c-cube/linol">https://github.com/c-cube/linol</a>

##### CHANGES:

- api break: put `spawn` in the server itself, not `IO`

- require OCaml 4.14
- migrate to lsp 1.17
- support inlay hints
- internal tracing with `trace`
- [c-cube/linol#24] Expose get_uri for notify_back
- expose log source
- [c-cube/linol#22] Threat shutdown and exit requests correctly
- [c-cube/linol#20] Handle messages with null value for  "params" field
- Handle server requests
- handle workDoneTokens
