### PR TITLE
Package signal.0.4.1

### DIFF
--- a/packages/signal/signal.0.4.1/opam
+++ b/packages/signal/signal.0.4.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Rizo I. <rizo@odis.io>"
+authors: "Rizo I. <rizo@odis.io>"
+homepage: "https://github.com/rizo/signal"
+bug-reports: "https://github.com/rizo/signal/issues"
+dev-repo: "git+https://github.com/rizo/signal.git"
+synopsis: "A small library for reactive signals"
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+
+depends: [
+  "ocaml"
+  "dune" {build}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+]
+url {
+  src: "https://github.com/rizo/signal/archive/refs/tags/0.4.1.tar.gz"
+  checksum: [
+    "md5=488e9de03a8c8605a10a000ed017230f"
+    "sha512=7c853972a9347b05e80fa019fb8df58ef551d3317cf8f698016b7121a1a11d7c64dfc66fd036d9acf5dc1265f35da2feaca02e86a89fa0679dd8159a2e1dfcd5"
+  ]
+}


### PR DESCRIPTION
### `signal.0.4.1`
A small library for reactive signals



---
* Homepage: https://github.com/rizo/signal
* Source repo: git+https://github.com/rizo/signal.git
* Bug tracker: https://github.com/rizo/signal/issues

---
:camel: Pull-request generated by opam-publish v2.3.0