### PR TITLE
[new release] mrmime (0.6.1)

### DIFF
--- a/packages/mrmime/mrmime.0.6.1/opam
+++ b/packages/mrmime/mrmime.0.6.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/mrmime"
+bug-reports:  "https://github.com/mirage/mrmime/issues"
+dev-repo:     "git+https://github.com/mirage/mrmime.git"
+doc:          "https://mirage.github.io/mrmime/"
+license:      "MIT"
+synopsis:     "Mr. MIME"
+description:  """Parser and generator of mail in OCaml"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.7"}
+  "ke"                {>= "0.4"}
+  "unstrctrd"         {>= "0.3"}
+  "ptime"             {>= "0.8.2"}
+  "uutf"
+  "rosetta"           {>= "0.3.0"}
+  "ipaddr"            {>= "5.0.0"}
+  "emile"             {>= "1.0"}
+  "base64"            {>= "3.1.0"}
+  "pecu"              {>= "0.6"}
+  "prettym"           {>= "0.0.2"}
+  "bigstringaf"       {>= "0.5.0"}
+  "bigarray-overlap"  {>= "0.2.0"}
+  "angstrom"          {>= "0.14.0"}
+  "fpath"             {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test}
+  "ocplib-endian"     {with-test}
+  "afl-persistent"    {with-test}
+  "alcotest"          {with-test}
+  "jsonm"             {with-test}
+  "crowbar"           {with-test}
+  "lwt"               {with-test}
+  "cmdliner"          {with-test & >= "1.1.0"}
+  "logs"              {with-test}
+]
+conflicts: [
+  "result"            {< "1.5"}
+]
+url {
+  src:
+    "https://github.com/mirage/mrmime/releases/download/v0.6.1/mrmime-0.6.1.tbz"
+  checksum: [
+    "sha256=0f3b2bef13f3bb9448cc876e6c5e0e0008c7258ec27415671d167141b702b016"
+    "sha512=606c47ba25f6ea194e6ad36c32683567c8b264932767027b04f459becc44b5834d66183db2cf8c0963eb65fc7349cd24a790d793c066b7ddc9a5bf9e3099917d"
+  ]
+}
+x-commit-hash: "a96c8d9ef5800a0e87df09b69a52acba27a4845b"


### PR DESCRIPTION
Mr. MIME

- Project page: <a href="https://github.com/mirage/mrmime">https://github.com/mirage/mrmime</a>
- Documentation: <a href="https://mirage.github.io/mrmime/">https://mirage.github.io/mrmime/</a>

##### CHANGES:

- Upgrade tests to be compatible with OCaml 5.2 (@kit-ty-kate, mirage/mrmime#99)
