### PR TITLE
[new release] coq-serapi (8.17.0+0.17.3)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.17.0+0.17.3/opam
+++ b/packages/coq-serapi/coq-serapi.8.17.0+0.17.3/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.09.0"              }
+  "coq"                 {           >= "8.17" & < "8.18"     }
+  "cmdliner"            {           >= "1.1.0"               }
+  "ocamlfind"           {           >= "1.8.0"               }
+  "sexplib"             {           >= "v0.13.0"             }
+  "dune"                {           >= "2.0.1"               }
+  "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
+  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_sexp_conv"       {           >= "v0.13.0"             }
+  "ppx_compare"         {           >= "v0.13.0"             }
+  "ppx_hash"            {           >= "v0.13.0"             }
+  "yojson"              {           >= "1.7.0"               }
+  "ppx_deriving_yojson" {           >= "3.4"                 }
+]
+
+conflicts: [
+  "result" {< "1.5"}
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.17.0%2B0.17.3/coq-serapi-8.17.0.0.17.3.tbz"
+  checksum: [
+    "sha256=bab246d97c66e06f7a65808a24a295bf288a2b7e07cc45ab4a1e8fc24a1ea3f6"
+    "sha512=33dfa7cb9857e30861ef4dc6bd1654799e6fd45d53d7ad9f79755920c1961e67f98f650db1e6dc288f0f1fe744fac28878ec03cce062cae78ae64bdd98614991"
+  ]
+}
+x-commit-hash: "9c3f5bf6060b8899851eeba160636b6a9a817c86"


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

 - [serlib] Fix (@ejgallego, ejgallego/coq-serapi#398, fixes ejgallego/coq-serapi#397 fixes sr-lab/coqpyt#35 ,
            thanks to @laetitia-teo and @Nfsaavedra for the bug
            report)
