### PR TITLE
oscisgen-start 6.3.0: remove upper bound on eliom to force CI tests

### DIFF
--- a/packages/ocsigen-start/ocsigen-start.6.3.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.6.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "4.0.0"}
-  "eliom" {>= "10.4.0" & < "11.0.0"}
+  "eliom" {>= "10.4.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-ppx-rpc"
   "ocsigen-i18n" {>= "3.7.0"}


### PR DESCRIPTION
Due to the erroneous merge of https://github.com/ocaml/opam-repository/pull/25579
Ping @balat 