### PR TITLE
[new release] promise_jsoo (2 packages) (0.4.2)

### DIFF
--- a/packages/promise_jsoo/promise_jsoo.0.4.2/opam
+++ b/packages/promise_jsoo/promise_jsoo.0.4.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Js_of_ocaml bindings to JS Promises with supplemental functions"
+maintainer: ["Max Lantas <mnxndev@outlook.com>"]
+authors: ["Max Lantas <mnxndev@outlook.com>"]
+license: "MIT"
+homepage: "https://github.com/mnxn/promise_jsoo"
+doc: "https://mnxn.github.io/promise_jsoo/"
+bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml"
+  "gen_js_api" {>= "1.0.8"}
+  "webtest" {with-test}
+  "webtest-js" {with-test}
+  "conf-npm" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mnxn/promise_jsoo.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@%{name}%/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mnxn/promise_jsoo/releases/download/v0.4.2/promise_jsoo-0.4.2.tbz"
+  checksum: [
+    "sha256=b262ff66d685cc86d309ac85847b2b399f0c3e99f9b9b06bd6b38b86036dc27c"
+    "sha512=dec192b51ad1189bec59c053de3aeca7fb8d6ba4195ed9617d753a202f3b50383f3c059d280833a39c1b3561a61e88d930293219010b2c2e0c102c0e59a8f4e8"
+  ]
+}
+x-commit-hash: "f04d7d8e37ff7c155c289ce2ad06760e8ab3a34a"

--- a/packages/promise_jsoo_lwt/promise_jsoo_lwt.0.4.2/opam
+++ b/packages/promise_jsoo_lwt/promise_jsoo_lwt.0.4.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Conversion functions between JS Promises and Lwt Promises"
+maintainer: ["Max Lantas <mnxndev@outlook.com>"]
+authors: ["Max Lantas <mnxndev@outlook.com>"]
+license: "MIT"
+homepage: "https://github.com/mnxn/promise_jsoo"
+doc: "https://mnxn.github.io/promise_jsoo/"
+bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "promise_jsoo"
+  "lwt"
+  "gen_js_api" {>= "1.0.8"}
+  "webtest" {with-test}
+  "webtest-js" {with-test}
+  "conf-npm" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mnxn/promise_jsoo.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@%{name}%/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mnxn/promise_jsoo/releases/download/v0.4.2/promise_jsoo-0.4.2.tbz"
+  checksum: [
+    "sha256=b262ff66d685cc86d309ac85847b2b399f0c3e99f9b9b06bd6b38b86036dc27c"
+    "sha512=dec192b51ad1189bec59c053de3aeca7fb8d6ba4195ed9617d753a202f3b50383f3c059d280833a39c1b3561a61e88d930293219010b2c2e0c102c0e59a8f4e8"
+  ]
+}
+x-commit-hash: "f04d7d8e37ff7c155c289ce2ad06760e8ab3a34a"


### PR DESCRIPTION
Js_of_ocaml bindings to JS Promises with supplemental functions

- Project page: <a href="https://github.com/mnxn/promise_jsoo">https://github.com/mnxn/promise_jsoo</a>
- Documentation: <a href="https://mnxn.github.io/promise_jsoo/">https://mnxn.github.io/promise_jsoo/</a>

##### CHANGES (v0.4.2):

- Separate tests by library and remove `lwt` dependency from `promise_jsoo`
  tests.
  
##### CHANGES (v0.4.1):

- Require `lwt` when running `promise_jsoo` tests.

##### CHANGES (v0.4.0):

- Add `promise_jsoo_lwt` library and `Promise_lwt` module to convert between JS
  promises and Lwt promises
- Change internal representation to `Ojs.t` and make `Promise.t` abstract.
- Remove `Promise.void` type (can now be expressed as `unit Promise.t`).
- Add a `Make` functor to create modules with a custom type representation.
- Give the `error` type a public `Ojs.t` type representation.
- Remove js_of_ocaml-ppx dependency.
