### PR TITLE
Package ocaml_intrinsics.v0.16.1

### DIFF
--- a/packages/ocaml_intrinsics/ocaml_intrinsics.v0.16.1/opam
+++ b/packages/ocaml_intrinsics/ocaml_intrinsics.v0.16.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ocaml_intrinsics"
+bug-reports: "https://github.com/janestreet/ocaml_intrinsics/issues"
+dev-repo: "git+https://github.com/janestreet/ocaml_intrinsics.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ocaml_intrinsics/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"             {>= "4.14.0"}
+  "dune"              {>= "2.0.0"}
+  "dune-configurator"
+]
+synopsis: "Intrinsics"
+description: "
+Provides functions to invoke amd64 instructions (such as clz,popcnt,rdtsc,rdpmc)
+     when available, or compatible software implementation on other targets.
+"
+available: (arch = "x86_64" | arch = "arm64") & os != "win32"
+url {
+  src:
+    "https://github.com/janestreet/ocaml_intrinsics/archive/refs/tags/v0.16.1.tar.gz"
+  checksum: [
+    "md5=c1ba2b1321f8fb5e3752b7d9250bfc6f"
+    "sha512=62986ffbcac6822ada73ae187c667de1059c398b1c64234d6a887111509e92159a20a560b1846577aced07e82adbb34ef0e8bfd46919f6a2ba79fce45ecf1849"
+  ]
+}


### PR DESCRIPTION
### `ocaml_intrinsics.v0.16.1`
Intrinsics
Provides functions to invoke amd64 instructions (such as clz,popcnt,rdtsc,rdpmc)
     when available, or compatible software implementation on other targets.



---
* Homepage: https://github.com/janestreet/ocaml_intrinsics
* Source repo: git+https://github.com/janestreet/ocaml_intrinsics.git
* Bug tracker: https://github.com/janestreet/ocaml_intrinsics/issues

---
:camel: Pull-request generated by opam-publish v2.3.0