### PR TITLE
pixz is now in edge/community on alpine

### DIFF
--- a/packages/conf-pixz/conf-pixz.1/opam
+++ b/packages/conf-pixz/conf-pixz.1/opam
@@ -11,7 +11,7 @@ depexts: [
   # Doesn't seem to be available on fedora, centos, rhel and ol
   ["pixz"] {os-family = "suse" | os-family = "opensuse"}
   ["pixz"] {os-family = "arch"}
-  ["pixz@testing"] {os-family = "alpine"}
+  ["pixz@edgecommunity"] {os-family = "alpine"}
   ["pixz"] {os-family = "gentoo"}
   ["pixz"] {os = "macos" & os-distribution = "homebrew"}
   ["pixz"] {os = "macos" & os-distribution = "macports"}


### PR DESCRIPTION
and not in `edge/testing` anymore

https://pkgs.alpinelinux.org/package/edge/community/x86_64/pixz