### PR TITLE
Fix conf-llvm.16 FreeBSD support

### DIFF
--- a/packages/conf-llvm/conf-llvm.16/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.16/files/configure.sh
@@ -10,7 +10,7 @@ if hash brew 2>/dev/null; then
 fi
 
 shopt -s nullglob
-for llvm_config in llvm-config-$version llvm-config-${version}.0 llvm-config${version}0 llvm-config-mp-$version llvm-config-mp-${version}.0 llvm${version}-config llvm-config-${version}-32 llvm-config-${version}-64 llvm-config $brew_llvm_config; do
+for llvm_config in llvm-config-$version llvm-config${version} llvm-config-${version}.0 llvm-config${version}0 llvm-config-mp-$version llvm-config-mp-${version}.0 llvm${version}-config llvm-config-${version}-32 llvm-config-${version}-64 llvm-config $brew_llvm_config; do
     llvm_version="`$llvm_config --version`" || true
     case $llvm_version in
     $version*)

--- a/packages/conf-llvm/conf-llvm.16/opam
+++ b/packages/conf-llvm/conf-llvm.16/opam
@@ -17,7 +17,8 @@ depexts: [
   ["llvm16-dev"] {os-distribution = "alpine"}
   ["llvm16"] {os-family = "arch"}
   ["llvm16-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm16-devel"] {os-distribution = "fedora"}
+  ["llvm16-devel"] {os-distribution = "fedora" & os-version >= "39"}
+  ["llvm-devel-16"] {os-distribution = "fedora" & os-version < "39"}
   ["llvm16-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm16"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.16/opam
+++ b/packages/conf-llvm/conf-llvm.16/opam
@@ -16,7 +16,7 @@ depexts: [
   ["llvm-16-dev" "zlib1g-dev" "libzstd-dev"] {os-family = "debian"}
   ["llvm16-dev"] {os-distribution = "alpine"}
   ["llvm16"] {os-family = "arch"}
-  ["llvm16-devel"] {os-family = "suse"}
+  ["llvm16-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["llvm16-devel"] {os-distribution = "fedora"}
   ["llvm16-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm16"] {os = "freebsd"}

--- a/packages/conf-llvm/conf-llvm.16/opam
+++ b/packages/conf-llvm/conf-llvm.16/opam
@@ -18,7 +18,7 @@ depexts: [
   ["llvm16"] {os-family = "arch"}
   ["llvm16-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["llvm16-devel"] {os-distribution = "fedora" & os-version >= "39"}
-  ["llvm-devel-16"] {os-distribution = "fedora" & os-version < "39"}
+  ["llvm-devel-16"] {os-distribution = "fedora" & os-version = "38"}
   ["llvm16-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm16"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.16/opam
+++ b/packages/conf-llvm/conf-llvm.16/opam
@@ -18,7 +18,7 @@ depexts: [
   ["llvm16"] {os-family = "arch"}
   ["llvm16-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["llvm16-devel"] {os-distribution = "fedora" & os-version >= "39"}
-  ["llvm-devel-16"] {os-distribution = "fedora" & os-version = "38"}
+  ["llvm-devel"] {os-distribution = "fedora" & os-version = "38"}
   ["llvm16-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm16"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.16/opam
+++ b/packages/conf-llvm/conf-llvm.16/opam
@@ -22,5 +22,5 @@ depexts: [
   ["devel/llvm16"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"
-extra-files: ["configure.sh" "md5=633155a6495a7afd1c87ffd0b94e8cf9"]
+extra-files: ["configure.sh" "md5=5e80960db32ce1939a40396c9fea005a"]
 flags: conf


### PR DESCRIPTION
conf-llvm.16 fails on FreeBSD on https://freebsd.check.ci.dev/

From the log https://freebsd.check.ci.dev/log/1708435041-55225ede92751fbc1bc34328c453e95a06a6cec6/5.1.0/bad/conf-llvm.16 one can see it repeatedly tries various `llvm-config` variations except `llvm-config16` (no dash before 16)
which should be the right name according to https://freebsd.pkgs.org/14/freebsd-aarch64/llvm16-16.0.6_10.pkg.html

