### PR TITLE
Package qiskit.1.0.2

### DIFF
--- a/packages/qiskit/qiskit.1.0.2/opam
+++ b/packages/qiskit/qiskit.1.0.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Qiskit for OCaml"
+description: """
+An OCaml wrapper for the Qiskit quantum computing toolkit
+"""
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: [
+  "Davide Gessa <gessadavide@gmail.com>"
+]
+
+homepage: "https://github.com/dakk/caml_qiskit"
+bug-reports: "https://github.com/dakk/caml_qiskit/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/dakk/caml_qiskit.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  
+  "dune" {>= "3.10.0"}
+  "pyml" {>= "20220905"}
+
+  "ounit" {with-test & >= "2.2.7"}
+
+  "odoc" {dev & >= "2.2.1"}
+  "bisect_ppx" {dev & >= "2.8.3"}
+]
+url {
+  src: "https://github.com/dakk/caml_qiskit/archive/refs/tags/v1.0.2.tar.gz"
+  checksum: [
+    "md5=4830377982b2b6a87fa9445e015e6747"
+    "sha512=485978cf181b74592f2adfb0be1f8af142c3f5ad7355226540c11ddf010cb9f57d7eda705f87edfd7e86d1a0d3ec43def91dc7324caa62ff17c1b4cebf8b03e8"
+  ]
+}


### PR DESCRIPTION
### `qiskit.1.0.2`
Qiskit for OCaml
An OCaml wrapper for the Qiskit quantum computing toolkit



---
* Homepage: https://github.com/dakk/caml_qiskit
* Source repo: git+https://github.com/dakk/caml_qiskit.git
* Bug tracker: https://github.com/dakk/caml_qiskit/issues

---
:camel: Pull-request generated by opam-publish v2.2.0