### PR TITLE
Expand conf-gssapi platform support

### DIFF
--- a/packages/conf-gssapi/conf-gssapi.1/opam
+++ b/packages/conf-gssapi/conf-gssapi.1/opam
@@ -5,6 +5,12 @@ authors: "The MIT Kerberos Team"
 build: [["pkg-config" "krb5-gssapi" "mit-krb5-gssapi"]]
 depexts: [
   ["libkrb5-dev"] {os-family = "debian"}
+  ["libkrb5-dev"] {os-family = "ubuntu"}
+  ["krb5-dev"] {os-distribution = "alpine"}
+  ["krb5"] {os-distribution = "arch"}
+  ["krb5-devel"] {os-distribution = "fedora"}
+  ["krb5"] {os-family = "suse" | os-family = "opensuse"}
+  ["krb5-devel"]  {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a krb5-gssapi system installation"
 description:


### PR DESCRIPTION
This PR expands conf-gssapi platform support to
- Ubuntu derivatives
- Alpine
- Arch
- Fedora
- (Open)Suse
- FreeBSD