### PR TITLE
multipart_form: Disable the tests on OCaml 5.2

### DIFF
--- a/packages/multipart_form/multipart_form.0.1.0/opam
+++ b/packages/multipart_form/multipart_form.0.1.0/opam
@@ -19,6 +19,7 @@ build: [
 
 depends: [
   "ocaml"      {>= "4.08.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune"       {>= "2.0.0"}
   "angstrom"   {>= "0.14.0"}
   "base64" {>= "3.0.0"}

--- a/packages/multipart_form/multipart_form.0.2.0/opam
+++ b/packages/multipart_form/multipart_form.0.2.0/opam
@@ -12,6 +12,7 @@ doc: "https://dinosaure.github.io/multipart_form/"
 bug-reports: "https://github.com/dinosaure/multipart_form/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune" {>= "2.0.0"}
   "angstrom" {>= "0.14.0"}
   "base64" {>= "3.0.0"}

--- a/packages/multipart_form/multipart_form.0.3.0/opam
+++ b/packages/multipart_form/multipart_form.0.3.0/opam
@@ -12,6 +12,7 @@ doc: "https://dinosaure.github.io/multipart_form/"
 bug-reports: "https://github.com/dinosaure/multipart_form/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune" {>= "2.0.0"}
   "angstrom" {>= "0.14.0"}
   "base64" {>= "3.0.0"}

--- a/packages/multipart_form/multipart_form.0.4.0/opam
+++ b/packages/multipart_form/multipart_form.0.4.0/opam
@@ -12,6 +12,7 @@ doc: "https://dinosaure.github.io/multipart_form/"
 bug-reports: "https://github.com/dinosaure/multipart_form/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune" {>= "2.0.0"}
   "angstrom" {>= "0.14.0"}
   "base64" {>= "3.0.0"}

--- a/packages/multipart_form/multipart_form.0.4.1/opam
+++ b/packages/multipart_form/multipart_form.0.4.1/opam
@@ -12,6 +12,7 @@ doc: "https://dinosaure.github.io/multipart_form/"
 bug-reports: "https://github.com/dinosaure/multipart_form/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune" {>= "2.0.0"}
   "angstrom" {>= "0.14.0"}
   "base64" {>= "3.0.0"}

--- a/packages/multipart_form/multipart_form.0.5.0/opam
+++ b/packages/multipart_form/multipart_form.0.5.0/opam
@@ -12,6 +12,7 @@ doc: "https://dinosaure.github.io/multipart_form/"
 bug-reports: "https://github.com/dinosaure/multipart_form/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune" {>= "2.0.0"}
   "angstrom" {>= "0.14.0"}
   "base64" {>= "3.0.0"}


### PR DESCRIPTION
`\r\n` are now parsed differently
Fix sent upstream in https://github.com/dinosaure/multipart_form/pull/37
```
#=== ERROR while compiling multipart_form.0.5.0 ===============================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/multipart_form.0.5.0
# command              ~/.opam/5.2/bin/dune runtest -p multipart_form -j 1
# exit-code            1
# env-file             ~/.opam/log/multipart_form-1594-240fcf.env
# output-file          ~/.opam/log/multipart_form-1594-240fcf.out
### output ###
# File "test/dune", line 13, characters 0-117:
# 13 | (rule
# 14 |  (alias runtest)
# 15 |  (package multipart_form)
# 16 |  (deps
# 17 |   (:test test.exe))
# 18 |  (action
# 19 |   (run %{test} --color=always)))
# (cd _build/default/test && ./test.exe --color=always)
# Testing `multipart_form'.
# This run has ID `F4MR7GX6'.
# 
#   [OK]          content-type                      0   text/plain; charset=us-...
#   [OK]          content-type                      1   text/plain; charset="us...
#   [OK]          content-type                      2   text/plain; charset=ISO...
# > [FAIL]        multipart_form (decoder)          0   simple.
#   [FAIL]        multipart_form (decoder)          1   simple with helpers.
#   [OK]          multipart_form (encoder)          0   simple.
#   [FAIL]        filename with space               0   filename with space.
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        multipart_form (decoder)          0   simple.                  │
# └──────────────────────────────────────────────────────────────────────────────┘
# ASSERT unamed values
# File "test/test.ml", line 105, character 6:
# FAIL unamed values
# 
#    Expected: `1'
#    Received: `0'
# 
# Raised at Alcotest_engine__Test.check in file "src/alcotest-engine/test.ml", lines 200-210, characters 4-19
# Called from Dune__exe__Test.simple_multipart_form.(fun) in file "test/test.ml", line 105, characters 6-60
# Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 181, characters 17-23
# Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
# 
# Logs saved to `~/.opam/5.2/.opam-switch/build/multipart_form.0.5.0/_build/default/test/_build/_tests/multipart_form/multipart_form U+0028decoderU+0029.000.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/multipart_form.0.5.0/_build/default/test/_build/_tests/multipart_form'.
# 3 failures! in 0.001s. 7 tests run.
```