### PR TITLE
multipart_form-lwt: Disable the tests on OCaml 5.2

### DIFF
--- a/packages/multipart_form-lwt/multipart_form-lwt.0.4.0/opam
+++ b/packages/multipart_form-lwt/multipart_form-lwt.0.4.0/opam
@@ -12,6 +12,7 @@ doc: "https://dinosaure.github.io/multipart_form/"
 bug-reports: "https://github.com/dinosaure/multipart_form/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune" {>= "2.0.0"}
   "angstrom"
   "bigarray-compat"

--- a/packages/multipart_form-lwt/multipart_form-lwt.0.4.1/opam
+++ b/packages/multipart_form-lwt/multipart_form-lwt.0.4.1/opam
@@ -12,6 +12,7 @@ doc: "https://dinosaure.github.io/multipart_form/"
 bug-reports: "https://github.com/dinosaure/multipart_form/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune" {>= "2.0.0"}
   "angstrom"
   "bigstringaf"

--- a/packages/multipart_form-lwt/multipart_form-lwt.0.5.0/opam
+++ b/packages/multipart_form-lwt/multipart_form-lwt.0.5.0/opam
@@ -12,6 +12,7 @@ doc: "https://dinosaure.github.io/multipart_form/"
 bug-reports: "https://github.com/dinosaure/multipart_form/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
+  "ocaml" {with-test & < "5.2"}
   "dune" {>= "2.0.0"}
   "angstrom"
   "bigstringaf"


### PR DESCRIPTION
`\r\n` are now parsed differently
Fix sent upstream in https://github.com/dinosaure/multipart_form/pull/37
```
#=== ERROR while compiling multipart_form-lwt.0.5.0 ===========================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/multipart_form-lwt.0.5.0
# command              ~/.opam/5.2/bin/dune runtest -p multipart_form-lwt -j 1
# exit-code            1
# env-file             ~/.opam/log/multipart_form-lwt-1655-8ca0b7.env
# output-file          ~/.opam/log/multipart_form-lwt-1655-8ca0b7.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I test/.test_lwt.eobjs/byte -I /home/opam/.opam/5.2/lib/alcotest -I /home/opam/.opam/5.2/lib/alcotest-lwt -I /home/opam/.opam/5.2/lib/fmt -I /home/opam/.opam/5.2/lib/logs -I /home/opam/.opam/5.2/lib/lwt -I /home/opam/.opam/5.2/lib/lwt/unix -I /home/opam/.opam/5.2/lib/multipart_form -I lib_lwt/.multipart_form_lwt.objs/byte -no-alias-deps -o test/.test_lwt.eobjs/byte/dune__exe__Test_lwt.cmo -c -impl test/test_lwt.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlopt.opt -w -40 -g -I test/.test_lwt.eobjs/byte -I test/.test_lwt.eobjs/native -I /home/opam/.opam/5.2/lib/alcotest -I /home/opam/.opam/5.2/lib/alcotest-lwt -I /home/opam/.opam/5.2/lib/fmt -I /home/opam/.opam/5.2/lib/logs -I /home/opam/.opam/5.2/lib/lwt -I /home/opam/.opam/5.2/lib/lwt/unix -I /home/opam/.opam/5.2/lib/multipart_form -I lib_lwt/.multipart_form_lwt.objs/byte -I lib_lwt/.multipart_form_lwt.objs/native -intf-suffix .ml -no-alias-deps -o test/.test_lwt.eobjs/native/dune__exe__Test_lwt.cmx -c -impl test/test_lwt.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# File "test/dune", line 21, characters 0-125:
# 21 | (rule
# 22 |  (alias runtest)
# 23 |  (package multipart_form-lwt)
# 24 |  (deps
# 25 |   (:test test_lwt.exe))
# 26 |  (action
# 27 |   (run %{test} --color=always)))
# (cd _build/default/test && ./test_lwt.exe --color=always)
# Testing `multipart_form_lwt'.
# This run has ID `O21TLIOI'.
# 
# > [FAIL]        truncated          0   truncated flow (with CRLF).
#   [OK]          truncated          1   truncated flow (without CRLF).
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        truncated          0   truncated flow (with CRLF).             │
# └──────────────────────────────────────────────────────────────────────────────┘
# [2613][DEBUG][multipart-form]: Partial state of the multipart/form stream.
# [2613][DEBUG][multipart-form]: Capacity of the internal queue: 4096 byte(s).
# [2613][DEBUG][multipart-form]: Length of the internal queue: 0 byte(s).
# ASSERT Unexpected error: Invalid multipart/form
# FAIL Unexpected error: Invalid multipart/form
# Raised at Alcotest_engine__Test.check_err in file "src/alcotest-engine/test.ml", line 157, characters 20-48
# Called from Alcotest_lwt.run_test.(fun) in file "src/alcotest-lwt/alcotest_lwt.ml", line 24, characters 47-57
# Called from Lwt.Sequential_composition.try_bind in file "src/core/lwt.ml", line 2139, characters 10-14
# 
# Logs saved to `~/.opam/5.2/.opam-switch/build/multipart_form-lwt.0.5.0/_build/default/test/_build/_tests/multipart_form_lwt/truncated.000.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/multipart_form-lwt.0.5.0/_build/default/test/_build/_tests/multipart_form_lwt'.
# 1 failure! in 0.000s. 2 tests run.
```