### PR TITLE
conf-libmosquitto: strengthen build test + add support for Arch, Ubuntu, Suse, Fedora, FreeBSD

### DIFF
--- a/packages/conf-libmosquitto/conf-libmosquitto.1/opam
+++ b/packages/conf-libmosquitto/conf-libmosquitto.1/opam
@@ -4,14 +4,16 @@ authors: [ "Markus W. Weissmann <markus.weissmann@in.tum.de>" ]
 homepage: "https://mosquitto.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: [ "EPL-1.0" "Eclipse Distribution License 1.0" ]
-build: [
-  ["ls" "/usr/include/mosquitto.h"] {os != "macos"}
-  ["brew" "ls" "--versions" "mosquitto"] {os = "macos"}
-]
+build: ["pkg-config" "libmosquitto"]
+depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libmosquitto-dev"] {os-family = "debian"}
+  ["mosquitto"] {os-distribution = "arch"}
+  ["libmosquitto-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["mosquitto-dev"] {os-distribution = "alpine"}
+  ["mosquitto-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["mosquitto-devel"] {os-distribution = "fedora"}
   ["mosquitto"] {os = "macos" & os-distribution = "homebrew"}
+  ["mosquitto"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a libmosquitto system installation"
 description:


### PR DESCRIPTION
Sources:
https://archlinux.org/packages/extra/x86_64/mosquitto/
https://opensuse.pkgs.org/tumbleweed/opensuse-oss-x86_64/mosquitto-devel-2.0.15-1.5.x86_64.rpm.html
https://packages.fedoraproject.org/pkgs/mosquitto/mosquitto-devel/fedora-39.html
https://www.freshports.org/net/mosquitto