### PR TITLE
Fix conf-jack FreeBSD support

### DIFF
--- a/packages/conf-jack/conf-jack.1/opam
+++ b/packages/conf-jack/conf-jack.1/opam
@@ -14,7 +14,8 @@ depexts: [
   ["epel-release" "jack-audio-connection-kit-devel"] {os-distribution = "centos"}
   ["libjack-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["jack"] {os-distribution = "nixos"}
-  ["jack"] {os-family = "arch" | os = "freebsd" | os = "macos" & os-distribution = "homebrew"}
+  ["jack"] {os-family = "arch" | os = "macos" & os-distribution = "homebrew"}
+  ["audio/jack"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on jack"
 description:


### PR DESCRIPTION
conf-jack fails on FreeBSD on https://freebsd.check.ci.dev/ as it uses the wrong sys package name `jack`
The right name is `audio/jack` or `jackit` according to https://www.freshports.org/audio/jack