### PR TITLE
conf-m4: add support for Ubuntu derivatives

### DIFF
--- a/packages/conf-m4/conf-m4.1/opam
+++ b/packages/conf-m4/conf-m4.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["m4"] {os-family = "suse" | os-family = "opensuse"}
   ["m4"] {os-distribution = "ol"}
   ["m4"] {os-distribution = "arch"}
+  # On FreeBSD m4 is part of the base system
 ]
 synopsis: "Virtual package relying on m4"
 description:

--- a/packages/conf-m4/conf-m4.1/opam
+++ b/packages/conf-m4/conf-m4.1/opam
@@ -7,6 +7,7 @@ license: "GPL-3.0-only"
 build: [["sh" "-exc" "echo | m4"]]
 depexts: [
   ["m4"] {os-family = "debian"}
+  ["m4"] {os-family = "ubuntu"}
   ["m4"] {os-distribution = "fedora"}
   ["m4"] {os-distribution = "rhel"}
   ["m4"] {os-distribution = "centos"}


### PR DESCRIPTION
For conf-m4 this PR
- adds support for Ubuntu derivatives
- documents that m4 [is included in FreeBSD's base system](https://svnweb.freebsd.org/base/head/usr.bin/m4/)