### PR TITLE
memprof-limits is not compatible with OCaml 5.2 (changes in Stdlib.Gc)

### DIFF
--- a/packages/memprof-limits/memprof-limits.0.2.0/opam
+++ b/packages/memprof-limits/memprof-limits.0.2.0/opam
@@ -33,7 +33,7 @@ homepage: "https://gitlab.com/gadmm/memprof-limits/"
 doc: "https://guillaume.munch.name/software/ocaml/memprof-limits/"
 bug-reports: "https://gitlab.com/gadmm/memprof-limits/issues/"
 depends: [
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "5.2"}
   "dune" {>= "1.2"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/memprof-limits/memprof-limits.0.2.0/opam
+++ b/packages/memprof-limits/memprof-limits.0.2.0/opam
@@ -33,7 +33,7 @@ homepage: "https://gitlab.com/gadmm/memprof-limits/"
 doc: "https://guillaume.munch.name/software/ocaml/memprof-limits/"
 bug-reports: "https://gitlab.com/gadmm/memprof-limits/issues/"
 depends: [
-  "ocaml" {>= "4.12.0" & < "5.2"}
+  "ocaml" {>= "4.12.0" & < "5.0"}
   "dune" {>= "1.2"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Reported upstream in https://gitlab.com/gadmm/memprof-limits/-/issues/2
```
#=== ERROR while compiling memprof-limits.0.2.0 ===============================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/memprof-limits.0.2.0
# command              ~/.opam/5.2/bin/dune build -p memprof-limits -j 1
# exit-code            1
# env-file             ~/.opam/log/memprof-limits-20-024667.env
# output-file          ~/.opam/log/memprof-limits-20-024667.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.memprof_limits.objs/byte -I src/.memprof_limits.objs/public_cmi -I /home/opam/.opam/5.2/lib/ocaml/threads -I /home/opam/.opam/5.2/lib/ocaml/unix -intf-suffix .ml -no-alias-deps -open Memprof_limits__ -o src/.memprof_limits.objs/byte/memprof_limits__Memprof.cmo -c -impl src/memprof.ml)
# File "src/memprof.ml", line 1:
# Error: The implementation "src/memprof.ml"
#        does not match the interface "src/memprof.ml": 
#        Values do not match:
#          val start :
#            sampling_rate:float ->
#            ?callstack_size:int -> ('a, 'b) Gc.Memprof.tracker -> unit
#        is not included in
#          val start :
#            sampling_rate:float ->
#            ?callstack_size:int -> ('minor, 'major) tracker -> t
#        The type
#          "sampling_rate:float ->
#          ?callstack_size:int -> ('a, 'b) Gc.Memprof.tracker -> unit"
#        is not compatible with the type
#          "sampling_rate:float -> ?callstack_size:int -> ('a, 'b) tracker -> t"
#        Type "unit" is not compatible with type "t" = "Gc.Memprof.t"
#        File "gc.mli", lines 498-502, characters 4-7: Expected declaration
#        File "src/memprof.ml", line 2, characters 4-9: Actual declaration
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.memprof_limits.objs/byte -I src/.memprof_limits.objs/public_cmi -I /home/opam/.opam/5.2/lib/ocaml/threads -I /home/opam/.opam/5.2/lib/ocaml/unix -intf-suffix .ml -no-alias-deps -open Memprof_limits__ -o src/.memprof_limits.objs/byte/memprof_limits__Memprof_server.cmo -c -impl src/memprof_server.ml)
# File "src/memprof_server.ml", line 58, characters 25-49:
# 58 |   if not !started_1 then start_for_limits_only () ;
#                               ^^^^^^^^^^^^^^^^^^^^^^^^
# Error: This expression has type "Gc.Memprof.t"
#        but an expression was expected of type "unit"
#        because it is in the result of a conditional with no else branch
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlopt.opt -w -40 -g -I src/.memprof_limits.objs/byte -I src/.memprof_limits.objs/native -I src/.memprof_limits.objs/public_cmi -I /home/opam/.opam/5.2/lib/ocaml/threads -I /home/opam/.opam/5.2/lib/ocaml/unix -intf-suffix .ml -no-alias-deps -open Memprof_limits__ -o src/.memprof_limits.objs/native/memprof_limits__Memprof_server.cmx -c -impl src/memprof_server.ml)
# File "src/memprof_server.ml", line 58, characters 25-49:
# 58 |   if not !started_1 then start_for_limits_only () ;
#                               ^^^^^^^^^^^^^^^^^^^^^^^^
# Error: This expression has type "Gc.Memprof.t"
#        but an expression was expected of type "unit"
#        because it is in the result of a conditional with no else branch
```