### PR TITLE
Release randomconv v0.2.0

### DIFF
--- a/packages/dns-certify/dns-certify.4.0.0/opam
+++ b/packages/dns-certify/dns-certify.4.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.7.1" & < "0.8.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.4.1.0/opam
+++ b/packages/dns-certify/dns-certify.4.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.8.0" & < "0.10.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.4.2.0/opam
+++ b/packages/dns-certify/dns-certify.4.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.8.0" & < "0.10.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.4.3.0/opam
+++ b/packages/dns-certify/dns-certify.4.3.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.8.0" & < "0.10.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.4.3.1/opam
+++ b/packages/dns-certify/dns-certify.4.3.1/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.8.0" & < "0.10.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.4.4.0/opam
+++ b/packages/dns-certify/dns-certify.4.4.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.10.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.4.4.1/opam
+++ b/packages/dns-certify/dns-certify.4.4.1/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.10.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.4.5.0/opam
+++ b/packages/dns-certify/dns-certify.4.5.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.10.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.4.6.0/opam
+++ b/packages/dns-certify/dns-certify.4.6.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.10.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.4.6.1/opam
+++ b/packages/dns-certify/dns-certify.4.6.1/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.10.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.4.6.2/opam
+++ b/packages/dns-certify/dns-certify.4.6.2/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.10.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.4.6.3/opam
+++ b/packages/dns-certify/dns-certify.4.6.3/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.10.0" & < "0.12.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.5.0.0/opam
+++ b/packages/dns-certify/dns-certify.5.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.12.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.5.0.1/opam
+++ b/packages/dns-certify/dns-certify.5.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.13.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.6.0.0/opam
+++ b/packages/dns-certify/dns-certify.6.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.13.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.6.0.1/opam
+++ b/packages/dns-certify/dns-certify.6.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.13.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.6.0.2/opam
+++ b/packages/dns-certify/dns-certify.6.0.2/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.13.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.6.1.0/opam
+++ b/packages/dns-certify/dns-certify.6.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.13.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.6.1.1/opam
+++ b/packages/dns-certify/dns-certify.6.1.1/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.13.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.6.1.2/opam
+++ b/packages/dns-certify/dns-certify.6.1.2/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.13.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.6.1.3/opam
+++ b/packages/dns-certify/dns-certify.6.1.3/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.13.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.6.1.4/opam
+++ b/packages/dns-certify/dns-certify.6.1.4/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.13.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.6.2.0/opam
+++ b/packages/dns-certify/dns-certify.6.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.13.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.6.2.1/opam
+++ b/packages/dns-certify/dns-certify.6.2.1/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.13.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.6.2.2/opam
+++ b/packages/dns-certify/dns-certify.6.2.2/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.13.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.6.3.0/opam
+++ b/packages/dns-certify/dns-certify.6.3.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.13.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.6.4.0/opam
+++ b/packages/dns-certify/dns-certify.6.4.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.13.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.6.4.1/opam
+++ b/packages/dns-certify/dns-certify.6.4.1/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.13.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.7.0.0/opam
+++ b/packages/dns-certify/dns-certify.7.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.15.2"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.7.0.1/opam
+++ b/packages/dns-certify/dns-certify.7.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.15.2"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.7.0.2/opam
+++ b/packages/dns-certify/dns-certify.7.0.2/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.15.2"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.7.0.3/opam
+++ b/packages/dns-certify/dns-certify.7.0.3/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.15.2"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-cli/dns-cli.4.6.3/opam
+++ b/packages/dns-cli/dns-cli.4.6.3/opam
@@ -30,7 +30,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.5.0.0/opam
+++ b/packages/dns-cli/dns-cli.5.0.0/opam
@@ -30,7 +30,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.5.0.1/opam
+++ b/packages/dns-cli/dns-cli.5.0.1/opam
@@ -30,7 +30,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.6.0.0/opam
+++ b/packages/dns-cli/dns-cli.6.0.0/opam
@@ -31,7 +31,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.6.0.1/opam
+++ b/packages/dns-cli/dns-cli.6.0.1/opam
@@ -30,7 +30,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.6.0.2/opam
+++ b/packages/dns-cli/dns-cli.6.0.2/opam
@@ -30,7 +30,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.6.1.0/opam
+++ b/packages/dns-cli/dns-cli.6.1.0/opam
@@ -30,7 +30,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.6.1.1/opam
+++ b/packages/dns-cli/dns-cli.6.1.1/opam
@@ -30,7 +30,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.6.1.2/opam
+++ b/packages/dns-cli/dns-cli.6.1.2/opam
@@ -30,7 +30,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.6.1.3/opam
+++ b/packages/dns-cli/dns-cli.6.1.3/opam
@@ -30,7 +30,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.6.1.4/opam
+++ b/packages/dns-cli/dns-cli.6.1.4/opam
@@ -30,7 +30,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.6.2.0/opam
+++ b/packages/dns-cli/dns-cli.6.2.0/opam
@@ -31,7 +31,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 build: [

--- a/packages/dns-cli/dns-cli.6.2.1/opam
+++ b/packages/dns-cli/dns-cli.6.2.1/opam
@@ -31,7 +31,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.6.2.2/opam
+++ b/packages/dns-cli/dns-cli.6.2.2/opam
@@ -31,7 +31,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.6.3.0/opam
+++ b/packages/dns-cli/dns-cli.6.3.0/opam
@@ -31,7 +31,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.6.4.0/opam
+++ b/packages/dns-cli/dns-cli.6.4.0/opam
@@ -31,7 +31,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.6.4.1/opam
+++ b/packages/dns-cli/dns-cli.6.4.1/opam
@@ -31,7 +31,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.7.0.0/opam
+++ b/packages/dns-cli/dns-cli.7.0.0/opam
@@ -31,7 +31,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.7.0.1/opam
+++ b/packages/dns-cli/dns-cli.7.0.1/opam
@@ -31,7 +31,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.7.0.2/opam
+++ b/packages/dns-cli/dns-cli.7.0.2/opam
@@ -31,7 +31,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.7.0.3/opam
+++ b/packages/dns-cli/dns-cli.7.0.3/opam
@@ -31,7 +31,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-client/dns-client.4.0.0/opam
+++ b/packages/dns-client/dns-client.4.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "logs" {>= "0.6.3"}
   "dns" {= version}
   "rresult" {>= "0.6.0"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.4.1.0/opam
+++ b/packages/dns-client/dns-client.4.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "logs" {>= "0.6.3"}
   "dns" {= version}
   "rresult" {>= "0.6.0"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.4.2.0/opam
+++ b/packages/dns-client/dns-client.4.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "logs" {>= "0.6.3"}
   "dns" {= version}
   "rresult" {>= "0.6.0"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.4.3.0/opam
+++ b/packages/dns-client/dns-client.4.3.0/opam
@@ -19,7 +19,7 @@ depends: [
   "logs" {>= "0.6.3"}
   "dns" {= version}
   "rresult" {>= "0.6.0"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.4.3.1/opam
+++ b/packages/dns-client/dns-client.4.3.1/opam
@@ -19,7 +19,7 @@ depends: [
   "logs" {>= "0.6.3"}
   "dns" {= version}
   "rresult" {>= "0.6.0"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.4.4.0/opam
+++ b/packages/dns-client/dns-client.4.4.0/opam
@@ -19,7 +19,7 @@ depends: [
   "logs" {>= "0.6.3"}
   "dns" {= version}
   "rresult" {>= "0.6.0"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.4.4.1/opam
+++ b/packages/dns-client/dns-client.4.4.1/opam
@@ -19,7 +19,7 @@ depends: [
   "logs" {>= "0.6.3"}
   "dns" {= version}
   "rresult" {>= "0.6.0"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.4.5.0/opam
+++ b/packages/dns-client/dns-client.4.5.0/opam
@@ -19,7 +19,7 @@ depends: [
   "logs" {>= "0.6.3"}
   "dns" {= version}
   "rresult" {>= "0.6.0"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.4.6.0/opam
+++ b/packages/dns-client/dns-client.4.6.0/opam
@@ -20,7 +20,7 @@ depends: [
   "logs" {>= "0.6.3"}
   "dns" {= version}
   "rresult" {>= "0.6.0"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.4.6.1/opam
+++ b/packages/dns-client/dns-client.4.6.1/opam
@@ -20,7 +20,7 @@ depends: [
   "logs" {>= "0.6.3"}
   "dns" {= version}
   "rresult" {>= "0.6.0"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.4.6.2/opam
+++ b/packages/dns-client/dns-client.4.6.2/opam
@@ -20,7 +20,7 @@ depends: [
   "logs" {>= "0.6.3"}
   "dns" {= version}
   "rresult" {>= "0.6.0"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.4.6.3/opam
+++ b/packages/dns-client/dns-client.4.6.3/opam
@@ -20,7 +20,7 @@ depends: [
   "logs" {>= "0.6.3"}
   "dns" {= version}
   "rresult" {>= "0.6.0"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.5.0.0/opam
+++ b/packages/dns-client/dns-client.5.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "logs" {>= "0.6.3"}
   "dns" {= version}
   "rresult" {>= "0.6.0"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.5.0.1/opam
+++ b/packages/dns-client/dns-client.5.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "logs" {>= "0.6.3"}
   "dns" {= version}
   "rresult" {>= "0.6.0"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.6.0.0/opam
+++ b/packages/dns-client/dns-client.6.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "logs" {>= "0.6.3"}
   "dns" {= version}
   "rresult" {>= "0.6.0"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.6.0.1/opam
+++ b/packages/dns-client/dns-client.6.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "logs" {>= "0.6.3"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.6.0.2/opam
+++ b/packages/dns-client/dns-client.6.0.2/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "logs" {>= "0.6.3"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.6.1.0/opam
+++ b/packages/dns-client/dns-client.6.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "logs" {>= "0.6.3"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.6.1.1/opam
+++ b/packages/dns-client/dns-client.6.1.1/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "logs" {>= "0.6.3"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.6.1.2/opam
+++ b/packages/dns-client/dns-client.6.1.2/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "logs" {>= "0.6.3"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.6.1.3/opam
+++ b/packages/dns-client/dns-client.6.1.3/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "logs" {>= "0.6.3"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.6.1.4/opam
+++ b/packages/dns-client/dns-client.6.1.4/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "logs" {>= "0.6.3"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.6.2.0/opam
+++ b/packages/dns-client/dns-client.6.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "logs" {>= "0.6.3"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.4.0"}
   "ipaddr" {>= "5.3.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.6.2.1/opam
+++ b/packages/dns-client/dns-client.6.2.1/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "logs" {>= "0.6.3"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.4.0"}
   "ipaddr" {>= "5.3.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.6.2.2/opam
+++ b/packages/dns-client/dns-client.6.2.2/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "logs" {>= "0.6.3"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.4.0"}
   "ipaddr" {>= "5.3.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.6.3.0/opam
+++ b/packages/dns-client/dns-client.6.3.0/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "logs" {>= "0.6.3"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.4.0"}
   "ipaddr" {>= "5.3.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.6.4.0/opam
+++ b/packages/dns-client/dns-client.6.4.0/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "logs" {>= "0.6.3"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.4.0"}
   "ipaddr" {>= "5.3.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.6.4.1/opam
+++ b/packages/dns-client/dns-client.6.4.1/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "logs" {>= "0.6.3"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.4.0"}
   "ipaddr" {>= "5.3.0"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-client/dns-client.7.0.0/opam
+++ b/packages/dns-client/dns-client.7.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>="2.0.0"}
   "ocaml" {>= "4.08.0"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.4.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.11.0"}

--- a/packages/dns-client/dns-client.7.0.1/opam
+++ b/packages/dns-client/dns-client.7.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>="2.0.0"}
   "ocaml" {>= "4.08.0"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.4.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.11.0"}

--- a/packages/dns-client/dns-client.7.0.2/opam
+++ b/packages/dns-client/dns-client.7.0.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>="2.0.0"}
   "ocaml" {>= "4.08.0"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.4.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.11.0"}

--- a/packages/dns-client/dns-client.7.0.3/opam
+++ b/packages/dns-client/dns-client.7.0.3/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>="2.0.0"}
   "ocaml" {>= "4.08.0"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.4.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.11.0"}

--- a/packages/dns-resolver/dns-resolver.4.0.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time-lwt" {>= "1.3.0"}
   "mirage-clock-lwt" {>= "2.0.0"}

--- a/packages/dns-resolver/dns-resolver.4.1.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.4.2.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.4.3.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.3.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.4.3.1/opam
+++ b/packages/dns-resolver/dns-resolver.4.3.1/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.4.4.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.4.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.4.4.1/opam
+++ b/packages/dns-resolver/dns-resolver.4.4.1/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.4.5.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.5.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.4.6.0/opam
+++ b/packages/dns-resolver/dns-resolver.4.6.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.4.6.1/opam
+++ b/packages/dns-resolver/dns-resolver.4.6.1/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.4.6.2/opam
+++ b/packages/dns-resolver/dns-resolver.4.6.2/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.4.6.3/opam
+++ b/packages/dns-resolver/dns-resolver.4.6.3/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.5.0.0/opam
+++ b/packages/dns-resolver/dns-resolver.5.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.5.0.1/opam
+++ b/packages/dns-resolver/dns-resolver.5.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.6.0.0/opam
+++ b/packages/dns-resolver/dns-resolver.6.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.6.0.1/opam
+++ b/packages/dns-resolver/dns-resolver.6.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.6.0.2/opam
+++ b/packages/dns-resolver/dns-resolver.6.0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.6.1.0/opam
+++ b/packages/dns-resolver/dns-resolver.6.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.6.1.1/opam
+++ b/packages/dns-resolver/dns-resolver.6.1.1/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.6.1.2/opam
+++ b/packages/dns-resolver/dns-resolver.6.1.2/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.6.1.3/opam
+++ b/packages/dns-resolver/dns-resolver.6.1.3/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.6.1.4/opam
+++ b/packages/dns-resolver/dns-resolver.6.1.4/opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.6.2.0/opam
+++ b/packages/dns-resolver/dns-resolver.6.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dnssec" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.6.2.1/opam
+++ b/packages/dns-resolver/dns-resolver.6.2.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dnssec" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.6.2.2/opam
+++ b/packages/dns-resolver/dns-resolver.6.2.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dnssec" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.6.3.0/opam
+++ b/packages/dns-resolver/dns-resolver.6.3.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dnssec" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.6.4.0/opam
+++ b/packages/dns-resolver/dns-resolver.6.4.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dnssec" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.6.4.1/opam
+++ b/packages/dns-resolver/dns-resolver.6.4.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dnssec" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.7.0.0/opam
+++ b/packages/dns-resolver/dns-resolver.7.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dnssec" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.7.0.1/opam
+++ b/packages/dns-resolver/dns-resolver.7.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dnssec" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.7.0.2/opam
+++ b/packages/dns-resolver/dns-resolver.7.0.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dnssec" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.7.0.3/opam
+++ b/packages/dns-resolver/dns-resolver.7.0.3/opam
@@ -16,7 +16,7 @@ depends: [
   "dnssec" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-server/dns-server.4.0.0/opam
+++ b/packages/dns-server/dns-server.4.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time-lwt" {>= "1.3.0"}

--- a/packages/dns-server/dns-server.4.1.0/opam
+++ b/packages/dns-server/dns-server.4.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.4.2.0/opam
+++ b/packages/dns-server/dns-server.4.2.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.4.3.0/opam
+++ b/packages/dns-server/dns-server.4.3.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.4.3.1/opam
+++ b/packages/dns-server/dns-server.4.3.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.4.4.0/opam
+++ b/packages/dns-server/dns-server.4.4.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.4.4.1/opam
+++ b/packages/dns-server/dns-server.4.4.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.4.5.0/opam
+++ b/packages/dns-server/dns-server.4.5.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.4.6.0/opam
+++ b/packages/dns-server/dns-server.4.6.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.4.6.1/opam
+++ b/packages/dns-server/dns-server.4.6.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.4.6.2/opam
+++ b/packages/dns-server/dns-server.4.6.2/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.4.6.3/opam
+++ b/packages/dns-server/dns-server.4.6.3/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.5.0.0/opam
+++ b/packages/dns-server/dns-server.5.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.5.0.1/opam
+++ b/packages/dns-server/dns-server.5.0.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.6.0.0/opam
+++ b/packages/dns-server/dns-server.6.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.6.0.1/opam
+++ b/packages/dns-server/dns-server.6.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.6.0.2/opam
+++ b/packages/dns-server/dns-server.6.0.2/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.6.1.0/opam
+++ b/packages/dns-server/dns-server.6.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.6.1.1/opam
+++ b/packages/dns-server/dns-server.6.1.1/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.6.1.2/opam
+++ b/packages/dns-server/dns-server.6.1.2/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.6.1.3/opam
+++ b/packages/dns-server/dns-server.6.1.3/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.6.1.4/opam
+++ b/packages/dns-server/dns-server.6.1.4/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.6.2.0/opam
+++ b/packages/dns-server/dns-server.6.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.6.2.1/opam
+++ b/packages/dns-server/dns-server.6.2.1/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.6.2.2/opam
+++ b/packages/dns-server/dns-server.6.2.2/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.6.3.0/opam
+++ b/packages/dns-server/dns-server.6.3.0/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.6.4.0/opam
+++ b/packages/dns-server/dns-server.6.4.0/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.6.4.1/opam
+++ b/packages/dns-server/dns-server.6.4.1/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.7.0.0/opam
+++ b/packages/dns-server/dns-server.7.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.7.0.1/opam
+++ b/packages/dns-server/dns-server.7.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.7.0.2/opam
+++ b/packages/dns-server/dns-server.7.0.2/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.7.0.3/opam
+++ b/packages/dns-server/dns-server.7.0.3/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-stub/dns-stub.4.4.0/opam
+++ b/packages/dns-stub/dns-stub.4.4.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.4.4.1/opam
+++ b/packages/dns-stub/dns-stub.4.4.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.4.5.0/opam
+++ b/packages/dns-stub/dns-stub.4.5.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.4.6.0/opam
+++ b/packages/dns-stub/dns-stub.4.6.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.4.6.1/opam
+++ b/packages/dns-stub/dns-stub.4.6.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.4.6.2/opam
+++ b/packages/dns-stub/dns-stub.4.6.2/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.4.6.3/opam
+++ b/packages/dns-stub/dns-stub.4.6.3/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.5.0.0/opam
+++ b/packages/dns-stub/dns-stub.5.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.5.0.1/opam
+++ b/packages/dns-stub/dns-stub.5.0.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.6.0.0/opam
+++ b/packages/dns-stub/dns-stub.6.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.6.0.1/opam
+++ b/packages/dns-stub/dns-stub.6.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.6.0.2/opam
+++ b/packages/dns-stub/dns-stub.6.0.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.6.1.0/opam
+++ b/packages/dns-stub/dns-stub.6.1.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.6.1.1/opam
+++ b/packages/dns-stub/dns-stub.6.1.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.6.1.2/opam
+++ b/packages/dns-stub/dns-stub.6.1.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.6.1.3/opam
+++ b/packages/dns-stub/dns-stub.6.1.3/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.6.1.4/opam
+++ b/packages/dns-stub/dns-stub.6.1.4/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.6.2.0/opam
+++ b/packages/dns-stub/dns-stub.6.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.6.2.1/opam
+++ b/packages/dns-stub/dns-stub.6.2.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.6.2.2/opam
+++ b/packages/dns-stub/dns-stub.6.2.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.6.3.0/opam
+++ b/packages/dns-stub/dns-stub.6.3.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.6.4.0/opam
+++ b/packages/dns-stub/dns-stub.6.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.6.4.1/opam
+++ b/packages/dns-stub/dns-stub.6.4.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.7.0.0/opam
+++ b/packages/dns-stub/dns-stub.7.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.7.0.1/opam
+++ b/packages/dns-stub/dns-stub.7.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.7.0.2/opam
+++ b/packages/dns-stub/dns-stub.7.0.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.7.0.3/opam
+++ b/packages/dns-stub/dns-stub.7.0.3/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/letsencrypt-app/letsencrypt-app.0.3.0/opam
+++ b/packages/letsencrypt-app/letsencrypt-app.0.3.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ptime"
   "bos"
   "fpath"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "cstruct" {< "6.1.0"}
 ]
 build: [

--- a/packages/letsencrypt-app/letsencrypt-app.0.4.0/opam
+++ b/packages/letsencrypt-app/letsencrypt-app.0.4.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ptime"
   "bos"
   "fpath"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "cstruct" {>= "6.0.0"}
 ]
 build: [

--- a/packages/letsencrypt-app/letsencrypt-app.0.4.1/opam
+++ b/packages/letsencrypt-app/letsencrypt-app.0.4.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ptime"
   "bos"
   "fpath"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "cstruct" {>= "6.0.0"}
 ]
 build: [

--- a/packages/letsencrypt-app/letsencrypt-app.0.5.0/opam
+++ b/packages/letsencrypt-app/letsencrypt-app.0.5.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ptime"
   "bos"
   "fpath"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "cstruct" {>= "6.0.0"}
 ]
 build: [

--- a/packages/letsencrypt-app/letsencrypt-app.0.5.1/opam
+++ b/packages/letsencrypt-app/letsencrypt-app.0.5.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ptime"
   "bos"
   "fpath"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "cstruct" {>= "6.0.0"}
 ]
 build: [

--- a/packages/letsencrypt/letsencrypt.0.1.0/opam
+++ b/packages/letsencrypt/letsencrypt.0.1.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ptime"
   "bos"
   "fpath"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "domain-name" {>= "0.2.0"}
 ]
 build: [

--- a/packages/letsencrypt/letsencrypt.0.1.1/opam
+++ b/packages/letsencrypt/letsencrypt.0.1.1/opam
@@ -31,7 +31,7 @@ depends: [
   "ptime"
   "bos"
   "fpath"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "domain-name" {>= "0.2.0"}
 ]
 build: [

--- a/packages/letsencrypt/letsencrypt.0.2.0/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ptime"
   "bos"
   "fpath"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "domain-name" {>= "0.2.0"}
 ]
 build: [

--- a/packages/letsencrypt/letsencrypt.0.2.1/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.1/opam
@@ -34,7 +34,7 @@ depends: [
   "ptime"
   "bos"
   "fpath"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "domain-name" {>= "0.2.0"}
 ]
 build: [

--- a/packages/letsencrypt/letsencrypt.0.2.2/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.2/opam
@@ -34,7 +34,7 @@ depends: [
   "ptime"
   "bos"
   "fpath"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "domain-name" {>= "0.2.0"}
 ]
 build: [

--- a/packages/letsencrypt/letsencrypt.0.2.3/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.3/opam
@@ -34,7 +34,7 @@ depends: [
   "ptime"
   "bos"
   "fpath"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "domain-name" {>= "0.2.0"}
 ]
 build: [

--- a/packages/letsencrypt/letsencrypt.0.2.4/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.4/opam
@@ -34,7 +34,7 @@ depends: [
   "ptime"
   "bos"
   "fpath"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "domain-name" {>= "0.2.0"}
 ]
 build: [

--- a/packages/letsencrypt/letsencrypt.0.2.5/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.5/opam
@@ -34,7 +34,7 @@ depends: [
   "ptime"
   "bos"
   "fpath"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "domain-name" {>= "0.2.0"}
   "cstruct" {< "6.1.0"}
 ]

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.1/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.2/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.3/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.3/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.4/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.4/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="6.00"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.5/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.5/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="6.00"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.6/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.6/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="6.00"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.7/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.7/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="6.00"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.11.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.11.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7"}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="6.00"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.11.1/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.11.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7"}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="6.00"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.11.2/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.11.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7"}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="6.00"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.11.3/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.11.3/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7"}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="6.00"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.7"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.1/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.7"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.2/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.7"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.7.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.7.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.7"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.7"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.1/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.7"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.10/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.10/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.2/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.7"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.3/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.3/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.7"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.4/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.4/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.7"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.5/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.5/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.7"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.6/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.6/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.7/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.7/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.8/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.8/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.9/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.9/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.9.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.9.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.9.1/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.9.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.9.2/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.9.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.0/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.0/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.1/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.1/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.2/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.2/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.3/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.3/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.4/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.4/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.5/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.5/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.6/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.6/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.7/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.10.7/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.11.0/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.11.0/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 ]
 conflicts: [ "mirage-runtime" {< "3.8.0"} ]
 description: """

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.11.1/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.11.1/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 ]
 conflicts: [ "mirage-runtime" {< "3.8.0"} ]
 description: """

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.11.2/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.11.2/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 ]
 conflicts: [ "mirage-runtime" {< "3.8.0"} ]
 description: """

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.11.3/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.11.3/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 ]
 conflicts: [ "mirage-runtime" {< "3.8.0"} ]
 description: """

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.6.0/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.6.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "ounit" {with-test}
 ]
 description: """

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.6.1/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.6.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "ounit" {with-test}
 ]
 description: """

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.6.2/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.6.2/opam
@@ -19,7 +19,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0"}
   "mirage-crypto" {=version}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "ounit" {with-test}
 ]
 description: """

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.7.0/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.7.0/opam
@@ -22,7 +22,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.0/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.0/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.1/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.1/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.10/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.10/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.2/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.2/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.3/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.3/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.4/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.4/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.5/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.5/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.6/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.6/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.7/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.7/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.8/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.8/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.9/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.8.9/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.9.0/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.9.0/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.9.1/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.9.1/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.9.2/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.9.2/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "mirage-crypto" {=version}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
 # lwt sublibrary
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}

--- a/packages/random/random.0.0.1/opam
+++ b/packages/random/random.0.0.1/opam
@@ -10,7 +10,7 @@ depends: [
   "mirage-crypto" {>= "0.11.2"}
   "mirage-crypto-rng" {>= "0.11.2"}
   "ocaml" {>= "4.14.0"}
-  "randomconv" {>= "0.1.3"}
+  "randomconv" {>= "0.1.3" & < "0.2.0"}
   "dune" {>= "3.14"}
   "odoc" {with-doc}
 ]

--- a/packages/randomconv/randomconv.0.2.0/opam
+++ b/packages/randomconv/randomconv.0.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/hannesm/randomconv"
+doc: "https://hannesm.github.io/randomconv/doc"
+bug-reports: "https://github.com/hannesm/randomconv/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/hannesm/randomconv.git"
+synopsis: "Convert from random byte vectors (int -> string) to random native numbers"
+description: """
+Given a function which produces random byte vectors, convert it to
+a number of your choice (int8/int16/int32/int64/int/float).
+"""
+url {
+  src:
+    "https://github.com/hannesm/randomconv/releases/download/v0.2.0/randomconv-0.2.0.tbz"
+  checksum: [
+    "sha256=b3171edf07e341a4468f92ffc21e2a8863b82ed5c36f7477cc98daf05d5b63ea"
+    "sha512=376c36da6b67ed1d817ea13fbbc3490f356f0890f9e009a55d12946c6811611ea9bd31aec733dd961de7209effa23649505f61d1ed3fc18af225ca4ec9131c38"
+  ]
+}
+x-commit-hash: "b2ce656d09738d676351f5a1c18aff0ff37a7dcc"

--- a/packages/riot/riot.0.0.8/opam
+++ b/packages/riot/riot.0.0.8/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml" {>= "5.1"}
   "odoc" {with-doc & >= "2.2.2"}
   "ptime" {>= "1.1.0"}
-  "randomconv" {>= "0.1.3"}
+  "randomconv" {>= "0.1.3" & < "0.2.0"}
   "telemetry" {>= "0.0.1"}
   "tls" {>= "0.17.3"}
   "uri" {>= "4.4.0"}

--- a/packages/tcpip/tcpip.3.0.0/opam
+++ b/packages/tcpip/tcpip.3.0.0/opam
@@ -65,7 +65,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "io-page" {< "2.0.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "cstruct-lwt"
 ]
 depopts: [

--- a/packages/tcpip/tcpip.3.1.0/opam
+++ b/packages/tcpip/tcpip.3.1.0/opam
@@ -64,7 +64,7 @@ depends: [
   "lwt" {>= "2.4.7" & < "3.0.0"}
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "cstruct-lwt"
   "io-page" {< "2.0.0"}
 ]

--- a/packages/tcpip/tcpip.3.1.1/opam
+++ b/packages/tcpip/tcpip.3.1.1/opam
@@ -64,7 +64,7 @@ depends: [
   "lwt" {>= "2.7.0"}
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "cstruct-lwt"
   "io-page" {< "2.0.0"}
 ]

--- a/packages/tcpip/tcpip.3.1.2/opam
+++ b/packages/tcpip/tcpip.3.1.2/opam
@@ -64,7 +64,7 @@ depends: [
   "lwt" {>= "2.7.0"}
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "cstruct-lwt"
   "io-page" {< "2.0.0"}
 ]

--- a/packages/tcpip/tcpip.3.1.3/opam
+++ b/packages/tcpip/tcpip.3.1.3/opam
@@ -64,7 +64,7 @@ depends: [
   "lwt" {>= "2.7.0"}
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "cstruct-lwt"
   "io-page" {< "2.0.0"}
 ]

--- a/packages/tcpip/tcpip.3.1.4/opam
+++ b/packages/tcpip/tcpip.3.1.4/opam
@@ -65,7 +65,7 @@ depends: [
   "lwt" {>= "2.7.0"}
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "io-page-unix" {>= "2.0.0"}
 ]
 depopts: [

--- a/packages/tcpip/tcpip.3.2.0/opam
+++ b/packages/tcpip/tcpip.3.2.0/opam
@@ -49,7 +49,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "io-page-unix"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
 ]
 synopsis: "An OCaml TCP/IP networking stack"
 description: """

--- a/packages/tcpip/tcpip.3.3.0/opam
+++ b/packages/tcpip/tcpip.3.3.0/opam
@@ -43,7 +43,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "io-page-unix"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}

--- a/packages/tcpip/tcpip.3.3.1/opam
+++ b/packages/tcpip/tcpip.3.3.1/opam
@@ -43,7 +43,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "io-page-unix"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}

--- a/packages/tcpip/tcpip.3.4.0/opam
+++ b/packages/tcpip/tcpip.3.4.0/opam
@@ -43,7 +43,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "io-page-unix"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}

--- a/packages/tcpip/tcpip.3.4.1/opam
+++ b/packages/tcpip/tcpip.3.4.1/opam
@@ -43,7 +43,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "io-page-unix"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}

--- a/packages/tcpip/tcpip.3.4.2/opam
+++ b/packages/tcpip/tcpip.3.4.2/opam
@@ -42,7 +42,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "io-page-unix"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}

--- a/packages/tcpip/tcpip.3.5.0/opam
+++ b/packages/tcpip/tcpip.3.5.0/opam
@@ -43,7 +43,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "io-page-unix"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}

--- a/packages/tcpip/tcpip.3.5.1/opam
+++ b/packages/tcpip/tcpip.3.5.1/opam
@@ -43,7 +43,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "io-page-unix"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}

--- a/packages/tcpip/tcpip.3.6.0/opam
+++ b/packages/tcpip/tcpip.3.6.0/opam
@@ -44,7 +44,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "io-page-unix"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}

--- a/packages/tcpip/tcpip.3.7.0/opam
+++ b/packages/tcpip/tcpip.3.7.0/opam
@@ -45,7 +45,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "io-page-unix"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {< "2.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}

--- a/packages/tcpip/tcpip.3.7.1/opam
+++ b/packages/tcpip/tcpip.3.7.1/opam
@@ -43,7 +43,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}

--- a/packages/tcpip/tcpip.3.7.2/opam
+++ b/packages/tcpip/tcpip.3.7.2/opam
@@ -43,7 +43,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}

--- a/packages/tcpip/tcpip.3.7.3/opam
+++ b/packages/tcpip/tcpip.3.7.3/opam
@@ -43,7 +43,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}

--- a/packages/tcpip/tcpip.3.7.4/opam
+++ b/packages/tcpip/tcpip.3.7.4/opam
@@ -43,7 +43,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}

--- a/packages/tcpip/tcpip.3.7.5/opam
+++ b/packages/tcpip/tcpip.3.7.5/opam
@@ -42,7 +42,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}

--- a/packages/tcpip/tcpip.3.7.6/opam
+++ b/packages/tcpip/tcpip.3.7.6/opam
@@ -42,7 +42,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}

--- a/packages/tcpip/tcpip.3.7.7/opam
+++ b/packages/tcpip/tcpip.3.7.7/opam
@@ -43,7 +43,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}

--- a/packages/tcpip/tcpip.3.7.8/opam
+++ b/packages/tcpip/tcpip.3.7.8/opam
@@ -43,7 +43,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}

--- a/packages/tcpip/tcpip.3.7.9/opam
+++ b/packages/tcpip/tcpip.3.7.9/opam
@@ -43,7 +43,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}

--- a/packages/tcpip/tcpip.4.0.0/opam
+++ b/packages/tcpip/tcpip.4.0.0/opam
@@ -42,7 +42,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
 #  "mirage-flow" {with-test & >= "2.0.0" & < "4.0.0"}
 #  "mirage-vnetif" {with-test & >= "0.5.0"}

--- a/packages/tcpip/tcpip.4.1.0/opam
+++ b/packages/tcpip/tcpip.4.1.0/opam
@@ -43,7 +43,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
 #  "mirage-vnetif" {with-test & >= "0.5.0"}

--- a/packages/tcpip/tcpip.5.0.0/opam
+++ b/packages/tcpip/tcpip.5.0.0/opam
@@ -42,7 +42,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
 #  "mirage-vnetif" {with-test & >= "0.5.0"}

--- a/packages/tcpip/tcpip.5.0.1/opam
+++ b/packages/tcpip/tcpip.5.0.1/opam
@@ -42,7 +42,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}

--- a/packages/tcpip/tcpip.6.0.0/opam
+++ b/packages/tcpip/tcpip.6.0.0/opam
@@ -40,7 +40,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}

--- a/packages/tcpip/tcpip.6.1.0/opam
+++ b/packages/tcpip/tcpip.6.1.0/opam
@@ -45,7 +45,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}

--- a/packages/tcpip/tcpip.6.2.0/opam
+++ b/packages/tcpip/tcpip.6.2.0/opam
@@ -45,7 +45,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}

--- a/packages/tcpip/tcpip.6.3.0/opam
+++ b/packages/tcpip/tcpip.6.3.0/opam
@@ -45,7 +45,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}

--- a/packages/tcpip/tcpip.6.4.0/opam
+++ b/packages/tcpip/tcpip.6.4.0/opam
@@ -45,7 +45,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}

--- a/packages/tcpip/tcpip.7.0.0/opam
+++ b/packages/tcpip/tcpip.7.0.0/opam
@@ -43,7 +43,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}

--- a/packages/tcpip/tcpip.7.0.1/opam
+++ b/packages/tcpip/tcpip.7.0.1/opam
@@ -43,7 +43,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}

--- a/packages/tcpip/tcpip.7.1.0/opam
+++ b/packages/tcpip/tcpip.7.1.0/opam
@@ -43,7 +43,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}

--- a/packages/tcpip/tcpip.7.1.1/opam
+++ b/packages/tcpip/tcpip.7.1.1/opam
@@ -43,7 +43,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}

--- a/packages/tcpip/tcpip.7.1.2/opam
+++ b/packages/tcpip/tcpip.7.1.2/opam
@@ -43,7 +43,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}

--- a/packages/tcpip/tcpip.8.0.0/opam
+++ b/packages/tcpip/tcpip.8.0.0/opam
@@ -40,7 +40,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}

--- a/packages/tls/tls.0.13.2/opam
+++ b/packages/tls/tls.0.13.2/opam
@@ -35,7 +35,7 @@ depends: [
   "hkdf"
   "logs"
   "alcotest" {with-test}
-  "randomconv" {with-test}
+  "randomconv" {with-test & < "0.2.0"}
 ]
 
 tags: [ "org:mirage"]

--- a/packages/tls/tls.0.14.0/opam
+++ b/packages/tls/tls.0.14.0/opam
@@ -35,7 +35,7 @@ depends: [
   "hkdf"
   "logs"
   "alcotest" {with-test}
-  "randomconv" {with-test}
+  "randomconv" {with-test & < "0.2.0"}
 ]
 
 tags: [ "org:mirage"]

--- a/packages/tls/tls.0.14.1/opam
+++ b/packages/tls/tls.0.14.1/opam
@@ -35,7 +35,7 @@ depends: [
   "hkdf"
   "logs"
   "alcotest" {with-test}
-  "randomconv" {with-test}
+  "randomconv" {with-test & < "0.2.0"}
 ]
 
 tags: [ "org:mirage"]

--- a/packages/tls/tls.0.15.0/opam
+++ b/packages/tls/tls.0.15.0/opam
@@ -37,7 +37,7 @@ depends: [
   "ipaddr"
   "ipaddr-sexp"
   "alcotest" {with-test}
-  "randomconv" {with-test}
+  "randomconv" {with-test & < "0.2.0"}
 ]
 
 tags: [ "org:mirage"]

--- a/packages/tls/tls.0.15.1/opam
+++ b/packages/tls/tls.0.15.1/opam
@@ -36,7 +36,7 @@ depends: [
   "ipaddr"
   "ipaddr-sexp"
   "alcotest" {with-test}
-  "randomconv" {with-test}
+  "randomconv" {with-test & < "0.2.0"}
 ]
 conflicts: [ "result" {< "1.5"} ]
 tags: [ "org:mirage"]

--- a/packages/tls/tls.0.15.2/opam
+++ b/packages/tls/tls.0.15.2/opam
@@ -36,7 +36,7 @@ depends: [
   "ipaddr"
   "ipaddr-sexp"
   "alcotest" {with-test}
-  "randomconv" {with-test}
+  "randomconv" {with-test & < "0.2.0"}
 ]
 conflicts: [ "result" {< "1.5"} ]
 tags: [ "org:mirage"]

--- a/packages/tls/tls.0.15.3/opam
+++ b/packages/tls/tls.0.15.3/opam
@@ -36,7 +36,7 @@ depends: [
   "ipaddr"
   "ipaddr-sexp"
   "alcotest" {with-test}
-  "randomconv" {with-test}
+  "randomconv" {with-test & < "0.2.0"}
   "cmdliner" {dev & > "1.1.0"}
 ]
 conflicts: [ "result" {< "1.5"} ]

--- a/packages/tls/tls.0.15.4/opam
+++ b/packages/tls/tls.0.15.4/opam
@@ -36,7 +36,7 @@ depends: [
   "ipaddr"
   "ipaddr-sexp"
   "alcotest" {with-test}
-  "randomconv" {with-test}
+  "randomconv" {with-test & < "0.2.0"}
   "cmdliner" {dev & > "1.1.0"}
 ]
 conflicts: [ "result" {< "1.5"} ]

--- a/packages/tls/tls.0.16.0/opam
+++ b/packages/tls/tls.0.16.0/opam
@@ -34,7 +34,7 @@ depends: [
   "ipaddr"
   "ipaddr-sexp"
   "alcotest" {with-test}
-  "randomconv" {with-test}
+  "randomconv" {with-test & < "0.2.0"}
 ]
 conflicts: [ "result" {< "1.5"} ]
 tags: [ "org:mirage"]

--- a/packages/tls/tls.0.17.0/opam
+++ b/packages/tls/tls.0.17.0/opam
@@ -29,7 +29,7 @@ depends: [
   "logs"
   "ipaddr"
   "alcotest" {with-test}
-  "randomconv" {with-test}
+  "randomconv" {with-test & < "0.2.0"}
 ]
 conflicts: [ "result" {< "1.5"} ]
 tags: [ "org:mirage"]

--- a/packages/tls/tls.0.17.1/opam
+++ b/packages/tls/tls.0.17.1/opam
@@ -29,7 +29,7 @@ depends: [
   "logs"
   "ipaddr"
   "alcotest" {with-test}
-  "randomconv" {with-test}
+  "randomconv" {with-test & < "0.2.0"}
 ]
 conflicts: [ "result" {< "1.5"} ]
 tags: [ "org:mirage"]

--- a/packages/tls/tls.0.17.3/opam
+++ b/packages/tls/tls.0.17.3/opam
@@ -29,7 +29,7 @@ depends: [
   "logs"
   "ipaddr"
   "alcotest" {with-test}
-  "randomconv" {with-test}
+  "randomconv" {with-test & < "0.2.0"}
 ]
 conflicts: [ "result" {< "1.5"} ]
 tags: [ "org:mirage"]


### PR DESCRIPTION
CHANGES:
* Use (int -> string) instead of (int -> Cstruct.t) as generator

the second commit adjusts all current users to only support the previous versions.