### PR TITLE
[new release] linenoise (1.5)

### DIFF
--- a/packages/linenoise/linenoise.1.5/opam
+++ b/packages/linenoise/linenoise.1.5/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Lightweight readline alternative"
+maintainer: "Simon Cruanes"
+authors: [ "Edgar Aroutiounian <edgar.factorial@gmail.com>" "Simon Cruanes" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/ocaml-community/ocaml-linenoise"
+dev-repo: "git+https://github.com/ocaml-community/ocaml-linenoise.git"
+bug-reports: "https://github.com/ocaml-community/ocaml-linenoise/issues"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "ocaml" { >= "4.03.0" }
+  "odoc" {with-doc}
+]
+url {
+  src:
+    "https://github.com/ocaml-community/ocaml-linenoise/releases/download/v1.5/linenoise-1.5.tbz"
+  checksum: [
+    "sha256=3031940f6068c5701cc64b87855998cda129573f67a753fde567b520894c9d40"
+    "sha512=5ad7a0a5fb0401fa866549a773e44c12c66bf723a927ea729be6bb0732af7df5bb83a0784805aec165488588453ac10868c3c872904b70fcef61c54b4ca0e6cd"
+  ]
+}
+x-commit-hash: "eb123671399476a9c7e36981ef4facda9f32b1ed"


### PR DESCRIPTION
Lightweight readline alternative

- Project page: <a href="https://github.com/ocaml-community/ocaml-linenoise">https://github.com/ocaml-community/ocaml-linenoise</a>

##### CHANGES:

- release runtime lock when calling `lnoise`
- fix potential memleaks and use of deprecate parts of
    the OCaml C API
- remove dependency on `result`
