### PR TITLE
[new release] picos (0.1.0)

### DIFF
--- a/packages/picos/picos.0.1.0/opam
+++ b/packages/picos/picos.0.1.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Pico scheduler framework"
+description:
+  "A framework for building interoperable elements of effects based cooperative concurrent programming models."
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/picos"
+bug-reports: "https://github.com/ocaml-multicore/picos/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "backoff" {>= "0.1.0"}
+  "thread-local-storage" {>= "0.1"}
+  "mtime" {>= "2.0.0"}
+  "psq" {>= "0.2.1"}
+  "multicore-magic" {>= "2.1.0"}
+  "multicore-bench" {>= "0.1.2" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "qcheck-core" {>= "0.21.2" & with-test}
+  "qcheck-stm" {>= "0.3" & with-test}
+  "qcheck-multicoretests-util" {>= "0.3" & with-test}
+  "mdx" {>= "2.4.0" & with-test}
+  "ocaml-version" {>= "3.6.4" & with-test}
+  "domain_shims" {>= "0.1.0" & with-test}
+  "js_of_ocaml" {>= "5.4.0" & with-test}
+  "conf-npm" {arch != "x86_32" & arch != "riscv64" & with-test}
+  "dscheck" {>= "0.4.0" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
+  "ocaml" {>= "4.12.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/picos.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/picos/releases/download/0.1.0/picos-0.1.0.tbz"
+  checksum: [
+    "sha256=0f2dcc67ddd127c68f388f2c36a8725a15723e6aeba7d1ddfcf4e016b54a4674"
+    "sha512=bee2a99458a451be285e2f13cc3a9deda8eed4e118bcdfc51c256d2da5bae92eec3386c318fe42dcf451421543b519dc064967158b3f417c9b7b44ce97c5fb75"
+  ]
+}
+x-commit-hash: "28d66414aaa58d61f9e6f1d2b5c2c25f6b647b2f"


### PR DESCRIPTION
Pico scheduler framework

- Project page: <a href="https://github.com/ocaml-multicore/picos">https://github.com/ocaml-multicore/picos</a>

##### CHANGES:

- First experimental release of Picos.

  Core:

  - `picos` — A framework for interoperable effects based concurrency.

  Sample schedulers:

  - `picos.fifos` — Basic single-threaded effects based Picos compatible
    scheduler for OCaml 5.
  - `picos.threaded` — Basic `Thread` based Picos compatible scheduler for
    OCaml 4.

  Scheduler agnostic libraries:

  - `picos.sync` — Basic communication and synchronization primitives for Picos.
  - `picos.stdio` — Basic IO facilities based on OCaml standard libraries for
    Picos.
  - `picos.select` — Basic `Unix.select` based IO event loop for Picos.

  Auxiliary libraries:

  - `picos.domain` — Minimalistic domain API available both on OCaml 5 and on
    OCaml 4.
  - `picos.exn_bt` — Wrapper for exceptions with backtraces.
  - `picos.fd` — Externally reference counted file descriptors.
  - `picos.htbl` — Lock-free hash table.
  - `picos.mpsc_queue` — Multi-producer, single-consumer queue.
  - `picos.rc` — External reference counting tables for disposable resources.
  - `picos.tls` — Thread-local storage.
