### PR TITLE
[new release] picos (0.2.0)

### DIFF
--- a/packages/picos/picos.0.2.0/opam
+++ b/packages/picos/picos.0.2.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Pico scheduler framework"
+description:
+  "A framework for building interoperable elements of effects based cooperative concurrent programming models."
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/picos"
+bug-reports: "https://github.com/ocaml-multicore/picos/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "backoff" {>= "0.1.0"}
+  "thread-local-storage" {>= "0.1"}
+  "mtime" {>= "2.0.0"}
+  "psq" {>= "0.2.1"}
+  "multicore-magic" {>= "2.1.0"}
+  "multicore-bench" {>= "0.1.2" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "qcheck-core" {>= "0.21.2" & with-test}
+  "qcheck-stm" {>= "0.3" & with-test}
+  "qcheck-multicoretests-util" {>= "0.3" & with-test}
+  "mdx" {>= "2.4.0" & with-test}
+  "ocaml-version" {>= "3.6.4" & with-test}
+  "domain_shims" {>= "0.1.0" & with-test}
+  "js_of_ocaml" {>= "5.4.0" & with-test}
+  "conf-npm" {arch != "x86_32" & arch != "riscv64" & with-test}
+  "dscheck" {>= "0.4.0" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
+  "ocaml" {>= "4.12.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/picos.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/picos/releases/download/0.2.0/picos-0.2.0.tbz"
+  checksum: [
+    "sha256=7b92d091098733f4d16f78f5cb52f7fcef97c90a66141500a0da66e659253bd7"
+    "sha512=0859345ab2a1feb4468515491aae99e390015f3b83019f6f3a13b061305deb19f0868ffa51fb6513b7071bba6fed4ef08c2a464b406bebf4dcde4cc70a9088d4"
+  ]
+}
+x-commit-hash: "a53cd12c7e2515a4ebea9844fe6a45aed4d609ac"


### PR DESCRIPTION
Pico scheduler framework

- Project page: <a href="https://github.com/ocaml-multicore/picos">https://github.com/ocaml-multicore/picos</a>

##### CHANGES:

- Documentation fixes and restructuring (@polytypic)
- Scheduler friendly `waitpid`, `wait`, and `system` in `Picos_stdio.Unix` for
  platforms other than Windows (@polytypic)
- Added `Picos_select.configure` to allow, and sometimes require, configuring
  `Picos_select` for co-operation with libraries that also deal with signals
  (@polytypic)
- Moved `Picos_tls` into `Picos_thread.TLS` (@polytypic)
- Enhanced `sleep` and `sleepf` in `Picos_stdio.Unix` to block in a scheduler
  friendly manner (@polytypic)
