### PR TITLE
conf-dssi: add support for FreeBSD and Ubuntu-derivatives

### DIFF
--- a/packages/conf-dssi/conf-dssi.1/opam
+++ b/packages/conf-dssi/conf-dssi.1/opam
@@ -8,12 +8,12 @@ depends: [
   "conf-alsa" {os = "linux"}
 ]
 depexts: [
-  ["dssi-dev"] {os-family = "debian" | os-distribution = "alpine"}
+  ["dssi-dev"] {os-family = "debian" | os-family = "ubuntu" | os-distribution = "alpine"}
   ["dssi-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
-  ["dssi"] {os-distribution = "nixos" | os-distribution = "arch"}
+  ["dssi"] {os-distribution = "nixos" | os-distribution = "arch" | os = "freebsd"}
   ["drfill/liquidsoap/libdssi"] {os = "macos" & os-distribution = "homebrew"}
 ]
-available: [ os = "linux" | os = "macos" ]
+available: [ os = "linux" | os = "macos" | os = "freebsd" ]
 synopsis: "Virtual package relying on dssi"
 description:
   "This package installs external dependencies to build dssi."


### PR DESCRIPTION
Source: https://www.freshports.org/audio/dssi/

For now, I've not added an `conf-alsa` dependency on FreeBSD (depends on #25540) because it is unclear to me whether it is needed, as there is no 'package test' included in `conf-dssi`. I suppose we will find out when rev-deps fail on FreeBSD... :shrug: 
