### PR TITLE
rlp is not compatible with ocaml 5.0, uses Stream

### DIFF
--- a/packages/rlp/rlp.0.1/opam
+++ b/packages/rlp/rlp.0.1/opam
@@ -13,7 +13,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocaml" "setup.ml" "-uninstall"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ounit"


### PR DESCRIPTION
Fails with
```
#=== ERROR while compiling rlp.0.1 ============================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/rlp.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.1
# exit-code            2
# env-file             ~/.opam/log/rlp-7-f5dc02.env
# output-file          ~/.opam/log/rlp-7-f5dc02.out
### output ###
# File "./setup.ml", line 575, characters 4-15:
# 575 |     Stream.from next
#           ^^^^^^^^^^^
# Error: Unbound module Stream
```