### PR TITLE
[new release] quickjs (0.1.0)

### DIFF
--- a/packages/quickjs/quickjs.0.1.0/opam
+++ b/packages/quickjs/quickjs.0.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Bindings for QuickJS (a Javascript Engine to be embedded https://bellard.org/quickjs)"
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/quickjs.ml"
+bug-reports: "https://github.com/ml-in-barcelona/quickjs.ml/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "5.0.0"}
+  "reason" {>= "3.10.0"}
+  "integers"
+  "ctypes"
+  "alcotest" {with-test}
+  "fmt" {with-test}
+  "odoc" {with-doc}
+  "ocaml-lsp-server" {with-test}
+  "ocamlformat" {= "0.26.1" & with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ml-in-barcelona/quickjs.ml.git"
+url {
+  src:
+    "https://github.com/ml-in-barcelona/quickjs.ml/releases/download/0.1.0/quickjs-0.1.0.tbz"
+  checksum: [
+    "sha256=bd0ada2cea7051f0d359310bfc6e67453ffc3057e158c4abefc6ba9073d4f1ce"
+    "sha512=bfda4ad6d72f27323eac592e2eff4fdab23f465f4a2fcad4743e0654ec18030bed952aec0c27c0b4ed43833c1c97ea4364b4ad563d9b2213aa851fdf3d06f394"
+  ]
+}
+x-commit-hash: "24aa18039f1c378fb3e0aae17b54fe13b38bcc2e"

--- a/packages/quickjs/quickjs.0.1.0/opam
+++ b/packages/quickjs/quickjs.0.1.0/opam
@@ -32,6 +32,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+conflicts: [ "ocaml-option-bytecode-only" ]
 dev-repo: "git+https://github.com/ml-in-barcelona/quickjs.ml.git"
 url {
   src:


### PR DESCRIPTION
Bindings for QuickJS (a Javascript Engine to be embedded https://bellard.org/quickjs)

- Project page: <a href="https://github.com/ml-in-barcelona/quickjs.ml">https://github.com/ml-in-barcelona/quickjs.ml</a>

##### CHANGES:

## 0.1.0

Initial release of quickjs. This release only includes bindings to libregexp and exposes the API of the QuickJS C library with the same shape as the JavaScript API.
