### PR TITLE
Add: omod.0.0.4

### DIFF
--- a/packages/omod/omod.0.0.4/opam
+++ b/packages/omod/omod.0.0.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Lookup and load installed OCaml modules"
+description: """\
+Omod is a library and command line tool to lookup and load installed
+OCaml modules. It provides a mechanism to load modules and their
+dependencies in the OCaml toplevel system (REPL).
+
+omod is distributed under the ISC license.
+
+Homepage: http://erratique.ch/software/omod"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The omod programmers"
+license: "ISC"
+tags: ["dev" "toplevel" "repl" "org:erratique"]
+homepage: "https://erratique.ch/software/omod"
+doc: "https://erratique.ch/software/omod/doc/"
+bug-reports: "https://github.com/dbuenzli/omod/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "cmdliner" {>= "1.1.0"}
+]
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%" "--lib-dir" "%{lib}%"
+]
+install: [
+  ["install" "-d" "%{lib}%/ocaml/"]
+  ["install" "src/omod.top" "src/omod.nattop" "%{lib}%/ocaml/"]
+]
+dev-repo: "git+https://erratique.ch/repos/omod.git"
+url {
+  src: "https://erratique.ch/software/omod/releases/omod-0.0.4.tbz"
+  checksum:
+    "sha512=cab9e8ab6ca6e836fdaa3dcf9552d31e4de2bf069fcab096c1565d204ff91fc3516cd017a13702d749580bd3563c462db3277ab036cfc5d3cb9703a08ddbb927"
+}


### PR DESCRIPTION
* Add: `omod.0.0.4` [home](https://erratique.ch/software/omod), [doc](https://erratique.ch/software/omod/doc/), [issues](https://github.com/dbuenzli/omod/issues)  
  *Lookup and load installed OCaml modules*


---

#### `omod` v0.0.4 2024-03-29 La Forclaz (VS)

- Require and support OCaml >= 4.14.0. 
- Stop using Toploop.directive_table, this means

---

Use `b0 -- .opam publish omod.0.0.4` to update the pull request.