### PR TITLE
[new release] smtml (0.1.0)

### DIFF
--- a/packages/encoding/encoding.0.0.1/opam
+++ b/packages/encoding/encoding.0.0.1/opam
@@ -40,3 +40,5 @@ url {
     "sha512=7946f81a6226378b493af9db129445bbe4f51e2924ed490692e485af1f16f09444cfc635e3c04064d5f9b64e64605f121e73e3c8feafa6bb03f8bd39ed99e671"
   ]
 }
+messages: [ "encoding is Deprecated. You should consider using 'smtml' instead" ]
+flags: deprecated

--- a/packages/encoding/encoding.0.0.2/opam
+++ b/packages/encoding/encoding.0.0.2/opam
@@ -42,3 +42,5 @@ url {
     "sha512=dbb083d238cbf9a7ab0f446d0753ad37d98e7b5c324f5c34b918ce38786f35a2d84260b96f0deb72e0d74b2481b929de469e0f826525e5f10f163896db36ad49"
   ]
 }
+messages: [ "encoding is Deprecated. You should consider using 'smtml' instead" ]
+flags: deprecated

--- a/packages/encoding/encoding.0.0.3/opam
+++ b/packages/encoding/encoding.0.0.3/opam
@@ -42,3 +42,5 @@ url {
     "sha512=03b70558322ef654bc1a3ea3ff1c029b8aecd7ed35d98ad4b4089c00905ee6eade180d5a4f4470078217ae60830591528ff2ccdc861083c840a0c52606cb0220"
   ]
 }
+messages: [ "encoding is Deprecated. You should consider using 'smtml' instead" ]
+flags: deprecated

--- a/packages/encoding/encoding.0.0.4/opam
+++ b/packages/encoding/encoding.0.0.4/opam
@@ -44,3 +44,5 @@ url {
     "sha512=c244e75b833cd5eae204749e6049003fb0ede5f202cd18219de8d3a771fc40475b2cc865e9b49f7694696c67389e5b5fe7d5bee415f5e6439ee7ff960ff3c9e0"
   ]
 }
+messages: [ "encoding is Deprecated. You should consider using 'smtml' instead" ]
+flags: deprecated

--- a/packages/smtml/smtml.0.1.0/opam
+++ b/packages/smtml/smtml.0.1.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "A Front-end library for SMT solvers in OCaml"
+description: "A Multi Back-end Front-end for SMT Solvers in OCaml."
+maintainer: ["Filipe Marques <filipe.s.marques@tecnico.ulisboa.pt>"]
+authors: ["Filipe Marques <filipe.s.marques@tecnico.ulisboa.pt>"]
+license: "GPL-3.0-only"
+homepage: "https://github.com/formalsec/smtml"
+doc: "https://formalsec.github.io/smtml/smtml/index.html"
+bug-reports: "https://github.com/formalsec/smtml/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.14.0"}
+  "ocaml_intrinsics"
+  "z3" {>= "4.12.2" & < "4.13"}
+  "menhir" {build & >= "20220210"}
+  "cmdliner" {>= "1.2.0"}
+  "zarith" {>= "1.5"}
+  "odoc" {with-doc}
+  "hc" {>= "0.3"}
+  "bisect_ppx" {with-test & >= "2.5.0" & dev}
+]
+depopts: [
+  "colibri2"
+  "bitwuzla-cxx" {>= "0.4.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/formalsec/smtml.git"
+available: arch != "arm32" & arch != "x86_32"
+pin-depends: [
+  ["colibri2.0.4.0" "git+https://git.frama-c.com/pub/colibrics.git#ae18d699b19e7967a81ccae6db454edfa968feae"]
+  ["colibrilib.0.4.0" "git+https://git.frama-c.com/pub/colibrics.git#ae18d699b19e7967a81ccae6db454edfa968feae"]
+]
+url {
+  src:
+    "https://github.com/formalsec/smtml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=f759570e77c816bd753b5f9d0a99a8e1"
+    "sha512=b40ec4258ad54da38165ad4e7f6dababb05040a3e98edeaea8f7019ff08ed52fa63f9066d876ae7a48efe1cc35e247da4e09b77f2b195dbcc237a7fae3bcf01c"
+  ]
+}


### PR DESCRIPTION
# Smt.ml Release Notes

**Repo**: https://github.com/formalsec/smtml

**Documentation**: https://formalsec.github.io/smtml/

In this PR we:

- Rename the project from the uninspiring `encoding` to `smtml` 
- Release a new major version of the library  

## Version 0.1.0 

See [CHANGES](https://github.com/formalsec/smtml/blob/main/CHANGES.md)