### PR TITLE
[new release] js_of_ocaml (7 packages) (5.7.0)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.7.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.7.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08" & < "5.3"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15.0"}
+  "re" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "sedlex" {>= "2.3"}
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.7.0/js_of_ocaml-5.7.0.tbz"
+  checksum: [
+    "sha256=cdf1dea0d9397a498b630abe8014908b6dd83b10ee0c7ff5777a6443a62983be"
+    "sha512=5cf7d883c97f4b81ab73687c8f29b624acaef28c002b5d739108954973671dd5fb4f869d8fedb485b4b17bc8aa10d8b55b30ae7ace21a9350c2a1ac59b28eb60"
+  ]
+}
+x-commit-hash: "ca84344d773d434a4f7aa0d76235fcb89b5b5ffc"

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.5.7.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.5.7.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "lwt" {>= "2.4.4"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["graphics" "lwt_log"]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.7.0/js_of_ocaml-5.7.0.tbz"
+  checksum: [
+    "sha256=cdf1dea0d9397a498b630abe8014908b6dd83b10ee0c7ff5777a6443a62983be"
+    "sha512=5cf7d883c97f4b81ab73687c8f29b624acaef28c002b5d739108954973671dd5fb4f869d8fedb485b4b17bc8aa10d8b55b30ae7ace21a9350c2a1ac59b28eb60"
+  ]
+}
+x-commit-hash: "ca84344d773d434a4f7aa0d76235fcb89b5b5ffc"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.5.7.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.5.7.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15.0"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.7.0/js_of_ocaml-5.7.0.tbz"
+  checksum: [
+    "sha256=cdf1dea0d9397a498b630abe8014908b6dd83b10ee0c7ff5777a6443a62983be"
+    "sha512=5cf7d883c97f4b81ab73687c8f29b624acaef28c002b5d739108954973671dd5fb4f869d8fedb485b4b17bc8aa10d8b55b30ae7ace21a9350c2a1ac59b28eb60"
+  ]
+}
+x-commit-hash: "ca84344d773d434a4f7aa0d76235fcb89b5b5ffc"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.5.7.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.5.7.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.7.0/js_of_ocaml-5.7.0.tbz"
+  checksum: [
+    "sha256=cdf1dea0d9397a498b630abe8014908b6dd83b10ee0c7ff5777a6443a62983be"
+    "sha512=5cf7d883c97f4b81ab73687c8f29b624acaef28c002b5d739108954973671dd5fb4f869d8fedb485b4b17bc8aa10d8b55b30ae7ace21a9350c2a1ac59b28eb60"
+  ]
+}
+x-commit-hash: "ca84344d773d434a4f7aa0d76235fcb89b5b5ffc"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.5.7.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.5.7.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml-compiler" {= version}
+  "ocamlfind" {>= "1.5.1"}
+  "cohttp-lwt-unix" {with-test}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.7.0/js_of_ocaml-5.7.0.tbz"
+  checksum: [
+    "sha256=cdf1dea0d9397a498b630abe8014908b6dd83b10ee0c7ff5777a6443a62983be"
+    "sha512=5cf7d883c97f4b81ab73687c8f29b624acaef28c002b5d739108954973671dd5fb4f869d8fedb485b4b17bc8aa10d8b55b30ae7ace21a9350c2a1ac59b28eb60"
+  ]
+}
+x-commit-hash: "ca84344d773d434a4f7aa0d76235fcb89b5b5ffc"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.5.7.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.5.7.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "react" {>= "1.2.1"}
+  "reactiveData" {>= "0.2"}
+  "tyxml" {>= "4.3"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.7.0/js_of_ocaml-5.7.0.tbz"
+  checksum: [
+    "sha256=cdf1dea0d9397a498b630abe8014908b6dd83b10ee0c7ff5777a6443a62983be"
+    "sha512=5cf7d883c97f4b81ab73687c8f29b624acaef28c002b5d739108954973671dd5fb4f869d8fedb485b4b17bc8aa10d8b55b30ae7ace21a9350c2a1ac59b28eb60"
+  ]
+}
+x-commit-hash: "ca84344d773d434a4f7aa0d76235fcb89b5b5ffc"

--- a/packages/js_of_ocaml/js_of_ocaml.5.7.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.5.7.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml-compiler" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.7.0/js_of_ocaml-5.7.0.tbz"
+  checksum: [
+    "sha256=cdf1dea0d9397a498b630abe8014908b6dd83b10ee0c7ff5777a6443a62983be"
+    "sha512=5cf7d883c97f4b81ab73687c8f29b624acaef28c002b5d739108954973671dd5fb4f869d8fedb485b4b17bc8aa10d8b55b30ae7ace21a9350c2a1ac59b28eb60"
+  ]
+}
+x-commit-hash: "ca84344d773d434a4f7aa0d76235fcb89b5b5ffc"


### PR DESCRIPTION
Compiler from OCaml bytecode to JavaScript

- Project page: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>
- Documentation: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>

##### CHANGES:

## Features/Changes
* Mics: fix support for OCaml 5.2
* Compiler: no longer rely on IIFE for scoping variable inside loops
* Compiler: avoid parsing bytecode sections twice, jsoo counter part of ocaml#12599
* Lib: add ellipse to canvasRenderingContext2D (@FayCarsons, ocsigen/js_of_ocaml#1555)

## Bug fixes
* Compiler: fix global dead code elimination in a toplevel context
* Compiler: fix exit-loop-early optim in presence of closure (ocsigen/js_of_ocaml#1561)
