### PR TITLE
2 packages from kit-ty-kate/opam-build at 0.2.1

### DIFF
--- a/packages/opam-build/opam-build.0.2.1/opam
+++ b/packages/opam-build/opam-build.0.2.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to build projects"
+maintainer: "Kate <kit-ty-kate@outlook.com>"
+authors: "Kate <kit-ty-kate@outlook.com>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.2" & < "2.3"}
+  "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
+]
+available: opam-version >= "2.2" & opam-version < "2.3"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.2.1/opam-build-0.2.1.tar.gz"
+  checksum: [
+    "md5=2b9a34fd54834ec3f80264ca42dfde35"
+    "sha512=ce5f735dbf8560bb9b7062c2d94d6dce0fa56aa4a734a3d2ebc2c55abf9dc44465c96010b9fb004b35337fa45d8cb9eebfd9ebcc98160ad6956cd8bd261d0a2c"
+  ]
+}

--- a/packages/opam-test/opam-test.0.2.1/opam
+++ b/packages/opam-test/opam-test.0.2.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to test projects"
+maintainer: "Kate <kit-ty-kate@outlook.com>"
+authors: "Kate <kit-ty-kate@outlook.com>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.2" & < "2.3"}
+  "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
+]
+available: opam-version >= "2.2" & opam-version < "2.3"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.2.1/opam-build-0.2.1.tar.gz"
+  checksum: [
+    "md5=2b9a34fd54834ec3f80264ca42dfde35"
+    "sha512=ce5f735dbf8560bb9b7062c2d94d6dce0fa56aa4a734a3d2ebc2c55abf9dc44465c96010b9fb004b35337fa45d8cb9eebfd9ebcc98160ad6956cd8bd261d0a2c"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `opam-build.0.2.1`: An opam plugin to build projects
- `opam-test.0.2.1`: An opam plugin to test projects



---
* Homepage: https://github.com/kit-ty-kate/opam-build
* Source repo: git+https://github.com/kit-ty-kate/opam-build.git
* Bug tracker: https://github.com/kit-ty-kate/opam-build/issues

---
:camel: Pull-request generated by opam-publish v2.3.0