### PR TITLE
[new release] multicore-bench (0.1.1)

### DIFF
--- a/packages/multicore-bench/multicore-bench.0.1.1/opam
+++ b/packages/multicore-bench/multicore-bench.0.1.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "Framework for writing multicore benchmark executables to run on current-bench"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-bench"
+bug-reports: "https://github.com/ocaml-multicore/multicore-bench/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.13.0"}
+  "domain-local-await" {>= "1.0.1"}
+  "multicore-magic" {>= "2.1.0"}
+  "mtime" {>= "2.0.0"}
+  "yojson" {>= "2.1.0"}
+  "domain_shims" {>= "0.1.0"}
+  "mdx" {>= "2.3.1" & with-test}
+  "odoc" {>= "2.2.0" & with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-bench.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-bench/releases/download/0.1.1/multicore-bench-0.1.1.tbz"
+  checksum: [
+    "sha256=218ac614a9d6b52cddf30d8306cb0d226fdc97b01f64098b79df12d40f07b08f"
+    "sha512=3e51c779ada112b2be967e8f0f1a39721e4460f93f916a227fd482a00ef5644c99f7cbaf7f7ac2c39397c5da54a98b85eeedb41610eb595a3dd04502b8dd1efb"
+  ]
+}
+x-commit-hash: "f55f88ff2df891459c698d2fb54ae8a99a1bf5e6"


### PR DESCRIPTION
Framework for writing multicore benchmark executables to run on current-bench

- Project page: <a href="https://github.com/ocaml-multicore/multicore-bench">https://github.com/ocaml-multicore/multicore-bench</a>

## 0.1.1

- Add debug flag/mode to print progress information (@polytypic)
- Fix to use same start time on all domains (@polytypic)
