### PR TITLE
ppx_import is not compatible with OCaml 5.2 (compiler-libs changes)

### DIFF
--- a/packages/ppx_import/ppx_import.1.10.0/opam
+++ b/packages/ppx_import/ppx_import.1.10.0/opam
@@ -10,7 +10,7 @@ dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
 tags: [ "syntax" ]
 
 depends: [
-  "ocaml"                   {>= "4.05.0" &  < "4.10.0"  } | ("ocaml" {>= "4.10.0"} "ppx_sexp_conv" {with-test & >= "v0.13.0"})
+  "ocaml"                   {>= "4.05.0" &  < "4.10.0"  } | ("ocaml" {>= "4.10.0" & < "5.2"} & "ppx_sexp_conv" {with-test & >= "v0.13.0"})
   "dune"                    {              >= "1.11.0"  }
   "ppxlib"                  { >= "0.26.0" & < "0.32.1~5.2preview" }
   "ounit"                   { with-test                 }


### PR DESCRIPTION
Reported upstream in https://github.com/ocaml-ppx/ppx_import/issues/93
```
#=== ERROR while compiling ppx_import.1.10.0 ==================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/ppx_import.1.10.0
# command              ~/.opam/5.2/bin/dune build -p ppx_import -j 1
# exit-code            1
# env-file             ~/.opam/log/ppx_import-20-7b1712.env
# output-file          ~/.opam/log/ppx_import-20-7b1712.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.ppx_import.objs/byte -I /home/opam/.opam/5.2/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.2/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/ppx_derivers -I /home/opam/.opam/5.2/lib/ppxlib -I /home/opam/.opam/5.2/lib/ppxlib/ast -I /home/opam/.opam/5.2/lib/ppxlib/astlib -I /home/opam/.opam/5.2/lib/ppxlib/print_diff -I /home/opam/.opam/5.2/lib/ppxlib/stdppx -I /home/opam/.opam/5.2/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.2/lib/sexplib0 -I /home/opam/.opam/5.2/lib/stdlib-shims -no-alias-deps -open Ppx_import__ -o src/.ppx_import.objs/byte/ppx_import__Compat.cmo -c -impl src/compat.pp.ml)
# File "src/compat.ml", line 45, characters 4-17:
# 45 |   | Type_abstract -> Type_abstract
#          ^^^^^^^^^^^^^
# Error: The constructor "Type_abstract" expects 1 argument(s),
#        but is applied here to 0 argument(s)
```