### PR TITLE
[new release] ppx_blob (0.8.0)

### DIFF
--- a/packages/ppx_blob/ppx_blob.0.8.0/opam
+++ b/packages/ppx_blob/ppx_blob.0.8.0/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml"
   "dune" {>= "1.11"}
-  "ppxlib" {>= "0.3.1"}
+  "ppxlib" {>= "0.9.0"}
   "alcotest" {with-test}
 ]
 synopsis: "Include a file as a string at compile time"

--- a/packages/ppx_blob/ppx_blob.0.8.0/opam
+++ b/packages/ppx_blob/ppx_blob.0.8.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+authors: "John Whitington"
+maintainer: "contact@coherentgraphics.co.uk"
+homepage: "https://github.com/johnwhitington/ppx_blob"
+dev-repo: "git+https://github.com/johnwhitington/ppx_blob.git"
+bug-reports: "https://github.com/johnwhitington/ppx_blob/issues/"
+doc: "https://johnwhitington.github.io/ppx_blob/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "ppxlib"
+  "alcotest" {with-test}
+]
+synopsis: "Include a file as a string at compile time"
+description:
+  "ppx_blob allows you to include a binary blob from a file as a string. Writing `[%blob \"filename\"]` will replace the string with the contents of the file at compile time. This allows the inclusion of arbitary, possibly compressed, data, without the need to respect OCaml's lexical conventions."
+url {
+  src:
+    "https://github.com/johnwhitington/ppx_blob/releases/download/0.8.0/ppx_blob-0.8.0.tbz"
+  checksum: [
+    "sha256=76ba1b17031329dfdadda3f9097ff4f1686f812d42900447eb3a3e9d28b0974f"
+    "sha512=bcbd58f7b0505063eaf4799792696f633a11ee734ce57d75b8f24b53d05fafbda8330bbf577a1d7a6149bb936b535216ae83574c1d40a61434e8d3bc6b6fd973"
+  ]
+}
+x-commit-hash: "213a711e5b491e599ddc5f2b2de638f203071aa7"

--- a/packages/ppx_blob/ppx_blob.0.8.0/opam
+++ b/packages/ppx_blob/ppx_blob.0.8.0/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/johnwhitington/ppx_blob"
 dev-repo: "git+https://github.com/johnwhitington/ppx_blob.git"
 bug-reports: "https://github.com/johnwhitington/ppx_blob/issues/"
 doc: "https://johnwhitington.github.io/ppx_blob/"
+license: "Unlicense"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
@@ -12,7 +13,7 @@ build: [
 depends: [
   "ocaml"
   "dune" {>= "1.11"}
-  "ppxlib"
+  "ppxlib" {>= "0.3.1"}
   "alcotest" {with-test}
 ]
 synopsis: "Include a file as a string at compile time"


### PR DESCRIPTION
Include a file as a string at compile time

- Project page: <a href="https://github.com/johnwhitington/ppx_blob">https://github.com/johnwhitington/ppx_blob</a>
- Documentation: <a href="https://johnwhitington.github.io/ppx_blob/">https://johnwhitington.github.io/ppx_blob/</a>

##### CHANGES:

- Fix the handling of paths relative to the source file in environments with
  `(lang dune 3.0)` (johnwhitington/ppx_blob#24).
