### PR TITLE
[new release] mirage-kv-unix (3.0.1)

### DIFF
--- a/packages/mirage-kv-unix/mirage-kv-unix.3.0.1/opam
+++ b/packages/mirage-kv-unix/mirage-kv-unix.3.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+authors:      [ "Mindy Preston" "Hannes Mehnert" "Anil Madhavapeddy"
+                "Thomas Gazagnaire" "Stefanie Schirmer" ]
+maintainer:   [ "anil@recoil.org" "thomas@gazagnaire.org" ]
+homepage:     "https://github.com/mirage/mirage-kv-unix"
+dev-repo:     "git+https://github.com/mirage/mirage-kv-unix.git"
+bug-reports:  "https://github.com/mirage/mirage-kv-unix/issues"
+doc:          "https://mirage.github.io/mirage-kv-unix/"
+tags:         [ "org:mirage" ]
+license:      "ISC"
+build: [
+  ["dune" "subst" ] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0"}
+  "mirage-kv" {>= "6.1.1"}
+  "optint"
+  "lwt" {>= "5.7.0"}
+  "ptime"
+  "cstruct" {with-test & >= "3.2.0"}
+  "rresult" {with-test}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+]
+synopsis: "Key-value store for MirageOS backed by Unix filesystem"
+description: """
+This is a Mirage key-value store backed by an underlying Unix directory.
+
+The current version supports the `Mirage_kv_lwt.RO` and `Mirage_kv_lwt.RW`
+signatures defined in the `mirage-kv-lwt` package.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv-unix/releases/download/v3.0.1/mirage-kv-unix-3.0.1.tbz"
+  checksum: [
+    "sha256=3cf9aeebb875f44f66f6e9825167e4021a3d4f4eea60269cbb14b0015fc84084"
+    "sha512=c23085b9e5cb0640a899f3a741764f6d57f32f9d0ad6ec20c45e8953f1ba6f57c0ddab742f472a0d7522246855154a0e274f204c7787c9685ba4d6ff421edd6e"
+  ]
+}
+x-commit-hash: "468a22626b4642901819ea37c3cac411929c706a"


### PR DESCRIPTION
Key-value store for MirageOS backed by Unix filesystem

- Project page: <a href="https://github.com/mirage/mirage-kv-unix">https://github.com/mirage/mirage-kv-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-kv-unix/">https://mirage.github.io/mirage-kv-unix/</a>

##### CHANGES:

* Remove extra debugging statement (mirage/mirage-kv-unix#8, @samoht)
* Adress reviews from @reynir (mirage/mirage-kv-unix#7, @samoht and @reynir)
  - Fail when keys contain '.' and '..' to match other `mirage-kv-*`
    implementations
  - Use failwith instead of Lwt.failwith
  - Use Lwt.reraise instead of Lwt.fail (requires lwt>=5.7)
  - `digest` on directories now return an error (requires mirage-kv>=6.1.1)
  - `set_partial` on directories return an error while `set` on directories work
    (and remove the directory)
  - fix fd leak in `set` and `set_partial`
