### PR TITLE
conf-sundials: fix FreeBSD support

### DIFF
--- a/packages/conf-sundials/conf-sundials.2/opam
+++ b/packages/conf-sundials/conf-sundials.2/opam
@@ -8,6 +8,7 @@ build: [
   "cc"
   "-E"
   "-I/opt/local/include" {os-distribution = "macports"}
+  "-I/usr/local/include" {os = "freebsd"}
   "test.c"
 ]
 depexts: [


### PR DESCRIPTION
conf-sundials fails on FreeBSD on https://freebsd.check.ci.dev/ due to a missing include directory.
This PR adds an appropriate one.