### PR TITLE
Fix some `git://` `dev-repo:` fields

### DIFF
--- a/packages/SZXX/SZXX.2.0.0/opam
+++ b/packages/SZXX/SZXX.2.0.0/opam
@@ -11,7 +11,7 @@ SZXX is able to output XLSX rows while a file is being read from the file descri
 license: "MIT"
 tags: ["Stream" "ZIP" "XML" "XLSX"]
 homepage: "https://github.com/asemio/SZXX"
-dev-repo: "git://github.com/asemio/SZXX"
+dev-repo: "git+https://github.com/asemio/SZXX"
 doc: "https://github.com/asemio/SZXX"
 bug-reports: "https://github.com/asemio/SZXX/issues"
 depends: [

--- a/packages/SZXX/SZXX.2.1.0/opam
+++ b/packages/SZXX/SZXX.2.1.0/opam
@@ -11,7 +11,7 @@ SZXX is able to output XLSX rows while a file is being read from the file descri
 license: "MIT"
 tags: ["Stream" "ZIP" "XML" "XLSX"]
 homepage: "https://github.com/asemio/SZXX"
-dev-repo: "git://github.com/asemio/SZXX"
+dev-repo: "git+https://github.com/asemio/SZXX"
 doc: "https://github.com/asemio/SZXX"
 bug-reports: "https://github.com/asemio/SZXX/issues"
 depends: [

--- a/packages/SZXX/SZXX.2.1.1/opam
+++ b/packages/SZXX/SZXX.2.1.1/opam
@@ -11,7 +11,7 @@ SZXX is able to output XLSX rows while a file is being read from the file descri
 license: "MIT"
 tags: ["Stream" "ZIP" "XML" "XLSX"]
 homepage: "https://github.com/asemio/SZXX"
-dev-repo: "git://github.com/asemio/SZXX"
+dev-repo: "git+https://github.com/asemio/SZXX"
 doc: "https://github.com/asemio/SZXX"
 bug-reports: "https://github.com/asemio/SZXX/issues"
 depends: [

--- a/packages/SZXX/SZXX.2.1.2/opam
+++ b/packages/SZXX/SZXX.2.1.2/opam
@@ -11,7 +11,7 @@ SZXX is able to output XLSX rows while a file is being read from the file descri
 license: "MIT"
 tags: ["Stream" "ZIP" "XML" "XLSX"]
 homepage: "https://github.com/asemio/SZXX"
-dev-repo: "git://github.com/asemio/SZXX"
+dev-repo: "git+https://github.com/asemio/SZXX"
 doc: "https://github.com/asemio/SZXX"
 bug-reports: "https://github.com/asemio/SZXX/issues"
 depends: [

--- a/packages/SZXX/SZXX.2.2.0/opam
+++ b/packages/SZXX/SZXX.2.2.0/opam
@@ -11,7 +11,7 @@ SZXX is able to output XLSX rows while a file is being read from the file descri
 license: "MIT"
 tags: ["Stream" "ZIP" "XML" "XLSX"]
 homepage: "https://github.com/asemio/SZXX"
-dev-repo: "git://github.com/asemio/SZXX"
+dev-repo: "git+https://github.com/asemio/SZXX"
 doc: "https://github.com/asemio/SZXX"
 bug-reports: "https://github.com/asemio/SZXX/issues"
 depends: [

--- a/packages/SZXX/SZXX.2.3.0/opam
+++ b/packages/SZXX/SZXX.2.3.0/opam
@@ -12,7 +12,7 @@ It can also stream data out of ZIP files and XML files without buffering.
 license: "MIT"
 tags: ["Stream" "ZIP" "XML" "XLSX"]
 homepage: "https://github.com/asemio/SZXX"
-dev-repo: "git://github.com/asemio/SZXX"
+dev-repo: "git+https://github.com/asemio/SZXX"
 doc: "https://github.com/asemio/SZXX"
 bug-reports: "https://github.com/asemio/SZXX/issues"
 depends: [

--- a/packages/SZXX/SZXX.3.0.0/opam
+++ b/packages/SZXX/SZXX.3.0.0/opam
@@ -12,7 +12,7 @@ It can also stream data out of ZIP files and XML files without buffering.
 license: "MIT"
 tags: ["Stream" "ZIP" "XML" "XLSX"]
 homepage: "https://github.com/asemio/SZXX"
-dev-repo: "git://github.com/asemio/SZXX"
+dev-repo: "git+https://github.com/asemio/SZXX"
 doc: "https://github.com/asemio/SZXX"
 bug-reports: "https://github.com/asemio/SZXX/issues"
 depends: [

--- a/packages/SZXX/SZXX.3.0.1/opam
+++ b/packages/SZXX/SZXX.3.0.1/opam
@@ -12,7 +12,7 @@ It can also stream data out of ZIP files and XML files without buffering.
 license: "MIT"
 tags: ["Stream" "ZIP" "XML" "XLSX"]
 homepage: "https://github.com/asemio/SZXX"
-dev-repo: "git://github.com/asemio/SZXX"
+dev-repo: "git+https://github.com/asemio/SZXX"
 doc: "https://github.com/asemio/SZXX"
 bug-reports: "https://github.com/asemio/SZXX/issues"
 depends: [

--- a/packages/SZXX/SZXX.3.0.2/opam
+++ b/packages/SZXX/SZXX.3.0.2/opam
@@ -12,7 +12,7 @@ It can also stream data out of ZIP files and XML files without buffering.
 license: "MIT"
 tags: ["Stream" "ZIP" "XML" "XLSX"]
 homepage: "https://github.com/asemio/SZXX"
-dev-repo: "git://github.com/asemio/SZXX"
+dev-repo: "git+https://github.com/asemio/SZXX"
 doc: "https://github.com/asemio/SZXX"
 bug-reports: "https://github.com/asemio/SZXX/issues"
 depends: [

--- a/packages/SZXX/SZXX.3.0.4/opam
+++ b/packages/SZXX/SZXX.3.0.4/opam
@@ -12,7 +12,7 @@ It can also stream data out of ZIP files and XML files without buffering.
 license: "MIT"
 tags: ["Stream" "ZIP" "XML" "XLSX"]
 homepage: "https://github.com/asemio/SZXX"
-dev-repo: "git://github.com/asemio/SZXX"
+dev-repo: "git+https://github.com/asemio/SZXX"
 doc: "https://github.com/asemio/SZXX"
 bug-reports: "https://github.com/asemio/SZXX/issues"
 depends: [

--- a/packages/SZXX/SZXX.4.0.0/opam
+++ b/packages/SZXX/SZXX.4.0.0/opam
@@ -14,7 +14,7 @@ Assumes a 64-bit architecture, large files (>4Gb) may not work on 32-bit systems
 license: "MIT"
 tags: ["Stream" "Streaming" "Excel" "ZIP" "XML" "XLSX"]
 homepage: "https://github.com/asemio/SZXX"
-dev-repo: "git://github.com/asemio/SZXX"
+dev-repo: "git+https://github.com/asemio/SZXX"
 doc: "https://github.com/asemio/SZXX"
 bug-reports: "https://github.com/asemio/SZXX/issues"
 depends: [

--- a/packages/SZXX/SZXX.4.0.1/opam
+++ b/packages/SZXX/SZXX.4.0.1/opam
@@ -12,7 +12,7 @@ It can also stream data (including network sockets) out of ZIP and XML files wit
 license: "MIT"
 tags: ["Stream" "Streaming" "Excel" "ZIP" "XML" "XLSX"]
 homepage: "https://github.com/asemio/SZXX"
-dev-repo: "git://github.com/asemio/SZXX"
+dev-repo: "git+https://github.com/asemio/SZXX"
 doc: "https://github.com/asemio/SZXX"
 bug-reports: "https://github.com/asemio/SZXX/issues"
 depends: [

--- a/packages/SZXX/SZXX.4.1.0/opam
+++ b/packages/SZXX/SZXX.4.1.0/opam
@@ -12,7 +12,7 @@ It can also stream data (including network sockets) out of ZIP and XML files wit
 license: "MIT"
 tags: ["XLSX" "Excel" "ZIP" "XML" "spreadsheet" "Stream" "Streaming"]
 homepage: "https://github.com/asemio/SZXX"
-dev-repo: "git://github.com/asemio/SZXX"
+dev-repo: "git+https://github.com/asemio/SZXX"
 doc: "https://github.com/asemio/SZXX"
 bug-reports: "https://github.com/asemio/SZXX/issues"
 depends: [

--- a/packages/SZXX/SZXX.4.1.1/opam
+++ b/packages/SZXX/SZXX.4.1.1/opam
@@ -12,7 +12,7 @@ It can also stream data (including network sockets) out of ZIP and XML files wit
 license: "MIT"
 tags: ["XLSX" "Excel" "ZIP" "XML" "spreadsheet" "Stream" "Streaming"]
 homepage: "https://github.com/asemio/SZXX"
-dev-repo: "git://github.com/asemio/SZXX"
+dev-repo: "git+https://github.com/asemio/SZXX"
 doc: "https://github.com/asemio/SZXX"
 bug-reports: "https://github.com/asemio/SZXX/issues"
 depends: [

--- a/packages/SZXX/SZXX.4.1.3/opam
+++ b/packages/SZXX/SZXX.4.1.3/opam
@@ -12,7 +12,7 @@ It can also stream data (including network sockets) out of ZIP and XML files wit
 license: "MIT"
 tags: ["XLSX" "Excel" "ZIP" "XML" "spreadsheet" "Stream" "Streaming"]
 homepage: "https://github.com/asemio/SZXX"
-dev-repo: "git://github.com/asemio/SZXX"
+dev-repo: "git+https://github.com/asemio/SZXX"
 doc: "https://github.com/asemio/SZXX"
 bug-reports: "https://github.com/asemio/SZXX/issues"
 depends: [

--- a/packages/bap-abi/bap-abi.2.4.0/opam
+++ b/packages/bap-abi/bap-abi.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-abi"]

--- a/packages/bap-abi/bap-abi.2.5.0/opam
+++ b/packages/bap-abi/bap-abi.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-abi"]

--- a/packages/bap-analyze/bap-analyze.2.4.0/opam
+++ b/packages/bap-analyze/bap-analyze.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-analyze"]

--- a/packages/bap-analyze/bap-analyze.2.5.0/opam
+++ b/packages/bap-analyze/bap-analyze.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-analyze"]

--- a/packages/bap-api/bap-api.2.4.0/opam
+++ b/packages/bap-api/bap-api.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-api"]

--- a/packages/bap-api/bap-api.2.5.0/opam
+++ b/packages/bap-api/bap-api.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-api"]

--- a/packages/bap-arm/bap-arm.2.4.0/opam
+++ b/packages/bap-arm/bap-arm.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-arm"]

--- a/packages/bap-arm/bap-arm.2.5.0/opam
+++ b/packages/bap-arm/bap-arm.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-arm"]

--- a/packages/bap-beagle-strings/bap-beagle-strings.2.4.0/opam
+++ b/packages/bap-beagle-strings/bap-beagle-strings.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-strings"]

--- a/packages/bap-beagle-strings/bap-beagle-strings.2.5.0/opam
+++ b/packages/bap-beagle-strings/bap-beagle-strings.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-strings"]

--- a/packages/bap-beagle/bap-beagle.2.4.0/opam
+++ b/packages/bap-beagle/bap-beagle.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-beagle"]

--- a/packages/bap-beagle/bap-beagle.2.5.0/opam
+++ b/packages/bap-beagle/bap-beagle.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-beagle"]

--- a/packages/bap-bil/bap-bil.2.4.0/opam
+++ b/packages/bap-bil/bap-bil.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-bil"]

--- a/packages/bap-bil/bap-bil.2.5.0/opam
+++ b/packages/bap-bil/bap-bil.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-bil"]

--- a/packages/bap-build/bap-build.2.4.0/opam
+++ b/packages/bap-build/bap-build.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-build"]

--- a/packages/bap-build/bap-build.2.5.0/opam
+++ b/packages/bap-build/bap-build.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-build"]

--- a/packages/bap-bundle/bap-bundle.2.4.0/opam
+++ b/packages/bap-bundle/bap-bundle.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-bundle"]

--- a/packages/bap-bundle/bap-bundle.2.5.0/opam
+++ b/packages/bap-bundle/bap-bundle.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-bundle"]

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.2.4.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-byteweight-frontend"]

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.2.5.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-byteweight-frontend"]

--- a/packages/bap-byteweight/bap-byteweight.2.4.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-byteweight"]

--- a/packages/bap-byteweight/bap-byteweight.2.5.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-byteweight"]

--- a/packages/bap-c/bap-c.2.4.0/opam
+++ b/packages/bap-c/bap-c.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-c"]

--- a/packages/bap-c/bap-c.2.5.0/opam
+++ b/packages/bap-c/bap-c.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-c"]

--- a/packages/bap-cache/bap-cache.2.4.0/opam
+++ b/packages/bap-cache/bap-cache.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-cache"]

--- a/packages/bap-cache/bap-cache.2.5.0/opam
+++ b/packages/bap-cache/bap-cache.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-cache"]

--- a/packages/bap-callgraph-collator/bap-callgraph-collator.2.4.0/opam
+++ b/packages/bap-callgraph-collator/bap-callgraph-collator.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-callgraph-collator"]

--- a/packages/bap-callgraph-collator/bap-callgraph-collator.2.5.0/opam
+++ b/packages/bap-callgraph-collator/bap-callgraph-collator.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-callgraph-collator"]

--- a/packages/bap-callsites/bap-callsites.2.4.0/opam
+++ b/packages/bap-callsites/bap-callsites.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-callsites/bap-callsites.2.5.0/opam
+++ b/packages/bap-callsites/bap-callsites.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-constant-tracker/bap-constant-tracker.2.4.0/opam
+++ b/packages/bap-constant-tracker/bap-constant-tracker.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-constant-tracker"]

--- a/packages/bap-constant-tracker/bap-constant-tracker.2.5.0/opam
+++ b/packages/bap-constant-tracker/bap-constant-tracker.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-constant-tracker"]

--- a/packages/bap-core-theory/bap-core-theory.2.4.0/opam
+++ b/packages/bap-core-theory/bap-core-theory.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-core-theory"]

--- a/packages/bap-core-theory/bap-core-theory.2.5.0/opam
+++ b/packages/bap-core-theory/bap-core-theory.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-core-theory"]

--- a/packages/bap-core/bap-core.2.4.0/opam
+++ b/packages/bap-core/bap-core.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 
 depends: [

--- a/packages/bap-core/bap-core.2.5.0/opam
+++ b/packages/bap-core/bap-core.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 
 depends: [

--- a/packages/bap-cxxfilt/bap-cxxfilt.2.4.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%"

--- a/packages/bap-cxxfilt/bap-cxxfilt.2.5.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%"

--- a/packages/bap-demangle/bap-demangle.2.4.0/opam
+++ b/packages/bap-demangle/bap-demangle.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-demangle"]

--- a/packages/bap-demangle/bap-demangle.2.5.0/opam
+++ b/packages/bap-demangle/bap-demangle.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-demangle"]

--- a/packages/bap-dependencies/bap-dependencies.2.4.0/opam
+++ b/packages/bap-dependencies/bap-dependencies.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-dependencies"]

--- a/packages/bap-dependencies/bap-dependencies.2.5.0/opam
+++ b/packages/bap-dependencies/bap-dependencies.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-dependencies"]

--- a/packages/bap-disassemble/bap-disassemble.2.4.0/opam
+++ b/packages/bap-disassemble/bap-disassemble.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-disassemble"]

--- a/packages/bap-disassemble/bap-disassemble.2.5.0/opam
+++ b/packages/bap-disassemble/bap-disassemble.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-disassemble"]

--- a/packages/bap-dump-symbols/bap-dump-symbols.2.4.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-dump-symbols"]

--- a/packages/bap-dump-symbols/bap-dump-symbols.2.5.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-dump-symbols"]

--- a/packages/bap-dwarf/bap-dwarf.2.4.0/opam
+++ b/packages/bap-dwarf/bap-dwarf.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-dwarf"]

--- a/packages/bap-dwarf/bap-dwarf.2.5.0/opam
+++ b/packages/bap-dwarf/bap-dwarf.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-dwarf"]

--- a/packages/bap-elementary/bap-elementary.2.4.0/opam
+++ b/packages/bap-elementary/bap-elementary.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-elementary"]

--- a/packages/bap-elementary/bap-elementary.2.5.0/opam
+++ b/packages/bap-elementary/bap-elementary.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-elementary"]

--- a/packages/bap-elf/bap-elf.2.4.0/opam
+++ b/packages/bap-elf/bap-elf.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-elf-loader"]

--- a/packages/bap-elf/bap-elf.2.5.0/opam
+++ b/packages/bap-elf/bap-elf.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-elf-loader"]

--- a/packages/bap-extra/bap-extra.2.4.0/opam
+++ b/packages/bap-extra/bap-extra.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 
 depends: [

--- a/packages/bap-extra/bap-extra.2.5.0/opam
+++ b/packages/bap-extra/bap-extra.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 
 depends: [

--- a/packages/bap-flatten/bap-flatten.2.4.0/opam
+++ b/packages/bap-flatten/bap-flatten.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flatten"]

--- a/packages/bap-flatten/bap-flatten.2.5.0/opam
+++ b/packages/bap-flatten/bap-flatten.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flatten"]

--- a/packages/bap-frontc/bap-frontc.2.4.0/opam
+++ b/packages/bap-frontc/bap-frontc.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-frontc-parser"]

--- a/packages/bap-frontc/bap-frontc.2.5.0/opam
+++ b/packages/bap-frontc/bap-frontc.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-frontc-parser"]

--- a/packages/bap-frontend/bap-frontend.2.4.0/opam
+++ b/packages/bap-frontend/bap-frontend.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-frontend/bap-frontend.2.5.0/opam
+++ b/packages/bap-frontend/bap-frontend.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.2.4.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-fsi-benchmark"]

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.2.5.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-fsi-benchmark"]

--- a/packages/bap-future/bap-future.2.4.0/opam
+++ b/packages/bap-future/bap-future.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-future"]

--- a/packages/bap-future/bap-future.2.5.0/opam
+++ b/packages/bap-future/bap-future.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-future"]

--- a/packages/bap-ghidra/bap-ghidra.2.4.0/opam
+++ b/packages/bap-ghidra/bap-ghidra.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-ghidra/bap-ghidra.2.5.0/opam
+++ b/packages/bap-ghidra/bap-ghidra.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-glibc-runtime/bap-glibc-runtime.2.4.0/opam
+++ b/packages/bap-glibc-runtime/bap-glibc-runtime.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-glibc-runtime"]

--- a/packages/bap-glibc-runtime/bap-glibc-runtime.2.5.0/opam
+++ b/packages/bap-glibc-runtime/bap-glibc-runtime.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-glibc-runtime"]

--- a/packages/bap-ida-plugin/bap-ida-plugin.2.4.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-emit-ida-script"]

--- a/packages/bap-ida-plugin/bap-ida-plugin.2.5.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-emit-ida-script"]

--- a/packages/bap-ida/bap-ida.2.4.0/opam
+++ b/packages/bap-ida/bap-ida.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-ida/bap-ida.2.5.0/opam
+++ b/packages/bap-ida/bap-ida.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-knowledge/bap-knowledge.2.4.0/opam
+++ b/packages/bap-knowledge/bap-knowledge.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-knowledge"]

--- a/packages/bap-knowledge/bap-knowledge.2.5.0/opam
+++ b/packages/bap-knowledge/bap-knowledge.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-knowledge"]

--- a/packages/bap-llvm/bap-llvm.2.4.0/opam
+++ b/packages/bap-llvm/bap-llvm.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-llvm/bap-llvm.2.5.0/opam
+++ b/packages/bap-llvm/bap-llvm.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-main/bap-main.2.4.0/opam
+++ b/packages/bap-main/bap-main.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-main"]

--- a/packages/bap-main/bap-main.2.5.0/opam
+++ b/packages/bap-main/bap-main.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-main"]

--- a/packages/bap-mc/bap-mc.2.4.0/opam
+++ b/packages/bap-mc/bap-mc.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-mc/bap-mc.2.5.0/opam
+++ b/packages/bap-mc/bap-mc.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-microx/bap-microx.2.4.0/opam
+++ b/packages/bap-microx/bap-microx.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-microx"]

--- a/packages/bap-microx/bap-microx.2.5.0/opam
+++ b/packages/bap-microx/bap-microx.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-microx"]

--- a/packages/bap-mips/bap-mips.2.4.0/opam
+++ b/packages/bap-mips/bap-mips.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-mips"]

--- a/packages/bap-mips/bap-mips.2.5.0/opam
+++ b/packages/bap-mips/bap-mips.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-mips"]

--- a/packages/bap-objdump/bap-objdump.2.4.0/opam
+++ b/packages/bap-objdump/bap-objdump.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%"

--- a/packages/bap-objdump/bap-objdump.2.5.0/opam
+++ b/packages/bap-objdump/bap-objdump.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%"

--- a/packages/bap-optimization/bap-optimization.2.4.0/opam
+++ b/packages/bap-optimization/bap-optimization.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-optimization"]

--- a/packages/bap-optimization/bap-optimization.2.5.0/opam
+++ b/packages/bap-optimization/bap-optimization.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-optimization"]

--- a/packages/bap-patterns/bap-patterns.2.4.0/opam
+++ b/packages/bap-patterns/bap-patterns.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-patterns"]

--- a/packages/bap-patterns/bap-patterns.2.5.0/opam
+++ b/packages/bap-patterns/bap-patterns.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-patterns"]

--- a/packages/bap-phoenix/bap-phoenix.2.4.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-phoenix/bap-phoenix.2.5.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-piqi/bap-piqi.2.4.0/opam
+++ b/packages/bap-piqi/bap-piqi.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-piqi/bap-piqi.2.5.0/opam
+++ b/packages/bap-piqi/bap-piqi.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-plugins/bap-plugins.2.4.0/opam
+++ b/packages/bap-plugins/bap-plugins.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-plugins"]

--- a/packages/bap-plugins/bap-plugins.2.5.0/opam
+++ b/packages/bap-plugins/bap-plugins.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-plugins"]

--- a/packages/bap-powerpc/bap-powerpc.2.4.0/opam
+++ b/packages/bap-powerpc/bap-powerpc.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-powerpc"]

--- a/packages/bap-powerpc/bap-powerpc.2.5.0/opam
+++ b/packages/bap-powerpc/bap-powerpc.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-powerpc"]

--- a/packages/bap-primus-dictionary/bap-primus-dictionary.2.4.0/opam
+++ b/packages/bap-primus-dictionary/bap-primus-dictionary.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-dictionary"]

--- a/packages/bap-primus-dictionary/bap-primus-dictionary.2.5.0/opam
+++ b/packages/bap-primus-dictionary/bap-primus-dictionary.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-dictionary"]

--- a/packages/bap-primus-exploring-scheduler/bap-primus-exploring-scheduler.2.4.0/opam
+++ b/packages/bap-primus-exploring-scheduler/bap-primus-exploring-scheduler.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-exploring"]

--- a/packages/bap-primus-exploring-scheduler/bap-primus-exploring-scheduler.2.5.0/opam
+++ b/packages/bap-primus-exploring-scheduler/bap-primus-exploring-scheduler.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-exploring"]

--- a/packages/bap-primus-greedy-scheduler/bap-primus-greedy-scheduler.2.4.0/opam
+++ b/packages/bap-primus-greedy-scheduler/bap-primus-greedy-scheduler.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-greedy"]

--- a/packages/bap-primus-greedy-scheduler/bap-primus-greedy-scheduler.2.5.0/opam
+++ b/packages/bap-primus-greedy-scheduler/bap-primus-greedy-scheduler.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-greedy"]

--- a/packages/bap-primus-limit/bap-primus-limit.2.4.0/opam
+++ b/packages/bap-primus-limit/bap-primus-limit.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-limit"]

--- a/packages/bap-primus-limit/bap-primus-limit.2.5.0/opam
+++ b/packages/bap-primus-limit/bap-primus-limit.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-limit"]

--- a/packages/bap-primus-lisp/bap-primus-lisp.2.4.0/opam
+++ b/packages/bap-primus-lisp/bap-primus-lisp.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-lisp"]

--- a/packages/bap-primus-lisp/bap-primus-lisp.2.5.0/opam
+++ b/packages/bap-primus-lisp/bap-primus-lisp.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-lisp"]

--- a/packages/bap-primus-loader/bap-primus-loader.2.4.0/opam
+++ b/packages/bap-primus-loader/bap-primus-loader.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-loader"]

--- a/packages/bap-primus-loader/bap-primus-loader.2.5.0/opam
+++ b/packages/bap-primus-loader/bap-primus-loader.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-loader"]

--- a/packages/bap-primus-mark-visited/bap-primus-mark-visited.2.4.0/opam
+++ b/packages/bap-primus-mark-visited/bap-primus-mark-visited.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-mark-visited"]

--- a/packages/bap-primus-mark-visited/bap-primus-mark-visited.2.5.0/opam
+++ b/packages/bap-primus-mark-visited/bap-primus-mark-visited.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-mark-visited"]

--- a/packages/bap-primus-powerpc/bap-primus-powerpc.2.4.0/opam
+++ b/packages/bap-primus-powerpc/bap-primus-powerpc.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-powerpc"]

--- a/packages/bap-primus-powerpc/bap-primus-powerpc.2.5.0/opam
+++ b/packages/bap-primus-powerpc/bap-primus-powerpc.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-powerpc"]

--- a/packages/bap-primus-print/bap-primus-print.2.4.0/opam
+++ b/packages/bap-primus-print/bap-primus-print.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-print"]

--- a/packages/bap-primus-print/bap-primus-print.2.5.0/opam
+++ b/packages/bap-primus-print/bap-primus-print.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-print"]

--- a/packages/bap-primus-promiscuous/bap-primus-promiscuous.2.4.0/opam
+++ b/packages/bap-primus-promiscuous/bap-primus-promiscuous.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-promiscuous"]

--- a/packages/bap-primus-promiscuous/bap-primus-promiscuous.2.5.0/opam
+++ b/packages/bap-primus-promiscuous/bap-primus-promiscuous.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-promiscuous"]

--- a/packages/bap-primus-propagate-taint/bap-primus-propagate-taint.2.4.0/opam
+++ b/packages/bap-primus-propagate-taint/bap-primus-propagate-taint.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%"

--- a/packages/bap-primus-propagate-taint/bap-primus-propagate-taint.2.5.0/opam
+++ b/packages/bap-primus-propagate-taint/bap-primus-propagate-taint.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%"

--- a/packages/bap-primus-random/bap-primus-random.2.4.0/opam
+++ b/packages/bap-primus-random/bap-primus-random.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-random"]

--- a/packages/bap-primus-random/bap-primus-random.2.5.0/opam
+++ b/packages/bap-primus-random/bap-primus-random.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-random"]

--- a/packages/bap-primus-region/bap-primus-region.2.4.0/opam
+++ b/packages/bap-primus-region/bap-primus-region.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-region"]

--- a/packages/bap-primus-region/bap-primus-region.2.5.0/opam
+++ b/packages/bap-primus-region/bap-primus-region.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-region"]

--- a/packages/bap-primus-round-robin-scheduler/bap-primus-round-robin-scheduler.2.4.0/opam
+++ b/packages/bap-primus-round-robin-scheduler/bap-primus-round-robin-scheduler.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-round-robin"]

--- a/packages/bap-primus-round-robin-scheduler/bap-primus-round-robin-scheduler.2.5.0/opam
+++ b/packages/bap-primus-round-robin-scheduler/bap-primus-round-robin-scheduler.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-round-robin"]

--- a/packages/bap-primus-support/bap-primus-support.2.4.0/opam
+++ b/packages/bap-primus-support/bap-primus-support.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 
 depends: [

--- a/packages/bap-primus-support/bap-primus-support.2.5.0/opam
+++ b/packages/bap-primus-support/bap-primus-support.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 
 depends: [

--- a/packages/bap-primus-symbolic-executor/bap-primus-symbolic-executor.2.4.0/opam
+++ b/packages/bap-primus-symbolic-executor/bap-primus-symbolic-executor.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-symbolic-executor"]

--- a/packages/bap-primus-symbolic-executor/bap-primus-symbolic-executor.2.5.0/opam
+++ b/packages/bap-primus-symbolic-executor/bap-primus-symbolic-executor.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-symbolic-executor"]

--- a/packages/bap-primus-systems/bap-primus-systems.2.4.0/opam
+++ b/packages/bap-primus-systems/bap-primus-systems.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-systems"]

--- a/packages/bap-primus-systems/bap-primus-systems.2.5.0/opam
+++ b/packages/bap-primus-systems/bap-primus-systems.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-systems"]

--- a/packages/bap-primus-taint/bap-primus-taint.2.4.0/opam
+++ b/packages/bap-primus-taint/bap-primus-taint.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-taint" ]

--- a/packages/bap-primus-taint/bap-primus-taint.2.5.0/opam
+++ b/packages/bap-primus-taint/bap-primus-taint.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-taint" ]

--- a/packages/bap-primus-test/bap-primus-test.2.4.0/opam
+++ b/packages/bap-primus-test/bap-primus-test.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-test"]

--- a/packages/bap-primus-test/bap-primus-test.2.5.0/opam
+++ b/packages/bap-primus-test/bap-primus-test.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-test"]

--- a/packages/bap-primus-track-visited/bap-primus-track-visited.2.4.0/opam
+++ b/packages/bap-primus-track-visited/bap-primus-track-visited.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-track-visited"]

--- a/packages/bap-primus-track-visited/bap-primus-track-visited.2.5.0/opam
+++ b/packages/bap-primus-track-visited/bap-primus-track-visited.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-track-visited"]

--- a/packages/bap-primus-wandering-scheduler/bap-primus-wandering-scheduler.2.4.0/opam
+++ b/packages/bap-primus-wandering-scheduler/bap-primus-wandering-scheduler.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-wandering"]

--- a/packages/bap-primus-wandering-scheduler/bap-primus-wandering-scheduler.2.5.0/opam
+++ b/packages/bap-primus-wandering-scheduler/bap-primus-wandering-scheduler.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-wandering"]

--- a/packages/bap-primus-x86/bap-primus-x86.2.4.0/opam
+++ b/packages/bap-primus-x86/bap-primus-x86.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-x86"]

--- a/packages/bap-primus-x86/bap-primus-x86.2.5.0/opam
+++ b/packages/bap-primus-x86/bap-primus-x86.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus-x86"]

--- a/packages/bap-primus/bap-primus.2.4.0/opam
+++ b/packages/bap-primus/bap-primus.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus"]

--- a/packages/bap-primus/bap-primus.2.5.0/opam
+++ b/packages/bap-primus/bap-primus.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-primus"]

--- a/packages/bap-print/bap-print.2.4.0/opam
+++ b/packages/bap-print/bap-print.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-print"]

--- a/packages/bap-print/bap-print.2.5.0/opam
+++ b/packages/bap-print/bap-print.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-print"]

--- a/packages/bap-radare2/bap-radare2.2.4.0/opam
+++ b/packages/bap-radare2/bap-radare2.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%"

--- a/packages/bap-radare2/bap-radare2.2.5.0/opam
+++ b/packages/bap-radare2/bap-radare2.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%"

--- a/packages/bap-raw/bap-raw.2.4.0/opam
+++ b/packages/bap-raw/bap-raw.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-raw"]

--- a/packages/bap-raw/bap-raw.2.5.0/opam
+++ b/packages/bap-raw/bap-raw.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-raw"]

--- a/packages/bap-recipe-command/bap-recipe-command.2.4.0/opam
+++ b/packages/bap-recipe-command/bap-recipe-command.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-recipe-command"]

--- a/packages/bap-recipe-command/bap-recipe-command.2.5.0/opam
+++ b/packages/bap-recipe-command/bap-recipe-command.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-recipe-command"]

--- a/packages/bap-recipe/bap-recipe.2.4.0/opam
+++ b/packages/bap-recipe/bap-recipe.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-recipe"]

--- a/packages/bap-recipe/bap-recipe.2.5.0/opam
+++ b/packages/bap-recipe/bap-recipe.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-recipe"]

--- a/packages/bap-relation/bap-relation.2.4.0/opam
+++ b/packages/bap-relation/bap-relation.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-relation"]

--- a/packages/bap-relation/bap-relation.2.5.0/opam
+++ b/packages/bap-relation/bap-relation.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-relation"]

--- a/packages/bap-relocatable/bap-relocatable.2.4.0/opam
+++ b/packages/bap-relocatable/bap-relocatable.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-relocatable"]

--- a/packages/bap-relocatable/bap-relocatable.2.5.0/opam
+++ b/packages/bap-relocatable/bap-relocatable.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-relocatable"]

--- a/packages/bap-report/bap-report.2.4.0/opam
+++ b/packages/bap-report/bap-report.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-report"]

--- a/packages/bap-report/bap-report.2.5.0/opam
+++ b/packages/bap-report/bap-report.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-report"]

--- a/packages/bap-riscv/bap-riscv.2.4.0/opam
+++ b/packages/bap-riscv/bap-riscv.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-riscv"]

--- a/packages/bap-riscv/bap-riscv.2.5.0/opam
+++ b/packages/bap-riscv/bap-riscv.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-riscv"]

--- a/packages/bap-run/bap-run.2.4.0/opam
+++ b/packages/bap-run/bap-run.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-run"]

--- a/packages/bap-run/bap-run.2.5.0/opam
+++ b/packages/bap-run/bap-run.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-run"]

--- a/packages/bap-signatures/bap-signatures.2.4.0/opam
+++ b/packages/bap-signatures/bap-signatures.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 install: [
   ["mkdir" "-p" "%{share}%/bap/signatures/"]

--- a/packages/bap-signatures/bap-signatures.2.5.0/opam
+++ b/packages/bap-signatures/bap-signatures.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 install: [
   ["mkdir" "-p" "%{share}%/bap/signatures/"]

--- a/packages/bap-specification/bap-specification.2.4.0/opam
+++ b/packages/bap-specification/bap-specification.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%"

--- a/packages/bap-specification/bap-specification.2.5.0/opam
+++ b/packages/bap-specification/bap-specification.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%"

--- a/packages/bap-ssa/bap-ssa.2.4.0/opam
+++ b/packages/bap-ssa/bap-ssa.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-ssa"]

--- a/packages/bap-ssa/bap-ssa.2.5.0/opam
+++ b/packages/bap-ssa/bap-ssa.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-ssa"]

--- a/packages/bap-std/bap-std.2.4.0/opam
+++ b/packages/bap-std/bap-std.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-std/bap-std.2.5.0/opam
+++ b/packages/bap-std/bap-std.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-strings/bap-strings.2.4.0/opam
+++ b/packages/bap-strings/bap-strings.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-strings-library"]

--- a/packages/bap-strings/bap-strings.2.5.0/opam
+++ b/packages/bap-strings/bap-strings.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-strings-library"]

--- a/packages/bap-stub-resolver/bap-stub-resolver.2.4.0/opam
+++ b/packages/bap-stub-resolver/bap-stub-resolver.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-stub-resolver"]

--- a/packages/bap-stub-resolver/bap-stub-resolver.2.5.0/opam
+++ b/packages/bap-stub-resolver/bap-stub-resolver.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-stub-resolver"]

--- a/packages/bap-symbol-reader/bap-symbol-reader.2.4.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-symbol-reader/bap-symbol-reader.2.5.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-systemz/bap-systemz.2.4.0/opam
+++ b/packages/bap-systemz/bap-systemz.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-systemz"]

--- a/packages/bap-systemz/bap-systemz.2.5.0/opam
+++ b/packages/bap-systemz/bap-systemz.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-systemz"]

--- a/packages/bap-taint-propagator/bap-taint-propagator.2.4.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-propagate-taint"]

--- a/packages/bap-taint-propagator/bap-taint-propagator.2.5.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-propagate-taint"]

--- a/packages/bap-taint/bap-taint.2.4.0/opam
+++ b/packages/bap-taint/bap-taint.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%"

--- a/packages/bap-taint/bap-taint.2.5.0/opam
+++ b/packages/bap-taint/bap-taint.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%"

--- a/packages/bap-term-mapper/bap-term-mapper.2.4.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-term-mapper/bap-term-mapper.2.5.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-thumb/bap-thumb.2.4.0/opam
+++ b/packages/bap-thumb/bap-thumb.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-thumb"]

--- a/packages/bap-thumb/bap-thumb.2.5.0/opam
+++ b/packages/bap-thumb/bap-thumb.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-thumb"]

--- a/packages/bap-toplevel/bap-toplevel.2.4.0/opam
+++ b/packages/bap-toplevel/bap-toplevel.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-toplevel/bap-toplevel.2.5.0/opam
+++ b/packages/bap-toplevel/bap-toplevel.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-trace/bap-trace.2.4.0/opam
+++ b/packages/bap-trace/bap-trace.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-trace/bap-trace.2.5.0/opam
+++ b/packages/bap-trace/bap-trace.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-traces/bap-traces.2.4.0/opam
+++ b/packages/bap-traces/bap-traces.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-traces/bap-traces.2.5.0/opam
+++ b/packages/bap-traces/bap-traces.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-trivial-condition-form/bap-trivial-condition-form.2.4.0/opam
+++ b/packages/bap-trivial-condition-form/bap-trivial-condition-form.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-trivial-condition-form"]

--- a/packages/bap-trivial-condition-form/bap-trivial-condition-form.2.5.0/opam
+++ b/packages/bap-trivial-condition-form/bap-trivial-condition-form.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-trivial-condition-form"]

--- a/packages/bap-warn-unused/bap-warn-unused.2.4.0/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-warn-unused/bap-warn-unused.2.5.0/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/bap-x86/bap-x86.2.4.0/opam
+++ b/packages/bap-x86/bap-x86.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-x86"]

--- a/packages/bap-x86/bap-x86.2.5.0/opam
+++ b/packages/bap-x86/bap-x86.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-x86"]

--- a/packages/bap/bap.2.4.0/opam
+++ b/packages/bap/bap.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 
 

--- a/packages/bare/bare.2.4.0/opam
+++ b/packages/bare/bare.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-bare"]

--- a/packages/bare/bare.2.5.0/opam
+++ b/packages/bare/bare.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-bare"]

--- a/packages/batteries/batteries.3.5.0/opam
+++ b/packages/batteries/batteries.3.5.0/opam
@@ -28,7 +28,7 @@ build: [
 ]
 run-test: [make "test"]
 install: [make "install"]
-dev-repo: "git://github.com/ocaml-batteries-team/batteries-included.git"
+dev-repo: "git+https://github.com/ocaml-batteries-team/batteries-included.git"
 url {
   src:
     "https://github.com/ocaml-batteries-team/batteries-included/archive/refs/tags/v3.5.0.tar.gz"

--- a/packages/batteries/batteries.3.5.1/opam
+++ b/packages/batteries/batteries.3.5.1/opam
@@ -28,7 +28,7 @@ build: [
 ]
 run-test: [make "test"]
 install: [make "install"]
-dev-repo: "git://github.com/ocaml-batteries-team/batteries-included.git"
+dev-repo: "git+https://github.com/ocaml-batteries-team/batteries-included.git"
 url {
   src: "https://github.com/ocaml-batteries-team/batteries-included/archive/refs/tags/v3.5.1.tar.gz"
   checksum: [

--- a/packages/batteries/batteries.3.6.0/opam
+++ b/packages/batteries/batteries.3.6.0/opam
@@ -28,7 +28,7 @@ build: [
 ]
 run-test: [make "test"]
 install: [make "install"]
-dev-repo: "git://github.com/ocaml-batteries-team/batteries-included.git"
+dev-repo: "git+https://github.com/ocaml-batteries-team/batteries-included.git"
 url {
   src: "https://github.com/ocaml-batteries-team/batteries-included/archive/refs/tags/v3.6.0.tar.gz"
   checksum: [

--- a/packages/bitvec-binprot/bitvec-binprot.2.4.0/opam
+++ b/packages/bitvec-binprot/bitvec-binprot.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-bitvec-binprot"]

--- a/packages/bitvec-binprot/bitvec-binprot.2.5.0/opam
+++ b/packages/bitvec-binprot/bitvec-binprot.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-bitvec-binprot"]

--- a/packages/bitvec-order/bitvec-order.2.4.0/opam
+++ b/packages/bitvec-order/bitvec-order.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-bitvec-order"]

--- a/packages/bitvec-order/bitvec-order.2.5.0/opam
+++ b/packages/bitvec-order/bitvec-order.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-bitvec-order"]

--- a/packages/bitvec-sexp/bitvec-sexp.2.4.0/opam
+++ b/packages/bitvec-sexp/bitvec-sexp.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-bitvec-sexp"]

--- a/packages/bitvec-sexp/bitvec-sexp.2.5.0/opam
+++ b/packages/bitvec-sexp/bitvec-sexp.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-bitvec-sexp"]

--- a/packages/bitvec/bitvec.2.4.0/opam
+++ b/packages/bitvec/bitvec.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-bitvec"]

--- a/packages/bitvec/bitvec.2.5.0/opam
+++ b/packages/bitvec/bitvec.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-bitvec"]

--- a/packages/camlpdf/camlpdf.2.5/opam
+++ b/packages/camlpdf/camlpdf.2.5/opam
@@ -3,7 +3,7 @@ maintainer: "contact@coherentgraphics.co.uk"
 authors: ["John Whitington"]
 homepage: "http://github.com/johnwhitington/camlpdf"
 bug-reports: "http://github.com/johnwhitington/camlpdf/issues"
-dev-repo: "git://github.com/johnwhitington/camlpdf"
+dev-repo: "git+https://github.com/johnwhitington/camlpdf"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build: [[make]]
 install: [[make "install"]]

--- a/packages/camlpdf/camlpdf.2.6/opam
+++ b/packages/camlpdf/camlpdf.2.6/opam
@@ -3,7 +3,7 @@ maintainer: "contact@coherentgraphics.co.uk"
 authors: ["John Whitington"]
 homepage: "http://github.com/johnwhitington/camlpdf"
 bug-reports: "http://github.com/johnwhitington/camlpdf/issues"
-dev-repo: "git://github.com/johnwhitington/camlpdf"
+dev-repo: "git+https://github.com/johnwhitington/camlpdf"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build: [[make]]
 install: [[make "install"]]

--- a/packages/camlpdf/camlpdf.2.7/opam
+++ b/packages/camlpdf/camlpdf.2.7/opam
@@ -3,7 +3,7 @@ maintainer: "contact@coherentgraphics.co.uk"
 authors: ["John Whitington"]
 homepage: "http://github.com/johnwhitington/camlpdf"
 bug-reports: "http://github.com/johnwhitington/camlpdf/issues"
-dev-repo: "git://github.com/johnwhitington/camlpdf"
+dev-repo: "git+https://github.com/johnwhitington/camlpdf"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build: [[make]]
 install: [[make "install"]]

--- a/packages/caper/caper.0.9/opam
+++ b/packages/caper/caper.0.9/opam
@@ -8,7 +8,7 @@ authors: "https://gitlab.com/niksu/caper#contributors"
 license: "GPL-3.0-or-later"
 homepage: "https://gitlab.com/niksu/caper"
 bug-reports: "https://gitlab.com/niksu/caper/issues"
-dev-repo: "git://gitlab.com/niksu/caper.git"
+dev-repo: "git+https://gitlab.com/niksu/caper.git"
 depends: [
   "ocaml" {>= "4.08"}
   "ocamlbuild"

--- a/packages/fuzzy_compare/fuzzy_compare.1.0.0/opam
+++ b/packages/fuzzy_compare/fuzzy_compare.1.0.0/opam
@@ -13,7 +13,7 @@ Once generated, an automaton can be reused to compare any 2 values in around 2-8
 """
 license: "MIT"
 homepage: "https://github.com/SGrondin/fuzzy_compare"
-dev-repo: "git://github.com/SGrondin/fuzzy_compare"
+dev-repo: "git+https://github.com/SGrondin/fuzzy_compare"
 doc: "https://github.com/SGrondin/fuzzy_compare"
 bug-reports: "https://github.com/SGrondin/fuzzy_compare/issues"
 depends: [

--- a/packages/fuzzy_compare/fuzzy_compare.2.0.0/opam
+++ b/packages/fuzzy_compare/fuzzy_compare.2.0.0/opam
@@ -13,7 +13,7 @@ Once generated, an automaton can be reused to compare any 2 values in around 2-8
 """
 license: "MIT"
 homepage: "https://github.com/SGrondin/fuzzy_compare"
-dev-repo: "git://github.com/SGrondin/fuzzy_compare"
+dev-repo: "git+https://github.com/SGrondin/fuzzy_compare"
 doc: "https://github.com/SGrondin/fuzzy_compare"
 bug-reports: "https://github.com/SGrondin/fuzzy_compare/issues"
 depends: [

--- a/packages/fuzzy_compare/fuzzy_compare.2.0.1/opam
+++ b/packages/fuzzy_compare/fuzzy_compare.2.0.1/opam
@@ -13,7 +13,7 @@ Once generated, an automaton can be reused to compare any 2 values in around 2-8
 """
 license: "MIT"
 homepage: "https://github.com/SGrondin/fuzzy_compare"
-dev-repo: "git://github.com/SGrondin/fuzzy_compare"
+dev-repo: "git+https://github.com/SGrondin/fuzzy_compare"
 doc: "https://github.com/SGrondin/fuzzy_compare"
 bug-reports: "https://github.com/SGrondin/fuzzy_compare/issues"
 depends: [

--- a/packages/gospel/gospel.0.1.0/opam
+++ b/packages/gospel/gospel.0.1.0/opam
@@ -8,7 +8,7 @@ authors: [
 ]
 license: "MIT"
 homepage: "https://github.com/ocaml-gospel/gospel"
-dev-repo: "git://github.com/ocaml-gospel/gospel"
+dev-repo: "git+https://github.com/ocaml-gospel/gospel"
 bug-reports: "https://github.com/ocaml-gospel/gospel/issues"
 
 build: [

--- a/packages/gospel/gospel.0.2.0/opam
+++ b/packages/gospel/gospel.0.2.0/opam
@@ -44,7 +44,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git://github.com/ocaml-gospel/gospel"
+dev-repo: "git+https://github.com/ocaml-gospel/gospel"
 
 url {
   src:

--- a/packages/graphlib/graphlib.2.4.0/opam
+++ b/packages/graphlib/graphlib.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/graphlib/graphlib.2.5.0/opam
+++ b/packages/graphlib/graphlib.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/hacl_func/hacl_func.0.1.0/opam
+++ b/packages/hacl_func/hacl_func.0.1.0/opam
@@ -25,7 +25,7 @@ build: [
   "@runtest" {with-test}
   "@doc" {with-doc}
 ]
-dev-repo: "git://gitlab.com/functori/dev/hacl"
+dev-repo: "git+https://gitlab.com/functori/dev/hacl"
 url {
   src:
     "https://gitlab.com/functori/dev/hacl/-/archive/0.1.0/hacl-0.1.0.tar.gz"

--- a/packages/jext/jext.0.1.0/opam
+++ b/packages/jext/jext.0.1.0/opam
@@ -30,7 +30,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git://gitlab.com/functori/dev/jext"
+dev-repo: "git+https://gitlab.com/functori/dev/jext"
 url {
   src:
     "https://gitlab.com/functori/dev/jext/-/archive/0.1.0/jext-0.1.0.tar.gz"

--- a/packages/lz4/lz4.1.2.0/opam
+++ b/packages/lz4/lz4.1.2.0/opam
@@ -6,7 +6,7 @@ license: "BSD-3-clause"
 homepage: "https://github.com/whitequark/ocaml-lz4"
 doc: "http://whitequark.github.io/ocaml-lz4"
 bug-reports: "https://github.com/whitequark/ocaml-lz4/issues"
-dev-repo: "git://github.com/whitequark/ocaml-lz4.git"
+dev-repo: "git+https://github.com/whitequark/ocaml-lz4.git"
 tags: [ "lz4" "compression" "decompression" ]
 build: [
   ["dune" "build" "@install" "-j" jobs "-p" name]

--- a/packages/monads/monads.2.4.0/opam
+++ b/packages/monads/monads.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-monads"]

--- a/packages/monads/monads.2.5.0/opam
+++ b/packages/monads/monads.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-monads"]

--- a/packages/mparser/mparser.1.2.1/opam
+++ b/packages/mparser/mparser.1.2.1/opam
@@ -3,7 +3,7 @@ maintainer: "Max Mouratov <mmouratov@gmail.com>"
 authors: "Holger Arnold <holger@harnold.org>"
 homepage: "https://github.com/cakeplus/mparser/"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
-dev-repo: "git://https://github.com/cakeplus/mparser"
+dev-repo: "git+https://github.com/cakeplus/mparser"
 bug-reports: "https://github.com/cakeplus/mparser/issues"
 depends: [
   "ocaml" {< "5.0"}

--- a/packages/mparser/mparser.1.2.2/opam
+++ b/packages/mparser/mparser.1.2.2/opam
@@ -3,7 +3,7 @@ maintainer: "Max Mouratov <mmouratov@gmail.com>"
 authors: "Holger Arnold <holger@harnold.org>"
 homepage: "https://github.com/cakeplus/mparser/"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
-dev-repo: "git://https://github.com/cakeplus/mparser"
+dev-repo: "git+https://github.com/cakeplus/mparser"
 bug-reports: "https://github.com/cakeplus/mparser/issues"
 depends: [
   "ocaml" {< "5.0.0"}

--- a/packages/mparser/mparser.1.2.3/opam
+++ b/packages/mparser/mparser.1.2.3/opam
@@ -3,7 +3,7 @@ maintainer: "Max Mouratov <mmouratov@gmail.com>"
 authors: "Holger Arnold <holger@harnold.org>"
 homepage: "https://github.com/cakeplus/mparser/"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
-dev-repo: "git://https://github.com/cakeplus/mparser"
+dev-repo: "git+https://github.com/cakeplus/mparser"
 bug-reports: "https://github.com/cakeplus/mparser/issues"
 depends: [
   "ocaml" {< "5.0.0"}

--- a/packages/mparser/mparser.1.2/opam
+++ b/packages/mparser/mparser.1.2/opam
@@ -3,7 +3,7 @@ maintainer: "Max Mouratov <mmouratov@gmail.com>"
 authors: "Holger Arnold <holger@harnold.org>"
 homepage: "https://github.com/cakeplus/mparser/"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
-dev-repo: "git://https://github.com/cakeplus/mparser"
+dev-repo: "git+https://github.com/cakeplus/mparser"
 bug-reports: "https://github.com/cakeplus/mparser/issues"
 depends: [
   "ocaml" {< "5.0.0"}

--- a/packages/mperf/mperf.0.5.0/opam
+++ b/packages/mperf/mperf.0.5.0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 authors:      [ "Vincent Bernardoff <vincent.bernardoff@ocamlpro.com>" "Pierre Chambart <pierre.chambart@ocamlpro.com>" ]
 homepage:     "http://github.com/dinosaure/bechamel"
-dev-repo:     "git://github.com/dinosaure/bechamel"
+dev-repo:     "git+https://github.com/dinosaure/bechamel"
 bug-reports:  "http://github.com/dinosaure/bechamel/issues"
 license:      "GPL-2.0-only"
 synopsis:     "Bindings to Linux perf's metrics"

--- a/packages/ocaml-sat-solvers/ocaml-sat-solvers.0.7.1/opam
+++ b/packages/ocaml-sat-solvers/ocaml-sat-solvers.0.7.1/opam
@@ -5,7 +5,7 @@ authors: [ "Oliver Friedmann"
            "Maurice Herwig" ]
 license: "BSD-3-clause"
 homepage: "https://github.com/tcsprojects/ocaml-sat-solvers"
-dev-repo: "git://github.com/tcsprojects/ocaml-sat-solvers.git"
+dev-repo: "git+https://github.com/tcsprojects/ocaml-sat-solvers.git"
 bug-reports: "https://github.com/tcsprojects/ocaml-sat-solvers/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/ocaml-sat-solvers/ocaml-sat-solvers.0.7/opam
+++ b/packages/ocaml-sat-solvers/ocaml-sat-solvers.0.7/opam
@@ -4,7 +4,7 @@ authors: [ "Oliver Friedmann"
            "Martin Lange" ]
 license: "BSD-3-clause"
 homepage: "https://github.com/tcsprojects/ocaml-sat-solvers"
-dev-repo: "git://github.com/tcsprojects/ocaml-sat-solvers.git"
+dev-repo: "git+https://github.com/tcsprojects/ocaml-sat-solvers.git"
 bug-reports: "https://github.com/tcsprojects/ocaml-sat-solvers/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]

--- a/packages/ocamltter/ocamltter.4.0.1/opam
+++ b/packages/ocamltter/ocamltter.4.0.1/opam
@@ -5,7 +5,7 @@ authors: [
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://github.com/yoshihiro503/ocamltter"
 bug-reports: "https://github.com/yoshihiro503/ocamltter/issues"
-dev-repo: "git://https://github.com/yoshihiro503/ocamltter.git"
+dev-repo: "git+https://github.com/yoshihiro503/ocamltter.git"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/ocamltter/ocamltter.4.0.2/opam
+++ b/packages/ocamltter/ocamltter.4.0.2/opam
@@ -5,7 +5,7 @@ authors: [
 maintainer: "jun.furuse@gmail.com"
 homepage: "https://github.com/yoshihiro503/ocamltter"
 bug-reports: "https://github.com/yoshihiro503/ocamltter/issues"
-dev-repo: "git://https://github.com/yoshihiro503/ocamltter.git"
+dev-repo: "git+https://github.com/yoshihiro503/ocamltter.git"
 build: [
   [ "ocaml" "setup.ml" "-configure" "--prefix" prefix ]
   [ "ocaml" "setup.ml" "-build" ]

--- a/packages/ogre/ogre.2.4.0/opam
+++ b/packages/ogre/ogre.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-ogre"]

--- a/packages/ogre/ogre.2.5.0/opam
+++ b/packages/ogre/ogre.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-ogre"]

--- a/packages/opam-grep/opam-grep.0.3.0/opam
+++ b/packages/opam-grep/opam-grep.0.3.0/opam
@@ -17,7 +17,7 @@ depends: [
 available: os != "win32"
 flags: plugin
 build: ["dune" "build" "-p" name "-j" jobs]
-dev-repo: "git://github.com/kit-ty-kate/opam-grep.git"
+dev-repo: "git+https://github.com/kit-ty-kate/opam-grep.git"
 url {
   src:
     "https://github.com/kit-ty-kate/opam-grep/releases/download/v0.3.0/opam-grep-0.3.0.tar.gz"

--- a/packages/pilat/pilat.1.6/opam
+++ b/packages/pilat/pilat.1.6/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Steven De Oliveira <de.oliveira.steven@gmail.com>"
 authors: "Steven De Oliveira <de.oliveira.steven@gmail.com>"
-dev-repo: "git://github.com/Stevendeo/Pilat.git"
+dev-repo: "git+https://github.com/Stevendeo/Pilat.git"
 homepage: "https://github.com/Stevendeo/Pilat/"
 synopsis: "Polynomial invariant generator"
 license: "LGPL-2.1-only"

--- a/packages/plato/plato.1.1.2/opam
+++ b/packages/plato/plato.1.1.2/opam
@@ -3,7 +3,7 @@ synopsis: "Python Library Adapted To OCaml"
 maintainer: "Marc Chevalier <github@marc.chevalier.com>"
 authors: "Marc Chevalier <github@marc.chevalier.com>"
 homepage: "https://github.com/marc-chevalier/plato"
-dev-repo: "git://github.com/marc-chevalier/plato"
+dev-repo: "git+https://github.com/marc-chevalier/plato"
 bug-reports: "https://github.com/marc-chevalier/plato/issues"
 depends: [
   "ocaml" {>= "4.06.0"}

--- a/packages/plato/plato.1.1.3/opam
+++ b/packages/plato/plato.1.1.3/opam
@@ -3,7 +3,7 @@ synopsis: "Python Library Adapted To OCaml"
 maintainer: "Marc Chevalier <github@marc-chevalier.com>"
 authors: "Marc Chevalier <github@marc-chevalier.com>"
 homepage: "https://github.com/marc-chevalier/plato"
-dev-repo: "git://github.com/marc-chevalier/plato"
+dev-repo: "git+https://github.com/marc-chevalier/plato"
 bug-reports: "https://github.com/marc-chevalier/plato/issues"
 depends: [
   "ocaml" {>= "4.06.0"}

--- a/packages/plebeia/plebeia.1.0.0/opam
+++ b/packages/plebeia/plebeia.1.0.0/opam
@@ -5,7 +5,7 @@ synopsis: "Merkle Patricia tree implementation"
 license: "MIT"
 homepage: "https://gitlab.com/dailambda/plebeia/"
 bug-reports: "https://gitlab.com/dailambda/plebeia/-/issues"
-dev-repo: "git://https://gitlab.com/dailambda/plebeia/"
+dev-repo: "git+https://gitlab.com/dailambda/plebeia/"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/polly/polly.0.4.1/opam
+++ b/packages/polly/polly.0.4.1/opam
@@ -17,7 +17,7 @@ depends: [
   "conf-linux-libc-dev"
 ]
 build: ["dune" "build" "-p" name "-j" jobs "@install"]
-dev-repo: "git://github.com/lindig/polly.git"
+dev-repo: "git+https://github.com/lindig/polly.git"
 url {
   src:
     "https://github.com/lindig/polly/releases/download/0.4.1/polly-0.4.1.tbz"

--- a/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.1/opam
+++ b/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.1/opam
@@ -25,7 +25,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git://gitlab.com/o-labs/ppx_deriving_encoding"
+dev-repo: "git+https://gitlab.com/o-labs/ppx_deriving_encoding"
 url {
   src:
     "https://gitlab.com/api/v4/projects/22769538/repository/archive?sha=81ca6736a770a3f09ec7051c30dca081564e33e4"

--- a/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2.1/opam
+++ b/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2.1/opam
@@ -25,7 +25,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git://gitlab.com/o-labs/ppx_deriving_encoding"
+dev-repo: "git+https://gitlab.com/o-labs/ppx_deriving_encoding"
 url {
   src:
     "https://gitlab.com/api/v4/projects/22769538/repository/archive?sha=c094a9058c849266dd52dca52c172841a6965bab"

--- a/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2.2/opam
+++ b/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2.2/opam
@@ -25,7 +25,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git://gitlab.com/o-labs/ppx_deriving_encoding"
+dev-repo: "git+https://gitlab.com/o-labs/ppx_deriving_encoding"
 url {
   src:
     "https://gitlab.com/api/v4/projects/22769538/repository/archive?sha=b7ffd2c2aefd6133c6dec8fa03c31129069a8478"

--- a/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2.3/opam
+++ b/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2.3/opam
@@ -26,7 +26,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git://gitlab.com/o-labs/ppx_deriving_encoding"
+dev-repo: "git+https://gitlab.com/o-labs/ppx_deriving_encoding"
 url {
   src:
     "https://gitlab.com/api/v4/projects/22769538/repository/archive?sha=9ffa2ee0d920be3ebce9abb37bbd670701b84e09"

--- a/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2/opam
+++ b/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.2/opam
@@ -25,7 +25,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git://gitlab.com/o-labs/ppx_deriving_encoding"
+dev-repo: "git+https://gitlab.com/o-labs/ppx_deriving_encoding"
 url {
   src:
     "https://gitlab.com/api/v4/projects/22769538/repository/archive?sha=1448f85d0ba13b4d1b7f780758e4088a8b68c6cf"

--- a/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.3.0/opam
+++ b/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.3.0/opam
@@ -27,7 +27,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git://gitlab.com/o-labs/ppx_deriving_encoding"
+dev-repo: "git+https://gitlab.com/o-labs/ppx_deriving_encoding"
 url {
   src:
     "https://gitlab.com/o-labs/ppx_deriving_encoding/-/archive/0.3.0/ppx_deriving_encoding-0.3.0.tar.gz"

--- a/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.1/opam
+++ b/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.1/opam
@@ -25,7 +25,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git://gitlab.com/o-labs/ppx_deriving_jsoo"
+dev-repo: "git+https://gitlab.com/o-labs/ppx_deriving_jsoo"
 url {
   src:
     "https://gitlab.com/api/v4/projects/22645789/repository/archive?sha=2fa6de4c7361e71048c308180e2d47aa1ae255f5"

--- a/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.2/opam
+++ b/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.2/opam
@@ -25,7 +25,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git://gitlab.com/o-labs/ppx_deriving_jsoo"
+dev-repo: "git+https://gitlab.com/o-labs/ppx_deriving_jsoo"
 url {
   src:
     "https://gitlab.com/api/v4/projects/22645789/repository/archive?sha=1544d22e6e68f309608f46b48f5349a692003ab8"

--- a/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.3/opam
+++ b/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.3/opam
@@ -28,7 +28,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git://gitlab.com/o-labs/ppx_deriving_jsoo"
+dev-repo: "git+https://gitlab.com/o-labs/ppx_deriving_jsoo"
 url {
   src:
     "https://gitlab.com/o-labs/ppx_deriving_jsoo/-/archive/0.3/ppx_deriving_jsoo-0.3.tar.gz"

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.1/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.1/opam
@@ -20,7 +20,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.2/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.2/opam
@@ -20,7 +20,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.9.0.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.9.0.0/opam
@@ -20,7 +20,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/ppx_units/ppx_units.1.0.0/opam
+++ b/packages/ppx_units/ppx_units.1.0.0/opam
@@ -9,7 +9,7 @@ ppx_units is a simple deriver to automatically generate single variant types fro
 """
 license: "MPL-2.0"
 homepage: "https://github.com/SGrondin/ppx_units"
-dev-repo: "git://github.com/SGrondin/ppx_units"
+dev-repo: "git+https://github.com/SGrondin/ppx_units"
 doc: "https://github.com/SGrondin/ppx_units"
 bug-reports: "https://github.com/SGrondin/ppx_units/issues"
 depends: [

--- a/packages/reason/reason.3.8.0/opam
+++ b/packages/reason/reason.3.8.0/opam
@@ -5,7 +5,7 @@ license: "MIT"
 homepage: "https://github.com/reasonml/reason"
 doc: "https://reasonml.github.io/"
 bug-reports: "https://github.com/reasonml/reason/issues"
-dev-repo: "git://github.com/reasonml/reason.git"
+dev-repo: "git+https://github.com/reasonml/reason.git"
 tags: [ "syntax" ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/regular/regular.2.4.0/opam
+++ b/packages/regular/regular.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/regular/regular.2.5.0/opam
+++ b/packages/regular/regular.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"

--- a/packages/rpc/rpc.8.1.1/opam
+++ b/packages/rpc/rpc.8.1.1/opam
@@ -22,7 +22,7 @@ build: [
     ["dune" "runtest" "-p" name "-j" jobs] {with-test}
     ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpc/rpc.8.1.2/opam
+++ b/packages/rpc/rpc.8.1.2/opam
@@ -22,7 +22,7 @@ build: [
     ["dune" "runtest" "-p" name "-j" jobs] {with-test}
     ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpc/rpc.9.0.0/opam
+++ b/packages/rpc/rpc.9.0.0/opam
@@ -22,7 +22,7 @@ build: [
     ["dune" "runtest" "-p" name "-j" jobs] {with-test}
     ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpclib-async/rpclib-async.8.1.1/opam
+++ b/packages/rpclib-async/rpclib-async.8.1.1/opam
@@ -19,7 +19,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpclib-async/rpclib-async.8.1.2/opam
+++ b/packages/rpclib-async/rpclib-async.8.1.2/opam
@@ -19,7 +19,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpclib-async/rpclib-async.9.0.0/opam
+++ b/packages/rpclib-async/rpclib-async.9.0.0/opam
@@ -19,7 +19,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpclib-html/rpclib-html.8.1.1/opam
+++ b/packages/rpclib-html/rpclib-html.8.1.1/opam
@@ -15,7 +15,7 @@ depends: [
   "cow" {>= "2.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpclib-html/rpclib-html.8.1.2/opam
+++ b/packages/rpclib-html/rpclib-html.8.1.2/opam
@@ -15,7 +15,7 @@ depends: [
   "cow" {>= "2.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpclib-html/rpclib-html.9.0.0/opam
+++ b/packages/rpclib-html/rpclib-html.9.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "cow" {>= "2.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpclib-js/rpclib-js.8.1.1/opam
+++ b/packages/rpclib-js/rpclib-js.8.1.1/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpclib-js/rpclib-js.8.1.2/opam
+++ b/packages/rpclib-js/rpclib-js.8.1.2/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpclib-js/rpclib-js.9.0.0/opam
+++ b/packages/rpclib-js/rpclib-js.9.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpclib-lwt/rpclib-lwt.8.1.1/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.8.1.1/opam
@@ -20,7 +20,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpclib-lwt/rpclib-lwt.8.1.2/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.8.1.2/opam
@@ -20,7 +20,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpclib-lwt/rpclib-lwt.9.0.0/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.9.0.0/opam
@@ -20,7 +20,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpclib/rpclib.8.1.1/opam
+++ b/packages/rpclib/rpclib.8.1.1/opam
@@ -22,7 +22,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpclib/rpclib.8.1.2/opam
+++ b/packages/rpclib/rpclib.8.1.2/opam
@@ -25,7 +25,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rpclib/rpclib.9.0.0/opam
+++ b/packages/rpclib/rpclib.9.0.0/opam
@@ -25,7 +25,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "git+https://github.com/mirage/ocaml-rpc"
 description: """
 `ocaml-rpc` is a library that provides remote procedure calls (RPC)
 using XML or JSON as transport encodings, and multiple generators

--- a/packages/rtop/rtop.3.8.0/opam
+++ b/packages/rtop/rtop.3.8.0/opam
@@ -5,7 +5,7 @@ license: "MIT"
 homepage: "https://github.com/reasonml/reason"
 doc: "https://reasonml.github.io/"
 bug-reports: "https://github.com/reasonml/reason/issues"
-dev-repo: "git://github.com/reasonml/reason.git"
+dev-repo: "git+https://github.com/reasonml/reason.git"
 tags: [ "syntax" ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/scaml/scaml.1.2.0/opam
+++ b/packages/scaml/scaml.1.2.0/opam
@@ -4,7 +4,7 @@ maintainer: "jun.furuse@dailambda.jp"
 synopsis: "SCaml, Smart Contract Abstract Machine Language"
 homepage: "https://gitlab.com/dailambda/scaml/"
 bug-reports: "https://gitlab.com/dailambda/scaml/"
-dev-repo: "git://https://gitlab.com/dailambda/scaml/"
+dev-repo: "git+https://gitlab.com/dailambda/scaml/"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/scaml/scaml.1.2.0~pre7/opam
+++ b/packages/scaml/scaml.1.2.0~pre7/opam
@@ -4,7 +4,7 @@ maintainer: "jun.furuse@dailambda.jp"
 synopsis: "SCaml, Smart Contract Abstract Machine Language"
 homepage: "https://gitlab.com/dailambda/scaml/"
 bug-reports: "https://gitlab.com/dailambda/scaml/"
-dev-repo: "git://https://gitlab.com/dailambda/scaml/"
+dev-repo: "git+https://gitlab.com/dailambda/scaml/"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/tablecloth-base/tablecloth-base.0.0.9/opam
+++ b/packages/tablecloth-base/tablecloth-base.0.0.9/opam
@@ -12,7 +12,7 @@ authors: [
 license: "MIT"
 homepage: "https://github.com/darklang/tablecloth-ocaml-base"
 bug-reports: "https://github.com/darklang/tablecloth-ocaml-base/issues"
-dev-repo: "git://github.com/darklang/tablecloth-ocaml-base"
+dev-repo: "git+https://github.com/darklang/tablecloth-ocaml-base"
 depends: [ "ocaml" {>= "4.08" < "4.15" } "dune" {>= "2.4" } "base" { >= "v0.12.0" & < "v0.15.0" } ]
 build: ["dune" "build" "-p" name "-j" jobs]
 conflicts: [ "tablecloth-native" {!= "transition"} ]

--- a/packages/tablecloth-melange/tablecloth-melange.0.0.9/opam
+++ b/packages/tablecloth-melange/tablecloth-melange.0.0.9/opam
@@ -11,7 +11,7 @@ authors: [
 license: "MIT"
 homepage: "https://github.com/tableclothdotdev/tablecloth-melange"
 bug-reports: "https://github.com/tableclothdotdev/tablecloth-melange/issues"
-dev-repo: "git://github.com/tableclothdotdev/tablecloth-melange"
+dev-repo: "git+https://github.com/tableclothdotdev/tablecloth-melange"
 depends: [
   "ocaml" {>= "5.1"}
   "dune" {>= "3.8"}

--- a/packages/tablecloth-native/tablecloth-native.0.0.8/opam
+++ b/packages/tablecloth-native/tablecloth-native.0.0.8/opam
@@ -11,7 +11,7 @@ authors: [
 license: "MIT"
 homepage: "https://github.com/darklang/tablecloth"
 bug-reports: "https://github.com/darklang/tablecloth/issues"
-dev-repo: "git://github.com/darklang/tablecloth"
+dev-repo: "git+https://github.com/darklang/tablecloth"
 depends: [ "ocaml" {>= "4.08" < "4.13" } "dune" {>= "2.4"} "base" { >= "v0.12.0" & < "v0.15.0" } ]
 build: ["dune" "build" "-p" name "-j" jobs]
 url {

--- a/packages/tablecloth-native/tablecloth-native.transition/opam
+++ b/packages/tablecloth-native/tablecloth-native.transition/opam
@@ -9,7 +9,7 @@ authors: [
 license: "MIT"
 homepage: "https://github.com/darklang/tablecloth-ocaml-base"
 bug-reports: "https://github.com/darklang/tablecloth-ocaml-base/issues"
-dev-repo: "git://github.com/darklang/tablecloth-ocaml-base"
+dev-repo: "git+https://github.com/darklang/tablecloth-ocaml-base"
 depends: [ "ocaml" "tablecloth-base" ]
 post-messages: [
   "tablecloth-native has been renamed and the tablecloth-native package is now a transition package.  Use the tablecloth-base package instead."

--- a/packages/tdigest/tdigest.1.0.0/opam
+++ b/packages/tdigest/tdigest.1.0.0/opam
@@ -14,7 +14,7 @@ Additionally, the T-Digest is concatenable, making it a good fit for distributed
 """
 license: "MIT"
 homepage: "https://github.com/SGrondin/tdigest"
-dev-repo: "git://github.com/SGrondin/tdigest"
+dev-repo: "git+https://github.com/SGrondin/tdigest"
 doc: "https://github.com/SGrondin/tdigest"
 bug-reports: "https://github.com/SGrondin/tdigest/issues"
 depends: [

--- a/packages/tdigest/tdigest.2.0.0/opam
+++ b/packages/tdigest/tdigest.2.0.0/opam
@@ -14,7 +14,7 @@ Additionally, the T-Digest is concatenable, making it a good fit for distributed
 """
 license: "MIT"
 homepage: "https://github.com/SGrondin/tdigest"
-dev-repo: "git://github.com/SGrondin/tdigest"
+dev-repo: "git+https://github.com/SGrondin/tdigest"
 doc: "https://github.com/SGrondin/tdigest"
 bug-reports: "https://github.com/SGrondin/tdigest/issues"
 depends: [

--- a/packages/tdigest/tdigest.2.1.0/opam
+++ b/packages/tdigest/tdigest.2.1.0/opam
@@ -14,7 +14,7 @@ Additionally, the T-Digest is concatenable, making it a good fit for distributed
 """
 license: "MIT"
 homepage: "https://github.com/SGrondin/tdigest"
-dev-repo: "git://github.com/SGrondin/tdigest"
+dev-repo: "git+https://github.com/SGrondin/tdigest"
 doc: "https://github.com/SGrondin/tdigest"
 bug-reports: "https://github.com/SGrondin/tdigest/issues"
 depends: [

--- a/packages/tdigest/tdigest.2.1.1/opam
+++ b/packages/tdigest/tdigest.2.1.1/opam
@@ -14,7 +14,7 @@ Additionally, the T-Digest is concatenable, making it a good fit for distributed
 """
 license: "MIT"
 homepage: "https://github.com/SGrondin/tdigest"
-dev-repo: "git://github.com/SGrondin/tdigest"
+dev-repo: "git+https://github.com/SGrondin/tdigest"
 doc: "https://github.com/SGrondin/tdigest"
 bug-reports: "https://github.com/SGrondin/tdigest/issues"
 depends: [

--- a/packages/tdigest/tdigest.2.1.2/opam
+++ b/packages/tdigest/tdigest.2.1.2/opam
@@ -14,7 +14,7 @@ Additionally, the T-Digest is concatenable, making it a good fit for distributed
 """
 license: "MIT"
 homepage: "https://github.com/SGrondin/tdigest"
-dev-repo: "git://github.com/SGrondin/tdigest"
+dev-repo: "git+https://github.com/SGrondin/tdigest"
 doc: "https://github.com/SGrondin/tdigest"
 bug-reports: "https://github.com/SGrondin/tdigest/issues"
 depends: [

--- a/packages/tdigest/tdigest.2.1.3/opam
+++ b/packages/tdigest/tdigest.2.1.3/opam
@@ -14,7 +14,7 @@ Additionally, the T-Digest is concatenable, making it a good fit for distributed
 """
 license: "MIT"
 homepage: "https://github.com/SGrondin/tdigest"
-dev-repo: "git://github.com/SGrondin/tdigest"
+dev-repo: "git+https://github.com/SGrondin/tdigest"
 doc: "https://github.com/SGrondin/tdigest"
 bug-reports: "https://github.com/SGrondin/tdigest/issues"
 depends: [

--- a/packages/tdigest/tdigest.2.2.0/opam
+++ b/packages/tdigest/tdigest.2.2.0/opam
@@ -14,7 +14,7 @@ Additionally, the T-Digest is concatenable, making it a good fit for distributed
 """
 license: "MIT"
 homepage: "https://github.com/SGrondin/tdigest"
-dev-repo: "git://github.com/SGrondin/tdigest"
+dev-repo: "git+https://github.com/SGrondin/tdigest"
 doc: "https://github.com/SGrondin/tdigest"
 bug-reports: "https://github.com/SGrondin/tdigest/issues"
 depends: [

--- a/packages/text-tags/text-tags.2.4.0/opam
+++ b/packages/text-tags/text-tags.2.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-text-tags"]

--- a/packages/text-tags/text-tags.2.5.0/opam
+++ b/packages/text-tags/text-tags.2.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+dev-repo: "git+https://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-text-tags"]

--- a/packages/unison-gui/unison-gui.2.53.4/opam
+++ b/packages/unison-gui/unison-gui.2.53.4/opam
@@ -8,7 +8,7 @@ authors: [
 license: "GPL-3.0-or-later"
 homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
 bug-reports: "https://github.com/bcpierce00/unison/issues"
-dev-repo: "git://github.com/bcpierce00/unison.git"
+dev-repo: "git+https://github.com/bcpierce00/unison.git"
 depends: [
   "unison" {= version}
   "lablgtk3"

--- a/packages/unison/unison.2.51.5/opam
+++ b/packages/unison/unison.2.51.5/opam
@@ -17,7 +17,7 @@ depends: [
   "lablgtk" {>= "2.18.6"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-dev-repo: "git://github.com/bcpierce00/unison.git"
+dev-repo: "git+https://github.com/bcpierce00/unison.git"
 url {
   src:
     "https://github.com/bcpierce00/unison/archive/refs/tags/v2.51.5.tar.gz"

--- a/packages/unison/unison.2.52.0/opam
+++ b/packages/unison/unison.2.52.0/opam
@@ -17,7 +17,7 @@ depends: [
   "lablgtk" {>= "2.18.6"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-dev-repo: "git://github.com/bcpierce00/unison.git"
+dev-repo: "git+https://github.com/bcpierce00/unison.git"
 url {
   src:
     "https://github.com/bcpierce00/unison/archive/refs/tags/v2.52.0.tar.gz"

--- a/packages/unison/unison.2.53.0/opam
+++ b/packages/unison/unison.2.53.0/opam
@@ -17,7 +17,7 @@ depends: [
   "lablgtk3" {>= "3.1.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-dev-repo: "git://github.com/bcpierce00/unison.git"
+dev-repo: "git+https://github.com/bcpierce00/unison.git"
 url {
   src:
     "https://github.com/bcpierce00/unison/archive/refs/tags/v2.53.0.tar.gz"

--- a/packages/unison/unison.2.53.3/opam
+++ b/packages/unison/unison.2.53.3/opam
@@ -17,7 +17,7 @@ depends: [
   "lablgtk3" {>= "3.1.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-dev-repo: "git://github.com/bcpierce00/unison.git"
+dev-repo: "git+https://github.com/bcpierce00/unison.git"
 url {
   src:
     "https://github.com/bcpierce00/unison/archive/refs/tags/v2.53.3.tar.gz"

--- a/packages/unison/unison.2.53.4/opam
+++ b/packages/unison/unison.2.53.4/opam
@@ -8,7 +8,7 @@ authors: [
 license: "GPL-3.0-or-later"
 homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
 bug-reports: "https://github.com/bcpierce00/unison/issues"
-dev-repo: "git://github.com/bcpierce00/unison.git"
+dev-repo: "git+https://github.com/bcpierce00/unison.git"
 build: [make "NATIVE=%{ocaml:native}%" "-j" jobs]
 install: [make "NATIVE=%{ocaml:native}%" "PREFIX=%{prefix}%" "install"]
 depends: [

--- a/packages/vue-jsoo/vue-jsoo.0.1/opam
+++ b/packages/vue-jsoo/vue-jsoo.0.1/opam
@@ -31,7 +31,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git://gitlab.com/o-labs/vue-jsoo"
+dev-repo: "git+https://gitlab.com/o-labs/vue-jsoo"
 url {
   src:
     "https://gitlab.com/api/v4/projects/18174793/repository/archive?sha=2a338bcccd3cdd4c5b3c488f84b954baa976840e"

--- a/packages/vue-ppx/vue-ppx.0.1.0/opam
+++ b/packages/vue-ppx/vue-ppx.0.1.0/opam
@@ -26,7 +26,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git://gitlab.com/functori/dev/vue-ppx"
+dev-repo: "git+https://gitlab.com/functori/dev/vue-ppx"
 url {
   src:
     "https://gitlab.com/functori/dev/vue-ppx/-/archive/0.1.0/vue-ppx-0.1.0.tar.gz"

--- a/packages/zstd/zstd.0.3/opam
+++ b/packages/zstd/zstd.0.3/opam
@@ -5,7 +5,7 @@ license: "BSD-3-Clause"
 authors: [ "ygrek" ]
 tags: [ "org:ygrek" "clib:zstd" ]
 doc: [ "https://ygrek.org/p/ocaml-zstd/api/index.html" ]
-dev-repo: "git://github.com/ygrek/ocaml-zstd.git"
+dev-repo: "git+https://github.com/ygrek/ocaml-zstd.git"
 bug-reports: "https://github.com/ygrek/ocaml-zstd/issues"
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
On some git servers, `git://` is no more accepted.
This PR updates some `dev-repo:` field, mainly github and gitlab.