### PR TITLE
Replace `oraclelinux` with `ol`

### DIFF
--- a/packages/conf-alsa/conf-alsa.1/opam
+++ b/packages/conf-alsa/conf-alsa.1/opam
@@ -11,7 +11,7 @@ depends: [
 depexts: [
   ["alsa-lib"] {os-distribution = "nixos" | os-family = "arch"}
   ["alsa-lib-dev"] {os-distribution = "alpine"}
-  ["alsa-lib-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse" | os-distribution = "oraclelinux"}
+  ["alsa-lib-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse" | os-distribution = "ol"}
   ["libasound2-dev"] {os-family = "debian" | os-family = "ubuntu"}
 
 ]

--- a/packages/conf-libX11/conf-libX11.1/opam
+++ b/packages/conf-libX11/conf-libX11.1/opam
@@ -14,7 +14,7 @@ build: [
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libx11-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["libX11-devel"] {os-distribution = "centos" | os-distribution = "oraclelinux" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["libX11-devel"] {os-distribution = "centos" | os-distribution = "ol" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["libx11-dev"] {os-distribution = "alpine"}
   ["libx11"] {os-distribution = "arch"}
   ["libX11-dev"] {os-distribution = "cygwin"}

--- a/packages/conf-libgccjit/conf-libgccjit.1/opam
+++ b/packages/conf-libgccjit/conf-libgccjit.1/opam
@@ -10,7 +10,7 @@ license: "GPL-2.0-or-later"
 # On MacOS, both cc and gcc bind to the clang compiler, so the gccjit bindings
 # might not work out-of-the-box and we use a specific version of gcc below.
 available: [
-  ((os-distribution != "ol" & os-distribution != "oraclelinux") | os-version >= "9")
+  !(os-distribution = "ol" & os-version < "9")
 ]
 build: [
   # Unfortunately on MacOS, the default compiler is clang, even for the
@@ -43,7 +43,7 @@ depexts: [
   ["libgccjit"] {os-family = "nixos"}
   ["libgccjit-devel"] {os-distribution = "centos"}
   ["libgccjit-devel"] {os-distribution = "fedora"}
-  ["libgccjit-devel"] {(os-distribution = "ol" | os-distribution = "oraclelinux") & os-version >= "9"}
+  ["libgccjit-devel"] {os-distribution = "ol" & os-version >= "9"}
   ["libgccjit"] {os-family = "arch"}
   ["libgccjit-dev"] {os-family = "alpine"}
   # Note: opam's automatic resolution of OS variables can be inconsistent across OS installations.

--- a/packages/conf-ninja/conf-ninja.1/opam
+++ b/packages/conf-ninja/conf-ninja.1/opam
@@ -5,7 +5,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Apache-2.0"
 build: ["ninja" "--version"]
 depexts: [
-  ["ninja-build"] {os-family = "debian" | os-family = "fedora" | os-distribution = "oraclelinux"}
+  ["ninja-build"] {os-family = "debian" | os-family = "fedora" | os-distribution = "ol"}
   ["samurai"] {os-distribution = "alpine"}
   ["ninja"] {os-family = "arch" | os-family = "suse" | os-family = "opensuse" | os-family = "bsd"}
   ["ninja"] {os = "macos" & ( os-distribution = "homebrew" | os-distribution = "macports" )}

--- a/packages/conf-portaudio/conf-portaudio.1/opam
+++ b/packages/conf-portaudio/conf-portaudio.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["portaudio-dev"] {os-distribution = "alpine"}
   ["portaudio-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["portaudio"] {os = "macos" & os-distribution = "homebrew"}
-  ["portaudio"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os-distribution = "oraclelinux"}
+  ["portaudio"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os-distribution = "ol"}
   ["portaudio"] {os = "win32" & os-distribution = "cygwinports"}
   ["portaudio19-dev"] {os-family = "debian" | os-family = "ubuntu"}
 ]

--- a/packages/conf-pulseaudio/conf-pulseaudio.1/opam
+++ b/packages/conf-pulseaudio/conf-pulseaudio.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["pulseaudio-dev"] {os-distribution = "alpine"}
   ["pulseaudio-libs-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["pulseaudio"] {os = "macos" & os-distribution = "homebrew"}
-  ["pulseaudio"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os-distribution = "oraclelinux"}
+  ["pulseaudio"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os-distribution = "ol"}
   ["libpulse-dev"] {os-family = "debian" | os-family = "ubunty"}
 ]
 synopsis: "Virtual package relying on pulseaudio"

--- a/packages/conf-soundtouch/conf-soundtouch.1/opam
+++ b/packages/conf-soundtouch/conf-soundtouch.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["soundtouch-dev"] {os-distribution = "alpine"}
   ["soundtouch-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["libsoundtouch-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["soundtouch"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os-distribution = "oraclelinux"}
+  ["soundtouch"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os-distribution = "ol"}
   ["sound-touch"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on soundtouch"

--- a/packages/dlm/dlm.0.3.1/opam
+++ b/packages/dlm/dlm.0.3.1/opam
@@ -26,7 +26,7 @@ depexts: [
   ["dlm-devel"] {os-distribution = "rhel"}
   ["dlm-devel"] {os-distribution = "centos"}
   ["dlm-devel"] {os-distribution = "fedora"}
-  ["dlm-devel"] {os-distribution = "oraclelinux"}
+  ["dlm-devel"] {os-distribution = "ol"}
   ["libdlm-devel"] {os-family = "suse" | os-family = "opensuse"}
 ]
 available: [ os = "linux"]


### PR DESCRIPTION
As @jmid kindly pointed out in #25506 the `os-distribution` value for Oracle Linux seems to be `ol`. In opam-repository some packages use `oraclelinux` which is presumably always false and confusing at best so this PR removes the mentions.

It also changes the logic of `conf-libgccjit` which seemed to check that the distribution is Oracle Linux OR the version was 9, which would filter out distributions with lower version numbers accidentally. I assume the idea was to make it not available on Oracle Linux <9.