### PR TITLE
[new release] eio (5 packages) (0.15)

### DIFF
--- a/packages/eio/eio.0.15/opam
+++ b/packages/eio/eio.0.15/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "5.1.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "hmap" {>= "0.8.1"}
+  "domain-local-await" {>= "0.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "2.0.0"}
+  "mdx" {>= "2.2.0" & with-test}
+  "dscheck" {>= "0.1.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "seq" {< "0.3"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.15/eio-0.15.tbz"
+  checksum: [
+    "sha256=807ecef337dda849b05d3dbd17a928e6f5c636e76eb15e2213667c91127718a7"
+    "sha512=8f055aec34c9347eed2cbaa4ee439399bbe3d6a546f2c2b52e27f733fe822f4acdee3e00e4e64ae3eb922c2772535952f8e81b546802fe945fd32d3fab88b7b9"
+  ]
+}
+x-commit-hash: "4f3ec08ef5d3ecee994daa291434d46ff3b9445d"

--- a/packages/eio_linux/eio_linux.0.15/opam
+++ b/packages/eio_linux/eio_linux.0.15/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An Eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "eio" {= version}
+  "mdx" {>= "2.2.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "0.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+available: [os = "linux"]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.15/eio-0.15.tbz"
+  checksum: [
+    "sha256=807ecef337dda849b05d3dbd17a928e6f5c636e76eb15e2213667c91127718a7"
+    "sha512=8f055aec34c9347eed2cbaa4ee439399bbe3d6a546f2c2b52e27f733fe822f4acdee3e00e4e64ae3eb922c2772535952f8e81b546802fe945fd32d3fab88b7b9"
+  ]
+}
+x-commit-hash: "4f3ec08ef5d3ecee994daa291434d46ff3b9445d"

--- a/packages/eio_main/eio_main.0.15/opam
+++ b/packages/eio_main/eio_main.0.15/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "mdx" {>= "2.2.0" & with-test}
+  "kcas" {>= "0.3.0" & with-test}
+  "yojson" {>= "2.0.2" & with-test}
+  "eio_linux"
+    {= version & os = "linux" &
+     (os-distribution != "centos" | os-version > "7")}
+  "eio_posix" {= version & os != "win32"}
+  "eio_windows" {= version & os = "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+x-ci-accept-failures: ["macos-homebrew"]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.15/eio-0.15.tbz"
+  checksum: [
+    "sha256=807ecef337dda849b05d3dbd17a928e6f5c636e76eb15e2213667c91127718a7"
+    "sha512=8f055aec34c9347eed2cbaa4ee439399bbe3d6a546f2c2b52e27f733fe822f4acdee3e00e4e64ae3eb922c2772535952f8e81b546802fe945fd32d3fab88b7b9"
+  ]
+}
+x-commit-hash: "4f3ec08ef5d3ecee994daa291434d46ff3b9445d"

--- a/packages/eio_posix/eio_posix.0.15/opam
+++ b/packages/eio_posix/eio_posix.0.15/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for POSIX systems"
+description: "An Eio implementation for most Unix-like platforms"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "iomux" {>= "0.2"}
+  "mdx" {>= "2.2.0" & with-test}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.15/eio-0.15.tbz"
+  checksum: [
+    "sha256=807ecef337dda849b05d3dbd17a928e6f5c636e76eb15e2213667c91127718a7"
+    "sha512=8f055aec34c9347eed2cbaa4ee439399bbe3d6a546f2c2b52e27f733fe822f4acdee3e00e4e64ae3eb922c2772535952f8e81b546802fe945fd32d3fab88b7b9"
+  ]
+}
+x-commit-hash: "4f3ec08ef5d3ecee994daa291434d46ff3b9445d"

--- a/packages/eio_windows/eio_windows.0.15/opam
+++ b/packages/eio_windows/eio_windows.0.15/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Windows"
+description: "An Eio implementation using OCaml's Unix.select"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "fmt" {>= "0.8.9"}
+  "kcas" {>= "0.3.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.15/eio-0.15.tbz"
+  checksum: [
+    "sha256=807ecef337dda849b05d3dbd17a928e6f5c636e76eb15e2213667c91127718a7"
+    "sha512=8f055aec34c9347eed2cbaa4ee439399bbe3d6a546f2c2b52e27f733fe822f4acdee3e00e4e64ae3eb922c2772535952f8e81b546802fe945fd32d3fab88b7b9"
+  ]
+}
+x-commit-hash: "4f3ec08ef5d3ecee994daa291434d46ff3b9445d"
+available: [os = "win32"]


### PR DESCRIPTION
Effect-based direct-style IO API for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/eio">https://github.com/ocaml-multicore/eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/eio/">https://ocaml-multicore.github.io/eio/</a>

##### CHANGES:

New features:

- eio_posix: use directory FDs instead of realpath (@talex5 ocaml-multicore/eio#694 ocaml-multicore/eio#696, reviewed by @SGrondin).
  Using realpath was an old hack from the libuv days and subject to races. It was also slow.

- Keep pool of systhreads for blocking operations (@SGrondin @talex5 ocaml-multicore/eio#681).
  This is much faster than creating a new thread for each operation.
  It mainly benefits the eio_posix backend, as that uses lots of systhreads.

- Make `Switch.on_release` thread-safe (@talex5 ocaml-multicore/eio#684, requested by @art-w and @clecat).
  This allows resource pools to be shared between domains easily.

- Add `Eio.Path.read_link` (@talex5 ocaml-multicore/eio#686).

- Add `Eio_unix.Fd.is_open` (@talex5 ocaml-multicore/eio#690).

- Include backtrace in systhread errors (@talex5 ocaml-multicore/eio#688, reviewed by @SGrondin).
  Also, add `Eio.Exn.empty_backtrace` as a convenience.

- eio.mock: add tracing support to mock backend (@talex5 ocaml-multicore/eio#687).

- Improve tracing (@talex5 ocaml-multicore/eio#675 ocaml-multicore/eio#683 ocaml-multicore/eio#676, reviewed by @SGrondin).
  Update tracing section of README and trace more things
  (`run_in_systhread`, `close`, `submit`, `traceln`, cancellation and domain spawning).

Documentation:

- Link to verification work in docs (@talex5 ocaml-multicore/eio#682).

- Add more trace diagrams to README (@talex5 ocaml-multicore/eio#698).

- Adjust COC contacts (@polytypic ocaml-multicore/eio#685, reviewed by @Sudha247).

Bug fixes:

- eio_linux: retry `openat2` on `EAGAIN` (@talex5 ocaml-multicore/eio#693, reviewed by @SGrondin).

- eio_posix and eio_windows: check for IO periodically (@talex5 ocaml-multicore/eio#674).

- Handle EPERM when trying to initialise uring (@talex5 ocaml-multicore/eio#691).
  This can happen when using a Docker container.

Build and tests:

- Benchmark `Eio_unix.run_in_systhread` (@talex5 ocaml-multicore/eio#678, reviewed by @SGrondin).

- Enable lintcstubs for `Eio_unix.Private` too (@talex5 ocaml-multicore/eio#689).

- Stat benchmark: report cleanup time and optimise (@talex5 ocaml-multicore/eio#692).

- Make benchmarks start faster (@talex5 ocaml-multicore/eio#673).

- Update build for new eio-trace CLI (@talex5 ocaml-multicore/eio#699).

- Expect opam-repo-ci tests to fail on macos (@talex5 ocaml-multicore/eio#672).
