### PR TITLE
[new release] ppx_deriving (6.0.1)

### DIFF
--- a/packages/current/current.0.2/opam
+++ b/packages/current/current.0.2/opam
@@ -34,6 +34,7 @@ depends: [
   "prometheus"
   "dune" {>= "1.9"}
   "re" {>= "1.9.0"}
+  "result"
   "lwt-dllist"
   "alcotest-lwt" {>= "1.0.1" & < "1.2.0" & with-test}
 ]

--- a/packages/current/current.0.3/opam
+++ b/packages/current/current.0.3/opam
@@ -34,6 +34,7 @@ depends: [
   "prometheus"
   "dune" {>= "2.0"}
   "re" {>= "1.9.0"}
+  "result"
   "lwt-dllist"
   "alcotest-lwt" {>= "1.0.1" & < "1.2.0" & with-test}
 ]

--- a/packages/ppx_deriving/ppx_deriving.6.0.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.6.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6.3"}
+  "cppo" {>= "1.1.0" & build}
+  "ocamlfind"
+  "ppx_derivers"
+  "ppxlib" {>= "0.32.0"}
+  "ounit2" {with-test}
+]
+synopsis: "Type-driven code generation for OCaml"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_deriving/releases/download/6.0.1/ppx_deriving-6.0.1.tbz"
+  checksum: [
+    "sha256=c01f56a7afc36d6c0383e26b9c270154719c686d78859738c5d7398b07a21e06"
+    "sha512=6ae49af9b9f64689fafbdd5264c80fb9cb9cb295e0da9bd0e1d0a6fb3bcb1e1f35bd4dfc7fa0327ed2ebf8df27549209b19b77f0c8088df698f594d656c9f3e2"
+  ]
+}
+x-commit-hash: "35dfd4ad83e58bcfbc03b564e5fe6df06b6cbdd7"


### PR DESCRIPTION
Type-driven code generation for OCaml

- Project page: <a href="https://github.com/ocaml-ppx/ppx_deriving">https://github.com/ocaml-ppx/ppx_deriving</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_deriving/">https://ocaml-ppx.github.io/ppx_deriving/</a>

##### CHANGES:

* Fix the unintentional removal of `Ppx_deriving_runtime.Result` in ocaml-ppx/ppx_deriving#279
  ocaml-ppx/ppx_deriving#282
  (@NathanReb)
