### PR TITLE
mrmime: Disable the tests on OCaml 5.2

### DIFF
--- a/packages/mrmime/mrmime.0.2.0/opam
+++ b/packages/mrmime/mrmime.0.2.0/opam
@@ -16,6 +16,7 @@ build: [
 
 depends: [
   "ocaml"           {>= "4.07.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune"            {>= "1.2"}
   "rresult"
   "fmt"

--- a/packages/mrmime/mrmime.0.3.0/opam
+++ b/packages/mrmime/mrmime.0.3.0/opam
@@ -16,6 +16,7 @@ build: [
 
 depends: [
   "ocaml"            {>= "4.07.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune"             {>= "1.2"}
   "rresult"
   "fmt"

--- a/packages/mrmime/mrmime.0.3.1/opam
+++ b/packages/mrmime/mrmime.0.3.1/opam
@@ -16,6 +16,7 @@ build: [
 
 depends: [
   "ocaml"            {>= "4.07.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune"             {>= "1.2"}
   "rresult"
   "fmt"

--- a/packages/mrmime/mrmime.0.3.2/opam
+++ b/packages/mrmime/mrmime.0.3.2/opam
@@ -16,6 +16,7 @@ build: [
 
 depends: [
   "ocaml"            {>= "4.07.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune"             {>= "1.2"}
   "rresult"
   "fmt"

--- a/packages/mrmime/mrmime.0.4.0/opam
+++ b/packages/mrmime/mrmime.0.4.0/opam
@@ -11,11 +11,12 @@ description:  """Parser and generator of mail in OCaml"""
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "5.0"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
   "ocaml"            {>= "4.08.0"}
+  "ocaml" {with-test & < "5.0"}
   "dune"             {>= "2.7"}
   "rresult"
   "fmt"

--- a/packages/mrmime/mrmime.0.5.0/opam
+++ b/packages/mrmime/mrmime.0.5.0/opam
@@ -11,11 +11,12 @@ description:  """Parser and generator of mail in OCaml"""
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "5.0"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
   "ocaml"            {>= "4.08.0"}
+  "ocaml" {with-test & < "5.0"}
   "dune"             {>= "2.7"}
   "rresult"
   "fmt"              {>= "0.8.7"}

--- a/packages/mrmime/mrmime.0.6.0/opam
+++ b/packages/mrmime/mrmime.0.6.0/opam
@@ -16,6 +16,7 @@ build: [
 
 depends: [
   "ocaml"             {>= "4.08.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune"              {>= "2.7"}
   "ke"                {>= "0.4"}
   "unstrctrd"         {>= "0.3"}


### PR DESCRIPTION
`\r\n` are now parsed differently
Fix sent upstream in https://github.com/mirage/mrmime/pull/99
```
#=== ERROR while compiling mrmime.0.6.0 =======================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/mrmime.0.6.0
# command              ~/.opam/5.2/bin/dune runtest -p mrmime -j 1
# exit-code            1
# env-file             ~/.opam/log/mrmime-1652-3fef57.env
# output-file          ~/.opam/log/mrmime-1652-3fef57.out
### output ###
# File "test/dune", line 68, characters 0-100:
# 68 | (rule
# 69 |  (alias runtest)
# 70 |  (deps
# 71 |   (:rfc5322 rfc5322.exe))
# 72 |  (action
# 73 |   (run %{rfc5322} --color=always)))
# (cd _build/default/test && ./rfc5322.exe --color=always)
# Testing `rfc5322'.
# This run has ID `6QJ5XZ4S'.
# 
#   [OK]          header          0   header 0.
#   [OK]          header          1   header 1.
#   [OK]          header          2   header 2.
#   [OK]          header          3   header 3.
#   [OK]          header          4   header 4.
#   [OK]          header          5   header 5.
#   [OK]          header          6   header 6.
#   [OK]          header          7   header 7.
#   [OK]          header          8   header 8.
#   [OK]          header          9   header 9.
#   [OK]          header         10   header 10.
#   [OK]          header         11   header 11.
#   [OK]          header         12   header 12.
#   [OK]          header         13   header 13.
#   [OK]          header         14   header 14.
#   [OK]          header         15   header 15.
#   [OK]          header         16   header 16.
# > [FAIL]        header         17   header - content-type.
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        header         17   header - content-type.                     │
# └──────────────────────────────────────────────────────────────────────────────┘
# [failure] Invalid header
#           Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
#           Called from Fmt.failwith in file "src/fmt.ml" (inlined), line 25, characters 19-36
#           Called from Dune__exe__Rfc5322.parse_content_type in file "test/rfc5322.ml", line 197, characters 11-40
#           Called from Dune__exe__Rfc5322.content_type_test.(fun) in file "test/rfc5322.ml", line 223, characters 29-57
#           Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 181, characters 17-23
#           Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
#           
# Logs saved to `~/.opam/5.2/.opam-switch/build/mrmime.0.6.0/_build/default/test/_build/_tests/rfc5322/header.017.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/mrmime.0.6.0/_build/default/test/_build/_tests/rfc5322'.
# 1 failure! in 0.003s. 18 tests run.
# File "test/dune", line 89, characters 0-96:
# 89 | (rule
# 90 |  (alias runtest)
# 91 |  (deps
# 92 |   (:mail test_mail.exe))
# 93 |  (action
# 94 |   (run %{mail} --color=always)))
# (cd _build/default/test && ./test_mail.exe --color=always)
# Testing `mail'.
# This run has ID `URG21E1Q'.
# 
#   [OK]          example          0   example 0.
#   [OK]          example          1   example 1.
#   [OK]          example          2   large subject.
# > [FAIL]        example          3   quoted-printable contents.
#   [FAIL]        example          4   7-bit contents.
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        example          3   quoted-printable contents.                │
# └──────────────────────────────────────────────────────────────────────────────┘
# [invalid] Invalid email
#           Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
#           Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 181, characters 17-23
#           Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
#           
# Logs saved to `~/.opam/5.2/.opam-switch/build/mrmime.0.6.0/_build/default/test/_build/_tests/mail/example.003.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/mrmime.0.6.0/_build/default/test/_build/_tests/mail'.
# 2 failures! in 0.013s. 5 tests run.
# File "test/dune", line 96, characters 0-90:
#  96 | (rule
#  97 |  (alias runtest)
#  98 |  (deps
#  99 |   (:hd test_hd.exe))
# 100 |  (action
# 101 |   (run %{hd} --color=always)))
# (cd _build/default/test && ./test_hd.exe --color=always)
# Testing `hd'.
# This run has ID `06K4TXUA'.
# 
# > [FAIL]        header          0   header-000.
#   [FAIL]        header          1   header-000.
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        header          0   header-000.                                │
# └──────────────────────────────────────────────────────────────────────────────┘
# ASSERT Hd.decode: char '\r'
# FAIL Hd.decode: char '\r'
# Raised at Alcotest_engine__Test.check_err in file "src/alcotest-engine/test.ml", line 157, characters 20-48
# Called from Dune__exe__Test_hd.test_000.(fun) in file "test/test_hd.ml", line 68, characters 15-29
# Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 181, characters 17-23
# Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
# 
# Logs saved to `~/.opam/5.2/.opam-switch/build/mrmime.0.6.0/_build/default/test/_build/_tests/hd/header.000.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/mrmime.0.6.0/_build/default/test/_build/_tests/hd'.
# 2 failures! in 0.000s. 2 tests run.
```