### PR TITLE
mirage-monitoring: bound to mirage-runtime < 4.5.0 (API change)

### DIFF
--- a/packages/mirage-monitoring/mirage-monitoring.0.0.3/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.3/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "tcpip" {>= "7.0.0"}
   "mirage-solo5" {>= "0.9.0"}
-  "mirage-runtime" {>= "4.3.0"}
+  "mirage-runtime" {>= "4.3.0" & < "4.5.0"}
   "memtrace-mirage" {>= "0.2.1.2.2"}
   "mirage-clock" {>= "4.0.0"}
 ]

--- a/packages/mirage-monitoring/mirage-monitoring.0.0.4/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.4/opam
@@ -16,7 +16,7 @@ depends: [
   "metrics-influx" {>= "0.2.0"}
   "mirage-time" {>= "2.0.0"}
   "tcpip" {>= "7.0.0"}
-  "mirage-runtime" {>= "4.3.0"}
+  "mirage-runtime" {>= "4.3.0" & < "4.5.0"}
   "memtrace-mirage" {>= "0.2.1.2.2"}
   "mirage-clock" {>= "4.0.0"}
 ]


### PR DESCRIPTION
as seen in #25642 


```
 === ERROR while compiling mirage-monitoring.0.0.3 ============================#
 context              2.2.0~beta2~dev | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
 path                 ~/.opam/4.14/.opam-switch/build/mirage-monitoring.0.0.3
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p mirage-monitoring -j 255
 exit-code            1
 env-file             ~/.opam/log/mirage-monitoring-7-2efd9f.env
 output-file          ~/.opam/log/mirage-monitoring-7-2efd9f.out
 ## output ###
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.mirage_monitoring.objs/byte -I /home/opam/.opam/4.14/lib/bheap -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/memtrace-mirage -I /home/opam/.opam/4.14/lib/metrics -I /home/opam/.opam/4.14/lib/metrics-influx -I /home/opam/.opam/4.14/lib/metrics-lwt -I /home/opam/.opam/4.14/lib/mirage-clock -I /home/opam/.opam/4.14/lib/mirage-flow -I /home/opam/.opam/4.14/lib/mirage-runtime -I /home/opam/.opam/4.14/lib/mirage-runtime/functoria -I /home/opam/.opam/4.14/lib/mirage-solo5 -I /home/opam/.opam/4.14/lib/mirage-time -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/tcpip -intf-suffix .ml -no-alias-deps -o src/.mirage_monitoring.objs/byte/mirage_monitoring.cmo -c -impl src/mirage_monitoring.ml)
 File "src/mirage_monitoring.ml", line 112, characters 21-53:
 112 |       (fun s -> (fst Mirage_runtime.Arg.log_threshold) s)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Unbound module Mirage_runtime.Arg
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I src/.mirage_monitoring.objs/byte -I src/.mirage_monitoring.objs/native -I /home/opam/.opam/4.14/lib/bheap -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/memtrace-mirage -I /home/opam/.opam/4.14/lib/metrics -I /home/opam/.opam/4.14/lib/metrics-influx -I /home/opam/.opam/4.14/lib/metrics-lwt -I /home/opam/.opam/4.14/lib/mirage-clock -I /home/opam/.opam/4.14/lib/mirage-flow -I /home/opam/.opam/4.14/lib/mirage-runtime -I /home/opam/.opam/4.14/lib/mirage-runtime/functoria -I /home/opam/.opam/4.14/lib/mirage-solo5 -I /home/opam/.opam/4.14/lib/mirage-time -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/tcpip -intf-suffix .ml -no-alias-deps -o src/.mirage_monitoring.objs/native/mirage_monitoring.cmx -c -impl src/mirage_monitoring.ml)
 File "src/mirage_monitoring.ml", line 112, characters 21-53:
 112 |       (fun s -> (fst Mirage_runtime.Arg.log_threshold) s)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Unbound module Mirage_runtime.Arg
```