### PR TITLE
stdlib-random is not compatible with OCaml 5.2

### DIFF
--- a/packages/stdlib-random/stdlib-random.1.0.0/opam
+++ b/packages/stdlib-random/stdlib-random.1.0.0/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/ocaml/stdlib-random/issues"
 depends: [
   "dune" {>= "2.7"}
   "cppo" {>= "1.1.0"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/stdlib-random/stdlib-random.1.1.0/opam
+++ b/packages/stdlib-random/stdlib-random.1.1.0/opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/ocaml/stdlib-random/issues"
 depends: [
   "dune" {>= "2.7"}
   "cppo" {>= "1.1.0"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Stdlib.Random changed signature.
Reported upstream in https://github.com/ocaml/stdlib-random/issues/3
```
#=== ERROR while compiling stdlib-random.1.1.0 ================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/stdlib-random.1.1.0
# command              ~/.opam/5.2/bin/dune build -p stdlib-random -j 1 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/stdlib-random-156-7f0e4a.env
# output-file          ~/.opam/log/stdlib-random-156-7f0e4a.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I tests/.consistency.eobjs/byte -I random3/.random3.objs/byte -I random4/.random4.objs/byte -I random5/.random5.objs/byte -I random5o/.random5o.objs/byte -no-alias-deps -o tests/.consistency.eobjs/byte/dune__exe__Consistency.cmo -c -impl tests/consistency.pp.ml)
# File "tests/consistency.ml", lines 29-31, characters 53-3:
# Error: Signature mismatch:
#        ...
#        ...
#        The second module type is not included in the first
#        ...
#        At position "module type t = <here>"
#        The value "int_in_range" is required but not provided
#        File "random.mli", line 80, characters 0-44: Expected declaration
#        The value "int32_in_range" is required but not provided
#        File "random.mli", line 102, characters 0-52: Expected declaration
#        The value "nativeint_in_range" is required but not provided
#        File "random.mli", line 119, characters 0-68: Expected declaration
#        The value "int64_in_range" is required but not provided
#        File "random.mli", line 136, characters 0-52: Expected declaration
```