### PR TITLE
Expand ubuntu family support for conf-* packages

### DIFF
--- a/packages/conf-automake/conf-automake.1/opam
+++ b/packages/conf-automake/conf-automake.1/opam
@@ -20,6 +20,7 @@ depexts: [
   # Note: although https://repology.org/project/automake/versions states debian has only automake packages
   # with explicit versions, there is an "automake" package, at least on Ubuntu 18.04
   [ "automake" ] {os-family = "debian"}
+  [ "automake" ] {os-family = "ubuntu"}
   [ "automake" ] {os-family = "fedora"}
   [ "sys-devel/automake" ] {os-family = "gentoo"}
   [ "automake" ] {os-family = "homebrew"}

--- a/packages/conf-blas/conf-blas.1/opam
+++ b/packages/conf-blas/conf-blas.1/opam
@@ -12,6 +12,7 @@ build: [
 ]
 depexts: [
   ["libblas-dev"] {os-family = "debian"}
+  ["libblas-dev"] {os-family = "ubuntu"}
   ["libblas-devel"] {os-distribution = "mageia"}
   ["blas-devel"] {os-distribution = "centos"}
   ["blas-devel"] {os-distribution = "fedora"}

--- a/packages/conf-bmake/conf-bmake.1.0/opam
+++ b/packages/conf-bmake/conf-bmake.1.0/opam
@@ -10,6 +10,7 @@ build: [
 ]
 depexts: [
   ["bmake"] {os-family = "debian"}
+  ["bmake"] {os-family = "ubuntu"}
   ["bmake"] {os-distribution = "centos"}
   ["bmake"] {os-distribution = "fedora"}
   ["bmake"] {os-distribution = "arch"}

--- a/packages/conf-cmake/conf-cmake.1/opam
+++ b/packages/conf-cmake/conf-cmake.1/opam
@@ -9,6 +9,7 @@ depexts: [
   ["cmake"] {os-distribution = "homebrew" & os = "macos"}
   ["cmake"] {os-distribution = "macports" & os = "macos"}
   ["cmake"] {os-family = "debian"}
+  ["cmake"] {os-family = "ubuntu"}
   ["cmake3" "epel-release"] {os-distribution = "centos"}
   ["cmake"] {os-distribution = "fedora"}
   ["cmake"] {os-distribution = "alpine"}

--- a/packages/conf-cpio/conf-cpio.1/opam
+++ b/packages/conf-cpio/conf-cpio.1/opam
@@ -7,6 +7,7 @@ license: ["GPL-3.0-only" "BSD-3-Clause"]
 build: ["cpio" "--version"]
 depexts: [
   ["cpio"] {os-family = "debian"}
+  ["cpio"] {os-family = "ubuntu"}
   ["cpio"] {os-distribution = "fedora"}
   ["cpio"] {os-distribution = "rhel"}
   ["cpio"] {os-distribution = "centos"}

--- a/packages/conf-diffutils/conf-diffutils.2/opam
+++ b/packages/conf-diffutils/conf-diffutils.2/opam
@@ -10,6 +10,7 @@ build: [
 ]
 depexts: [
   ["diffutils"] {os-family = "debian"}
+  ["diffutils"] {os-family = "ubuntu"}
   ["diffutils"] {os-distribution = "fedora"}
   ["diffutils"] {os-distribution = "rhel"}
   ["diffutils"] {os-distribution = "centos"}

--- a/packages/conf-gfortran/conf-gfortran.0/opam
+++ b/packages/conf-gfortran/conf-gfortran.0/opam
@@ -9,6 +9,7 @@ flags: conf
 build: ["gfortran" "--version"]
 depexts: [
   ["gfortran"] {os-family = "debian"}
+  ["gfortran"] {os-family = "ubuntu"}
   ["gfortran"] {os-distribution = "alpine"}
   ["gcc-gfortran"] {os-distribution = "fedora"}
   ["gcc-gfortran"] {os-distribution = "centos"}

--- a/packages/conf-glib-2/conf-glib-2.1/opam
+++ b/packages/conf-glib-2/conf-glib-2.1/opam
@@ -7,6 +7,7 @@ license: "LGPL-2.0-only"
 build: [["pkg-config" "glib-2.0"]]
 depexts: [
   ["libglib2.0-dev"] {os-family = "debian"}
+  ["libglib2.0-dev"] {os-family = "ubuntu"}
   ["glib2-devel"] {os-distribution = "fedora"}
   ["glib2-devel"] {os-distribution = "centos"}
   ["glib-dev"] {os-distribution = "alpine"}

--- a/packages/conf-gnuplot/conf-gnuplot.0.1/opam
+++ b/packages/conf-gnuplot/conf-gnuplot.0.1/opam
@@ -7,6 +7,7 @@ license: "gnuplot"
 build: ["gnuplot" "--version"]
 depexts: [
   ["gnuplot-x11"] {os-family = "debian"}
+  ["gnuplot-x11"] {os-family = "ubuntu"}
   ["gnuplot"] {os-distribution = "centos"}
   ["gnuplot"] {os-distribution = "fedora"}
   ["gnuplot"] {os-distribution = "ol"}

--- a/packages/conf-gsl/conf-gsl.2/opam
+++ b/packages/conf-gsl/conf-gsl.2/opam
@@ -6,6 +6,7 @@ license: "GPL-1.0-or-later"
 build: [["pkg-config" "gsl"]]
 depexts: [
   ["libgsl-dev"] {os-family = "debian"}
+  ["libgsl-dev"] {os-family = "ubuntu"}
   ["libgsl-devel"] {os-distribution = "mageia"}
   ["gsl-devel"] {os-distribution = "centos"}
   ["gsl-devel"] {os-distribution = "fedora"}

--- a/packages/conf-gstreamer/conf-gstreamer.1/opam
+++ b/packages/conf-gstreamer/conf-gstreamer.1/opam
@@ -17,7 +17,7 @@ depexts: [
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]
     {os-distribution = "centos"}
   ["libgstreamer1.0-dev" "libgstreamer-plugins-base1.0-dev"]
-    {os-family = "debian"}
+    {os-family = "debian" | os-family = "ubuntu"}
   ["gstreamer1" "gstreamer1-plugins-core"] {os = "freebsd"}
   ["gstreamer1.0" "gstreamer1.0-plugins-base"]
     {os = "win32" & os-distribution = "cygwinports"}

--- a/packages/conf-hidapi/conf-hidapi.0/opam
+++ b/packages/conf-hidapi/conf-hidapi.0/opam
@@ -11,6 +11,7 @@ build: [
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libhidapi-dev"] {os-family = "debian"}
+  ["libhidapi-dev"] {os-family = "ubuntu"}
   ["libhidapi-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["hidapi" "libusb"] {os-distribution = "arch"}
   ["hidapi-devel"] {os-distribution = "fedora"}

--- a/packages/conf-lapack/conf-lapack.1/opam
+++ b/packages/conf-lapack/conf-lapack.1/opam
@@ -12,6 +12,7 @@ build: [
 ]
 depexts: [
   ["liblapack-dev"] {os-family = "debian"}
+  ["liblapack-dev"] {os-family = "ubuntu"}
   ["liblapack-devel"] {os-distribution = "mageia"}
   ["lapack-devel"] {os-distribution = "centos"}
   ["lapack-devel"] {os-distribution = "fedora"}

--- a/packages/conf-libclang/conf-libclang.15/opam
+++ b/packages/conf-libclang/conf-libclang.15/opam
@@ -24,7 +24,7 @@ depexts: [
   ["libclang-dev" "libclang-cpp-dev" "llvm-dev"] {
      os-distribution = "debian" & os-version >= "11"}
   ["libclang-dev" "llvm-dev"] {
-     os-family = "debian" &
+     (os-family = "debian" | os-family = "ubuntu") &
      !(os-distribution = "debian" & os-version >= "11") &
      !(os-distribution = "ubuntu" & os-version >= "22.04")}
   ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}

--- a/packages/conf-libffi/conf-libffi.2.0.0/opam
+++ b/packages/conf-libffi/conf-libffi.2.0.0/opam
@@ -9,6 +9,7 @@ depexts: [
   ["libffi"] {os = "macos" & os-distribution = "macports"}
   ["libffi-dev"] {os-distribution = "alpine"}
   ["libffi-dev"] {os-family = "debian"}
+  ["libffi-dev"] {os-family = "ubuntu"}
   ["libffi-devel"] {os-distribution = "centos"}
   ["libffi-devel"] {os-distribution = "fedora"}
   ["libffi-devel"] {os-distribution = "mageia"}

--- a/packages/conf-libflac/conf-libflac.1/opam
+++ b/packages/conf-libflac/conf-libflac.1/opam
@@ -10,6 +10,7 @@ depends: [
 ]
 depexts: [
   ["libflac-dev"] {os-family = "debian"}
+  ["libflac-dev"] {os-family = "ubuntu"}
   ["flac-devel"] {os-distribution = "centos"}
   ["flac-devel"] {os-distribution = "fedora"}
   ["flac-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-libogg/conf-libogg.1/opam
+++ b/packages/conf-libogg/conf-libogg.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["libogg-dev"] {os-distribution = "alpine"}
   ["libogg"] {os-distribution = "arch"}
   ["libogg-dev"] {os-family = "debian"}
+  ["libogg-dev"] {os-family = "ubuntu"}
   ["libogg-devel"] {os-distribution = "centos"}
   ["libogg-devel"] {os-distribution = "fedora"}
   ["libogg-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-libpcre/conf-libpcre.1/opam
+++ b/packages/conf-libpcre/conf-libpcre.1/opam
@@ -12,6 +12,7 @@ depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 depexts: [
   ["libpcre3-dev"] {os-family = "debian"}
+  ["libpcre3-dev"] {os-family = "ubuntu"}
   ["libpcre-devel"] {os-distribution = "mageia"}
   ["pcre-devel"] {os-distribution = "centos"}
   ["pcre-devel"] {os-distribution = "fedora"}

--- a/packages/conf-libpcre2-8/conf-libpcre2-8.1/opam
+++ b/packages/conf-libpcre2-8/conf-libpcre2-8.1/opam
@@ -12,6 +12,7 @@ depends: ["conf-pkg-config" {build}]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 depexts: [
   ["libpcre2-dev"] {os-family = "debian"}
+  ["libpcre2-dev"] {os-family = "ubuntu"}
   ["libpcre2-devel"] {os-distribution = "mageia"}
   ["pcre2-devel"] {os-distribution = "centos"}
   ["pcre2-devel"] {os-distribution = "fedora"}

--- a/packages/conf-libspeex/conf-libspeex.1/opam
+++ b/packages/conf-libspeex/conf-libspeex.1/opam
@@ -14,6 +14,7 @@ depexts: [
   ["speex-devel"] {os-distribution = "fedora"}
   ["speex-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libspeex-dev"] {os-family = "debian"}
+  ["libspeex-dev"] {os-family = "ubuntu"}
   ["speex"] {os-family = "bsd"}
   ["speex"] {os = "macos" & os-distribution = "homebrew"}
   ["speex"] {os = "win32" & os-distribution = "cygwinports"}

--- a/packages/conf-mpi/conf-mpi.1/opam
+++ b/packages/conf-mpi/conf-mpi.1/opam
@@ -7,6 +7,7 @@ build: [["sh" "configure" os]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["mpi-default-dev"] {os-family = "debian"}
+  ["mpi-default-dev"] {os-family = "ubuntu"}
   ["openmpi-devel"] {os-distribution = "centos"}
   ["openmpi-devel"] {os-distribution = "fedora"}
   ["openmpi"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-mysql/conf-mysql.1/opam
+++ b/packages/conf-mysql/conf-mysql.1/opam
@@ -9,6 +9,7 @@ build: [["mysql_config" "--include"]]
 depexts: [
   ["libmysqlclient-dev"] {os-distribution = "ubuntu" | (os-distribution = "debian" & os-version < "9")}
   ["default-libmysqlclient-dev"] {os-family = "debian" & ! (os-distribution = "ubuntu" | (os-distribution = "debian" & os-version < "9"))}
+  ["default-libmysqlclient-dev"] {os-family = "ubuntu"}
   ["community-mysql-devel"] {os-distribution = "fedora"}
   ["libmysqld-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["mysql-devel"] {os-distribution = "centos"}

--- a/packages/conf-npm/conf-npm.1/opam
+++ b/packages/conf-npm/conf-npm.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["epel-release" "npm"] {os-distribution = "centos"}
   ["npm"] {os-distribution = "ol" & os-version >= "8"}
   ["npm"] {os-family = "debian"}
+  ["npm"] {os-family = "ubuntu"}
   ["npm"] {os-distribution = "fedora"}
   ["npm"] {os = "freebsd"}
   ["nodejs"] {os-distribution = "gentoo"}

--- a/packages/conf-openblas/conf-openblas.0.2.2/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.2/opam
@@ -29,6 +29,7 @@ depexts: [
   ["libc-dev" "openblas-dev" "lapack-dev"] {os-distribution = "alpine"}
   ["epel-release" "openblas-devel"] {os-distribution = "centos"}
   ["libopenblas-dev" "liblapacke-dev"] {os-family = "debian"}
+  ["libopenblas-dev" "liblapacke-dev"] {os-family = "ubuntu"}
   ["openblas-devel"] {os-distribution = "fedora"}
   ["openblas-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["openblas" "lapacke" "cblas"] {os-distribution = "arch"}

--- a/packages/conf-postgresql/conf-postgresql.1/opam
+++ b/packages/conf-postgresql/conf-postgresql.1/opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 
 depexts: [
   ["libpq-dev"] {os-family = "debian"}
+  ["libpq-dev"] {os-family = "ubuntu"}
   ["libpq-devel"] {os-distribution = "centos" & os-version >= "8"}
   ["libpq-devel"] {os-distribution = "rhel" & os-version >= "8"}
   ["libpq-devel"] {os-distribution = "ol" & os-version >= "8"}

--- a/packages/conf-ppl/conf-ppl.1/opam
+++ b/packages/conf-ppl/conf-ppl.1/opam
@@ -10,6 +10,7 @@ build: [
 ]
 depexts: [
   ["libppl-dev"] {os-family = "debian"}
+  ["libppl-dev"] {os-family = "ubuntu"}
   ["ppl"] {os-distribution = "arch"}
   ["dev-libs/ppl"] {os-distribution = "gentoo"}
   ["libppl" "libppl-devel"] {os-distribution = "centos"}

--- a/packages/conf-r/conf-r.1.0.0/opam
+++ b/packages/conf-r/conf-r.1.0.0/opam
@@ -9,6 +9,7 @@ depexts: [
   ["r"] {os = "macos" & os-distribution = "homebrew"}
   ["r"] {os-distribution = "arch"}
   ["r-base-core"] {os-family = "debian"}
+  ["r-base-core"] {os-family = "ubuntu"}
   ["R-core"] {os-family = "suse" | os-family = "opensuse"}
   ["R"] {os-distribution = "alpine"}
   ["epel-release" "R"] {os-distribution = "centos"}

--- a/packages/conf-rust/conf-rust.0.1/opam
+++ b/packages/conf-rust/conf-rust.0.1/opam
@@ -14,6 +14,7 @@ depexts: [
   ["cargo"] {os-distribution = "fedora"}
   ["cargo"] {os-family = "suse" | os-family = "opensuse"}
   ["cargo"] {os-family = "debian"}
+  ["cargo"] {os-family = "ubuntu"}
   ["cargo" "rustc"] {os-distribution = "nixos"}
   ["cargo"] {os-distribution = "alpine"}
   ["rust"] {os-distribution = "arch"}

--- a/packages/conf-sdl2/conf-sdl2.1/opam
+++ b/packages/conf-sdl2/conf-sdl2.1/opam
@@ -9,6 +9,7 @@ depexts: [
   ["sdl2-dev"] {os-distribution = "alpine"}
   ["sdl2"] {os-distribution = "arch"}
   ["libsdl2-dev"] {os-family = "debian"}
+  ["libsdl2-dev"] {os-family = "ubuntu"}
   ["SDL2-devel"] {os-distribution = "fedora"}
   ["SDL2-devel" "libwayland-egl" "adwaita-cursor-theme"] {os-distribution = "fedora" & (os-version = "37" | os-version = "36")}
   ["epel-release" "SDL2-devel"] {os-distribution = "centos"}

--- a/packages/conf-tcl/conf-tcl.1/opam
+++ b/packages/conf-tcl/conf-tcl.1/opam
@@ -7,6 +7,7 @@ build: [["sh" "check.sh"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["tcl-dev"] {os-family = "debian"}
+  ["tcl-dev"] {os-family = "ubuntu"}
   ["tcl"] {os-distribution = "nixos"}
   ["tcl"] {os = "win32" & os-distribution = "cygwinports"}
   ["tcl"] {os-family = "arch"}

--- a/packages/conf-wget/conf-wget.1/opam
+++ b/packages/conf-wget/conf-wget.1/opam
@@ -8,6 +8,7 @@ build: [["which" "wget"]]
 depends: ["conf-which" {build}]
 depexts: [
   ["wget"] {os-family = "debian"}
+  ["wget"] {os-family = "ubuntu"}
   ["wget"] {os-distribution = "fedora"}
   ["wget"] {os-distribution = "arch"}
   ["wget"] {os-distribution = "nixos"}

--- a/packages/conf-xen/conf-xen.1/opam
+++ b/packages/conf-xen/conf-xen.1/opam
@@ -10,6 +10,7 @@ build: [
 depexts: [
   ["xen-dev"] {os-distribution = "alpine"}
   ["libxen-dev"] {os-family = "debian"}
+  ["libxen-dev"] {os-family = "ubuntu"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
   ["xen-devel"] {os-distribution = "rhel"}

--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -10,6 +10,7 @@ build: [
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libzmq3-dev"] {os-family = "debian"}
+  ["libzmq3-dev"] {os-family = "ubuntu"}
   ["zeromq"] {os = "macos" & os-distribution = "homebrew"}
   ["zmq"] {os = "macos" & os-distribution = "macports"}
   ["zeromq-dev"] {os-distribution = "alpine"}

--- a/packages/conf-zstd/conf-zstd.1.3.8/opam
+++ b/packages/conf-zstd/conf-zstd.1.3.8/opam
@@ -10,6 +10,7 @@ build: [
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libzstd-dev"] {os-family = "debian"}
+  ["libzstd-dev"] {os-family = "ubuntu"}
   ["libzstd-devel"] {os-distribution = "centos"}
   ["libzstd-devel"] {os-distribution = "rhel"}
   ["libzstd-devel"] {os-distribution = "fedora"}


### PR DESCRIPTION
This PR expands support for Ubuntu derivatives for 34 conf-* packages:
- conf-automake
- conf-blas
- conf-bmake
- conf-cmake
- conf-cpio
- conf-diffutils
- conf-fortran
- conf-glib-2
- conf-gnuplot
- conf-gsl
- conf-gstreamer
- conf-hidapi
- conf-lapack
- conf-libclang
- conf-libffi
- conf-libflac
- conf-libogg
- conf-libpcre
- conf-libpcre2
- conf-libspeex
- conf-mpi
- conf-mysql
- conf-npm
- conf-openblas
- conf-postgresql
- conf-ppl
- conf-r
- conf-rust
- conf-sdl2
- conf-tcl
- conf-wget
- conf-xen
- conf-zmq
- conf-zstd

Since such Linux distros are not tested on opam-ci, these changes should have no effect on the CI outcome.