### PR TITLE
conf-libMagickCore: add support for Arch, Alpine, Fedora, OpenSuse, FreeBSD, homebrew, and Ubuntu derivatives

### DIFF
--- a/packages/conf-libMagickCore/conf-libMagickCore.1/opam
+++ b/packages/conf-libMagickCore/conf-libMagickCore.1/opam
@@ -10,7 +10,7 @@ depexts: [
   ["libmagickcore-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["ImageMagick-devel"] {os-distribution = "fedora"}
   ["libMagick-devel"] {os-distribution = "mageia"}
-  ["ImageMagick"] {os-family = "suse" | os-family = "opensuse"}
+  ["ImageMagick-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["ImageMagick7"] {os = "freebsd"}
   ["imagemagick"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-libMagickCore/conf-libMagickCore.1/opam
+++ b/packages/conf-libMagickCore/conf-libMagickCore.1/opam
@@ -5,8 +5,14 @@ homepage: "http://www.imagemagick.org/"
 license: "Apache-1.0+"
 build: [["pkg-config" "MagickCore"]]
 depexts: [
-  ["libmagickcore-dev"] {os-family = "debian"}
+  ["imagemagick"] {os-distribution = "arch"}
+  ["imagemagick-dev"] {os-distribution = "alpine"}
+  ["libmagickcore-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["ImageMagick-devel"] {os-distribution = "fedora"}
   ["libMagick-devel"] {os-distribution = "mageia"}
+  ["ImageMagick"] {os-family = "suse" | os-family = "opensuse"}
+  ["ImageMagick7"] {os = "freebsd"}
+  ["imagemagick"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on an ImageMagick system installation"
 description: """


### PR DESCRIPTION
Sources:
https://archlinux.org/packages/extra/x86_64/imagemagick/
https://alpine.pkgs.org/3.18/alpine-community-x86_64/imagemagick-dev-7.1.1.13-r1.apk.html
https://packages.fedoraproject.org/pkgs/ImageMagick/ImageMagick-devel/fedora-39-updates.html
https://build.opensuse.org/package/show/openSUSE%3AFactory/ImageMagick
https://www.freshports.org/graphics/ImageMagick7
https://formulae.brew.sh/formula/imagemagick