### PR TITLE
[new release] gospel (0.3.0)

### DIFF
--- a/packages/gospel/gospel.0.3.0/opam
+++ b/packages/gospel/gospel.0.3.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "A tool-agnostic formal specification language for OCaml"
+description: """\
+Gospel is a behavioural specification language for OCaml programs. It provides
+developers with a non-invasive and easy-to-use syntax to annotate their module
+interfaces with formal contracts that describe type invariants, mutability,
+function pre-conditions and post-conditions, effects, exceptions, and much more!"""
+maintainer: "Jean-Christophe.Filliatre@lri.fr"
+authors: [
+  "Jean-Christophe Filliâtre"
+  "Samuel Hym"
+  "Cláudio Lourenço"
+  "Nicolas Obsorne"
+  "Clément Pascutto"
+  "Mário Pereira"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-gospel/gospel"
+dev-repo: "git://github.com/ocaml-gospel/gospel"
+bug-reports: "https://github.com/ocaml-gospel/gospel/issues"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+depends: [
+  "ocaml" {>= "4.11"}
+  "ocamlfind"
+  "dune" {>= "3.0.0"}
+  "dune-build-info"
+  "menhir" {>= "20181006"}
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "ocaml-compiler-libs" {>= "v0.12.0"}
+  "ppxlib" {>= "0.26.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "pp_loc" {>= "2.1.0"}
+  "odoc" {with-test}
+]
+
+url {
+  src:
+    "https://github.com/ocaml-gospel/gospel/archive/refs/tags/0.3.0.tar.gz"
+  checksum: [
+    "md5=e5b7f601526cbf590a070b6b9aebe1ad"
+    "sha512=a1375603a3f0ac7681e7e2e989be8af809edef78becc7d920e1d18af4f1db576dce91525cec70292c4ba559eb3f3bac67b023bcc826ea3dfdab956c86990ef91"
+  ]
+}


### PR DESCRIPTION
This release brings two main improvements:

- Make the type-checker save type information in a file
- Make the `with` necessary when declaring type invariants
