### PR TITLE
[new release] odep (0.2.1)

### DIFF
--- a/packages/odep/odep.0.2.1/opam
+++ b/packages/odep/odep.0.2.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Dependency graphs for OCaml modules, libraries and packages"
+maintainer: ["Simmo Saan <simmo.saan@gmail.com>"]
+authors: ["Simmo Saan"]
+license: "MIT"
+homepage: "https://github.com/sim642/odep"
+bug-reports: "https://github.com/sim642/odep/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "sexplib"
+  "ppx_sexp_conv" {>= "v0.13"}
+  "parsexp"
+  "opam-core" {>= "2.1.0"}
+  "opam-state" {>= "2.1.0"}
+  "opam-format"
+  "ocamlfind" {>= "1.8.1"}
+  "cmdliner" {>= "1.1.0"}
+  "bos"
+  "ppx_deriving"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sim642/odep.git"
+url {
+  src:
+    "https://github.com/sim642/odep/releases/download/0.2.1/odep-0.2.1.tbz"
+  checksum: [
+    "sha256=fae1e859ce276189038c3f8d840d60ec9fc26b733485077b5a6a19f2dcf9dc6a"
+    "sha512=15fd00d21fef777819f3ab45cd851ef7cd505bd19e907d6663885af2a28de75bf41d2349d2c06f03d1e665ad573b90454515916a604536549e7a108288f302f1"
+  ]
+}
+x-commit-hash: "86b8f95fa378ab7d0cf158abcdce7c09ef90ba47"


### PR DESCRIPTION
Dependency graphs for OCaml modules, libraries and packages

- Project page: <a href="https://github.com/sim642/odep">https://github.com/sim642/odep</a>

##### CHANGES:

* Fix dune library main module names with dots from public names.
* Fix non-singleton executables missing from dot output.
