### PR TITLE
[new release] smtlib-utils (0.5)

### DIFF
--- a/packages/smtlib-utils/smtlib-utils.0.5/opam
+++ b/packages/smtlib-utils/smtlib-utils.0.5/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Parser for SMTLIB2"
+maintainer: ["simon.cruanes.2007@m4x.org"]
+authors: ["Simon Cruanes"]
+license: "BSD-2-Clause"
+tags: ["SMTLIB" "smt2" "parse" "logic"]
+homepage: "https://github.com/c-cube/smtlib-utils/"
+bug-reports: "https://github.com/c-cube/smtlib-utils/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "menhir" {build & >= "20180523"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+  "trace" {with-test}
+  "trace-tef" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/smtlib-utils.git"
+url {
+  src:
+    "https://github.com/c-cube/smtlib-utils/releases/download/v0.5/smtlib-utils-0.5.tbz"
+  checksum: [
+    "sha256=40eb11f7ebbd05f32e67ea46cb5fdbc9092797ddbf7f92d0b0eb141e636f1742"
+    "sha512=0930b6022151c51490500d6f8d0fe014f6a3785631fcaeb9afbc22dfbf4589ba9de90fd981b7de857d44a885d8d11f89ca96cfa7fcf4e37d15985df94f311430"
+  ]
+}
+x-commit-hash: "93dfede0b928357b46c33975d0d774c71de93160"

--- a/packages/smtlib-utils/smtlib-utils.0.5/opam
+++ b/packages/smtlib-utils/smtlib-utils.0.5/opam
@@ -15,7 +15,7 @@ depends: [
   "trace-tef" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
Parser for SMTLIB2

- Project page: <a href="https://github.com/c-cube/smtlib-utils/">https://github.com/c-cube/smtlib-utils/</a>

##### CHANGES:

- added bitvector support
- added support for declare-datatype
