### PR TITLE
[new release] ocaml-protoc-plugin (6.0.0)

### DIFF
--- a/packages/conf-protoc-dev/conf-protoc-dev.1.0.0/opam
+++ b/packages/conf-protoc-dev/conf-protoc-dev.1.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann"
+authors: "Google"
+license: "BSD-3-Clause"
+homepage: "https://developers.google.com/protocol-buffers/"
+bug-reports: "https://github.com/protocolbuffers/protobuf/issues"
+dev-repo: "git+https://github.com/protocolbuffers/protobuf.git"
+build: [ make ]
+
+depends: [
+  "conf-pkg-config"
+]
+
+depexts: [
+  ["libprotoc-dev"]       {os-family = "debian"}
+  ["libprotoc-dev"]       {os-family = "ubuntu"}
+  ["lib64protobuf-devel"] {os-distribution = "mageia"}
+  ["protobuf-devel"]      {os-distribution = "centos"}
+  ["protobuf-devel"]      {os-distribution = "fedora"}
+  ["protobuf-devel"]      {os-distribution = "rhel"}
+  ["protobuf-dev"]        {os-family = "alpine"}
+  ["protobuf"]            {os-family = "arch"}
+  ["protobuf-devel"]      {os-family = "suse"}
+  ["protobuf"]            {os = "freebsd"}
+  ["protobuf"]            {os = "macos" & os-distribution = "homebrew"}
+]
+
+x-ci-accept-failures: [
+  "oraclelinux-7" # Package not available by default
+  "oraclelinux-8" # Package not available by default
+  "oraclelinux-9" # Package not available by default
+]
+
+available: (os-distribution != "ubuntu" | os-version >= "18.04") & (os-distribution != "centos" | os-version >= "8")
+synopsis: "Virtual package to install protobuf cpp headers"
+description:
+  "This package will install c header files and libaries for google protocol buffers via `opam depext`"
+flags: conf
+url {
+  src:
+    "https://github.com/andersfugmann/ocaml-protoc-plugin/releases/download/6.0.0/ocaml-protoc-plugin-6.0.0.tbz"
+  checksum: [
+    "sha256=aaaf3beaa6c22c86a4d7e311c6531d3d3c0c02768c08985d35a2a2f6fe9b36a0"
+    "sha512=5726b052754420af8ca52cc6b519980d24b08fbe99d938fbe46f76c4136f86a909cdd9dbb2efc56d0fa25915b7c1c9ed51f859633c7e70604daf818f34253fe2"
+  ]
+}
+x-commit-hash: "3dc72f98678c1c29f0d45ccb9560d02afd3edd57"

--- a/packages/conf-protoc-dev/conf-protoc-dev.1.0.0/opam
+++ b/packages/conf-protoc-dev/conf-protoc-dev.1.0.0/opam
@@ -5,7 +5,6 @@ license: "BSD-3-Clause"
 homepage: "https://developers.google.com/protocol-buffers/"
 bug-reports: "https://github.com/protocolbuffers/protobuf/issues"
 dev-repo: "git+https://github.com/protocolbuffers/protobuf.git"
-build: [ make ]
 
 depends: [
   "conf-pkg-config"
@@ -36,12 +35,3 @@ synopsis: "Virtual package to install protobuf cpp headers"
 description:
   "This package will install c header files and libaries for google protocol buffers via `opam depext`"
 flags: conf
-url {
-  src:
-    "https://github.com/andersfugmann/ocaml-protoc-plugin/releases/download/6.0.0/ocaml-protoc-plugin-6.0.0.tbz"
-  checksum: [
-    "sha256=aaaf3beaa6c22c86a4d7e311c6531d3d3c0c02768c08985d35a2a2f6fe9b36a0"
-    "sha512=5726b052754420af8ca52cc6b519980d24b08fbe99d938fbe46f76c4136f86a909cdd9dbb2efc56d0fa25915b7c1c9ed51f859633c7e70604daf818f34253fe2"
-  ]
-}
-x-commit-hash: "3dc72f98678c1c29f0d45ccb9560d02afd3edd57"

--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.6.0.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.6.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "conf-pkg-config" {build}
   "dune-configurator" {with-test}
   "yojson" {with-test}
-  "base64" {>= 3.0.0}
+  "base64" {>= "3.0.0"}
   "ptime"
 ]
 

--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.6.0.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.6.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "conf-pkg-config" {build}
   "dune-configurator" {with-test}
   "yojson" {with-test}
-  "base64" {>= "3.0.0"}
+  "base64" {>= "3.1.0"}
   "ptime"
 ]
 

--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.6.0.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.6.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "conf-pkg-config" {build}
   "dune-configurator" {with-test}
   "yojson" {with-test}
-  "base64"
+  "base64" {>= 3.0.0}
   "ptime"
 ]
 

--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.6.0.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.6.0.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann"
+authors: "Anders Fugmann <anders@fugmann.net>"
+license: "APACHE-2.0"
+homepage: "https://github.com/andersfugmann/ocaml-protoc-plugin"
+dev-repo: "git+https://github.com/andersfugmann/ocaml-protoc-plugin"
+bug-reports: "https://github.com/andersfugmann/ocaml-protoc-plugin/issues"
+doc: "https://andersfugmann.github.io/ocaml-protoc-plugin/"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "arm32" & arch != "x86_32"}
+]
+
+depends: [
+  "conf-protoc" {>= "1.0.0"}
+  "conf-pkg-config"
+  "conf-protoc-dev" {with-test}
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.08.0"}
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_deriving" {with-test}
+  "bisect_ppx" {with-test}
+  "odoc" {with-doc}
+  "conf-pkg-config" {build}
+  "dune-configurator" {with-test}
+  "yojson" {with-test}
+  "base64"
+  "ptime"
+]
+
+
+synopsis: "Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file"
+
+description: """ The plugin generates ocaml type definitions,
+serialization and deserialization functions from a protobuf file.
+The types generated aims to create ocaml idiomatic types;
+- messages are mapped into modules
+- oneof constructs are mapped to polymorphic variants
+- enums are mapped to adt's
+- map types are mapped to assoc lists
+- all integer types are mapped to int by default (exact mapping is also possible)
+- all floating point types are mapped to float.
+- packages are mapped to nested modules
+
+The package aims to be a 100% compliant protobuf implementation.
+It also includes serializing to and from json (Yojson format) based on
+protobuf json specification
+"""
+url {
+  src:
+    "https://github.com/andersfugmann/ocaml-protoc-plugin/releases/download/6.0.0/ocaml-protoc-plugin-6.0.0.tbz"
+  checksum: [
+    "sha256=aaaf3beaa6c22c86a4d7e311c6531d3d3c0c02768c08985d35a2a2f6fe9b36a0"
+    "sha512=5726b052754420af8ca52cc6b519980d24b08fbe99d938fbe46f76c4136f86a909cdd9dbb2efc56d0fa25915b7c1c9ed51f859633c7e70604daf818f34253fe2"
+  ]
+}
+x-commit-hash: "3dc72f98678c1c29f0d45ccb9560d02afd3edd57"

--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.6.0.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.6.0.0/opam
@@ -52,8 +52,8 @@ url {
   src:
     "https://github.com/andersfugmann/ocaml-protoc-plugin/releases/download/6.0.0/ocaml-protoc-plugin-6.0.0.tbz"
   checksum: [
-    "sha256=aaaf3beaa6c22c86a4d7e311c6531d3d3c0c02768c08985d35a2a2f6fe9b36a0"
-    "sha512=5726b052754420af8ca52cc6b519980d24b08fbe99d938fbe46f76c4136f86a909cdd9dbb2efc56d0fa25915b7c1c9ed51f859633c7e70604daf818f34253fe2"
+    "sha256=0620159e24482188276ce4acc070c1d6fa1d3baa882190216a02e7131db65c37"
+    "sha512=0df9dfb2b858f57f23d8c89dec289fbb69312db166639925836031e6ec29aa61b2d2ea564eece6ef4b0ddcdfdb738fa8dd6ef3efe6d261f1c9efb331308e4a93"
   ]
 }
-x-commit-hash: "3dc72f98678c1c29f0d45ccb9560d02afd3edd57"
+x-commit-hash: "ae98477f104d7e96742aed81c7a77a6ce4545776"


### PR DESCRIPTION
Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file

- Project page: <a href="https://github.com/andersfugmann/ocaml-protoc-plugin">https://github.com/andersfugmann/ocaml-protoc-plugin</a>
- Documentation: <a href="https://andersfugmann.github.io/ocaml-protoc-plugin/">https://andersfugmann.github.io/ocaml-protoc-plugin/</a>

##### CHANGES:

### New features
- Implement json serialization and deserialization (andersfugmann/ocaml-protoc-plugin#5)
- Support special json mapping for google types (andersfugmann/ocaml-protoc-plugin#9)
- Add deprecation annotations for deprecated fields, services etc (andersfugmann/ocaml-protoc-plugin#8)
- Add option to prefix generated files with their package name
- Copy documentation from proto files into generated ocaml bindings

### Bug fixes
- Fix file output name if files contains a '-'
- Resolve bug for Request/Response module aliases leading to generating uncompilable code. (andersfugmann/ocaml-protoc-plugin#21)
- Fix codegen bug for messages with out fields and setting singleton_records = true (andersfugmann/ocaml-protoc-plugin#20)
- In Services, the package field is now correctly set to None if the service if not defined in a package scope (andersfugmann/ocaml-protoc-plugin#24)

### Misc changes
- Unify serialization and deserialization spec and optimize oneof handling
- Simplify types used in code generation to improve readaility
- *Replace `val name': unit -> string` with `val name: unit -> string` which will only return the full protobuf name
- Optimize merge functions by applying eager evaluation
- Change signature of `to_proto'` to return unit and not a writer

(`*` indicates breaking change)

### Notes
  `Message.name': unit -> string` has been renamed to `Message.name:
  unit -> string`, and is now contains the fully qualified protobuf
  message name. Before the name was the ocaml module name of the
  message.

  `Service.Message` signature has been deprecated and replaced with
  `Spec.Message` signature. `Service.Message` is now an alias for
  `Spec.Message` and will be removed in future releases.
