### PR TITLE
[new release] mirage-random (4.0.0)

### DIFF
--- a/packages/mirage-random/mirage-random.4.0.0/opam
+++ b/packages/mirage-random/mirage-random.4.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-random"
+bug-reports:   "https://github.com/mirage/mirage-random/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-random.git"
+doc:           "https://mirage.github.io/mirage-random/"
+authors:       ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune" {>="1.1.0"}
+  "ocaml" {>= "4.08.0"}
+]
+
+synopsis: "Random-related devices for MirageOS"
+description: """
+mirage-random defines `Mirage_random.S` the signature for random-related devices for MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-random/releases/download/v4.0.0/mirage-random-4.0.0.tbz"
+  checksum: [
+    "sha256=93d0a623f922f49a647231c6d4470752b2aabfed206eecfebaba5a5162074cd1"
+    "sha512=86e4776891f7c63e7622268af6f4c85a0c464bf8ce86f0db3c70b7971c0cc222d3791443da1e6e57ace18f803ba98714111fc1d9beccb030f68b8f126de93027"
+  ]
+}
+x-commit-hash: "5da4b2852b73baf28d2077bb4599947a72a1ec7e"


### PR DESCRIPTION
Random-related devices for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-random">https://github.com/mirage/mirage-random</a>
- Documentation: <a href="https://mirage.github.io/mirage-random/">https://mirage.github.io/mirage-random/</a>

##### CHANGES:

* Revise API: `val generate : ?g:g -> int -> string`, and
  `val generate_into : ?g:g -> bytes -> ?off:int -> int -> unit`
  Remove cstruct dependency (mirage/mirage-random#15 @hannesm)
