### PR TITLE
[new release] ppx_deriving (5.3.0)

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.5.3.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6.3"}
+  "cppo" {>= "1.1.0" & build}
+  "ocamlfind"
+  "ppx_derivers"
+  "ppxlib" {>= "0.32.0"}
+  "result"
+  "ounit2" {with-test}
+]
+synopsis: "Type-driven code generation for OCaml"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_deriving/releases/download/5.3.0/ppx_deriving-5.3.0.tbz"
+  checksum: [
+    "sha256=ed4f2c104699a88930bfaa2bbcc3bb712d0f0fc42fdfb3821c9875dc66a68a89"
+    "sha512=9bed9b00accf9a385f1f60ac4099bcab3c9a06a09b5cb11ecc378f7abde72caa53ed1ed7b92dd9c4479888b0f0af03f33f42126644c85a1b33c5665ec3c8ba9b"
+  ]
+}
+x-commit-hash: "344fa34fb28b1df9a6cb0c3f2c13502297a21dca"


### PR DESCRIPTION
Type-driven code generation for OCaml

- Project page: <a href="https://github.com/ocaml-ppx/ppx_deriving">https://github.com/ocaml-ppx/ppx_deriving</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_deriving/">https://ocaml-ppx.github.io/ppx_deriving/</a>

##### CHANGES:

* Port standard plugins to ppxlib registration and attributes
  ocaml-ppx/ppx_deriving#263
  (Simmo Saan)

* Optimize forwarding in eq and ord plugins
  ocaml-ppx/ppx_deriving#252
  (Simmo Saan)

* Delegate quoter to ppxlib
  ocaml-ppx/ppx_deriving#263
  (Simmo Saan)

* Introduce `Ppx_deriving_runtime.Stdlib` with OCaml >= 4.07.
  This module already exists in OCaml < 4.07 but was missing otherwise.
  ocaml-ppx/ppx_deriving#258
  (Kate Deplaix)
