### PR TITLE
relax bound on dot-merlin-reader -> merlin-lib constraint

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.9/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.9/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08" & < "6.0"}
   "dune" {>= "2.9.0"}
-  "merlin-lib" {>= "4.9" & < "4.14"}
+  "merlin-lib" {>= "4.9" & < "4.14-500"}
   "ocamlfind" {>= "1.6.0"}
 ]
 description:


### PR DESCRIPTION
attempting to fix https://github.com/ocaml/opam-repository/issues/25583