### PR TITLE
Fix some MDX 2.4 revdep failures

### DIFF
--- a/packages/castore/castore.0.0.2/opam
+++ b/packages/castore/castore.0.0.2/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "5.1"}
   "dune" {>= "3.11"}
   "x509" {with-test}
-  "mdx" {with-test}
+  "mdx" {with-test & < "2.4"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_main/eio_main.0.10/opam
+++ b/packages/eio_main/eio_main.0.10/opam
@@ -9,7 +9,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.7"}
-  "mdx" {>= "2.2.0" & with-test}
+  "mdx" {>= "2.2.0" & < "2.4" & with-test}
   "kcas" {>= "0.3.0" & < "0.7.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
   "eio_linux" {= version & os = "linux"}

--- a/packages/eio_main/eio_main.0.11/opam
+++ b/packages/eio_main/eio_main.0.11/opam
@@ -9,7 +9,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.9"}
-  "mdx" {>= "2.2.0" & with-test}
+  "mdx" {>= "2.2.0" & < "2.4" & with-test}
   "kcas" {>= "0.3.0" & < "0.7.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
   "eio_linux" {= version & os = "linux"}

--- a/packages/eio_main/eio_main.0.12/opam
+++ b/packages/eio_main/eio_main.0.12/opam
@@ -9,7 +9,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.9"}
-  "mdx" {>= "2.2.0" & with-test}
+  "mdx" {>= "2.2.0" & < "2.4" & with-test}
   "kcas" {>= "0.3.0" & < "0.7.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
   "eio_linux" {= version & os = "linux"}

--- a/packages/eio_main/eio_main.0.13/opam
+++ b/packages/eio_main/eio_main.0.13/opam
@@ -9,7 +9,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.9"}
-  "mdx" {>= "2.2.0" & with-test}
+  "mdx" {>= "2.2.0" & < "2.4" & with-test}
   "kcas" {>= "0.3.0" & < "0.7.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
   "eio_linux"

--- a/packages/eio_main/eio_main.0.14/opam
+++ b/packages/eio_main/eio_main.0.14/opam
@@ -9,7 +9,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.9"}
-  "mdx" {>= "2.2.0" & with-test}
+  "mdx" {>= "2.2.0" & < "2.4" & with-test}
   "kcas" {>= "0.3.0" & < "0.7.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
   "eio_linux"

--- a/packages/eio_main/eio_main.0.15/opam
+++ b/packages/eio_main/eio_main.0.15/opam
@@ -9,7 +9,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.9"}
-  "mdx" {>= "2.2.0" & with-test}
+  "mdx" {>= "2.2.0" & < "2.4" & with-test}
   "kcas" {>= "0.3.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
   "eio_linux"

--- a/packages/eio_main/eio_main.0.15/opam
+++ b/packages/eio_main/eio_main.0.15/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.9"}
   "mdx" {>= "2.2.0" & < "2.4" & with-test}
-  "kcas" {>= "0.3.0" & with-test}
+  "kcas" {>= "0.3.0" & < "0.7.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
   "eio_linux"
     {= version & os = "linux" &


### PR DESCRIPTION
While investigating possible regressions in dune 3.4.1 I ran into some new failures that I have tracked down to be not caused by dune but rather MDX 2.4.0: #25355 so this PR fixes some of the most obvious ones.