### PR TITLE
[new release] multicont (1.0.2)

### DIFF
--- a/packages/multicont/multicont.1.0.2/opam
+++ b/packages/multicont/multicont.1.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Multi-shot continuations in OCaml"
+description:
+  "This library provides facilities for programming with multi-shot continuations in OCaml"
+maintainer: ["Daniel Hillerström"]
+authors: ["Daniel Hillerström"]
+license: "MIT"
+tags: ["multi-shot continuations" "effect handlers"]
+homepage: "https://github.com/dhil/ocaml-multicont"
+bug-reports: "https://github.com/dhil/ocaml-multicont/issues"
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.14"}
+  "dune-configurator" {>= "3.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dhil/ocaml-multicont.git"
+url {
+  src:
+    "https://github.com/dhil/ocaml-multicont/releases/download/v1.0.2/multicont-1.0.2.tbz"
+  checksum: [
+    "sha256=a083532a53e0200312b6a1de968dd8b6e3e2167c81208f51dd60eaeb30d11a4d"
+    "sha512=a7d317f15ec78f046cc3351e2b701a880ac71f6c6f41f207c1ab5825b2918c02490b522b19f6ecb95baaa096f6f7e1ccea87c8c0ffe61bc46685b2fe336f5b39"
+  ]
+}
+x-commit-hash: "e38a5f33a527de785dbfbbc451bb6f36b6b5eaee"


### PR DESCRIPTION
Multi-shot continuations in OCaml

- Project page: <a href="https://github.com/dhil/ocaml-multicont">https://github.com/dhil/ocaml-multicont</a>

##### CHANGES:

This release adds support for the anticipated release of OCaml 5.2.

Changes:

* Patch dhil/ocaml-multicont#7: OCaml 5.2 support (thanks to kit-ty-kate for the issue
  report dhil/ocaml-multicont#6; thanks to David Allsopp for reviewing the patch).  The
  change accounts for the new continuation representation.
* Added a basic testsuite runnable via `dune runtest`.
* Fixed a memory leak in the rollback parsing example.
* Added an entry about subtle interactions of unrestricted and linear
  effects in the "Cautionary tales" section of the README.
