### PR TITLE
prbnmcn-dagger-stats upper bounds

### DIFF
--- a/packages/prbnmcn-dagger-stats/prbnmcn-dagger-stats.0.0.3/opam
+++ b/packages/prbnmcn-dagger-stats/prbnmcn-dagger-stats.0.0.3/opam
@@ -11,7 +11,7 @@ bug-reports: "http://github.com/igarnier/prbnmcn-dagger"
 depends: [
   "dune" {>= "2.8"}
   "prbnmcn-dagger" {= version}
-  "prbnmcn-stats" {>= "0.0.7"}
+  "prbnmcn-stats" {>= "0.0.7" & < "0.0.8"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/prbnmcn-dagger-stats/prbnmcn-dagger-stats.0.0.4/opam
+++ b/packages/prbnmcn-dagger-stats/prbnmcn-dagger-stats.0.0.4/opam
@@ -11,7 +11,7 @@ bug-reports: "http://github.com/igarnier/prbnmcn-dagger"
 depends: [
   "dune" {>= "2.8"}
   "prbnmcn-dagger" {= version}
-  "prbnmcn-stats" {>= "0.0.7"}
+  "prbnmcn-stats" {>= "0.0.7" & < "0.0.8"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
they are not compatible with the upcoming prbnmcn-stats:
```
=== ERROR while compiling prbnmcn-dagger-stats.0.0.4 =========================#
 context              2.2.0~beta2~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
 path                 ~/.opam/5.1/.opam-switch/build/prbnmcn-dagger-stats.0.0.4
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p prbnmcn-dagger-stats -j 255 @install
 exit-code            1
 env-file             ~/.opam/log/prbnmcn-dagger-stats-7-4ceb11.env
 output-file          ~/.opam/log/prbnmcn-dagger-stats-7-4ceb11.out
 (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I stats_dist/.stats_dist.objs/byte -I /home/opam/.opam/5.1/lib/prbnmcn-basic-structures -I /home/opam/.opam/5.1/lib/prbnmcn-dagger -I /home/opam/.opam/5.1/lib/prbnmcn-stats -no-alias-deps -o stats_dist/.stats_dist.objs/byte/stats_dist.cmo -c -impl stats_dist/stats_dist.ml)
 File "stats_dist/stats_dist.ml", line 7, characters 73-74:
 7 |   let poisson_ln ~lambda ~k = Log_space.unsafe_cast (poisson_ln ~lambda ~k)
                                                                              ^
 Error: The function applied to this argument has type
          int -> Stats__Log_space.t
 This argument cannot be applied with label ~k
```

Seen on https://github.com/ocaml/opam-repository/pull/25256