### PR TITLE
Broaden conf-sdl-* support

### DIFF
--- a/packages/conf-sdl-gfx/conf-sdl-gfx.1/opam
+++ b/packages/conf-sdl-gfx/conf-sdl-gfx.1/opam
@@ -5,8 +5,13 @@ license: "LGPL-2.1-or-later"
 build: [["pkg-config" "SDL_gfx"]]
 depexts: [
   ["libsdl-gfx1.2-dev"] {os-family = "debian"}
+  ["libsdl-gfx1.2-dev"] {os-family = "ubuntu"}
+  ["sdl_gfx"] {os-distribution = "arch"}
   ["libSDL_gfx-devel"] {os-distribution = "mageia"}
+  ["SDL_gfx-devel"] {os-distribution = "fedora"}
+  ["SDL_gfx"] {os-family = "suse" | os-family = "opensuse"}
   ["sdl_gfx"] {os = "macos" & os-distribution = "homebrew"}
+  ["sdl_gfx"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a sdl-gfx system installation"
 description:

--- a/packages/conf-sdl-image/conf-sdl-image.1/opam
+++ b/packages/conf-sdl-image/conf-sdl-image.1/opam
@@ -5,10 +5,15 @@ license: "LGPL-2.1-or-later"
 build: [["pkg-config" "SDL_image"]]
 depexts: [
   ["sdl_image-dev"] {os-distribution = "alpine"}
+  ["sdl_image"] {os-distribution = "arch"}
   ["libsdl-image1.2-dev"] {os-family = "debian"}
+  ["libsdl-image1.2-dev"] {os-family = "ubuntu"}
   ["libSDL_image-devel"] {os-distribution = "mageia"}
+  ["SDL_image-devel"] {os-distribution = "fedora"}
+  ["SDL_image"] {os-family = "suse" | os-family = "opensuse"}
   ["SDL_image"] {os = "win32" & os-distribution = "cygwinports"}
   ["sdl_image"] {os = "macos" & os-distribution = "homebrew"}
+  ["sdl_image"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a sdl-image system installation"
 description:

--- a/packages/conf-sdl-mixer/conf-sdl-mixer.1/opam
+++ b/packages/conf-sdl-mixer/conf-sdl-mixer.1/opam
@@ -5,10 +5,15 @@ license: "LGPL-2.1-or-later"
 build: [["pkg-config" "SDL_mixer"]]
 depexts: [
   ["sdl_mixer-dev"] {os-distribution = "alpine"}
+  ["sdl_mixer"] {os-distribution = "arch"}
   ["libsdl-mixer1.2-dev"] {os-family = "debian"}
+  ["libsdl-mixer1.2-dev"] {os-family = "ubuntu"}
   ["libSDL_mixer-devel"] {os-distribution = "mageia"}
+  ["SDL_mixer-devel"] {os-distribution = "fedora"}
+  ["SDL_mixer"] {os-family = "suse" | os-family = "opensuse"}
   ["SDL_mixer"] {os = "win32" & os-distribution = "cygwinports"}
   ["sdl_mixer"] {os = "macos" & os-distribution = "homebrew"}
+  ["sdl_mixer"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a sdl-mixer system installation"
 description:

--- a/packages/conf-sdl-net/conf-sdl-net.1/opam
+++ b/packages/conf-sdl-net/conf-sdl-net.1/opam
@@ -4,10 +4,15 @@ homepage: "http://www.libsdl.org/projects/SDL_net/release-1.2.html"
 license: "Zlib"
 build: [["pkg-config" "SDL_net"]]
 depexts: [
+  ["sdl_net"] {os-distribution = "arch"}
   ["libsdl-net1.2-dev"] {os-family = "debian"}
+  ["libsdl-net1.2-dev"] {os-family = "ubuntu"}
   ["libSDL_net-devel"] {os-distribution = "mageia"}
+  ["SDL_net-devel"] {os-distribution = "fedora"}
+  ["SDL_net"] {os-family = "suse" | os-family = "opensuse"}
   ["SDL_net"] {os = "win32" & os-distribution = "cygwinports"}
   ["sdl_net"] {os = "macos" & os-distribution = "homebrew"}
+  ["sdl_net"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a sdl-net system installation"
 description:

--- a/packages/conf-sdl-ttf/conf-sdl-ttf.1/opam
+++ b/packages/conf-sdl-ttf/conf-sdl-ttf.1/opam
@@ -4,10 +4,15 @@ homepage: "http://www.libsdl.org/projects/SDL_ttf/release-1.2.html"
 license: "LGPL-2.1-or-later"
 build: [["pkg-config" "SDL_ttf"]]
 depexts: [
+  ["sdl_ttf"] {os-distribution = "arch"}
   ["libsdl-ttf2.0-dev"] {os-family = "debian"}
+  ["libsdl-ttf2.0-dev"] {os-family = "ubuntu"}
   ["libSDL_ttf-devel"] {os-distribution = "mageia"}
+  ["SDL_ttf-devel"] {os-distribution = "fedora"}
+  ["SDL_ttf"] {os-family = "suse" | os-family = "opensuse"}
   ["SDL_ttf"] {os = "win32" & os-distribution = "cygwinports"}
   ["sdl_ttf"] {os = "macos" & os-distribution = "homebrew"}
+  ["sdl_ttf"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a sdl-ttf system installation"
 description:


### PR DESCRIPTION
This PR broadens the support of the conf-sdl-{gfx,image,mixer,ttf,net} packages to support
- Ubuntu-derivatives
- Arch
- Fedora
- (Open)Suse
- FreeBSD