### PR TITLE
2 packages from bcpierce00/unison at 2.53.4

### DIFF
--- a/packages/unison-gui/unison-gui.2.53.4/opam
+++ b/packages/unison-gui/unison-gui.2.53.4/opam
@@ -12,6 +12,7 @@ dev-repo: "git://github.com/bcpierce00/unison.git"
 depends: [
   "unison" {= version}
   "lablgtk3"
+  "ocamlfind"
 ]
 synopsis: "Pseudo-package for Unison GUI"
 description: """

--- a/packages/unison-gui/unison-gui.2.53.4/opam
+++ b/packages/unison-gui/unison-gui.2.53.4/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "unison-hackers@lists.seas.upenn.edu"
+authors: [
+  "Trevor Jim"
+  "Benjamin C. Pierce"
+  "Jérôme Vouillon"
+]
+license: "GPL-3.0-or-later"
+homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
+bug-reports: "https://github.com/bcpierce00/unison/issues"
+dev-repo: "git://github.com/bcpierce00/unison.git"
+depends: [
+  "unison" {= version}
+  "lablgtk3"
+]
+synopsis: "Pseudo-package for Unison GUI"
+description: """
+Unison is a file-synchronization tool for Unix and Windows. It allows
+two replicas of a collection of files and directories to be stored on
+different hosts (or different disks on the same host), modified
+separately, and then brought up to date by propagating the changes in
+each replica to the other."""
+url {
+  src:
+    "https://github.com/bcpierce00/unison/archive/refs/tags/v2.53.4.tar.gz"
+  checksum: [
+    "md5=87962a9aef0caf940049d1e587f63368"
+    "sha512=91077955aabbd919e6d6df04a704878238d745ac3693e0e41b8a37a922db4ebfceb204378ab1283303ef5ad9d80445bc8caeafad36f67b8df8c30d8b4e0c6947"
+  ]
+}

--- a/packages/unison/unison.2.53.4/opam
+++ b/packages/unison/unison.2.53.4/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "unison-hackers@lists.seas.upenn.edu"
+authors: [
+  "Trevor Jim"
+  "Benjamin C. Pierce"
+  "Jérôme Vouillon"
+]
+license: "GPL-3.0-or-later"
+homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
+bug-reports: "https://github.com/bcpierce00/unison/issues"
+dev-repo: "git://github.com/bcpierce00/unison.git"
+build: [make "-j" jobs]
+install: [make "PREFIX=%{prefix}%" "install"]
+depends: [
+  "ocaml" {>= "4.08"}
+]
+depopts: [
+  "lablgtk3" {>= "3.1.0"}
+]
+synopsis: "File-synchronization tool for Unix and Windows"
+description: """
+Unison is a file-synchronization tool for Unix and Windows. It allows
+two replicas of a collection of files and directories to be stored on
+different hosts (or different disks on the same host), modified
+separately, and then brought up to date by propagating the changes in
+each replica to the other."""
+url {
+  src:
+    "https://github.com/bcpierce00/unison/archive/refs/tags/v2.53.4.tar.gz"
+  checksum: [
+    "md5=87962a9aef0caf940049d1e587f63368"
+    "sha512=91077955aabbd919e6d6df04a704878238d745ac3693e0e41b8a37a922db4ebfceb204378ab1283303ef5ad9d80445bc8caeafad36f67b8df8c30d8b4e0c6947"
+  ]
+}

--- a/packages/unison/unison.2.53.4/opam
+++ b/packages/unison/unison.2.53.4/opam
@@ -16,6 +16,7 @@ depends: [
 ]
 depopts: [
   "lablgtk3" {>= "3.1.0"}
+  "ocamlfind"
 ]
 synopsis: "File-synchronization tool for Unix and Windows"
 description: """

--- a/packages/unison/unison.2.53.4/opam
+++ b/packages/unison/unison.2.53.4/opam
@@ -9,8 +9,8 @@ license: "GPL-3.0-or-later"
 homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
 bug-reports: "https://github.com/bcpierce00/unison/issues"
 dev-repo: "git://github.com/bcpierce00/unison.git"
-build: [make "-j" jobs]
-install: [make "PREFIX=%{prefix}%" "install"]
+build: [make "NATIVE=%{ocaml:native}%" "-j" jobs]
+install: [make "NATIVE=%{ocaml:native}%" "PREFIX=%{prefix}%" "install"]
 depends: [
   "ocaml" {>= "4.08"}
 ]


### PR DESCRIPTION
This pull-request concerns:
- `unison.2.53.4`: File-synchronization tool for Unix and Windows
- `unison-gui.2.53.4`: Pseudo-package for Unison GUI



---
* Homepage: https://www.cis.upenn.edu/~bcpierce/unison/
* Source repo: git://github.com/bcpierce00/unison.git
* Bug tracker: https://github.com/bcpierce00/unison/issues

---
:camel: Pull-request generated by opam-publish v2.3.0