### PR TITLE
[new release] mirage-kv-unix (3.0.0)

### DIFF
--- a/packages/mirage-kv-unix/mirage-kv-unix.3.0.0/opam
+++ b/packages/mirage-kv-unix/mirage-kv-unix.3.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+authors:      [ "Mindy Preston" "Hannes Mehnert" "Anil Madhavapeddy"
+                "Thomas Gazagnaire" "Stefanie Schirmer" ]
+maintainer:   [ "anil@recoil.org" "thomas@gazagnaire.org" ]
+homepage:     "https://github.com/mirage/mirage-kv-unix"
+dev-repo:     "git+https://github.com/mirage/mirage-kv-unix.git"
+bug-reports:  "https://github.com/mirage/mirage-kv-unix/issues"
+doc:          "https://mirage.github.io/mirage-kv-unix/"
+tags:         [ "org:mirage" ]
+license:      "ISC"
+build: [
+  ["dune" "subst" ] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0"}
+  "mirage-kv" {>= "6.0.0"}
+  "optint"
+  "lwt" {>= "5.3.0"}
+  "ptime"
+  "cstruct" {with-test & >= "3.2.0"}
+  "rresult" {with-test}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+]
+synopsis: "Key-value store for MirageOS backed by Unix filesystem"
+description: """
+This is a Mirage key-value store backed by an underlying Unix directory.
+
+The current version supports the `Mirage_kv_lwt.RO` and `Mirage_kv_lwt.RW`
+signatures defined in the `mirage-kv-lwt` package.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv-unix/releases/download/v3.0.0/mirage-kv-unix-3.0.0.tbz"
+  checksum: [
+    "sha256=7e88544e19b4e29fbd4479d6edb54ac86366f9bf24594b0548bbc34ed62a56c5"
+    "sha512=932bffaa5c18b89f1129984dbb1a1b671ab68596228791ac3069c81d3a8972acf2a8b611839a7ce8cb94c158509551fd11d94c9d9d3a4d58f00345569bd568bb"
+  ]
+}
+x-commit-hash: "52b108802d7ceb998275322b973606bd638dfb6d"

--- a/packages/mirage-kv-unix/mirage-kv-unix.3.0.0/opam
+++ b/packages/mirage-kv-unix/mirage-kv-unix.3.0.0/opam
@@ -9,7 +9,7 @@ doc:          "https://mirage.github.io/mirage-kv-unix/"
 tags:         [ "org:mirage" ]
 license:      "ISC"
 build: [
-  ["dune" "subst" ] {pinned}
+  ["dune" "subst" ] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]


### PR DESCRIPTION
Key-value store for MirageOS backed by Unix filesystem

- Project page: <a href="https://github.com/mirage/mirage-kv-unix">https://github.com/mirage/mirage-kv-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-kv-unix/">https://mirage.github.io/mirage-kv-unix/</a>

##### CHANGES:

* Update to mirage-kv>6 (mirage/mirage-kv-unix#5, @samoht)
