### PR TITLE
7 packages from framagit.org/zoggy/ocaml-rdf/-/archive/1.0.0/ocaml-rdf-1.0.0.tar.gz

### DIFF
--- a/packages/rdf/rdf.1.0.0/opam
+++ b/packages/rdf/rdf.1.0.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "OCaml library to manipulate RDF graphs; implements SPARQL"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://www.good-eris.net/ocaml-rdf/"
+doc: "https://www.good-eris.net/ocaml-rdf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "dune-build-info" {>= "2.9.1"}
+  "fmt" {>= "0.9.0"}
+  "iri" {>= "1.0.0"}
+  "jsonm" {>= "1.0.2"}
+  "logs" {>= "0.7.0"}
+  "menhir" {>= "20231231"}
+  "pcre" {>= "7.5.0"}
+  "ptime" {>= "1.1.0"}
+  "re" {>= "1.11.0"}
+  "sedlex" {>= "3.2"}
+  "uri" {>= "4.4.0"}
+  "uucp" {>= "15.1.0"}
+  "uuidm" {>= "0.9.8"}
+  "uutf" {>= "1.0.3"}
+  "xmlm" {>= "1.4.0"}
+  "yojson" {>= "2.1.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-rdf.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-rdf/-/archive/1.0.0/ocaml-rdf-1.0.0.tar.gz"
+  checksum: [
+    "md5=43ce517489f775e6b65fcdef5e713e74"
+    "sha512=6130e46d186ca4abf0c44a35ab040f696f8b4d10fd16db9212e8280500f8263626f0ab8d53479b926924b41e45ae4793251727de725c03c409052a96ad2d40bd"
+  ]
+}

--- a/packages/rdf_impls/rdf_impls.1.0.0/opam
+++ b/packages/rdf_impls/rdf_impls.1.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "C implementations (using Cyrptokit and Pcre) of functions used by Rdf"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://www.good-eris.net/ocaml-rdf/"
+doc: "https://www.good-eris.net/ocaml-rdf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "rdf" {= version}
+  "cryptokit" {>= "1.19"}
+  "pcre" {>= "7.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-rdf.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-rdf/-/archive/1.0.0/ocaml-rdf-1.0.0.tar.gz"
+  checksum: [
+    "md5=43ce517489f775e6b65fcdef5e713e74"
+    "sha512=6130e46d186ca4abf0c44a35ab040f696f8b4d10fd16db9212e8280500f8263626f0ab8d53479b926924b41e45ae4793251727de725c03c409052a96ad2d40bd"
+  ]
+}

--- a/packages/rdf_json_ld/rdf_json_ld.1.0.0/opam
+++ b/packages/rdf_json_ld/rdf_json_ld.1.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Json-ld"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://www.good-eris.net/ocaml-rdf/"
+doc: "https://www.good-eris.net/ocaml-rdf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "rdf" {= version}
+  "cohttp-lwt-unix" {>= "5.3.0"}
+  "jsonm" {>= "1.0.2"}
+  "lwt" {>= "5.7.0"}
+  "lwt_ppx" {>= "2.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-rdf.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-rdf/-/archive/1.0.0/ocaml-rdf-1.0.0.tar.gz"
+  checksum: [
+    "md5=43ce517489f775e6b65fcdef5e713e74"
+    "sha512=6130e46d186ca4abf0c44a35ab040f696f8b4d10fd16db9212e8280500f8263626f0ab8d53479b926924b41e45ae4793251727de725c03c409052a96ad2d40bd"
+  ]
+}

--- a/packages/rdf_lwt/rdf_lwt.1.0.0/opam
+++ b/packages/rdf_lwt/rdf_lwt.1.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Sparql HTTP with Lwt"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://www.good-eris.net/ocaml-rdf/"
+doc: "https://www.good-eris.net/ocaml-rdf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "rdf" {= version}
+  "cohttp-lwt-unix" {>= "5.3.0"}
+  "lwt" {>= "5.7.0"}
+  "lwt_ppx" {>= "2.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-rdf.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-rdf/-/archive/1.0.0/ocaml-rdf-1.0.0.tar.gz"
+  checksum: [
+    "md5=43ce517489f775e6b65fcdef5e713e74"
+    "sha512=6130e46d186ca4abf0c44a35ab040f696f8b4d10fd16db9212e8280500f8263626f0ab8d53479b926924b41e45ae4793251727de725c03c409052a96ad2d40bd"
+  ]
+}

--- a/packages/rdf_mysql/rdf_mysql.1.0.0/opam
+++ b/packages/rdf_mysql/rdf_mysql.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Mysql backend for rdf"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://www.good-eris.net/ocaml-rdf/"
+doc: "https://www.good-eris.net/ocaml-rdf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "rdf" {= version}
+  "mysql" {>= "1.2.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-rdf.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-rdf/-/archive/1.0.0/ocaml-rdf-1.0.0.tar.gz"
+  checksum: [
+    "md5=43ce517489f775e6b65fcdef5e713e74"
+    "sha512=6130e46d186ca4abf0c44a35ab040f696f8b4d10fd16db9212e8280500f8263626f0ab8d53479b926924b41e45ae4793251727de725c03c409052a96ad2d40bd"
+  ]
+}

--- a/packages/rdf_postgresql/rdf_postgresql.1.0.0/opam
+++ b/packages/rdf_postgresql/rdf_postgresql.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Postgresql backend for rdf"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://www.good-eris.net/ocaml-rdf/"
+doc: "https://www.good-eris.net/ocaml-rdf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "rdf" {= version}
+  "postgresql" {>= "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-rdf.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-rdf/-/archive/1.0.0/ocaml-rdf-1.0.0.tar.gz"
+  checksum: [
+    "md5=43ce517489f775e6b65fcdef5e713e74"
+    "sha512=6130e46d186ca4abf0c44a35ab040f696f8b4d10fd16db9212e8280500f8263626f0ab8d53479b926924b41e45ae4793251727de725c03c409052a96ad2d40bd"
+  ]
+}

--- a/packages/rdf_ppx/rdf_ppx.1.0.0/opam
+++ b/packages/rdf_ppx/rdf_ppx.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Syntax extension for rdf"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://www.good-eris.net/ocaml-rdf/"
+doc: "https://www.good-eris.net/ocaml-rdf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "rdf" {= version}
+  "ppxlib" {>= "0.32.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-rdf.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-rdf/-/archive/1.0.0/ocaml-rdf-1.0.0.tar.gz"
+  checksum: [
+    "md5=43ce517489f775e6b65fcdef5e713e74"
+    "sha512=6130e46d186ca4abf0c44a35ab040f696f8b4d10fd16db9212e8280500f8263626f0ab8d53479b926924b41e45ae4793251727de725c03c409052a96ad2d40bd"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `rdf.1.0.0`: OCaml library to manipulate RDF graphs; implements SPARQL
- `rdf_impls.1.0.0`: C implementations (using Cyrptokit and Pcre) of functions
  used by Rdf
- `rdf_json_ld.1.0.0`: Json-ld
- `rdf_lwt.1.0.0`: Sparql HTTP with Lwt
- `rdf_mysql.1.0.0`: Mysql backend for rdf
- `rdf_postgresql.1.0.0`: Postgresql backend for rdf
- `rdf_ppx.1.0.0`: Syntax extension for rdf



---
* Homepage: https://www.good-eris.net/ocaml-rdf/
* Source repo: git+https://framagit.org/zoggy/ocaml-rdf.git
* Bug tracker: https://framagit.org/zoggy/ocaml-rdf/issues

---
:camel: Pull-request generated by opam-publish v2.3.0