### PR TITLE
dose3: tests are incompatible with ocaml 5

### DIFF
--- a/packages/dose3-extra/dose3-extra.7.0.0/opam
+++ b/packages/dose3-extra/dose3-extra.7.0.0/opam
@@ -41,6 +41,7 @@ bug-reports: "https://gitlab.com/irill/dose3/issues/"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.03"}
+  "ocaml" {with-test & < "5.0"}
   "dose3" {= version}
   "extlib" {>= "1.7.8"}
   "camlbz2" {>= "0.7.0"}

--- a/packages/dose3/dose3.6.1/opam
+++ b/packages/dose3/dose3.6.1/opam
@@ -41,6 +41,7 @@ bug-reports: "https://gitlab.com/irill/dose3/issues/"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.03"}
+  "ocaml" {with-test & < "5.0"}
   "extlib" {>= "1.7.8"}
   "base64" {>= "3.1.0"}
   "camlbz2" {>= "0.7.0"}


### PR DESCRIPTION
They fail with
```
(cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I tests/DebianPackages/.debGrep.eobjs/byte -I /home/opam/.opam/5.1/lib/base64 -I /home/opam/.opam/5.1/lib/bz2 -I /home/opam/.opam/5.1/lib/cudf -I /home/opam/.opam/5.1/lib/extlib -I /home/opam/.opam/5.1/lib/ocaml/unix -I /home/opam/.opam/5.1/lib/re -I /home/opam/.opam/5.1/lib/re/pcre -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/stdlib-shims -I /home/opam/.opam/5.1/lib/zip -I src/common/.dose_common.objs/byte -I src/deb/.dose_debian.objs/byte -I src/doseparse/.dose_doseparse.objs/byte -I src/npm/.dose_npm.objs/byte -I src/opam2/.dose_opam2.objs/byte -I src/opencsw/.dose_opencsw.objs/byte -I src/pef/.dose_pef.objs/byte -I src/versioning/.dose_versioning.objs/byte -no-alias-deps -open Dune__exe -o tests/DebianPackages/.debGrep.eobjs/byte/dune__exe__DebGrep.cmo -c -impl tests/DebianPackages/debGrep.ml)
File "tests/DebianPackages/debGrep.ml", line 28, characters 17-31:
28 |     let stream = Stream.of_list (List.tl (Array.to_list Sys.argv)) in
                      ^^^^^^^^^^^^^^
Error: Unbound module Stream
```

Note that since v 7.0 this has moved to dose3-extra

Seen on revdeps of #25637