### PR TITLE
Release Caqti 2.1.0.

### DIFF
--- a/packages/caqti-async/caqti-async.2.1.0/opam
+++ b/packages/caqti-async/caqti-async.2.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "async_kernel" {>= "v0.11.0"}
+  "async_unix" {>= "v0.11.0"}
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "core" {>= "v0.16.1"}
+  "core_unix"
+  "domain-name"
+  "dune" {>= "3.9"}
+  "ipaddr"
+  "logs"
+  "ocaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Async support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.0/caqti-v2.1.0.tbz"
+  checksum: [
+    "sha256=c74c71a0963d01adab3a1e65527882340d2d9eccdf4ce709c1d723b818147f61"
+    "sha512=17a89609d8ef74f3210ec63a96d8085f3099d8ee62c67a9573e9c3ba4bc088817b9706679e02c08a6784c06ce18ea65cde3595f1357a6109833e2119200161f1"
+  ]
+}
+x-commit-hash: "c05d71a7765482143ea8a4cf98adb78cdd151514"

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.2.1.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.2.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocaml"
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "3.9"}
+  "mariadb" {>= "1.1.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MariaDB driver for Caqti using C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.0/caqti-v2.1.0.tbz"
+  checksum: [
+    "sha256=c74c71a0963d01adab3a1e65527882340d2d9eccdf4ce709c1d723b818147f61"
+    "sha512=17a89609d8ef74f3210ec63a96d8085f3099d8ee62c67a9573e9c3ba4bc088817b9706679e02c08a6784c06ce18ea65cde3595f1357a6109833e2119200161f1"
+  ]
+}
+x-commit-hash: "c05d71a7765482143ea8a4cf98adb78cdd151514"

--- a/packages/caqti-driver-pgx/caqti-driver-pgx.2.1.0/opam
+++ b/packages/caqti-driver-pgx/caqti-driver-pgx.2.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "domain-name"
+  "dune" {>= "3.9"}
+  "ipaddr"
+  "pgx" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on the pure-OCaml PGX library"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.0/caqti-v2.1.0.tbz"
+  checksum: [
+    "sha256=c74c71a0963d01adab3a1e65527882340d2d9eccdf4ce709c1d723b818147f61"
+    "sha512=17a89609d8ef74f3210ec63a96d8085f3099d8ee62c67a9573e9c3ba4bc088817b9706679e02c08a6784c06ce18ea65cde3595f1357a6109833e2119200161f1"
+  ]
+}
+x-commit-hash: "c05d71a7765482143ea8a4cf98adb78cdd151514"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.2.1.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.2.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "James Owen <james@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocaml"
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "3.9"}
+  "odoc" {with-doc}
+  "postgresql" {>= "5.0.0"}
+  "uri" {>= "4.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.0/caqti-v2.1.0.tbz"
+  checksum: [
+    "sha256=c74c71a0963d01adab3a1e65527882340d2d9eccdf4ce709c1d723b818147f61"
+    "sha512=17a89609d8ef74f3210ec63a96d8085f3099d8ee62c67a9573e9c3ba4bc088817b9706679e02c08a6784c06ce18ea65cde3595f1357a6109833e2119200161f1"
+  ]
+}
+x-commit-hash: "c05d71a7765482143ea8a4cf98adb78cdd151514"

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.2.1.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.2.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocaml"
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "3.9"}
+  "odoc" {with-doc}
+  "sqlite3"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Sqlite3 driver for Caqti using C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.0/caqti-v2.1.0.tbz"
+  checksum: [
+    "sha256=c74c71a0963d01adab3a1e65527882340d2d9eccdf4ce709c1d723b818147f61"
+    "sha512=17a89609d8ef74f3210ec63a96d8085f3099d8ee62c67a9573e9c3ba4bc088817b9706679e02c08a6784c06ce18ea65cde3595f1357a6109833e2119200161f1"
+  ]
+}
+x-commit-hash: "c05d71a7765482143ea8a4cf98adb78cdd151514"

--- a/packages/caqti-eio/caqti-eio.2.1.0/opam
+++ b/packages/caqti-eio/caqti-eio.2.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "dune" {>= "3.9"}
+  "eio" {>= "0.12"}
+  "logs"
+  "ocaml" {>= "5.0.0~"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Lwt support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.0/caqti-v2.1.0.tbz"
+  checksum: [
+    "sha256=c74c71a0963d01adab3a1e65527882340d2d9eccdf4ce709c1d723b818147f61"
+    "sha512=17a89609d8ef74f3210ec63a96d8085f3099d8ee62c67a9573e9c3ba4bc088817b9706679e02c08a6784c06ce18ea65cde3595f1357a6109833e2119200161f1"
+  ]
+}
+x-commit-hash: "c05d71a7765482143ea8a4cf98adb78cdd151514"

--- a/packages/caqti-lwt/caqti-lwt.2.1.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.2.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "caqti-dynload" {with-test & >= "2.0.0" & < "3.0.0~"}
+  "caqti-driver-sqlite3" {with-test & >= "2.0.0" & < "3.0.0~"}
+  "dune" {>= "3.9"}
+  "domain-name"
+  "ipaddr"
+  "logs"
+  "mtime" {>= "2.0.0"}
+  "lwt" {>= "5.3.0"}
+  "ocaml"
+  "alcotest" {with-test & >= "1.5.0"}
+  "alcotest-lwt" {with-test & >= "1.5.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Lwt support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.0/caqti-v2.1.0.tbz"
+  checksum: [
+    "sha256=c74c71a0963d01adab3a1e65527882340d2d9eccdf4ce709c1d723b818147f61"
+    "sha512=17a89609d8ef74f3210ec63a96d8085f3099d8ee62c67a9573e9c3ba4bc088817b9706679e02c08a6784c06ce18ea65cde3595f1357a6109833e2119200161f1"
+  ]
+}
+x-commit-hash: "c05d71a7765482143ea8a4cf98adb78cdd151514"

--- a/packages/caqti-mirage/caqti-mirage.2.1.0/opam
+++ b/packages/caqti-mirage/caqti-mirage.2.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "caqti-lwt" {>= "2.1.0" & < "2.2.0~"}
+  "caqti-tls" {>= "2.1.0" & < "2.2.0~"}
+  "dns-client" {>= "7.0.0"}
+  "dns-client-mirage" {>= "7.0.0"}
+  "domain-name"
+  "dune" {>= "3.9"}
+  "ipaddr"
+  "logs"
+  "lwt" {>= "5.3.0"}
+  "mirage-channel"
+  "mirage-clock"
+  "mirage-random"
+  "mirage-time"
+  "ocaml"
+  "odoc" {with-doc}
+  "tls"
+  "tls-mirage"
+  "tcpip"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MirageOS support for Caqti including TLS"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.0/caqti-v2.1.0.tbz"
+  checksum: [
+    "sha256=c74c71a0963d01adab3a1e65527882340d2d9eccdf4ce709c1d723b818147f61"
+    "sha512=17a89609d8ef74f3210ec63a96d8085f3099d8ee62c67a9573e9c3ba4bc088817b9706679e02c08a6784c06ce18ea65cde3595f1357a6109833e2119200161f1"
+  ]
+}
+x-commit-hash: "c05d71a7765482143ea8a4cf98adb78cdd151514"

--- a/packages/caqti-tls/caqti-tls.2.1.0/opam
+++ b/packages/caqti-tls/caqti-tls.2.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "dune" {>= "3.9"}
+  "ocaml"
+  "odoc" {with-doc}
+  "tls"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Caqti TLS support for PGX; config and caqti.unix implementation"
+description: """
+This package contains the shared configuration and caqti.unix-specific
+implementation of TLS for the Caqti network API.  This package only applies
+to PGX, since drivers based on bindings use their own TLS implementation
+(libpq, mariadb) or have no need for it (sqlite3).
+
+The implementation for caqti-eio and caqti-lwt can be found in caqti-tls-eio
+and caqti-tls-lwt, respectively.
+"""
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.0/caqti-v2.1.0.tbz"
+  checksum: [
+    "sha256=c74c71a0963d01adab3a1e65527882340d2d9eccdf4ce709c1d723b818147f61"
+    "sha512=17a89609d8ef74f3210ec63a96d8085f3099d8ee62c67a9573e9c3ba4bc088817b9706679e02c08a6784c06ce18ea65cde3595f1357a6109833e2119200161f1"
+  ]
+}
+x-commit-hash: "c05d71a7765482143ea8a4cf98adb78cdd151514"

--- a/packages/caqti/caqti.2.1.0/opam
+++ b/packages/caqti/caqti.2.1.0/opam
@@ -15,7 +15,8 @@ depends: [
   "bigstringaf"
   "cmdliner" {with-test & >= "1.1.0"}
   "domain-name" {>= "0.2.0"}
-  "dune" {>= "2.5"}
+  "dune" {>= "3.9"}
+  "dune-site"
   "ipaddr" {>= "3.0.0"}
   "logs"
   "lwt-dllist"
@@ -24,16 +25,16 @@ depends: [
   "odoc" {with-doc}
   "ptime"
   "re" {with-test}
+  "tls"
   "uri" {>= "2.2.0"}
+  "x509"
 ]
 conflicts: [
   "result" {< "1.5"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  # runtest has been restricted to caqti subdirectory in this version since
-  # plugin dependencies don't work with -p option.
-  ["dune" "runtest" "-p" name "-j" jobs caqti] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
@@ -56,10 +57,10 @@ decoding returned tuples. It is hoped that this agnostic choice makes it a
 suitable target for higher level interfaces and code generators."""
 url {
   src:
-    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.0.1/caqti-v2.0.1.tbz"
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.0/caqti-v2.1.0.tbz"
   checksum: [
-    "sha256=7eb57225c521fe25395653d960b1c381bb2b2ccae47bc2a827bb16611988da8b"
-    "sha512=eeafaf495b08fb8620ddee1711b8f9fa2ca0c79fb450a905c8d071806b7046d665e1e2ac0e7d3c7ca1258455decbf184e689e9ecb2453ec9d952b864f9dd14f4"
+    "sha256=c74c71a0963d01adab3a1e65527882340d2d9eccdf4ce709c1d723b818147f61"
+    "sha512=17a89609d8ef74f3210ec63a96d8085f3099d8ee62c67a9573e9c3ba4bc088817b9706679e02c08a6784c06ce18ea65cde3595f1357a6109833e2119200161f1"
   ]
 }
-x-commit-hash: "7fb87f8f956ae84b191bc297f300649941110850"
+x-commit-hash: "c05d71a7765482143ea8a4cf98adb78cdd151514"


### PR DESCRIPTION
I would like to release Caqti 2.1.0 ([release notes](https://github.com/paurkedal/ocaml-caqti/releases/tag/v2.1.0)).  This release includes one new package, `caqti-tls`.  There are actually 3 more TLS-related packages in the tarball, which I'm withholding for now, in the hope I of reducing the number of additional packages and 2 packages which are unchanged:

Package                 | 2.1.0
----------------------- | -----
caqti                   |  yes
caqti-async             |  yes
caqti-eio               |  yes
caqti-lwt               |  yes
caqti-mirage            |  yes
caqti-tls-async         |  no, omitted for now
caqti-tls-eio           |  no, omitted for now
caqti-tls-lwt           |  no, omitted for now
caqti-tls               |  yes
caqti-driver-mariadb    |  yes
caqti-driver-pgx        |  yes
caqti-driver-postgresql |  yes
caqti-driver-sqlite3    |  yes
caqti-dynload           |  no, unchanged
caqti-type-calendar     |  no, unchanged

I'll take a look at the CI results later today.