### PR TITLE
Packages for OCaml 4.14.2~rc1

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.2~rc1/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.2~rc1/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.2~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.2~rc1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "First release candidate of OCaml 4.14.2"
+maintainer: "platform@lists.ocaml.org"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml#4.14"
+depends: [
+  "ocaml" {= "4.14.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-options-vanilla" {post}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.2-rc1.tar.gz"
+  checksum: "sha256=0779d4871c5a3be4ae24dc2f5a49ec5463973f951a11953a7da6089e02587a37"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+available: os != "win32"

--- a/packages/ocaml-variants/ocaml-variants.4.14.2~rc1+options/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.4.14.2~rc1+options/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.4.14.2~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.2~rc1+options/opam
@@ -1,0 +1,80 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First release candidate of OCaml 4.14.2"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.14"
+depends: [
+  "ocaml" {= "4.14.2" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string" {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--disable-naked-pointers" {ocaml-option-nnp:installed}
+    "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+    "LIBS=-static" {ocaml-option-static:installed}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.2-rc1.tar.gz"
+  checksum: "sha256=0779d4871c5a3be4ae24dc2f5a49ec5463973f951a11953a7da6089e02587a37"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+  "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
+]
+available: os != "win32"


### PR DESCRIPTION
The two usual packages (`ocaml-base` and `ocaml-variants.4.14.2+options`) for the first release candidate of OCaml 4.14.2, which is a LTS maintenance update with quite a collection of minor bug fixes:

----------------------------
### Runtime system:

- 11764, 12577: Add prototypes to old-style C function definitions
   and declarations.
  (Antonin Décimo, review by Xavier Leroy and Nick Barnes)

- 11763, 11759, 11861, 12509, 12577: Use strict prototypes on primitives.
  (Antonin Décimo, review by Xavier Leroy, David Allsopp, Sébastien
   Hinderer and Nick Barnes)

* 10723: do not use `-flat-namespace` linking for macOS.
  (Carlo Cabrera, review by Damien Doligez)

- 11332, 12702: make sure `Bool_val(v)` has type `bool` in C++
  (Xavier Leroy, report by ygrek, review by Gabriel Scherer)

### Build system:

- 11590: Allow installing to a destination path containing spaces.
  (Élie Brami, review by Sébastien Hinderer and David Allsopp)

- 12372: Pass option -no-execute-only to the linker for OpenBSD >= 7.3
  so that code sections remain readable, as needed for closure marshaling.
  (Xavier Leroy and Anil Madhavapeddy, review by Anil Madhavapeddy and
  Sébastien Hinderer)

- 12903: Disable control flow integrity on OpenBSD >= 7.4 to avoid
  illegal instruction errors on certain CPUs.
  (Michael Hendricks, review by Miod Vallat)

### Bug fixes:

- 12061, 12063: don't add inconsistent equalities when computing
  high-level error messages for functor applications and inclusions.
  (Florian Angeletti, review by Gabriel Scherer)

- 12878: fix incorrect treatment of injectivity for private recursive types.
  (Jeremy Yallop, review by Gabriel Scherer and Jacques Garrigue)

- 12971, 12974: fix an uncaught Ctype.Escape exception on some
  invalid programs forming recursive types.
  (Gabriel Scherer, review by Florian Angeletti, report by Neven Villani)

- 12264, 12289: Fix compact_allocate to avoid a pathological case
  that causes very slow compaction.
  (Damien Doligez, report by Arseniy Alekseyev, review by Sadiq Jaffer)

- 12513, 12518: Automatically enable emulated `fma` for Visual Studio 2019+
  to allow configuration with either pre-Haswell/pre-Piledriver CPUs or running
  in VirtualBox. Restores parity with the other Windows ports, which don't
  require explicit `--enable-imprecise-c99-float-ops`.
  (David Allsopp, report by Jonah Beckford and Kate Deplaix, review by
   Sébastien Hinderer)

- 11633, 11636: bugfix in caml_unregister_frametable
  (Frédéric Recoules, review by Gabriel Scherer)

- 12636, 12646: More prudent reinitialization of I/O mutexes after a fork()
  (Xavier Leroy, report by Zach Baylin, review by Enguerrand Decorne)

* 10845 Emit frametable size on amd64 BSD (OpenBSD, FreeBSD, NetBSD) systems
  (emitted for Linux in 8805)
  (Hannes Mehnert, review by Nicolás Ojeda Bär)

- 12958: Fix tail-modulo-cons compilation of try-with, && and ||
  expressions.
  (Gabriel Scherer and Nicolás Ojeda Bär, report by Sylvain Boilard, review by
  Gabriel Scherer)

