### PR TITLE
[new release] mdx (2.4.0)

### DIFF
--- a/packages/mdx/mdx.2.4.0/opam
+++ b/packages/mdx/mdx.2.4.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Executable code blocks inside markdown files"
+description: """
+`ocaml-mdx` allows to execute code blocks inside markdown files.
+There are (currently) two sub-commands, corresponding
+to two modes of operations: pre-processing (`ocaml-mdx pp`)
+and tests (`ocaml-mdx test`).
+
+The pre-processor mode allows to mix documentation and code,
+and to practice "literate programming" using markdown and OCaml.
+
+The test mode allows to ensure that shell scripts and OCaml fragments
+in the documentation always stays up-to-date."""
+maintainer: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+license: "ISC"
+homepage: "https://github.com/realworldocaml/mdx"
+bug-reports: "https://github.com/realworldocaml/mdx/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind"
+  "fmt" {>= "0.8.7"}
+  "cppo" {build & >= "1.1.0"}
+  "csexp" {>= "1.3.2"}
+  "astring"
+  "logs" {>= "0.7.0"}
+  "cmdliner" {>= "1.1.0"}
+  "re" {>= "1.7.2"}
+  "ocaml-version" {>= "2.3.0"}
+  "lwt" {with-test}
+  "camlp-streams"
+  "result"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/realworldocaml/mdx.git"
+url {
+  src:
+    "https://github.com/realworldocaml/mdx/releases/download/2.4.0/mdx-2.4.0.tbz"
+  checksum: [
+    "sha256=dde0eb73ebf6108fc5c7e30c4e37dd9f839a59fdb68c6ab61459ac28cba9783a"
+    "sha512=5e2472657d8e2b38f8f87284ded405e78f07681f61b46285f26c1f4b4c41ebdb22101da0868982ef39ea5083cefd764e08fd0031236fc639423529931d3fecc7"
+  ]
+}
+x-commit-hash: "bf33f76471d81d1e8313fbc5c2fd86a20ad96239"


### PR DESCRIPTION
CHANGES:

#### Added

- Handle the error-blocks syntax (realworldocaml/mdx#439, @jonludlam, @gpetiot)
- Allow execution of included OCaml code blocks (realworldocaml/mdx#446, @panglesd)
- Make MDX compatible with OCaml 5.2 (realworldocaml/mdx#448, @gpetiot)

#### Fixed

- Reduce false-positives while detecting warnings (realworldocaml/mdx#440, @Julow)