### PR TITLE
conf-libargon2: add FreeBSD support

### DIFF
--- a/packages/conf-libargon2/conf-libargon2.1/opam
+++ b/packages/conf-libargon2/conf-libargon2.1/opam
@@ -19,6 +19,7 @@ depexts: [
   ["argon2"] {os = "macos" & os-distribution = "macports"}
   ["libargon2"] {os = "openbsd"}
   ["security/argon2"] {os = "netbsd"}
+  ["libargon2"] {os = "freebsd"}
 ]
 
 x-ci-accept-failures: [


### PR DESCRIPTION
Source: https://www.freshports.org/security/libargon2