### PR TITLE
[new release] progress (2 packages) (0.3.0)

### DIFF
--- a/packages/progress/progress.0.3.0/opam
+++ b/packages/progress/progress.0.3.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "User-definable progress bars"
+description: """
+A progress bar library for OCaml, featuring a DSL for declaratively specifying
+progress bar formats. Supports rendering multiple progress bars simultaneously."""
+maintainer: ["Craig Ferguson <me@craigfe.io>"]
+authors: ["Craig Ferguson <me@craigfe.io>"]
+license: "MIT"
+homepage: "https://github.com/CraigFe/progress"
+doc: "https://CraigFe.github.io/progress/"
+bug-reports: "https://github.com/CraigFe/progress/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "terminal" {= version}
+  "fmt" {>= "0.8.5"}
+  "logs" {>= "0.7.0"}
+  "mtime" {>= "2.0.0"}
+  "uucp" {>= "2.0.0"}
+  "uutf" {>= "1.0.0"}
+  "vector"
+  "optint" {>= "0.1.0"}
+  "alcotest" {with-test & >= "1.4.0"}
+  "astring" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CraigFe/progress.git"
+url {
+  src:
+    "https://github.com/craigfe/progress/releases/download/0.3.0/progress-0.3.0.tbz"
+  checksum: [
+    "sha256=3dfd00bd4def773239159b17781d02fdbfd8ea191801681a94aa0a5be1d06b7c"
+    "sha512=fd64ff8a819b2db2460c06b7fbd5663e2a1941f9e2d4e9b921a3d5f24509fe3be543521fbe1bb6baedad9f62b579aae933efac3903db03a27385233f5461f09c"
+  ]
+}
+x-commit-hash: "6324cfb69f5ae17d14bda5b19f4da3eb5bea00f6"

--- a/packages/terminal/terminal.0.3.0/opam
+++ b/packages/terminal/terminal.0.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Basic utilities for interacting with terminals"
+description: "Basic utilities for interacting with terminals"
+maintainer: ["Craig Ferguson <me@craigfe.io>"]
+authors: ["Craig Ferguson <me@craigfe.io>"]
+license: "MIT"
+homepage: "https://github.com/CraigFe/progress"
+doc: "https://CraigFe.github.io/progress/"
+bug-reports: "https://github.com/CraigFe/progress/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.03.0"}
+  "uucp" {>= "2.0.0"}
+  "uutf" {>= "1.0.0"}
+  "stdlib-shims"
+  "alcotest" {with-test & >= "1.4.0"}
+  "fmt" {with-test}
+  "astring" {with-test}
+  "mtime" {with-test & >= "2.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CraigFe/progress.git"
+url {
+  src:
+    "https://github.com/craigfe/progress/releases/download/0.3.0/progress-0.3.0.tbz"
+  checksum: [
+    "sha256=3dfd00bd4def773239159b17781d02fdbfd8ea191801681a94aa0a5be1d06b7c"
+    "sha512=fd64ff8a819b2db2460c06b7fbd5663e2a1941f9e2d4e9b921a3d5f24509fe3be543521fbe1bb6baedad9f62b579aae933efac3903db03a27385233f5461f09c"
+  ]
+}
+x-commit-hash: "6324cfb69f5ae17d14bda5b19f4da3eb5bea00f6"


### PR DESCRIPTION
User-definable progress bars

- Project page: <a href="https://github.com/CraigFe/progress">https://github.com/CraigFe/progress</a>
- Documentation: <a href="https://CraigFe.github.io/progress/">https://CraigFe.github.io/progress/</a>

##### CHANGES:

- Be compatible with MirageOS and remove `ocaml_terminal_get_sigwinch` (@art-w, CraigFe/progress#38)
- Clear all lines in `interject_with` (@Gbury, CraigFe/progress#30)
- Add `Display.remove_line` (@mbarbin, CraigFe/progress#26)
- Fix compilation for OCaml 5.2 (reported by @Gbury, fixed by @dinosaure, CraigFe/progress#40)
- Add `Display.{pause,resume}` (@Gbury, CraigFe/progress#37)
