### PR TITLE
conf-efl: clean-up logic and fix Debian and Ubuntu package names

### DIFF
--- a/packages/conf-efl/conf-efl.1.8/opam
+++ b/packages/conf-efl/conf-efl.1.8/opam
@@ -7,13 +7,13 @@ build: [["pkg-config" "elementary" "--atleast-version=1.8"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["efl"] {os-distribution = "arch"}
-  ["libelementary-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
+  ["libelementary-dev"] {os-family = "debian"}
+  ["libelementary-dev"] {os-family = "ubuntu"}
   ["elementary-devel"] {os-distribution = "fedora"}
   ["efl"] {os = "freebsd"}
   ["efl"] {os-distribution = "gentoo"}
   ["efl"] {os = "macos" & os-distribution = "homebrew"}
   ["efl"] {os-family = "suse" | os-distribution = "opensuse"}
-  ["libelementary-dev"] {os-distribution = "ubuntu"}
   ["elementary-devel"] {os-distribution = "centos"}
   ["efl"] {os-distribution = "mageia"}
 ]

--- a/packages/conf-efl/conf-efl.1.8/opam
+++ b/packages/conf-efl/conf-efl.1.8/opam
@@ -7,8 +7,7 @@ build: [["pkg-config" "elementary" "--atleast-version=1.8"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["efl"] {os-distribution = "arch"}
-  ["libelementary-dev"] {os-family = "debian"}
-  ["libelementary-dev"] {os-family = "ubuntu"}
+  ["libefl-all-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["elementary-devel"] {os-distribution = "fedora"}
   ["efl"] {os = "freebsd"}
   ["efl"] {os-distribution = "gentoo"}

--- a/packages/conf-efl/conf-efl.1.8/opam
+++ b/packages/conf-efl/conf-efl.1.8/opam
@@ -6,14 +6,14 @@ license: "various"
 build: [["pkg-config" "elementary" "--atleast-version=1.8"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["efl"] {os-distribution = "arch" & os = "linux"}
-  ["libelementary-dev"] {os-family = "debian" & os-distribution != "ubuntu" & os = "linux"}
-  ["elementary-devel"] {os-distribution = "fedora" & os = "linux"}
+  ["efl"] {os-distribution = "arch"}
+  ["libelementary-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
+  ["elementary-devel"] {os-distribution = "fedora"}
   ["efl"] {os = "freebsd"}
   ["efl"] {os-distribution = "gentoo"}
   ["efl"] {os = "macos" & os-distribution = "homebrew"}
-  ["efl"] {(os-family = "suse" | os-distribution = "opensuse") & os = "linux"}
-  ["libelementary-dev"] {os-distribution = "ubuntu" & os = "linux"}
+  ["efl"] {os-family = "suse" | os-distribution = "opensuse"}
+  ["libelementary-dev"] {os-distribution = "ubuntu"}
   ["elementary-devel"] {os-distribution = "centos"}
   ["efl"] {os-distribution = "mageia"}
 ]


### PR DESCRIPTION
Sources:
https://packages.ubuntu.com/mantic/libefl-all-dev
https://packages.debian.org/sid/libefl-all-dev