### PR TITLE
melange is not compatible with OCaml 5.2 (uses compiler-libs)

### DIFF
--- a/packages/melange/melange.2.2.0/opam
+++ b/packages/melange/melange.2.2.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/melange-re/melange"
 bug-reports: "https://github.com/melange-re/melange/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "5.1.1"}
+  "ocaml" {>= "5.1.1" & < "5.2"}
   "cmdliner" {>= "1.1.0"}
   "dune-build-info"
   "cppo" {build}

--- a/packages/melange/melange.3.0.0-51/opam
+++ b/packages/melange/melange.3.0.0-51/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/melange-re/melange"
 bug-reports: "https://github.com/melange-re/melange/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "5.1"}
+  "ocaml" {>= "5.1" & < "5.2"}
   "cmdliner" {>= "1.1.0"}
   "dune-build-info"
   "cppo" {build}


### PR DESCRIPTION
Reported upstream in https://github.com/melange-re/melange/issues/1071
```
#=== ERROR while compiling melange.3.0.0-51 ===================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/melange.3.0.0-51
# command              ~/.opam/5.2/bin/dune build -p melange -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/melange-20-0841f9.env
# output-file          ~/.opam/log/melange-20-0841f9.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -9 -g -bin-annot -I vendor/melange-compiler-libs/lib/.melange_compiler_libs.objs/byte -I /home/opam/.opam/5.2/lib/menhirLib -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I vendor/melange-compiler-libs/wrapper/.melange_wrapper.objs/byte -no-alias-deps -open Melange_compiler_libs__ -o vendor/melange-compiler-libs/lib/.melange_compiler_libs.objs/byte/melange_compiler_libs__Misc.cmi -c -intf vendor/melange-compiler-libs/lib/misc.mli)
# File "vendor/melange-compiler-libs/utils/misc.mli", line 469, characters 15-47:
# Error: Unbound type constructor "Melange_wrapper.Misc.Color.color"
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -w -69 -g -bin-annot -I jscomp/js_parser/.js_parser.objs/byte -no-alias-deps -open Js_parser -o jscomp/js_parser/.js_parser.objs/byte/js_parser__Flow_ast_mapper.cmo -c -impl jscomp/js_parser/flow_ast_mapper.ml)
# File "jscomp/js_parser/flow_ast_mapper.ml", line 1906, characters 7-12:
# 1906 |     [@@alert deprecated "Use either function_expression or class_method"]
#               ^^^^^
# Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlopt.opt -w -40 -w -69 -g -O3 -unbox-closures -I jscomp/js_parser/.js_parser.objs/byte -I jscomp/js_parser/.js_parser.objs/native -intf-suffix .ml -no-alias-deps -open Js_parser -o jscomp/js_parser/.js_parser.objs/native/js_parser__Flow_ast_mapper.cmx -c -impl jscomp/js_parser/flow_ast_mapper.ml)
# File "jscomp/js_parser/flow_ast_mapper.ml", line 1906, characters 7-12:
# 1906 |     [@@alert deprecated "Use either function_expression or class_method"]
#               ^^^^^
# Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
# (cd _build/.sandbox/18ba18a7722dac8844b705e4c060f6d2/default && /home/opam/.opam/5.2/bin/menhir --lalr --explain --dump --require-aliases --strict --table -lg 1 -la 1 --unused-token COMMENT --unused-token DOCSTRING --unused-token EOL --unused-token GREATERRBRACKET --fixed-exception vendor/melange-compiler-libs/lib/parser.mly --base vendor/melange-compiler-libs/lib/parser --infer-read-reply vendor/melange-compiler-libs/lib/parser__mock.mli.inferred)
# Grammar has 208 nonterminal symbols, among which 15 start symbols.
# Grammar has 123 terminal symbols.
# Grammar has 859 productions.
# Built an LR(0) automaton with 1875 states.
# The grammar is not SLR(1) -- 140 states have a conflict.
# The construction mode is lalr.
# Built an LR(1) automaton with 1875 states.
# 1069 shift/reduce conflicts were silently solved.
```