### PR TITLE
[new release] mimic (2 packages) (0.0.7)

### DIFF
--- a/packages/gpt/gpt.1.0.0/opam
+++ b/packages/gpt/gpt.1.0.0/opam
@@ -18,6 +18,7 @@ depends: [
   "uuidm" {>= "0.9.7"}
   "checkseum" {>= "0.4.0"}
   "mbr-format" {>= "2.0.0"}
+  "ocplib-endian" {>= "1.2"}
   "alcotest" {with-test}
   "fmt" {with-test}
   "odoc" {with-doc}

--- a/packages/mimic-happy-eyeballs/mimic-happy-eyeballs.0.0.7/opam
+++ b/packages/mimic-happy-eyeballs/mimic-happy-eyeballs.0.0.7/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "A happy-eyeballs integration into mimic"
+description: "A happy-eyeballs integration into mimic for MirageOS"
+maintainer: ["romain.calascibetta@gmail.com"]
+authors: "Romain Calascibetta"
+license: "ISC"
+homepage: "https://github.com/dinosaure/mimic"
+doc: "https://dinosaure.github.io/mimic/"
+bug-reports: "https://github.com/dinosaure/mimic/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "mimic" {= version}
+  "happy-eyeballs-mirage" {>= "0.3.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/mimic.git"
+url {
+  src:
+    "https://github.com/dinosaure/mimic/releases/download/0.0.7/mimic-0.0.7.tbz"
+  checksum: [
+    "sha256=49cab86754cfe5370512f1ad410a0e779c5c8a66775a7a801c3965982980322d"
+    "sha512=cab646e4b3af476d0baee489266a7631b1a4971bc42d5c4b311c13ac0f14d191b0ec01a87187610da46f38bed03b1d99af96e17ea03e0a14c5ea88893aa21308"
+  ]
+}
+x-commit-hash: "ca24a82419e525b1727478b3dae87c133b88c289"

--- a/packages/mimic/mimic.0.0.7/opam
+++ b/packages/mimic/mimic.0.0.7/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "A simple protocol dispatcher"
+description: "A middleware to dispatch protocols"
+maintainer: ["romain.calascibetta@gmail.com"]
+authors: "Romain Calascibetta"
+license: "ISC"
+homepage: "https://github.com/dinosaure/mimic"
+doc: "https://dinosaure.github.io/mimic/"
+bug-reports: "https://github.com/dinosaure/mimic/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "lwt" {>= "5.3.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+dev-repo: "git+https://github.com/dinosaure/mimic.git"
+url {
+  src:
+    "https://github.com/dinosaure/mimic/releases/download/0.0.7/mimic-0.0.7.tbz"
+  checksum: [
+    "sha256=49cab86754cfe5370512f1ad410a0e779c5c8a66775a7a801c3965982980322d"
+    "sha512=cab646e4b3af476d0baee489266a7631b1a4971bc42d5c4b311c13ac0f14d191b0ec01a87187610da46f38bed03b1d99af96e17ea03e0a14c5ea88893aa21308"
+  ]
+}
+x-commit-hash: "ca24a82419e525b1727478b3dae87c133b88c289"

--- a/packages/paf/paf.0.1.0/opam
+++ b/packages/paf/paf.0.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "tcpip" {>= "7.0.0"}
   "mirage-time" {>= "2.0.0"}
   "tls-mirage" {>= "0.15.0"}
-  "mimic" {>= "0.0.5"}
+  "mimic" {>= "0.0.5" & < "0.0.7"}
   "ke" {>= "0.4"}
   "lwt" {with-test}
   "base-unix" {with-test}

--- a/packages/paf/paf.0.2.0/opam
+++ b/packages/paf/paf.0.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "tcpip" {>= "7.0.0"}
   "mirage-time" {>= "2.0.0"}
   "tls-mirage" {>= "0.15.0"}
-  "mimic" {>= "0.0.5"}
+  "mimic" {>= "0.0.5" & < "0.0.7"}
   "ke" {>= "0.4"}
   "lwt" {with-test}
   "base-unix" {with-test}

--- a/packages/paf/paf.0.3.0/opam
+++ b/packages/paf/paf.0.3.0/opam
@@ -13,7 +13,7 @@ depends: [
   "tcpip" {>= "7.0.0"}
   "mirage-time" {>= "2.0.0"}
   "tls-mirage" {>= "0.15.0"}
-  "mimic" {>= "0.0.5"}
+  "mimic" {>= "0.0.5" & < "0.0.7"}
   "ke" {>= "0.4"}
   "lwt" {with-test}
   "base-unix" {with-test}

--- a/packages/paf/paf.0.4.0/opam
+++ b/packages/paf/paf.0.4.0/opam
@@ -13,7 +13,7 @@ depends: [
   "tcpip" {>= "7.0.0"}
   "mirage-time" {>= "2.0.0"}
   "tls-mirage" {>= "0.15.0"}
-  "mimic" {>= "0.0.5"}
+  "mimic" {>= "0.0.5" & < "0.0.7"}
   "ke" {>= "0.4"}
   "lwt" {with-test}
   "base-unix" {with-test}

--- a/packages/paf/paf.0.5.0/opam
+++ b/packages/paf/paf.0.5.0/opam
@@ -13,7 +13,7 @@ depends: [
   "tcpip" {>= "7.0.0"}
   "mirage-time" {>= "2.0.0"}
   "tls-mirage" {>= "0.15.0"}
-  "mimic" {>= "0.0.5" & < "0.7.0"}
+  "mimic" {>= "0.0.5" & < "0.0.7"}
   "ke" {>= "0.4"}
   "lwt" {with-test}
   "base-unix" {with-test}

--- a/packages/paf/paf.0.5.0/opam
+++ b/packages/paf/paf.0.5.0/opam
@@ -13,7 +13,7 @@ depends: [
   "tcpip" {>= "7.0.0"}
   "mirage-time" {>= "2.0.0"}
   "tls-mirage" {>= "0.15.0"}
-  "mimic" {>= "0.0.5"}
+  "mimic" {>= "0.0.5" & < "0.7.0"}
   "ke" {>= "0.4"}
   "lwt" {with-test}
   "base-unix" {with-test}


### PR DESCRIPTION
A simple protocol dispatcher

- Project page: <a href="https://github.com/dinosaure/mimic">https://github.com/dinosaure/mimic</a>
- Documentation: <a href="https://dinosaure.github.io/mimic/">https://dinosaure.github.io/mimic/</a>

##### CHANGES:

* Delete `mimic_mirage` which is not used (@hannesm, dinosaure/mimic#17)
* Delete the `fmt` dependency (@dinosaure, dinosaure/mimic#18)
* Support `mirage-flow.4.0.0` (@hannesm, dinosaure/mimic#20)
