### PR TITLE
[new release] binsec (0.8.2)

### DIFF
--- a/packages/binsec/binsec.0.8.2/opam
+++ b/packages/binsec/binsec.0.8.2/opam
@@ -1,0 +1,103 @@
+opam-version: "2.0"
+synopsis: "Semantic analysis of binary executables"
+description: """
+
+BINSEC aims at developing an open-source platform filling the gap between formal
+methods over executable code and binary-level security analyses currently used
+in the security industry.
+
+The project targets the following applicative domains:
+
+    vulnerability analyses
+    malware comprehension
+    code protection
+    binary-level verification
+
+BINSEC is developed at CEA List in scientfic collaboration with Verimag and LORIA.
+
+An overview of some BINSEC features can be found in our SSPREW'17 tutorial."""
+maintainer: ["BINSEC <binsec@saxifrage.saclay.cea.fr>"]
+authors: [
+  "Adel Djoudi"
+  "Benjamin Farinier"
+  "Chakib Foulani"
+  "Dorian Lesbre"
+  "Frédéric Recoules"
+  "Guillaume Girol"
+  "Josselin Feist"
+  "Lesly-Ann Daniel"
+  "Manh-Dung Nguyen"
+  "Mathéo Vergnolle"
+  "Mathilde Ollivier"
+  "Matthieu Lemerre"
+  "Olivier Nicole"
+  "Richard Bonichon"
+  "Robin David"
+  "Sébastien Bardin"
+  "Soline Ducousso"
+  "Ta Thanh Dinh"
+  "Yaëlle Vinçont"
+]
+license: "LGPL-2.1-or-later"
+tags: [
+  "binary code analysis"
+  "symbolic execution"
+  "deductive"
+  "program verification"
+  "formal specification"
+  "automated theorem prover"
+  "plugins"
+  "abstract interpretation"
+  "dataflow analysis"
+  "linking"
+  "disassembly"
+]
+homepage: "https://binsec.github.io"
+bug-reports: "mailto:binsec@saxifrage.saclay.cea.fr"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.11"}
+  "menhir" {build & >= "20181113"}
+  "ocamlgraph" {>= "1.8.5"}
+  "zarith" {>= "1.4"}
+  "dune-site"
+  "grain_dypgen"
+  "toml" {>= "6"}
+  "ounit2" {with-test & >= "2"}
+  "qcheck" {with-test & >= "0.7"}
+  "ocamlformat" {with-dev-setup & = "0.26.1"}
+  "odoc" {with-doc}
+]
+depopts: ["curses" "llvm" "unisim_archisec" "bitwuzla"]
+conflicts: [
+  "llvm" {< "6.0.0" | >= "16.0.0"}
+  "bitwuzla" {< "1.0.4"}
+  "unisim_archisec" {< "0.0.6"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/binsec/binsec.git"
+available: [ arch = "x86_64" | arch = "ppc64" | arch = "arm64" | arch = "sparc64" ]
+url {
+  src:
+    "https://github.com/binsec/binsec/releases/download/0.8.2/binsec-0.8.2.tbz"
+  checksum: [
+    "sha256=b8e7b9c756245656c481e992549fb7b1864ee6eeb492e16488e7a9d962d39cdb"
+    "sha512=07a5e4105e5275751fcc6832743f5f9eedc72bd061273ec54c4466135032852120df3784ba571656c788e5f3cd971aad8a53f030336a364e77e940e26dff38d7"
+  ]
+}
+x-commit-hash: "6a27aec3f314e5790e2295db2d60ec877f975481"


### PR DESCRIPTION
Semantic analysis of binary executables

- Project page: <a href="https://binsec.github.io">https://binsec.github.io</a>

##### CHANGES:

** Misc

  - Best effort handling of `<`*symbol*`@plt>` in SSE script (`x86` for now)
  - Add an option to ignore or simply warn when trying to `replace`
    a symbol absent of the binary (`-sse-missing-symbol`)
  - Warn for different threats to completeness at the end of SSE analysis

** Bugs

  - Fix several issues in `checkct` analysis
  - Fix *choice* option not showing the alternatives
  - Fix several parsing issues
  - Fix some download links in examples
  - Fix several issues in architecture handling
  - Fix compilation issues with OCaml 5
