### PR TITLE
[new release] ocamlregextkit (1.0.1)

### DIFF
--- a/packages/ocamlregextkit/ocamlregextkit.1.0.1/opam
+++ b/packages/ocamlregextkit/ocamlregextkit.1.0.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "A regular expression toolkit for OCaml"
+description:
+  "Provides data structures and algorithms for Regular Expressions, Deterministic Finite Automata, and Non-Deterministic Finite Automata"
+maintainer: ["Dominic Too"]
+authors: ["Dominic Too"]
+license: "GPL-3.0-or-later"
+tags: [
+  "automata"
+  "regular expressions"
+  "regular languages"
+  "regex"
+  "library"
+  "DFA"
+  "NFA"
+  "RE"
+]
+homepage: "https://github.com/toodom02/ocamlregextkit"
+doc: "https://toodom02.github.io/ocamlregextkit/"
+bug-reports: "https://github.com/toodom02/ocamlregextkit/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/toodom02/ocamlregextkit.git"
+url {
+  src:
+    "https://github.com/toodom02/ocamlregextkit/releases/download/v1.0.1/ocamlregextkit-1.0.1.tbz"
+  checksum: [
+    "sha256=15cedecc15b217ef7074b0265ce5e8d1a42beb374579d8f3e494185906307ddd"
+    "sha512=3e1c50bb0c2b2db77ce3d2aa4f59c66624db5a751e0552415554cb764ba161d005f2b516211e58287fec0daa745fadc936bfd89459a910e5cecdcd31fe96d589"
+  ]
+}
+x-commit-hash: "b0f2f37b6db71cebdbc5701be40a37c6253be3d1"


### PR DESCRIPTION
A regular expression toolkit for OCaml

- Project page: <a href="https://github.com/toodom02/ocamlregextkit">https://github.com/toodom02/ocamlregextkit</a>
- Documentation: <a href="https://toodom02.github.io/ocamlregextkit/">https://toodom02.github.io/ocamlregextkit/</a>

##### CHANGES:

### Fix

 - Error handling for DFA `product_construction` over different alphabets (toodom02/ocamlregextkit#6).