### PR TITLE
[new release] iostream (2 packages) (0.2.1)

### DIFF
--- a/packages/iostream-camlzip/iostream-camlzip.0.2.1/opam
+++ b/packages/iostream-camlzip/iostream-camlzip.0.2.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ounit2" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/iostream-camlzip/iostream-camlzip.0.2.1/opam
+++ b/packages/iostream-camlzip/iostream-camlzip.0.2.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Stream (de)compression using deflate"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["topics" "io" "channels" "streams" "zip" "deflate"]
+homepage: "https://github.com/c-cube/ocaml-iostream"
+doc: "https://c-cube.github.io/ocaml-iostream"
+bug-reports: "https://github.com/c-cube/ocaml-iostream/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "iostream" {= version}
+  "camlzip"
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-iostream.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-iostream/releases/download/v0.2.1/iostream-0.2.1.tbz"
+  checksum: [
+    "sha256=09cd438f755d46bf10e986be0d3dd2ab243b1f5455c3c7410dcde8de521615a9"
+    "sha512=c5f4c251ba33386dd027d2cf340268d14fdbcd3119be6bac3586fd9ad1e9f90992ef12e8fd9fbf2442c6747560d84fd2461656ea639f818e53d0b08e82dd8e9a"
+  ]
+}
+x-commit-hash: "3ddbf6b07523b7e9bead61e3db469cb168a51a23"

--- a/packages/iostream/iostream.0.2.1/opam
+++ b/packages/iostream/iostream.0.2.1/opam
@@ -14,7 +14,7 @@ depends: [
 ]
 depopts: ["base-unix"]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/iostream/iostream.0.2.1/opam
+++ b/packages/iostream/iostream.0.2.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Generic, composable IO input and output streams"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["topics" "io" "channels" "streams"]
+homepage: "https://github.com/c-cube/ocaml-iostream"
+doc: "https://c-cube.github.io/ocaml-iostream"
+bug-reports: "https://github.com/c-cube/ocaml-iostream/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "ounit2" {with-test}
+]
+depopts: ["base-unix"]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-iostream.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-iostream/releases/download/v0.2.1/iostream-0.2.1.tbz"
+  checksum: [
+    "sha256=09cd438f755d46bf10e986be0d3dd2ab243b1f5455c3c7410dcde8de521615a9"
+    "sha512=c5f4c251ba33386dd027d2cf340268d14fdbcd3119be6bac3586fd9ad1e9f90992ef12e8fd9fbf2442c6747560d84fd2461656ea639f818e53d0b08e82dd8e9a"
+  ]
+}
+x-commit-hash: "3ddbf6b07523b7e9bead61e3db469cb168a51a23"


### PR DESCRIPTION
Generic, composable IO input and output streams

- Project page: <a href="https://github.com/c-cube/ocaml-iostream">https://github.com/c-cube/ocaml-iostream</a>
- Documentation: <a href="https://c-cube.github.io/ocaml-iostream">https://c-cube.github.io/ocaml-iostream</a>

##### CHANGES:

- bugfix for iostream-camlzip
