### PR TITLE
[new release] ppx_deriving (6.0.0)

### DIFF
--- a/packages/current/current.0.2/opam
+++ b/packages/current/current.0.2/opam
@@ -34,6 +34,7 @@ depends: [
   "prometheus"
   "dune" {>= "1.9"}
   "re" {>= "1.9.0"}
+  "result"
   "lwt-dllist"
   "alcotest-lwt" {>= "1.0.1" & < "1.2.0" & with-test}
 ]

--- a/packages/current/current.0.3/opam
+++ b/packages/current/current.0.3/opam
@@ -34,6 +34,7 @@ depends: [
   "prometheus"
   "dune" {>= "2.0"}
   "re" {>= "1.9.0"}
+  "result"
   "lwt-dllist"
   "alcotest-lwt" {>= "1.0.1" & < "1.2.0" & with-test}
 ]

--- a/packages/ppx_deriving/ppx_deriving.6.0.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.6.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6.3"}
+  "cppo" {>= "1.1.0" & build}
+  "ocamlfind"
+  "ppx_derivers"
+  "ppxlib" {>= "0.32.0"}
+  "ounit2" {with-test}
+]
+synopsis: "Type-driven code generation for OCaml"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_deriving/releases/download/6.0.0/ppx_deriving-6.0.0.tbz"
+  checksum: [
+    "sha256=86bfb2af159b985974e12f5e940756d4641837376954601ecebe9f29568fac25"
+    "sha512=ff8900b66dbf3a8655c25845b237dd0e3639a98793f63511c3cc0011cd6985a362323b5368ffb738802478d722b6281bdac7f4f044676ccf14e2886167cdbd33"
+  ]
+}
+x-commit-hash: "928f1ca49ed6047695d28309d98bfd730f0796a1"


### PR DESCRIPTION
Type-driven code generation for OCaml

- Project page: <a href="https://github.com/ocaml-ppx/ppx_deriving">https://github.com/ocaml-ppx/ppx_deriving</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_deriving/">https://ocaml-ppx.github.io/ppx_deriving/</a>

##### CHANGES:

* Fix a bug in `[@@deriving make]` that caused errors when it was used on a set
  of type declarations containing at least one non record type.
  ocaml-ppx/ppx_deriving#281
  (@NathanReb)

* Embed errors instead of raising exceptions when generating code
  with `ppx_deriving.make`
  ocaml-ppx/ppx_deriving#281
  (@NathanReb)

* Remove `[%derive.iter ...]`, `[%derive.map ...]` and `[%derive.fold ...]`
  extensions
  ocaml-ppx/ppx_deriving#278
  (Simmo Saan)

* Port standard plugins to ppxlib registration and attributes
  ocaml-ppx/ppx_deriving#263
  (Simmo Saan)

* Optimize forwarding in eq and ord plugins
  ocaml-ppx/ppx_deriving#252
  (Simmo Saan)

* Delegate quoter to ppxlib
  ocaml-ppx/ppx_deriving#263
  (Simmo Saan)

* Introduce `Ppx_deriving_runtime.Stdlib` with OCaml >= 4.07.
  This module already exists in OCaml < 4.07 but was missing otherwise.
  ocaml-ppx/ppx_deriving#258
  (Kate Deplaix)
