### PR TITLE
add patch fixing lablgtk3 #178

### DIFF
--- a/packages/lablgtk3/lablgtk3.3.1.4/files/ml_gtk.c.diff
+++ b/packages/lablgtk3/lablgtk3.3.1.4/files/ml_gtk.c.diff
@@ -1,0 +1,13 @@
+diff --git a/src/ml_gtk.c b/src/ml_gtk.c
+index deb1b4c7a9..0dcc104e6f 100644
+--- a/src/ml_gtk.c
++++ b/src/ml_gtk.c
+@@ -233,7 +233,7 @@ ML_2 (gtk_style_context_add_class, GtkStyleContext_val, String_val, Unit)
+ ML_2 (gtk_style_context_remove_class, GtkStyleContext_val, String_val, Unit)
+ ML_2 (gtk_style_context_has_class, GtkStyleContext_val, String_val, Val_bool)
+ CAMLprim value ml_gtk_style_context_list_classes(value ctx)
+-{ return Val_GList(gtk_style_context_list_classes(GtkStyleContext_val(ctx)), Val_string); }
++{ return Val_GList(gtk_style_context_list_classes(GtkStyleContext_val(ctx)), (value_in)Val_string); }
+ 
+ /* gtkdata.h */
+ 

--- a/packages/lablgtk3/lablgtk3.3.1.4/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.4/opam
@@ -24,6 +24,7 @@ depends: [
   "ocamlfind" { dev                 }
   "camlp5"    { dev                 }
 ]
+patches: ["ml_gtk.c.diff"]
 
 build: [
   [ "dune" "subst"] {dev}
@@ -31,6 +32,9 @@ build: [
 ]
 run-test: [
   [ "dune" "build" "-p" name "-j" jobs "examples/buttons.exe" ]
+]
+extra-files: [
+  [ "ml_gtk.c.diff" "md5=ad9e468e33ae3a1e234238df088f784e" ]
 ]
 url {
   src:


### PR DESCRIPTION
Recent versions of clang and gcc trigger a type error in a newly added function in ml_gtk.c (https://github.com/garrigue/lablgtk/issues/178).
This commit adds a patch fixing that.
The fix is already merged in lablgtk3, but making a new release will take a while.