### PR TITLE
dot-merlin-reader preview for OCaml 5.2

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.14-502~preview/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.14-502~preview/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" & < "5.3"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "ocamlfind" {>= "1.6.0"}
+]
+flags: avoid-version
+available: opam-version >= "2.1.0"
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/archive/74191f149fe3967cd38d628c2063b00904196081.tar.gz"
+  checksum: [
+    "sha256=cb32d1207dfc0ccb843df07a17b715df18f30e385ce5fe8dd0d8767ad175b451"
+    "sha512=b1266daebc72ca5ccbd5edca027110614c5f73ffe354829c3fac68b02977f92e2dce45115042a8ad24c8b6a82e485df4c665096d08816a0f859078f6eb3c0d69"
+  ]
+}

--- a/packages/dot-merlin-reader/dot-merlin-reader.4.9/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.9/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08" & < "6.0"}
   "dune" {>= "2.9.0"}
-  "merlin-lib" {>= "4.9"}
+  "merlin-lib" {>= "4.9" & < "4.14"}
   "ocamlfind" {>= "1.6.0"}
 ]
 description:


### PR DESCRIPTION
I missed this in #25269, sorry about that. It otherwise fails with:
```
#=== ERROR while compiling dot-merlin-reader.4.9 ==============================#
# context     2.2.0~beta1 | linux/arm64 | ocaml-variants.5.2.0+trunk | git+https://github.com/ocaml/opam-repository
# path        ~/.opam/trunk/.opam-switch/build/dot-merlin-reader.4.9
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p dot-merlin-reader -j 9
# exit-code   1
# env-file    ~/.opam/log/dot-merlin-reader-3921-8d3500.env
# output-file ~/.opam/log/dot-merlin-reader-3921-8d3500.out
### output ###
# Error: This expression has type
# [...]
#          list"
#        Type
#          "Merlin_dot_protocol.Directive.include_path" =
#            "[ `B of string
#            | `CMI of string
#            | `CMT of string
#            | `H of string
#            | `S of string ]"
#        is not compatible with type
#          "[< `B of string | `CMI of string | `CMT of string | `S of string ]"
#        The second variant type does not allow tag(s) "`H"
```