### PR TITLE
Release Caqti 2.1.1.

### DIFF
--- a/packages/caqti-async/caqti-async.2.1.1/opam
+++ b/packages/caqti-async/caqti-async.2.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "async_kernel" {>= "v0.11.0"}
+  "async_unix" {>= "v0.11.0"}
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "core" {>= "v0.16.1"}
+  "core_unix"
+  "domain-name"
+  "dune" {>= "3.9"}
+  "ipaddr"
+  "logs"
+  "ocaml"
+  "alcotest" {with-test & >= "1.5.0"}
+  "alcotest-async" {with-test}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "caqti-driver-sqlite3" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Async support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.1/caqti-v2.1.1.tbz"
+  checksum: [
+    "sha256=483a535f41e2641917fc1832ce4ad15ffc3f4e8283b1b3018a2617349583090a"
+    "sha512=6a1222c0c55cb16a9d409980f9f2400340689b87e21aafed2d7459fd7feaeb109c2dfaf77f55f8422fbb7d3772342565ced7fed78a7b77af5aedab5bfd5ae882"
+  ]
+}
+x-commit-hash: "91622d9b7dca6a96d86063496d252c8a761a37cc"

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.2.1.1/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.2.1.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocaml"
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "3.9"}
+  "mariadb" {>= "1.1.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MariaDB driver for Caqti using C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.1/caqti-v2.1.1.tbz"
+  checksum: [
+    "sha256=483a535f41e2641917fc1832ce4ad15ffc3f4e8283b1b3018a2617349583090a"
+    "sha512=6a1222c0c55cb16a9d409980f9f2400340689b87e21aafed2d7459fd7feaeb109c2dfaf77f55f8422fbb7d3772342565ced7fed78a7b77af5aedab5bfd5ae882"
+  ]
+}
+x-commit-hash: "91622d9b7dca6a96d86063496d252c8a761a37cc"

--- a/packages/caqti-driver-pgx/caqti-driver-pgx.2.1.1/opam
+++ b/packages/caqti-driver-pgx/caqti-driver-pgx.2.1.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "domain-name"
+  "dune" {>= "3.9"}
+  "ipaddr"
+  "pgx" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on the pure-OCaml PGX library"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.1/caqti-v2.1.1.tbz"
+  checksum: [
+    "sha256=483a535f41e2641917fc1832ce4ad15ffc3f4e8283b1b3018a2617349583090a"
+    "sha512=6a1222c0c55cb16a9d409980f9f2400340689b87e21aafed2d7459fd7feaeb109c2dfaf77f55f8422fbb7d3772342565ced7fed78a7b77af5aedab5bfd5ae882"
+  ]
+}
+x-commit-hash: "91622d9b7dca6a96d86063496d252c8a761a37cc"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.2.1.1/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.2.1.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "James Owen <james@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocaml"
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "3.9"}
+  "odoc" {with-doc}
+  "postgresql" {>= "5.0.0"}
+  "uri" {>= "4.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.1/caqti-v2.1.1.tbz"
+  checksum: [
+    "sha256=483a535f41e2641917fc1832ce4ad15ffc3f4e8283b1b3018a2617349583090a"
+    "sha512=6a1222c0c55cb16a9d409980f9f2400340689b87e21aafed2d7459fd7feaeb109c2dfaf77f55f8422fbb7d3772342565ced7fed78a7b77af5aedab5bfd5ae882"
+  ]
+}
+x-commit-hash: "91622d9b7dca6a96d86063496d252c8a761a37cc"

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.2.1.1/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.2.1.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocaml"
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "3.9"}
+  "odoc" {with-doc}
+  "sqlite3"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Sqlite3 driver for Caqti using C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.1/caqti-v2.1.1.tbz"
+  checksum: [
+    "sha256=483a535f41e2641917fc1832ce4ad15ffc3f4e8283b1b3018a2617349583090a"
+    "sha512=6a1222c0c55cb16a9d409980f9f2400340689b87e21aafed2d7459fd7feaeb109c2dfaf77f55f8422fbb7d3772342565ced7fed78a7b77af5aedab5bfd5ae882"
+  ]
+}
+x-commit-hash: "91622d9b7dca6a96d86063496d252c8a761a37cc"

--- a/packages/caqti-eio/caqti-eio.2.1.1/opam
+++ b/packages/caqti-eio/caqti-eio.2.1.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "dune" {>= "3.9"}
+  "eio" {>= "0.12"}
+  "logs"
+  "ocaml" {>= "5.0.0~"}
+  "alcotest" {with-test & >= "1.5.0"}
+  "caqti-driver-sqlite3" {with-test}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "eio_main" {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng-eio" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Lwt support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.1/caqti-v2.1.1.tbz"
+  checksum: [
+    "sha256=483a535f41e2641917fc1832ce4ad15ffc3f4e8283b1b3018a2617349583090a"
+    "sha512=6a1222c0c55cb16a9d409980f9f2400340689b87e21aafed2d7459fd7feaeb109c2dfaf77f55f8422fbb7d3772342565ced7fed78a7b77af5aedab5bfd5ae882"
+  ]
+}
+x-commit-hash: "91622d9b7dca6a96d86063496d252c8a761a37cc"

--- a/packages/caqti-lwt/caqti-lwt.2.1.1/opam
+++ b/packages/caqti-lwt/caqti-lwt.2.1.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "dune" {>= "3.9"}
+  "domain-name"
+  "ipaddr"
+  "logs"
+  "mtime" {>= "2.0.0"}
+  "lwt" {>= "5.3.0"}
+  "ocaml"
+  "alcotest" {with-test & >= "1.5.0"}
+  "alcotest-lwt" {with-test & >= "1.5.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "caqti-driver-sqlite3" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Lwt support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.1/caqti-v2.1.1.tbz"
+  checksum: [
+    "sha256=483a535f41e2641917fc1832ce4ad15ffc3f4e8283b1b3018a2617349583090a"
+    "sha512=6a1222c0c55cb16a9d409980f9f2400340689b87e21aafed2d7459fd7feaeb109c2dfaf77f55f8422fbb7d3772342565ced7fed78a7b77af5aedab5bfd5ae882"
+  ]
+}
+x-commit-hash: "91622d9b7dca6a96d86063496d252c8a761a37cc"

--- a/packages/caqti-mirage/caqti-mirage.2.1.1/opam
+++ b/packages/caqti-mirage/caqti-mirage.2.1.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "caqti-lwt" {>= "2.1.0" & < "2.2.0~"}
+  "caqti-tls" {>= "2.1.0" & < "2.2.0~"}
+  "dns-client" {>= "7.0.0"}
+  "dns-client-mirage" {>= "7.0.0"}
+  "domain-name"
+  "dune" {>= "3.9"}
+  "ipaddr"
+  "logs"
+  "lwt" {>= "5.3.0"}
+  "mirage-channel"
+  "mirage-clock"
+  "mirage-random"
+  "mirage-time"
+  "ocaml"
+  "odoc" {with-doc}
+  "tls"
+  "tls-mirage"
+  "tcpip"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MirageOS support for Caqti including TLS"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.1/caqti-v2.1.1.tbz"
+  checksum: [
+    "sha256=483a535f41e2641917fc1832ce4ad15ffc3f4e8283b1b3018a2617349583090a"
+    "sha512=6a1222c0c55cb16a9d409980f9f2400340689b87e21aafed2d7459fd7feaeb109c2dfaf77f55f8422fbb7d3772342565ced7fed78a7b77af5aedab5bfd5ae882"
+  ]
+}
+x-commit-hash: "91622d9b7dca6a96d86063496d252c8a761a37cc"

--- a/packages/caqti-tls/caqti-tls.2.1.1/opam
+++ b/packages/caqti-tls/caqti-tls.2.1.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "dune" {>= "3.9"}
+  "ocaml"
+  "odoc" {with-doc}
+  "tls"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Caqti TLS support for PGX; config and caqti.unix implementation"
+description: """
+This package contains the shared configuration and caqti.unix-specific
+implementation of TLS for the Caqti network API.  This package only applies
+to PGX, since drivers based on bindings use their own TLS implementation
+(libpq, mariadb) or have no need for it (sqlite3).
+
+The implementation for caqti-eio and caqti-lwt can be found in caqti-tls-eio
+and caqti-tls-lwt, respectively.
+"""
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.1/caqti-v2.1.1.tbz"
+  checksum: [
+    "sha256=483a535f41e2641917fc1832ce4ad15ffc3f4e8283b1b3018a2617349583090a"
+    "sha512=6a1222c0c55cb16a9d409980f9f2400340689b87e21aafed2d7459fd7feaeb109c2dfaf77f55f8422fbb7d3772342565ced7fed78a7b77af5aedab5bfd5ae882"
+  ]
+}
+x-commit-hash: "91622d9b7dca6a96d86063496d252c8a761a37cc"

--- a/packages/caqti/caqti.2.1.1/opam
+++ b/packages/caqti/caqti.2.1.1/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "Nathan Rebours <nathan@cryptosense.com>"
+  "Basile Clément"
+]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "angstrom" {>= "0.14.0"}
+  "bigstringaf"
+  "cmdliner" {with-test & >= "1.1.0"}
+  "domain-name" {>= "0.2.0"}
+  "dune" {>= "3.9"}
+  "dune-site"
+  "ipaddr" {>= "3.0.0"}
+  "logs"
+  "lwt-dllist"
+  "mtime" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+  "ptime"
+  "re" {with-test}
+  "tls"
+  "uri" {>= "2.2.0"}
+  "x509"
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Unified interface to relational database libraries"
+description: """
+Caqti provides a monadic cooperative-threaded OCaml connector API for
+relational databases.
+
+The purpose of Caqti is further to help make applications independent of a
+particular database system. This is achieved by defining a common signature,
+which is implemented by the database drivers. Connection parameters are
+specified as an URI, which is typically provided at run-time. Caqti then
+loads a driver which can handle the URI, and provides a first-class module
+which implements the driver API and additional convenience functionality.
+
+Caqti does not make assumptions about the structure of the query language,
+and only provides the type information needed at the edges of communication
+between the OCaml code and the database; i.e. for encoding parameters and
+decoding returned tuples. It is hoped that this agnostic choice makes it a
+suitable target for higher level interfaces and code generators."""
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.1/caqti-v2.1.1.tbz"
+  checksum: [
+    "sha256=483a535f41e2641917fc1832ce4ad15ffc3f4e8283b1b3018a2617349583090a"
+    "sha512=6a1222c0c55cb16a9d409980f9f2400340689b87e21aafed2d7459fd7feaeb109c2dfaf77f55f8422fbb7d3772342565ced7fed78a7b77af5aedab5bfd5ae882"
+  ]
+}
+x-commit-hash: "91622d9b7dca6a96d86063496d252c8a761a37cc"


### PR DESCRIPTION
(This replaces the just closed PR #25283.)

I would like to release Caqti 2.1.1 ([release notes](https://github.com/paurkedal/ocaml-caqti/releases/tag/v2.1.1)).  This release includes one new package, `caqti-tls`.  There are actually 3 more TLS-related packages in the tarball, which I'm withholding for now, in the hope I of reducing the number of additional packages and 2 packages which are unchanged:

Package                 | 2.1.1
----------------------- | -----
caqti                   |  yes
caqti-async             |  yes
caqti-eio               |  yes
caqti-lwt               |  yes
caqti-mirage            |  yes
caqti-tls-async         |  no, omitted for now
caqti-tls-eio           |  no, omitted for now
caqti-tls-lwt           |  no, omitted for now
caqti-tls               |  yes
caqti-driver-mariadb    |  yes
caqti-driver-pgx        |  yes
caqti-driver-postgresql |  yes
caqti-driver-sqlite3    |  yes
caqti-dynload           |  no, unchanged
caqti-type-calendar     |  no, unchanged
