### PR TITLE
[new release] atacama (0.0.5)

### DIFF
--- a/packages/atacama/atacama.0.0.5/opam
+++ b/packages/atacama/atacama.0.0.5/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Modern, pure OCaml socket pool for Riot"
+description:
+  "Atacama is a modern, pure OCaml socket pool for Riot inspired by Thousand Island. It aims to be easy to understand and reason about, while also being at least as stable and performant as the alternatives."
+maintainer: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+authors: ["Leandro Ostera <leandro@abstractmachines.dev>"]
+license: "MIT"
+tags: ["socket" "socket pool" "tcp" "riot"]
+homepage: "https://github.com/suri-framework/atacama"
+bug-reports: "https://github.com/suri-framework/atacama/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "mdx" {with-test & >= "2.3.1"}
+  "ocaml" {>= "5.1"}
+  "odoc" {with-doc & >= "2.2.2"}
+  "riot" {>= "0.0.1"}
+  "telemetry" {>= "0.0.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/suri-framework/atacama.git"
+url {
+  src:
+    "https://github.com/suri-framework/atacama/releases/download/0.0.5/atacama-0.0.5.tbz"
+  checksum: [
+    "sha256=143ee67ef8eb4e4a7ef27ca96c4644cc7e8d7935cfb86c76a737c7badaa2060e"
+    "sha512=7de1100df32120f3a9541183569fb3d48525e70c981dbac1aa1760d3b78a39c41eb3f0bbe5be7e7ff639dfbf421b5f7c3f0e467199dc7d263a16a0ca7549eec8"
+  ]
+}
+x-commit-hash: "d1cb9be17df073705805b5a19408f6d02638b453"

--- a/packages/atacama/atacama.0.0.5/opam
+++ b/packages/atacama/atacama.0.0.5/opam
@@ -13,7 +13,7 @@ depends: [
   "mdx" {with-test & >= "2.3.1"}
   "ocaml" {>= "5.1"}
   "odoc" {with-doc & >= "2.2.2"}
-  "riot" {>= "0.0.1"}
+  "riot" {>= "0.0.9"}
   "telemetry" {>= "0.0.1"}
 ]
 build: [


### PR DESCRIPTION
Modern, pure OCaml socket pool for Riot

- Project page: <a href="https://github.com/suri-framework/atacama">https://github.com/suri-framework/atacama</a>

##### CHANGES:

* Bring up to latest Riot version – thanks @metame! :clap:

* Introduce `handle_message` callback to allow connector processes to receive
  out-of-band messages from other Riot processes

* Introduce configurable transports with their own configruation

* Introduce configurable connection limits and a dynamic connection pool

* Introduce SSL Transport

* Introduce Connection Peer data including the address and port

* Expose new connection measurements such as time the connection was accepted
  (`accepted_at`) and time at which the connection was established (`connected_at`)

* Move to bytestrings and iovecs

* Default to not reusing ports
