### PR TITLE
Add flexdll.0.35-flexdll.0.43 and winpthreads.20240209-1

### DIFF
--- a/packages/flexdll/flexdll.0.35/opam
+++ b/packages/flexdll/flexdll.0.35/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors: "Alain Frisch"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/flexdll/issues"
+dev-repo: "git+https://github.com/ocaml/flexdll.git"
+homepage: "https://github.com/ocaml/flexdll#readme"
+license: "Zlib"
+synopsis: "FlexDLL Sources"
+description: "Source package for FlexDLL. Installs the required files for
+bootstrapping FlexDLL as part of an OCaml build."
+url {
+  src: "https://github.com/ocaml/flexdll/archive/refs/tags/0.35.tar.gz"
+  checksum: [
+    "sha256=b69a08e6f8e5ac41452e4300f739acdf87f09c1567ca25753d28f4b13b80e4e1"
+    "sha512=ef67086366705c8da746cd4f7748d2a0469e15cda672fd29d05bd5b10a079cf02469b8fc4836115f72a96ab74491017622ca2907feb8f952e1c8cd87624f6f91"
+  ]
+}
+extra-source "flexdll.install" {
+  src: "https://raw.githubusercontent.com/ocaml/flexdll/5969494fb15550e78c5748c58ea4e5086fea92ae/flexdll.install"
+  checksum: [
+    "sha256=82aacd10fe906ee207f057573e3897e4b74a39a85a33b2d474c868b048c2bb6c"
+    "sha512=5f47e4ecfc769d1eeec5d1f9cb781960a4b4153e92c6d4e1ca03b08f1c778f308a969a1ce08fd844e08c40d9e12112fd081b3c19f3e465d5ce1c09f744861731"
+  ]
+}

--- a/packages/flexdll/flexdll.0.36/opam
+++ b/packages/flexdll/flexdll.0.36/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors: "Alain Frisch"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/flexdll/issues"
+dev-repo: "git+https://github.com/ocaml/flexdll.git"
+homepage: "https://github.com/ocaml/flexdll#readme"
+license: "Zlib"
+synopsis: "FlexDLL Sources"
+description: "Source package for FlexDLL. Installs the required files for
+bootstrapping FlexDLL as part of an OCaml build."
+url {
+  src: "https://github.com/ocaml/flexdll/archive/refs/tags/0.36.tar.gz"
+  checksum: [
+    "sha256=0541683317284d765062dcc7ee09c0fe76f8e0ba7d8599441f0852c68221b6f3"
+    "sha512=495ffbbfd4ae20570f75a4b273de6bd6849d7bf5bb2622a8d406fe7acccf165a9352005adcf9e102656ef8395f65b1f0dfc9f2e7fca58755161a1bc7a3bc403c"
+  ]
+}
+extra-source "flexdll.install" {
+  src: "https://raw.githubusercontent.com/ocaml/flexdll/5969494fb15550e78c5748c58ea4e5086fea92ae/flexdll.install"
+  checksum: [
+    "sha256=82aacd10fe906ee207f057573e3897e4b74a39a85a33b2d474c868b048c2bb6c"
+    "sha512=5f47e4ecfc769d1eeec5d1f9cb781960a4b4153e92c6d4e1ca03b08f1c778f308a969a1ce08fd844e08c40d9e12112fd081b3c19f3e465d5ce1c09f744861731"
+  ]
+}

--- a/packages/flexdll/flexdll.0.37/opam
+++ b/packages/flexdll/flexdll.0.37/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors: "Alain Frisch"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/flexdll/issues"
+dev-repo: "git+https://github.com/ocaml/flexdll.git"
+homepage: "https://github.com/ocaml/flexdll#readme"
+license: "Zlib"
+synopsis: "FlexDLL Sources"
+description: "Source package for FlexDLL. Installs the required files for
+bootstrapping FlexDLL as part of an OCaml build."
+url {
+  src: "https://github.com/ocaml/flexdll/archive/refs/tags/0.37.tar.gz"
+  checksum: [
+    "sha256=0e2ff1992f94e30fbce6cc26cdf5383eeca961e112fa551546e044f850665510"
+    "sha512=54e20ef923649356334519933f861cbe7fdf85480a4b1c9821d9aa6c3a60b45876d3962e8e5ef8c404803f26a8376e9010090fc1ab8f7b369db43bd0317bef09"
+  ]
+}
+extra-source "flexdll.install" {
+  src: "https://raw.githubusercontent.com/ocaml/flexdll/5969494fb15550e78c5748c58ea4e5086fea92ae/flexdll.install"
+  checksum: [
+    "sha256=82aacd10fe906ee207f057573e3897e4b74a39a85a33b2d474c868b048c2bb6c"
+    "sha512=5f47e4ecfc769d1eeec5d1f9cb781960a4b4153e92c6d4e1ca03b08f1c778f308a969a1ce08fd844e08c40d9e12112fd081b3c19f3e465d5ce1c09f744861731"
+  ]
+}

--- a/packages/flexdll/flexdll.0.38/opam
+++ b/packages/flexdll/flexdll.0.38/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors: "Alain Frisch"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/flexdll/issues"
+dev-repo: "git+https://github.com/ocaml/flexdll.git"
+homepage: "https://github.com/ocaml/flexdll#readme"
+license: "Zlib"
+synopsis: "FlexDLL Sources"
+description: "Source package for FlexDLL. Installs the required files for
+bootstrapping FlexDLL as part of an OCaml build."
+url {
+  src: "https://github.com/ocaml/flexdll/archive/refs/tags/0.38.tar.gz"
+  checksum: [
+    "sha256=dcd4b9a038b93f30fca8fae777434dcc1d23a70a7186c698ee8e2605b335de38"
+    "sha512=810d17bcb085009a848066ceff2c94b14c6044d83c02e8777a12320b1c15226425803cd4e54c853dee464d0a8da2319a2324ad40eb0f56f3e63ccec77581d4fc"
+  ]
+}
+extra-source "flexdll.install" {
+  src: "https://raw.githubusercontent.com/ocaml/flexdll/5969494fb15550e78c5748c58ea4e5086fea92ae/flexdll.install"
+  checksum: [
+    "sha256=82aacd10fe906ee207f057573e3897e4b74a39a85a33b2d474c868b048c2bb6c"
+    "sha512=5f47e4ecfc769d1eeec5d1f9cb781960a4b4153e92c6d4e1ca03b08f1c778f308a969a1ce08fd844e08c40d9e12112fd081b3c19f3e465d5ce1c09f744861731"
+  ]
+}

--- a/packages/flexdll/flexdll.0.39/opam
+++ b/packages/flexdll/flexdll.0.39/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors: "Alain Frisch"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/flexdll/issues"
+dev-repo: "git+https://github.com/ocaml/flexdll.git"
+homepage: "https://github.com/ocaml/flexdll#readme"
+license: "Zlib"
+synopsis: "FlexDLL Sources"
+description: "Source package for FlexDLL. Installs the required files for
+bootstrapping FlexDLL as part of an OCaml build."
+url {
+  src: "https://github.com/ocaml/flexdll/archive/refs/tags/0.39.tar.gz"
+  checksum: [
+    "sha256=51a6ef2e67ff475c33a76b3dc86401a0f286c9a3339ee8145053ea02d2fb5974"
+    "sha512=9c322d8538bbf1dec7ed0add06540a7b4fed384ff205a5a9c57ba22a8bf987f520d8e9a510e376bc0e898ec1f5459979c67a291ac85192f64aa93faf31e7cf6f"
+  ]
+}
+extra-source "flexdll.install" {
+  src: "https://raw.githubusercontent.com/ocaml/flexdll/5969494fb15550e78c5748c58ea4e5086fea92ae/flexdll.install"
+  checksum: [
+    "sha256=82aacd10fe906ee207f057573e3897e4b74a39a85a33b2d474c868b048c2bb6c"
+    "sha512=5f47e4ecfc769d1eeec5d1f9cb781960a4b4153e92c6d4e1ca03b08f1c778f308a969a1ce08fd844e08c40d9e12112fd081b3c19f3e465d5ce1c09f744861731"
+  ]
+}

--- a/packages/flexdll/flexdll.0.40/opam
+++ b/packages/flexdll/flexdll.0.40/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors: "Alain Frisch"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/flexdll/issues"
+dev-repo: "git+https://github.com/ocaml/flexdll.git"
+homepage: "https://github.com/ocaml/flexdll#readme"
+license: "Zlib"
+synopsis: "FlexDLL Sources"
+description: "Source package for FlexDLL. Installs the required files for
+bootstrapping FlexDLL as part of an OCaml build."
+url {
+  src: "https://github.com/ocaml/flexdll/archive/refs/tags/0.40.tar.gz"
+  checksum: [
+    "sha256=cfce676f761de7f841ba22bc8d586d5eab0237d54ee666d6c30c49a8615edda1"
+    "sha512=70fa7201d39f782b116dcb1c6f7b4a484d1fb5d9a714dc380d2213ea90408bbf969cb8af6f513ee2a0a4dd50c9dd5c69851700ffeca2e969948e50ff63404d89"
+  ]
+}
+extra-source "flexdll.install" {
+  src: "https://raw.githubusercontent.com/ocaml/flexdll/5969494fb15550e78c5748c58ea4e5086fea92ae/flexdll.install"
+  checksum: [
+    "sha256=82aacd10fe906ee207f057573e3897e4b74a39a85a33b2d474c868b048c2bb6c"
+    "sha512=5f47e4ecfc769d1eeec5d1f9cb781960a4b4153e92c6d4e1ca03b08f1c778f308a969a1ce08fd844e08c40d9e12112fd081b3c19f3e465d5ce1c09f744861731"
+  ]
+}

--- a/packages/flexdll/flexdll.0.41/opam
+++ b/packages/flexdll/flexdll.0.41/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors: "Alain Frisch"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/flexdll/issues"
+dev-repo: "git+https://github.com/ocaml/flexdll.git"
+homepage: "https://github.com/ocaml/flexdll#readme"
+license: "Zlib"
+synopsis: "FlexDLL Sources"
+description: "Source package for FlexDLL. Installs the required files for
+bootstrapping FlexDLL as part of an OCaml build."
+url {
+  src: "https://github.com/ocaml/flexdll/archive/refs/tags/0.41.tar.gz"
+  checksum: [
+    "sha256=d537923a7d9ecf4c4b262705dacd51aeac4dfcdd12f863ab981bd35a5e5910f4"
+    "sha512=02d65eb5b1bdcfef64841540756a46fa54b4bba2d2b832064d2576251d279ca2eae24f834a21713ad5a443cfc23484e1c4c226efcd508c5209cc88c3fd7d72ea"
+  ]
+}
+extra-source "flexdll.install" {
+  src: "https://raw.githubusercontent.com/ocaml/flexdll/5969494fb15550e78c5748c58ea4e5086fea92ae/flexdll.install"
+  checksum: [
+    "sha256=82aacd10fe906ee207f057573e3897e4b74a39a85a33b2d474c868b048c2bb6c"
+    "sha512=5f47e4ecfc769d1eeec5d1f9cb781960a4b4153e92c6d4e1ca03b08f1c778f308a969a1ce08fd844e08c40d9e12112fd081b3c19f3e465d5ce1c09f744861731"
+  ]
+}

--- a/packages/flexdll/flexdll.0.42/opam
+++ b/packages/flexdll/flexdll.0.42/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors: "Alain Frisch"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/flexdll/issues"
+dev-repo: "git+https://github.com/ocaml/flexdll.git"
+homepage: "https://github.com/ocaml/flexdll#readme"
+license: "Zlib"
+synopsis: "FlexDLL Sources"
+description: "Source package for FlexDLL. Installs the required files for
+bootstrapping FlexDLL as part of an OCaml build."
+url {
+  src: "https://github.com/ocaml/flexdll/archive/refs/tags/0.42.tar.gz"
+  checksum: [
+    "sha256=a2dce0a0d2f2c5c9f52f65e281db7405f51ff22dc71cdbf494eb241c8a4bdf0f"
+    "sha512=ef432e09e50feb87bc7ce7e9ef9b3b6a9fabf7593a47d66e804758c751ce2a2d97b82b032113a4147f570c52169f39c519202f81d1487ecbe10d5d429ce6ef5d"
+  ]
+}
+extra-source "flexdll.install" {
+  src: "https://raw.githubusercontent.com/ocaml/flexdll/62f20c339e285e4ae1fc83faa99f638bedf4c4ab/flexdll.install"
+  checksum: [
+    "sha256=18953e4630975873e659b481e1bbb2f514897aa41c0e5638c029ea0844ec1884"
+    "sha512=da8435f10010b1513fd945f8b3c21588e7e11a2d8cfa6b20fb3449aeda36b497e3ee3d4d809b9ef6f37073d47a4ab1a0ae6023ddb6790d226eb52b39ae2e9704"
+  ]
+}

--- a/packages/flexdll/flexdll.0.43/opam
+++ b/packages/flexdll/flexdll.0.43/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors: "Alain Frisch"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/flexdll/issues"
+dev-repo: "git+https://github.com/ocaml/flexdll.git"
+homepage: "https://github.com/ocaml/flexdll#readme"
+license: "Zlib"
+synopsis: "FlexDLL Sources"
+description: "Source package for FlexDLL. Installs the required files for
+bootstrapping FlexDLL as part of an OCaml build."
+url {
+  src: "https://github.com/ocaml/flexdll/archive/refs/tags/0.43.tar.gz"
+  checksum: [
+    "sha256=10e171ab7d2f8b2f238b53bb9944d4b26686f5703fbc1c059532791bc91be949"
+    "sha512=56048cdbd35fb5e3e34594da00badfe12df98b7d48fb847f96fcae7fd38b3a3458128510b502376250f753ef8f860735e3756875ccb7cceb594f8bb887984a49"
+  ]
+}
+extra-source "flexdll.install" {
+  src: "https://raw.githubusercontent.com/ocaml/flexdll/62f20c339e285e4ae1fc83faa99f638bedf4c4ab/flexdll.install"
+  checksum: [
+    "sha256=18953e4630975873e659b481e1bbb2f514897aa41c0e5638c029ea0844ec1884"
+    "sha512=da8435f10010b1513fd945f8b3c21588e7e11a2d8cfa6b20fb3449aeda36b497e3ee3d4d809b9ef6f37073d47a4ab1a0ae6023ddb6790d226eb52b39ae2e9704"
+  ]
+}

--- a/packages/winpthreads/winpthreads.20240209-1/opam
+++ b/packages/winpthreads/winpthreads.20240209-1/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+authors: "mingw-w64 project"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/winpthreads/issues"
+dev-repo: "git+https://github.com/ocaml/winpthreads.git#20240209-1"
+homepage: "https://github.com/ocaml/winpthreads#readme"
+license: "BSD-3-Clause AND MIT"
+synopsis: "Posix Threads for Windows (winpthreads) Sources"
+description: "Source package for winpthreads. Installs the required files for
+compiling winpthreads as part of an MSVC OCaml build."
+available: os = "win32"
+url {
+  src: "https://github.com/ocaml/winpthreads/archive/20240209-1.tar.gz"
+  checksum: [
+    "sha256=bd6f1ea4fbfa7d537ebaa12c0d4feb7146e6d7667511e3864b82a67c11f23025"
+    "sha512=116edf0be0764d44402efae6420a5118b6f08c9ade6ae8397f96b02e01df91a3ef45ff9911681f96006f1375c45c13132df76759339b3d9c8c7abd2d75b86db4"
+  ]
+}


### PR DESCRIPTION
This I think is the last prequisite before opening the "main" PR updating the compiler packages for Windows support.

Both of these packages provide sources needed in _addition_ to the compiler's own sources when compiling on Windows. Windows OCaml has required [FlexDLL](https://github.com/ocaml/flexdll) since OCaml 3.11, but it had to be installed separately. Adding to the complexity, the main part of FlexDLL is written in OCaml. Since OCaml 4.03.0, it has been possible to build OCaml and FlexDLL simultaneously, but the compiler does not distribute the required sources, and those what this flexdll package provides (this required support in FlexDLL was first added in 0.35, which is the reason for the older releases going back no further - these are the only releases there can have ever been).

OCaml 5.3.0 will introduce a requirement for the MSVC ports of OCaml in a very similar way with the [winpthreads](https://github.com/ocaml/winpthreads) library.

These packages simply install required sources to the `share` directory of the switch which are then picked up by the `configure` script of OCaml (using it's `--with-flexdll` and `--with-winpthreads-msvc` options). The packages are not constrained to Windows as the _opam packages_ aren't particularly Windows-specific (and, indeed, at some point cross-compilers will certain want the FlexDLL sources).

flexdll 0.35-0.43 are already released, which is why they reference `flexdll.install` from the master branch of the repository. When it's released, FlexDLL 0.44's tarball will include the .install file.