### PR TITLE
[new release] icalendar (0.1.8)

### DIFF
--- a/packages/icalendar/icalendar.0.1.8/opam
+++ b/packages/icalendar/icalendar.0.1.8/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/robur-coop/icalendar"
+bug-reports: "https://github.com/robur-coop/icalendar/issues"
+dev-repo: "git+https://github.com/robur-coop/icalendar.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://robur-coop.github.io/icalendar/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.3"}
+  "alcotest" {with-test}
+  "fmt"
+  "angstrom" {>= "0.14.0"}
+  "re" {>= "1.7.2"}
+  "uri"
+  "ptime"
+  "ppx_deriving"
+  "gmap" {>= "0.3.0"}
+]
+
+synopsis: "A library to parse and print the iCalendar (RFC 5545) format"
+description: """
+Parse and print .ics files as specified in RFC 5545.
+Supports recurrent events, but only to the day level of detail.
+Does not support vJournal components.
+"""
+url {
+  src:
+    "https://github.com/robur-coop/icalendar/releases/download/v0.1.8/icalendar-0.1.8.tbz"
+  checksum: [
+    "sha256=6fea0a85b667d51c9b69a613d0c3f19e744c4bbef3a7165cfead273a94cf16c3"
+    "sha512=2aaf4e9067fb2cc5f4f03263a43f0fd1396b54c4458e0ac7dedcbdead04a920aaae424e5da3141b3ba3286b7b476afd1c88746f0b64bed6f53f316dcf1328420"
+  ]
+}
+x-commit-hash: "2d1ea877d5f67a3922e5994cca886fde66569152"


### PR DESCRIPTION
A library to parse and print the iCalendar (RFC 5545) format

- Project page: <a href="https://github.com/robur-coop/icalendar">https://github.com/robur-coop/icalendar</a>
- Documentation: <a href="https://robur-coop.github.io/icalendar/">https://robur-coop.github.io/icalendar/</a>

##### CHANGES:

* BUGFIX: exception dates are now comma-separated (reported robur-coop/icalendar#9, fixed robur-coop/icalendar#10 by
  @monomon)
