### PR TITLE
mbr-format.2.0.0 doesn't depend on lwt

### DIFF
--- a/packages/mbr-format/mbr-format.1.0.0/opam
+++ b/packages/mbr-format/mbr-format.1.0.0/opam
@@ -12,7 +12,6 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "3.4.0"}
-  "lwt"
   "cstruct" {>= "6.0.0"}
   "ppx_cstruct"
   "fmt" {with-test}

--- a/packages/mbr-format/mbr-format.2.0.0/opam
+++ b/packages/mbr-format/mbr-format.2.0.0/opam
@@ -13,7 +13,6 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "3.4.0"}
-  "lwt"
   "cstruct" {>= "6.0.0"}
   "cstruct" {dev & >= "6.2.0"}
   "fmt" {with-test}


### PR DESCRIPTION
After making this change I discovered it was unused since 1.0.0 even.