### PR TITLE
[new release] bitwuzla-cxx (0.4.0)

### DIFF
--- a/packages/bitwuzla-cxx/bitwuzla-cxx.0.4.0/opam
+++ b/packages/bitwuzla-cxx/bitwuzla-cxx.0.4.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "SMT solver for AUFBVFP (C++ API)"
+description: """
+
+OCaml binding for the SMT solver Bitwuzla C++ API.
+
+Bitwuzla is a Satisfiability Modulo Theories (SMT) solver for the theories of fixed-size bit-vectors, arrays and uninterpreted functions and their combinations. Its name is derived from an Austrian dialect expression that can be translated as “someone who tinkers with bits”."""
+maintainer: ["Frédéric Recoules <frederic.recoules@cea.fr>"]
+authors: ["Frédéric Recoules"]
+license: "MIT"
+tags: ["SMT solver" "AUFBVFP"]
+homepage: "https://bitwuzla.github.io"
+doc: "https://bitwuzla.github.io/docs/ocaml/"
+bug-reports: "https://github.com/bitwuzla/ocaml-bitwuzla/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.12"}
+  "conf-git" {build}
+  "conf-gcc" {build}
+  "conf-g++" {build}
+  "zarith"
+  "ppx_inline_test" {with-test & >= "v0.13"}
+  "ppx_expect" {with-test & >= "v0.13"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
+available: [ os = "linux" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) | os = "macos" & os-distribution = "homebrew" ]
+url {
+  src:
+    "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/0.4.0/bitwuzla-cxx-0.4.0.tbz"
+  checksum: [
+    "sha256=87d43d446390cdfb24ed4e2dfb8e5435bd678a0cec2171a840b4a5d5c025cb68"
+    "sha512=2a9b97f316e3fd56e060dad51956bcc11d832237136b38c97f1cf16f8e1befd722a0569585c3a4f804392a71b64cc00a17c229434ea04ffaf81b1e581ac5f83e"
+  ]
+}
+x-commit-hash: "f79e1db3a3055f9e0daa259b9d5e3dc7afd8e4ea"


### PR DESCRIPTION
SMT solver for AUFBVFP (C++ API)

- Project page: <a href="https://bitwuzla.github.io">https://bitwuzla.github.io</a>
- Documentation: <a href="https://bitwuzla.github.io/docs/ocaml/">https://bitwuzla.github.io/docs/ocaml/</a>

##### CHANGES:

Update [Bitwuzla](https://github.com/bitwuzla/bitwuzla/releases/tag/0.4.0) sources.

`Bitwuzla_cxx` should now be usable with OCaml 5 (not thoroughly tested).

Vendor submodules:
- [Cadical](https://github.com/arminbiere/cadical) tag:rel-1.7.4
- [Bitwuzla](https://github.com/bitwuzla/bitwuzla) tag:0.4.0
