### PR TITLE
Patch conf-binutils on FreeBSD

### DIFF
--- a/packages/conf-binutils/conf-binutils.0.3/files/find-binutils.ml.in
+++ b/packages/conf-binutils/conf-binutils.0.3/files/find-binutils.ml.in
@@ -207,7 +207,7 @@ let t =
 let () =
   try
     match "%{os}%" with
-    | "linux" -> write @@ collect t @@ all_paths ()
+    | "linux" | "freebsd" -> write @@ collect t @@ all_paths ()
     | "macos" ->
       let t = match cmd "brew --cellar" with
         | None -> t

--- a/packages/conf-binutils/conf-binutils.0.3/opam
+++ b/packages/conf-binutils/conf-binutils.0.3/opam
@@ -29,4 +29,4 @@ depends: [
 ]
 substs: [ "find-binutils.ml" ]
 flags: [ conf ]
-extra-files: ["find-binutils.ml.in" "md5=2bde83d0b7658cac4ffa113f9bcd87c2"]
+extra-files: ["find-binutils.ml.in" "md5=c58b89b0755853f68458f3421270af7e"]


### PR DESCRIPTION
https://freebsd.check.ci.dev/ indicates that `conf-binutils` fails on FreeBSD with `unsupported OS freebsd`

This PR attempts to
- install the relevant system package [containing `objdump`, `cxxfilt` and `readelf`](https://github.com/freebsd/freebsd-ports/blob/main/devel/binutils/pkg-plist)
- patch the test script accordingly