### PR TITLE
Add conf-sqlite support for opam var os-family=ubuntu

### DIFF
--- a/packages/conf-sqlite3/conf-sqlite3.1/opam
+++ b/packages/conf-sqlite3/conf-sqlite3.1/opam
@@ -14,6 +14,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 
 depexts: [
   ["libsqlite3-dev"] {os-family = "debian"}
+  ["libsqlite3-dev"] {os-family = "ubuntu"}
   ["sqlite3"] {os = "freebsd"}
   ["database/sqlite3"] {os = "openbsd"}
   ["sqlite-devel"] {os-distribution = "centos"}


### PR DESCRIPTION
This little PR adds `conf-sqlite` support for Linux Mint and other derivative distributions with
```
$ opam var os-family
ubuntu
```