### PR TITLE
[new release] dream-html (3.3.1)

### DIFF
--- a/packages/dream-html/dream-html.3.3.1/opam
+++ b/packages/dream-html/dream-html.3.3.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.3.1/dream-html-3.3.1.tbz"
+  checksum: [
+    "sha256=bc6924eecfe8784d9e02fd6781754531d24717caf8fdbc5d08f0e027dd6a7d06"
+    "sha512=1ba54f79b8c467eb47ee01069c0ddef148cc6591f1b218d7e89dcfa26d3c85d6d1c13e61936c57a4d9cf87d21365cb1539e62c2241eba542bae986b30c4515d1"
+  ]
+}
+x-commit-hash: "64b02a07ba278f523d14c9d6e8e008da2ae08b90"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
