### PR TITLE
Mark cppo < 1.6.7 incompatible with OCaml 5.2

### DIFF
--- a/packages/cppo/cppo.1.6.1/opam
+++ b/packages/cppo/cppo.1.6.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.2"} # Technically this should be < 4.12 as cppo < 1.6.7 does not support the 4.12.0~alpha version scheme that started with the first alpha version of OCaml 4.12
   "jbuilder" {>= "1.0+beta10"}
   "base-bytes"
   "base-unix"

--- a/packages/cppo/cppo.1.6.2/opam
+++ b/packages/cppo/cppo.1.6.2/opam
@@ -12,7 +12,7 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.2"} # Technically this should be < 4.12 as cppo < 1.6.7 does not support the 4.12.0~alpha version scheme that started with the first alpha version of OCaml 4.12
   "jbuilder" {>= "1.0+beta17"}
   "base-bytes"
   "base-unix"

--- a/packages/cppo/cppo.1.6.4/opam
+++ b/packages/cppo/cppo.1.6.4/opam
@@ -12,7 +12,7 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.2"} # Technically this should be < 4.12 as cppo < 1.6.7 does not support the 4.12.0~alpha version scheme that started with the first alpha version of OCaml 4.12
   "jbuilder" {>= "1.0+beta17"}
   "base-bytes"
   "base-unix"

--- a/packages/cppo/cppo.1.6.5/opam
+++ b/packages/cppo/cppo.1.6.5/opam
@@ -12,7 +12,7 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.2"} # Technically this should be < 4.12 as cppo < 1.6.7 does not support the 4.12.0~alpha version scheme that started with the first alpha version of OCaml 4.12
   "jbuilder" {>= "1.0+beta17"}
   "base-unix"
 ]

--- a/packages/cppo/cppo.1.6.6/opam
+++ b/packages/cppo/cppo.1.6.6/opam
@@ -6,7 +6,7 @@ homepage: "http://mjambon.com/cppo.html"
 doc: "https://ocaml-community.github.io/cppo/"
 bug-reports: "https://github.com/ocaml-community/cppo/issues"
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.2"} # Technically this should be < 4.12 as cppo < 1.6.7 does not support the 4.12.0~alpha version scheme that started with the first alpha version of OCaml 4.12
   "dune" {>= "1.0"}
   "base-unix"
 ]


### PR DESCRIPTION
Does not support `~` characters in version number, e.g. `5.2.0~alpha1`.
Noticed in https://github.com/ocaml/opam-repository/pull/25265
```
#=== ERROR while compiling ppx_deriving.5.2 ===================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-base-compiler.5.2.0~alpha1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.2~alpha1/.opam-switch/build/ppx_deriving.5.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ppx_deriving -j 71
# exit-code            1
# env-file             ~/.opam/log/ppx_deriving-7-a51cf7.env
# output-file          ~/.opam/log/ppx_deriving-7-a51cf7.out
### output ###
# File "src_plugins/create/dune", line 1, characters 0-157:
# 1 | (rule
# 2 |  (targets ppx_deriving_create.ml)
# 3 |  (action (run %{bin:cppo} -V OCAML:%{ocaml_version}
# 4 |               %{dep:ppx_deriving_create.cppo.ml} -o %{targets})))
# (cd _build/default/src_plugins/create && /home/opam/.opam/5.2~alpha1/bin/cppo -V OCAML:5.2.0~alpha1 ppx_deriving_create.cppo.ml -o ppx_deriving_create.ml)
# Error: Invalid version specification: "OCAML:5.2.0~alpha1"
```