### PR TITLE
Update conf-pulseaudio dependencies.

### DIFF
--- a/packages/conf-pulseaudio/conf-pulseaudio.1/opam
+++ b/packages/conf-pulseaudio/conf-pulseaudio.1/opam
@@ -10,9 +10,11 @@ depends: [
 ]
 depexts: [
   ["pulseaudio-dev"] {os-distribution = "alpine"}
-  ["pulseaudio-libs-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["pulseaudio-libs-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse" | os-distribution = "ol"}
   ["pulseaudio"] {os = "macos" & os-distribution = "homebrew"}
-  ["pulseaudio"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os-distribution = "ol"}
+  ["pulseaudio"] {os = "freebsd" }
+  ["libpulseaudio"] { os-distribution = "nixos" }
+  ["libpulse"] { os-family = "arch" }
   ["libpulse-dev"] {os-family = "debian" | os-family = "ubunty"}
 ]
 synopsis: "Virtual package relying on pulseaudio"


### PR DESCRIPTION
Some of the dependencies were on the pulseaudio server which can now be replaced by pipewire. It worked because they were pulling the pulseaudio library headers. However, the real requirement is that libpulseaudio's headers and shared/static libraries are present.