### PR TITLE
[new release] printbox (4 packages) (0.10)

### DIFF
--- a/packages/printbox-html/printbox-html.0.10/opam
+++ b/packages/printbox-html/printbox-html.0.10/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Printbox unicode handling"
+description: """
+
+Adds html output handling to the printbox package.
+Printbox allows to print nested boxes, lists, arrays, tables in several formats"""
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "printbox" {= version}
+  "printbox-text" {= version & with-test}
+  "odoc" {with-test}
+  "tyxml" {>= "4.3"}
+  "mdx" {>= "1.4" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.10/printbox-0.10.tbz"
+  checksum: [
+    "sha256=c644dfb01edbdcb48cb46696e178d587a4c6cce168f5c5d4d13a845cbec42203"
+    "sha512=8daa5123e161226d00732fe81396c87539c5b7787e0fbf354f1014557604c46ffa8307f158243a31b26b2da2c26337b29f69bc7e3fd1f3ca7169ce355def0f79"
+  ]
+}
+x-commit-hash: "31d83514a2279dc6b872106a9615722003d76494"

--- a/packages/printbox-md/printbox-md.0.10/opam
+++ b/packages/printbox-md/printbox-md.0.10/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Printbox Markdown rendering"
+description: """
+
+Adds Markdown output handling to the printbox package, with fallback to text and simplified HTML.
+Printbox allows to print nested boxes, lists, arrays, tables in several formats"""
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "printbox" {= version}
+  "printbox-text" {= version}
+  "printbox-html" {= version}
+  "odoc" {with-test}
+  "mdx" {>= "1.4" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.10/printbox-0.10.tbz"
+  checksum: [
+    "sha256=c644dfb01edbdcb48cb46696e178d587a4c6cce168f5c5d4d13a845cbec42203"
+    "sha512=8daa5123e161226d00732fe81396c87539c5b7787e0fbf354f1014557604c46ffa8307f158243a31b26b2da2c26337b29f69bc7e3fd1f3ca7169ce355def0f79"
+  ]
+}
+x-commit-hash: "31d83514a2279dc6b872106a9615722003d76494"

--- a/packages/printbox-text/printbox-text.0.10/opam
+++ b/packages/printbox-text/printbox-text.0.10/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Text renderer for printbox, using unicode edges"
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "printbox" {= version}
+  "uutf" {>= "1.0"}
+  "uucp" {>= "2.0"}
+  "odoc" {with-test}
+  "mdx" {>= "1.4" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.10/printbox-0.10.tbz"
+  checksum: [
+    "sha256=c644dfb01edbdcb48cb46696e178d587a4c6cce168f5c5d4d13a845cbec42203"
+    "sha512=8daa5123e161226d00732fe81396c87539c5b7787e0fbf354f1014557604c46ffa8307f158243a31b26b2da2c26337b29f69bc7e3fd1f3ca7169ce355def0f79"
+  ]
+}
+x-commit-hash: "31d83514a2279dc6b872106a9615722003d76494"

--- a/packages/printbox/printbox.0.10/opam
+++ b/packages/printbox/printbox.0.10/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Allows to print nested boxes, lists, arrays, tables in several formats"
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+tags: ["print" "box" "table" "tree"]
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.10/printbox-0.10.tbz"
+  checksum: [
+    "sha256=c644dfb01edbdcb48cb46696e178d587a4c6cce168f5c5d4d13a845cbec42203"
+    "sha512=8daa5123e161226d00732fe81396c87539c5b7787e0fbf354f1014557604c46ffa8307f158243a31b26b2da2c26337b29f69bc7e3fd1f3ca7169ce355def0f79"
+  ]
+}
+x-commit-hash: "31d83514a2279dc6b872106a9615722003d76494"


### PR DESCRIPTION
Allows to print nested boxes, lists, arrays, tables in several formats

- Project page: <a href="https://github.com/c-cube/printbox">https://github.com/c-cube/printbox</a>

##### CHANGES:

## 0.10

- Fixes c-cube/printbox#10: ANSI encoded hyperlinks for printbox-text
- Fixes c-cube/printbox#39: more compact markdown output Remove double empty lines after `</details>`.
- More compact html output: no empty class annotations
- Provide context for the `line` exception
