### PR TITLE
Create `conf-*` packages for OpenGL related system libraries

### DIFF
--- a/packages/conf-freeglut/conf-freeglut.1/opam
+++ b/packages/conf-freeglut/conf-freeglut.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Marek Kubica <marek@xivilization.net>"
+authors: ["Pawel W. Olszta" "Andreas Umbach" "Steve Baker" "John F. Fay" "John Tsiombikas" "Diederick C. Niehorster"]
+homepage: "https://freeglut.sourceforge.net/"
+license: "X11"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+build: [
+  ["pkg-config" "--exists" "freeglut"]
+]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  ["freeglut3-dev"] {os-family = "debian"}
+  ["freeglut-dev"] {os-distribution = "alpine"}
+  ["freeglut-devel"] {os-distribution = "centos"}
+  ["freeglut-devel"] {os-distribution = "fedora"}
+  ["freeglut-devel"] {os-distribution = "oraclelinux"}
+  ["freeglut-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["freeglut"] {os-family = "arch"}
+  ["freeglut"] {os = "freebsd"}
+]
+synopsis: "Virtual package relying on a FreeGLUT system installation"
+flags: conf

--- a/packages/conf-freeglut/conf-freeglut.1/opam
+++ b/packages/conf-freeglut/conf-freeglut.1/opam
@@ -5,7 +5,7 @@ homepage: "https://freeglut.sourceforge.net/"
 license: "X11"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
-  ["pkg-config" "--exists" "freeglut"]
+  ["pkg-config" "--exists" "glut"]
 ]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-freeglut/conf-freeglut.1/opam
+++ b/packages/conf-freeglut/conf-freeglut.1/opam
@@ -5,10 +5,10 @@ homepage: "https://freeglut.sourceforge.net/"
 license: "X11"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
-  ["pkg-config" "--exists" "glut"] {os-distribution != "debian" & os-distribution != "ubuntu" & os-distribution != "ol"}
+  ["pkg-config" "--exists" "glut"] {os-distribution != "debian" & os-distribution != "ubuntu"}
 ]
 depends: [
-  "conf-pkg-config" {build & os-distribution != "debian" & os-distribution != "ubuntu" & os-distribution != "ol"}
+  "conf-pkg-config" {build & os-distribution != "debian" & os-distribution != "ubuntu"}
 ]
 depexts: [
   ["freeglut3-dev"] {os-family = "debian" | os-family = "ubuntu"}

--- a/packages/conf-freeglut/conf-freeglut.1/opam
+++ b/packages/conf-freeglut/conf-freeglut.1/opam
@@ -5,15 +5,15 @@ homepage: "https://freeglut.sourceforge.net/"
 license: "X11"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
-  ["pkg-config" "--exists" "glut"] {os-distribution != "debian" & os-distribution != "ubuntu" & os-distribution != "oraclelinux"}
+  ["pkg-config" "--exists" "glut"] {os-distribution != "debian" & os-distribution != "ubuntu" & os-distribution != "ol"}
 ]
 depends: [
-  "conf-pkg-config" {build & os-distribution != "debian" & os-distribution != "ubuntu" & os-distribution != "oraclelinux"}
+  "conf-pkg-config" {build & os-distribution != "debian" & os-distribution != "ubuntu" & os-distribution != "ol"}
 ]
 depexts: [
   ["freeglut3-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["freeglut-dev"] {os-distribution = "alpine"}
-  ["freeglut-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "oraclelinux"}
+  ["freeglut-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
   ["freeglut-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["freeglut"] {os-family = "arch"}
   ["freeglut"] {os = "freebsd"}

--- a/packages/conf-freeglut/conf-freeglut.1/opam
+++ b/packages/conf-freeglut/conf-freeglut.1/opam
@@ -11,12 +11,9 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["freeglut3-dev"] {os-family = "debian"}
-  ["freeglut3-dev"] {os-family = "ubuntu"}
+  ["freeglut3-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["freeglut-dev"] {os-distribution = "alpine"}
-  ["freeglut-devel"] {os-distribution = "centos"}
-  ["freeglut-devel"] {os-distribution = "fedora"}
-  ["freeglut-devel"] {os-distribution = "oraclelinux"}
+  ["freeglut-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "oraclelinux"}
   ["freeglut-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["freeglut"] {os-family = "arch"}
   ["freeglut"] {os = "freebsd"}

--- a/packages/conf-freeglut/conf-freeglut.1/opam
+++ b/packages/conf-freeglut/conf-freeglut.1/opam
@@ -5,10 +5,10 @@ homepage: "https://freeglut.sourceforge.net/"
 license: "X11"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
-  ["pkg-config" "--exists" "glut"] {os-distribution != "debian" & os-distribution != "ubuntu"}
+  ["pkg-config" "--exists" "glut"] {os-distribution != "debian" & os-distribution != "ubuntu" & !(os-distribution = "ol" & os-version < "9")}
 ]
 depends: [
-  "conf-pkg-config" {build & os-distribution != "debian" & os-distribution != "ubuntu"}
+  "conf-pkg-config" {build & os-distribution != "debian" & os-distribution != "ubuntu" & !(os-distribution = "ol" & os-version < "9")}
 ]
 depexts: [
   ["freeglut3-dev"] {os-family = "debian" | os-family = "ubuntu"}

--- a/packages/conf-freeglut/conf-freeglut.1/opam
+++ b/packages/conf-freeglut/conf-freeglut.1/opam
@@ -12,6 +12,7 @@ depends: [
 ]
 depexts: [
   ["freeglut3-dev"] {os-family = "debian"}
+  ["freeglut3-dev"] {os-family = "ubuntu"}
   ["freeglut-dev"] {os-distribution = "alpine"}
   ["freeglut-devel"] {os-distribution = "centos"}
   ["freeglut-devel"] {os-distribution = "fedora"}

--- a/packages/conf-freeglut/conf-freeglut.1/opam
+++ b/packages/conf-freeglut/conf-freeglut.1/opam
@@ -5,10 +5,10 @@ homepage: "https://freeglut.sourceforge.net/"
 license: "X11"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
-  ["pkg-config" "--exists" "glut"]
+  ["pkg-config" "--exists" "glut"] {os-distribution != "debian" & os-distribution != "ubuntu" & os-distribution != "oraclelinux"}
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {build & os-distribution != "debian" & os-distribution != "ubuntu" & os-distribution != "oraclelinux"}
 ]
 depexts: [
   ["freeglut3-dev"] {os-family = "debian" | os-family = "ubuntu"}

--- a/packages/conf-libgl/conf-libgl.1/opam
+++ b/packages/conf-libgl/conf-libgl.1/opam
@@ -11,6 +11,7 @@ depends: [
 ]
 depexts: [
   ["mesa-common-dev"] {os-family = "debian"}
+  ["mesa-common-dev"] {os-family = "ubuntu"}
   ["mesa-libGL-devel"] {os-distribution = "fedora"}
   ["mesa-dev"] {os-distribution = "alpine"}
   ["libgl"] {os-family = "arch"}

--- a/packages/conf-libgl/conf-libgl.1/opam
+++ b/packages/conf-libgl/conf-libgl.1/opam
@@ -12,6 +12,7 @@ depends: [
 depexts: [
   ["mesa-common-dev"] {os-family = "debian"}
   ["mesa-libGL-devel"] {os-distribution = "fedora"}
+  ["mesa-dev"] {os-distribution = "alpine"}
   ["libgl"] {os-family = "arch"}
 ]
 synopsis: "Virtual package relying on a OpenGL system installation"

--- a/packages/conf-libgl/conf-libgl.1/opam
+++ b/packages/conf-libgl/conf-libgl.1/opam
@@ -4,10 +4,10 @@ authors: ["ARB"]
 homepage: "https://www.khronos.org/opengl"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
-  ["pkg-config" "--exists" "gl"] {os-distribution != "debian" & os-distribution != "ol"}
+  ["pkg-config" "--exists" "gl"] {os-distribution != "debian"}
 ]
 depends: [
-  "conf-pkg-config" {build & os-distribution != "debian" & os-distribution != "ol"}
+  "conf-pkg-config" {build & os-distribution != "debian"}
 ]
 depexts: [
   ["mesa-common-dev"] {os-family = "debian" | os-family = "ubuntu"}

--- a/packages/conf-libgl/conf-libgl.1/opam
+++ b/packages/conf-libgl/conf-libgl.1/opam
@@ -11,6 +11,7 @@ depends: [
 ]
 depexts: [
   ["mesa-common-dev"] {os-family = "debian"}
+  ["mesa-libGL-devel"] {os-distribution = "fedora"}
   ["libgl"] {os-family = "arch"}
 ]
 synopsis: "Virtual package relying on a OpenGL system installation"

--- a/packages/conf-libgl/conf-libgl.1/opam
+++ b/packages/conf-libgl/conf-libgl.1/opam
@@ -10,9 +10,8 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["mesa-common-dev"] {os-family = "debian"}
-  ["mesa-common-dev"] {os-family = "ubuntu"}
-  ["mesa-libGL-devel"] {os-distribution = "fedora"}
+  ["mesa-common-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["mesa-libGL-devel"] {os-distribution = "fedora" | os-distribution = "oraclelinux"}
   ["mesa-dev"] {os-distribution = "alpine"}
   ["libgl"] {os-family = "arch"}
 ]

--- a/packages/conf-libgl/conf-libgl.1/opam
+++ b/packages/conf-libgl/conf-libgl.1/opam
@@ -4,10 +4,10 @@ authors: ["ARB"]
 homepage: "https://www.khronos.org/opengl"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
-  ["pkg-config" "--exists" "gl"]
+  ["pkg-config" "--exists" "gl"] {os-distribution != "debian" & os-distribution != "oraclelinux"}
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {build & os-distribution != "debian" & os-distribution != "oraclelinux"}
 ]
 depexts: [
   ["mesa-common-dev"] {os-family = "debian" | os-family = "ubuntu"}

--- a/packages/conf-libgl/conf-libgl.1/opam
+++ b/packages/conf-libgl/conf-libgl.1/opam
@@ -12,6 +12,7 @@ depends: [
 depexts: [
   ["mesa-common-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["mesa-libGL-devel"] {os-distribution = "fedora" | os-distribution = "oraclelinux"}
+  ["Mesa-libGL-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["mesa-dev"] {os-distribution = "alpine"}
   ["libgl"] {os-family = "arch"}
 ]

--- a/packages/conf-libgl/conf-libgl.1/opam
+++ b/packages/conf-libgl/conf-libgl.1/opam
@@ -15,6 +15,7 @@ depexts: [
   ["Mesa-libGL-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["mesa-dev"] {os-distribution = "alpine"}
   ["libgl"] {os-family = "arch"}
+  ["libglvnd"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a OpenGL system installation"
 flags: conf

--- a/packages/conf-libgl/conf-libgl.1/opam
+++ b/packages/conf-libgl/conf-libgl.1/opam
@@ -4,14 +4,14 @@ authors: ["ARB"]
 homepage: "https://www.khronos.org/opengl"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
-  ["pkg-config" "--exists" "gl"] {os-distribution != "debian" & os-distribution != "oraclelinux"}
+  ["pkg-config" "--exists" "gl"] {os-distribution != "debian" & os-distribution != "ol"}
 ]
 depends: [
-  "conf-pkg-config" {build & os-distribution != "debian" & os-distribution != "oraclelinux"}
+  "conf-pkg-config" {build & os-distribution != "debian" & os-distribution != "ol"}
 ]
 depexts: [
   ["mesa-common-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["mesa-libGL-devel"] {os-distribution = "fedora" | os-distribution = "oraclelinux"}
+  ["mesa-libGL-devel"] {os-distribution = "fedora" | os-distribution = "ol"}
   ["Mesa-libGL-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["mesa-dev"] {os-distribution = "alpine"}
   ["libgl"] {os-family = "arch"}

--- a/packages/conf-libgl/conf-libgl.1/opam
+++ b/packages/conf-libgl/conf-libgl.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+maintainer: "Marek Kubica <marek@xivilization.net>"
+authors: ["ARB"]
+homepage: "https://www.khronos.org/opengl"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+build: [
+  ["pkg-config" "--exists" "gl"]
+]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  ["mesa-common-dev"] {os-family = "debian"}
+  ["libgl"] {os-family = "arch"}
+]
+synopsis: "Virtual package relying on a OpenGL system installation"
+flags: conf

--- a/packages/conf-libglu/conf-libglu.1/opam
+++ b/packages/conf-libglu/conf-libglu.1/opam
@@ -4,8 +4,15 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Brian Paul"]
 homepage: "https://mesa3d.org/"
 license: "SGI-B-2.0"
+build: [
+  ["pkg-config" "--exists" "glu"]
+]
+depends: [
+  "conf-pkg-config" {build}
+]
 depexts: [
   ["libglu1-mesa-dev"] {os-family = "debian"}
+  ["mesa-libGLU-devel"] {os-distribution = "fedora"}
   ["glu"] {os-family = "arch"}
 ]
 synopsis: "Virtual package relying on a libGLU system installation"

--- a/packages/conf-libglu/conf-libglu.1/opam
+++ b/packages/conf-libglu/conf-libglu.1/opam
@@ -11,9 +11,8 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libglu1-mesa-dev"] {os-family = "debian"}
-  ["libglu1-mesa-dev"] {os-family = "ubuntu"}
-  ["mesa-libGLU-devel"] {os-distribution = "fedora"}
+  ["libglu1-mesa-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["mesa-libGLU-devel"] {os-distribution = "fedora" | os-distribution = "oraclelinux"}
   ["glu"] {os-family = "arch"}
   ["glu-dev"] {os-distribution = "alpine"}
 ]

--- a/packages/conf-libglu/conf-libglu.1/opam
+++ b/packages/conf-libglu/conf-libglu.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["glu-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["glu"] {os-family = "arch"}
   ["glu-dev"] {os-distribution = "alpine"}
+  ["libGLU"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a libGLU system installation"
 flags: conf

--- a/packages/conf-libglu/conf-libglu.1/opam
+++ b/packages/conf-libglu/conf-libglu.1/opam
@@ -13,6 +13,7 @@ depends: [
 depexts: [
   ["libglu1-mesa-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["mesa-libGLU-devel"] {os-distribution = "fedora" | os-distribution = "oraclelinux"}
+  ["glu-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["glu"] {os-family = "arch"}
   ["glu-dev"] {os-distribution = "alpine"}
 ]

--- a/packages/conf-libglu/conf-libglu.1/opam
+++ b/packages/conf-libglu/conf-libglu.1/opam
@@ -5,14 +5,14 @@ authors: ["Brian Paul"]
 homepage: "https://mesa3d.org/"
 license: "SGI-B-2.0"
 build: [
-  ["pkg-config" "--exists" "glu"] {os-distribution != "ubuntu" & os-distribution != "oraclelinux"}
+  ["pkg-config" "--exists" "glu"] {os-distribution != "ubuntu" & os-distribution != "ol"}
 ]
 depends: [
-  "conf-pkg-config" {build & os-distribution != "ubuntu" & os-distribution != "oraclelinux"}
+  "conf-pkg-config" {build & os-distribution != "ubuntu" & os-distribution != "ol"}
 ]
 depexts: [
   ["libglu1-mesa-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["mesa-libGLU-devel"] {os-distribution = "fedora" | os-distribution = "oraclelinux"}
+  ["mesa-libGLU-devel"] {os-distribution = "fedora" | os-distribution = "ol"}
   ["glu-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["glu"] {os-family = "arch"}
   ["glu-dev"] {os-distribution = "alpine"}

--- a/packages/conf-libglu/conf-libglu.1/opam
+++ b/packages/conf-libglu/conf-libglu.1/opam
@@ -14,6 +14,7 @@ depexts: [
   ["libglu1-mesa-dev"] {os-family = "debian"}
   ["mesa-libGLU-devel"] {os-distribution = "fedora"}
   ["glu"] {os-family = "arch"}
+  ["glu-dev"] {os-distribution = "alpine"}
 ]
 synopsis: "Virtual package relying on a libGLU system installation"
 flags: conf

--- a/packages/conf-libglu/conf-libglu.1/opam
+++ b/packages/conf-libglu/conf-libglu.1/opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+maintainer: "Marek Kubica <marek@xivilization.net>"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Brian Paul"]
+homepage: "https://mesa3d.org/"
+license: "SGI-B-2.0"
+depexts: [
+  ["libglu1-mesa-dev"] {os-family = "debian"}
+  ["glu"] {os-family = "arch"}
+]
+synopsis: "Virtual package relying on a libGLU system installation"
+flags: conf

--- a/packages/conf-libglu/conf-libglu.1/opam
+++ b/packages/conf-libglu/conf-libglu.1/opam
@@ -12,6 +12,7 @@ depends: [
 ]
 depexts: [
   ["libglu1-mesa-dev"] {os-family = "debian"}
+  ["libglu1-mesa-dev"] {os-family = "ubuntu"}
   ["mesa-libGLU-devel"] {os-distribution = "fedora"}
   ["glu"] {os-family = "arch"}
   ["glu-dev"] {os-distribution = "alpine"}

--- a/packages/conf-libglu/conf-libglu.1/opam
+++ b/packages/conf-libglu/conf-libglu.1/opam
@@ -5,10 +5,10 @@ authors: ["Brian Paul"]
 homepage: "https://mesa3d.org/"
 license: "SGI-B-2.0"
 build: [
-  ["pkg-config" "--exists" "glu"]
+  ["pkg-config" "--exists" "glu"] {os-distribution != "ubuntu" & os-distribution != "oraclelinux"}
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {build & os-distribution != "ubuntu" & os-distribution != "oraclelinux"}
 ]
 depexts: [
   ["libglu1-mesa-dev"] {os-family = "debian" | os-family = "ubuntu"}

--- a/packages/conf-libglu/conf-libglu.1/opam
+++ b/packages/conf-libglu/conf-libglu.1/opam
@@ -5,10 +5,10 @@ authors: ["Brian Paul"]
 homepage: "https://mesa3d.org/"
 license: "SGI-B-2.0"
 build: [
-  ["pkg-config" "--exists" "glu"] {os-distribution != "ubuntu" & os-distribution != "ol"}
+  ["pkg-config" "--exists" "glu"] {os-distribution != "ubuntu"}
 ]
 depends: [
-  "conf-pkg-config" {build & os-distribution != "ubuntu" & os-distribution != "ol"}
+  "conf-pkg-config" {build & os-distribution != "ubuntu"}
 ]
 depexts: [
   ["libglu1-mesa-dev"] {os-family = "debian" | os-family = "ubuntu"}

--- a/packages/lablgl/lablgl.1.04.20120306/opam
+++ b/packages/lablgl/lablgl.1.04.20120306/opam
@@ -3,7 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Jacques Garrigue et al., Nagoya University"]
 homepage: "https://github.com/garrigue/lablgl"
 bug-reports: "https://github.com/garrigue/lablgl/issues"
-dev-repo: "https://github.com/garrigue/lablgl.git"
+dev-repo: "git+https://github.com/garrigue/lablgl.git"
 license: "BSD-3-Clause"
 build: [
   ["cp" "Makefile.config.ex" "Makefile.config"]

--- a/packages/lablgl/lablgl.1.04.20120306/opam
+++ b/packages/lablgl/lablgl.1.04.20120306/opam
@@ -10,11 +10,9 @@ build: [
 depends: [
   "ocaml" {< "5.0"}
   "camlp4"
+  "conf-libgl"
   "conf-libglu"
   "conf-freeglut"
-]
-depexts: [
-  ["mesa-common-dev"] {os-family = "debian"}
 ]
 install: [
   [

--- a/packages/lablgl/lablgl.1.04.20120306/opam
+++ b/packages/lablgl/lablgl.1.04.20120306/opam
@@ -10,10 +10,10 @@ build: [
 depends: [
   "ocaml" {< "5.0"}
   "camlp4"
+  "conf-freeglut"
 ]
 depexts: [
-  ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]
-    {os-family = "debian"}
+  ["libglu1-mesa-dev" "mesa-common-dev"] {os-family = "debian"}
 ]
 install: [
   [

--- a/packages/lablgl/lablgl.1.04.20120306/opam
+++ b/packages/lablgl/lablgl.1.04.20120306/opam
@@ -10,10 +10,11 @@ build: [
 depends: [
   "ocaml" {< "5.0"}
   "camlp4"
+  "conf-libglu"
   "conf-freeglut"
 ]
 depexts: [
-  ["libglu1-mesa-dev" "mesa-common-dev"] {os-family = "debian"}
+  ["mesa-common-dev"] {os-family = "debian"}
 ]
 install: [
   [

--- a/packages/lablgl/lablgl.1.04.20120306/opam
+++ b/packages/lablgl/lablgl.1.04.20120306/opam
@@ -1,5 +1,10 @@
 opam-version: "2.0"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgl"
+bug-reports: "https://github.com/garrigue/lablgl/issues"
+dev-repo: "https://github.com/garrigue/lablgl.git"
+license: "BSD-3-Clause"
 build: [
   ["cp" "Makefile.config.ex" "Makefile.config"]
   ["cp" "Makefile.config.osx" "Makefile.config"] {os = "macos"}

--- a/packages/lablgl/lablgl.1.05/opam
+++ b/packages/lablgl/lablgl.1.05/opam
@@ -23,11 +23,9 @@ remove: [
 depends: [
   "ocaml" {< "5.0"}
   "camlp4"
+  "conf-libgl"
   "conf-libglu"
   "conf-freeglut"
-]
-depexts: [
-  ["mesa-common-dev"] {os-family = "debian"}
 ]
 synopsis: "Interface to OpenGL"
 description: """

--- a/packages/lablgl/lablgl.1.05/opam
+++ b/packages/lablgl/lablgl.1.05/opam
@@ -23,10 +23,10 @@ remove: [
 depends: [
   "ocaml" {< "5.0"}
   "camlp4"
+  "conf-freeglut"
 ]
 depexts: [
-  ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]
-    {os-family = "debian"}
+  ["libglu1-mesa-dev" "mesa-common-dev"] {os-family = "debian"}
 ]
 synopsis: "Interface to OpenGL"
 description: """

--- a/packages/lablgl/lablgl.1.05/opam
+++ b/packages/lablgl/lablgl.1.05/opam
@@ -23,10 +23,11 @@ remove: [
 depends: [
   "ocaml" {< "5.0"}
   "camlp4"
+  "conf-libglu"
   "conf-freeglut"
 ]
 depexts: [
-  ["libglu1-mesa-dev" "mesa-common-dev"] {os-family = "debian"}
+  ["mesa-common-dev"] {os-family = "debian"}
 ]
 synopsis: "Interface to OpenGL"
 description: """

--- a/packages/lablgl/lablgl.1.05/opam
+++ b/packages/lablgl/lablgl.1.05/opam
@@ -1,9 +1,9 @@
 opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: ["Jacques Garrigue et al., Nagoya University"]
-homepage: "http://labltk.forge.ocamlcore.org/"
-bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=291"
-dev-repo: "git+https://forge.ocamlcore.org/anonscm/git/lablgl/lablgl.git"
+homepage: "https://github.com/garrigue/lablgl"
+bug-reports: "https://github.com/garrigue/lablgl/issues"
+dev-repo: "git+https://github.com/garrigue/lablgl.git"
 license: "BSD-3-Clause"
 build: [
   ["cp" "Makefile.config.ex" "Makefile.config"]

--- a/packages/lablgl/lablgl.1.06/opam
+++ b/packages/lablgl/lablgl.1.06/opam
@@ -23,12 +23,9 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "5.0"}
   "camlp5"
+  "conf-libgl"
   "conf-libglu"
   "conf-freeglut"
-]
-depexts: [
-  ["mesa-common-dev"] {os-family = "debian"}
-  ["libgl"] {os-family = "arch"}
 ]
 synopsis: "Interface to OpenGL"
 description: """

--- a/packages/lablgl/lablgl.1.06/opam
+++ b/packages/lablgl/lablgl.1.06/opam
@@ -23,10 +23,11 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "5.0"}
   "camlp5"
+  "conf-libglu"
   "conf-freeglut"
 ]
 depexts: [
-  ["libglu1-mesa-dev" "mesa-common-dev"] {os-family = "debian"}
+  ["mesa-common-dev"] {os-family = "debian"}
   ["libgl"] {os-family = "arch"}
 ]
 synopsis: "Interface to OpenGL"

--- a/packages/lablgl/lablgl.1.06/opam
+++ b/packages/lablgl/lablgl.1.06/opam
@@ -23,17 +23,11 @@ remove: [
 depends: [
   "ocaml" {>= "4.03" & < "5.0"}
   "camlp5"
+  "conf-freeglut"
 ]
 depexts: [
-  ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]
-    {os-family = "debian"}
-  ["freeglut-dev"] {os-distribution = "alpine"}
-  ["freeglut-devel"] {os-distribution = "centos"}
-  ["freeglut-devel"] {os-distribution = "fedora"}
-  ["freeglut-devel"] {os-distribution = "oraclelinux"}
-  ["freeglut-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["freeglut" "libgl"] {os-family = "arch"}
-  ["freeglut"] {os = "freebsd"}
+  ["libglu1-mesa-dev" "mesa-common-dev"] {os-family = "debian"}
+  ["libgl"] {os-family = "arch"}
 ]
 synopsis: "Interface to OpenGL"
 description: """

--- a/packages/lablgl/lablgl.1.07/opam
+++ b/packages/lablgl/lablgl.1.07/opam
@@ -25,10 +25,11 @@ depends: [
   "ocamlfind" {>= "1.2.1"}
   "camlp-streams" {build}
   "camlp5"
+  "conf-libglu"
   "conf-freeglut"
 ]
 depexts: [
-  ["libglu1-mesa-dev" "mesa-common-dev"] {os-family = "debian"}
+  ["mesa-common-dev"] {os-family = "debian"}
   ["libgl"] {os-family = "arch"}
 ]
 synopsis: "Interface to OpenGL"

--- a/packages/lablgl/lablgl.1.07/opam
+++ b/packages/lablgl/lablgl.1.07/opam
@@ -25,12 +25,9 @@ depends: [
   "ocamlfind" {>= "1.2.1"}
   "camlp-streams" {build}
   "camlp5"
+  "conf-libgl"
   "conf-libglu"
   "conf-freeglut"
-]
-depexts: [
-  ["mesa-common-dev"] {os-family = "debian"}
-  ["libgl"] {os-family = "arch"}
 ]
 synopsis: "Interface to OpenGL"
 description: """

--- a/packages/lablgl/lablgl.1.07/opam
+++ b/packages/lablgl/lablgl.1.07/opam
@@ -25,17 +25,11 @@ depends: [
   "ocamlfind" {>= "1.2.1"}
   "camlp-streams" {build}
   "camlp5"
+  "conf-freeglut"
 ]
 depexts: [
-  ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]
-    {os-family = "debian"}
-  ["freeglut-dev"] {os-distribution = "alpine"}
-  ["freeglut-devel"] {os-distribution = "centos"}
-  ["freeglut-devel"] {os-distribution = "fedora"}
-  ["freeglut-devel"] {os-distribution = "oraclelinux"}
-  ["freeglut-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["freeglut" "libgl"] {os-family = "arch"}
-  ["freeglut"] {os = "freebsd"}
+  ["libglu1-mesa-dev" "mesa-common-dev"] {os-family = "debian"}
+  ["libgl"] {os-family = "arch"}
 ]
 synopsis: "Interface to OpenGL"
 description: """

--- a/packages/raylib/raylib.0.1.0/opam
+++ b/packages/raylib/raylib.0.1.0/opam
@@ -10,6 +10,7 @@ depends: [
   "ctypes"
   "ppx_cstubs"
   "conf-cmake"
+  "conf-libglu"
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -27,7 +28,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/tjammer/raylib-ocaml.git"
 depexts: [
-  ["libasound2-dev" "mesa-common-dev" "libx11-dev" "libxrandr-dev" "libxi-dev" "xorg-dev" "libgl1-mesa-dev" "libglu1-mesa-dev"] {os-family = "debian"}
+  ["libasound2-dev" "mesa-common-dev" "libx11-dev" "libxrandr-dev" "libxi-dev" "xorg-dev" "libgl1-mesa-dev"] {os-family = "debian"}
   ["alsa-lib-devel" "mesa-libGL-devel" "libX11-devel" "libXrandr-devel" "libXi-devel" "libXcursor-devel" "libXinerama-devel"] {os-distribution = "fedora"}
 ]
 available: [os = "linux" ]

--- a/packages/raylib/raylib.0.1.0/opam
+++ b/packages/raylib/raylib.0.1.0/opam
@@ -10,6 +10,7 @@ depends: [
   "ctypes"
   "ppx_cstubs"
   "conf-cmake"
+  "conf-libgl"
   "conf-libglu"
 ]
 build: [
@@ -28,7 +29,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/tjammer/raylib-ocaml.git"
 depexts: [
-  ["libasound2-dev" "mesa-common-dev" "libx11-dev" "libxrandr-dev" "libxi-dev" "xorg-dev" "libgl1-mesa-dev"] {os-family = "debian"}
+  ["libasound2-dev" "libx11-dev" "libxrandr-dev" "libxi-dev" "xorg-dev" "libgl1-mesa-dev"] {os-family = "debian"}
   ["alsa-lib-devel" "mesa-libGL-devel" "libX11-devel" "libXrandr-devel" "libXi-devel" "libXcursor-devel" "libXinerama-devel"] {os-distribution = "fedora"}
 ]
 available: [os = "linux" ]

--- a/packages/raylib/raylib.0.2.2/opam
+++ b/packages/raylib/raylib.0.2.2/opam
@@ -10,6 +10,7 @@ depends: [
   "dune-configurator"
   "ctypes"
   "ppx_cstubs"
+  "conf-libglu"
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -27,7 +28,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/tjammer/raylib-ocaml.git"
 depexts: [
-  ["libasound2-dev" "mesa-common-dev" "libx11-dev" "libxrandr-dev" "libxi-dev" "xorg-dev" "libgl1-mesa-dev" "libglu1-mesa-dev"] {os-family = "debian"}
+  ["libasound2-dev" "mesa-common-dev" "libx11-dev" "libxrandr-dev" "libxi-dev" "xorg-dev" "libgl1-mesa-dev"] {os-family = "debian"}
   ["alsa-lib-devel" "mesa-libGL-devel" "libX11-devel" "libXrandr-devel" "libXi-devel" "libXcursor-devel" "libXinerama-devel"] {os-distribution = "fedora"}
   ["alsa-lib-devel" "mesa-libGL-devel" "libX11-devel" "libXrandr-devel" "libXi-devel" "libXcursor-devel" "libXinerama-devel"] {os-distribution = "centos"}
   ["alsa-lib-dev" "mesa-dev" "libx11-dev" "libxrandr-dev" "libxi-dev" "libxcursor-dev" "libxinerama-dev"] {os-distribution = "alpine"}

--- a/packages/raylib/raylib.0.2.2/opam
+++ b/packages/raylib/raylib.0.2.2/opam
@@ -10,6 +10,7 @@ depends: [
   "dune-configurator"
   "ctypes"
   "ppx_cstubs"
+  "conf-libgl"
   "conf-libglu"
 ]
 build: [
@@ -28,7 +29,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/tjammer/raylib-ocaml.git"
 depexts: [
-  ["libasound2-dev" "mesa-common-dev" "libx11-dev" "libxrandr-dev" "libxi-dev" "xorg-dev" "libgl1-mesa-dev"] {os-family = "debian"}
+  ["libasound2-dev" "libx11-dev" "libxrandr-dev" "libxi-dev" "xorg-dev" "libgl1-mesa-dev"] {os-family = "debian"}
   ["alsa-lib-devel" "mesa-libGL-devel" "libX11-devel" "libXrandr-devel" "libXi-devel" "libXcursor-devel" "libXinerama-devel"] {os-distribution = "fedora"}
   ["alsa-lib-devel" "mesa-libGL-devel" "libX11-devel" "libXrandr-devel" "libXi-devel" "libXcursor-devel" "libXinerama-devel"] {os-distribution = "centos"}
   ["alsa-lib-dev" "mesa-dev" "libx11-dev" "libxrandr-dev" "libxi-dev" "libxcursor-dev" "libxinerama-dev"] {os-distribution = "alpine"}


### PR DESCRIPTION
Given the depexts for OpenGL can be kinda hairy with complicated dependency names, this PR attempts to move the dependencies of `lablgl` into its own `conf-*` packages (and updates raylib to use them where there is agreement).

The libraries in question:

* libGL
* libGLU (part of Mesa but still a separate library)
* freeglut (implementation of GLUT)