### PR TITLE
[new release] pecu (0.7)

### DIFF
--- a/packages/pecu/pecu.0.7/opam
+++ b/packages/pecu/pecu.0.7/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/pecu"
+bug-reports:  "https://github.com/mirage/pecu/issues"
+dev-repo:     "git+https://github.com/mirage/pecu.git"
+doc:          "https://mirage.github.io/pecu/"
+license:      "MIT"
+synopsis:     "Encoder/Decoder of Quoted-Printable (RFC2045 & RFC2047)"
+description:  """A non-blocking encoder/decoder of Quoted-Printable according to
+RFC2045 and RFC2047 (about encoded-word). Useful to translate contents of emails."""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.4"}
+  "fmt" {with-test & >= "0.8.7"}
+  "alcotest" {with-test}
+  "crowbar" {with-test}
+  "astring" {with-test}
+]
+url {
+  src: "https://github.com/mirage/pecu/releases/download/v0.7/pecu-0.7.tbz"
+  checksum: [
+    "sha256=ad7477b5b16428d33c32440067684953d94efaa43faaf620857918bace9fd778"
+    "sha512=8b2dd94af614d99f67c49fddb55bf7ed1ef280378acf862eb3269964bc515a963d28efa4fdcc09d07bfc966aced44e41195451ead13bee59d30d482ab17fcdf5"
+  ]
+}
+x-commit-hash: "f41b3c74d0c375be3057de33e409c99bffaab273"


### PR DESCRIPTION
Encoder/Decoder of Quoted-Printable (RFC2045 & RFC2047)

- Project page: <a href="https://github.com/mirage/pecu">https://github.com/mirage/pecu</a>
- Documentation: <a href="https://mirage.github.io/pecu/">https://mirage.github.io/pecu/</a>

##### CHANGES:

* Upgrade the distribution with `fmt.0.8.7` (@dinosaure, mirage/pecu#12)
* Upgrade tests to be compatible with OCaml 5.2 (@kit-ty-kate, mirage/pecu#14)
