### PR TITLE
[new release] moonpool (2 packages) (0.6)

### DIFF
--- a/packages/moonpool-lwt/moonpool-lwt.0.6/opam
+++ b/packages/moonpool-lwt/moonpool-lwt.0.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Event loop for moonpool based on Lwt-engine (experimental)"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+homepage: "https://github.com/c-cube/moonpool"
+bug-reports: "https://github.com/c-cube/moonpool/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "moonpool" {= version}
+  "ocaml" {>= "5.0"}
+  "lwt"
+  "base-unix"
+  "trace" {with-test}
+  "trace-tef" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/moonpool.git"
+url {
+  src:
+    "https://github.com/c-cube/moonpool/releases/download/v0.6/moonpool-0.6.tbz"
+  checksum: [
+    "sha256=3efd095c82a37bba8c7ab6a2532aee3c445ebe1ecaed84ef3ffb560bc65e7633"
+    "sha512=e4bcab82e6638299c2d0beb1dbf204f7b43379a5387418c6edff85b9bf90c13ad1bdd8eb44b69cd421268d1bc45bcf918bcf77e1c924348211ac27d6643aac78"
+  ]
+}
+x-commit-hash: "0750e6af41847e77f33ad85f2d5da2c0408e8f5a"

--- a/packages/moonpool/moonpool.0.6/opam
+++ b/packages/moonpool/moonpool.0.6/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Pools of threads supported by a pool of domains"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["thread" "pool" "domain" "futures" "fork-join"]
+homepage: "https://github.com/c-cube/moonpool"
+bug-reports: "https://github.com/c-cube/moonpool/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.0"}
+  "either" {>= "1.0"}
+  "trace" {with-test}
+  "trace-tef" {with-test}
+  "qcheck-core" {with-test & >= "0.19"}
+  "odoc" {with-doc}
+  "mdx" {>= "1.9.0" & with-test}
+]
+depopts: [
+  "trace" {>= "0.6"}
+  "thread-local-storage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/moonpool.git"
+url {
+  src:
+    "https://github.com/c-cube/moonpool/releases/download/v0.6/moonpool-0.6.tbz"
+  checksum: [
+    "sha256=3efd095c82a37bba8c7ab6a2532aee3c445ebe1ecaed84ef3ffb560bc65e7633"
+    "sha512=e4bcab82e6638299c2d0beb1dbf204f7b43379a5387418c6edff85b9bf90c13ad1bdd8eb44b69cd421268d1bc45bcf918bcf77e1c924348211ac27d6643aac78"
+  ]
+}
+x-commit-hash: "0750e6af41847e77f33ad85f2d5da2c0408e8f5a"


### PR DESCRIPTION
Pools of threads supported by a pool of domains

- Project page: <a href="https://github.com/c-cube/moonpool">https://github.com/c-cube/moonpool</a>

##### CHANGES:

- breaking: remove `Immediate_runner` (bug prone and didn't
    handle effects). `Moonpool_fib.main` can be used to handle
    effects in the main function.
- remove deprecated alias `Moonpool.Pool`

- feat: add structured concurrency sub-library `moonpool.fib` with
    fibers. Fibers can use `await` and spawn other fibers that will
    be appropriately cancelled when their parent is.
- feat: add add `moonpool-lwt` as an experimental bridge between moonpool and lwt.
    This allows moonpool runners to be used from within Lwt to
    perform background computations, and conversely to call Lwt from
    moonpool with some precautions.
- feat: task-local storage in the main moonpool runners, available from
    fibers and regular tasks.
- feat: add `Exn_bt` to core
- feat: add `Runner.dummy`
- make `moonpool.forkjoin` optional (only on OCaml >= 5.0)
- feat: add `Fut.Advanced.barrier_on_abstract_container_of_futures`
- feat: add `Fut.map_list`

- refactor: split off domain pool to `moonpool.dpool`
- fix too early exit in Ws_pool
