### PR TITLE
Fix conf-libopus FreeBSD support

### DIFF
--- a/packages/conf-libopus/conf-libopus.1/opam
+++ b/packages/conf-libopus/conf-libopus.1/opam
@@ -12,7 +12,8 @@ depexts: [
   ["libopus-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["opus-dev"] {os-family = "alpine"}
   ["opus"] {os-family = "arch"}
-  ["libopus"] {os = "freebsd" | os-distribution = "nixos"}
+  ["libopus"] {os-distribution = "nixos"}
+  ["audio/opus"] {os = "freebsd"}
   ["libopus0"] {os-family = "suse" | os-family = "opensuse"}
   ["libopusenc"] {os = "macos" & os-distribution = "homebrew"}
   ["opus-devel"] {os-distribution="centos" | os-family = "fedora"}


### PR DESCRIPTION
conf-libopus fails on FreeBSD on https://freebsd.check.ci.dev/ as it uses the wrong sys package name libopus
The right name is audio/opus or opus according to https://www.freshports.org/audio/opus/
