### PR TITLE
PRINGO version 1.4

### DIFF
--- a/packages/pringo/pringo.1.4/opam
+++ b/packages/pringo/pringo.1.4/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "Pseudo-random, splittable number generators"
+description:
+  "Pseudo-random number generators that support splitting and two interfaces: one stateful, one purely functional"
+maintainer: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+authors: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xavierleroy/pringo"
+bug-reports: "https://github.com/xavierleroy/pringo/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind"
+  "testu01" {with-test}
+]
+build: make
+install: [make "install"]
+run-test: [make "smalltest"] {ocaml:version >= "4.08"}
+conflicts: [ "ocaml-option-bytecode-only" ]
+dev-repo: "git+https://https://github.com/xavierleroy/pringo"
+url {
+  src: "https://github.com/xavierleroy/pringo/archive/1.4.tar.gz"
+  checksum: [
+    "md5=cf57361241b74422d8a1eed675c4e9ba"
+    "sha512=3088152c01804fa7fe03f71db139f0ad02b4fb2f2b53926fa853f05c7c1e677a8ffedf684d87860aa1935ee39769c718c1785c712ff2f491af8afd1d17a77f22"
+  ]
+}


### PR DESCRIPTION
- Fix GC root registration in the pure LXM implementation (https://github.com/xavierleroy/pringo/issues/6)