### PR TITLE
conf-emacs and conf-zlib: update depext for Fedora 40

### DIFF
--- a/packages/conf-emacs/conf-emacs.1/opam
+++ b/packages/conf-emacs/conf-emacs.1/opam
@@ -9,7 +9,8 @@ depexts: [
   ["emacs"] {os-distribution = "ubuntu"}
   ["emacs-nox"] {os-distribution = "centos"}
   ["emacs-nox"] {os-distribution = "rhel"}
-  ["emacs-nox"] {os-distribution = "fedora"}
+  ["emacs-nox"] {os-distribution = "fedora" & os-version < "40" }
+  ["emacs-nw"] {os-distribution = "fedora" & os-version >= "40" }
   ["emacs-nox"] {os-distribution = "alpine"}
   ["emacs-nox"] {os-family = "suse" | os-family = "opensuse"}
   ["emacs-nox"] {os-distribution = "ol"}

--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -11,7 +11,8 @@ depexts: [
   ["zlib1g-dev"] {os-family = "debian"}
   ["zlib1g-dev"] {os-family = "ubuntu"}
   ["zlib-devel"] {os-distribution = "centos"}
-  ["zlib-devel"] {os-distribution = "fedora"}
+  ["zlib-devel"] {os-distribution = "fedora" & os-version < "40" }
+  ["zlib-ng-compat-devel"] {os-distribution = "fedora" & os-version >= "40" }
   ["zlib-devel"] {os-distribution = "ol"}
   ["zlib"] {os-distribution = "nixos"}
   ["zlib"] {os-distribution = "homebrew" & os = "macos"}


### PR DESCRIPTION
I just upgraded to Fedora 40 (still in beta), and some package names seem to have changed, causing a very annoying behavior: whenever I try to install any package, I get messages such as:

    [WARNING] Opam packages conf-emacs.1 and conf-zlib.1
    depend on the following system packages that are no longer installed: emacs-nox zlib-devel

This leads to lots of reinstallation and recompilation; for instance, simply trying to install Merlin results in:

```
The following actions will be performed:
  ∗ install   merlin-lib        4.14-501 [required by merlin]
  ↻ recompile conf-zlib         1        [upstream or system changes]
  ∗ install   dot-merlin-reader 4.9      [required by merlin]
  ↻ recompile camlzip           1.11     [uses conf-zlib]
  ∗ install   merlin            4.14-501
  ↻ recompile why3              1.7.1    [uses camlzip]
  ↻ recompile tuareg            3.0.1    [uses merlin]
```

opam tries to recompile `conf-zlib`, which succeeds, since it finds the actual new package name:

    Package zlib-ng-compat-devel-2.1.6-2.fc40.x86_64 is already installed.

And it recompiles every package depending on conf-zlib.

So, in the end, everything works, but it stills wastes lots of time recompiling things.

I assume the issue is due to the package names in the `conf-*` opam files, so I tried updating them, but to be honest I'm not entirely sure this will solve it.