### PR TITLE
pringo 1.3 requires ocamlopt

### DIFF
--- a/packages/pringo/pringo.1.0/opam
+++ b/packages/pringo/pringo.1.0/opam
@@ -13,6 +13,7 @@ depends: [
 ]
 build: make
 install: [make "install"]
+conflicts: [ "ocaml-option-bytecode-only" ]
 dev-repo: "git+https://https://github.com/xavierleroy/pringo"
 url {
   src: "https://github.com/xavierleroy/pringo/archive/1.0.tar.gz"

--- a/packages/pringo/pringo.1.1/opam
+++ b/packages/pringo/pringo.1.1/opam
@@ -13,6 +13,7 @@ depends: [
 ]
 build: make
 install: [make "install"]
+conflicts: [ "ocaml-option-bytecode-only" ]
 dev-repo: "git+https://https://github.com/xavierleroy/pringo"
 url {
   src: "https://github.com/xavierleroy/pringo/archive/1.1.tar.gz"

--- a/packages/pringo/pringo.1.2/opam
+++ b/packages/pringo/pringo.1.2/opam
@@ -13,6 +13,7 @@ depends: [
 ]
 build: make
 install: [make "install"]
+conflicts: [ "ocaml-option-bytecode-only" ]
 dev-repo: "git+https://https://github.com/xavierleroy/pringo"
 url {
   src: "https://github.com/xavierleroy/pringo/archive/1.2.tar.gz"

--- a/packages/pringo/pringo.1.3/opam
+++ b/packages/pringo/pringo.1.3/opam
@@ -15,6 +15,7 @@ depends: [
 build: make
 install: [make "install"]
 run-test: [make "smalltest"] {ocaml:version >= "4.08"}
+conflicts: [ "ocaml-option-bytecode-only" ]
 dev-repo: "git+https://https://github.com/xavierleroy/pringo"
 url {
   src: "https://github.com/xavierleroy/pringo/archive/1.3.tar.gz"


### PR DESCRIPTION
Fails with
```
#=== ERROR while compiling pringo.1.3 =========================================#
# context              2.2.0~beta2~dev | linux/arm32 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/pringo.1.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/pringo-7-97e876.env
# output-file          ~/.opam/log/pringo-7-97e876.out
### output ###
# ocamlopt -g -safe-string -bin-annot -c PRNG.mli
# make: ocamlopt: No such file or directory
# make: *** [Makefile:27: PRNG.cmi] Error 127
```