### PR TITLE
Specifying where to find ppl and gmp in the build in case of macOS with homebrew

### DIFF
--- a/packages/conf-ppl/conf-ppl.1/opam
+++ b/packages/conf-ppl/conf-ppl.1/opam
@@ -5,6 +5,7 @@ bug-reports: "http://bugseng.com/products/ppl/bugs"
 license: "GPL-1.0-or-later"
 build: [
   ["sh" "-c"
+	"cc test.c -I${HOMEBREW_PREFIX}/opt/gmp/include -L${HOMEBREW_PREFIX}/opt/gmp/lib -I${HOMEBREW_PREFIX}/opt/ppl/include -L${HOMEBREW_PREFIX}/opt/ppl/lib -lppl_c -lppl" {os = "macos" & os-distribution = "homebrew"}
 	"cc test.c -lppl_c -lppl" {os != "freebsd" & os != "openbsd"}
 	"cc test.c -I/usr/local/include -L/usr/local/lib -lppl_c -lppl" {os = "freebsd" | os = "openbsd"}]
 ]


### PR DESCRIPTION
On my setup, trying to install conf-ppl results on the following error:
```
[ERROR] The compilation of conf-ppl.1 failed at "sh -c cc test.c -lppl_c -lppl".

#=== ERROR while compiling conf-ppl.1 =========================================#
# context     2.1.5 | macos/arm64 | ocaml-base-compiler.4.13.1 | https://opam.ocaml.org#c55e2f61
# path        ~/.opam/4.13.1/.opam-switch/build/conf-ppl.1
# command     ~/.opam/opam-init/hooks/sandbox.sh build sh -c cc test.c -lppl_c -lppl
# exit-code   1
# env-file    ~/.opam/log/conf-ppl-63991-0708ed.env
# output-file ~/.opam/log/conf-ppl-63991-0708ed.out
### output ###
# test.c:1:10: fatal error: 'ppl_c.h' file not found
# #include <ppl_c.h>
#          ^~~~~~~~~
# 1 error generated.



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build conf-ppl 1
+-
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
```

This is an attempt at addressing this issue.