### PR TITLE
conf-brotli: Broaden support to Alpine, Arch, Fedora, OpenSuse, and U…

### DIFF
--- a/packages/conf-brotli/conf-brotli.0.0.1/opam
+++ b/packages/conf-brotli/conf-brotli.0.0.1/opam
@@ -14,6 +14,9 @@ depexts: [
   ["brotli"] {os = "freebsd"}
   ["brotli"] {os-distribution = "homebrew" & os = "macos"}
 ]
+x-ci-accept-failures: [
+  "oraclelinux-8" "oraclelinux-9" # not available
+]
 synopsis: "Virtual package relying on a brotli system installation"
 description:
   "This package can only install if libbrotli is installed on the system."

--- a/packages/conf-brotli/conf-brotli.0.0.1/opam
+++ b/packages/conf-brotli/conf-brotli.0.0.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["libbrotli-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["brotli-devel"] {os-distribution = "fedora"}
   ["libbrotli-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["libbrotli"] {os = "freebsd"}
+  ["brotli"] {os = "freebsd"}
   ["brotli"] {os-distribution = "homebrew" & os = "macos"}
 ]
 synopsis: "Virtual package relying on a brotli system installation"

--- a/packages/conf-brotli/conf-brotli.0.0.1/opam
+++ b/packages/conf-brotli/conf-brotli.0.0.1/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "MIT"
 build: [ "pkg-config" "libbrotlidec" "libbrotlienc" ]
 depexts: [
-  ["libbrotli-dev"] {os-family = "debian"}
+  ["brotli-dev"] {os-distribution = "alpine"}
+  ["brotli"] {os-distribution = "arch"}
+  ["libbrotli-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["brotli-devel"] {os-distribution = "fedora"}
+  ["libbrotli-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libbrotli"] {os = "freebsd"}
   ["brotli"] {os-distribution = "homebrew" & os = "macos"}
 ]


### PR DESCRIPTION
…buntu-derivatives

Sources:
https://pkgs.alpinelinux.org/package/v3.19/main/x86_64/brotli-dev
https://archlinux.org/packages/core/x86_64/brotli/
https://packages.fedoraproject.org/pkgs/brotli/brotli-devel/
https://opensuse.pkgs.org/tumbleweed/opensuse-oss-x86_64/libbrotli-devel-1.1.0-1.1.x86_64.rpm.html