### PR TITLE
[new release] printbox (4 packages) (0.11)

### DIFF
--- a/packages/printbox-html/printbox-html.0.11/opam
+++ b/packages/printbox-html/printbox-html.0.11/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Printbox unicode handling"
+description: """
+
+Adds html output handling to the printbox package.
+Printbox allows to print nested boxes, lists, arrays, tables in several formats"""
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "printbox" {= version}
+  "printbox-text" {= version & with-test}
+  "odoc" {with-test}
+  "tyxml" {>= "4.3"}
+  "mdx" {>= "1.4" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.11/printbox-0.11.tbz"
+  checksum: [
+    "sha256=7a3935545f8b44c4380bdd78ac434d4e83b18c98ba96241b3c79530bd75839e9"
+    "sha512=a77692bfb5e96d6512646f6c7e3a6eb15770e12abb19bd09ef6d0cecf84976f69ff45ac703e56bed0552ed845d8b5afa08346cf0b6895bc3e3fd2add088cfc78"
+  ]
+}
+x-commit-hash: "0f51fe8cfe2666dc5f357e4a22b133e98f540bcd"

--- a/packages/printbox-md/printbox-md.0.11/opam
+++ b/packages/printbox-md/printbox-md.0.11/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Printbox Markdown rendering"
+description: """
+
+Adds Markdown output handling to the printbox package, with fallback to text and simplified HTML.
+Printbox allows to print nested boxes, lists, arrays, tables in several formats"""
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "printbox" {= version}
+  "printbox-text" {= version}
+  "printbox-html" {= version}
+  "odoc" {with-test}
+  "mdx" {>= "1.4" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.11/printbox-0.11.tbz"
+  checksum: [
+    "sha256=7a3935545f8b44c4380bdd78ac434d4e83b18c98ba96241b3c79530bd75839e9"
+    "sha512=a77692bfb5e96d6512646f6c7e3a6eb15770e12abb19bd09ef6d0cecf84976f69ff45ac703e56bed0552ed845d8b5afa08346cf0b6895bc3e3fd2add088cfc78"
+  ]
+}
+x-commit-hash: "0f51fe8cfe2666dc5f357e4a22b133e98f540bcd"

--- a/packages/printbox-text/printbox-text.0.11/opam
+++ b/packages/printbox-text/printbox-text.0.11/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Text renderer for printbox, using unicode edges"
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "printbox" {= version}
+  "uutf" {>= "1.0"}
+  "uucp" {>= "2.0"}
+  "odoc" {with-test}
+  "mdx" {>= "1.4" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.11/printbox-0.11.tbz"
+  checksum: [
+    "sha256=7a3935545f8b44c4380bdd78ac434d4e83b18c98ba96241b3c79530bd75839e9"
+    "sha512=a77692bfb5e96d6512646f6c7e3a6eb15770e12abb19bd09ef6d0cecf84976f69ff45ac703e56bed0552ed845d8b5afa08346cf0b6895bc3e3fd2add088cfc78"
+  ]
+}
+x-commit-hash: "0f51fe8cfe2666dc5f357e4a22b133e98f540bcd"

--- a/packages/printbox/printbox.0.11/opam
+++ b/packages/printbox/printbox.0.11/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Allows to print nested boxes, lists, arrays, tables in several formats"
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+tags: ["print" "box" "table" "tree"]
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.11/printbox-0.11.tbz"
+  checksum: [
+    "sha256=7a3935545f8b44c4380bdd78ac434d4e83b18c98ba96241b3c79530bd75839e9"
+    "sha512=a77692bfb5e96d6512646f6c7e3a6eb15770e12abb19bd09ef6d0cecf84976f69ff45ac703e56bed0552ed845d8b5afa08346cf0b6895bc3e3fd2add088cfc78"
+  ]
+}
+x-commit-hash: "0f51fe8cfe2666dc5f357e4a22b133e98f540bcd"


### PR DESCRIPTION
Allows to print nested boxes, lists, arrays, tables in several formats

- Project page: <a href="https://github.com/c-cube/printbox">https://github.com/c-cube/printbox</a>

##### CHANGES:

- Anchors (with self-links if inner is non-empty)
- Support `hlist` and `vlist` inside summaries Implemented as poor-man's support of arbitrary grids.
