### PR TITLE
earlybird is not compatible with OCaml 5.2 (uses compiler-libs)

### DIFF
--- a/packages/earlybird/earlybird.1.2.1/opam
+++ b/packages/earlybird/earlybird.1.2.1/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/hackwaly/ocamlearlybird"
 bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "5.2"}
   "ppx_deriving" {>= "5.1"}
   "ppx_deriving_yojson" {>= "3.6.1"}
   "menhir" {>= "20201216" & build}

--- a/packages/earlybird/earlybird.1.3.0/opam
+++ b/packages/earlybird/earlybird.1.3.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/hackwaly/ocamlearlybird"
 bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "5.2"}
   "ppx_deriving" {>= "5.1"}
   "ppx_deriving_yojson" {>= "3.6.1"}
   "menhir" {>= "20201216" & build}


### PR DESCRIPTION
Reported upstream in https://github.com/hackwaly/ocamlearlybird/issues/60
```
#=== ERROR while compiling earlybird.1.3.0 ====================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/earlybird.1.3.0
# command              ~/.opam/5.2/bin/dune build -p earlybird -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/earlybird-19-f89a06.env
# output-file          ~/.opam/log/earlybird-19-f89a06.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlopt.opt -w -40 -w -9 -g -I src/typenv/.typenv.objs/byte -I src/typenv/.typenv.objs/native -I /home/opam/.opam/5.2/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -intf-suffix .ml -no-alias-deps -o src/typenv/.typenv.objs/native/typenv.cmx -c -impl src/typenv/typenv.pp.ml)
# File "src/typenv/typenv.ml", lines 11-15, characters 46-5:
# 11 | ..............................................(fun ~unit_name ->
# 12 |       let search_dirs = !persistent_env_get_search_dirs unit_name in
# 13 |       load_path_init search_dirs;
# 14 |       old_load ~unit_name
# 15 |     )
# Error: This function should have type
#          "allow_hidden:bool ->
#          unit_name:string -> Persistent_env.Persistent_signature.t option"
#        but its first argument is labeled "~unit_name" instead of "~allow_hidden"
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I src/debugger/.debugger.objs/byte -I /home/opam/.opam/5.2/lib/bytes -I /home/opam/.opam/5.2/lib/iter -I /home/opam/.opam/5.2/lib/logs -I /home/opam/.opam/5.2/lib/lru -I /home/opam/.opam/5.2/lib/lwt -I /home/opam/.opam/5.2/lib/lwt/unix -I /home/opam/.opam/5.2/lib/lwt_react -I /home/opam/.opam/5.2/lib/menhirLib -I /home/opam/.opam/5.2/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/ocaml/str -I /home/opam/.opam/5.2/lib/ocaml/threads -I /home/opam/.opam/5.2/lib/ocaml/unix -I /home/opam/.opam/5.2/lib/ocplib-endian -I /home/opam/.opam/5.2/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.2/lib/path_glob -I /home/opam/.opam/5.2/lib/ppx_deriving/runtime -I /home/opam/.opam/5.2/lib/psq -I /home/opam/.opam/5.2/lib/react -I /home/opam/.opam/5.2/lib/result -I /home/opam/.opam/5.2/lib/seq -I src/global/.global.objs/byte -I src/ground/.ground.objs/byte -I src/trivia_check/.trivia_check.objs/byte -I src/typenv/.typenv.objs/byte -no-alias-deps -open Debugger__ -o src/debugger/.debugger.objs/byte/debugger__Eval.cmo -c -impl src/debugger/inspect/eval.pp.ml)
# File "src/debugger/inspect/eval.ml", line 17, characters 58-65:
# 17 |             let pos = Ident.find_same id event.ev_compenv.ce_heap in
#                                                                ^^^^^^^
# Error: This expression has type "Instruct.compilation_env"
#        There is no field "ce_heap" within type "Instruct.compilation_env"
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I src/debugger/.debugger.objs/byte -I /home/opam/.opam/5.2/lib/bytes -I /home/opam/.opam/5.2/lib/iter -I /home/opam/.opam/5.2/lib/logs -I /home/opam/.opam/5.2/lib/lru -I /home/opam/.opam/5.2/lib/lwt -I /home/opam/.opam/5.2/lib/lwt/unix -I /home/opam/.opam/5.2/lib/lwt_react -I /home/opam/.opam/5.2/lib/menhirLib -I /home/opam/.opam/5.2/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/ocaml/str -I /home/opam/.opam/5.2/lib/ocaml/threads -I /home/opam/.opam/5.2/lib/ocaml/unix -I /home/opam/.opam/5.2/lib/ocplib-endian -I /home/opam/.opam/5.2/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.2/lib/path_glob -I /home/opam/.opam/5.2/lib/ppx_deriving/runtime -I /home/opam/.opam/5.2/lib/psq -I /home/opam/.opam/5.2/lib/react -I /home/opam/.opam/5.2/lib/result -I /home/opam/.opam/5.2/lib/seq -I src/global/.global.objs/byte -I src/ground/.ground.objs/byte -I src/trivia_check/.trivia_check.objs/byte -I src/typenv/.typenv.objs/byte -no-alias-deps -open Debugger__ -o src/debugger/.debugger.objs/byte/debugger__Value_basic.cmo -c -impl src/debugger/inspect/value_basic.pp.ml)
# File "src/debugger/inspect/value_basic.ml", line 80, characters 21-34:
# 80 |          type_kind = Type_abstract;
#                           ^^^^^^^^^^^^^
# Error: The constructor "Type_abstract" expects 1 argument(s),
#        but is applied here to 0 argument(s)
```