### PR TITLE
ctypes < 0.22.0 is not compatible with OCaml 5.2

### DIFF
--- a/packages/ctypes/ctypes.0.10.0/opam
+++ b/packages/ctypes/ctypes.0.10.0/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.10.1/opam
+++ b/packages/ctypes/ctypes.0.10.1/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.10.2/opam
+++ b/packages/ctypes/ctypes.0.10.2/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.10.3/opam
+++ b/packages/ctypes/ctypes.0.10.3/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.10.4/opam
+++ b/packages/ctypes/ctypes.0.10.4/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.10.5/opam
+++ b/packages/ctypes/ctypes.0.10.5/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.11.0/opam
+++ b/packages/ctypes/ctypes.0.11.0/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.11.1/opam
+++ b/packages/ctypes/ctypes.0.11.1/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.11.2/opam
+++ b/packages/ctypes/ctypes.0.11.2/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.11.3/opam
+++ b/packages/ctypes/ctypes.0.11.3/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.11.4/opam
+++ b/packages/ctypes/ctypes.0.11.4/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.11.5/opam
+++ b/packages/ctypes/ctypes.0.11.5/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.12.0/opam
+++ b/packages/ctypes/ctypes.0.12.0/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "integers" { < "0.3.0" }
   "ocamlfind" {build}

--- a/packages/ctypes/ctypes.0.12.1/opam
+++ b/packages/ctypes/ctypes.0.12.1/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "integers" { < "0.3.0" }
   "ocamlfind" {build}

--- a/packages/ctypes/ctypes.0.13.0/opam
+++ b/packages/ctypes/ctypes.0.13.0/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "integers" { < "0.3.0" }
   "ocamlfind" {build}

--- a/packages/ctypes/ctypes.0.13.1/opam
+++ b/packages/ctypes/ctypes.0.13.1/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "integers" { < "0.3.0" }
   "ocamlfind" {build}

--- a/packages/ctypes/ctypes.0.14.0/opam
+++ b/packages/ctypes/ctypes.0.14.0/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "integers" { < "0.3.0" }
   "ocamlfind" {build}

--- a/packages/ctypes/ctypes.0.15.0/opam
+++ b/packages/ctypes/ctypes.0.15.0/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-   "ocaml" {>= "4.02.3"}
+   "ocaml" {>= "4.02.3" & < "5.2"}
    "base-bytes"
    "integers" { >= "0.3.0" }
    "ocamlfind" {build}

--- a/packages/ctypes/ctypes.0.15.1/opam
+++ b/packages/ctypes/ctypes.0.15.1/opam
@@ -18,7 +18,7 @@ install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
 ]
 depends: [
-   "ocaml" {>= "4.02.3"}
+   "ocaml" {>= "4.02.3" & < "5.2"}
    "base-bytes"
    "integers" { >= "0.3.0" }
    "ocamlfind" {build}

--- a/packages/ctypes/ctypes.0.16.0/opam
+++ b/packages/ctypes/ctypes.0.16.0/opam
@@ -18,7 +18,7 @@ install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
 ]
 depends: [
-   "ocaml" {>= "4.02.3"}
+   "ocaml" {>= "4.02.3" & < "5.2"}
    "base-bytes"
    "integers" { >= "0.3.0" }
    "ocamlfind" {build}

--- a/packages/ctypes/ctypes.0.17.0/opam
+++ b/packages/ctypes/ctypes.0.17.0/opam
@@ -18,7 +18,7 @@ install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
 ]
 depends: [
-   "ocaml" {>= "4.02.3"}
+   "ocaml" {>= "4.02.3" & < "5.2"}
    "integers" { >= "0.3.0" }
    "ocamlfind" {build}
    "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.17.1/opam
+++ b/packages/ctypes/ctypes.0.17.1/opam
@@ -18,7 +18,7 @@ install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
 ]
 depends: [
-   "ocaml" {>= "4.02.3"}
+   "ocaml" {>= "4.02.3" & < "5.2"}
    "integers" { >= "0.3.0" }
    "ocamlfind" {build}
    "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.18.0/opam
+++ b/packages/ctypes/ctypes.0.18.0/opam
@@ -18,7 +18,7 @@ install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.2"}
   "integers" { >= "0.3.0" }
   "ocamlfind" {build}
   "lwt" {with-test & >= "3.2.0"}

--- a/packages/ctypes/ctypes.0.19.1/opam
+++ b/packages/ctypes/ctypes.0.19.1/opam
@@ -18,7 +18,7 @@ install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.2"}
   "integers" { >= "0.3.0" }
   "ocamlfind" {build}
   "lwt" {with-test & >= "3.2.0"}

--- a/packages/ctypes/ctypes.0.20.0/opam
+++ b/packages/ctypes/ctypes.0.20.0/opam
@@ -18,7 +18,7 @@ install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.2"}
   "integers" { >= "0.3.0" }
   "ocamlfind" {build}
   "lwt" {with-test & >= "3.2.0"}

--- a/packages/ctypes/ctypes.0.20.1/opam
+++ b/packages/ctypes/ctypes.0.20.1/opam
@@ -18,7 +18,7 @@ install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.2"}
   "integers" { >= "0.3.0" }
   "ocamlfind" {build}
   "lwt" {with-test & >= "3.2.0"}

--- a/packages/ctypes/ctypes.0.20.2/opam
+++ b/packages/ctypes/ctypes.0.20.2/opam
@@ -18,7 +18,7 @@ install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.2"}
   "integers" { >= "0.3.0" }
   "ocamlfind" {build}
   "lwt" {with-test & >= "3.2.0"}

--- a/packages/ctypes/ctypes.0.21.1/opam
+++ b/packages/ctypes/ctypes.0.21.1/opam
@@ -26,7 +26,7 @@ doc: "https://yallop.github.io/ocaml-ctypes/"
 bug-reports: "https://github.com/yallop/ocaml-ctypes/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.2"}
   "integers"
   "dune-configurator"
   "bigarray-compat"

--- a/packages/ctypes/ctypes.0.8.0/opam
+++ b/packages/ctypes/ctypes.0.8.0/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.8.1/opam
+++ b/packages/ctypes/ctypes.0.8.1/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.8.2/opam
+++ b/packages/ctypes/ctypes.0.8.2/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.9.0/opam
+++ b/packages/ctypes/ctypes.0.9.0/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.9.1/opam
+++ b/packages/ctypes/ctypes.0.9.1/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.9.2/opam
+++ b/packages/ctypes/ctypes.0.9.2/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.9.3/opam
+++ b/packages/ctypes/ctypes.0.9.3/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.9.4/opam
+++ b/packages/ctypes/ctypes.0.9.4/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}

--- a/packages/ctypes/ctypes.0.9.5/opam
+++ b/packages/ctypes/ctypes.0.9.5/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.2"}
   "base-bytes"
   "ocamlfind" {build}
   "conf-pkg-config" {build}


### PR DESCRIPTION
This is not a strict error unless `OCAMLPARAM=warn-error=+8,_` is present in your environment (which it is in [opam-health-check-ng](https://github.com/kit-ty-kate/opam-health-check-ng) for quality checking purpose), but i would argue that disabling those packages on OCaml 5.2 is wanted to improve the quality of the packages.
```
#=== ERROR while compiling ctypes.0.21.1 ======================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/ctypes.0.21.1
# command              ~/.opam/5.2/bin/dune build -p ctypes -j 1 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/ctypes-20-61ccb2.env
# output-file          ~/.opam/log/ctypes-20-61ccb2.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I src/ctypes/.ctypes.objs/byte -I /home/opam/.opam/5.2/lib/bigarray-compat -I /home/opam/.opam/5.2/lib/integers -I /home/opam/.opam/5.2/lib/stdlib-shims -no-alias-deps -o src/ctypes/.ctypes.objs/byte/ctypes_bigarray_stubs.cmo -c -impl src/ctypes/ctypes_bigarray_stubs.ml)
# File "src/ctypes/ctypes_bigarray_stubs.ml", lines 23-36, characters 61-37:
# 23 | .............................................................function
# 24 |   | Bigarray_compat.Float32 -> Kind_float32
# 25 |   | Bigarray_compat.Float64 -> Kind_float64
# 26 |   | Bigarray_compat.Int8_signed -> Kind_int8_signed
# 27 |   | Bigarray_compat.Int8_unsigned -> Kind_int8_unsigned
# ...
# 33 |   | Bigarray_compat.Nativeint -> Kind_nativeint
# 34 |   | Bigarray_compat.Complex32 -> Kind_complex32
# 35 |   | Bigarray_compat.Complex64 -> Kind_complex64
# 36 |   | Bigarray_compat.Char -> Kind_char
# Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
# Here is an example of a case that is not matched:
# Float16
```