### PR TITLE
2 packages from kit-ty-kate/opam-build at 0.2.0

### DIFF
--- a/packages/opam-build/opam-build.0.2.0/opam
+++ b/packages/opam-build/opam-build.0.2.0/opam
@@ -6,7 +6,7 @@ license: "MIT"
 homepage: "https://github.com/kit-ty-kate/opam-build"
 bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "5.1"}
   "dune" {>= "2.0"}
   "opam-client" {>= "2.2" & < "2.3"}
   "cmdliner" {>= "1.1"}

--- a/packages/opam-build/opam-build.0.2.0/opam
+++ b/packages/opam-build/opam-build.0.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to build projects"
+maintainer: "Kate <kit-ty-kate@outlook.com>"
+authors: "Kate <kit-ty-kate@outlook.com>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.2" & < "2.3"}
+  "cmdliner" {>= "1.1"}
+]
+available: opam-version >= "2.2" & opam-version < "2.3"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.2.0/opam-build-0.2.0.tar.gz"
+  checksum: [
+    "md5=8497cf10d1e9897d697a94dd8bf1a6ff"
+    "sha512=6cefa130ca6cf55997e8b37ee135753a532df8cdbef943f1aeaaee4ad854c125d63e28f54e3a3b21466f8d7b48b2b0d1cda7aca4d6aed35228377fa171bb781d"
+  ]
+}

--- a/packages/opam-build/opam-build.0.2.0/opam
+++ b/packages/opam-build/opam-build.0.2.0/opam
@@ -6,10 +6,11 @@ license: "MIT"
 homepage: "https://github.com/kit-ty-kate/opam-build"
 bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.08"}
   "dune" {>= "2.0"}
   "opam-client" {>= "2.2" & < "2.3"}
   "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
 ]
 available: opam-version >= "2.2" & opam-version < "2.3"
 flags: plugin

--- a/packages/opam-test/opam-test.0.2.0/opam
+++ b/packages/opam-test/opam-test.0.2.0/opam
@@ -6,7 +6,7 @@ license: "MIT"
 homepage: "https://github.com/kit-ty-kate/opam-build"
 bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "5.1"}
   "dune" {>= "2.0"}
   "opam-client" {>= "2.2" & < "2.3"}
   "cmdliner" {>= "1.1"}

--- a/packages/opam-test/opam-test.0.2.0/opam
+++ b/packages/opam-test/opam-test.0.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to test projects"
+maintainer: "Kate <kit-ty-kate@outlook.com>"
+authors: "Kate <kit-ty-kate@outlook.com>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.2" & < "2.3"}
+  "cmdliner" {>= "1.1"}
+]
+available: opam-version >= "2.2" & opam-version < "2.3"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.2.0/opam-build-0.2.0.tar.gz"
+  checksum: [
+    "md5=8497cf10d1e9897d697a94dd8bf1a6ff"
+    "sha512=6cefa130ca6cf55997e8b37ee135753a532df8cdbef943f1aeaaee4ad854c125d63e28f54e3a3b21466f8d7b48b2b0d1cda7aca4d6aed35228377fa171bb781d"
+  ]
+}

--- a/packages/opam-test/opam-test.0.2.0/opam
+++ b/packages/opam-test/opam-test.0.2.0/opam
@@ -6,10 +6,11 @@ license: "MIT"
 homepage: "https://github.com/kit-ty-kate/opam-build"
 bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.08"}
   "dune" {>= "2.0"}
   "opam-client" {>= "2.2" & < "2.3"}
   "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
 ]
 available: opam-version >= "2.2" & opam-version < "2.3"
 flags: plugin


### PR DESCRIPTION
This pull-request concerns:
- `opam-build.0.2.0`: An opam plugin to build projects
- `opam-test.0.2.0`: An opam plugin to test projects



---
* Homepage: https://github.com/kit-ty-kate/opam-build
* Source repo: git+https://github.com/kit-ty-kate/opam-build.git
* Bug tracker: https://github.com/kit-ty-kate/opam-build/issues

---
:camel: Pull-request generated by opam-publish v2.3.0