### PR TITLE
melange: remove `ocaml` constraints in 3 pkgs

### DIFF
--- a/packages/melange-fetch/melange-fetch.0.1.0/opam
+++ b/packages/melange-fetch/melange-fetch.0.1.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/melange-community/melange-fetch"
 bug-reports: "https://github.com/melange-community/melange-fetch"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "5.1"}
+  "ocaml"
   "melange" {>= "2.0.0"}
   "odoc" {with-doc}
 ]

--- a/packages/melange-json/melange-json.1.1.0/opam
+++ b/packages/melange-json/melange-json.1.1.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/melange-community/melange-json/"
 bug-reports: "https://github.com/melange-community/melange-json/issues"
 depends: [
   "dune" {>= "3.9"}
-  "ocaml" {>= "5.1"}
+  "ocaml"
   "melange" {>= "3.0.0"}
   "melange-jest" {with-test}
   "reason" {>= "3.10.0" & with-test}

--- a/packages/reason-react/reason-react.0.14.0/opam
+++ b/packages/reason-react/reason-react.0.14.0/opam
@@ -17,7 +17,7 @@ doc: "https://reasonml.github.io/reason-react"
 bug-reports: "https://github.com/reasonml/reason-react/issues"
 depends: [
   "dune" {>= "3.9"}
-  "ocaml" {>= "5.1.1" & < "5.2.0"}
+  "ocaml"
   "melange" {>= "3.0.0"}
   "reason-react-ppx" {= version}
   "reason" {>= "3.10.0"}


### PR DESCRIPTION
These 3 packages were constraining the version of the OCaml compiler, but since version 3, Melange allows to be installed in switches with 4.x and 5.x.