### PR TITLE
Package provider.0.0.4

### DIFF
--- a/packages/provider/provider.0.0.4/opam
+++ b/packages/provider/provider.0.0.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Parametrize your OCaml library with values that behave like objects but aren't"
+maintainer: ["Mathieu Barbin"]
+authors: ["Mathieu Barbin"]
+license: "ISC"
+homepage: "https://github.com/mbarbin/provider"
+doc: "https://mbarbin.github.io/provider/"
+bug-reports: "https://github.com/mbarbin/provider/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1"}
+  "base" {>= "v0.16" & < "v0.17"}
+  "bisect_ppx" {dev & >= "2.8.3"}
+  "ppx_compare" {>= "v0.16" & < "v0.17"}
+  "ppx_hash" {>= "v0.16" & < "v0.17"}
+  "ppx_js_style" {dev & >= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv" {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_value" {>= "v0.16" & < "v0.17"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/provider.git"
+url {
+  src:
+    "https://github.com/mbarbin/provider/releases/download/0.0.4/provider-0.0.4.tbz"
+  checksum: [
+    "sha256=5115476c5d4d08b19c867806b291ce1d509c6e61e99d7a2d457bde9422503c0b"
+    "sha512=28d8b65af3263227ff09faa774caca6874016043b6d643da5fd8d0b649151facf3439c92e72795fc78b0a8bdd79f2e4e457f967e44c6f275480a0ec29264b6a0"
+  ]
+}
+x-commit-hash: "d30ff2a59e457fb4d2527e2a7710f39696a7a019"


### PR DESCRIPTION
### `provider.0.0.4`
Parametrize your OCaml library with values that behave like objects but aren't



---
* Homepage: https://github.com/mbarbin/provider
* Source repo: git+https://github.com/mbarbin/provider.git
* Bug tracker: https://github.com/mbarbin/provider/issues

---
## 0.0.4 (2024-03-05)

### Changed

- Uses `expect-test-helpers` (reduce core dependencies)
- Upgrade `eio` to `0.15`.
- Run `ppx_js_style` as a linter & make it a `dev` dependency.
- Upgrade GitHub workflows `actions/checkout` to v4.
- In CI, specify build target `@all`, and add `@lint`.
- List ppxs instead of `ppx_jane`.

## 0.0.3 (2024-02-21)

### Added

- Add new tests, improve test coverage.

### Changed

- Improve organization of test files.
- Rename `Class` => `Trait` (breaking change).

### Fixed

- Fix `Interface.implements` which shouldn't raise on empty interface (#3, @mbarbin).

## 0.0.2 (2024-02-18)

### Changed

- Improve tests and documentation.

## 0.0.1 (2024-02-18)

- Initial release.


---
:camel: Pull-request generated by opam-publish v2.3.0