### PR TITLE
Disable ocaml-variants.4.14.1+BER on Windows

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.14.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+BER/opam
@@ -80,4 +80,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: !(os = "macos" & arch = "arm64")
+available: !(os = "macos" & arch = "arm64") & os != "win32"


### PR DESCRIPTION
There's not a huge amount of work needed to have BER MetaOCaml work on native Windows, but it doesn't at the moment.