### PR TITLE
lablgl: Add dependency on camlp5

### DIFF
--- a/packages/lablgl/lablgl.1.06/opam
+++ b/packages/lablgl/lablgl.1.06/opam
@@ -22,6 +22,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.03" & < "5.0"}
+  "camlp5"
 ]
 depexts: [
   ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]

--- a/packages/lablgl/lablgl.1.06/opam
+++ b/packages/lablgl/lablgl.1.06/opam
@@ -30,7 +30,10 @@ depexts: [
   ["freeglut-dev"] {os-distribution = "alpine"}
   ["freeglut-devel"] {os-distribution = "centos"}
   ["freeglut-devel"] {os-distribution = "fedora"}
+  ["freeglut-devel"] {os-distribution = "oraclelinux"}
   ["freeglut-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["freeglut"] {os-family = "arch"}
+  ["freeglut"] {os = "freebsd"}
 ]
 synopsis: "Interface to OpenGL"
 description: """

--- a/packages/lablgl/lablgl.1.06/opam
+++ b/packages/lablgl/lablgl.1.06/opam
@@ -32,7 +32,7 @@ depexts: [
   ["freeglut-devel"] {os-distribution = "fedora"}
   ["freeglut-devel"] {os-distribution = "oraclelinux"}
   ["freeglut-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["freeglut"] {os-family = "arch"}
+  ["freeglut" "libgl"] {os-family = "arch"}
   ["freeglut"] {os = "freebsd"}
 ]
 synopsis: "Interface to OpenGL"

--- a/packages/lablgl/lablgl.1.07/opam
+++ b/packages/lablgl/lablgl.1.07/opam
@@ -32,7 +32,10 @@ depexts: [
   ["freeglut-dev"] {os-distribution = "alpine"}
   ["freeglut-devel"] {os-distribution = "centos"}
   ["freeglut-devel"] {os-distribution = "fedora"}
+  ["freeglut-devel"] {os-distribution = "oraclelinux"}
   ["freeglut-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["freeglut"] {os-family = "arch"}
+  ["freeglut"] {os = "freebsd"}
 ]
 synopsis: "Interface to OpenGL"
 description: """

--- a/packages/lablgl/lablgl.1.07/opam
+++ b/packages/lablgl/lablgl.1.07/opam
@@ -34,7 +34,7 @@ depexts: [
   ["freeglut-devel"] {os-distribution = "fedora"}
   ["freeglut-devel"] {os-distribution = "oraclelinux"}
   ["freeglut-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["freeglut"] {os-family = "arch"}
+  ["freeglut" "libgl"] {os-family = "arch"}
   ["freeglut"] {os = "freebsd"}
 ]
 synopsis: "Interface to OpenGL"


### PR DESCRIPTION
Currently FTBFS with

    cd src && make all LIBDIR="`ocamlc -where`"
    make[1]: Entering directory '/home/opam/.opam/4.14/.opam-switch/build/lablgl.1.06/src'
    camlp5o pr_o.cmo -impl var2def.ml4 -o var2def.ml
    make[1]: camlp5o: No such file or directory
    make[1]: *** [../Makefile.common:64: var2def.ml] Error 127
    make[1]: Leaving directory '/home/opam/.opam/4.14/.opam-switch/build/lablgl.1.06/src'
    make: *** [Makefile:12: lib] Error 2

CI log: https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/c1d400d20b9fda73fd4e9cdc25a502d21b1ea7f1/variant/compilers,4.14,dune-configurator.3.14.2,revdeps,lablgl.1.06