### PR TITLE
[new release] ocaml-version (3.6.5)

### DIFF
--- a/packages/ocaml-version/ocaml-version.3.6.5/opam
+++ b/packages/ocaml-version/ocaml-version.3.6.5/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """
+This library provides facilities to parse version numbers of the OCaml compiler, and enumerates the various official OCaml releases and configuration variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the `patch` and `extra` fields are optional.  This library offers the following functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under the Ecosystem category.
+- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+license: "ISC"
+tags: ["org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-version"
+doc: "https://ocurrent.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-version/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.07.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-version/releases/download/v3.6.5/ocaml-version-3.6.5.tbz"
+  checksum: [
+    "sha256=8473f697425ccfd61a971098d30720747eb34f3f8ea910fa24eca307eaf9dfd2"
+    "sha512=4d85b6c612f316b68a296ff54beed460705d471d425fe3fa9bab9c94191e05a95d94f0006da578e3cd9e2910ed5291f2efa5198f47617f0c9e9fcf8690718da2"
+  ]
+}
+x-commit-hash: "fb47870abcc459bf758e415b6665217ff5ea7c19"


### PR DESCRIPTION
Manipulate, parse and generate OCaml compiler version strings

Project page: https://github.com/ocurrent/ocaml-version
Documentation: https://ocurrent.github.io/ocaml-version/doc

CHANGES:
* Add 5.2.0~alpha1 to `unreleased_betas` (@benmandrew https://github.com/ocurrent/ocaml-version/pull/69)
* Add OCaml 4.14.2 version (@Octachron https://github.com/ocurrent/ocaml-version/pull/70)
