### PR TITLE
[new release] patricia-tree (0.9.0)

### DIFF
--- a/packages/patricia-tree/patricia-tree.0.9.0/opam
+++ b/packages/patricia-tree/patricia-tree.0.9.0/opam
@@ -14,7 +14,7 @@ bug-reports:
 depends: [
   "ocaml" {>= "4.14"}
   "zarith" {>= "1.13"}
-  "dune" {>= "2.7" & >= "2.0"}
+  "dune" {>= "2.7"}
   "qcheck-core" {>= "0.21.2" & with-test}
   "ppx_inline_test" {>= "v0.16.0" & with-test}
   "odoc" {with-doc}

--- a/packages/patricia-tree/patricia-tree.0.9.0/opam
+++ b/packages/patricia-tree/patricia-tree.0.9.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Patricia Tree data structure in OCaml for maps and sets. Supports generic key-value pairs"
+maintainer: ["Dorian Lesbre <dorian.lesbre@cea.fr>"]
+authors: [
+  "Matthieu Lemerre <matthieu.lemerre@cea.fr>"
+  "Dorian Lesbre <dorian.lesbre@cea.fr>"
+]
+license: "LGPL-2.1"
+homepage: "https://codex.top/patricia-tree/"
+doc: "https://codex.top/patricia-tree/"
+bug-reports:
+  "https://github.com/codex-semantics-library/patricia-tree/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "qcheck-core" {>= "0.21.2"}
+  "zarith" {>= "1.13"}
+  "dune" {>= "2.0"}
+  "ppx_inline_test" {>= "v0.16.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/codex-semantics-library/patricia-tree.git"
+url {
+  src:
+    "https://github.com/codex-semantics-library/patricia-tree/releases/download/v0.9.0/patricia-tree-0.9.0.tbz"
+  checksum: [
+    "sha256=a1c431db349146feec0c4c454adf43a9065cc644a9ed10c58be4a5e6f569ca3d"
+    "sha512=0c715ecd53321e9d2551ccbe655fc5725e6eba1396e985525161f34c4dfe3d0f1e9a550e55e7ec0612eb37ae606194600da90f2efc1e4fb5f67ac96247432339"
+  ]
+}
+x-commit-hash: "9e936051cef522b65e08cd1541e62fa631f71232"

--- a/packages/patricia-tree/patricia-tree.0.9.0/opam
+++ b/packages/patricia-tree/patricia-tree.0.9.0/opam
@@ -6,20 +6,21 @@ authors: [
   "Matthieu Lemerre <matthieu.lemerre@cea.fr>"
   "Dorian Lesbre <dorian.lesbre@cea.fr>"
 ]
-license: "LGPL-2.1"
+license: "LGPL-2.1-only"
 homepage: "https://codex.top/patricia-tree/"
 doc: "https://codex.top/patricia-tree/"
 bug-reports:
   "https://github.com/codex-semantics-library/patricia-tree/issues"
 depends: [
   "ocaml" {>= "4.14"}
-  "qcheck-core" {>= "0.21.2"}
   "zarith" {>= "1.13"}
-  "dune" {>= "2.0"}
-  "ppx_inline_test" {>= "v0.16.0"}
+  "dune" {>= "2.7" & >= "2.0"}
+  "qcheck-core" {>= "0.21.2" & with-test}
+  "ppx_inline_test" {>= "v0.16.0" & with-test}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"
@@ -41,4 +42,4 @@ url {
     "sha512=0c715ecd53321e9d2551ccbe655fc5725e6eba1396e985525161f34c4dfe3d0f1e9a550e55e7ec0612eb37ae606194600da90f2efc1e4fb5f67ac96247432339"
   ]
 }
-x-commit-hash: "9e936051cef522b65e08cd1541e62fa631f71232"
+x-commit-hash: "a15fd857e1f719169179c1ef3097f12f89a5d012"


### PR DESCRIPTION
Patricia Tree data structure in OCaml for maps and sets. Supports generic key-value pairs

- Project page: <a href="https://codex.top/patricia-tree/">https://codex.top/patricia-tree/</a>
- Documentation: <a href="https://codex.top/patricia-tree/">https://codex.top/patricia-tree/</a>

##### CHANGES:

- Initial release of Patricia Tree
