### PR TITLE
2 packages from kit-ty-kate/opam-build at 0.2.4

### DIFF
--- a/packages/opam-build/opam-build.0.2.4/opam
+++ b/packages/opam-build/opam-build.0.2.4/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to build projects"
+maintainer: "Kate <kit-ty-kate@outlook.com>"
+authors: "Kate <kit-ty-kate@outlook.com>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.2" & < "2.3"}
+  "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
+]
+available: opam-version >= "2.2" & opam-version < "2.3"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.2.4/opam-build-0.2.4.tar.gz"
+  checksum: [
+    "md5=d0896c27023dd928193bef6e118abcbe"
+    "sha512=93eb631de9535e3d5e04474c7f51ad8806ed65aef3ec284e1cb435fb2448f630ebd77e038bde1798b770d071a815dab0b5e55681e207f615b4c2bdd26b973dc5"
+  ]
+}

--- a/packages/opam-test/opam-test.0.2.4/opam
+++ b/packages/opam-test/opam-test.0.2.4/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to test projects"
+maintainer: "Kate <kit-ty-kate@outlook.com>"
+authors: "Kate <kit-ty-kate@outlook.com>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.2" & < "2.3"}
+  "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
+]
+available: opam-version >= "2.2" & opam-version < "2.3"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.2.4/opam-build-0.2.4.tar.gz"
+  checksum: [
+    "md5=d0896c27023dd928193bef6e118abcbe"
+    "sha512=93eb631de9535e3d5e04474c7f51ad8806ed65aef3ec284e1cb435fb2448f630ebd77e038bde1798b770d071a815dab0b5e55681e207f615b4c2bdd26b973dc5"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `opam-build.0.2.4`: An opam plugin to build projects
- `opam-test.0.2.4`: An opam plugin to test projects



---
* Homepage: https://github.com/kit-ty-kate/opam-build
* Source repo: git+https://github.com/kit-ty-kate/opam-build.git
* Bug tracker: https://github.com/kit-ty-kate/opam-build/issues

---
:camel: Pull-request generated by opam-publish v2.3.0