### PR TITLE
[new release] hol2dk (1.0.0)

### DIFF
--- a/packages/hol2dk/hol2dk.1.0.0/opam
+++ b/packages/hol2dk/hol2dk.1.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "HOL-Light to Dedukti/Lambdapi and Coq translator"
+description: "HOL-Light to Dedukti/Lambdapi and Coq translator"
+maintainer: ["Frédéric Blanqui"]
+authors: ["Frédéric Blanqui" "Anthony Bordg"]
+license: "CeCILL-2.1"
+homepage: "https://github.com/Deducteam/hol2dk"
+bug-reports: "https://github.com/Deducteam/hol2dk/issues"
+depends: [
+  "ocaml" {>= "4.13"}
+  "dune" {>= "3.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Deducteam/hol2dk.git"
+url {
+  src:
+    "https://github.com/Deducteam/hol2dk/releases/download/1.0.0/hol2dk-1.0.0.tbz"
+  checksum: [
+    "sha256=b9a304e56acda8367944c8590497ede7a386850b423432186309f36cc3aaed98"
+    "sha512=80027e2966d0b4192b5c297b6932ce10d7f20890be93e3f20570afb0ecd3b0b8f0ae84438a1f1aca5e8839e157240de8aedc772b3087c79b5c9ff2dca7792e7c"
+  ]
+}
+x-commit-hash: "3330bf799499a8e452fdb5e578f4936ee7c18a25"

--- a/packages/hol2dk/hol2dk.1.0.0/opam
+++ b/packages/hol2dk/hol2dk.1.0.0/opam
@@ -5,6 +5,7 @@ maintainer: ["Frédéric Blanqui"]
 authors: ["Frédéric Blanqui" "Anthony Bordg"]
 license: "CeCILL-2.1"
 homepage: "https://github.com/Deducteam/hol2dk"
+doc: "https://github.com/Deducteam/hol2dk/blob/master/README.md"
 bug-reports: "https://github.com/Deducteam/hol2dk/issues"
 depends: [
   "ocaml" {>= "4.13"}


### PR DESCRIPTION
HOL-Light to Dedukti/Lambdapi and Coq translator

- Project page: <a href="https://github.com/Deducteam/hol2dk">https://github.com/Deducteam/hol2dk</a>

##### CHANGES:

### Added

- add-links script
- command rewrite to simplify prf files
- command purge to compute useless theorems
  these two commands greatly reduce the size of generated proofs
- command simp is equivalent to rewrite and purge
- command dump-simp is equivalent to dump, pos, use and simp
- allow simultaneous dumping
- alignments of the types option, Sum and list
- command split to generate a pos/use/sti/nbp file for each named theorem
  (an sti file contains the starting index of the corresponding proof)
- command theorem to generate the lp files corresponding to a named theorem
- Makefile to generate and check lp and coq files generated with split
- command size to get statistics on the size of terms
- option --print-stats to print statistics on hash tables at exit
- use hash tables instead of maps to build abbreviations maps
- use sharing when building canonical types and terms
- add option --use-sharing for using sharing in lp output when defining term abbreviations
- command nbp to get the number of proof steps
- commands patch, unpatch and link to call the corresponding scripts
- command env to print $HOL2DK_DIR and $HOLLIGHT_DIR

### Modified

- identifier renamings
- merged the command dg in the command mk
- fusion.ml: do not generate new theorems for empty instantiations

### Fixed

- valid dedukti and lambdapi identifiers
