### PR TITLE
Package bnfgen.3.1.0

### DIFF
--- a/packages/bnfgen/bnfgen.3.1.0/opam
+++ b/packages/bnfgen/bnfgen.3.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Random text generator that takes context-free grammars from BNF files"
+description: """\
+BNFGen generates random texts based on user-defined context-free grammars
+specified in a BNF-like syntax. There are descriptive syntax error messages
+and tracing options.
+
+You can specify "weight" for rules with alternation to influence their probabilities.
+For example, in `<foo> ::= 10 <foo> "foo" | "foo";` the first (recursive) option will be
+taken ten times more often.
+
+You can also specify deterministic repetition ranges, like `<foo>{4}` (exactly four of `<foo>`)
+or `<foo>{1,5}` (from one to five of `<foo>`).
+
+This package includes both a library and a CLI tool based on it."""
+maintainer: "Daniil Baturin <daniil@baturin.org>"
+authors: "Daniil Baturin <daniil@baturin.org>"
+license: "MIT"
+homepage: "https://baturin.org/tools/bnfgen"
+bug-reports: "https://github.com/dmbaturin/bnfgen/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "menhir" {>= "20211128"}
+  "dune" {>= "1.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/dmbaturin/bnfgen"
+url {
+  src: "https://github.com/dmbaturin/bnfgen/archive/3.1.0.tar.gz"
+  checksum: [
+    "md5=e9e9fdd121dd2d4a188dc1ac03089c82"
+    "sha512=069ad2497ac2f6f180d853ef7cb85084a6be3d94df5e7f72496eae9e41e81120c95dc392c20d8b4428698519d921a7ddbc2a18df8093dc698ef11b772e0c66cb"
+  ]
+}


### PR DESCRIPTION
### `bnfgen.3.1.0`
Random text generator that takes context-free grammars from BNF files
BNFGen generates random texts based on user-defined context-free grammars
specified in a BNF-like syntax. There are descriptive syntax error messages
and tracing options.

You can specify "weight" for rules with alternation to influence their probabilities.
For example, in `<foo> ::= 10 <foo> "foo" | "foo";` the first (recursive) option will be
taken ten times more often.

You can also specify deterministic repetition ranges, like `<foo>{4}` (exactly four of `<foo>`)
or `<foo>{1,5}` (from one to five of `<foo>`).

This package includes both a library and a CLI tool based on it.



---
* Homepage: https://baturin.org/tools/bnfgen
* Source repo: git+https://github.com/dmbaturin/bnfgen
* Bug tracker: https://github.com/dmbaturin/bnfgen/issues

---
:camel: Pull-request generated by opam-publish v2.2.0