### PR TITLE
[new release] moonpool (2 packages) (0.6)

### DIFF
--- a/packages/moonpool-lwt/moonpool-lwt.0.6/opam
+++ b/packages/moonpool-lwt/moonpool-lwt.0.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Event loop for moonpool based on Lwt-engine (experimental)"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+homepage: "https://github.com/c-cube/moonpool"
+bug-reports: "https://github.com/c-cube/moonpool/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "moonpool" {= version}
+  "ocaml" {>= "5.0"}
+  "lwt"
+  "base-unix"
+  "trace" {with-test}
+  "trace-tef" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/moonpool.git"
+url {
+  src:
+    "https://github.com/c-cube/moonpool/releases/download/v0.6/moonpool-0.6.tbz"
+  checksum: [
+    "sha256=6b55b1f8515bf681b86f1c94b7e1e3ce51c1be6f939630a6b95fc46e6662d62e"
+    "sha512=da4d95202fa172cf034ffe120e9f04072b797b5698bd14ccf112b090c5411e53896fb1c040c8016f6cbe66c94f0c6ce30a59ee1741b72aab0c9fe4e26c7d48cf"
+  ]
+}
+x-commit-hash: "d384fbcc708efc68e8cad4014a4009fd0fb1b733"

--- a/packages/moonpool/moonpool.0.6/opam
+++ b/packages/moonpool/moonpool.0.6/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Pools of threads supported by a pool of domains"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["thread" "pool" "domain" "futures" "fork-join"]
+homepage: "https://github.com/c-cube/moonpool"
+bug-reports: "https://github.com/c-cube/moonpool/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.0"}
+  "either" {>= "1.0"}
+  "trace" {with-test}
+  "trace-tef" {with-test}
+  "qcheck-core" {with-test & >= "0.19"}
+  "odoc" {with-doc}
+  "mdx" {>= "1.9.0" & with-test}
+]
+depopts: [
+  "trace" {>= "0.6"}
+  "thread-local-storage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/moonpool.git"
+url {
+  src:
+    "https://github.com/c-cube/moonpool/releases/download/v0.6/moonpool-0.6.tbz"
+  checksum: [
+    "sha256=6b55b1f8515bf681b86f1c94b7e1e3ce51c1be6f939630a6b95fc46e6662d62e"
+    "sha512=da4d95202fa172cf034ffe120e9f04072b797b5698bd14ccf112b090c5411e53896fb1c040c8016f6cbe66c94f0c6ce30a59ee1741b72aab0c9fe4e26c7d48cf"
+  ]
+}
+x-commit-hash: "d384fbcc708efc68e8cad4014a4009fd0fb1b733"


### PR DESCRIPTION
Pools of threads supported by a pool of domains

- Project page: <a href="https://github.com/c-cube/moonpool">https://github.com/c-cube/moonpool</a>

##### CHANGES:

- breaking: remove `Immediate_runner` (bug prone and didn't
    handle effects). `Moonpool_fib.main` can be used to handle
    effects in the main function.
- remove deprecated alias `Moonpool.Pool`

- feat: add structured concurrency sub-library `moonpool.fib` with
    fibers. Fibers can use `await` and spawn other fibers that will
    be appropriately cancelled when their parent is.
- feat: add add `moonpool-lwt` as an experimental bridge between moonpool and lwt.
    This allows moonpool runners to be used from within Lwt to
    perform background computations, and conversely to call Lwt from
    moonpool with some precautions.
- feat: task-local storage in the main moonpool runners, available from
    fibers and regular tasks.
- feat: add `Exn_bt` to core
- feat: add `Runner.dummy`
- make `moonpool.forkjoin` optional (only on OCaml >= 5.0)
- feat: add `Fut.Advanced.barrier_on_abstract_container_of_futures`
- feat: add `Fut.map_list`

- refactor: split off domain pool to `moonpool.dpool`
- fix too early exit in Ws_pool
