### PR TITLE
iri: change archive urls to be more stable

### DIFF
--- a/packages/iri/iri.0.1.0/opam
+++ b/packages/iri/iri.0.1.0/opam
@@ -29,6 +29,6 @@ This implementation does not depend on regular expression library. Is is impleme
 Sedlex, thus it will be usable in Javascript (with Js_of_ocaml)."""
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/ocaml-iri/-/archive/0.1.0/ocaml-iri-0.1.0.tar.gz"
+  src: "https://zoggy.frama.io/ocaml-iri/releases/ocaml-iri-0.1.0.tar.gz"
   checksum: "md5=d345a473366c0ce29199188908d711f6"
 }

--- a/packages/iri/iri.0.2.0/opam
+++ b/packages/iri/iri.0.2.0/opam
@@ -29,6 +29,6 @@ This implementation does not depend on regular expression library. Is is impleme
 Sedlex, thus it will be usable in Javascript (with Js_of_ocaml)."""
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/ocaml-iri/-/archive/0.2.0/ocaml-iri-0.2.0.tar.gz"
+  src: "https://zoggy.frama.io/ocaml-iri/releases/ocaml-iri-0.2.0.tar.gz"
   checksum: "md5=633d0e7f23609ce61bdf3804380133d8"
 }

--- a/packages/iri/iri.0.3.0/opam
+++ b/packages/iri/iri.0.3.0/opam
@@ -28,6 +28,6 @@ extra-files: [
   "ocaml-before.4.03.0.patch" "md5=f1d93a26710029c3b0f105221e8a51fe"
 ]
 url {
-  src: "https://framagit.org/zoggy/ocaml-iri/-/archive/0.3.0/ocaml-iri-0.3.0.tar.gz"
+  src: "https://zoggy.frama.io/ocaml-iri/releases/ocaml-iri-0.3.0.tar.gz"
   checksum: "md5=47d0ccc536971d149aff32acf89d2b0e"
 }

--- a/packages/iri/iri.0.4.0/opam
+++ b/packages/iri/iri.0.4.0/opam
@@ -24,6 +24,6 @@ This implementation does not depend on regular expression library. Is is impleme
 Sedlex, thus it will be usable in Javascript (with Js_of_ocaml)."""
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/ocaml-iri/-/archive/0.4.0/ocaml-iri-0.4.0.tar.gz"
+  src: "https://zoggy.frama.io/ocaml-iri/releases/ocaml-iri-0.4.0.tar.gz"
   checksum: "md5=ec34f9a8d1ee28130bed89ea486cf168"
 }

--- a/packages/iri/iri.0.5.0/opam
+++ b/packages/iri/iri.0.5.0/opam
@@ -17,7 +17,7 @@ build: [make "all"]
 install: [make "install"]
 dev-repo: "git+https://framagit.org/zoggy/ocaml-iri.git"
 url {
-  src: "https://framagit.org/zoggy/ocaml-iri/-/archive/0.5.0/ocaml-iri-0.5.0.tar.gz"
+  src: "https://zoggy.frama.io/ocaml-iri/releases/ocaml-iri-0.5.0.tar.gz"
   checksum: [
     "md5=8a1c5d07a47938970facae11a7367aa5"
     "sha512=bbd2a5025b3c9d15a7e35c2d59737236acdc0b4b59dc33db0479945c0458add1d7e3e8deea7dab907525639925ffea95fb602f6965daf91c342317ca7dd102e4"

--- a/packages/iri/iri.0.6.0/opam
+++ b/packages/iri/iri.0.6.0/opam
@@ -34,7 +34,7 @@ build: [
 dev-repo: "git+https://framagit.org/zoggy/ocaml-iri.git"
 url {
   src:
-    "https://framagit.org/zoggy/ocaml-iri/-/archive/0.6.0/ocaml-iri-0.6.0.tar.bz2"
+    "https://zoggy.frama.io/ocaml-iri/releases/ocaml-iri-0.6.0.tar.bz2"
   checksum: [
     "md5=40574cd88a7fc984adae1839fedb2b10"
     "sha512=91cccd28a7e051ab4b8842f8dba6db2b7784e15d3f15c9d97ff64aefc40fce5d51b90b7ad996341da8b1f027ddff06e7c13e8d663c93fda864b2992447bf7454"

--- a/packages/iri/iri.0.7.0/opam
+++ b/packages/iri/iri.0.7.0/opam
@@ -34,7 +34,7 @@ build: [
 dev-repo: "git+https://framagit.org/zoggy/ocaml-iri.git"
 url {
   src:
-    "https://framagit.org/zoggy/ocaml-iri/-/archive/0.7.0/ocaml-iri-0.7.0.tar.bz2"
+    "https://zoggy.frama.io/ocaml-iri/releases/ocaml-iri-0.7.0.tar.bz2"
   checksum: [
     "md5=c6f5b156c6ffa182d4fbf248578da320"
     "sha512=21f7d3766d1dab912b4115a9da578dc9fafb5191a25bc3e31940f1b0709caf8cdb652de812feed692a87e431b950013f007232170496b6d4f1834bd737b50994"

--- a/packages/iri/iri.1.0.0/opam
+++ b/packages/iri/iri.1.0.0/opam
@@ -34,7 +34,7 @@ build: [
 dev-repo: "git+https://framagit.org/zoggy/ocaml-iri.git"
 url {
   src:
-    "https://framagit.org/zoggy/ocaml-iri/-/archive/1.0.0/ocaml-iri-1.0.0.tar.bz2"
+    "https://zoggy.frama.io/ocaml-iri/releases/ocaml-iri-1.0.0.tar.bz2"
   checksum: [
     "md5=6ce4f0992e9f029e461af19fb232d50b"
     "sha512=dad58975f1f601a56c113c5646a7b3c29ae5eb1c505e17c6120f492634d867d961f3f5cda8198b6e2a3cd84d23b04e4d230683a325c3935da1655c129a328eee"


### PR DESCRIPTION
Urls now points to real archives, no on-the-fly export from gitlab.