### PR TITLE
Disable conf-zstd.0.1

### DIFF
--- a/packages/conf-zstd/conf-zstd.0.1/opam
+++ b/packages/conf-zstd/conf-zstd.0.1/opam
@@ -4,19 +4,11 @@ homepage: "http://zstd.net/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Facebook"]
 license: "BSD-3-Clause"
-build: [["pkg-config" "libzstd"]]
-depends: ["conf-pkg-config" {build}]
-depexts: [
-  ["libzstd-dev"] {os-family = "debian"}
-  ["libzstd-devel"] {os-distribution = "centos"}
-  ["libzstd-devel"] {os-distribution = "rhel"}
-  ["libzstd-devel"] {os-distribution = "fedora"}
-  ["zstd-dev"] {os-distribution = "alpine"}
-  ["zstd"] {os-distribution = "homebrew" & os = "macos"}
-  ["zstd"] {os = "win32" & os-distribution = "cygwinports"}
-]
-synopsis: "Virtual package relying on zstd"
-description:"
-This package can only install if the zstd library is installed on the system.
-"
-flags: conf
+synopsis: "Virtual package relying on zstd (legacy)"
+description: "This package version has been deprecated - use conf-zstd.1.3.8."
+flags: [ conf deprecated ]
+# This package has been disabled in order to simplify the maintenance of
+# conf-zstd. conf-zstd.1.3.8 was added to "encode" a build requirement of at
+# least version 1.3.8, but this should have been done using an entirely new
+# package.
+available: false

--- a/packages/conf-zstd/conf-zstd.0.1/opam
+++ b/packages/conf-zstd/conf-zstd.0.1/opam
@@ -4,11 +4,18 @@ homepage: "http://zstd.net/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Facebook"]
 license: "BSD-3-Clause"
+build: [["pkg-config" "libzstd"]]
+depends: ["conf-pkg-config" {build}]
+depexts: [
+  ["libzstd-dev"] {os-family = "debian"}
+  ["libzstd-devel"] {os-distribution = "centos"}
+  ["libzstd-devel"] {os-distribution = "rhel"}
+  ["libzstd-devel"] {os-distribution = "fedora"}
+  ["zstd-dev"] {os-distribution = "alpine"}
+  ["zstd"] {os-distribution = "homebrew" & os = "macos"}
+  ["zstd"] {os = "win32" & os-distribution = "cygwinports"}
+]
 synopsis: "Virtual package relying on zstd (legacy)"
 description: "This package version has been deprecated - use conf-zstd.1.3.8."
 flags: [ conf deprecated ]
-# This package has been disabled in order to simplify the maintenance of
-# conf-zstd. conf-zstd.1.3.8 was added to "encode" a build requirement of at
-# least version 1.3.8, but this should have been done using an entirely new
-# package.
-available: false
+available: os != "win32" | os-distribution = "cygwinports"

--- a/packages/conf-zstd/conf-zstd.0.1/opam
+++ b/packages/conf-zstd/conf-zstd.0.1/opam
@@ -11,6 +11,7 @@ depexts: [
   ["libzstd-devel"] {os-distribution = "centos"}
   ["libzstd-devel"] {os-distribution = "rhel"}
   ["libzstd-devel"] {os-distribution = "fedora"}
+  ["libzstd-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["zstd-dev"] {os-distribution = "alpine"}
   ["zstd"] {os-distribution = "homebrew" & os = "macos"}
   ["zstd"] {os = "win32" & os-distribution = "cygwinports"}

--- a/packages/ppxlib/ppxlib.0.5.0/opam
+++ b/packages/ppxlib/ppxlib.0.5.0/opam
@@ -16,7 +16,7 @@ run-test: [
 depends: [
   "ocaml"                   {>= "4.04.1" & < "4.08.0"}
   "base"                    {>= "v0.11.0"}
-  "dune"
+  "dune"                    {>= "1.6.0"}
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.0.9" & < "2.0.0"}
   "ppx_derivers"            {>= "1.0"}

--- a/packages/zstandard/zstandard.v0.12.0/opam
+++ b/packages/zstandard/zstandard.v0.12.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"       {>= "4.07.0"}
   "core_kernel" {>= "v0.12" & < "v0.13"}
   "ppx_jane"    {>= "v0.12" & < "v0.13"}
-  "conf-zstd"   {= "1.3.8"}
+  "conf-zstd"
   "ctypes"
   "dune"        {>= "1.5.1" & < "2.0.0"}
 ]

--- a/packages/zstandard/zstandard.v0.12.1/opam
+++ b/packages/zstandard/zstandard.v0.12.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"       {>= "4.07.0"}
   "core_kernel" {>= "v0.12" & < "v0.13"}
   "ppx_jane"    {>= "v0.12" & < "v0.13"}
-  "conf-zstd"   {= "1.3.8"}
+  "conf-zstd"
   "ctypes"
   "dune"        {>= "1.5.1"}
 ]


### PR DESCRIPTION
As we move towards proper depext support for Windows in opam-repository, old versions of conf- packages are an increasing nuisance, as either they all need updating or old versions need constraining away from Windows for lowerbounds purposes (cf. #25235).

conf-zstd has two versions - the original conf-zstd.0.1 and then a version constraining conf-zstd.1.3.8 added in #13602.

In general, I find that these pseudo-version conf- packages add more maintenance burden/confusion than they solve. However, in this particular case, the passage of time means that pretty much any supported distro has at least version 1.3.8 (Ubuntu's had 1.3.8+ since Disco (19.04); Fedora has had 1.3.8+ since Fedora 28; Alpine has had 1.3.8+ since 3.9), so rather than just changing the constraint for the older conf-zstd.0.1, how about just simply disabling it?