### PR TITLE
OCaml compiler: pedagogical preview for effect handler syntax

### DIFF
--- a/packages/base-effects/base-effects.base/opam
+++ b/packages/base-effects/base-effects.base/opam
@@ -7,6 +7,7 @@ depends: [
  "ocaml" {>= "4.12.0"}
  "ocaml-variants" {
     = "4.12.0+domains+effects"
+   | = "5.1.1+effect-syntax"
  }
  "base-domains"
 ]

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
@@ -21,7 +21,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
@@ -1,0 +1,82 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "OCaml 5.1.1, with effect syntax support"
+maintainer: "platform@lists.ocaml.org"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+homepage: "https://github.com/ocaml/ocaml"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git+https://github.com/xavierleroy/ocaml.git#5.1.1+effect-syntax"
+depends: [
+  "ocaml" {= "5.1.1" & post}
+  "base-unix" {post}
+  "base-effects" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build-env: [
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--enable-tsan" {ocaml-option-tsan:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/xavierleroy/ocaml/archive/5.1.1+effect-syntax.tar.gz"
+  checksum: "sha256=300b540f60a823933af76c572e5931b502634830ea838f96bead309336c44579"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+  "ocaml-option-tsan"
+]


### PR DESCRIPTION
This PR adds a compiler variant that integrates the syntactic support for effect handler:
```ocaml
let handle f = match f () with
| x -> [ x ]
| effect E, k -> Effect.Deep.continue k 0
```

This variant is intended as a pedagogical preview version. In particular, it is not expected that the full opam ecosystem work with this variant which adds a new keyword `effect`.

To keep track of possible incompatibilities, I am reusing the `base-effects` package on a suggestion by @kit-ty-kate.