### PR TITLE
[new release] styled-ppx (0.56.0)

### DIFF
--- a/packages/styled-ppx/styled-ppx.0.56.0/opam
+++ b/packages/styled-ppx/styled-ppx.0.56.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Type-safe styled components for ReScript and Melange"
+description:
+  "styled-ppx is the ppx that brings styled components to ReScript and Melange, allowing you to create React Components with type-safe style definitions using CSS."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://styled-ppx.vercel.app"
+bug-reports: "https://github.com/davesnx/styled-ppx/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "5.1.0"}
+  "reason" {>= "3.11.0"}
+  "menhir" {>= "20220210"}
+  "ppx_deriving" {>= "5.0"}
+  "ppx_deriving_yojson" {>= "3.7.0"}
+  "ppxlib" {>= "0.27.0"}
+  "sedlex" {>= "3.2"}
+  "melange" {>= "3.0.0"}
+  "server-reason-react"
+  "reason-react" {>= "0.14.0"}
+  "alcotest" {with-test}
+  "conf-npm" {with-test}
+  "reason-react-ppx" {with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+  "utop" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/styled-ppx.git"
+url {
+  src:
+    "https://github.com/davesnx/styled-ppx/releases/download/0.56.0/styled-ppx-0.56.0.tbz"
+  checksum: [
+    "sha256=f93a08d11849c6010fc3e1c5650d811a14dc60d1f2ea74edb6e2514f12d9f35f"
+    "sha512=ad90141c288c368ee60455380706deacc41daffb412e9716c28eadc7aff0360110ca0b953a71b4c58eb6ad33c4dafbc066a9002cc0b17a2fd2dd8a5714f7c668"
+  ]
+}
+x-commit-hash: "c38b8044898f306002ddb52425fbad9cc3ba7226"


### PR DESCRIPTION
Type-safe styled components for ReScript and Melange

- Project page: <a href="https://styled-ppx.vercel.app">https://styled-ppx.vercel.app</a>

##### CHANGES:

## 0.56.0

- Improvement for locations in both code-gen and error reporting (davesnx/styled-ppx#456) by @davesnx
- Support css min and max functions (davesnx/styled-ppx#411) by @lubegasimon
- Update docs (davesnx/styled-ppx#457) by @zakybilfagih
- Native support for styled.{{tag}} (davesnx/styled-ppx#461) by @zakybilfagih
- background-clip: text support by @davesnx
- Fix linear-gradient and radial-gradient (davesnx/styled-ppx#464) by @davesnx
- Rename emotion-hash into murmur2 and remove public testing cli by @davesnx
- Use server-reason-react from opam by @davesnx
