### PR TITLE
[new release] asn1-combinators (0.3.0)

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.3.0/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.3.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+authors: "David Kaloper Meršinjak"
+maintainer: "David Kaloper Meršinjak <dk505@cam.ac.uk>"
+homepage: "https://github.com/mirleft/ocaml-asn1-combinators"
+doc: "https://mirleft.github.io/ocaml-asn1-combinators/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/mirleft/ocaml-asn1-combinators.git"
+bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
+synopsis: "Embed typed ASN.1 grammars in OCaml"
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+depends: [
+  "ocaml" {>="4.08.0"}
+  "dune" {>= "1.2.0"}
+  "ptime" {>= "0.8.6"}
+  "alcotest" {with-test & >= "0.8.1"}
+]
+description: """
+asn1-combinators is a library for expressing ASN.1 in OCaml. Skip the notation
+part of ASN.1, and embed the abstract syntax directly in the language. These
+abstract syntax representations can be used for parsing, serialization, or
+random testing.
+
+The only ASN.1 encodings currently supported are BER and DER.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.3.0/asn1-combinators-0.3.0.tbz"
+  checksum: [
+    "sha256=da8bedd169db56a106543b16a80cf94c81c1671549faa40557ae6c0fda359044"
+    "sha512=adebc412aeeda855d2a478eed53e0902e04dc8cb2e067241feaa479624b171b798faba55bb7c718ede002fa786ea19d9cf65d5576b451062528c996b9e31b573"
+  ]
+}
+x-commit-hash: "df4ad9e454d53412bb3988c1f7051d29bf7b30f3"


### PR DESCRIPTION
Embed typed ASN.1 grammars in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-asn1-combinators">https://github.com/mirleft/ocaml-asn1-combinators</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-asn1-combinators/doc">https://mirleft.github.io/ocaml-asn1-combinators/doc</a>

##### CHANGES:

* BUGFIX: utctime 50 should be 1950 (not 2050) (mirleft/ocaml-asn1-combinators#39 @reynir)
* drop zarith dependency, Asn.S.integer is now a Cstruct.t (mirleft/ocaml-asn1-combinators#42 @hannesm)
* drop cstruct dependency, use string instead (mirleft/ocaml-asn1-combinators#43 @hannesm)
  this changes the allocation discipline, and while benchmarking the decoding
  of certificates takes less time now, there may be performance differences
  (since now String.sub is used which allocates and copies data)
