### PR TITLE
[new release] minttea (3 packages) (0.0.3)

### DIFF
--- a/packages/leaves/leaves.0.0.3/opam
+++ b/packages/leaves/leaves.0.0.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A collection of reusable components from Mint Tea"
+description:
+  "Leaves is a collection of reusable components for writing TUI applications with Mint Tea"
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: ["tui" "terminal-ui" "apps" "components" "component" "library"]
+homepage: "https://github.com/leostera/minttea"
+bug-reports: "https://github.com/leostera/minttea/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "5.1"}
+  "minttea" {= version}
+  "mdx" {with-test & >= "2.3.1"}
+  "spices" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/leostera/minttea.git"
+url {
+  src:
+    "https://github.com/leostera/minttea/releases/download/0.0.3/minttea-0.0.3.tbz"
+  checksum: [
+    "sha256=5846895420afb2629c17cfb2ce8be58edf1d196688bf852602bef88eae95a3d3"
+    "sha512=cf48698811f9ad764385b7ec80a17921a0f335a6f0d5ef8dd0ac7cd4f9eca38eafff4f92800cabffaa0e10b6eb84bc3bb88bf1012d9fbeab014c67ec25450a98"
+  ]
+}
+x-commit-hash: "fca6652761605d5f42f5ab575ba674359d3dc51d"

--- a/packages/minttea/minttea.0.0.3/opam
+++ b/packages/minttea/minttea.0.0.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "A fun, functional, and stateful way to build terminal apps in OCaml heavily inspired by Go's BubbleTea"
+description: "A longer description"
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: ["tui" "terminal-ui" "framework" "riot"]
+homepage: "https://github.com/leostera/minttea"
+bug-reports: "https://github.com/leostera/minttea/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "5.1"}
+  "riot" {= "0.0.8"}
+  "mdx" {with-test & >= "2.3.1"}
+  "tty" {>= "0.0.2"}
+  "uuseg"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/leostera/minttea.git"
+url {
+  src:
+    "https://github.com/leostera/minttea/releases/download/0.0.3/minttea-0.0.3.tbz"
+  checksum: [
+    "sha256=5846895420afb2629c17cfb2ce8be58edf1d196688bf852602bef88eae95a3d3"
+    "sha512=cf48698811f9ad764385b7ec80a17921a0f335a6f0d5ef8dd0ac7cd4f9eca38eafff4f92800cabffaa0e10b6eb84bc3bb88bf1012d9fbeab014c67ec25450a98"
+  ]
+}
+x-commit-hash: "fca6652761605d5f42f5ab575ba674359d3dc51d"

--- a/packages/spices/spices.0.0.3/opam
+++ b/packages/spices/spices.0.0.3/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "5.1"}
   "colors" {>= "0.0.1"}
   "mdx" {with-test & >= "2.3.1"}
+  "minttea" {= version & with-test}
   "tty" {>= "0.0.2"}
   "odoc" {with-doc}
 ]

--- a/packages/spices/spices.0.0.3/opam
+++ b/packages/spices/spices.0.0.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Declarative styles for TUI applications"
+description:
+  "Spices lets you create style definitions for TUIs and provide handy renderers for strings over them"
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: [
+  "styling" "styles" "declarative" "framework" "tui" "terminal-ui" "apps"
+]
+homepage: "https://github.com/leostera/minttea"
+bug-reports: "https://github.com/leostera/minttea/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "5.1"}
+  "colors" {>= "0.0.1"}
+  "mdx" {with-test & >= "2.3.1"}
+  "tty" {>= "0.0.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/leostera/minttea.git"
+url {
+  src:
+    "https://github.com/leostera/minttea/releases/download/0.0.3/minttea-0.0.3.tbz"
+  checksum: [
+    "sha256=5846895420afb2629c17cfb2ce8be58edf1d196688bf852602bef88eae95a3d3"
+    "sha512=cf48698811f9ad764385b7ec80a17921a0f335a6f0d5ef8dd0ac7cd4f9eca38eafff4f92800cabffaa0e10b6eb84bc3bb88bf1012d9fbeab014c67ec25450a98"
+  ]
+}
+x-commit-hash: "fca6652761605d5f42f5ab575ba674359d3dc51d"


### PR DESCRIPTION
A fun, functional, and stateful way to build terminal apps in OCaml heavily inspired by Go's BubbleTea

- Project page: <a href="https://github.com/leostera/minttea">https://github.com/leostera/minttea</a>

##### CHANGES:

## 0.0.3

#### Mint Tea

* Upgrade to Riot 0.0.8 – this release brings stability fixes, performance
  fixes, and includes new microsecond resolution timers.

* Add better trace logs

* Make sure we restore and show the cursor on exit

* Fix bug where alt-screen rendering cleaned extra lines - thanks @jmcavanillas 👏

* Small doc fixes – thanks @sam-huckaby ✨

#### Spices

* Expose color type as Tty.Color.t for more flexibility and supporting fallback
  colors

* Implement rendering of padding – thanks @wonbyte 🚀

#### Leaves

* Add new Virtualized Table component with support for columns and moving a
  cursor around – thanks @sabine 🧡

* Progress bar now defaults color to gray if the terminal profile isn't
  supported

* Progress bar now can toggle the percentage number – thanks @wesleimp 🌈