### PR TITLE
[new release] dream-html (3.0.1)

### DIFF
--- a/packages/dream-html/dream-html.3.0.1/opam
+++ b/packages/dream-html/dream-html.3.0.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.0.1/dream-html-3.0.1.tbz"
+  checksum: [
+    "sha256=c05f8787ebb58c089d704b5035b187dc92e733f9a0883d92bba0f0d0ee9ce390"
+    "sha512=56348558025b818cbac7a99a0c838804881b3bc81a992f6f6da967c677c96bef1be92c5566cd1b6f0857827e237ce1b5cc2cdbdcb49c43231b9fe7e4b8f886bd"
+  ]
+}
+x-commit-hash: "f47fbfdc4c713e49f4e9bccb17ec8858c3ff1898"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
