### PR TITLE
Extend conf-libjpeg platform support

### DIFF
--- a/packages/conf-libjpeg/conf-libjpeg.1/opam
+++ b/packages/conf-libjpeg/conf-libjpeg.1/opam
@@ -10,7 +10,7 @@ license: "BSD-like"
 build: ["pkg-config" "libjpeg"]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libjpeg-turbo"] {os-distribution = "alpine"}
+  ["libjpeg-turbo-dev"] {os-distribution = "alpine"}
   ["libjpeg-turbo"] {os-distribution = "arch"}
   ["libjpeg-dev"] {os-family = "debian"}
   ["libjpeg-dev"] {os-family = "ubuntu"}

--- a/packages/conf-libjpeg/conf-libjpeg.1/opam
+++ b/packages/conf-libjpeg/conf-libjpeg.1/opam
@@ -10,10 +10,16 @@ license: "BSD-like"
 build: ["pkg-config" "libjpeg"]
 depends: ["conf-pkg-config" {build}]
 depexts: [
+  ["libjpeg-turbo"] {os-distribution = "alpine"}
+  ["libjpeg-turbo"] {os-distribution = "arch"}
   ["libjpeg-dev"] {os-family = "debian"}
+  ["libjpeg-dev"] {os-family = "ubuntu"}
+  ["libjpeg-turbo"] {os-distribution = "fedora"}
   ["libjpeg-devel"] {os-family = "mageia"}
   ["jpeg"] {os = "macos" & os-distribution = "homebrew"}
+  ["libjpeg-turbo"] {os-family = "suse" | os-family = "opensuse"}
   ["libjpeg-turbo"] {os = "win32" & os-distribution = "cygwinports"}
+  ["jpeg-turbo"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a libjpeg system installation"
 description:

--- a/packages/conf-libjpeg/conf-libjpeg.1/opam
+++ b/packages/conf-libjpeg/conf-libjpeg.1/opam
@@ -17,7 +17,7 @@ depexts: [
   ["libjpeg-turbo-devel"] {os-distribution = "fedora"}
   ["libjpeg-devel"] {os-family = "mageia"}
   ["jpeg"] {os = "macos" & os-distribution = "homebrew"}
-  ["libjpeg-turbo"] {os-family = "suse" | os-family = "opensuse"}
+  ["libjpeg8-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libjpeg-turbo"] {os = "win32" & os-distribution = "cygwinports"}
   ["jpeg-turbo"] {os = "freebsd"}
 ]

--- a/packages/conf-libjpeg/conf-libjpeg.1/opam
+++ b/packages/conf-libjpeg/conf-libjpeg.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["libjpeg-turbo"] {os-distribution = "arch"}
   ["libjpeg-dev"] {os-family = "debian"}
   ["libjpeg-dev"] {os-family = "ubuntu"}
-  ["libjpeg-turbo"] {os-distribution = "fedora"}
+  ["libjpeg-turbo-devel"] {os-distribution = "fedora"}
   ["libjpeg-devel"] {os-family = "mageia"}
   ["jpeg"] {os = "macos" & os-distribution = "homebrew"}
   ["libjpeg-turbo"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-libjpeg/conf-libjpeg.1/opam
+++ b/packages/conf-libjpeg/conf-libjpeg.1/opam
@@ -16,7 +16,7 @@ depexts: [
   ["libjpeg-dev"] {os-family = "ubuntu"}
   ["libjpeg-turbo-devel"] {os-distribution = "fedora"}
   ["libjpeg-devel"] {os-family = "mageia"}
-  ["jpeg"] {os = "macos" & os-distribution = "homebrew"}
+  ["jpeg-turbo"] {os = "macos" & os-distribution = "homebrew"}
   ["libjpeg8-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libjpeg-turbo"] {os = "win32" & os-distribution = "cygwinports"}
   ["jpeg-turbo"] {os = "freebsd"}


### PR DESCRIPTION
This PR extends conf-libjpeg support to Arch, Alpine, Ubuntu-deriv, Fedora, Open/Suse, and FreeBSD