### PR TITLE
[new release] mirage-monitoring (0.0.5)

### DIFF
--- a/packages/mirage-monitoring/mirage-monitoring.0.0.5/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.5/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mirage-monitoring"
+doc: "https://robur-coop.github.io/mirage-monitoring"
+dev-repo: "git+https://github.com/robur-coop/mirage-monitoring.git"
+bug-reports: "https://github.com/robur-coop/mirage-monitoring/issues"
+license: "AGPL-3.0-only"
+
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune"
+  "logs" {>= "0.6.3"}
+  "metrics" {>= "0.4.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "mirage-time" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-runtime" {>= "4.5.0"}
+  "memtrace-mirage" {>= "0.2.1.2.2"}
+  "mirage-clock" {>= "4.0.0"}
+]
+conflicts: [
+  "mirage-solo5" {< "0.9.2"}
+  "mirage-xen" {< "8.0.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Monitoring of MirageOS unikernels"
+description: """
+Reporting metrics to Influx, Telegraf. Dynamic adjusting log level and metrics
+sources, memprof profiling.
+"""
+url {
+  src:
+    "https://github.com/robur-coop/mirage-monitoring/releases/download/v0.0.5/mirage-monitoring-0.0.5.tbz"
+  checksum: [
+    "sha256=f76f95a35cc38f7d249fc2cc6336a27f64be2a9a6947dad156a2cb428ff065e8"
+    "sha512=3bc27b5892417e6469857b677e7165517d23e7116e0966990fd9bd537e8b0d2537eb88e84910b1f48ad4b40306909f48cd15c40b30053cdc42d52f82ae390409"
+  ]
+}
+x-commit-hash: "ca9bd2f4a3823187f472ceec2b9699a90c0d2283"


### PR DESCRIPTION
Monitoring of MirageOS unikernels

- Project page: <a href="https://github.com/robur-coop/mirage-monitoring">https://github.com/robur-coop/mirage-monitoring</a>
- Documentation: <a href="https://robur-coop.github.io/mirage-monitoring">https://robur-coop.github.io/mirage-monitoring</a>

##### CHANGES:

* Update to mirage-runtime 4.5.0 API changes (Arg.log_threshold is now
  Conv.log_threshold)
