### PR TITLE
[new release] tuntap (2.0.1)

### DIFF
--- a/packages/tuntap/tuntap.2.0.1/opam
+++ b/packages/tuntap/tuntap.2.0.1/opam
@@ -31,7 +31,7 @@ depends: [
   "cmdliner" {with-test & >= "1.1.0"} # for bin/otunctl
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/packages/tuntap/tuntap.2.0.1/opam
+++ b/packages/tuntap/tuntap.2.0.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "vb@luminar.eu.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-tuntap"
+doc: "https://mirage.github.io/ocaml-tuntap/"
+bug-reports: "https://github.com/mirage/ocaml-tuntap/issues"
+synopsis: "OCaml library for handling TUN/TAP devices"
+description: """
+This is an OCaml library for handling TUN/TAP devices.  TUN refers to layer 3
+virtual interfaces whereas TAP refers to layer 2 Ethernet ones.
+
+See <http://en.wikipedia.org/wiki/TUN/TAP> for more information.
+
+Linux, FreeBSD, OpenBSD and macOS should all be supported.  You will need
+to install the third-party <http://tuntaposx.sourceforge.net/> on macOS before
+using this library.
+"""
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "ounit2" {with-test}
+  "lwt" {with-test & >= "5.0.0"}
+  "cmdliner" {with-test & >= "1.1.0"} # for bin/otunctl
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+dev-repo: "git+https://github.com/mirage/ocaml-tuntap.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tuntap/releases/download/v2.0.1/tuntap-2.0.1.tbz"
+  checksum: [
+    "sha256=27c60197cc3bc459680eab7f5e2cf4dca08896ce4147bd954fc5ff2d864c0cdd"
+    "sha512=7311438c0b4c79da932c54452c977257bca5bcd0a963567521fde6717f358624b3a42ff094bc4278c103cc839a3896c9d6a9967733cc5366faac1663fb17e801"
+  ]
+}
+x-commit-hash: "bfb11dd8c283762e377bffa1463b08961208739a"


### PR DESCRIPTION
OCaml library for handling TUN/TAP devices

- Project page: <a href="https://github.com/mirage/ocaml-tuntap">https://github.com/mirage/ocaml-tuntap</a>
- Documentation: <a href="https://mirage.github.io/ocaml-tuntap/">https://mirage.github.io/ocaml-tuntap/</a>

##### CHANGES:

* Use `Bytes_val` in C bindings to write to a string value (@avsm)
* Fix typos in ocamldoc
* Do not install otunctl example binary, and update to cmdliner>=1.1.0 (@reynir)
* Switch to ounit2 (@Alessandro-Barbieri)
