### PR TITLE
OCaml 5.2.0~beta1 opam packages

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta1/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta1/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "First beta release of OCaml 5.2.0"
+maintainer: "platform@lists.ocaml.org"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml#5.2"
+depends: [
+  "ocaml" {= "5.2.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "ocaml-options-vanilla" {post}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.2.0-beta1.tar.gz"
+  checksum: "sha256=8fa1101f92091dd333d9dbd101f52ea3db86b827e8f1d26e45c98f8eac7e9e28"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/opam
@@ -1,0 +1,83 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First beta release of OCaml 5.2.0"
+maintainer: "platform@lists.ocaml.org"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.2"
+depends: [
+  "ocaml" {= "5.2.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build-env: [
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--without-zstd" {ocaml-option-no-compression:installed}
+    "--enable-tsan" {ocaml-option-tsan:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.2.0-beta1.tar.gz"
+  checksum: "sha256=8fa1101f92091dd333d9dbd101f52ea3db86b827e8f1d26e45c98f8eac7e9e28"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-no-compression"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+  "ocaml-option-tsan"
+]


### PR DESCRIPTION
This PR adds the opam packages for the first beta release of OCaml 5.2.0 (`ocaml-base` and `ocaml-variants.5.2.0~beta1+options`).

Compared to the first alpha, this beta release contains a majority of runtime-related fixes, and
a handful of fixes uniformly distributed on various subsystems
(build and configuration, error messages, type system, standard library, compiler internals).

-------------------------------------------------

# Changes compared to the first alpha release

## Runtime system

- 12875, 12879, 12882: Execute preemptive systhread switching as a
  delayed pending action. This ensures that one can reason within the
  FFI that no mutation happens on the same domain when allocating on
  the OCaml heap from C, consistently with OCaml 4. This also fixes
  further bugs with the multicore systhreads implementation.
  (Guillaume Munch-Maccagnoni, bug reports and suggestion by Mark
   Shinwell, review by Nick Barnes and Stephen Dolan)

- 12876: Port ThreadSanitizer support to Linux on POWER
  (Miod Vallat, review by Tim McGilchrist)

- 12678, 12898: free channel buffers on close rather than on finalization
  (Damien Doligez, review by Jan Midtgaard and Gabriel Scherer, report
   by Jan Midtgaard)

- 12915: Port ThreadSanitizer support to Linux on s390x
  (Miod Vallat, review by Tim McGilchrist)

- 12914: Slightly change the s390x assembly dialect in order to build with
  Clang's integrated assembler.
  (Miod Vallat, review by Gabriel Scherer)

- 12897: fix locking bugs in Runtime_events
  (Gabriel Scherer and Thomas Leonard,
   review by Olivier Nicole, Vincent Laviron and Damien Doligez,
   report by Thomas Leonard)

- 12860: Fix an assertion that wasn't taking into account the possibility of an
  ephemeron pointing at static data.
  (Mark Shinwell, review by Gabriel Scherer and KC Sivaramakrishnan)

- 11040, 12894: Silence false data race observed between caml_shared_try_alloc
  and oldify. Introduces macros to call tsan annotations which help annotate
  a ``happens before'' relationship.
  (Hari Hara Naveen S and Olivier Nicole,
   review by Gabriel Scherer and Miod Vallat)

- 12919: Fix register corruption in caml_callback2_asm on s390x.
  (Miod Vallat, review by Gabriel Scherer)

- 12969: Fix a data race in caml_darken_cont
  (Fabrice Buoro and Olivier Nicole, review by Gabriel Scherer and Miod Vallat)

## Standard library

- 12677, 12889: make Domain.DLS thread-safe
  (Gabriel Scherer, review by Olivier Nicole and Damien Doligez,
   report by Vesa Karvonen)

## Type system

- 12924, 12930: Rework package constraint checking to improve interaction with
  immediacy
  (Chris Casinghino and Florian Angeletti, review by Florian Angeletti and
   Richard Eisenberg)

## Compiler user-interface

- 12971, 12974: fix an uncaught Ctype.Escape exception on some
  invalid programs forming recursive types.
  (Gabriel Scherer, review by Florian Angeletti, report by Neven Villani)

## Build system

+ 12198, 12321, 12586, 12616, 12706, +13048: continue the merge of the
   sub-makefiles into the root Makefile started with #11243, #11248,
   #11268, #11420 and #11675.
   (Sébastien Hinderer, review by David Allsopp and Florian Angeletti)

+ 12768, +13030: Detect mingw-w64 coupling with GCC or LLVM, detect clang-cl,
   and fix C compiler feature detection on macOS.
   (Antonin Décimo, review by Miod Vallat and Sébastien Hinderer)

- 13019: Remove linking instructions for the Unix library from threads.cma
  (this was done for threads.cmxa in OCaml 3.11). Eliminates warnings from
  new lld when using threads.cma of duplicated libraries.
  (David Allsopp, review by Nicolás Ojeda Bär)

+ 12758, +12998: Remove the `Marshal.Compression` flag to the
   `Marshal.to_*` functions.  The compilers are still able to use
   ZSTD compression for compilation artefacts.
   This is a forward port and clean-up of the emergency fix that was introduced

## Compiler internals

+ 12389, 12544, 12984, +12987: centralize the handling of metadata for
  compilation units and artifacts in preparation for better unicode support for
  OCaml source files.
  (Florian Angeletti, review by Vincent Laviron and Gabriel Scherer)
