### PR TITLE
ocp-index is not compatible with OCaml 5.2

### DIFF
--- a/packages/ocp-index/ocp-index.1.3.5/opam
+++ b/packages/ocp-index/ocp-index.1.3.5/opam
@@ -21,7 +21,7 @@ tags: [ "org:ocamlpro" "org:typerex" ]
 dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}


### PR DESCRIPTION
Was fixed upstream by https://github.com/OCamlPro/ocp-index/pull/169
```
#=== ERROR while compiling ocp-index.1.3.5 ====================================#
# context     2.2.0~beta1 | linux/arm64 | ocaml-variants.5.2.0+trunk | git+https://github.com/ocaml/opam-repository
# path        ~/.opam/trunk/.opam-switch/build/ocp-index.1.3.5
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ocp-index -j 9
# exit-code   1
# env-file    ~/.opam/log/ocp-index-5409-51339f.env
# output-file ~/.opam/log/ocp-index-5409-51339f.out
### output ###
# Error: This expression has type
# [...]
# (cd _build/default && /home/kit_ty_kate/.opam/trunk/bin/ocamlopt.opt -w -40 -w -9 -g -I libs/.indexLib.objs/byte -I libs/.indexLib.objs/native -I /home/kit_ty_kate/.opam/trunk/lib/bytes -I /home/kit_ty_kate/.opam/trunk/lib/ocaml/compiler-libs -I /home/kit_ty_kate/.opam/trunk/lib/ocp-indent/lexer -I /home/kit_ty_kate/.opam/trunk/lib/ocp-indent/utils -intf-suffix .ml -no-alias-deps -o libs/.ind[...]
# File "libs/indexPredefined.ml", line 35, characters 24-89:
# Error: This expression has type
#          "('a * (Asttypes.variance * Asttypes.injectivity)) list"
#        but an expression was expected of type "Outcometree.out_type_param list"
#        Type "'a * (Asttypes.variance * Asttypes.injectivity)"
#        is not compatible with type "Outcometree.out_type_param"
# (cd _build/default && /home/kit_ty_kate/.opam/trunk/bin/ocamlc.opt -w -40 -w -9 -g -bin-annot -I libs/.indexLib.objs/byte -I /home/kit_ty_kate/.opam/trunk/lib/bytes -I /home/kit_ty_kate/.opam/trunk/lib/ocaml/compiler-libs -I /home/kit_ty_kate/.opam/trunk/lib/ocp-indent/lexer -I /home/kit_ty_kate/.opam/trunk/lib/ocp-indent/utils -intf-suffix .ml -no-alias-deps -o libs/.indexLib.objs/byte/index[...]
# File "libs/indexBuild.ml", line 450, characters 4-23:
# Error: The constructor "Types.Type_abstract" expects 1 argument(s),
#        but is applied here to 0 argument(s)
```