### PR TITLE
Expand conf-* FreeBSD support

### DIFF
--- a/packages/conf-arb/conf-arb.1/opam
+++ b/packages/conf-arb/conf-arb.1/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "1"
 maintainer: "bobot"
 homepage: "http://arblib.org/"
 bug-reports: "https://github.com/fredrik-johansson/arb"

--- a/packages/conf-arb/conf-arb.1/opam
+++ b/packages/conf-arb/conf-arb.1/opam
@@ -28,6 +28,7 @@ depexts: [
   ["libarb-dev"] {os-distribution = "alpine"}
   ["arb-devel"] {os-family = "suse"}
   ["arb"] {os-distribution = "nixos"}
+  ["arb"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a Arb lib system installation"
 description:

--- a/packages/conf-flint/conf-flint.1/opam
+++ b/packages/conf-flint/conf-flint.1/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "1"
 maintainer: "bobot"
 homepage: "http://flint.org"
 bug-reports: "https://github.com/flintlib/flint2.git"

--- a/packages/conf-flint/conf-flint.1/opam
+++ b/packages/conf-flint/conf-flint.1/opam
@@ -30,6 +30,7 @@ depexts: [
   ["flint-devel"] {os-family = "suse"}
   ["libflint-devel"] {os = "win32" & os-distribution = "cygwinports"}
   ["flint"] {os-distribution = "nixos"}
+  ["flint2"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a Flint lib system installation"
 description:

--- a/packages/conf-git/conf-git.1.1/opam
+++ b/packages/conf-git/conf-git.1.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["git"] {os-family = "arch"}
   ["git"] {os-family = "alpine"}
   ["system:git"] {os = "win32" & os-distribution = "cygwinports"}
+  ["git"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on git"
 description:

--- a/packages/conf-mad/conf-mad.1/opam
+++ b/packages/conf-mad/conf-mad.1/opam
@@ -15,6 +15,7 @@ depexts: [
   ["libmad0-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libmad"] {os = "win32" & os-distribution = "cygwinports"}
   ["mad"] {os = "macos" & os-distribution = "homebrew"}
+  ["libmad"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on mad"
 description:

--- a/packages/conf-mad/conf-mad.1/opam
+++ b/packages/conf-mad/conf-mad.1/opam
@@ -4,7 +4,10 @@ homepage: "https://www.underbit.com/products/mad/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "mad dev team"
 license: "GPL-2.0-only"
-build: ["pkg-config" "--exists" "mad"]
+build: [
+  ["pkg-config" "--exists" "mad"] {os != "freebsd"}
+  ["pkg-config" "--exists" "libmad"] {os = "freebsd"}
+]
 depends: [
   "conf-pkg-config" {build}
 ]

--- a/packages/conf-python-3-dev/conf-python-3-dev.1/opam
+++ b/packages/conf-python-3-dev/conf-python-3-dev.1/opam
@@ -3,7 +3,7 @@ maintainer: "zachshipko@gmail.com"
 homepage: "https://www.python.org/downloads/"
 authors: "Python Software Foundation"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-license: "PSF"
+license: "PSF-2.0"
 build: [
   [make]
 ]

--- a/packages/conf-python-3-dev/conf-python-3-dev.1/opam
+++ b/packages/conf-python-3-dev/conf-python-3-dev.1/opam
@@ -18,6 +18,7 @@ depexts: [
   ["python"] {os-family = "arch"}
   ["python3"] {os = "macos" & os-distribution = "homebrew"}
   ["python38"] {os = "macos" & os-distribution = "macports"}
+  ["python3"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on Python 3 development package installation"
 description: """


### PR DESCRIPTION
This PR add FreeBSD support for
- conf-arb
- conf-flint
- conf-git
- conf-mad
- conf-python-3-dev

The latter includes `python3-config` according to https://freebsd.pkgs.org/13/freebsd-amd64/python3-3_3.pkg.html but I'm less sure of the `Python.h` header... :thinking: 