### PR TITLE
Extend conf-snappy platform support

### DIFF
--- a/packages/conf-snappy/conf-snappy.1/opam
+++ b/packages/conf-snappy/conf-snappy.1/opam
@@ -6,9 +6,14 @@ build: [
   ["c++" "test.cpp" "-lsnappy" "-std=c++11"]
 ]
 depexts: [
+  ["snappy"] {os-distribution = "arch"}
+  ["snappy-dev"] {os-distribution = "alpine"}
   ["libsnappy-dev"] {os-family = "debian"}
+  ["libsnappy-dev"] {os-family = "ubuntu"}
   ["snappy"] {os = "macos" & os-distribution = "homebrew"}
   ["snappy-devel"] {os-distribution = "fedora"}
+  ["snappy"] {os-family = "suse" | os-family = "opensuse"}
+  ["snappy"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on snappy"
 description:


### PR DESCRIPTION
This PR extend conf-snappy's support to
- Arch
- Alpine
- Ubuntu-deriv
- Open/Suse
- FreeBSD