### PR TITLE
[new release] promise_jsoo (2 packages) (0.4.1)

### DIFF
--- a/packages/promise_jsoo/promise_jsoo.0.4.1/opam
+++ b/packages/promise_jsoo/promise_jsoo.0.4.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Js_of_ocaml bindings to JS Promises with supplemental functions"
+maintainer: ["Max Lantas <mnxndev@outlook.com>"]
+authors: ["Max Lantas <mnxndev@outlook.com>"]
+license: "MIT"
+homepage: "https://github.com/mnxn/promise_jsoo"
+doc: "https://mnxn.github.io/promise_jsoo/"
+bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml"
+  "gen_js_api" {>= "1.0.8"}
+  "lwt" {with-test}
+  "webtest" {with-test}
+  "webtest-js" {with-test}
+  "conf-npm" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mnxn/promise_jsoo.git"
+url {
+  src:
+    "https://github.com/mnxn/promise_jsoo/releases/download/v0.4.1/promise_jsoo-0.4.1.tbz"
+  checksum: [
+    "sha256=3b70da9c146f56e1417a5ec9305faf1b746f1ba0645e57301e0f9eb6d07690f1"
+    "sha512=5eef4b5106350f5a27827754b722d2931fefce9beb7d81617ad952d82bb993c6df9a32a56276e54fd1cde7b492f9bd077b75942cd477865aca1b1cf3d31ed941"
+  ]
+}
+x-commit-hash: "c56c6bbfff28ebf95ecefa6091951316b5f10e22"

--- a/packages/promise_jsoo_lwt/promise_jsoo_lwt.0.4.1/opam
+++ b/packages/promise_jsoo_lwt/promise_jsoo_lwt.0.4.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Conversion functions between JS Promises and Lwt Promises"
+maintainer: ["Max Lantas <mnxndev@outlook.com>"]
+authors: ["Max Lantas <mnxndev@outlook.com>"]
+license: "MIT"
+homepage: "https://github.com/mnxn/promise_jsoo"
+doc: "https://mnxn.github.io/promise_jsoo/"
+bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "promise_jsoo"
+  "lwt"
+  "gen_js_api" {>= "1.0.8"}
+  "webtest" {with-test}
+  "webtest-js" {with-test}
+  "conf-npm" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mnxn/promise_jsoo.git"
+url {
+  src:
+    "https://github.com/mnxn/promise_jsoo/releases/download/v0.4.1/promise_jsoo-0.4.1.tbz"
+  checksum: [
+    "sha256=3b70da9c146f56e1417a5ec9305faf1b746f1ba0645e57301e0f9eb6d07690f1"
+    "sha512=5eef4b5106350f5a27827754b722d2931fefce9beb7d81617ad952d82bb993c6df9a32a56276e54fd1cde7b492f9bd077b75942cd477865aca1b1cf3d31ed941"
+  ]
+}
+x-commit-hash: "c56c6bbfff28ebf95ecefa6091951316b5f10e22"


### PR DESCRIPTION
Js_of_ocaml bindings to JS Promises with supplemental functions

- Project page: <a href="https://github.com/mnxn/promise_jsoo">https://github.com/mnxn/promise_jsoo</a>
- Documentation: <a href="https://mnxn.github.io/promise_jsoo/">https://mnxn.github.io/promise_jsoo/</a>

##### CHANGES (v0.4.1):

- Require `lwt` when running `promise_jsoo` tests.

##### CHANGES (v0.4.0):

- Add `promise_jsoo_lwt` library and `Promise_lwt` module to convert between JS
  promises and Lwt promises
- Change internal representation to `Ojs.t` and make `Promise.t` abstract.
- Remove `Promise.void` type (can now be expressed as `unit Promise.t`).
- Add a `Make` functor to create modules with a custom type representation.
- Give the `error` type a public `Ojs.t` type representation.
- Remove js_of_ocaml-ppx dependency.
