### PR TITLE
Mark older versions of `result` only compatible with <4.08

### DIFF
--- a/packages/result/result.1.0/opam
+++ b/packages/result/result.1.0/opam
@@ -12,7 +12,7 @@ description: """
 Projects that want to use the new result type defined in OCaml >= 4.03
 while staying compatible with older version of OCaml should use the
 Result module defined in this library."""
-depends: ["ocaml" {< "4.14"}]
+depends: ["ocaml" {< "4.08"}]
 url {
   src: "https://github.com/janestreet/result/archive/1.0.tar.gz"
   checksum: "md5=01391a66385ab1a43f90455dfb5c6843"

--- a/packages/result/result.1.1/opam
+++ b/packages/result/result.1.1/opam
@@ -11,7 +11,7 @@ description: """
 Projects that want to use the new result type defined in OCaml >= 4.03
 while staying compatible with older version of OCaml should use the
 Result module defined in this library."""
-depends: ["ocaml" {< "4.14"}]
+depends: ["ocaml" {< "4.08"}]
 url {
   src: "https://github.com/janestreet/result/archive/1.1.tar.gz"
   checksum: "md5=1e0005783d4f70e1a9772723fa0e846b"

--- a/packages/result/result.1.2/opam
+++ b/packages/result/result.1.2/opam
@@ -14,7 +14,7 @@ description: """
 Projects that want to use the new result type defined in OCaml >= 4.03
 while staying compatible with older version of OCaml should use the
 Result module defined in this library."""
-depends: ["ocaml" {< "4.14"}]
+depends: ["ocaml" {< "4.08"}]
 url {
   src: "https://github.com/janestreet/result/archive/1.2.tar.gz"
   checksum: "md5=3d5b66c5526918f0f2ca9d6811ef09c8"

--- a/packages/result/result.1.3/opam
+++ b/packages/result/result.1.3/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/janestreet/result/issues"
 license: "BSD-3-Clause"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
-  "ocaml" {< "4.14"}
+  "ocaml" {< "4.08"}
   "jbuilder" {>= "1.0+beta11"}
 ]
 synopsis: "Compatibility Result module"

--- a/packages/result/result.1.4/opam
+++ b/packages/result/result.1.4/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/janestreet/result/issues"
 license: "BSD-3-Clause"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
-  "ocaml" {< "4.14"}
+  "ocaml" {< "4.08"}
   "dune" {>= "1.0"}
 ]
 synopsis: "Compatibility Result module"


### PR DESCRIPTION
We ran across this when attempting to release Dune 3.15.0~alpha1, where we removed our reference to the `result` package. Thus in the [lower version check](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/68b4763e3857d91953e14b698593ea06ced07650) it would use `result.1.0`. The code would then fail because of

```
# Error: This expression has type (string, exn) Result.result Lwt.t
#        but an expression was expected of type (string, exn) result Lwt.t
#        Type (string, exn) Result.result is not compatible with type
#          (string, exn) result 
```

Given the types should be equal on 4.08 (and later, the same failure keeps happening for the whole 4.x branch) something is fishy here.

Before https://github.com/janestreet/result/pull/9 on 4.08+ the types `Result.result` and `result` would not unify, thus causing compilation errors when code that was using both ended up interfacing. The fix has been part of `result.1.5`.

Given Dune doesn't depend on `result` anymore we can't constrain it to `result >= 1.5`, we'd need to add a `conflict` and that would solve the problem, however it seems weird to solve this in Dune in the first place. @emillon pointed out that a number of other packages already have a conflict for `result < 1.5` so it seems like this is an issue that packages keep running into the same solution: excluding older versions of result.