### PR TITLE
[new release] dream-html (3.3.0)

### DIFF
--- a/packages/dream-html/dream-html.3.3.0/opam
+++ b/packages/dream-html/dream-html.3.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.3.0/dream-html-3.3.0.tbz"
+  checksum: [
+    "sha256=e0397ff25448b27241cb7dd243c69b3890fc9977eda66fa7b39b41ae5237cdc5"
+    "sha512=ea3375302442a409ea495b9aa89ce12e6fed6531547114c4cd5229e490ab0452a3d471d967874b8e34436da966266ea7ea573388503112efdb390710c2a79a45"
+  ]
+}
+x-commit-hash: "567005e16de920a1a2eabd6342762c74e8f138cb"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
