### PR TITLE
Package ocsigen-start.6.3.0

### DIFF
--- a/packages/ocsigen-start/ocsigen-start.6.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.6.1.0/opam
@@ -21,7 +21,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "4.0.0"}
-  "eliom" {>= "10.0.0" & < "11.0.0"}
+  "eliom" {>= "10.0.0" & < "10.4.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-ppx-rpc"
   "ocsigen-i18n" {>= "3.7.0"}

--- a/packages/ocsigen-start/ocsigen-start.6.1.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.6.1.1/opam
@@ -21,7 +21,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "4.0.0"}
-  "eliom" {>= "10.0.0" & < "11.0.0"}
+  "eliom" {>= "10.0.0" & < "10.4.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-ppx-rpc"
   "ocsigen-i18n" {>= "3.7.0"}

--- a/packages/ocsigen-start/ocsigen-start.6.1.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.6.1.2/opam
@@ -21,7 +21,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "4.0.0"}
-  "eliom" {>= "10.0.0" & < "11.0.0"}
+  "eliom" {>= "10.0.0" & < "10.4.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-ppx-rpc"
   "ocsigen-i18n" {>= "3.7.0"}

--- a/packages/ocsigen-start/ocsigen-start.6.2.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.6.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "4.0.0"}
-  "eliom" {>= "10.0.0" & < "11.0.0"}
+  "eliom" {>= "10.0.0" & < "10.4.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-ppx-rpc"
   "ocsigen-i18n" {>= "3.7.0"}

--- a/packages/ocsigen-start/ocsigen-start.6.3.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.6.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+authors: "dev@ocsigen.org"
+maintainer: "dev@ocsigen.org"
+synopsis: "Higher-level library for developing Web and mobile applications with users, registration, notifications, etc"
+description: """
+Ocsigen Start is a set of higher-level libraries for building client-server Web and mobile applications with Ocsigen (Js_of_ocaml and Eliom).
+It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users.
+Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management.
+This template is intended to serve as a basis for quickly building the Minimum Viable Product for Web and mobile applications with users.
+The goal is to enable the programmer to concentrate on the core of the app, and not on user management.
+"""
+homepage: "https://ocsigen.org/ocsigen-start/"
+bug-reports: "https://github.com/ocsigen/ocsigen-start/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-start.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.08.1"}
+  "pgocaml" {>= "4.0"}
+  "pgocaml_ppx" {>= "4.0"}
+  "safepass" {>= "3.0"}
+  "ocsigen-i18n" {>= "4.0.0"}
+  "eliom" {>= "10.4.0" & < "11.0.0"}
+  "ocsigen-toolkit" {>= "2.7.0"}
+  "ocsigen-ppx-rpc"
+  "ocsigen-i18n" {>= "3.7.0"}
+  "yojson" {>= "1.6.0"}
+  "resource-pooling" {>= "1.0" & < "2.0"}
+  "cohttp-lwt-unix"
+  "conf-npm" {>= "1"}
+  "re" {>= "1.7.2"}
+]
+depexts: [
+  ["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}
+  ["postgresql" "md5sha1sum" "sassc"] {os = "macos" & os-distribution = "homebrew"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsigen-start/archive/refs/tags/6.3.0.tar.gz"
+  checksum: [
+    "md5=df540ce462ee28da6a9dde20ee3ed58a"
+    "sha512=8c7951b6b16b8abae7a17b9228e6bd17dee2f6b87302cb83a2e741a7cb8ef7dbee462fb6fcba1a973e4a468e30ebde22711b51b0d3aaf3a2ab16b00942be917e"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-start.6.3.0`
Higher-level library for developing Web and mobile applications with users, registration, notifications, etc
Ocsigen Start is a set of higher-level libraries for building client-server Web and mobile applications with Ocsigen (Js_of_ocaml and Eliom).
It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users.
Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management.
This template is intended to serve as a basis for quickly building the Minimum Viable Product for Web and mobile applications with users.
The goal is to enable the programmer to concentrate on the core of the app, and not on user management.



---
* Homepage: https://ocsigen.org/ocsigen-start/
* Source repo: git+https://github.com/ocsigen/ocsigen-start.git
* Bug tracker: https://github.com/ocsigen/ocsigen-start/issues

---
:camel: Pull-request generated by opam-publish v2.3.0