### PR TITLE
conf-clang-format: add FreeBSD and Ubuntu-derivative support

### DIFF
--- a/packages/conf-clang-format/conf-clang-format.1/opam
+++ b/packages/conf-clang-format/conf-clang-format.1/opam
@@ -6,13 +6,14 @@ authors: "The Clang Team"
 license: "NCSA"
 build: ["clang-format" "--version"]
 depexts: [
-  ["clang-format"] {os-family = "debian"}
+  ["clang-format"] {os-family = "debian" | os-family = "ubuntu"}
   ["clang-tools-extra"] {os-family = "fedora"}
   ["clang-extra-tools"] {os-distribution = "alpine" & os-version < "3.17" }
   ["clang15-extra-tools"] {os-distribution = "alpine" & os-version >= "3.17" }
   ["clang-tools"] {os-family = "suse" | os-family = "opensuse"}
   ["clang"] {os-distribution = "arch"}
   ["clang-format"] {os-distribution = "homebrew" & os = "macos"}
+  ["llvm"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on clang-format"
 description:

--- a/packages/conf-clang-format/conf-clang-format.1/opam
+++ b/packages/conf-clang-format/conf-clang-format.1/opam
@@ -9,7 +9,9 @@ depexts: [
   ["clang-format"] {os-family = "debian" | os-family = "ubuntu"}
   ["clang-tools-extra"] {os-family = "fedora"}
   ["clang-extra-tools"] {os-distribution = "alpine" & os-version < "3.17" }
-  ["clang15-extra-tools"] {os-distribution = "alpine" & os-version >= "3.17" }
+  ["clang15-extra-tools"] {os-distribution = "alpine" & os-version = "3.17" }
+  ["clang16-extra-tools"] {os-distribution = "alpine" & os-version = "3.18" }
+  ["clang17-extra-tools"] {os-distribution = "alpine" & os-version >= "3.19" }
   ["clang-tools"] {os-family = "suse" | os-family = "opensuse"}
   ["clang"] {os-distribution = "arch"}
   ["clang-format"] {os-distribution = "homebrew" & os = "macos"}


### PR DESCRIPTION
For FreeBSD https://www.freshports.org/devel/llvm lists an explicit `bin/clang-format` in pkg-plist
whereas Hannes's base list contains no such thing: https://data.robur.coop/freebsd14-base.txt