### PR TITLE
Add missing conf-c++ dependencies to mccs

### DIFF
--- a/packages/mccs/mccs.1.1+10/opam
+++ b/packages/mccs/mccs.1.1+10/opam
@@ -10,8 +10,9 @@ license: ["LGPL-2.1-only WITH OCaml-LGPL-linking-exception" "BSD-3-Clause" "GPL-
 dev-repo: "git+https://github.com/AltGr/ocaml-mccs.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["sh" "-c" "dune build @settests --auto-promote --profile=release || true"] {with-test}
-  ["dune" "runtest" "--profile=release"] {with-test}
+  # Tests fail on these platforms without ocaml-opam/ocaml-mccs#50 in 1.1+17
+  ["sh" "-c" "dune build @settests --auto-promote --profile=release || true"] {with-test & os != "freebsd" & os != "macos"}
+  ["dune" "runtest" "--profile=release"] {with-test & os != "freebsd" & os != "macos"}
 ]
 depends: [
   "ocaml" {< "4.10"}

--- a/packages/mccs/mccs.1.1+11/opam
+++ b/packages/mccs/mccs.1.1+11/opam
@@ -10,8 +10,9 @@ license: ["LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception" "BSD-3-Clause" "
 dev-repo: "git+https://github.com/AltGr/ocaml-mccs.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["sh" "-c" "dune build @settests --auto-promote --profile=release || true"] {with-test}
-  ["dune" "runtest" "--profile=release"] {with-test}
+  # Tests fail on these platforms without ocaml-opam/ocaml-mccs#50 in 1.1+17
+  ["sh" "-c" "dune build @settests --auto-promote --profile=release || true"] {with-test & os != "freebsd" & os != "macos"}
+  ["dune" "runtest" "--profile=release"] {with-test & os != "freebsd" & os != "macos"}
 ]
 depends: [
   "ocaml"

--- a/packages/mccs/mccs.1.1+12/opam
+++ b/packages/mccs/mccs.1.1+12/opam
@@ -10,8 +10,9 @@ license: ["LGPL-2.1-only WITH OCaml-LGPL-linking-exception" "BSD-3-clause" "GPL-
 dev-repo: "git+https://github.com/AltGr/ocaml-mccs.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["sh" "-c" "dune build --profile=release @settests --auto-promote || true"] {with-test}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  # Tests fail on these platforms without ocaml-opam/ocaml-mccs#50 in 1.1+17
+  ["sh" "-c" "dune build --profile=release @settests --auto-promote || true"] {with-test & os != "freebsd" & os != "macos"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "freebsd" & os != "macos"}
 ]
 depends: [
   "ocaml"

--- a/packages/mccs/mccs.1.1+13/opam
+++ b/packages/mccs/mccs.1.1+13/opam
@@ -10,8 +10,9 @@ license: ["LGPL-2.1-only WITH OCaml-LGPL-linking-exception" "BSD-3-clause" "GPL-
 dev-repo: "git+https://github.com/AltGr/ocaml-mccs.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["sh" "-c" "dune build @settests --auto-promote || true"] {with-test}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  # Tests fail on these platforms without ocaml-opam/ocaml-mccs#50 in 1.1+17
+  ["sh" "-c" "dune build @settests --auto-promote || true"] {with-test & os != "freebsd" & os != "macos"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "freebsd" & os != "macos"}
 ]
 depends: [
   "ocaml"

--- a/packages/mccs/mccs.1.1+14/opam
+++ b/packages/mccs/mccs.1.1+14/opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml"
   "dune" {>= "1.0"}
   "cudf" {>= "0.7"}
+  "conf-c++" {build}
 ]
 synopsis: "MCCS (which stands for Multi Criteria CUDF Solver) is a CUDF problem solver
 developed at UNS during the European MANCOOSI project"

--- a/packages/mccs/mccs.1.1+14/opam
+++ b/packages/mccs/mccs.1.1+14/opam
@@ -10,8 +10,9 @@ license: ["LGPL-2.1-only WITH OCaml-LGPL-linking-exception" "BSD-3-clause" "GPL-
 dev-repo: "git+https://github.com/AltGr/ocaml-mccs.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["sh" "-c" "dune build @settests --auto-promote || true"] {with-test}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  # Tests fail on these platforms without ocaml-opam/ocaml-mccs#50 in 1.1+17
+  ["sh" "-c" "dune build @settests --auto-promote || true"] {with-test & os != "freebsd" & os != "macos"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "freebsd" & os != "macos"}
 ]
 depends: [
   "ocaml"

--- a/packages/mccs/mccs.1.1+16/opam
+++ b/packages/mccs/mccs.1.1+16/opam
@@ -18,6 +18,7 @@ depends: [
   "ocaml"
   "dune" {>= "1.0"}
   "cudf" {>= "0.7"}
+  "conf-c++" {build}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/mccs/mccs.1.1+16/opam
+++ b/packages/mccs/mccs.1.1+16/opam
@@ -22,8 +22,9 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["sh" "-c" "dune build @settests --auto-promote || true"] {with-test}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  # Tests fail on these platforms without ocaml-opam/ocaml-mccs#50 in 1.1+17
+  ["sh" "-c" "dune build @settests --auto-promote || true"] {with-test & os != "freebsd" & os != "macos"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "freebsd" & os != "macos"}
 ]
 dev-repo: "git+https://github.com/ocaml-opam/ocaml-mccs.git"
 url {

--- a/packages/mccs/mccs.1.1+17/opam
+++ b/packages/mccs/mccs.1.1+17/opam
@@ -18,6 +18,7 @@ depends: [
   "ocaml"
   "dune" {>= "1.0"}
   "cudf" {>= "0.7"}
+  "conf-c++" {build}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/mccs/mccs.1.1+8/opam
+++ b/packages/mccs/mccs.1.1+8/opam
@@ -10,8 +10,9 @@ license: ["LGPL-2.1-only WITH OCaml-LGPL-linking-exception" "BSD-3-Clause" "GPL-
 dev-repo: "git+https://github.com/AltGr/ocaml-mccs.git"
 build: [
   ["dune" "build" "-p" name]
-  ["sh" "-c" "dune build @settests --auto-promote || true"] {with-test}
-  ["dune" "runtest"] {with-test}
+  # Tests fail on these platforms without ocaml-opam/ocaml-mccs#50 in 1.1+17
+  ["sh" "-c" "dune build @settests --auto-promote || true"] {with-test & os != "freebsd" & os != "macos"}
+  ["dune" "runtest"] {with-test & os != "freebsd" & os != "macos"}
 ]
 depends: [
   "ocaml" {< "4.10"}

--- a/packages/mccs/mccs.1.1+9/opam
+++ b/packages/mccs/mccs.1.1+9/opam
@@ -16,8 +16,9 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name]
-  ["sh" "-c" "dune build @settests --auto-promote || true"] {with-test}
-  ["dune" "runtest"] {with-test}
+  # Tests fail on these platforms without ocaml-opam/ocaml-mccs#50 in 1.1+17
+  ["sh" "-c" "dune build @settests --auto-promote || true"] {with-test & os != "freebsd" & os != "macos"}
+  ["dune" "runtest"] {with-test & os != "freebsd" & os != "macos"}
 ]
 dev-repo: "git+https://github.com/AltGr/ocaml-mccs.git"
 url {


### PR DESCRIPTION
#19829 added the `conf-c++` dependency to the mccs packages, but as it wasn't upstreamed back to the source repo, the releases since then have missed it. I've upstreamed it in https://github.com/ocaml-opam/ocaml-mccs/pull/52 and here are the updates to the 3 packages which are missing it.