### PR TITLE
[new release] dream-html (3.1.0)

### DIFF
--- a/packages/dream-html/dream-html.3.1.0/opam
+++ b/packages/dream-html/dream-html.3.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.1.0/dream-html-3.1.0.tbz"
+  checksum: [
+    "sha256=a3cab7ab8bad69c446da70416d60ad2d3368c43e5167a225068abcb4a28dce06"
+    "sha512=ca31a969e6d68da56b11dd30fe70f8508df1fa5ff30aec5b964eecf86f79646aa9661ef2be8e92afa5827ed80126379a3090b73bb3d651390859c880f3ad0757"
+  ]
+}
+x-commit-hash: "664b9e5696a5916d2200086943566f4a6b7ed37c"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
