### PR TITLE
Support conf-perl-* under FreeBSD and Ubuntu-derivatives

### DIFF
--- a/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.3/opam
+++ b/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.3/opam
@@ -13,6 +13,7 @@ build: [
 ]
 depexts: [
   ["libipc-system-simple-perl"] {os-family = "debian"}
+  ["libipc-system-simple-perl"] {os-family = "ubuntu"}
   ["perl-ipc-system-simple"] {os-distribution = "alpine"}
   ["epel-release" "perl-IPC-System-Simple"] {os-distribution = "centos"}
   ["perl-IPC-System-Simple"] {os-distribution = "ol" & os-version >= "8"}
@@ -20,6 +21,7 @@ depexts: [
   ["perl-IPC-System-Simple"] {os-distribution = "fedora"}
   ["perl-ipc-system-simple"] {os-family = "arch"}
   ["p5-ipc-system-simple"] {os-distribution = "macports" & os = "macos"}
+  ["p5-IPC-System-Simple"] {os = "freebsd"}
 ]
 x-ci-accept-failures: [
   "oraclelinux-7"

--- a/packages/conf-perl-string-shellquote/conf-perl-string-shellquote.3/opam
+++ b/packages/conf-perl-string-shellquote/conf-perl-string-shellquote.3/opam
@@ -13,6 +13,7 @@ build: [
 ]
 depexts: [
   ["libstring-shellquote-perl"] {os-family = "debian"}
+  ["libstring-shellquote-perl"] {os-family = "ubuntu"}
   ["perl-string-shellquote"] {os-distribution = "alpine"}
   ["perl-String-ShellQuote"] {os-distribution = "centos"}
   ["perl-String-ShellQuote"] {os-distribution = "ol"}
@@ -20,6 +21,7 @@ depexts: [
   ["perl-String-ShellQuote"] {os-family = "fedora"}
   ["perl-string-shellquote"] {os-family = "arch"}
   ["p5-string-shellquote"] {os-distribution = "macports" & os = "macos"}
+  ["p5-String-ShellQuote"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on perl's String::ShellQuote"
 description:


### PR DESCRIPTION
This PR adds FreeBSD and Ubuntu-derivative support for
- conf-perl-ipc-system-simple
- conf-perl-string-shellquote