### PR TITLE
eio_main: upper bound on kcas for the tests

### DIFF
--- a/packages/eio_main/eio_main.0.10/opam
+++ b/packages/eio_main/eio_main.0.10/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.7"}
   "mdx" {>= "2.2.0" & with-test}
-  "kcas" {>= "0.3.0" & with-test}
+  "kcas" {>= "0.3.0" & < "0.7.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
   "eio_linux" {= version & os = "linux"}
   "eio_posix" {= version & os != "win32"}

--- a/packages/eio_main/eio_main.0.11/opam
+++ b/packages/eio_main/eio_main.0.11/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.9"}
   "mdx" {>= "2.2.0" & with-test}
-  "kcas" {>= "0.3.0" & with-test}
+  "kcas" {>= "0.3.0" & < "0.7.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
   "eio_linux" {= version & os = "linux"}
   "eio_posix" {= version & os != "win32"}

--- a/packages/eio_main/eio_main.0.12/opam
+++ b/packages/eio_main/eio_main.0.12/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.9"}
   "mdx" {>= "2.2.0" & with-test}
-  "kcas" {>= "0.3.0" & with-test}
+  "kcas" {>= "0.3.0" & < "0.7.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
   "eio_linux" {= version & os = "linux"}
   "eio_posix" {= version & os != "win32"}

--- a/packages/eio_main/eio_main.0.13/opam
+++ b/packages/eio_main/eio_main.0.13/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.9"}
   "mdx" {>= "2.2.0" & with-test}
-  "kcas" {>= "0.3.0" & with-test}
+  "kcas" {>= "0.3.0" & < "0.7.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
   "eio_linux"
     {= version & os = "linux" &

--- a/packages/eio_main/eio_main.0.14/opam
+++ b/packages/eio_main/eio_main.0.14/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.9"}
   "mdx" {>= "2.2.0" & with-test}
-  "kcas" {>= "0.3.0" & with-test}
+  "kcas" {>= "0.3.0" & < "0.7.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
   "eio_linux"
     {= version & os = "linux" &


### PR DESCRIPTION
Kcas type representation has changed and breaks the expect tests