### PR TITLE
conf-libfuse: add support for FreeBSD and Ubuntu derivatives

### DIFF
--- a/packages/conf-libfuse/conf-libfuse.1/opam
+++ b/packages/conf-libfuse/conf-libfuse.1/opam
@@ -9,7 +9,7 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libfuse-dev"] {os-family = "debian"}
+  ["libfuse-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["fuse-dev"] {os-distribution = "alpine"}
   ["fuse-devel"] {os-distribution = "centos"}
   ["fuse-devel"] {os-distribution = "fedora"}
@@ -17,6 +17,7 @@ depexts: [
   ["fuse-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["fuse2"] {os-family = "arch"}
   ["macfuse"] {os = "macos" & os-distribution = "homebrew"}
+  ["fusefs-libs"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on FUSE"
 description:


### PR DESCRIPTION
Source: https://www.freshports.org/sysutils/fusefs-libs/