### PR TITLE
saturn_lockfree: disable tests

### DIFF
--- a/packages/saturn_lockfree/saturn_lockfree.0.4.1/opam
+++ b/packages/saturn_lockfree/saturn_lockfree.0.4.1/opam
@@ -27,7 +27,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
They require saturn, which requires saturn_lockfree

Ping @polytypic, I think the issue with saturn_lockfree tests has not to do just with the other package but is that saturn_lockfree tries to run saturn tests as well.