### PR TITLE
[new release] ppx_deriving_hash (0.1.2)

### DIFF
--- a/packages/ppx_deriving_hash/ppx_deriving_hash.0.1.2/opam
+++ b/packages/ppx_deriving_hash/ppx_deriving_hash.0.1.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "[@@deriving hash]"
+description:
+  "Deriver for standard hash functions without extra dependencies."
+maintainer: ["Simmo Saan <simmo.saan@gmail.com>"]
+authors: ["Simmo Saan <simmo.saan@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/sim642/ppx_deriving_hash"
+bug-reports: "https://github.com/sim642/ppx_deriving_hash/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppxlib"
+  "ppx_deriving" {>= "5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sim642/ppx_deriving_hash.git"
+url {
+  src:
+    "https://github.com/sim642/ppx_deriving_hash/releases/download/0.1.2/ppx_deriving_hash-0.1.2.tbz"
+  checksum: [
+    "sha256=b2cdce00b0fef439b9c2dc20bd0d1248bec2bb4c56ba6c0a98b04a3c387815af"
+    "sha512=3bd89f1215439a20aa81f8eae46574d8b80800a059ce4590774616e5ec349f73f010e0126c3390909942f8c5c258b67ab0ef10df7a5084322861a542a4ec8399"
+  ]
+}
+x-commit-hash: "c916f11a2365b3fe2ab77096b6073ebf62ea082b"


### PR DESCRIPTION
[@@deriving hash]

- Project page: <a href="https://github.com/sim642/ppx_deriving_hash">https://github.com/sim642/ppx_deriving_hash</a>

##### CHANGES:

* Add inline record support (sim642/ppx_deriving_hash#1).
* Add `float` support (sim642/ppx_deriving_hash#2).
* Add `ref` support (sim642/ppx_deriving_hash#3).
* Add `array` support (sim642/ppx_deriving_hash#4).
