### PR TITLE
conf-pkg-config: rename nixos package pkgconfig to pkg-config

### DIFF
--- a/packages/conf-pkg-config/conf-pkg-config.1.0/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.0/opam
@@ -16,6 +16,7 @@ depexts: [
   ["pkgconfig"] {os-distribution = "rhel"}
   ["pkgconfig"] {os-distribution = "ol"}
   ["pkgconf"] {os-distribution = "alpine"}
+  ["pkg-config"] {os-distribution = "nixos"}
   ["devel/pkgconf"] {os = "openbsd"}
   ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconf"] {os = "freebsd"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.1/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.1/opam
@@ -26,7 +26,7 @@ depexts: [
   ["pkgconfig"] {os-distribution = "rhel"}
   ["pkgconfig"] {os-distribution = "ol"}
   ["pkgconf"] {os-distribution = "alpine"}
-  ["pkgconfig"] {os-distribution = "nixos"}
+  ["pkg-config"] {os-distribution = "nixos"}
   ["devel/pkgconf"] {os = "openbsd"}
   ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconf"] {os = "freebsd"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.2/opam
@@ -26,7 +26,7 @@ depexts: [
   ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
   ["pkgconfig"] {os-distribution = "ol"}
   ["pkgconf"] {os-distribution = "alpine"}
-  ["pkgconfig"] {os-distribution = "nixos"}
+  ["pkg-config"] {os-distribution = "nixos"}
   ["devel/pkgconf"] {os = "openbsd"}
   ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconf"] {os = "freebsd"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.3/opam
@@ -26,7 +26,7 @@ depexts: [
   ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
   ["pkgconfig"] {os-distribution = "ol"}
   ["pkgconf"] {os-distribution = "alpine"}
-  ["pkgconfig"] {os-distribution = "nixos"}
+  ["pkg-config"] {os-distribution = "nixos"}
   ["devel/pkgconf"] {os = "openbsd"}
   ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconfig"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-pkg-config/conf-pkg-config.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.2/opam
@@ -26,7 +26,7 @@ depexts: [
   ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
   ["pkgconfig"] {os-distribution = "ol" & os-version <= "7"}
   ["pkgconf"] {os-distribution = "alpine"}
-  ["pkgconfig"] {os-distribution = "nixos"}
+  ["pkg-config"] {os-distribution = "nixos"}
   ["devel/pkgconf"] {os = "openbsd"}
   ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconfig"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-pkg-config/conf-pkg-config.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.3/opam
@@ -17,7 +17,7 @@ depexts: [
   ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
   ["pkgconfig"] {os-distribution = "ol" & os-version <= "7"}
   ["pkgconf"] {os-distribution = "alpine"}
-  ["pkgconfig"] {os-distribution = "nixos"}
+  ["pkg-config"] {os-distribution = "nixos"}
   ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
   ["pkgconf"] {os = "freebsd"}


### PR DESCRIPTION
`pkg-config` has been the correct name since 2018 ([reference](https://github.com/NixOS/nixpkgs/commit/9bb3fccb5b55326cb3c2c507464a8a28d44d1730)), but `pkgconfig` was an alias that worked for many years, so I never noticed it was the non-preferred option.

Now that `pkgconfig` doesn't work, I've retrospectively changed it in historical versions since it's not as if the package name actually changed, it was previously relying on an alias to the correct name.