### PR TITLE
ppx_import is incompatible with ocaml 5.2 ppxlib

### DIFF
--- a/packages/ppx_import/ppx_import.1.10.0/opam
+++ b/packages/ppx_import/ppx_import.1.10.0/opam
@@ -12,7 +12,7 @@ tags: [ "syntax" ]
 depends: [
   "ocaml"                   {>= "4.05.0" &  < "4.10.0"  } | ("ocaml" {>= "4.10.0"} "ppx_sexp_conv" {with-test & >= "v0.13.0"})
   "dune"                    {              >= "1.11.0"  }
-  "ppxlib"                  {              >= "0.26.0"  }
+  "ppxlib"                  { >= "0.26.0" & < "0.32.1~5.2preview" }
   "ounit"                   { with-test                 }
   "ppx_deriving"            { with-test  & >= "4.2.1"   }
 ]


### PR DESCRIPTION
Fails with
```
=== ERROR while compiling ppx_import.1.10.0 ==================================#
 context              2.2.0~beta2~dev | linux/x86_64 | ocaml-base-compiler.5.2.0~alpha1 | file:///home/opam/opam-repository
 path                 ~/.opam/5.2~alpha1/.opam-switch/build/ppx_import.1.10.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ppx_import -j 71
 exit-code            1
 env-file             ~/.opam/log/ppx_import-7-62c57a.env
 output-file          ~/.opam/log/ppx_import-7-62c57a.out
 (cd _build/default && /home/opam/.opam/5.2~alpha1/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.ppx_import.objs/byte -I /home/opam/.opam/5.2~alpha1/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.2~alpha1/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.2~alpha1/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2~alpha1/lib/ppx_derivers -I /home/opam/.opam/5.2~alpha1/lib/ppxlib -I /home/opam/.opam/5.2~alpha1/lib/ppxlib/ast -I /home/opam/.opam/5.2~alpha1/lib/ppxlib/astlib -I /home/opam/.opam/5.2~alpha1/lib/ppxlib/print_diff -I /home/opam/.opam/5.2~alpha1/lib/ppxlib/stdppx -I /home/opam/.opam/5.2~alpha1/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.2~alpha1/lib/sexplib0 -I /home/opam/.opam/5.2~alpha1/lib/stdlib-shims -no-alias-deps -open Ppx_import__ -o src/.ppx_import.objs/byte/ppx_import__Compat.cmo -c -impl src/compat.pp.ml)
 File "src/compat.ml", line 45, characters 4-17:
 45 |   | Type_abstract -> Type_abstract
          ^^^^^^^^^^^^^
 Error: The constructor "Type_abstract" expects 1 argument(s),
        but is applied here to 0 argument(s)
```
Seen on https://github.com/ocaml/opam-repository/pull/25286