### PR TITLE
[new release] mirage (2 packages) (4.5.0)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.4.5.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.4.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.9.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "4.0.0"}
+  "ipaddr" {>= "5.5.0"}
+  "cmdliner" {>= "1.2.0"}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "ppxlib" {= "0.29.0"} #0.29.0 provides a vendored ppx_sexp_conv
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.5.0/mirage-4.5.0.tbz"
+  checksum: [
+    "sha256=68da8f19fa48f1815c045cb1249afe35dcc32a90b58f6315b025bad7d1c74e78"
+    "sha512=110aa2155dda5cea8263b723cb263336910fe5677ceb39d3d56a0123181c79d8767a97f7f20f3e757ba9889b73b8b188207b290cebae4cd96ce3b307e745a86c"
+  ]
+}
+x-commit-hash: "88faf8f466c2778f18fa63391ece8635682ef21e"

--- a/packages/mirage/mirage.4.5.0/opam
+++ b/packages/mirage/mirage.4.5.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+available: opam-version >= "2.1.0"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.9.0"}
+  "astring"
+  "cmdliner" {>= "1.2.0"}
+  "emile" {>= "1.1"}
+  "fmt" {>= "0.8.7"}
+  "ipaddr" {>= "5.0.0"}
+  "bos"
+  "fpath"
+  "rresult" {>= "0.7.0"}
+  "uri" {>= "4.2.0"}
+  "logs" {>= "0.7.0"}
+  "opam-monorepo" {>= "0.3.2"}
+  "alcotest" {with-test}
+  "mirage-runtime" {with-test & = version}
+]
+
+conflicts: [ "jbuilder" {with-test} ]
+
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.5.0/mirage-4.5.0.tbz"
+  checksum: [
+    "sha256=68da8f19fa48f1815c045cb1249afe35dcc32a90b58f6315b025bad7d1c74e78"
+    "sha512=110aa2155dda5cea8263b723cb263336910fe5677ceb39d3d56a0123181c79d8767a97f7f20f3e757ba9889b73b8b188207b290cebae4cd96ce3b307e745a86c"
+  ]
+}
+x-commit-hash: "88faf8f466c2778f18fa63391ece8635682ef21e"


### PR DESCRIPTION
The MirageOS library operating system

- Project page: <a href="https://github.com/mirage/mirage">https://github.com/mirage/mirage</a>
- Documentation: <a href="https://mirage.github.io/mirage/">https://mirage.github.io/mirage/</a>

##### CHANGES:

- This release introduces a significant change in the Mirage tool by
  splitting the definition of command-line arguments used at
  configure-time and runtime. Command-line arguments used in the
  configure script (also called 'configuration keys' and defined in
  the `Key` module) are essential during the setup of module
  dependencies for the unikernel, allowing for a specialized
  production of a unikernel for a given target runtime environment. On
  the other hand, command-line arguments that the unikernel can use at
  runtime (defined in the `Runtime_arg` module) are useful for
  customizing deployments without altering the dependencies of the
  unikernels. (mirage/mirage#1449, mirage/mirage#1450, mirage/mirage#1451, mirage/mirage#1455 @samoht, review by @hannesm)

  * API changes:
    - There is no more `~stage` parameter for `Key.Arg.info`.
    - `Key` now define command-line arguments for the configuration tool.
    - There is a new module `Runtime_arg` to define command-line arguments
      for the unikernel.
    - As there are no more keys type `'Both`, users are now expected to create
      two separated keys in that case (one for configure-time, one for runtime)
      or decide if the key is useful at runtime of configure-time.

  * Intended use of configuration keys (values of type `'a key`):
    - Used to set up module dependencies of the unikernel, such as the
      target (hvt, xen, etc.) and whether to use DHCP or a fixed IP address.
    - Enable the production of specialized unikernels suitable for
      specific target runtime environments and dedicated network and
      storage stacks.
    - Similar keys will produce reproducible binaries to be uploaded to artifact
      repositories like Docker Hub or https://builds.robur.coop/.

  * Intended use of command-line runtime arguments (values of type
    `a runtime_arg`):
    - Allow users to customize deployments by changing device
      configuration, like IP addresses, secrets, block device names,
      etc., post downloading of binaries.
    - These keys don’t alter the dependencies of the unikernels.
    - A runtime keys is just a reference to a normal Cmdliner term.

  * `key_gen.ml` is not generated anymore, so users cannot refer to
    `Key_gen.<key_name>` directy.
    - Any runtime argument has to be declared (using `runtime_arg` and
      registered on the device (using `~runtime_args`). The value of that
      argument will then be passed  as an extra parameter of the `connect`
      function of that device.
    - Configuration keys are not available at runtime anymore. For
      instance, `Key_gen.target` has been removed.

* Code migration:
    ```ocaml
    (* in config.ml *)
    let key =
      let doc = Key.Arg.info ~doc:"A Key." ~stage:`Run [ "key" ] in
      Key.(create "key" Arg.(opt_all ~stage:`Run string doc))
    ```
    becomes:
    ```ocaml
    (* in unikernel.ml *)
    open Cmdliner

    let key =
      let doc = Arg.info ~doc:"A Key." [ "key" ] in
      Arg.(value & opt_all string [] doc)
    ```

    ```ocaml
    (* in unikernel.ml *)
    let start _ =
      let key = Key_gen.hello () in
      ...
    ```
    becomes:
    ```ocaml
    (* in config.ml *)
    let hello = runtime_arg ~pos:__POS__ "Unikernel.hello"
    let main = main ~runtime_args:[hello] ...
    ```

    ```
    (* in unikernel.ml *)
    let hello =
      let open Cmdliner in
      let doc = Arg.info ~doc:"How to say hello." [ "hello" ] in
      Arg.(value & opt string "Hello World!" doc)

    let start _ hello =
      ...
    ```

- bump minimal ocaml-solo5 version bound to 0.8.2 to avoid fast memory usage
  error (mirage/mirage#1507, @palainp)
- BREAKING: the packages `functoria` and `functoria-runtime` are removed. The
  respectives libraries became `mirage.functoria` and `mirage-runtime.functoria`
  (mirage/mirage#1509, @samoht)
- BREAKING: `Mirage.keys` is renamed to `Mirage.runtime_args` (mirage/mirage#1506, @samoht)
- BREAKING: remove `Mirage.foreign. Use `Mirage.main` instead (mirage/mirage#1505, @samoht)
- BREAKING: `Mirage.main` does not take a `?extra_deps` parameter anymore
  (mirage/mirage#1505, @samoht)
- BREAKING: the `Mirage.connect` functions passed to create devices
  (with `Mirage.impl`)  now take values of type `'a Mirage.code` instead
  of `string`. Value of type `code` are created using a new `Mirage.code`
  function, that takes `~pos:__POS__` as parameter. This is used to generate
  better locations in the generated code, leading to better error messages
  (mirage/mirage#1504, @samoht)
- BUGFIX: fix `mirage describe` output (mirage/mirage#1446 @samoht), add test (mirage/mirage#1458 @samoht)
- Remove ipaddr from runtime (mirage/mirage#1437 @samoht, mirage/mirage#1465 @hannesm)
- BREAKING: `Mirage.register` no longer have `?packages` and `?keys` arguments
  (mirage/mirage#1433, mirage/mirage#1434 @hannesm)
- BREAKING: Remove deprecated bindings and types (mirage/mirage#1461 @hannesm)
- BREAKING: Remove `mirage build` subcommand, use `dune build` in Makefile
  (mirage/mirage#1404 @hannesm), put `--profile release` in Makefile instead of
  dune-workspace (mirage/mirage#1470 @hannesm)
- Increase dune version to 2.9 in generated dune-project (mirage/mirage#1443 @samoht)
