### PR TITLE
[new release] opentelemetry (5 packages) (0.8)

### DIFF
--- a/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.8/opam
+++ b/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.8/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Collector client for opentelemetry, using cohttp + lwt"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team and contributors"]
+license: "MIT"
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "mtime" {>= "1.4"}
+  "opentelemetry" {= version}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "lwt_ppx" {>= "2.0"}
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.8/opentelemetry-0.8.tbz"
+  checksum: [
+    "sha256=8696157e2b9fc279223dd9436c009709b6d8888065bdb0382f6f13696c229691"
+    "sha512=9b5273c5fe082da5ef436051da059b5ea7a01b5568f6c64299953a79f1a8c1c118edc79d956378a684f0154727a47ccd0da1bd4ed96ad40a36e0334eb6ee3a0e"
+  ]
+}
+x-commit-hash: "267ac195ef57057db40018ba7018c6204f3d5d2a"

--- a/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.8/opam
+++ b/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.8/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Collector client for opentelemetry, using http + ezcurl"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team and contributors"]
+license: "MIT"
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "mtime" {>= "1.4"}
+  "opentelemetry" {= version}
+  "odoc" {with-doc}
+  "ezcurl" {>= "0.2.3"}
+  "ocurl"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.8/opentelemetry-0.8.tbz"
+  checksum: [
+    "sha256=8696157e2b9fc279223dd9436c009709b6d8888065bdb0382f6f13696c229691"
+    "sha512=9b5273c5fe082da5ef436051da059b5ea7a01b5568f6c64299953a79f1a8c1c118edc79d956378a684f0154727a47ccd0da1bd4ed96ad40a36e0334eb6ee3a0e"
+  ]
+}
+x-commit-hash: "267ac195ef57057db40018ba7018c6204f3d5d2a"

--- a/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.8/opam
+++ b/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.8/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Opentelemetry tracing for Cohttp HTTP servers"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team and contributors"]
+license: "MIT"
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "opentelemetry" {= version}
+  "opentelemetry-lwt" {= version}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "cohttp-lwt" {>= "4.0.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.8/opentelemetry-0.8.tbz"
+  checksum: [
+    "sha256=8696157e2b9fc279223dd9436c009709b6d8888065bdb0382f6f13696c229691"
+    "sha512=9b5273c5fe082da5ef436051da059b5ea7a01b5568f6c64299953a79f1a8c1c118edc79d956378a684f0154727a47ccd0da1bd4ed96ad40a36e0334eb6ee3a0e"
+  ]
+}
+x-commit-hash: "267ac195ef57057db40018ba7018c6204f3d5d2a"

--- a/packages/opentelemetry-lwt/opentelemetry-lwt.0.8/opam
+++ b/packages/opentelemetry-lwt/opentelemetry-lwt.0.8/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Lwt-compatible instrumentation for https://opentelemetry.io"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team and contributors"]
+license: "MIT"
+tags: ["instrumentation" "tracing" "opentelemetry" "datadog" "lwt"]
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "ambient-context"
+  "opentelemetry" {= version}
+  "cohttp-lwt-unix" {with-test}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "lwt_ppx" {>= "2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.8/opentelemetry-0.8.tbz"
+  checksum: [
+    "sha256=8696157e2b9fc279223dd9436c009709b6d8888065bdb0382f6f13696c229691"
+    "sha512=9b5273c5fe082da5ef436051da059b5ea7a01b5568f6c64299953a79f1a8c1c118edc79d956378a684f0154727a47ccd0da1bd4ed96ad40a36e0334eb6ee3a0e"
+  ]
+}
+x-commit-hash: "267ac195ef57057db40018ba7018c6204f3d5d2a"

--- a/packages/opentelemetry/opentelemetry.0.8/opam
+++ b/packages/opentelemetry/opentelemetry.0.8/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Instrumentation for https://opentelemetry.io"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team and contributors"]
+license: "MIT"
+tags: ["instrumentation" "tracing" "opentelemetry" "datadog" "jaeger"]
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "ptime"
+  "hmap"
+  "ambient-context"
+  "odoc" {with-doc}
+  "alcotest" {with-test}
+  "pbrt" {>= "3.0" & < "4.0"}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup & >= "0.24" & < "0.25"}
+]
+depopts: ["trace"]
+conflicts: [
+  "trace" {< "0.4" | >= "0.7"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.8/opentelemetry-0.8.tbz"
+  checksum: [
+    "sha256=8696157e2b9fc279223dd9436c009709b6d8888065bdb0382f6f13696c229691"
+    "sha512=9b5273c5fe082da5ef436051da059b5ea7a01b5568f6c64299953a79f1a8c1c118edc79d956378a684f0154727a47ccd0da1bd4ed96ad40a36e0334eb6ee3a0e"
+  ]
+}
+x-commit-hash: "267ac195ef57057db40018ba7018c6204f3d5d2a"


### PR DESCRIPTION
Instrumentation for https://opentelemetry.io

- Project page: <a href="https://github.com/imandra-ai/ocaml-opentelemetry">https://github.com/imandra-ai/ocaml-opentelemetry</a>

##### CHANGES:

- feat: add dep on `hmap`, add standard keys to carry around a span context or trace id
- add semantic conventions for code and HTTP

- better debug message in curl backend
- make otel-trace a bit more lightweight
