### PR TITLE
Package cpdf.2.7

### DIFF
--- a/packages/cpdf/cpdf.2.7/opam
+++ b/packages/cpdf/cpdf.2.7/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "contact@coherentgraphics.co.uk"
+license: "LicenseRef-Coherent-Graphics-Ltd-Non-Commercial-Use-License-Agreement"
+build: [[make]]
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "ocamlfind" {build}
+  "camlpdf" {= version}
+]
+homepage: "http://github.com/johnwhitington/cpdf-source"
+authors: ["John Whitington"]
+bug-reports: "http://github.com/johnwhitington/cpdf-source/issues"
+dev-repo: "git+https://github.com/johnwhitington/cpdf-source"
+install: [[make "install"]]
+synopsis: "High-level PDF tools based on CamlPDF"
+url {
+  src:
+    "https://github.com/johnwhitington/cpdf-source/archive/refs/tags/v2.7.zip"
+  checksum: [
+    "md5=8dd7b420b71374640679351cfa618c44"
+    "sha512=ddb2f30d10699ef4b843d06d30620ba018dbaec1ac9180b3fb7e85d1100718ece13212d56eca18139fdf1a19e4b27dbc6f31f628c4296273813448fb29d624e0"
+  ]
+}


### PR DESCRIPTION
### `cpdf.2.7`
High-level PDF tools based on CamlPDF



---
* Homepage: http://github.com/johnwhitington/cpdf-source
* Source repo: git+https://github.com/johnwhitington/cpdf-source
* Bug tracker: http://github.com/johnwhitington/cpdf-source/issues

---
:camel: Pull-request generated by opam-publish v2.3.0