### PR TITLE
Package jsonschema2atd.0.0.2

### DIFF
--- a/packages/jsonschema2atd/jsonschema2atd.0.0.2/opam
+++ b/packages/jsonschema2atd/jsonschema2atd.0.0.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Generate ATD types out of JSON Schema and OpenAPI document"
+description: "Generate ATD types out of JSON Schema and OpenAPI document"
+maintainer: "Egor Chemokhonenko <egor.chemohonenko@ahrefs.com>"
+authors: "Ahrefs"
+license: "MIT"
+homepage: "https://github.com/ahrefs/jsonschema2atd"
+bug-reports: "https://github.com/ahrefs/jsonschema2atd/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.10"}
+  "atdgen" {>= "2.7"}
+  "atdgen-runtime" {>= "2.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup & = "0.24.1"}
+  "odoc" {with-doc}
+  "ounit2" {with-test}
+  "yojson"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/jsonschema2atd.git"
+url {
+  src:
+    "https://github.com/ahrefs/jsonschema2atd/archive/refs/tags/0.0.2.tar.gz"
+  checksum: [
+    "md5=74831bc11604208e02d552482389a1ae"
+    "sha512=a9ef6ef9a8b0414b25a764c2f51cf6ad61730016d0822aa8303e9a519ee67d27cd28d89575cb28dfdb13dd4c98c5373182f82835030d6822bec021834dbb3675"
+  ]
+}

--- a/packages/jsonschema2atd/jsonschema2atd.0.0.2/opam
+++ b/packages/jsonschema2atd/jsonschema2atd.0.0.2/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/ahrefs/jsonschema2atd"
 bug-reports: "https://github.com/ahrefs/jsonschema2atd/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.10"}
+  "ocaml" {>= "4.14"}
   "atdgen" {>= "2.7"}
   "atdgen-runtime" {>= "2.0"}
   "cmdliner" {>= "1.1.0"}


### PR DESCRIPTION
### `jsonschema2atd.0.0.2`
Generate ATD types out of JSON Schema and OpenAPI document

## 0.0.2
- Support for external references
- Support for multiple input JSON schemas
- Description jsonschema field utilization in ATD doc
- Relaxed error handling for Enum types

---
* Homepage: https://github.com/ahrefs/jsonschema2atd
* Source repo: git+https://github.com/ahrefs/jsonschema2atd.git
* Bug tracker: https://github.com/ahrefs/jsonschema2atd/issues

---
:camel: Pull-request generated by opam-publish v2.3.0