### PR TITLE
[new release] multicore-bench (0.1.2)

### DIFF
--- a/packages/multicore-bench/multicore-bench.0.1.2/opam
+++ b/packages/multicore-bench/multicore-bench.0.1.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Framework for writing multicore benchmark executables to run on current-bench"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-bench"
+bug-reports: "https://github.com/ocaml-multicore/multicore-bench/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "domain-local-await" {>= "1.0.1"}
+  "multicore-magic" {>= "2.1.0"}
+  "mtime" {>= "2.0.0"}
+  "yojson" {>= "2.1.0"}
+  "domain_shims" {>= "0.1.0"}
+  "backoff" {>= "0.1.0" & with-test}
+  "mdx" {>= "2.4.0" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
+  "ocaml" {>= "4.13.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-bench.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-bench/releases/download/0.1.2/multicore-bench-0.1.2.tbz"
+  checksum: [
+    "sha256=e52416c0678080a0f848cea1f07b794ec92088bc43b2e0d95b3d93c9d5e643b2"
+    "sha512=acc0a6888d5b5e82bc729d9979ab8ce8731cf4898b5e16185931202afff13c87428e47a8b40468d0768cb4a929bcf673f719d0cdb808375e79fb033e11ed2ea0"
+  ]
+}
+x-commit-hash: "7e093ef56418a322daf414832cc5b63a287f3d89"


### PR DESCRIPTION
Framework for writing multicore benchmark executables to run on current-bench

- Project page: <a href="https://github.com/ocaml-multicore/multicore-bench">https://github.com/ocaml-multicore/multicore-bench</a>

##### CHANGES:

- Add `-brief` to show results in a concise human readable format (@polytypic)
- Add support for `wrap`ping the work without timing `wrap` itself (@polytypic)
- Add `-diff base.json` switch to diff against base results from file
  (@polytypic)
