### PR TITLE
[new release] digestif (1.2.0)

### DIFF
--- a/packages/digestif/digestif.1.2.0/opam
+++ b/packages/digestif/digestif.1.2.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer:   [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/digestif"
+bug-reports:  "https://github.com/mirage/digestif/issues"
+dev-repo:     "git+https://github.com/mirage/digestif.git"
+doc:          "https://mirage.github.io/digestif/"
+license:      "MIT"
+synopsis:     "Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)"
+description: """
+Digestif is a toolbox to provide hashes implementations in C and OCaml.
+
+It uses the linking trick and user can decide at the end to use the C implementation or the OCaml implementation.
+
+We provides implementation of:
+ * MD5
+ * SHA1
+ * SHA224
+ * SHA256
+ * SHA384
+ * SHA512
+ * SHA3
+ * Keccak-256
+ * WHIRLPOOL
+ * BLAKE2B
+ * BLAKE2S
+ * RIPEMD160
+"""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+install:  [
+  [ "dune" "install" "-p" name ] {with-test}
+  [ "ocaml" "./test/test_runes.ml" ] {with-test}
+]
+
+depends: [
+  "ocaml"           {>= "4.08.0"}
+  "dune"            {>= "2.6.0"}
+  "eqaf"
+  "fmt"             {with-test & >= "0.8.7"}
+  "alcotest"        {with-test}
+  "bos"             {with-test}
+  "astring"         {with-test}
+  "fpath"           {with-test}
+  "rresult"         {with-test}
+  "ocamlfind"       {with-test}
+  "crowbar"         {with-test}
+]
+
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding"
+]
+url {
+  src:
+    "https://github.com/mirage/digestif/releases/download/v1.2.0/digestif-1.2.0.tbz"
+  checksum: [
+    "sha256=c30168cafe279a665367806b3e5e6398fd7474f1e5260e76826d5ec9d3b2a508"
+    "sha512=1a4d6ff31fa59d99548cf21a3cedbb0cdb2000d890fcb1c4633eda2723ea6157b10b7dfd089411d51e2d6f653466875efa7aed9807055ecdd3df24ec8d72c234"
+  ]
+}
+x-commit-hash: "f8f383581fd2e29f873d2d699c4be58fcc341290"


### PR DESCRIPTION
Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)

- Project page: <a href="https://github.com/mirage/digestif">https://github.com/mirage/digestif</a>
- Documentation: <a href="https://mirage.github.io/digestif/">https://mirage.github.io/digestif/</a>

##### CHANGES:

- Update the description to include SHA3 (@Leonidas-from-XIV, mirage/digestif#146)
- Add a new type `hash'`, a polymorphic variant (@reynir, @dinosaure, mirage/digestif#150)
- Lint `fmt` dependency lower-bound (@reynir, mirage/digestif#152)
- Add `get_into_bytes` function and a fuzzer about it (@reynir, @dinosaure, mirage/digestif#149)
