### PR TITLE
Relax dependency on merlin-lib

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.9/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.9/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08" & < "6.0"}
   "dune" {>= "2.9.0"}
-  "merlin-lib" {>= "4.9" & < "4.14-500"}
+  "merlin-lib" {>= "4.9" & < "4.14-502"}
   "ocamlfind" {>= "1.6.0"}
 ]
 description:


### PR DESCRIPTION
See comment https://github.com/ocaml/opam-repository/commit/dcb0fb6e629e707e29a45e65cf72603f3a7ea2d4#r140497176

This version of dot-merlin-reader should be co-installable with merlin-lib `4.14-501`.

In the future we will need to specifiy which variants (>= xxx-502) actually conflict with older dot-merlin-readers.