### PR TITLE
pecu.0.6: Disable the tests on OCaml 5.2

### DIFF
--- a/packages/pecu/pecu.0.6/opam
+++ b/packages/pecu/pecu.0.6/opam
@@ -17,6 +17,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune" {>= "1.4"}
   "fmt" {with-test}
   "alcotest" {with-test}


### PR DESCRIPTION
`\r\n` are now parsed differently.
Fix sent upstream in https://github.com/mirage/pecu/pull/14
```
#=== ERROR while compiling pecu.0.6 ===========================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/pecu.0.6
# command              ~/.opam/5.2/bin/dune runtest -p pecu -j 1
# exit-code            1
# env-file             ~/.opam/log/pecu-40-503db8.env
# output-file          ~/.opam/log/pecu-40-503db8.out
### output ###
# File "test/dune", line 5, characters 0-129:
# 5 | (alias
# 6 |  (name runtest)
# 7 |  (package pecu)
# 8 |  (deps (:test test.exe) (glob_files "contents/*"))
# 9 |  (action (run %{test} --color=always)))
# (cd _build/default/test && ./test.exe --color=always)
# Testing `pecu'.
# This run has ID `QBBAEDI8'.
# 
#   [OK]          input fuzz          0   contents/id:000000,src:000000,op:havo...
#   [OK]          input fuzz          1   contents/id:000000,src:000050,op:havo...
#   [OK]          input fuzz          2   contents/id:000001,src:000023,op:havo...
#   [OK]          input fuzz          3   contents/id:000001,src:000026+000032,...
#   [OK]          input fuzz          4   contents/id:000002,src:000023,op:havo...
#   [OK]          input fuzz          5   contents/id:000002,src:000063,op:int1...
#   [OK]          input fuzz          6   contents/id:000003,src:000024+000025,...
#   [OK]          input fuzz          7   contents/id:000003,src:000055,op:havo...
#   [OK]          input fuzz          8   contents/id:000004,src:000037+000000,...
# > [FAIL]        simple              0   simple example.
#   [OK]          simple              1   split at cr.
#   [OK]          rfc2047             0   rfc2047:0.
#   [OK]          rfc2047             1   rfc2047:1.
#   [OK]          rfc2047             2   rfc2047:2.
#   [OK]          rfc2047             3   rfc2047:3.
#   [OK]          rfc2047             4   rfc2047:4.
#   [OK]          rfc2047             5   rfc2047:5.
#   [OK]          rfc2047             6   rfc2047:6.
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        simple              0   simple example.                        │
# └──────────────────────────────────────────────────────────────────────────────┘
# ASSERT =
#  
# FAIL =
#  
# Raised at Alcotest_engine__Test.check_err in file "src/alcotest-engine/test.ml", line 157, characters 20-48
# Called from Test.simple.(fun) in file "test/test.ml", line 189, characters 15-49
# Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 181, characters 17-23
# Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
# 
# Logs saved to `~/.opam/5.2/.opam-switch/build/pecu.0.6/_build/default/test/_build/_tests/pecu/simple.000.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/pecu.0.6/_build/default/test/_build/_tests/pecu'.
# 1 failure! in 0.002s. 18 tests run.
```