### PR TITLE
[new release] iostream (2 packages) (0.2)

### DIFF
--- a/packages/iostream-camlzip/iostream-camlzip.0.2/opam
+++ b/packages/iostream-camlzip/iostream-camlzip.0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "ounit2" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/iostream-camlzip/iostream-camlzip.0.2/opam
+++ b/packages/iostream-camlzip/iostream-camlzip.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Stream (de)compression using deflate"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["topics" "io" "channels" "streams" "zip" "deflate"]
+homepage: "https://github.com/c-cube/ocaml-iostream"
+doc: "https://c-cube.github.io/ocaml-iostream"
+bug-reports: "https://github.com/c-cube/ocaml-iostream/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "iostream" {= version}
+  "camlzip"
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-iostream.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-iostream/releases/download/v0.2/iostream-0.2.tbz"
+  checksum: [
+    "sha256=3ef4da60bdbb7036d62e3f715833e474a343b06f6115841e3a9923baf5fbe350"
+    "sha512=d651adfd8e15aed5083c38eb602729fb4a827ca2e75fa25065f5185f67922049436c6c5e2f311f7ca78d77c4c0f374ce3854e8da0c0ce18ae624427176abc9b8"
+  ]
+}
+x-commit-hash: "42082bffaacaeee54b1573e9e71ea3e35204fa80"

--- a/packages/iostream/iostream.0.2/opam
+++ b/packages/iostream/iostream.0.2/opam
@@ -14,7 +14,7 @@ depends: [
 ]
 depopts: ["base-unix"]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/iostream/iostream.0.2/opam
+++ b/packages/iostream/iostream.0.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Generic, composable IO input and output streams"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["topics" "io" "channels" "streams"]
+homepage: "https://github.com/c-cube/ocaml-iostream"
+doc: "https://c-cube.github.io/ocaml-iostream"
+bug-reports: "https://github.com/c-cube/ocaml-iostream/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "ounit2" {with-test}
+]
+depopts: ["base-unix"]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-iostream.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-iostream/releases/download/v0.2/iostream-0.2.tbz"
+  checksum: [
+    "sha256=3ef4da60bdbb7036d62e3f715833e474a343b06f6115841e3a9923baf5fbe350"
+    "sha512=d651adfd8e15aed5083c38eb602729fb4a827ca2e75fa25065f5185f67922049436c6c5e2f311f7ca78d77c4c0f374ce3854e8da0c0ce18ae624427176abc9b8"
+  ]
+}
+x-commit-hash: "42082bffaacaeee54b1573e9e71ea3e35204fa80"


### PR DESCRIPTION
Generic, composable IO input and output streams

- Project page: <a href="https://github.com/c-cube/ocaml-iostream">https://github.com/c-cube/ocaml-iostream</a>
- Documentation: <a href="https://c-cube.github.io/ocaml-iostream">https://c-cube.github.io/ocaml-iostream</a>

##### CHANGES:

- camlzip: add buffered version of the input stream transducers
- add In_buf.skip
- add `iostream-camlzip`, depends on `iostream`
- rename Out to Out_buf, add Out
- add `Slice` type, used for buffered input
- add `iostream.unix` optional library
- split seekable into its own class
- breaking: use OO and `class type` for all types
