### PR TITLE
unstrctrd: Disable the tests on OCaml 5.2

### DIFF
--- a/packages/unstrctrd/unstrctrd.0.1/opam
+++ b/packages/unstrctrd/unstrctrd.0.1/opam
@@ -15,6 +15,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"       {>= "4.07.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune"        {>= "1.10"}
   "uutf"
   "fmt"

--- a/packages/unstrctrd/unstrctrd.0.2/opam
+++ b/packages/unstrctrd/unstrctrd.0.2/opam
@@ -15,6 +15,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"       {>= "4.07.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune"        {>= "1.10"}
   "uutf"
   "angstrom"    {>= "0.14.0"}

--- a/packages/unstrctrd/unstrctrd.0.3/opam
+++ b/packages/unstrctrd/unstrctrd.0.3/opam
@@ -9,6 +9,7 @@ doc: "https://dinosaure.github.io/unstrctrd/"
 bug-reports: "https://github.com/dinosaure/unstrctrd/issues"
 depends: [
   "ocaml" {>= "4.07.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune" {>= "2.0"}
   "uutf"
   "angstrom" {>= "0.14.0"}


### PR DESCRIPTION
`\r\n` are now parsed differently
Fix sent upstream in https://github.com/dinosaure/unstrctrd/pull/17
```
#=== ERROR while compiling unstrctrd.0.2 ======================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/unstrctrd.0.2
# command              ~/.opam/5.2/bin/dune runtest -p unstrctrd -j 1
# exit-code            1
# env-file             ~/.opam/log/unstrctrd-1192-228c5b.env
# output-file          ~/.opam/log/unstrctrd-1192-228c5b.out
### output ###
# File "test/dune", line 11, characters 0-87:
# 11 | (alias
# 12 |  (name runtest)
# 13 |  (deps (:test test.exe))
# 14 |  (action (run %{test} --color=always)))
# (cd _build/default/test && ./test.exe --color=always)
# Testing `unstrctrd'.
# This run has ID `TJ3QZPTD'.
# 
#   [OK]          valid             0   "Hello".
#   [OK]          valid             1   "Hello\r\n World".
#   [OK]          valid             2   "Hello\r\n \r\n \r\n World".
#   [OK]          valid             3   " \r\n ".
#   [OK]          valid             4   "".
#   [OK]          valid             5   " ".
#   [OK]          valid             6   " \r\n ".
#   [OK]          valid             7   "Hello".
#   [OK]          valid             8   "".
#   [OK]          valid             9   "\r".
#   [OK]          valid            10   "\r\r".
#   [OK]          valid            11   "\r\n \r".
#   [OK]          valid            12   "\n".
#   [OK]          valid            13   "\n\n".
#   [OK]          valid            14   "\n\n\r\n ".
#   [OK]          valid            15   "\n\r\n Hello\r\n World\r\n !".
#   [OK]          comments          0   "Hello".
#   [OK]          comments          1   "Hello World!".
#   [OK]          comments          2   "".
#   [OK]          comments          3   "Hello".
#   [OK]          comments          4   "(Hello)".
#   [OK]          comments          5   "Hello".
# > [FAIL]        complex           0   "To:A Group :Chris Jones <c@public.exam...
#   [FAIL]        complex           1   "To    : Mary Smith  <mary@example.net>".
#   [FAIL]        complex           2   "Date: Thu, 13 Feb 1969 23:32 -0330 ".
#   [OK]          split_at          0   ("", "").
#   [OK]          split_at          1   ("", "Hello").
#   [OK]          split_at          2   ("Hello", "\r\n World!").
#   [OK]          split_on          0   "\r\n".
#   [OK]          split_on          1   "Hello\r\n".
#   [OK]          split_on          2   "Hello\r\n World!\r\n".
#   [OK]          split_on          3   "Hello World!\r\n".
#   [OK]          invalid           0   "Hello".
#   [OK]          invalid           1   "Hello\r".
#   [OK]          invalid           2   "Hello\n".
#   [OK]          invalid           3   "Hello\r\n ".
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        complex           0   "To:A Group :Chris Jones <c@public.e...  │
# └──────────────────────────────────────────────────────────────────────────────┘
# ASSERT expect
# FAIL expect
# 
#    Expected: `Error Non-terminating unstructured form'
#    Received: `Ok
#                 "To:A Group :Chris Jones <c@public.example>, joe@example.org, John <jdoe@one.test> ; "'
# 
# Raised at Alcotest_engine__Test.check in file "src/alcotest-engine/test.ml", lines 196-206, characters 4-19
# Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 180, characters 17-23
# Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
# 
# Logs saved to `~/.opam/5.2/.opam-switch/build/unstrctrd.0.2/_build/default/test/_build/_tests/unstrctrd/complex.000.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/unstrctrd.0.2/_build/default/test/_build/_tests/unstrctrd'.
# 3 failures! in 0.007s. 36 tests run.
# File "test/dune", line 16, characters 0-96:
# 16 | (alias
# 17 |  (name runtest)
# 18 |  (deps (:test test_angstrom.exe))
# 19 |  (action (run %{test} --color=always)))
# (cd _build/default/test && ./test_angstrom.exe --color=always)
# Testing `unstrctrd + angstrom'.
# This run has ID `4SN0DRL3'.
# 
#   [OK]          valid            0   ["Hello World!\r\n"].
#   [OK]          valid            1   ["\r\r\n"].
#   [OK]          valid            2   ["\r\r\r\n"].
#   [OK]          valid            3   ["\r\n \r\r\n"].
#   [OK]          valid            4   ["\n\r\n"].
#   [OK]          valid            5   ["\n\n\r\n \r\n"].
#   [OK]          valid            6   ["Hello World!\r\nSubject"].
#   [OK]          valid            7   ["Hello"; " "; "World!\r\n"].
#   [OK]          valid            8   ["Hello"; ""; ""; ""; ""; ""; "\r\n"; "S...
#   [OK]          valid            9   ["Hello"; "\r\n "; ""; "World!"; "\r\n"].
#   [OK]          valid           10   ["Hello"; "\r\n"; " "; "\r\n"; ""; " "; ...
#   [OK]          valid           11   ["Hello"; "\r"; "\n"; "Subject"].
#   [OK]          valid           12   ["Hello"; "\r"; "\n"; "\r"; "\n"].
# > [FAIL]        valid           13   "From: John Doe <jdoe@machine.example>\n...
#   [FAIL]        valid           14   "From: John Doe <jdoe@machine.example>\n...
#   [OK]          valid           15   header.
#   [OK]          invalid          0   ["Hello"].
#   [OK]          invalid          1   ["Hello\r"].
#   [OK]          invalid          2   ["Hello\r\n "].
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        valid           13   "From: John Doe <jdoe@machine.example...  │
# └──────────────────────────────────────────────────────────────────────────────┘
# >>> Start to recognize value of "From"
# ASSERT : Non-terminating unstructured form
# FAIL : Non-terminating unstructured form
# Raised at Alcotest_engine__Test.check_err in file "src/alcotest-engine/test.ml", line 157, characters 20-48
# Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 180, characters 17-23
# Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
# 
# Logs saved to `~/.opam/5.2/.opam-switch/build/unstrctrd.0.2/_build/default/test/_build/_tests/unstrctrd U+002B angstrom/valid.013.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/unstrctrd.0.2/_build/default/test/_build/_tests/unstrctrd U+002B angstrom'.
# 2 failures! in 0.005s. 19 tests run.
```