### PR TITLE
lintcstubs-arity is not compatible with OCaml 5.2

### DIFF
--- a/packages/lintcstubs-arity/lintcstubs-arity.0.1.0/opam
+++ b/packages/lintcstubs-arity/lintcstubs-arity.0.1.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/edwintorok/lintcstubs-arity"
 bug-reports: "https://github.com/edwintorok/lintcstubs-arity/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.2"}
   "odoc" {with-doc}
 ]
 depopts: [

--- a/packages/lintcstubs-arity/lintcstubs-arity.0.2.0/opam
+++ b/packages/lintcstubs-arity/lintcstubs-arity.0.2.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/edwintorok/lintcstubs-arity"
 bug-reports: "https://github.com/edwintorok/lintcstubs-arity/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.2"}
   "odoc" {with-doc}
 ]
 depopts: [

--- a/packages/lintcstubs-arity/lintcstubs-arity.0.2.1/opam
+++ b/packages/lintcstubs-arity/lintcstubs-arity.0.2.1/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/edwintorok/lintcstubs-arity"
 bug-reports: "https://github.com/edwintorok/lintcstubs-arity/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.2"}
   "odoc" {with-doc}
 ]
 depopts: [

--- a/packages/lintcstubs-arity/lintcstubs-arity.0.2.2/opam
+++ b/packages/lintcstubs-arity/lintcstubs-arity.0.2.2/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/edwintorok/lintcstubs-arity"
 bug-reports: "https://github.com/edwintorok/lintcstubs-arity/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.2"}
   "odoc" {with-doc}
 ]
 depopts: [

--- a/packages/lintcstubs-arity/lintcstubs-arity.0.4.1/opam
+++ b/packages/lintcstubs-arity/lintcstubs-arity.0.4.1/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/edwintorok/lintcstubs-arity"
 bug-reports: "https://github.com/edwintorok/lintcstubs-arity/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.10"}
+  "ocaml" {>= "4.10" & < "5.2"}
   "odoc" {with-doc}
 ]
 depopts: [


### PR DESCRIPTION
Uses `compiler-libs`
Reported upstream in https://github.com/edwintorok/lintcstubs-arity/issues/1
```
#=== ERROR while compiling lintcstubs-arity.0.4.1 =============================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/lintcstubs-arity.0.4.1
# command              ~/.opam/5.2/bin/dune build -p lintcstubs-arity -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/lintcstubs-arity-19-84087e.env
# output-file          ~/.opam/log/lintcstubs-arity-19-84087e.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlopt.opt -w -40 -g -I cmt/lib/.primitives_of_cmt.objs/byte -I cmt/lib/.primitives_of_cmt.objs/native -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -intf-suffix .ml -no-alias-deps -o cmt/lib/.primitives_of_cmt.objs/native/primitives_of_cmt.cmx -c -impl cmt/lib/primitives_of_cmt.ml)
# File "cmt/lib/primitives_of_cmt.ml", line 46, characters 4-16:
# 46 |   | Untagged_int ->
#          ^^^^^^^^^^^^
# Error: This variant pattern is expected to have type "Primitive.native_repr"
#        There is no constructor "Untagged_int" within type "Primitive.native_repr"
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I cmt/lib/.primitives_of_cmt.objs/byte -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -intf-suffix .ml -no-alias-deps -o cmt/lib/.primitives_of_cmt.objs/byte/primitives_of_cmt.cmo -c -impl cmt/lib/primitives_of_cmt.ml)
# File "cmt/lib/primitives_of_cmt.ml", line 46, characters 4-16:
# 46 |   | Untagged_int ->
#          ^^^^^^^^^^^^
# Error: This variant pattern is expected to have type "Primitive.native_repr"
#        There is no constructor "Untagged_int" within type "Primitive.native_repr"
```