### PR TITLE
[new release] runtime_events_tools (0.5.1)

### DIFF
--- a/packages/runtime_events_tools/runtime_events_tools.0.5.1/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.5.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Tools for the runtime events tracing system in OCaml"
+description: "Various tools for the runtime events tracing system in OCaml"
+maintainer: ["Sadiq Jaffer" "KC Sivaramakrishnan" "Sudha Parimala"]
+authors: ["Sadiq Jaffer"]
+license: "ISC"
+homepage: "https://github.com/tarides/runtime_events_tools"
+bug-reports: "https://github.com/tarides/runtime_events_tools/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "5.0.0~"}
+  "hdr_histogram"
+  "cmdliner" {>= "1.1.0"}
+  "tracing"
+  "ocaml_intrinsics" {>= "v0.16.1"}
+  "menhir" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/runtime_events_tools.git"
+available: (arch = "x86_64" | arch = "arm64") & os != "win32"
+url {
+  src:
+    "https://github.com/tarides/runtime_events_tools/releases/download/0.5.1/runtime_events_tools-0.5.1.tbz"
+  checksum: [
+    "sha256=b09d346a2e62b2ec15e8ca7ce921f1cecea01799bf1137dd6df40459d7656564"
+    "sha512=c8bf22dc7ddeadfc4bbc5a263ad5355938b4763466eec3fbc7929440ed25e54abf56abb39bfe4f2f7e2a3daf83df983b840aaaff243fda447a46a145026c9a66"
+  ]
+}
+x-commit-hash: "129c73f38e1c4c2b1346cf71ab526dbd121c2d9b"


### PR DESCRIPTION
Tools for the runtime events tracing system in OCaml

- Project page: <a href="https://github.com/tarides/runtime_events_tools">https://github.com/tarides/runtime_events_tools</a>

##### CHANGES:

* Fix support on ARM64 platforms (Linux and MacOS) (tarides/runtime_events_tools#34, @tmcgilchrist)
* Remove ocamlfind dependency. (tarides/runtime_events_tools#36, @tmcgilchrist)
* Expand gc-stats help (tarides/runtime_events_tools#28, @ju-sh)
