### PR TITLE
Tentative fix for conf-{antic,arb,calcium,flint} on arch-linux

### DIFF
--- a/packages/conf-antic/conf-antic.1/opam
+++ b/packages/conf-antic/conf-antic.1/opam
@@ -5,8 +5,10 @@ homepage: "https://github.com/flintlib/antic.git"
 bug-reports: "https://github.com/flintlib/antic.git"
 license: "LGPL-2.1-only"
 build: [
-  ["sh" "-exc" "echo \"#include  \\\"antic/qfb.h\\\"\" > test.c"]
-  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "macos" & os != "win32"}
+  ["sh" "-exc" "echo \"#include  \\\"qfb.h\\\"\" > test.c"] {os-distribution = "arch"}
+  ["sh" "-exc" "echo \"#include  \\\"antic/qfb.h\\\"\" > test.c"] {os-distribution != "arch"}
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/include/flint test.c"] {os != "macos" & os != "win32" & os-distribution = "arch"}
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "macos" & os != "win32" & os-distribution != "arch"}
   [
 		"sh"
 		"-exc"
@@ -28,6 +30,7 @@ depexts: [
   ["antic-devel"] {os-family = "suse"}
   ["antic"] {os-distribution = "nixos"}
   ["antic"] {os = "freebsd"}
+  ["flint"] {os-distribution = "arch"}
 ]
 synopsis: "Virtual package relying on a Antic lib system installation"
 description:

--- a/packages/conf-arb/conf-arb.1/opam
+++ b/packages/conf-arb/conf-arb.1/opam
@@ -5,7 +5,8 @@ bug-reports: "https://github.com/fredrik-johansson/arb"
 license: "LGPL-2.1-only"
 build: [
   ["sh" "-exc" "echo \"#include  \\\"arb.h\\\"\" > test.c"]
-  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "macos" & os != "win32"}
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/include/flint test.c"] {os != "macos" & os != "win33" & os-distribution = "arch"}
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "macos" & os != "win32" & os-distribution != "arch"}
   [
 		"sh"
 		"-exc"
@@ -28,6 +29,7 @@ depexts: [
   ["arb-devel"] {os-family = "suse"}
   ["arb"] {os-distribution = "nixos"}
   ["arb"] {os = "freebsd"}
+  ["flint"] {os-distribution = "arch"}
 ]
 synopsis: "Virtual package relying on a Arb lib system installation"
 description:

--- a/packages/conf-calcium/conf-calcium.1/opam
+++ b/packages/conf-calcium/conf-calcium.1/opam
@@ -5,8 +5,10 @@ homepage: "https://fredrikj.net/calcium/"
 bug-reports: "https://github.com/fredrik-johansson/calcium"
 license: "LGPL-2.1-only"
 build: [
-  ["sh" "-exc" "echo \"#include  \\\"calcium/calcium.h\\\"\" > test.c"]
-  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "macos" & os != "win32"}
+  ["sh" "-exc" "echo \"#include  \\\"calcium.h\\\"\" > test.c"] {os-distribution = "arch"}
+  ["sh" "-exc" "echo \"#include  \\\"calcium/calcium.h\\\"\" > test.c"] {os-distribution != "arch"}
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/include/flint test.c"] {os != "macos" & os != "win32" & os-distribution = "arch"}
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "macos" & os != "win32" & os-distribution != "arch"}
   [
 		"sh"
 		"-exc"
@@ -30,6 +32,7 @@ depexts: [
   ["calcium" "calcium-devel"] {os-distribution = "ol"}
   ["calcium-devel"] {os-family = "suse"}
   ["calcium"] {os-distribution = "nixos"}
+  ["flint"] {os-distribution = "arch"}
 ]
 synopsis: "Virtual package relying on a Calcium lib system installation"
 description:

--- a/packages/conf-flint/conf-flint.1/opam
+++ b/packages/conf-flint/conf-flint.1/opam
@@ -4,8 +4,10 @@ homepage: "http://flint.org"
 bug-reports: "https://github.com/flintlib/flint2.git"
 license: "LGPL-2.1-only"
 build: [
-  ["sh" "-exc" "echo \"#include  \\\"flint/fmpz_poly.h\\\"\" > test.c"]
-  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "macos" & os != "win32"}
+  ["sh" "-exc" "echo \"#include  \\\"fmpz_poly.h\\\"\" > test.c"] {os-distribution = "arch"}
+  ["sh" "-exc" "echo \"#include  \\\"flint/fmpz_poly.h\\\"\" > test.c"] {os-distribution != "arch"}
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/include/flint test.c"] {os != "macos" & os != "win32" & os-distribution = "arch"}
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "macos" & os != "win32" & os-distribution != "arch"}
   [
 		"sh"
 		"-exc"
@@ -30,6 +32,7 @@ depexts: [
   ["libflint-devel"] {os = "win32" & os-distribution = "cygwinports"}
   ["flint"] {os-distribution = "nixos"}
   ["flint2"] {os = "freebsd"}
+  ["flint"] {os-distribution = "arch"}
 ]
 synopsis: "Virtual package relying on a Flint lib system installation"
 description:


### PR DESCRIPTION
Flint version 3 incorporates `arb`, `antic`, and `calcium` (and is now the released version on Arch Linux), so we have to change the build commands for `arch`.

This solution is a bit hackish as it simply adds additional commands and constraints for `os-distribution="arch"`. Perhaps we could have only one `test.c` file and echo only the basename of the include file. But then, we would need to specify the correct include path for each `os`, and I'm unable to test this on platforms other than Linux, so I cannot do this.