### PR TITLE
[new release] mirage-block-xen (2.1.2)

### DIFF
--- a/packages/mirage-block-xen/mirage-block-xen.2.1.2/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.2.1.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott" "Thomas Leonard"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-block-xen"
+doc: "https://mirage.github.io/mirage-block-xen/"
+bug-reports: "https://github.com/mirage/mirage-block-xen/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "logs"
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "6.0.0"}
+  "ppx_cstruct" {>= "3.6.0"}
+  "shared-memory-ring"
+  "shared-memory-ring-lwt"
+  "mirage-block" {>= "2.0.0"}
+  "io-page" {>= "2.0.0"}
+  "mirage-xen" {>= "7.0.0"}
+  "xenstore"
+  "fmt" {>= "0.8.7"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block-xen.git"
+synopsis: "MirageOS block driver for Xen that implements the blkfront/back protocol"
+description: """
+This library allows a Mirage OCaml application to
+
+  1. read and write blocks from any Xen "backend" (server)
+  2. service block requests from any Xen "frontend" (client)
+
+This library can be used in both kernelspace (on Xen)
+or in userspace (using libraries that come with Xen).
+
+This library depends on the
+[shared-memory-ring](https://github.com/mirage/shared-memory-ring)
+library which enables high-throughput, low-latency data
+transfers over shared memory on both x86 and ARM architectures,
+using the standard Xen RPC and event channel semantics.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block-xen/releases/download/v2.1.2/mirage-block-xen-2.1.2.tbz"
+  checksum: [
+    "sha256=5f68d0d34c7a8e7b07034241e80b232cf9fec83f925e21e6365ded31a2dfbc70"
+    "sha512=784a36c8f17cd06f33d4c1435bef4868d1e2c473d7da102adaba566ec5904c27dad68884a19ede2bb599d975dcc3089858d7473ace0105f0d2e039791878d922"
+  ]
+}
+x-commit-hash: "b6d1e67463a5bc60fbbc78270c4a9829e0e5ae00"


### PR DESCRIPTION
MirageOS block driver for Xen that implements the blkfront/back protocol

- Project page: <a href="https://github.com/mirage/mirage-block-xen">https://github.com/mirage/mirage-block-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-xen/">https://mirage.github.io/mirage-block-xen/</a>

##### CHANGES:

* Enforce address alignement with Xen (@palainp, mirage/mirage-block-xen#95)
