### PR TITLE
Add: down.0.2.0

### DIFF
--- a/packages/down/down.0.2.0/opam
+++ b/packages/down/down.0.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "An OCaml toplevel (REPL) upgrade"
+description: """\
+Down is an unintrusive user experience upgrade for the `ocaml`
+toplevel (REPL). 
+
+Simply load the zero dependency `Down` library in the `ocaml` toplevel
+and you get line edition, history, session support and identifier
+completion and documentation (courtesy of [`ocp-index`][ocp-index]).
+
+Add this to your `~/.ocamlinit`:
+
+    #use "down.top"
+
+![tty](doc/tty.png)
+
+Down is distributed under the ISC license.
+
+Homepage: http://erratique.ch/software/down
+
+[ocp-index]: https://github.com/OCamlPro/ocp-index"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The down programmers"
+license: "ISC"
+tags: ["dev" "toplevel" "repl" "org:erratique"]
+homepage: "https://erratique.ch/software/down"
+doc: "https://erratique.ch/software/down/doc/"
+bug-reports: "https://github.com/dbuenzli/down/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "uucp" {dev}
+]
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%" "--lib-dir" "%{lib}%"
+]
+install: [
+  ["install" "-d" "%{lib}%/ocaml/"]
+  ["install" "src/down.top" "src/down.nattop" "%{lib}%/ocaml/"]
+]
+dev-repo: "git+https://erratique.ch/repos/down.git"
+url {
+  src: "https://erratique.ch/software/down/releases/down-0.2.0.tbz"
+  checksum:
+    "sha512=d0991ff7238a15252f06f96e0ab29a2cdf349762db2057ba0b6b90d9b2152fc65675b593f5b21a97c5900bc576f3ff45e06f4306793a58de6d3f648496c448ff"
+}


### PR DESCRIPTION
* Add: `down.0.2.0` [home](https://erratique.ch/software/down), [doc](https://erratique.ch/software/down/doc/), [issues](https://github.com/dbuenzli/down/issues)  
  *An OCaml toplevel (REPL) upgrade*


---

#### `down` v0.2.0 2024-03-29 La Forclaz (VS)

- Update Unicode TTY width data to Unicode 15.1.0 
- Implement bracketed paste. Improves responsiveness
  on large code pastes ([#16](https://github.com/dbuenzli/down/issues/16)). Thanks to Etienne Millon
  for the suggestion and Hannes Mehnert for the report.

---

Use `b0 -- .opam publish down.0.2.0` to update the pull request.