### PR TITLE
Make eio-luv unavailable

### DIFF
--- a/packages/eio_luv/eio_luv.0.1/opam
+++ b/packages/eio_luv/eio_luv.0.1/opam
@@ -13,7 +13,6 @@ depends: [
   "eio" {= version}
   "luv" {>= "0.5.11"}
   "luv_unix" {>= "0.5.0"}
-  "mdx" {>= "1.10.0" & with-test}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "odoc" {with-doc}
@@ -29,7 +28,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    # no tests because package is essentially deprecated and bit-rotting
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/eio_luv/eio_luv.0.1/opam
+++ b/packages/eio_luv/eio_luv.0.1/opam
@@ -43,3 +43,4 @@ url {
   ]
 }
 x-commit-hash: "ba1fbbe60b94500c79556585134ffbe0dd1ec2fa"
+available: false

--- a/packages/eio_luv/eio_luv.0.2/opam
+++ b/packages/eio_luv/eio_luv.0.2/opam
@@ -13,7 +13,6 @@ depends: [
   "eio" {= version}
   "luv" {>= "0.5.11"}
   "luv_unix" {>= "0.5.0"}
-  "mdx" {>= "1.10.0" & with-test}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "odoc" {with-doc}
@@ -29,7 +28,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    # no tests because package is essentially deprecated and bit-rotting
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/eio_luv/eio_luv.0.2/opam
+++ b/packages/eio_luv/eio_luv.0.2/opam
@@ -43,3 +43,4 @@ url {
   ]
 }
 x-commit-hash: "85841dc0b779a920bc4b1daca9172456e33988ee"
+available: false

--- a/packages/eio_luv/eio_luv.0.3/opam
+++ b/packages/eio_luv/eio_luv.0.3/opam
@@ -13,7 +13,6 @@ depends: [
   "eio" {= version}
   "luv" {>= "0.5.11"}
   "luv_unix" {>= "0.5.0"}
-  "mdx" {>= "1.10.0" & with-test}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "odoc" {with-doc}
@@ -29,7 +28,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    # no tests because package is essentially deprecated and bit-rotting
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/eio_luv/eio_luv.0.3/opam
+++ b/packages/eio_luv/eio_luv.0.3/opam
@@ -43,3 +43,4 @@ url {
   ]
 }
 x-commit-hash: "0b56cec54f3c9e0b9c4382e33b7594eef13af3d0"
+available: false

--- a/packages/eio_luv/eio_luv.0.4/opam
+++ b/packages/eio_luv/eio_luv.0.4/opam
@@ -42,3 +42,4 @@ url {
   ]
 }
 x-commit-hash: "34d1d26ac4f5d5b506a7a216c2c205d83f09110c"
+available: false

--- a/packages/eio_luv/eio_luv.0.4/opam
+++ b/packages/eio_luv/eio_luv.0.4/opam
@@ -12,7 +12,6 @@ depends: [
   "eio" {= version}
   "luv" {>= "0.5.11"}
   "luv_unix" {>= "0.5.0"}
-  "mdx" {>= "1.10.0" & with-test}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "odoc" {with-doc}
@@ -28,7 +27,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    # no tests because package is essentially deprecated and bit-rotting
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/eio_luv/eio_luv.0.5/opam
+++ b/packages/eio_luv/eio_luv.0.5/opam
@@ -12,7 +12,6 @@ depends: [
   "eio" {= version}
   "luv" {>= "0.5.11"}
   "luv_unix" {>= "0.5.0"}
-  "mdx" {>= "1.10.0" & with-test}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "odoc" {with-doc}
@@ -28,7 +27,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    # no tests because package is essentially deprecated and bit-rotting
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/eio_luv/eio_luv.0.5/opam
+++ b/packages/eio_luv/eio_luv.0.5/opam
@@ -42,3 +42,4 @@ url {
   ]
 }
 x-commit-hash: "d86a4fddc8952f028d1db8de5a23bfb174ac9145"
+available: false

--- a/packages/eio_luv/eio_luv.0.6/opam
+++ b/packages/eio_luv/eio_luv.0.6/opam
@@ -12,7 +12,6 @@ depends: [
   "eio" {= version}
   "luv" {>= "0.5.11"}
   "luv_unix" {>= "0.5.0"}
-  "mdx" {>= "1.10.0" & with-test}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "odoc" {with-doc}
@@ -28,7 +27,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    # no tests because package is essentially deprecated and bit-rotting
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/eio_luv/eio_luv.0.6/opam
+++ b/packages/eio_luv/eio_luv.0.6/opam
@@ -42,3 +42,4 @@ url {
   ]
 }
 x-commit-hash: "9faa07bb934e7e44521f84eec110429faaab8ed4"
+available: false

--- a/packages/eio_luv/eio_luv.0.7/opam
+++ b/packages/eio_luv/eio_luv.0.7/opam
@@ -42,3 +42,4 @@ url {
   ]
 }
 x-commit-hash: "aa91a7bf813b9ab2eddeae35c17bc7439f2c0836"
+available: false

--- a/packages/eio_luv/eio_luv.0.7/opam
+++ b/packages/eio_luv/eio_luv.0.7/opam
@@ -12,7 +12,6 @@ depends: [
   "eio" {= version}
   "luv" {>= "0.5.11"}
   "luv_unix" {>= "0.5.0"}
-  "mdx" {>= "1.10.0" & with-test}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "odoc" {with-doc}
@@ -28,7 +27,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    # no tests because package is essentially deprecated and bit-rotting
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/eio_luv/eio_luv.0.8.1/opam
+++ b/packages/eio_luv/eio_luv.0.8.1/opam
@@ -12,7 +12,6 @@ depends: [
   "eio" {= version}
   "luv" {>= "0.5.11"}
   "luv_unix" {>= "0.5.0"}
-  "mdx" {>= "1.10.0" & with-test}
   "fmt" {>= "0.8.9"}
   "odoc" {with-doc}
 ]
@@ -26,7 +25,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    # no tests because package is essentially deprecated and bit-rotting
     "@doc" {with-doc}
   ]
 ]

--- a/packages/eio_luv/eio_luv.0.8.1/opam
+++ b/packages/eio_luv/eio_luv.0.8.1/opam
@@ -39,3 +39,4 @@ url {
   ]
 }
 x-commit-hash: "38c337e888bac215c52b696d61e2f58cab75380f"
+available: false

--- a/packages/eio_luv/eio_luv.0.9/opam
+++ b/packages/eio_luv/eio_luv.0.9/opam
@@ -12,7 +12,6 @@ depends: [
   "eio" {= version}
   "luv" {>= "0.5.11"}
   "luv_unix" {>= "0.5.0"}
-  "mdx" {>= "2.2.0" & with-test}
   "fmt" {>= "0.8.9"}
   "odoc" {with-doc}
 ]
@@ -26,7 +25,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    # no tests because package is essentially deprecated and bit-rotting
     "@doc" {with-doc}
   ]
 ]

--- a/packages/eio_luv/eio_luv.0.9/opam
+++ b/packages/eio_luv/eio_luv.0.9/opam
@@ -39,3 +39,4 @@ url {
   ]
 }
 x-commit-hash: "72f9d77642e2ecafefb8057e711d05666e3e5918"
+available: false


### PR DESCRIPTION
This follows failures noticed on https://github.com/ocaml/opam-repository/pull/25369 and general deprecation of the package.