### PR TITLE
asai is not compatible with OCaml 5.2

### DIFF
--- a/packages/asai/asai.0.1.1/opam
+++ b/packages/asai/asai.0.1.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/RedPRL/asai"
 bug-reports: "https://github.com/RedPRL/asai/issues"
 depends: [
   "dune" {>= "3.1"}
-  "ocaml" {>= "5.0"}
+  "ocaml" {>= "5.0" & < "5.2"}
   "algaeff" {>= "1.0" & < "2.0"}
   "bwd" {>= "2.2"}
   "eio" {>= "0.12"}

--- a/packages/asai/asai.0.2.0/opam
+++ b/packages/asai/asai.0.2.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/RedPRL/asai"
 bug-reports: "https://github.com/RedPRL/asai/issues"
 depends: [
   "dune" {>= "3.1"}
-  "ocaml" {>= "5.0"}
+  "ocaml" {>= "5.0" & < "5.2"}
   "algaeff" {>= "1.0" & < "2.0"}
   "bwd" {>= "2.2"}
   "notty" {>= "0.2.3"}

--- a/packages/asai/asai.0.3.0/opam
+++ b/packages/asai/asai.0.3.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/RedPRL/asai"
 bug-reports: "https://github.com/RedPRL/asai/issues"
 depends: [
   "dune" {>= "3.1"}
-  "ocaml" {>= "5.0"}
+  "ocaml" {>= "5.0" & < "5.2"}
   "algaeff" {>= "2.0"}
   "bwd" {>= "2.2"}
   "alcotest" {with-test & >= "1.5"}


### PR DESCRIPTION
`Format.pp_set_geometry` now fails at runtime when margin > `10^9`
Fix sent upstream in https://github.com/RedPRL/asai/pull/149
See https://github.com/ocaml/ocaml/discussions/12986
```
#=== ERROR while compiling asai.0.3.0 =========================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/asai.0.3.0
# command              ~/.opam/5.2/bin/dune build -p asai -j 1 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/asai-62-9d2d7d.env
# output-file          ~/.opam/log/asai-62-9d2d7d.out
### output ###
# (cd _build/default/test && ./TestUserContent.exe)
# Testing `UserContent'.
# This run has ID `9FIAG1G5'.
# 
#   [OK]          replace_control          0   tab.
#   [OK]          replace_control          1   C1 control.
#   [OK]          replace_control          2   C2 control.
#   [OK]          replace_control          3   invalid UTF-8.
#   [OK]          replace_control          4   invalid UTF-8.
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/asai.0.3.0/_build/default/test/_build/_tests/UserContent'.
# Test Successful in 0.000s. 5 tests run.
# File "test/dune", line 7, characters 24-38:
# 7 |  (names TestUserContent TestDiagnostic)
#                             ^^^^^^^^^^^^^^
# (cd _build/default/test && ./TestDiagnostic.exe)
# Testing `UserContent'.
# This run has ID `P63ACD2O'.
# 
# > [FAIL]        string_of_text          0   \n.
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        string_of_text          0   \n.                                │
# └──────────────────────────────────────────────────────────────────────────────┘
# [invalid] Format.pp_set_geometry: margin >= pp_infinity
#           Raised at Stdlib__Format.pp_set_geometry in file "format.ml", line 844, characters 4-63
#           Called from Asai__Diagnostic.string_of_text in file "src/Diagnostic.ml", line 45, characters 11-71
#           Called from Dune__exe__TestDiagnostic.of_test.(fun) in file "test/TestDiagnostic.ml", line 4, characters 2-38
#           Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 181, characters 17-23
#           Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
#           
# Logs saved to `~/.opam/5.2/.opam-switch/build/asai.0.3.0/_build/default/test/_build/_tests/UserContent/string_of_text.000.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/asai.0.3.0/_build/default/test/_build/_tests/UserContent'.
# 1 failure! in 0.000s. 1 test run.
# (cd _build/default/test && ./TestExplicator.exe)
# Testing `Explicator'.
# This run has ID `VS14DHRF'.
# 
#   [OK]          single-line          0   traditional, empty.
#   [OK]          single-line          1   traditional, CR.
#   [OK]          single-line          2   traditional, LF.
#   [OK]          single-line          3   traditional, CRLF.
#   [OK]          single-line          4   unicode, empty.
#   [OK]          single-line          5   unicode, CR.
#   [OK]          single-line          6   unicode, LF.
#   [OK]          single-line          7   unicode, CRLF.
#   [OK]          single-line          8   unicode, VT.
#   [OK]          single-line          9   unicode, FF.
#   [OK]          single-line         10   unicode, NEL.
#   [OK]          single-line         11   unicode, LS.
#   [OK]          single-line         12   unicode, PS.
#   [OK]          multi-line           0   multi-line range with LS.
#   [OK]          multi-line           1   multi-line range with CRLF.
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/asai.0.3.0/_build/default/test/_build/_tests/Explicator'.
# Test Successful in 0.001s. 15 tests run.
# (cd _build/default/test && ./TestFlattener.exe)
# Testing `Flattener'.
# This run has ID `ZU125I9G'.
# 
#   [OK]          flattening          0   single-line ranges.
#   [OK]          flattening          1   multi-line ranges.
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/asai.0.3.0/_build/default/test/_build/_tests/Flattener'.
# Test Successful in 0.000s. 2 tests run.
```