### PR TITLE
Add +https protocol to hc.0.2 and hc.0.3 dev-repo fields

### DIFF
--- a/packages/hc/hc.0.2/opam
+++ b/packages/hc/hc.0.2/opam
@@ -27,7 +27,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git://git.zapashcanon.fr/zapashcanon/hc.git"
+dev-repo: "git+https://git.zapashcanon.fr/zapashcanon/hc.git"
 url {
   src: "https://git.zapashcanon.fr/zapashcanon/hc/archive/0.2.tar.gz"
   checksum: [

--- a/packages/hc/hc.0.3/opam
+++ b/packages/hc/hc.0.3/opam
@@ -27,7 +27,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git://git.zapashcanon.fr/zapashcanon/hc.git"
+dev-repo: "git+https://git.zapashcanon.fr/zapashcanon/hc.git"
 url {
   src: "https://git.zapashcanon.fr/zapashcanon/hc/archive/0.3.tar.gz"
   checksum: [


### PR DESCRIPTION
Hello!

Just a minor update to `hc.0.2` and `hc.0.3` opam files to include the `+https` protocol in the `dev-repo` field. 
I need to update these packages because of an upcoming blog post which includes them in examples around pinning URLs :innocent: 

Anyway, thank you,
Kind regards!