### PR TITLE
[new release] eio (5 packages) (1.0)

### DIFF
--- a/packages/eio/eio.1.0/opam
+++ b/packages/eio/eio.1.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "5.1.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "hmap" {>= "0.8.1"}
+  "domain-local-await" {>= "0.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "2.0.0"}
+  "mdx" {>= "2.2.0" & < "2.4.0" & with-test}
+  "dscheck" {>= "0.1.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "seq" {< "0.3"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.0/eio-1.0.tbz"
+  checksum: [
+    "sha256=da260d9da38b3dde9f316652a20b13a261cf90b85a2498ac669b7d564e61942d"
+    "sha512=5886e1159f48ede237769baa1d8b5daafa0310e4192d7fe0e8c32aef70f2b6378cef72d0fbae308457e25d87a69802b9ee83a5e8f23e0591d83086a92d701c46"
+  ]
+}
+x-commit-hash: "edfe8debb26ab6a372103c859a27bf8738cb611f"

--- a/packages/eio_linux/eio_linux.1.0/opam
+++ b/packages/eio_linux/eio_linux.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An Eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "eio" {= version}
+  "mdx" {>= "2.2.0" & < "2.4.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "0.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+available: [os = "linux"]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.0/eio-1.0.tbz"
+  checksum: [
+    "sha256=da260d9da38b3dde9f316652a20b13a261cf90b85a2498ac669b7d564e61942d"
+    "sha512=5886e1159f48ede237769baa1d8b5daafa0310e4192d7fe0e8c32aef70f2b6378cef72d0fbae308457e25d87a69802b9ee83a5e8f23e0591d83086a92d701c46"
+  ]
+}
+x-commit-hash: "edfe8debb26ab6a372103c859a27bf8738cb611f"

--- a/packages/eio_main/eio_main.1.0/opam
+++ b/packages/eio_main/eio_main.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "mdx" {>= "2.2.0" & < "2.4.0" & with-test}
+  "kcas" {>= "0.3.0" & with-test}
+  "yojson" {>= "2.0.2" & with-test}
+  "eio_linux"
+    {= version & os = "linux" &
+     (os-distribution != "centos" | os-version > "7")}
+  "eio_posix" {= version & os != "win32"}
+  "eio_windows" {= version & os = "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+x-ci-accept-failures: ["macos-homebrew"]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.0/eio-1.0.tbz"
+  checksum: [
+    "sha256=da260d9da38b3dde9f316652a20b13a261cf90b85a2498ac669b7d564e61942d"
+    "sha512=5886e1159f48ede237769baa1d8b5daafa0310e4192d7fe0e8c32aef70f2b6378cef72d0fbae308457e25d87a69802b9ee83a5e8f23e0591d83086a92d701c46"
+  ]
+}
+x-commit-hash: "edfe8debb26ab6a372103c859a27bf8738cb611f"

--- a/packages/eio_posix/eio_posix.1.0/opam
+++ b/packages/eio_posix/eio_posix.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for POSIX systems"
+description: "An Eio implementation for most Unix-like platforms"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "iomux" {>= "0.2"}
+  "mdx" {>= "2.2.0" & < "2.4.0" & with-test}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.0/eio-1.0.tbz"
+  checksum: [
+    "sha256=da260d9da38b3dde9f316652a20b13a261cf90b85a2498ac669b7d564e61942d"
+    "sha512=5886e1159f48ede237769baa1d8b5daafa0310e4192d7fe0e8c32aef70f2b6378cef72d0fbae308457e25d87a69802b9ee83a5e8f23e0591d83086a92d701c46"
+  ]
+}
+x-commit-hash: "edfe8debb26ab6a372103c859a27bf8738cb611f"

--- a/packages/eio_windows/eio_windows.1.0/opam
+++ b/packages/eio_windows/eio_windows.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Windows"
+description: "An Eio implementation using OCaml's Unix.select"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "fmt" {>= "0.8.9"}
+  "kcas" {>= "0.3.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.0/eio-1.0.tbz"
+  checksum: [
+    "sha256=da260d9da38b3dde9f316652a20b13a261cf90b85a2498ac669b7d564e61942d"
+    "sha512=5886e1159f48ede237769baa1d8b5daafa0310e4192d7fe0e8c32aef70f2b6378cef72d0fbae308457e25d87a69802b9ee83a5e8f23e0591d83086a92d701c46"
+  ]
+}
+x-commit-hash: "edfe8debb26ab6a372103c859a27bf8738cb611f"
+available: [os = "win32"]


### PR DESCRIPTION
Effect-based direct-style IO API for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/eio">https://github.com/ocaml-multicore/eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/eio/">https://ocaml-multicore.github.io/eio/</a>

##### CHANGES:

New features:

- Add `Eio_unix.Cap` module to enable Capsicum mode (@talex5 ocaml-multicore/eio#697, reviewed by @SGrondin).

- eio_linux: expose more functions in the `Low_level` module (@talex5 ocaml-multicore/eio#705, reviewed by @SGrondin).
  Add all the functions used by other parts of eio_linux (`openat`, `mkdir`, `read_link`, `unlink`, `rename` and `pipe`).
  Tidied the API up a bit too:
  - `mkdir_beneath` is now just `mkdir`.
  - `statx_confined` is now just `statx`.
  - `open_dir` is gone; the single user now calls `openat` directly.

Documentation:

- Add README documentation for `Eio.Executor_pool` (@SGrondin @talex5 ocaml-multicore/eio#707, reviewed by @Sudha247).

- eio_linux: remove logging (@talex5 ocaml-multicore/eio#708, requested by @clecat).
  There were only two remaining uses of Logs, neither of which has proved useful.

Build:

- Add upper-bound on MDX (@talex5 ocaml-multicore/eio#706).
  The new version attempts to execute included blocks.

- Fix tests to pass with both old and new Kcas (@polytypic ocaml-multicore/eio#704).

- Make posix `open_beneath` test idempotent (@SGrondin ocaml-multicore/eio#703).

- Executor_pool: mention requested weight in error message (@talex5 ocaml-multicore/eio#702, reported by @yawaramin).
