### PR TITLE
2 packages from OCamlPro/ocp-index at 1.3.6

### DIFF
--- a/packages/ocp-browser/ocp-browser.1.3.6/opam
+++ b/packages/ocp-browser/ocp-browser.1.3.6/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "louis.gesbert@ocamlpro.com"
+synopsis: "Console browser for the documentation of installed OCaml libraries"
+description: """
+ocp-browser is a ncurses-like interface that allows to easily browse the
+interfaces and documentation of all installed OCaml modules.
+"""
+authors: [
+  "Louis Gesbert"
+  "Gabriel Radanne"
+]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+license: "GPL-3.0-only"
+tags: [ "org:ocamlpro" "org:typerex" ]
+dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.0"}
+  "ocp-index" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "lambda-term" {>= "3.3.0"}
+  "zed" {>= "2.0.0"}
+  "odoc" {with-test}
+]
+url {
+  src: "https://github.com/OCamlPro/ocp-index/archive/refs/tags/1.3.6.tar.gz"
+  checksum: [
+    "md5=b4d5f80b168a31146df5eb30613cc1b9"
+    "sha512=f8f97e846e37473a77636518ceefafa72a62f26ed9e7fc65ee4625498bcc1797187e895d903dfb2e874e93889956ee02b2e1f6f90c61717107db8e96d388d65a"
+  ]
+}

--- a/packages/ocp-index/ocp-index.1.3.6/opam
+++ b/packages/ocp-index/ocp-index.1.3.6/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "louis.gesbert@ocamlpro.com"
+synopsis:
+  "Lightweight completion and documentation browsing for OCaml libraries"
+description: """
+This package includes
+* The `ocp-index` library and command-line tool
+* `ocp-grep`, a tool that finds uses of a given (qualified) identifier in a source tree
+* bindings for emacs and vim (sublime text also [available](https://github.com/whitequark/sublime-ocp-index/))
+
+To automatically configure your editors, install this with package `user-setup`.
+"""
+authors: [
+  "Louis Gesbert"
+  "Gabriel Radanne"
+]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+license: ["LGPL-2.1-only WITH OCaml-LGPL-linking-exception" "GPL-3.0-only"]
+tags: [ "org:ocamlpro" "org:typerex" ]
+dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.0"}
+  "ocp-indent" {>= "1.4.2"}
+  "re" {>= "1.9.0"}
+  "cmdliner" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+post-messages:
+  "This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path \"%{prefix}%/share/emacs/site-lisp\")
+  (require 'ocp-index)
+
+* for Vim, add the following line to ~/.vimrc:
+  set rtp+=%{share}%/ocp-index/vim
+" {success & !user-setup:installed}
+url {
+  src: "https://github.com/OCamlPro/ocp-index/archive/refs/tags/1.3.6.tar.gz"
+  checksum: [
+    "md5=b4d5f80b168a31146df5eb30613cc1b9"
+    "sha512=f8f97e846e37473a77636518ceefafa72a62f26ed9e7fc65ee4625498bcc1797187e895d903dfb2e874e93889956ee02b2e1f6f90c61717107db8e96d388d65a"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `ocp-browser.1.3.6`: Console browser for the documentation of installed OCaml libraries
- `ocp-index.1.3.6`: Lightweight completion and documentation browsing for OCaml libraries



---
* Homepage: http://www.typerex.org/ocp-index.html
* Source repo: git+https://github.com/OCamlPro/ocp-index.git
* Bug tracker: https://github.com/OCamlPro/ocp-index/issues

---
:camel: Pull-request generated by opam-publish v2.2.0