### PR TITLE
[new release] iostream (2 packages) (0.2.2)

### DIFF
--- a/packages/iostream-camlzip/iostream-camlzip.0.2.2/opam
+++ b/packages/iostream-camlzip/iostream-camlzip.0.2.2/opam
@@ -15,7 +15,7 @@ depends: [
   "ounit2" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/iostream-camlzip/iostream-camlzip.0.2.2/opam
+++ b/packages/iostream-camlzip/iostream-camlzip.0.2.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Stream (de)compression using deflate"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["topics" "io" "channels" "streams" "zip" "deflate"]
+homepage: "https://github.com/c-cube/ocaml-iostream"
+doc: "https://c-cube.github.io/ocaml-iostream"
+bug-reports: "https://github.com/c-cube/ocaml-iostream/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "iostream" {= version}
+  "camlzip"
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-iostream.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-iostream/releases/download/v0.2.2/iostream-0.2.2.tbz"
+  checksum: [
+    "sha256=6d2725f20fcca4fe8c8c54fcaa442fb088f20d1c5788c437182042cfcce3829d"
+    "sha512=8eb87e13ff448d627062ffb2b0e9b10c29fe5406dcac24889499f358a9d1c50fc1ea02dc601f49fecebd38833b415431265e7fad991a55308923f63fb0aa79ad"
+  ]
+}
+x-commit-hash: "7a951a60b481c5ef9f4f0a72fa308d907a80dff5"

--- a/packages/iostream/iostream.0.2.2/opam
+++ b/packages/iostream/iostream.0.2.2/opam
@@ -14,7 +14,7 @@ depends: [
 ]
 depopts: ["base-unix"]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/iostream/iostream.0.2.2/opam
+++ b/packages/iostream/iostream.0.2.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Generic, composable IO input and output streams"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["topics" "io" "channels" "streams"]
+homepage: "https://github.com/c-cube/ocaml-iostream"
+doc: "https://c-cube.github.io/ocaml-iostream"
+bug-reports: "https://github.com/c-cube/ocaml-iostream/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "ounit2" {with-test}
+]
+depopts: ["base-unix"]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-iostream.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-iostream/releases/download/v0.2.2/iostream-0.2.2.tbz"
+  checksum: [
+    "sha256=6d2725f20fcca4fe8c8c54fcaa442fb088f20d1c5788c437182042cfcce3829d"
+    "sha512=8eb87e13ff448d627062ffb2b0e9b10c29fe5406dcac24889499f358a9d1c50fc1ea02dc601f49fecebd38833b415431265e7fad991a55308923f63fb0aa79ad"
+  ]
+}
+x-commit-hash: "7a951a60b481c5ef9f4f0a72fa308d907a80dff5"


### PR DESCRIPTION
Generic, composable IO input and output streams

- Project page: <a href="https://github.com/c-cube/ocaml-iostream">https://github.com/c-cube/ocaml-iostream</a>
- Documentation: <a href="https://c-cube.github.io/ocaml-iostream">https://c-cube.github.io/ocaml-iostream</a>

##### CHANGES:

- bugfix for iostream-camlzip (assertion failure)
