### PR TITLE
2 packages from kit-ty-kate/opam-build at 0.2.3

### DIFF
--- a/packages/opam-build/opam-build.0.2.1/opam
+++ b/packages/opam-build/opam-build.0.2.1/opam
@@ -12,7 +12,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "xdg" {>= "3.0.0"}
 ]
-available: opam-version >= "2.2" & opam-version < "2.3"
+available: false
 flags: plugin
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"

--- a/packages/opam-build/opam-build.0.2.3/opam
+++ b/packages/opam-build/opam-build.0.2.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to build projects"
+maintainer: "Kate <kit-ty-kate@outlook.com>"
+authors: "Kate <kit-ty-kate@outlook.com>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.2" & < "2.3"}
+  "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
+]
+available: opam-version >= "2.2" & opam-version < "2.3"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.2.3/opam-build-0.2.3.tar.gz"
+  checksum: [
+    "md5=e6616c0264524d174e226a03d2442337"
+    "sha512=71a9d39a1a5607f8c439b20c79998ca50aae79b449886ac0d1982a42e7ca34e75a49407289bba4ff43485fc5299b6725cfaaa968fad1ed068708987ffbedf8c6"
+  ]
+}

--- a/packages/opam-test/opam-test.0.2.1/opam
+++ b/packages/opam-test/opam-test.0.2.1/opam
@@ -12,7 +12,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "xdg" {>= "3.0.0"}
 ]
-available: opam-version >= "2.2" & opam-version < "2.3"
+available: false
 flags: plugin
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"

--- a/packages/opam-test/opam-test.0.2.3/opam
+++ b/packages/opam-test/opam-test.0.2.3/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to test projects"
+maintainer: "Kate <kit-ty-kate@outlook.com>"
+authors: "Kate <kit-ty-kate@outlook.com>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.2" & < "2.3"}
+  "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
+]
+available: opam-version >= "2.2" & opam-version < "2.3"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.2.3/opam-build-0.2.3.tar.gz"
+  checksum: [
+    "md5=e6616c0264524d174e226a03d2442337"
+    "sha512=71a9d39a1a5607f8c439b20c79998ca50aae79b449886ac0d1982a42e7ca34e75a49407289bba4ff43485fc5299b6725cfaaa968fad1ed068708987ffbedf8c6"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `opam-build.0.2.3`: An opam plugin to build projects
- `opam-test.0.2.3`: An opam plugin to test projects



---
* Homepage: https://github.com/kit-ty-kate/opam-build
* Source repo: git+https://github.com/kit-ty-kate/opam-build.git
* Bug tracker: https://github.com/kit-ty-kate/opam-build/issues

---
:camel: Pull-request generated by opam-publish v2.3.0