### PR TITLE
[new release] tcpip (8.0.1)

### DIFF
--- a/packages/tcpip/tcpip.8.0.1/opam
+++ b/packages/tcpip/tcpip.8.0.1/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding"
+  "result" {< "1.5"}
+]
+depends: [
+  "dune" {>= "2.7.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "mirage-net" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>="4.0.0"}
+  "macaddr-cstruct"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv" {< "0.2.0"}
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "alcotest" {with-test & >="1.5.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "ipaddr-cstruct"
+  "macaddr-cstruct"
+  "lru" {>= "0.3.0"}
+  "metrics"
+  "cmdliner" {>= "1.1.0"}
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v8.0.1/tcpip-8.0.1.tbz"
+  checksum: [
+    "sha256=5bbe976f984fc2afe6ea0df4f5f535a1f0b224f6dc32fdae5546a0461f301d8d"
+    "sha512=5883739ab213082fdc82baeb4f241c62ec7f688b6548d57c293c6277e2e71ec5f5cbea78bdb2c28fab4c54a84e05f32a55ccf9b3853d516f805ae5e0ce528eae"
+  ]
+}
+x-commit-hash: "be78e22eb6e19019eee30b166256f16660d8b2a8"

--- a/packages/tcpip/tcpip.8.0.1/opam
+++ b/packages/tcpip/tcpip.8.0.1/opam
@@ -30,7 +30,7 @@ depends: [
   "cstruct-lwt"
   "mirage-net" {>= "3.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-random" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0" & < "4.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "5.0.0"}
   "macaddr" {>="4.0.0"}


### PR DESCRIPTION
OCaml TCP/IP networking stack, used in MirageOS

- Project page: <a href="https://github.com/mirage/mirage-tcpip">https://github.com/mirage/mirage-tcpip</a>
- Documentation: <a href="https://mirage.github.io/mirage-tcpip/">https://mirage.github.io/mirage-tcpip/</a>

##### CHANGES:

* TCP: add `src : flow -> ipaddr * int`, implemented by `getsockname` on unix
  (mirage/mirage-tcpip#511 @hannesm)
* TCP unix stack: increase TCP buffer size (was 4096, is now 65536)
  (mirage/mirage-tcpip#510 @edwintorok)
* TCP: adapt to mirage-flow 4.0:
  add ``val shutdown : flow -> [ `read | `write | `read_write ] -> unit Lwt.t``
  (mirage/mirage-tcpip#512 @hannesm, review by @djs55)
