### PR TITLE
Broaden conf-* FreeBSD and Ubuntu family support

### DIFF
--- a/packages/conf-dbm/conf-dbm.1.0.0/opam
+++ b/packages/conf-dbm/conf-dbm.1.0.0/opam
@@ -9,6 +9,7 @@ build: [
 ]
 depexts: [
   ["libgdbm-dev"] {os-family = "debian"}
+  ["libgdbm-dev"] {os-family = "ubuntu"}
   ["gdbm"] {os-distribution = "nixos"}
   ["gdbm-devel"] {os-distribution = "centos"}
   ["gdbm-devel"] {os-distribution = "rhel"}
@@ -17,6 +18,7 @@ depexts: [
   ["gdbm-dev"] {os-distribution = "alpine"}
   ["gdbm"] {os-distribution = "arch"}
   ["sys-libs/gdbm"] {os-distribution = "gentoo"}
+  ["gdbm"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on gdbm"
 description:

--- a/packages/conf-gd/conf-gd.1/opam
+++ b/packages/conf-gd/conf-gd.1/opam
@@ -12,9 +12,11 @@ depexts: [
   ["libgd3-devel"] {os-distribution = "fedora"}
   ["libgd3-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libgd-dev"] {os-family = "debian"}
+  ["libgd-dev"] {os-family = "ubuntu"}
   ["gd"] {os-distribution = "nixos"}
   ["gd"] {os = "macos" & os-distribution = "homebrew"}
   ["gd"] {os = "win32" & os-distribution = "cygwinports"}
+  ["libgd"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a libgd system installation"
 description:

--- a/packages/conf-ladspa/conf-ladspa.1/opam
+++ b/packages/conf-ladspa/conf-ladspa.1/opam
@@ -7,9 +7,10 @@ license: "LGPL-2.1-or-later"
 depexts: [
   ["ladspa-dev"] {os-distribution = "alpine"}
   ["ladspa-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
-  ["ladspa-sdk"] {os-family = "debian"}
+  ["ladspa-sdk"] {os-family = "debian" | os-family = "ubuntu"}
   ["drfill/liquidsoap/ladspa_header"]
     {os = "macos" & os-distribution = "homebrew"}
+  ["ladspa"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on ladspa"
 description:

--- a/packages/conf-libcurl/conf-libcurl.2/opam
+++ b/packages/conf-libcurl/conf-libcurl.2/opam
@@ -6,6 +6,7 @@ license: "BSD-like"
 build: ["curl-config" "--libs"]
 depexts: [
   ["libcurl4-gnutls-dev"] {os-family = "debian"}
+  ["libcurl4-gnutls-dev"] {os-family = "ubuntu"}
   ["libcurl-devel"] {os-distribution = "mageia"}
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
   ["curl"] {os-distribution = "nixos"}
@@ -17,6 +18,7 @@ depexts: [
   ["libcurl-devel"] {os-distribution = "ol"}
   ["curl"] {os-distribution = "homebrew" & os = "macos"}
   ["curl"] {os-distribution = "macports" & os = "macos"}
+  ["curl"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a libcurl system installation"
 description:

--- a/packages/conf-libgif/conf-libgif.1/opam
+++ b/packages/conf-libgif/conf-libgif.1/opam
@@ -17,8 +17,10 @@ homepage: "http://giflib.sourceforge.net/"
 license: "GIFLIB"
 depexts: [
   ["libgif-dev"] {os-family = "debian"}
+  ["libgif-dev"] {os-family = "ubuntu"}
   ["giflib"] {os = "macos" & os-distribution = "homebrew"}
   ["giflib"] {os = "win32" & os-distribution = "cygwinports"}
+  ["giflib"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a libgif system installation"
 description:

--- a/packages/conf-liblz4/conf-liblz4.1/opam
+++ b/packages/conf-liblz4/conf-liblz4.1/opam
@@ -8,6 +8,7 @@ build: ["pkg-config" "liblz4"]
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["liblz4-dev"] {os-family = "debian"}
+  ["liblz4-dev"] {os-family = "ubuntu"}
   ["lz4-devel"] {os-distribution = "centos"}
   ["lz4-devel"] {os-distribution = "rhel"}
   ["lz4-devel"] {os-distribution = "fedora"}
@@ -16,6 +17,7 @@ depexts: [
   ["liblz4-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["lz4"] {os = "macos" & os-distribution = "homebrew"}
   ["lz4"] {os = "win32" & os-distribution = "cygwinports"}
+  ["liblz4"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on liblz4 system installation"
 flags: conf

--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -8,6 +8,7 @@ build: ["pkg-config" "ncurses"] {os-distribution != "opensuse" &  os != "macos" 
 depends: ["conf-pkg-config" {build & os-distribution != "opensuse" & os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd"}]
 depexts: [
   ["ncurses-dev"] {os-family = "debian"}
+  ["lib64ncurses-dev"] {os-family = "ubuntu"}
   ["ncurses"] {os-distribution = "nixos"}
   ["ncurses-dev"] {os-distribution = "alpine"}
   ["ncurses-devel"] {os-distribution = "fedora"}
@@ -17,6 +18,7 @@ depexts: [
   ["ncurses-devel"] {os-family = "suse"}
   ["ncurses"] {os-distribution = "arch"}
   ["ncurses"] {os = "win32" & os-distribution = "cygwinports"}
+  ["ncurses"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on ncurses"
 description:

--- a/packages/conf-plplot/conf-plplot.1/opam
+++ b/packages/conf-plplot/conf-plplot.1/opam
@@ -10,12 +10,14 @@ depends: [
 ]
 depexts: [
   ["libplplot-dev" "libshp-dev"] {os-family = "debian"}
+  ["libplplot-dev" "libshp-dev"] {os-family = "ubuntu"}
   ["plplot"] {os = "macos" & os-distribution = "homebrew"}
   ["plplot-devel"] {os-family = "rhel"}
   ["plplot-devel"] {os-distribution = "fedora"}
   ["plplot-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["plplot-devel" "epel-release"] {os-distribution = "centos"}
   ["plplot"] {os-distribution = "nixos"}
+  ["plplot"] {os = "freebsd"}
 ]
 x-ci-accept-failures: [
   # plplot is not available on these platforms


### PR DESCRIPTION
This PR adds support for FreeBSD and Ubuntu derivatives for the following conf-* packages:
- conf-dbm
- conf-gd
- conf-ladspa
- conf-libcurl
- conf-libgif
- conf-liblz4
- conf-curses
- conf-plplot