### PR TITLE
[new release] promise_jsoo (2 packages) (0.4.0)

### DIFF
--- a/packages/promise_jsoo/promise_jsoo.0.4.0/opam
+++ b/packages/promise_jsoo/promise_jsoo.0.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Js_of_ocaml bindings to JS Promises with supplemental functions"
+maintainer: ["Max Lantas <mnxndev@outlook.com>"]
+authors: ["Max Lantas <mnxndev@outlook.com>"]
+license: "MIT"
+homepage: "https://github.com/mnxn/promise_jsoo"
+doc: "https://mnxn.github.io/promise_jsoo/"
+bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml"
+  "gen_js_api" {>= "1.0.8"}
+  "webtest" {with-test}
+  "webtest-js" {with-test}
+  "conf-npm" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mnxn/promise_jsoo.git"
+url {
+  src:
+    "https://github.com/mnxn/promise_jsoo/releases/download/v0.4.0/promise_jsoo-0.4.0.tbz"
+  checksum: [
+    "sha256=cd9b512fb0699fdaa662b63d7761b8c1355ce5b8e860edbac3bb21710651c137"
+    "sha512=c022c683f4aa444b6cb96a253c0d3e5beaf4bdd67b53096d39a5ebbe21fe2e8df7f2ac974d64d93397078423c9fc09369bb919c2ab8a7acacbdb9f4b58211374"
+  ]
+}
+x-commit-hash: "314b746069fbfcb5c6f3dd7a34dc53bddd6f327b"

--- a/packages/promise_jsoo_lwt/promise_jsoo_lwt.0.4.0/opam
+++ b/packages/promise_jsoo_lwt/promise_jsoo_lwt.0.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Conversion functions between JS Promises and Lwt Promises"
+maintainer: ["Max Lantas <mnxndev@outlook.com>"]
+authors: ["Max Lantas <mnxndev@outlook.com>"]
+license: "MIT"
+homepage: "https://github.com/mnxn/promise_jsoo"
+doc: "https://mnxn.github.io/promise_jsoo/"
+bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "promise_jsoo"
+  "lwt"
+  "gen_js_api" {>= "1.0.8"}
+  "webtest" {with-test}
+  "webtest-js" {with-test}
+  "conf-npm" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mnxn/promise_jsoo.git"
+url {
+  src:
+    "https://github.com/mnxn/promise_jsoo/releases/download/v0.4.0/promise_jsoo-0.4.0.tbz"
+  checksum: [
+    "sha256=cd9b512fb0699fdaa662b63d7761b8c1355ce5b8e860edbac3bb21710651c137"
+    "sha512=c022c683f4aa444b6cb96a253c0d3e5beaf4bdd67b53096d39a5ebbe21fe2e8df7f2ac974d64d93397078423c9fc09369bb919c2ab8a7acacbdb9f4b58211374"
+  ]
+}
+x-commit-hash: "314b746069fbfcb5c6f3dd7a34dc53bddd6f327b"


### PR DESCRIPTION
Js_of_ocaml bindings to JS Promises with supplemental functions

- Project page: <a href="https://github.com/mnxn/promise_jsoo">https://github.com/mnxn/promise_jsoo</a>
- Documentation: <a href="https://mnxn.github.io/promise_jsoo/">https://mnxn.github.io/promise_jsoo/</a>

##### CHANGES:

- Add `promise_jsoo_lwt` library and `Promise_lwt` module to convert between JS
  promises and Lwt promises
- Change internal representation to `Ojs.t` and make `Promise.t` abstract.
- Remove `Promise.void` type (can now be expressed as `unit Promise.t`).
- Add a `Make` functor to create modules with a custom type representation.
- Give the `error` type a public `Ojs.t` type representation.
- Remove js_of_ocaml-ppx dependency.
