### PR TITLE
Rewrite CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ git commit -pm "Release yourpkg.version"
 git remote add your-github-handle git@github.com:your-github-handle/opam-repository.git
 git push your-github-handle release-yourpkg-version
 ```
-and open a PR on opam-repository on GitHub. Congratulation!
+and open a PR on opam-repository on GitHub. Congratulations!
 
 For more technical information about opam files, please read the [opam manual](https://opam.ocaml.org/doc/Manual.html)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,263 +5,185 @@ Contributions under the form of new packages, issue reports and pull
 requests to fix and enhance the quality of packages are always
 welcome. Thanks for your time and involvement.
 
-Becoming the maintainer of orphaned packages is
-[easy](#adopting-and-relinquishing-package-maintainership) and very
-welcome.
+Table of content:
+* [Add a new package](#add-a-new-package)
+* [Fixing packages](#fixing-packages)
+* [Governance](#governance)
+* [Policies](#policies)
+* [How to deal with CI](#how-to-deal-with-ci)
 
-The following lists a few points that help in making the contribution
-process and repository management as smooth and efficient as possible
-for everyone involved.
+Add a new package
+-----------------
 
-Note that if your have an issue with the opam tool itself this
-should not be filed here but on the opam tool
-[issue tracker](https://github.com/ocaml/opam/issues).
+There are several ways to add a new package to opam-repository.
+You can either use a tool such as `dune-release` or `opam-publish`, or open a PR manually.
+Each ones have their strenghts and weaknesses. For example:
+* `dune-release` is a tool more focused into helping people do their whole release process from start to finish for them. To that end it:
+  * helps with tagging
+  * parses (and enforces a format, can be good or bad) for the changelog, to put it in the tag
+  * creates the github release with that information
+  * builds, run tests, lint
+  * uploads the documentation
+  * creates and uploads a separate archive (also has an option to include the git submodules)
+  * works only if your project is on GitHub
+  * doesn’t support force-pushed tags
+* `opam-publish` is a more malleable tool focused on publishing. To that end it:
+  * works for any type of projects (you can just use a custom archive as an argument)
+  * simpler to use than dune-release
+  * more focused tool so you should encounter less issues and resistance but it’s more manual
+  * only handles the opam linting and publishing
+* you can also open a PR manually:
+  * this one gives you the most freedom. It is only recommended for experienced users
+  * this is however currently the only way to fix packages (as opposed to adding packages). See the appropriate section below
 
-Reporting package installation issues
--------------------------------------
+We'll cover each ones in the following subsections:
 
-To report package installation issues:
+### using dune-release
 
-1. First try to search the issue tracker to see if someone already
-   reported the issue. If that is the case mention on this issue that
-   you are also affected and, if available, add more diagnostic details.
-2. If you create a new issue make sure the issue title mentions the
-   package name and the affected version.
-3. Try to give as much information as possible about your setup in
-   the issue body:
-   1. Add the output of `opam config report`
-   2. Add the exact opam invocation and the resulting tool output.
+*if you encounter any issues, please read [dune-release's README](https://github.com/tarides/dune-release/blob/main/README.md)*
+
+First, make sure your project is using dune and is hosted on GitHub.
+Then, make sure you’ve forked opam-repository on GitHub. If not go to https://github.com/ocaml/opam-repository/fork
+Then, create a new file in `~/.config/dune/release.yml` with the content as indicated below, change `<username>` by your local username and `<github-user>` by your own github username:
+```
+remote: git@github.com:<github-username>/opam-repository.git
+local: /home/<username>/.cache/dune/opam-repository/
+```
+Then, you can tag the release using:
+```
+dune-release tag
+```
+Once done, you can simply call:
+```
+dune release
+```
+If all goes well this should create the Release on GitHub and open the PR to publish the package on opam-repository.
+
+For any subsequent releases only the last two steps are necessary.
+
+### using opam-publish
+
+*if you encounter any issues, please read [opam-publish's README](https://github.com/ocaml-opam/opam-publish/blob/master/README.md)*
+
+Once you have done your release and have an archive available publicly on the internet, simply call:
+```
+opam-publish <url>
+```
+This will open the PR to publish the package on opam-repository.
+
+For other options, please refer to `opam-publish --help`
+
+### publish manually
+
+An opam repository is a tree-like structure of directories and files as follow:
+```
+./
+|- packages/
+   |- pkgname/
+   |  |- pkgname.2.0/
+   |     |- opam
+   |- another-pkgname/
+      |- another-pkgname.1.0.0/
+      |  |- opam
+      |  |- files/
+      |     |- fix1.patch
+      |     |- fix2.patch
+      |- another-pkgname.1.0.1/
+         |- opam
+|- ...
+```
+So to add a package, simply create a directory with your package name (pkgname) and version
+```
+mkdir -p packages/pkgname/pkgname.version/
+```
+once done, copy the opam file for said package into the newly created directory.
+Edit that copied opam file by removing redundant or forbidden fields such as `name`, `version`, `pin-depends` if present, as well as adding or editing the `url` section as follow:
+```
+url {
+  src: "https://a.publicly-accessible.url/your-archive.tar.gz"
+  checksum: [
+    "sha256=the-sha256-hash-of-your-archive"
+    "sha512=the-sha512-hash-of-your-archive"
+  ]
+}
+```
+we recommend using more than one checksum and at least sha256 or stronger. Opam currently supports only md5, sha256 and sha512.
+
+Optionally you might want to integrate files (such as patches) in the repository.
+To do so, create a `files` directory in the directory of your package
+```
+mkdir packages/pkgname/pkgname.version/files/
+```
+then add the files you want to add to this directory. Note that large files are forbidden and the [extra-source](https://opam.ocaml.org/doc/Manual.html#opamsection-extra-sources) section should be used instead.
+
+Each time you add a file to the `files` directory, you must edit the associated opam file to add the file to the `extra-files` field as follow:
+```
+extra-files: [
+  ["the-filename" "md5=the-checksum-for-that-file"]
+  ...
+]
+```
+
+Once all that is done, you need to create a new git branch, commit your change, push it to your own fork 
+```
+git switch -c release-yourpkg-version
+git add packages/yourpkg/yourpkg.version/
+git commit -pm "Release yourpkg.version"
+git remote add your-github-handle git@github.com:your-github-handle/opam-repository.git
+git push your-github-handle release-yourpkg-version
+```
+and open a PR on opam-repository on GitHub. Congratulation!
+
+For more technical information about opam files, please read the [opam manual](https://opam.ocaml.org/doc/Manual.html)
 
 Fixing packages
 ---------------
 
-If you happen to have a fix for a package, please have a look at the
-issue tracker to see if it doesn't concern an existing issue. If that
-is the case mention it in your pull request.
+Packages are fixed as they show up as broken, if the opam-repository maintainers have time.
+If, as an external contributor, you are willing to help out, you can send a PR to fix the packages that are broken. This is extremely helpful.
 
-Adding new packages
+There are several types of fixes:
+* **Changes to the metadata** (e.g. `homepage`, `synopsis`, …) are simple, usualy harmless and easy to do and get merged.
+* **Changes to the dependencies or availibility** require some scrutiny from the opam-repository maintainers to verify that the new constraints are correct and do not break existing working installations.
+* **Changes to the way the package is built** (e.g. changes to the build rules, addition of patches, …) require a lot more scrutiny from the opam-repository maintainers and maybe a new revision.
+* **Changes to the source archive(s)** is prohibited but in the case where there is no other choice and the checksum is not the same, the difference with the original must be negligable.
+
+**PSA**: if the PR envisioned is large or involved, please ping the maintainers beforehand.
+
+**IMPORTANT**: If you are maintaining a package that you want to fix, never change the source archive pointed by a package that has already been merged in opam-repository. This would otherwise break anyone who is trying to install it and the archive's checksum would change which renders the installation impossible. Sending a PR in opam-repository that change this checksum is **prohibited** (see [wiki/Policies](https://github.com/ocaml/opam-repository/wiki/Policies)). Instead, if the already released version is broken in some way you can send a PR making it `available: false` and make a new point-release. If this is really too complicated or impossible, you can also send a patch.
+
+#### Revisions
+
+Revision versions are packages whose version is of the form `<version>-<revision>` with the revision number typically starting at 1.
+They typically privide a slightly modified version of an original release.
+
+For example `pkg.1.0.0` is not maintained anymore (be it this specific version or the package as a whole), and someone would like to privide a patch to fix something that some people might rely on even if it might be a buggy behivour. In this case the package is duplicated into the original version (left untouched) and the revision with the fix. This way, if the fix broke someone's setup they case still use the original version.
+
+#### Patches
+
+To fix packages, patches might sometimes be useful. This can be given to a package through the [patches field](https://opam.ocaml.org/doc/Manual.html#opamfield-patches), and either added through the [extra-source section](https://opam.ocaml.org/doc/Manual.html#opamsection-extra-sources) or the [extra-files field and the files/ subdirectory](https://opam.ocaml.org/doc/Manual.html#opamfield-extra-files) (`extra-source` is preferred to avoid making opam-repository too big).
+
+As a rule of thumb, unless urgent, the patch should go through upstream first and only if the maintainer is not responding in a reasonable timeframe, we can then think about including the patch in opam-repository, the focus should be for upstream to do a new release.
+
+As an external contributor looking to patch a package, whose maintainer do not agree with it or is unresponsive, another solution could be to fork the project or ask the current maintainer to transfer the maintenance to you.
+
+Governance
+----------
+
+The current points of contact and the full list of maintainers is available in [wiki/Governance](https://github.com/ocaml/opam-repository/wiki/Governance).
+Informations about the infrastructure is available in [wiki/Infrastructure-info](https://github.com/ocaml/opam-repository/wiki/Infrastructure-info).
+
+Typically maintainers gather weekly to discuss ongoing topics, review PRs together and train maintainers in training.
+If you wish to help and become an opam-repository maintainer, you can send a message to the maintainers listed above and you will be invited to the next meeting in which they will explain how things work.
+
+Policies
+--------
+
+Maintainers enforce a certain number of policies applied on packages in opam-repository.
+You can read about them in [wiki/Policies](https://github.com/ocaml/opam-repository/wiki/Policies).
+
+How to deal with CI
 -------------------
 
-Information about creating new packages and adding them to repository
-is available in
-[opam's manual](https://opam.ocaml.org/doc/Packaging.html).
-
-If you are using `dune` and hosting your git repository on `github` you can use the following tutorial that provides a step-by-step procedure to
-make a `hello` package available in opam.ocaml.org.
-If you are not using `dune` or hosting your project on `github` you can still use `opam-publish` as described by the manual page linked above.
-
-The top-level sources contain the following files with the opam file having the same
-name of the project.
-
-```
-$ ls hello/
-
-src/
-dune
-dune-project
-hello.opam
-```
-
-A quick summary of the steps to be followed are listed below:
-
-```
-$ dune build
-$ dune-release lint
-$ dune-release tag
-$ dune-release distrib
-$ dune-release publish
-$ dune-release opam pkg
-$ dune-release opam submit
-```
-
-We will now go through each of the above commands in detail:
-
-* `dune build`
-
-The OCaml source package needs to be built with `dune`, `dune-project`
-and `.opam` files along with the sources. The build should be
-successful before proceeding further. For example:
-
-```
-$ dune build
-Done: 56/61 (jobs: 1)
-```
-
-* `dune-release lint`
-
-The `lint` command checks for the presence of meta files in the
-project folder, and also runs `opam lint`. A sample output is given
-below for your reference:
-
-```
-$ dune-release lint
-[ OK ] File README is present.
-[ OK ] File LICENSE is present.
-[ OK ] File CHANGES is present.
-[ OK ] File opam is present.
-[ OK ] lint opam file hello.opam.
-[ OK ] opam field description is present
-[ OK ] opam fields homepage and dev-repo can be parsed by dune-release
-[ OK ] Skipping doc field linting, no doc field found
-[ OK ] lint /home/guest/hello success
-```
-
-You need to fix any errors reported by linting, and commit the changes
-locally.
-
-* `dune-release tag`
-
-A ChangeLog `CHANGES` file is required, and the format used is
-available in the
-[dune-release](https://github.com/ocamllabs/dune-release)
-documentation. A minimal example is as follows:
-
-```
-$ cat CHANGES
-
-## v0.0.1 (2021-02-23)
-### Added
-- Meta files for dune release
-```
-
-After updating the CHANGES file, you need to tag the release. You will
-be prompted to confirm the version, as can be seen in the following
-output:
-
-```
-$ dune-release tag
-[-] Extracting tag from first entry in CHANGES
-[-] Using tag "v0.0.1"
-[?] Create git tag v0.0.1 for HEAD? [Y/n]
-Y
-[+] Tagged HEAD with version v0.0.1
-```
-
-* `dune-release distrib`
-
-The sources are then archived to create a distribution as illustrated
-below:
-
-```
- $ dune-release distrib
-[-] Building source archive
-[+] Wrote archive _build/hello-v0.0.1.tbz
-
-[-] Linting distrib in _build/hello-v0.0.1
-[ OK ] File README is present.
-[ OK ] File LICENSE is present.
-[ OK ] File CHANGES is present.
-[ OK ] File opam is present.
-[ OK ] lint opam file hello.opam.
-[ OK ] opam field description is present
-[ OK ] opam fields homepage and dev-repo can be parsed by dune-release
-[ OK ] Skipping doc field linting, no doc field found
-[ OK ] lint _build/hello-v0.0.1 success
-
-[-] Building package in _build/hello-v0.0.1
-Done: 56/60 (jobs: 1)[ OK ] package builds
-
-[-] Running package tests in _build/hello-v0.0.1
-Done: 0/0 (jobs: 0)[ OK ] package tests
-
-[+] Distribution for hello 0.0.1
-[+] Commit c9935ac42271ce23cc422c299c5c3aaf92646499
-[+] Archive _build/hello-v0.0.1.tbz
-```
-
-* `dune-release publish`
-
-You can now publish the distribution to your GitHub repository as
-follows:
-
-```
-$ dune-release publish
-[-] Skipping documentation publication for package hello: no doc field in hello.opam
-[-] Publishing distribution
-[-] Publishing to github
-[?] Push tag v0.0.1 to git@github.com:guest/hello? [Y/n]
-Y
-[-] Pushing tag v0.0.1 to git@github.com:guest/hello
-[?] Create release v0.0.1 on git@github.com:guest/hello? [Y/n]
-Y
-[-] Creating release v0.0.1 on git@github.com:guest/hello via github's API
-[+] Succesfully created release with id 38465706
-[?] Upload _build/hello-v0.0.1.tbz as release asset? [Y/n]
-Y
-[-] Uploading _build/hello-v0.0.1.tbz as a release asset for v0.0.1 via github's API
-```
-
-* `dune-release opam pkg`
-
-The .opam file can then be generated using the following command:
-
-```
-$ dune-release opam pkg
-[-] Creating opam package description for hello
-[+] Wrote opam package description _build/hello.0.0.1/opam
-```
-
-* `dune-release opam submit`
-
-The `~/.config/dune/release.yml` file should then be updated with your
-opam repository settings as indicated below (in particular, change `<username>` by your local username and `<github-user>` by your own github username):
-
-```
-$ cat ~/.config/dune/release.yml
-
-user: <username>
-remote: git@github.com:<github-username>/opam-repository.git
-local: /home/<username>/.cache/dune/opam-repository/
-```
-
-You can now submit your package to be included to opam.ocaml.org using
-the following command, which will create a new pull request to
-ocaml/opam-repository:
-
-```
-$ dune-release opam submit
-[-] Submitting
-[-] Preparing pull request to ocaml/opam-repository
-[-] Fetching https://github.com/ocaml/opam-repository.git#master
-[-] Checking out a local release-hello-0.0.1 branch
-[-] Pushing release-hello-0.0.1 to git@github.com:guest/opam-repository
-[?] Open PR to ocaml/opam-repository? [Y/n]
-Y
-[-] Opening pull request to merge branch release-hello-0.0.1 of git@github.com:guest/opam-repository into ocaml/opam-repository
-```
-
-Congratulations on submitting your first OCaml package!
-
-Adopting and relinquishing package maintainership
--------------------------------------------------
-
-Orphaned packages either have no `maintainer:` field or the field is
-set to the repository issue tracker:
-
-```
-maintainer: "https://github.com/ocaml/opam-repository/issues"
-```
-
-If you care about a package and it is orphaned we are keen on having
-you as the maintainer of the package. In order to do so simply issue a
-pull request on the latest version of the package and add your contact
-details in the `maintainer:` field.
-
-If it is no longer possible for you to commit to maintain a package
-you can either:
-
-1. Try to find a person to replace yourself in that role. Let her
-issue a pull request that updates all the `maintainer:` fields that
-contain your details with her own and do acknowledge the transfer on
-her pull request.
-2. Or, if you cannot find someone to replace you, simply issue a pull
-request that updates all the `maintainer:` fields that have your details
-with the address of the repository issue tracker (see above).
-
-Other questions
----------------
-
-If your question about contributing is not answered here, please post on the
-<https://discuss.ocaml.org> forum in the `ecosystem` category with your query.
-Beginners questions are welcome there, particularly since we can use your
-question to refine the documentation of the project.
+When you open a PR, a number of checks are done to verify that builds and runs correctly on a number of different platforms.
+You can read about how to deal with our CI (Continuous Integration) in [wiki/How-to-deal-with-CI](https://github.com/ocaml/opam-repository/wiki/How-to-deal-with-CI).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ For more technical information about opam files, please read the [opam manual](h
 Fixing packages
 ---------------
 
-Packages are fixed as they show up as broken, if the opam-repository maintainers have time.
+Packages are fixed as soon as they show up as broken in opam-repository CI or in the repository issues, if the opam-repository maintainers have time.
 If, as an external contributor, you are willing to help out, you can send a PR to fix the packages that are broken. This is extremely helpful.
 
 There are several types of fixes:

--- a/README.md
+++ b/README.md
@@ -1,23 +1,13 @@
-This repository contains OCaml package and compiler metadata and is
-used by the default installation of [opam](https://opam.ocaml.org/).
+This repository contains OCaml package and compiler metadata and is used by the default installation of [opam](https://opam.ocaml.org/).
 
 The state of the package ecosystem can be explored using opam-health-check<sup>[[1]]</sup>: http://check.ci.ocaml.org/
-
-# CI troubleshooting
-
-* If you have an issue or a feature request for opam-CI (used for all PRs), please open a ticket at https://github.com/ocurrent/opam-repo-ci/issues
-* If you think there is an issue in the CI infrastructure, please open a ticket at https://github.com/ocaml/infrastructure/issues
-* If you have an issue or a feature request for opam-health-check, please open a ticket at https://github.com/ocurrent/opam-health-check/issues
 
 ## How to Contribute
 
 Contributions are welcome !
 
 The [CONTRIBUTING.md](CONTRIBUTING.md) document has general guidelines
-on how to contribute.
-
-If you would like to add a new package consult
-[these instructions](https://opam.ocaml.org/doc/Packaging.html#Publishing).
+on how to contribute and add new packages.
 
 ## License
 


### PR DESCRIPTION
This PR rewrites the documentation at destination to package maintainers in hopes of being more helpful for beginner and well as experimented publishers.

This work, as well as the associated changes to the [opam-repository wiki](https://github.com/ocaml/opam-repository/wiki) was part of an effort ongoing since August last year for myself to be able to retire from the maintenance of opam-repository as smoothly as possible, after 6 and half years spent maintaining it.