### PR TITLE
Prepare for printbox update (prevent reverse dependency failures)

### DIFF
--- a/packages/ppx_minidebug/ppx_minidebug.1.0.0/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.1.0.0/opam
@@ -18,8 +18,8 @@ depends: [
   "ppxlib" {>= "0.26.0"}
   "printbox" {>= "0.7"}
   "printbox-text"
-  "printbox-html" {= "0.8"}
-  "printbox-md" {= "0.8"}
+  "printbox-html" {>= "0.8" & <= "0.9"}
+  "printbox-md" {>= "0.8" & <= "0.9"}
   "ptime"
   "re"
   "sexplib0"

--- a/packages/ppx_minidebug/ppx_minidebug.1.0.0/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.1.0.0/opam
@@ -18,8 +18,8 @@ depends: [
   "ppxlib" {>= "0.26.0"}
   "printbox" {>= "0.7"}
   "printbox-text"
-  "printbox-html" {>= "0.8"}
-  "printbox-md"
+  "printbox-html" {= "0.8"}
+  "printbox-md" {= "0.8"}
   "ptime"
   "re"
   "sexplib0"


### PR DESCRIPTION
We have exact match tests that are fragile to changes in the printbox package.