### PR TITLE
Package hl_yaml.1.0.0

### DIFF
--- a/packages/hl_yaml/hl_yaml.1.0.0/opam
+++ b/packages/hl_yaml/hl_yaml.1.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Simon Grondin"
+authors: [ "Simon Grondin" ]
+synopsis: "High-level preprocessing wrapper around the yaml library"
+description: """
+High Level YAML ("HL YAML") is a lightweight all-in-one tool to read, parse, preprocess, validate and deserialize YAML files.
+
+For example, it enables configuration files written in YAML to reference environment variables, inline credentials files, and import other configuration files.
+Additionally, the `<<:` "operator" similar to OCaml's `include`, as well as anchors (`&`) and references (`*`) can greatly reduce the amount of repetition in your YAML files.
+
+HL YAML's features can be disabled individually and new ones added to serve specific use cases.
+
+For IO, HL YAML can use Lwt, Eio, or the standard library.
+"""
+license: "MIT"
+homepage: "https://github.com/SGrondin/hl_yaml"
+dev-repo: "git://github.com/SGrondin/hl_yaml"
+doc: "https://github.com/SGrondin/hl_yaml"
+bug-reports: "https://github.com/SGrondin/hl_yaml/issues"
+depends: [
+  "ocaml" { >= "5.0.0" }
+  "dune" { >= "1.9.0" }
+
+  # DEPENDENCIES
+  "yojson"
+  "ppx_deriving_yojson"
+  "yaml" { >= "3.2.0" }
+
+  # TESTS ONLY
+  "core" { with-test & >= "v0.16" }
+  "ppx_expect" { with-test }
+  "ppx_sexp_conv" { with-test }
+  "ppx_deriving_yojson" { with-test }
+  "ppx_custom_printf" { with-test }
+  "lwt" { with-test }
+  "eio_main" { with-test }
+
+  # "ocamlformat" { = "0.25.1" } # Development
+  # "ocaml-lsp-server" # Development
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/SGrondin/hl_yaml/archive/refs/tags/1.0.0.tar.gz"
+  checksum: [
+    "md5=df710f758a0937a92537956d8b768c88"
+    "sha512=b0882038cf0a1be411006921733f101b5954456d18fb8f4a1b527f47088e862c482ad997ecffc2226c84b018d48c39b4f4a2555157cc98896b1093136d16ff68"
+  ]
+}


### PR DESCRIPTION
### `hl_yaml.1.0.0`
High-level preprocessing wrapper around the yaml library
High Level YAML ("HL YAML") is a lightweight all-in-one tool to read, parse, preprocess, validate and deserialize YAML files.

For example, it enables configuration files written in YAML to reference environment variables, inline credentials files, and import other configuration files.
Additionally, the `<<:` "operator" similar to OCaml's `include`, as well as anchors (`&`) and references (`*`) can greatly reduce the amount of repetition in your YAML files.

HL YAML's features can be disabled individually and new ones added to serve specific use cases.

For IO, HL YAML can use Lwt, Eio, or the standard library.



---
* Homepage: https://github.com/SGrondin/hl_yaml
* Source repo: git://github.com/SGrondin/hl_yaml
* Bug tracker: https://github.com/SGrondin/hl_yaml/issues

---
:camel: Pull-request generated by opam-publish v2.2.0