### PR TITLE
dune 3.9.0 should not be available on macos

### DIFF
--- a/packages/dune/dune.3.9.0/opam
+++ b/packages/dune/dune.3.9.0/opam
@@ -46,6 +46,7 @@ depends: [
   "base-unix"
   "base-threads"
 ]
+available: os != "macos"
 url {
   src: "https://github.com/ocaml/dune/releases/download/3.9.0/dune-3.9.0.tbz"
   checksum: [


### PR DESCRIPTION
see https://github.com/ocaml/opam-repository/pull/24083
was erroneusly reverted in https://github.com/ocaml/opam-repository/pull/25609