### PR TITLE
ocamlformat-lib is not compatible with OCaml 5.2 (uses compiler-libs)

### DIFF
--- a/packages/ocamlformat-lib/ocamlformat-lib.0.25.1/opam
+++ b/packages/ocamlformat-lib/ocamlformat-lib.0.25.1/opam
@@ -7,7 +7,7 @@ authors: ["Josh Berdine <jjb@fb.com>"]
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.2"}
   "alcotest" {with-test & >= "1.3.0"}
   "base" {>= "v0.12.0"}
   "dune" {>= "2.8"}

--- a/packages/ocamlformat-lib/ocamlformat-lib.0.26.0/opam
+++ b/packages/ocamlformat-lib/ocamlformat-lib.0.26.0/opam
@@ -7,7 +7,7 @@ authors: ["Josh Berdine <jjb@fb.com>"]
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.2"}
   "alcotest" {with-test & >= "1.3.0"}
   "base" {>= "v0.12.0"}
   "dune" {>= "2.8"}

--- a/packages/ocamlformat-lib/ocamlformat-lib.0.26.1/opam
+++ b/packages/ocamlformat-lib/ocamlformat-lib.0.26.1/opam
@@ -17,7 +17,7 @@ authors: [
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.2"}
   "alcotest" {with-test & >= "1.3.0"}
   "base" {>= "v0.12.0"}
   "dune" {>= "2.8"}


### PR DESCRIPTION
Reported upstream in https://github.com/ocaml-ppx/ocamlformat/issues/2524
```
#=== ERROR while compiling ocamlformat-lib.0.26.1 =============================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/ocamlformat-lib.0.26.1
# command              ~/.opam/5.2/bin/dune build -p ocamlformat-lib -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/ocamlformat-lib-20-b94c97.env
# output-file          ~/.opam/log/ocamlformat-lib-20-b94c97.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -noassert -g -bin-annot -I vendor/parser-shims/.parser_shims.objs/byte -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -no-alias-deps -o vendor/parser-shims/.parser_shims.objs/byte/parser_shims.cmi -c -intf vendor/parser-shims/parser_shims.mli)
# File "vendor/parser-shims/parser_shims.mli", line 21, characters 9-14:
# 21 |   module Color : sig
#               ^^^^^
# Error: Illegal shadowing of included module "Color/2" by "Color".
# File "vendor/parser-shims/parser_shims.mli", line 19, characters 2-29:
# 19 |   include module type of Misc
#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
#   Module "Color/2" came from this include.
# File "utils/misc.mli", lines 473-522, characters 0-3:
#   The module "Style" has no valid type if "Color/2" is shadowed.
```