### PR TITLE
[new release] tls (5 packages) (0.17.4)

### DIFF
--- a/packages/tls-async/tls-async.0.17.4/opam
+++ b/packages/tls-async/tls-async.0.17.4/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "x509" {>= "0.14.0"}
+  "ptime" {>= "0.8.1"}
+  "async" {>= "v0.16"}
+  "async_unix" {>= "v0.16"}
+  "core" {>= "v0.16"}
+  "cstruct-async"
+  "ppx_jane" {>= "v0.16"}
+  "mirage-crypto-rng-async"
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, Async layer"
+description: """
+Tls-async provides Async-friendly tls bindings
+"""
+authors: [
+  "David Kaloper <david@numm.org>"
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "Eric Ebinger <github@eric.theebingers.com>"
+  "Calascibetta Romain <romain.calascibetta@gmail.com>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.17.4/tls-0.17.4.tbz"
+  checksum: [
+    "sha256=62a4290971dffae0e436493ec06c811560e242ba810ed2a86dd749763de1a43f"
+    "sha512=0569fbfcb56e75a1ce37a317f2f00f9f3032c5b186a65d041446e39be576a4b756f8a53e078d7814837f9f8f07e66859627d2e132e33e2a7dddd9f21c3082bde"
+  ]
+}
+x-commit-hash: "fc78dd87b26600ed977eb2f18aab4e86d43dfb73"

--- a/packages/tls-eio/tls-eio.0.17.4/opam
+++ b/packages/tls-eio/tls-eio.0.17.4/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+authors:      ["Thomas Leonard"]
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
+]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "mirage-crypto-rng" {>= "0.11.2"}
+  "mirage-crypto-rng-eio" {>= "0.11.2" with-test}
+  "x509" {>= "0.15.0"}
+  "eio" {>= "0.12"}
+  "eio_main" {>= "0.12" with-test}
+  "mdx" {with-test}
+  "crowbar" {>= "0.2.1" with-test}
+  "logs" {>= "0.7.0" with-test}
+  "ptime" {>= "1.0.0"}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml - Eio"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.17.4/tls-0.17.4.tbz"
+  checksum: [
+    "sha256=62a4290971dffae0e436493ec06c811560e242ba810ed2a86dd749763de1a43f"
+    "sha512=0569fbfcb56e75a1ce37a317f2f00f9f3032c5b186a65d041446e39be576a4b756f8a53e078d7814837f9f8f07e66859627d2e132e33e2a7dddd9f21c3082bde"
+  ]
+}
+x-commit-hash: "fc78dd87b26600ed977eb2f18aab4e86d43dfb73"

--- a/packages/tls-lwt/tls-lwt.0.17.4/opam
+++ b/packages/tls-lwt/tls-lwt.0.17.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "mirage-crypto-rng-lwt" {>= "0.11.0"}
+  "x509" {>= "0.15.0"}
+  "lwt" {>= "5.7.0"}
+  "cmdliner" {>= "1.1.0"}
+  "ptime" {>= "0.8.1"}
+  "randomconv" {with-test & < "0.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, Lwt layer"
+description: """
+Tls-lwt provides an effectful Tls_lwt module to be used with Lwt.
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.17.4/tls-0.17.4.tbz"
+  checksum: [
+    "sha256=62a4290971dffae0e436493ec06c811560e242ba810ed2a86dd749763de1a43f"
+    "sha512=0569fbfcb56e75a1ce37a317f2f00f9f3032c5b186a65d041446e39be576a4b756f8a53e078d7814837f9f8f07e66859627d2e132e33e2a7dddd9f21c3082bde"
+  ]
+}
+x-commit-hash: "fc78dd87b26600ed977eb2f18aab4e86d43dfb73"

--- a/packages/tls-mirage/tls-mirage.0.17.4/opam
+++ b/packages/tls-mirage/tls-mirage.0.17.4/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "x509" {>= "0.13.0"}
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "3.0.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, MirageOS layer"
+description: """
+Tls-mirage provides an effectful FLOW module to be used in the MirageOS
+ecosystem.
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.17.4/tls-0.17.4.tbz"
+  checksum: [
+    "sha256=62a4290971dffae0e436493ec06c811560e242ba810ed2a86dd749763de1a43f"
+    "sha512=0569fbfcb56e75a1ce37a317f2f00f9f3032c5b186a65d041446e39be576a4b756f8a53e078d7814837f9f8f07e66859627d2e132e33e2a7dddd9f21c3082bde"
+  ]
+}
+x-commit-hash: "fc78dd87b26600ed977eb2f18aab4e86d43dfb73"

--- a/packages/tls/tls.0.17.4/opam
+++ b/packages/tls/tls.0.17.4/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.0"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-crypto" {>= "0.11.0"}
+  "mirage-crypto-ec" {>= "0.10.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "x509" {>= "0.15.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt" {>= "0.8.7"}
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "ounit2" {with-test & >= "2.2.0"}
+  "hkdf"
+  "logs"
+  "ipaddr"
+  "alcotest" {with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.17.4/tls-0.17.4.tbz"
+  checksum: [
+    "sha256=62a4290971dffae0e436493ec06c811560e242ba810ed2a86dd749763de1a43f"
+    "sha512=0569fbfcb56e75a1ce37a317f2f00f9f3032c5b186a65d041446e39be576a4b756f8a53e078d7814837f9f8f07e66859627d2e132e33e2a7dddd9f21c3082bde"
+  ]
+}
+x-commit-hash: "fc78dd87b26600ed977eb2f18aab4e86d43dfb73"


### PR DESCRIPTION
Transport Layer Security purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-tls">https://github.com/mirleft/ocaml-tls</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-tls/doc">https://mirleft.github.io/ocaml-tls/doc</a>

##### CHANGES:

* tls: handle half-closed connection properly: a received CLOSE_NOTIFY does not
  lead to a CLOSE_NOTIFY to be sent (a `send_close_notify` sends it explicitly)
  (mirleft/ocaml-tls#488 @hannesm)
* tls: modify return type of `handle_tls` - the Alert is now in the right hand
  side, and `` `Eof `` is explicit in the second part of the tuple
  (mirleft/ocaml-tls#488 @hannesm)
* tls: remove `can_handle_appdata`, the function `handshake_in_progress` is
  available (mirleft/ocaml-tls#488 @hannesm)
* tls-mirage: avoid exceptions in reneg and rekey (mirleft/ocaml-tls#487 @hannesm)
* tls: remove HEARTBEAT decoding - HEARTBEAT was never supported in this
  library, the decoder was superfluous (mirleft/ocaml-tls#487 @hannesm)
* tls-mirage: provide `underlying : flow -> FLOW.flow` (mirleft/ocaml-tls#487 @hannesm,
  fixes mirleft/ocaml-tls#425 @dinosaure)
* tls-mirage: implement mirage-flow 4 API (`val shutdown`) (mirleft/ocaml-tls#488 @hannesm)
* tls-eio: adapt to half-closed connections (mirleft/ocaml-tls#488 @talex5)
