### PR TITLE
Package vscoq-language-server.2.1.1+coq8.19

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.1.1+coq8.19/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.1.1+coq8.19/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/coq-community/vscoq"
+bug-reports: "https://github.com/coq-community/vscoq/issues"
+dev-repo: "git+https://github.com/coq-community/vscoq"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { >= "4.13.1" }
+  "dune" { >= "3.5" }
+  "coq-core" { ((>= "8.18" < "8.20") | (= "dev")) }
+  "coq-stdlib" { ((>= "8.18" < "8.20") | (= "dev")) }
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_yojson_conv" {< "v0.16.0"}
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "ppx_optcomp"
+  "result" { >= "1.5" }
+  "lsp" { >= "1.15"}
+  "sel" {>= "0.4.0"}
+]
+synopsis: "VSCoq language server"
+description: """
+LSP based language server for Coq and its VSCoq user interface
+"""
+url {
+  src:
+    "https://github.com/coq-community/vscoq/releases/download/v2.1.1+coq8.19/vscoq-language-server-2.1.1-coq8.19.tar.gz"
+  checksum: [
+    "md5=5694c37594deb29bc1e9d5859eece5a9"
+    "sha512=21f7fb1beb1e2935e5500234e670270150c5a3d6ddb05bed1355e112d66b5085b99672b33559edc58e3db67f8d59774b6f0479b012bb611286877cd8cfb6604b"
+  ]
+}


### PR DESCRIPTION
### `vscoq-language-server.2.1.1+coq8.19`
VSCoq language server
LSP based language server for Coq and its VSCoq user interface



---
* Homepage: https://github.com/coq-community/vscoq
* Source repo: git+https://github.com/coq-community/vscoq
* Bug tracker: https://github.com/coq-community/vscoq/issues

---
:camel: Pull-request generated by opam-publish v2.0.3