### PR TITLE
[new release] server-reason-react (0.2.0)

### DIFF
--- a/packages/server-reason-react/server-reason-react.0.2.0/opam
+++ b/packages/server-reason-react/server-reason-react.0.2.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Rendering React components on the server natively"
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/server-reason-react"
+bug-reports: "https://github.com/ml-in-barcelona/server-reason-react/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "5.0.0"}
+  "reason" {>= "3.10.0"}
+  "melange" {>= "3.0.0"}
+  "ppxlib" {> "0.23.0"}
+  "quickjs" {>= "0.1.1"}
+  "promise" {>= "1.1.2"}
+  "lwt" {>= "5.6.0"}
+  "lwt_ppx" {>= "2.1.0"}
+  "uri" {>= "4.2.0"}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "fmt" {with-test}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {= "0.26.1" & with-test}
+  "ocaml-lsp-server" {with-test}
+  "tiny_httpd" {with-test}
+  "melange-webapi" {with-test}
+  "reason-react" {with-test}
+  "melange-webapi" {with-test}
+  "reason-react-ppx" {with-test}
+]
+dev-repo: "git+https://github.com/ml-in-barcelona/server-reason-react.git"
+# build command is custom to add "@new-doc"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@new-doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ml-in-barcelona/server-reason-react/releases/download/0.2.0/server-reason-react-0.2.0.tbz"
+  checksum: [
+    "sha256=f7e93b2c24e6420ed7352f5b04ff028ea6ea8b9b91679bbce43aadfcae028f34"
+    "sha512=b74f883d8fad95738b7dd9b51f23af27ef1b541939ad9b8ea65cfb0d48a217c2265ca9319e9355c7782bf223a5168ee4ff236677503afa301c8b7b08561fcd8c"
+  ]
+}
+x-commit-hash: "84d3b3ed92b6e7bd3849a0ca96c31acbadee5ba4"

--- a/packages/universal-portal/universal-portal.0.1/opam
+++ b/packages/universal-portal/universal-portal.0.1/opam
@@ -14,7 +14,7 @@ depends: [
   "melange-webapi"
   "dream"
   "quickjs"
-  "server-reason-react"
+  "server-reason-react" {<= "0.1.0"}
   "reason-react-ppx"
   "lambdasoup"
   "reason-react"

--- a/packages/universal-portal/universal-portal.0.2.0/opam
+++ b/packages/universal-portal/universal-portal.0.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "melange-webapi"
   "dream"
   "quickjs"
-  "server-reason-react"
+  "server-reason-react" {<= "0.1.0"}
   "reason-react-ppx"
   "lambdasoup"
   "reason-react"


### PR DESCRIPTION
Rendering React components on the server natively

- Project page: <a href="https://github.com/ml-in-barcelona/server-reason-react">https://github.com/ml-in-barcelona/server-reason-react</a>

##### CHANGES:

## 0.2.0

- Remove data-reactroot attr from ReactDOM.renderToString ml-in-barcelona/server-reason-react#129 by @pedrobslisboa
- Make useUrl return the provided serverUrl ml-in-barcelona/server-reason-react#125 by @purefunctor
- Replace Js.Re implemenation from `pcre` to quickjs b1a3e225cdad1298d705fbbd9618e15b0427ef0f by @davesnx
- Remove Belt.Array.push ml-in-barcelona/server-reason-react#122 by @davesnx
