### PR TITLE
Cohttp depends on base-bytes when on OCaml >= 5.0

### DIFF
--- a/packages/cohttp/cohttp.2.3.0/opam
+++ b/packages/cohttp/cohttp.2.3.0/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  ("ocaml" {>= "4.04.1" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "1.1.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.2.4.0/opam
+++ b/packages/cohttp/cohttp.2.4.0/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  ("ocaml" {>= "4.04.1" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "1.1.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.2.5.0/opam
+++ b/packages/cohttp/cohttp.2.5.0/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  ("ocaml" {>= "4.04.1" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "1.1.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.2.5.1/opam
+++ b/packages/cohttp/cohttp.2.5.1/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  ("ocaml" {>= "4.04.1" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "1.1.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.2.5.2-1/opam
+++ b/packages/cohttp/cohttp.2.5.2-1/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  ("ocaml" {>= "4.04.1" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "1.1.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.2.5.2/opam
+++ b/packages/cohttp/cohttp.2.5.2/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  ("ocaml" {>= "4.04.1" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "1.1.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.2.5.3/opam
+++ b/packages/cohttp/cohttp.2.5.3/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  ("ocaml" {>= "4.04.1" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "1.1.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.2.5.4/opam
+++ b/packages/cohttp/cohttp.2.5.4/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  ("ocaml" {>= "4.04.1" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "1.1.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.2.5.5/opam
+++ b/packages/cohttp/cohttp.2.5.5/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  ("ocaml" {>= "4.04.1" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "1.1.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.2.5.6/opam
+++ b/packages/cohttp/cohttp.2.5.6/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  ("ocaml" {>= "4.04.1" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "1.1.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.2.5.7/opam
+++ b/packages/cohttp/cohttp.2.5.7/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  ("ocaml" {>= "4.04.1" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "1.1.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.2.5.8/opam
+++ b/packages/cohttp/cohttp.2.5.8/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  ("ocaml" {>= "4.04.1" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "1.1.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.3.0.0/opam
+++ b/packages/cohttp/cohttp.3.0.0/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "1.1.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.4.0.0/opam
+++ b/packages/cohttp/cohttp.4.0.0/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "2.0.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.4.1.1/opam
+++ b/packages/cohttp/cohttp.4.1.1/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "2.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.4.1.2/opam
+++ b/packages/cohttp/cohttp.4.1.2/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "2.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.5.0.0/opam
+++ b/packages/cohttp/cohttp.5.0.0/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "2.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.5.1.0/opam
+++ b/packages/cohttp/cohttp.5.1.0/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "2.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.5.2.0/opam
+++ b/packages/cohttp/cohttp.5.2.0/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "2.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.5.3.0/opam
+++ b/packages/cohttp/cohttp.5.3.0/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "2.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.5.3.1/opam
+++ b/packages/cohttp/cohttp.5.3.1/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "2.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}


### PR DESCRIPTION
With OCaml < 5.0 previously dune would make bytes a dummy library. Fixed in cohttp 6.0 by removing the dependency on `bytes`
Otherwise you can get the following random failure:
```
#=== ERROR while compiling cohttp.5.3.1 =======================================#
# context     2.2.0~beta1 | linux/arm64 | ocaml-variants.5.2.0+trunk | git+https://github.com/ocaml/opam-repository
# path        ~/.opam/trunk/.opam-switch/build/cohttp.5.3.1
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p cohttp -j 9
# exit-code   1
# env-file    ~/.opam/log/cohttp-93509-e08455.env
# output-file ~/.opam/log/cohttp-93509-e08455.out
### output ###
# File "cohttp/src/dune", line 21, characters 47-52:
# 21 |  (libraries re stringext uri uri-sexp sexplib0 bytes base64))
#                                                     ^^^^^
# Error: Library "bytes" not found.
# -> required by library "cohttp" in _build/default/cohttp/src
# -> required by _build/default/META.cohttp
# -> required by _build/install/default/lib/cohttp/META
# -> required by _build/default/cohttp.install
# -> required by alias install
```
in the case where `cohttp` is built at the same time as `ocamlfind`