### PR TITLE
[new release] trace (4 packages) (0.7)

### DIFF
--- a/packages/ppx_trace/ppx_trace.0.7/opam
+++ b/packages/ppx_trace/ppx_trace.0.7/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A ppx-based preprocessor for trace"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "ppx"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "ppxlib" {>= "0.28"}
+  "trace" {= version}
+  "trace-tef" {= version & with-test}
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.7/trace-0.7.tbz"
+  checksum: [
+    "sha256=ebd0be29b30b49536c9659882790b9f0c121ffb06c0bec2eaeba8cfed4909339"
+    "sha512=d14b72db713315093c931351b9b04d2fd5ce793a8595970fa31cbf71477516ef25de129adddf4075514581fe9ea3e27d998530efacb17c0d00bb5616b8d18b91"
+  ]
+}
+x-commit-hash: "62063f3f941224b6532d588f0926cd3a22cc194a"

--- a/packages/trace-fuchsia/trace-fuchsia.0.7/opam
+++ b/packages/trace-fuchsia/trace-fuchsia.0.7/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "A high-performance backend for trace, emitting a Fuchsia trace into a file"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "tracing" "fuchsia"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "trace" {= version}
+  "mtime" {>= "2.0"}
+  "thread-local-storage"
+  "base-bigarray"
+  "base-unix"
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+available: arch != "s390x"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.7/trace-0.7.tbz"
+  checksum: [
+    "sha256=ebd0be29b30b49536c9659882790b9f0c121ffb06c0bec2eaeba8cfed4909339"
+    "sha512=d14b72db713315093c931351b9b04d2fd5ce793a8595970fa31cbf71477516ef25de129adddf4075514581fe9ea3e27d998530efacb17c0d00bb5616b8d18b91"
+  ]
+}
+x-commit-hash: "62063f3f941224b6532d588f0926cd3a22cc194a"

--- a/packages/trace-tef/trace-tef.0.7/opam
+++ b/packages/trace-tef/trace-tef.0.7/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "A simple backend for trace, emitting Catapult/TEF JSON into a file"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "tracing" "catapult" "TEF" "chrome-format"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "trace" {= version}
+  "mtime" {>= "2.0"}
+  "base-unix"
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.7/trace-0.7.tbz"
+  checksum: [
+    "sha256=ebd0be29b30b49536c9659882790b9f0c121ffb06c0bec2eaeba8cfed4909339"
+    "sha512=d14b72db713315093c931351b9b04d2fd5ce793a8595970fa31cbf71477516ef25de129adddf4075514581fe9ea3e27d998530efacb17c0d00bb5616b8d18b91"
+  ]
+}
+x-commit-hash: "62063f3f941224b6532d588f0926cd3a22cc194a"

--- a/packages/trace/trace.0.7/opam
+++ b/packages/trace/trace.0.7/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "A stub for tracing/observability, agnostic in how data is collected"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "tracing" "observability" "profiling"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "hmap"
+  "mtime" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.7/trace-0.7.tbz"
+  checksum: [
+    "sha256=ebd0be29b30b49536c9659882790b9f0c121ffb06c0bec2eaeba8cfed4909339"
+    "sha512=d14b72db713315093c931351b9b04d2fd5ce793a8595970fa31cbf71477516ef25de129adddf4075514581fe9ea3e27d998530efacb17c0d00bb5616b8d18b91"
+  ]
+}
+x-commit-hash: "62063f3f941224b6532d588f0926cd3a22cc194a"


### PR DESCRIPTION
A stub for tracing/observability, agnostic in how data is collected

- Project page: <a href="https://github.com/c-cube/ocaml-trace">https://github.com/c-cube/ocaml-trace</a>

##### CHANGES:

- feat: add levels to `Trace_core`. Levels are similar to `logs` levels, to help control verbosity.
- add hmap as a depopt (c-cube/ocaml-trace#28)

- fix: truncate large strings in fuchsia
