### PR TITLE
ocaml-migrate-parsetree.2.3.0 is a 404 right now

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.3.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.3.0/opam
@@ -34,10 +34,10 @@ rewriters independent of a compiler version.
 """
 url {
   src:
-    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v2.3.0/ocaml-migrate-parsetree-2.3.0.tbz"
+    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/archive/refs/tags/v2.3.0.tar.gz"
   checksum: [
-    "sha256=108126b247f190e04c8afd3d72ced0b63ffdf73c3f801f09be5db0cd7280bf0a"
-    "sha512=cccd766d33e2c70015735e050c2b7cdacf9f046e2874b563ef64b77706f56d004aa9b9df7d5cc201e5f3ba6e3267f95f654e1e3de58891b91f9c28a61988a9ee"
+    "sha256=a1c8f8aba45043034b28f1815ab1067e4f914619fd3ebe51d4eb0a11537f5c7a"
+    "sha512=f2000939eee0b2eac93d059292b0bc13aa809c9fe5e54b1e0bf412e41921647e9bc71ef23e0c6fba70e481891ece5a65763743932c69bf278a1036c437313219"
   ]
 }
 x-commit-hash: "7ef6ff49bfd7d6d816be61d3acea460af25d7d99"


### PR DESCRIPTION
I don't know if it is due to some GitHub fault or some intentional activity somehow, but this link is busted right now.

Use the (equivalent?) github-made tarball.