### PR TITLE
Add a conflict between gmp.6.2.1-5 & ocaml-solo5.0.8.3

### DIFF
--- a/packages/gmp/gmp.6.2.1-5/opam
+++ b/packages/gmp/gmp.6.2.1-5/opam
@@ -18,6 +18,9 @@ depends: [
 depexts: [
   [ "xz" ] {os = "macos" & os-distribution = "homebrew"}
 ]
+conflicts: [
+  "ocaml-solo5" {< "0.8.3"}
+]
 synopsis: "The GNU Multiple Precision Arithmetic Library"
 description: """Dune packaging of the GMP library, suitable for 
 cross-compilation."""


### PR DESCRIPTION
Spotted by @hannesm, if we use `gmp` and we install `ocaml-solo5`, we should have the last version of `ocaml-solo5` (0.8.3).