### PR TITLE
Relax windows incompatibility for dune 3.7.0

### DIFF
--- a/packages/dune/dune.3.7.0/opam
+++ b/packages/dune/dune.3.7.0/opam
@@ -54,4 +54,6 @@ url {
   ]
 }
 x-commit-hash: "d3d628f2eda2278bd2df6e37452d8693f367fcfd"
-available: os != "win32"
+post-messages: [
+  "Please note that this version of dune does not support unicode characters on Windows and may behave unexpectedly, consider updating to version 3.14.2 or greater" {os = "win32"}
+]


### PR DESCRIPTION
This is currently breaking windows installations of coq, see https://github.com/ocaml/opam-repository/pull/25484

Ping @MSoegtropIMC 