### PR TITLE
[new release] starred_ml (0.0.3)

### DIFF
--- a/packages/starred_ml/starred_ml.0.0.3/opam
+++ b/packages/starred_ml/starred_ml.0.0.3/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Generates a awesome list makdown"
+description: "Turn your starred items into a awesomeness list of repos"
+maintainer: ["Paulo Suzart"]
+authors: ["Paulo Suzart"]
+license: "CC0-1.0"
+homepage: "https://github.com/paulosuzart/starred_ml"
+bug-reports: "https://github.com/paulosuzart/starred_ml/issues"
+depends: [
+  "re2" {>= "v0.16.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "yojson" {>= "2.1.2"}
+  "tls-eio" {>= "0.17.3"}
+  "ppx_deriving_yojson" {>= "3.7.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "mirage-crypto-rng-eio" {>= "0.11.3"}
+  "logs" {>= "0.7.0"}
+  "jingoo" {>= "1.5.0"}
+  "fmt" {>= "0.9.0"}
+  "eio_main" {>= "1.0"}
+  "eio" {>= "1.0"}
+  "cohttp-eio" {>= "6.0.0~beta2"}
+  "ocaml"
+  "dune" {>= "3.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/paulosuzart/starred_ml.git"
+url {
+  src:
+    "https://github.com/paulosuzart/starred_ml/releases/download/0.0.3/starred_ml-0.0.3.tbz"
+  checksum: [
+    "sha256=9aa031882893b4c3d83c83d9b964f034c37086372216f43a0edcff91701ac204"
+    "sha512=a117041724dfc47ad8d297593ea6a1219a6bd8a191e52c1749f4c3f7fcacb4d12d781fcee460c5aa182ea6283640d476c1dc225628550edc4386e859b86e6d31"
+  ]
+}
+x-commit-hash: "97ed651c027d4ba140d232f2134e6b880df22bea"


### PR DESCRIPTION
CHANGES:

- The generated output was using `url` of the repo, that points to the GitHub API. This release fixes it by using the proper `html_url`.
- Some other small typos were fixed
- A reference to the template repository using `starred_ml` was also added