### PR TITLE
conf-tk patches

### DIFF
--- a/packages/conf-tk/conf-tk.1/opam
+++ b/packages/conf-tk/conf-tk.1/opam
@@ -13,7 +13,6 @@ depexts: [
   ["tk-dev"] {os-family = "ubuntu"}
   ["tk"] {os-distribution = "nixos"}
   ["tk"] {os = "win32" & os-distribution = "cygwinports"}
-  ["tk"] {os-family = "alpine"}
   ["tk"] {os-family = "arch"}
   ["tk-dev"] {os-family = "alpine"}
   ["tk-devel"] {os-family = "rhel"}

--- a/packages/conf-tk/conf-tk.1/opam
+++ b/packages/conf-tk/conf-tk.1/opam
@@ -10,6 +10,7 @@ depends: [
 ]
 depexts: [
   ["tk-dev"] {os-family = "debian"}
+  ["tk-dev"] {os-family = "ubuntu"}
   ["tk"] {os-distribution = "nixos"}
   ["tk"] {os = "win32" & os-distribution = "cygwinports"}
   ["tk"] {os-family = "alpine"}


### PR DESCRIPTION
For conf-tk this PR
- add Ubuntu derivative support
- removes a duplicate `alpine` entry which listed both `tk` and `tk-dev` as dependencies in separate lines. I believe the latter one, containing the headers is the correct one