### PR TITLE
reason is not compatible with OCaml 5.2 (uses compiler-libs)

### DIFF
--- a/packages/reason/reason.3.10.0/opam
+++ b/packages/reason/reason.3.10.0/opam
@@ -14,7 +14,7 @@ homepage: "https://reasonml.github.io/"
 bug-reports: "https://github.com/reasonml/reason/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.2"}
   "ocamlfind" {build}
   "dune-build-info" {>= "2.9.3"}
   "menhir" {>= "20180523"}


### PR DESCRIPTION
Fixed upstream in https://github.com/reasonml/reason/pull/2734
```
#=== ERROR while compiling reason.3.10.0 ======================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/reason.3.10.0
# command              ~/.opam/5.2/bin/dune build -p reason -j 1 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/reason-20-76ac0a.env
# output-file          ~/.opam/log/reason-20-76ac0a.out
### output ###
# File "src/vendored-omp/src/dune", line 34, characters 0-118:
# 34 | (rule
# 35 |  (targets ast-version compiler-functions-file)
# 36 |  (action
# 37 |   (run %{ocaml} %{dep:config/gen.ml} %{ocaml_version})))
# (cd _build/default/src/vendored-omp/src && /home/opam/.opam/5.2/bin/ocaml config/gen.ml 5.2.0+dev4-2024-02-05)
# Unknown OCaml version 5.2.0+dev4-2024-02-05
```