### PR TITLE
[new release] multipart_form (4 packages) (0.6.0)

### DIFF
--- a/packages/multipart_form-cohttp-lwt/multipart_form-cohttp-lwt.0.6.0/opam
+++ b/packages/multipart_form-cohttp-lwt/multipart_form-cohttp-lwt.0.6.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Multipart-form for CoHTTP"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/multipart_form"
+doc: "https://dinosaure.github.io/multipart_form/"
+bug-reports: "https://github.com/dinosaure/multipart_form/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cohttp-lwt" {>= "5.3.1"}
+  "multipart_form" {= version}
+  "multipart_form-lwt" {= version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/multipart_form.git"
+url {
+  src:
+    "https://github.com/dinosaure/multipart_form/releases/download/v0.6.0/multipart_form-0.6.0.tbz"
+  checksum: [
+    "sha256=a0e329c323cffaad4167cd5af87a68a1e6a09546600f1773d8c0cd2f28062116"
+    "sha512=46d6aa185df8224f983e06ff904db80f4a4f859810c9040ea894ebc82510ba43719b276b43c5939ac7eba75491cb5633fbb47934a9e66637a185d19e35aab688"
+  ]
+}
+x-commit-hash: "3637a3fe83d9be1c715c8464671a7997dc57af7f"

--- a/packages/multipart_form-eio/multipart_form-eio.0.6.0/opam
+++ b/packages/multipart_form-eio/multipart_form-eio.0.6.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Multipart-form: RFC2183, RFC2388 & RFC7578"
+description: """\
+Implementation of RFC7578 in OCaml
+
+Returning values from forms: multipart/form-data"""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/multipart_form"
+doc: "https://dinosaure.github.io/multipart_form/"
+bug-reports: "https://github.com/dinosaure/multipart_form/issues"
+depends: [
+  "ocaml" {>= "5.0"}
+  "dune" {>= "2.0.0"}
+  "angstrom"
+  "bigstringaf"
+  "eio"
+  "eio_main"
+  "ke"
+  "multipart_form" {= version}
+  "alcotest" {with-test}
+  "fmt" {with-test}
+  "rosetta" {with-test}
+  "rresult" {with-test}
+  "unstrctrd" {with-test}
+  "logs" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/multipart_form.git"
+url {
+  src:
+    "https://github.com/dinosaure/multipart_form/releases/download/v0.6.0/multipart_form-0.6.0.tbz"
+  checksum: [
+    "sha256=a0e329c323cffaad4167cd5af87a68a1e6a09546600f1773d8c0cd2f28062116"
+    "sha512=46d6aa185df8224f983e06ff904db80f4a4f859810c9040ea894ebc82510ba43719b276b43c5939ac7eba75491cb5633fbb47934a9e66637a185d19e35aab688"
+  ]
+}
+x-commit-hash: "3637a3fe83d9be1c715c8464671a7997dc57af7f"

--- a/packages/multipart_form-lwt/multipart_form-lwt.0.6.0/opam
+++ b/packages/multipart_form-lwt/multipart_form-lwt.0.6.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Multipart-form: RFC2183, RFC2388 & RFC7578"
+description: """\
+Implementation of RFC7578 in OCaml
+
+Returning values from forms: multipart/form-data"""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/multipart_form"
+doc: "https://dinosaure.github.io/multipart_form/"
+bug-reports: "https://github.com/dinosaure/multipart_form/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "angstrom"
+  "bigstringaf"
+  "ke"
+  "lwt" {>= "5.4.0"}
+  "multipart_form" {= version}
+  "alcotest-lwt" {with-test}
+  "alcotest" {with-test}
+  "fmt" {with-test}
+  "rosetta" {with-test}
+  "rresult" {with-test}
+  "unstrctrd" {with-test}
+  "logs" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/multipart_form.git"
+url {
+  src:
+    "https://github.com/dinosaure/multipart_form/releases/download/v0.6.0/multipart_form-0.6.0.tbz"
+  checksum: [
+    "sha256=a0e329c323cffaad4167cd5af87a68a1e6a09546600f1773d8c0cd2f28062116"
+    "sha512=46d6aa185df8224f983e06ff904db80f4a4f859810c9040ea894ebc82510ba43719b276b43c5939ac7eba75491cb5633fbb47934a9e66637a185d19e35aab688"
+  ]
+}
+x-commit-hash: "3637a3fe83d9be1c715c8464671a7997dc57af7f"

--- a/packages/multipart_form/multipart_form.0.6.0/opam
+++ b/packages/multipart_form/multipart_form.0.6.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Multipart-form: RFC2183, RFC2388 & RFC7578"
+description: """\
+Implementation of RFC7578 in OCaml
+
+Returning values from forms: multipart/form-data"""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/multipart_form"
+doc: "https://dinosaure.github.io/multipart_form/"
+bug-reports: "https://github.com/dinosaure/multipart_form/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "base64" {>= "3.0.0"}
+  "unstrctrd" {>= "0.2"}
+  "uutf"
+  "pecu" {>= "0.4"}
+  "prettym"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "ke" {>= "0.4"}
+  "alcotest" {with-test}
+  "rosetta" {with-test}
+  "rresult" {with-test}
+  "bigstringaf" {>= "0.9.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/multipart_form.git"
+url {
+  src:
+    "https://github.com/dinosaure/multipart_form/releases/download/v0.6.0/multipart_form-0.6.0.tbz"
+  checksum: [
+    "sha256=a0e329c323cffaad4167cd5af87a68a1e6a09546600f1773d8c0cd2f28062116"
+    "sha512=46d6aa185df8224f983e06ff904db80f4a4f859810c9040ea894ebc82510ba43719b276b43c5939ac7eba75491cb5633fbb47934a9e66637a185d19e35aab688"
+  ]
+}
+x-commit-hash: "3637a3fe83d9be1c715c8464671a7997dc57af7f"


### PR DESCRIPTION
Multipart-form: RFC2183, RFC2388 & RFC7578

- Project page: <a href="https://github.com/dinosaure/multipart_form">https://github.com/dinosaure/multipart_form</a>
- Documentation: <a href="https://dinosaure.github.io/multipart_form/">https://dinosaure.github.io/multipart_form/</a>

##### CHANGES:

- Introduce a new package `multipart_form-eio` (@Willenbrink, dinosaure/multipart_form#35)
- Delete the `result` dependency (@dinosaure, dinosaure/multipart_form#38)
- Fix tests for OCaml 5.2 (@kit-ty-kate, dinosaure/multipart_form#37)
