### PR TITLE
lru-cache and css: fix tarball urls (and checksum for lru_cache 0.4.0)

### DIFF
--- a/packages/css/css.0.1.0/opam
+++ b/packages/css/css.0.1.0/opam
@@ -43,7 +43,7 @@ build: [
 dev-repo: "git+https://framagit.org/zoggy/ocaml-css.git"
 url {
   src:
-    "https://framagit.org/zoggy/ocaml-css/-/archive/0.1.0/ocaml-css-0.1.0.tar.bz2"
+    "https://zoggy.frama.io/ocaml-css/releases/ocaml-css-0.1.0.tar.bz2"
   checksum: [
     "md5=bc4bdcf47b37c7bd50bf9f31c391dcd2"
     "sha512=8fa12c193638ba8c2d307f48e477cdac839ca25f865f7f350bc7675086c3c4a70bc1e5936d35d64aab9d8da2c9806005be70c59ac3d7f3c407a3861f6e0a7cf8"

--- a/packages/lru-cache/lru-cache.0.1.0/opam
+++ b/packages/lru-cache/lru-cache.0.1.0/opam
@@ -27,6 +27,6 @@ the [Least Recently Used (LRU)](https://en.wikipedia.org/wiki/Cache_algorithms)
 strategy."""
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/ocaml-lru-cache/-/archive/0.1.0/ocaml-lru-cache-0.1.0.tar.gz"
+  src: "https://zoggy.frama.io/ocaml-lru-cache/releases/ocaml-lru-cache-0.1.0.tar.gz"
   checksum: "md5=0d5398118c2c7d1e5d5a86f1ed23b893"
 }

--- a/packages/lru-cache/lru-cache.0.2.0/opam
+++ b/packages/lru-cache/lru-cache.0.2.0/opam
@@ -27,6 +27,6 @@ the [Least Recently Used (LRU)](https://en.wikipedia.org/wiki/Cache_algorithms)
 strategy."""
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/ocaml-lru-cache/-/archive/0.2.0/ocaml-lru-cache-0.2.0.tar.gz"
+  src: "https://zoggy.frama.io/ocaml-lru-cache/releases/ocaml-lru-cache-0.2.0.tar.gz"
   checksum: "md5=9217dd7dc3c74e7fe52665efc2785a4d"
 }

--- a/packages/lru-cache/lru-cache.0.3.0/opam
+++ b/packages/lru-cache/lru-cache.0.3.0/opam
@@ -22,6 +22,6 @@ the [Least Recently Used (LRU)](https://en.wikipedia.org/wiki/Cache_algorithms)
 strategy."""
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/ocaml-lru-cache/-/archive/0.3.0/ocaml-lru-cache-0.3.0.tar.gz"
+  src: "https://zoggy.frama.io/ocaml-lru-cache/releases/ocaml-lru-cache-0.3.0.tar.gz"
   checksum: "md5=33da0c73f5cb1d671d2e6158c5d0edd1"
 }

--- a/packages/lru_cache/lru_cache.0.4.0/opam
+++ b/packages/lru_cache/lru_cache.0.4.0/opam
@@ -32,9 +32,9 @@ build: [
 dev-repo: "git+https://framagit.org/zoggy/ocaml-lru-cache.git"
 url {
   src:
-    "https://zoggy.frama.io/ocaml-lru-cache/releases/ocaml-lru-cache-0.4.0.tar.gz"
+    "https://zoggy.frama.io/ocaml-lru-cache/releases/ocaml-lru-cache-0.4.0.tar.bz2"
   checksum: [
-    "md5=dd04c5b744cc0b1469b91fa0c068fa14"
-    "sha512=d24ba9eb6097f5334b8ce1660ef657dc12a1fecdceca9463fabd7fbdb450ed5649d1569488e525e8fd76b52ed33361a155b6f23c6e92fec055d76a67fe66790c"
+    "md5=700969587b907565f94d5bb434c7114b"
+    "sha512=a7ae4b7f5c0f33dfc686f32b277a8b1f0530c5990384a6eacfe2dc22cf5483c2303ffa090fd13d5d3449273500a005b70c5cda7ff9b90e7a6433d2c72974cf22"
   ]
 }

--- a/packages/lru_cache/lru_cache.0.4.0/opam
+++ b/packages/lru_cache/lru_cache.0.4.0/opam
@@ -32,7 +32,7 @@ build: [
 dev-repo: "git+https://framagit.org/zoggy/ocaml-lru-cache.git"
 url {
   src:
-    ""https://zoggy.frama.io/ocaml-lru-cache/releases/ocaml-lru-cache-0.4.0.tar.gz
+    "https://zoggy.frama.io/ocaml-lru-cache/releases/ocaml-lru-cache-0.4.0.tar.gz"
   checksum: [
     "md5=dd04c5b744cc0b1469b91fa0c068fa14"
     "sha512=d24ba9eb6097f5334b8ce1660ef657dc12a1fecdceca9463fabd7fbdb450ed5649d1569488e525e8fd76b52ed33361a155b6f23c6e92fec055d76a67fe66790c"

--- a/packages/lru_cache/lru_cache.0.4.0/opam
+++ b/packages/lru_cache/lru_cache.0.4.0/opam
@@ -32,9 +32,9 @@ build: [
 dev-repo: "git+https://framagit.org/zoggy/ocaml-lru-cache.git"
 url {
   src:
-    "https://framagit.org/zoggy/ocaml-lru-cache/-/archive/0.4.0/ocaml-lru-cache-0.4.0.tar.bz2"
+    ""https://zoggy.frama.io/ocaml-lru-cache/releases/ocaml-lru-cache-0.4.0.tar.gz
   checksum: [
-    "md5=700969587b907565f94d5bb434c7114b"
-    "sha512=a7ae4b7f5c0f33dfc686f32b277a8b1f0530c5990384a6eacfe2dc22cf5483c2303ffa090fd13d5d3449273500a005b70c5cda7ff9b90e7a6433d2c72974cf22"
+    "md5=dd04c5b744cc0b1469b91fa0c068fa14"
+    "sha512=d24ba9eb6097f5334b8ce1660ef657dc12a1fecdceca9463fabd7fbdb450ed5649d1569488e525e8fd76b52ed33361a155b6f23c6e92fec055d76a67fe66790c"
   ]
 }


### PR DESCRIPTION
Fix after discussions in https://github.com/ocaml/opam-repository/issues/25344 and https://github.com/ocaml/opam-repository/issues/25361 .