### PR TITLE
Package obus.1.2.5

### DIFF
--- a/packages/obus/obus.1.2.5/opam
+++ b/packages/obus/obus.1.2.5/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/ocaml-community/obus/issues"
 depends: [
   "ocaml" {>= "4.07"}
   "dune" {>= "1.4"}
-  "menhir" {build}
+  "menhir" {build & >= "20180528"}
   "xmlm"
   "lwt" {>= "4.3.0"}
   "lwt_ppx"

--- a/packages/obus/obus.1.2.5/opam
+++ b/packages/obus/obus.1.2.5/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Pure Ocaml implementation of the D-Bus protocol"
+maintainer: "freyrnjordrson@gmail.com"
+authors: "Jérémie Dimino"
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/obus"
+bug-reports: "https://github.com/ocaml-community/obus/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {>= "1.1"}
+  "menhir" {build}
+  "xmlm"
+  "lwt" {>= "4.3.0"}
+  "lwt_ppx"
+  "lwt_log"
+  "lwt_react"
+  "ppxlib" {>= "0.26.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml-community/obus.git"
+url {
+  src:
+    "https://github.com/ocaml-community/obus/releases/download/1.2.5/obus-1.2.5.tar.gz"
+  checksum: [
+    "md5=81eb1034c6ef4421a2368a9b352199de"
+    "sha512=4b540497188a7d78f4f14f94c6b7fdff47dd06436a34e650ff378dd77bb3e2acb7afd45cd72daf4ddba06e732e9944d560c2882dc37862f1b1f1bb6df37e6205"
+  ]
+}

--- a/packages/obus/obus.1.2.5/opam
+++ b/packages/obus/obus.1.2.5/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/ocaml-community/obus"
 bug-reports: "https://github.com/ocaml-community/obus/issues"
 depends: [
   "ocaml" {>= "4.07"}
-  "dune" {>= "1.1"}
+  "dune" {>= "1.4"}
   "menhir" {build}
   "xmlm"
   "lwt" {>= "4.3.0"}


### PR DESCRIPTION
### `obus.1.2.5`
Pure Ocaml implementation of the D-Bus protocol



---
* Homepage: https://github.com/ocaml-community/obus
* Source repo: git+https://github.com/ocaml-community/obus.git
* Bug tracker: https://github.com/ocaml-community/obus/issues

---
:camel: Pull-request generated by opam-publish v2.3.0