### PR TITLE
[new release] dream-html (3.2.0)

### DIFF
--- a/packages/dream-html/dream-html.3.2.0/opam
+++ b/packages/dream-html/dream-html.3.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.2.0/dream-html-3.2.0.tbz"
+  checksum: [
+    "sha256=0c0745e6225cb50e40b6663e1ac5e3fa14ed9f8f1e078b8bc25c2c32c9cd66e7"
+    "sha512=52b131fe5326318a1cd399868aa43506d266f61dc2c1f11336c7f0f68a0aca985268587dab41b48589bf5b031be7e06501a04e072f308a81bcf577d127f81c14"
+  ]
+}
+x-commit-hash: "59be8c503f0ccf57a5a8efca016b7f1da9ff6ed9"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
