### PR TITLE
Use os-family for debian/ubuntu in conf-srt* packages

### DIFF
--- a/packages/conf-srt-gnutls/conf-srt-gnutls.1/opam
+++ b/packages/conf-srt-gnutls/conf-srt-gnutls.1/opam
@@ -9,7 +9,7 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libsrt-gnutls-dev" "libgnutls28-dev"] {os-distribution = "debian" | os-distribution = "ubuntu"}
+  ["libsrt-gnutls-dev" "libgnutls28-dev"] {os-family = "debian" | os-family = "ubuntu"}
 ]
 synopsis: "Virtual package relying on srt build with gnutls"
 description:

--- a/packages/conf-srt-openssl/conf-srt-openssl.1/opam
+++ b/packages/conf-srt-openssl/conf-srt-openssl.1/opam
@@ -9,7 +9,7 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libsrt-openssl-dev" "libssl-dev"] {os-distribution = "debian" | os-distribution = "ubuntu"}
+  ["libsrt-openssl-dev" "libssl-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["srt" "openssl"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on srt compiled with openssl"

--- a/packages/conf-srt/conf-srt.2/opam
+++ b/packages/conf-srt/conf-srt.2/opam
@@ -7,7 +7,7 @@ license: "MPL-2.0"
 build: ["pkg-config" "--exists" "srt"]
 depends: [
   "conf-pkg-config" {build}
-  "conf-srt-openssl" {os-distribution = "debian" | os-distribution = "ubuntu" | os = "macos" & os-distribution = "homebrew"} | "conf-srt-gnutls" {os-distribution = "debian" | os-distribution = "ubuntu"}
+  "conf-srt-openssl" {os-family = "debian" | os-family = "ubuntu" | os = "macos" & os-distribution = "homebrew"} | "conf-srt-gnutls" {os-family = "debian" | os-family = "ubuntu"}
 ]
 depexts: [
   ["srt-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}


### PR DESCRIPTION
This PR switches
- conf-srt
- conf-srt-gnutls
- conf-srt-openssl

to use `os-family` for debian and ubuntu in order to broaden the package to support debian and ubuntu derivatives.
