### PR TITLE
grain_dypgen needs the native compiler

### DIFF
--- a/packages/grain_dypgen/grain_dypgen.0.1/opam
+++ b/packages/grain_dypgen/grain_dypgen.0.1/opam
@@ -17,6 +17,7 @@ install: [
   "BINDIR=%{bin}%"
   "MANDIR=%{man}%/man1"
 ]
+conflicts: [ "ocaml-option-bytecode-only" ]
 synopsis: "Self-extensible parsers and lexers for OCaml"
 description: """
 dypgen is a GLR parser generator for OCaml, it is able to

--- a/packages/grain_dypgen/grain_dypgen.0.2/opam
+++ b/packages/grain_dypgen/grain_dypgen.0.2/opam
@@ -15,6 +15,7 @@ install: [
   ["sh.exe" "-c" "if [ -f '%{bin}%/dypgen' ] && [ ! -f '%{bin}%/dypgen.exe' ] ; then mv '%{bin}%/dypgen' '%{bin}%/dypgen.exe' ; fi" ] { os = "win32" }
   ["sh.exe" "-c" "if [ -f '%{bin}%/dypgen.opt' ] && [ ! -f '%{bin}%/dypgen.opt.exe' ] ; then mv '%{bin}%/dypgen.opt' '%{bin}%/dypgen.opt.exe' ; fi" ] { os = "win32" }
 ]
+conflicts: [ "ocaml-option-bytecode-only" ]
 synopsis: "Self-extensible parsers and lexers for OCaml"
 description: """
 dypgen is a GLR parser generator for OCaml, it is able to


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/25437

Fails with
```
=== ERROR while compiling grain_dypgen.0.2 ===================================#
 context              2.2.0~beta2~dev | linux/ppc64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
 path                 ~/.opam/5.1/.opam-switch/build/grain_dypgen.0.2
 command              ~/.opam/opam-init/hooks/sandbox.sh build make
 exit-code            2
 env-file             ~/.opam/log/grain_dypgen-7-6f8e35.env
 output-file          ~/.opam/log/grain_dypgen-7-6f8e35.out
 cd dyplib; make
 make[1]: Entering directory '/home/opam/.opam/5.1/.opam-switch/build/grain_dypgen.0.2/dyplib'
 ocamlc  -c dyp.mli
 ocamlc  -c priority_by_relation.ml
 ocamlc  -c automaton.ml
 ocamlc  -c dyplex.ml
 File "dyplex.ml", line 598, characters 29-52:
 598 |         with Invalid_argument("index out of bounds")
                                    ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
 and may change in future versions. (see manual section 13.5.3)
 ocamlc  -c dyp.ml
 File "dyp.ml", line 5067, characters 19-40:
 5067 |       with Failure "lexing: empty token" ->
                           ^^^^^^^^^^^^^^^^^^^^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
 and may change in future versions. (see manual section 13.5.3)

 File "dyp.ml", line 5085, characters 29-43:
 5085 |         with Invalid_argument("String.sub") ->
                                     ^^^^^^^^^^^^^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
 and may change in future versions. (see manual section 13.5.3)

 File "dyp.ml", line 5095, characters 29-43:
 5095 |         with Invalid_argument("String.sub") ->
                                     ^^^^^^^^^^^^^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
 and may change in future versions. (see manual section 13.5.3)
 ocamlc -a -o dyp.cma priority_by_relation.cmo automaton.cmo dyplex.cmo dyp.cmo
 ocamlopt  -c priority_by_relation.ml
 make[1]: ocamlopt: No such file or directory
 make[1]: *** [Makefile:61: priority_by_relation.cmx] Error 127
 make[1]: Leaving directory '/home/opam/.opam/5.1/.opam-switch/build/grain_dypgen.0.2/dyplib'
 make: *** [Makefile:6: dyp] Error 2
```