### PR TITLE
libc 0.0.1 is not compatible with riscv64

### DIFF
--- a/packages/libc/libc.0.0.1/opam
+++ b/packages/libc/libc.0.0.1/opam
@@ -29,7 +29,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-sys/libc.ml.git"
-available: arch != "x86_32" & arch != "arm32" & arch != "ppc64" & arch != "s390x"
+available: arch != "x86_32" & arch != "arm32" & arch != "ppc64" & arch != "s390x" & arch != "riscv64"
 url {
   src:
     "https://github.com/ocaml-sys/libc.ml/releases/download/0.0.1/libc-0.0.1.tbz"


### PR DESCRIPTION
Fails with
```

#=== ERROR while compiling libc.0.0.1 =========================================#
# context              2.2.0~beta2~dev | linux/riscv64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/libc.0.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p libc -j 3 @install
# exit-code            1
# env-file             ~/.opam/log/libc-7-f97f5e.env
# output-file          ~/.opam/log/libc-7-f97f5e.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I libc/.libc.objs/byte -no-alias-deps -open Libc__ -o libc/.libc.objs/byte/libc.cmo -c -impl libc/libc.pp.ml)
# File "libc/libc.ml", line 25, characters 8-12:
# 25 | include Impl
#              ^^^^
# Error: Unbound module Impl
```