### PR TITLE
[new release] melange-fest (0.1.0)

### DIFF
--- a/packages/melange-fest/melange-fest.0.1.0/opam
+++ b/packages/melange-fest/melange-fest.0.1.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "A minimal test framework for Melange"
+description: "A minimal test framework for Melange using Node test runner"
+maintainer: [
+  "Feihong Hsu <feihong.hsu@ahrefs.com>"
+  "Javier Chávarri <javier.chavarri@ahrefs.com>"
+]
+authors: [
+  "Feihong Hsu <feihong.hsu@ahrefs.com>"
+  "Javier Chávarri <javier.chavarri@ahrefs.com>"
+]
+tags: ["melange" "node" "org:ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/melange-fest"
+bug-reports: "https://github.com/ahrefs/melange-fest/issues"
+dev-repo: "git+https://github.com/ahrefs/melange-fest.git"
+depends: [
+  "ocaml"
+  "dune" {>= "3.8"}
+  "melange"
+  "reason" {with-test}
+  "reason-react" {with-test}
+  "reason-react-ppx" {with-test}
+  "melange-testing-library" {with-test}
+  "ocaml-lsp-server" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ahrefs/melange-fest/releases/download/0.1.0/melange-fest-0.1.0.tbz"
+  checksum: [
+    "sha256=34f8c000dfee70dda1838c600584e6b6f67f7de1a230b2a46d1bc024c50e1afb"
+    "sha512=63d29ab4434a4c3de24ff8c86fd01c114f3a9b068e568f7848b2ff63086bc0a6526493e21c18e4d12067e7f8fa85872de514d828a30d2ce49cfc5a5acbc6014d"
+  ]
+}
+x-commit-hash: "5b0413e417a3013d6b913f863af0aab8b54e1331"

--- a/packages/melange-fest/melange-fest.0.1.0/opam
+++ b/packages/melange-fest/melange-fest.0.1.0/opam
@@ -16,7 +16,7 @@ bug-reports: "https://github.com/ahrefs/melange-fest/issues"
 dev-repo: "git+https://github.com/ahrefs/melange-fest.git"
 depends: [
   "ocaml"
-  "dune" {>= "3.8"}
+  "dune" {>= "3.9"}
   "melange" {>= "3.0"}
   "reason" {with-test}
   "reason-react" {with-test}

--- a/packages/melange-fest/melange-fest.0.1.0/opam
+++ b/packages/melange-fest/melange-fest.0.1.0/opam
@@ -17,7 +17,7 @@ dev-repo: "git+https://github.com/ahrefs/melange-fest.git"
 depends: [
   "ocaml"
   "dune" {>= "3.8"}
-  "melange"
+  "melange" {>= "3.0"}
   "reason" {with-test}
   "reason-react" {with-test}
   "reason-react-ppx" {with-test}
@@ -36,7 +36,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
A minimal test framework for Melange

- Project page: <a href="https://github.com/ahrefs/melange-fest">https://github.com/ahrefs/melange-fest</a>

##### CHANGES:

- Add bindings for `node:test` and `node:assert/strict`
