### PR TITLE
Set upper bound for tls compatibility.

### DIFF
--- a/packages/liquidsoap-core/liquidsoap-core.2.2.0/opam
+++ b/packages/liquidsoap-core/liquidsoap-core.2.2.0/opam
@@ -109,6 +109,7 @@ conflicts: [
   "taglib" {< "0.3.10"}
   "sdl-liquidsoap" {< "2"}
   "theora" {< "0.4.0"}
+  "tls" {>= "0.17.4"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
 ]

--- a/packages/liquidsoap-core/liquidsoap-core.2.2.1/opam
+++ b/packages/liquidsoap-core/liquidsoap-core.2.2.1/opam
@@ -107,6 +107,7 @@ conflicts: [
   "srt" {< "0.3.0"}
   "ssl" {< "0.7.0"}
   "taglib" {< "0.3.10"}
+  "tls" {>= "0.17.4"}
   "sdl-liquidsoap" {< "2"}
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}

--- a/packages/liquidsoap-core/liquidsoap-core.2.2.2/opam
+++ b/packages/liquidsoap-core/liquidsoap-core.2.2.2/opam
@@ -107,6 +107,7 @@ conflicts: [
   "srt" {< "0.3.0"}
   "ssl" {< "0.7.0"}
   "taglib" {< "0.3.10"}
+  "tls" {>= "0.17.4"}
   "sdl-liquidsoap" {< "2"}
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}

--- a/packages/liquidsoap-core/liquidsoap-core.2.2.3/opam
+++ b/packages/liquidsoap-core/liquidsoap-core.2.2.3/opam
@@ -106,6 +106,7 @@ conflicts: [
   "srt" {< "0.3.0"}
   "ssl" {< "0.7.0"}
   "taglib" {< "0.3.10"}
+  "tls" {>= "0.17.4"}
   "sdl-liquidsoap" {< "2"}
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}

--- a/packages/liquidsoap-core/liquidsoap-core.2.2.4-1/opam
+++ b/packages/liquidsoap-core/liquidsoap-core.2.2.4-1/opam
@@ -106,6 +106,7 @@ conflicts: [
   "srt" {< "0.3.0"}
   "ssl" {< "0.7.0"}
   "taglib" {< "0.3.10"}
+  "tls" {>= "0.17.4"}
   "sdl-liquidsoap" {< "2"}
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}

--- a/packages/liquidsoap-core/liquidsoap-core.2.2.4/opam
+++ b/packages/liquidsoap-core/liquidsoap-core.2.2.4/opam
@@ -107,6 +107,7 @@ conflicts: [
   "srt" {< "0.3.0"}
   "ssl" {< "0.7.0"}
   "taglib" {< "0.3.10"}
+  "tls" {>= "0.17.4"}
   "sdl-liquidsoap" {< "2"}
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}


### PR DESCRIPTION
The latest `ocaml-tls` release has an API change that breaks optional compilation with `liquidsoap`.