### PR TITLE
[new release] mirage-qubes (2 packages) (0.9.4)

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.4/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "mirage-qubes" {= version}
+  "tcpip" { >= "7.0.0" }
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "ipaddr" { >= "3.0.0" }
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "lwt" {>= "5.7.0"}
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.9.4/mirage-qubes-0.9.4.tbz"
+  checksum: [
+    "sha256=a214b006c7d0b1ff630138c4d7078b3f655480780a23b29c807b694bfe5bb049"
+    "sha512=2df99dec5c9b41d9e877f6773572089f410370cb5ddf4c85198d77e36d2065420e7afd38fe38a7a7dc351e7b6bc6fc739c545331b88d62744da11f70d5390b4b"
+  ]
+}
+x-commit-hash: "bf6b08bcc674a68513aac87bf24a347d36a84960"

--- a/packages/mirage-qubes/mirage-qubes.0.9.4/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.9.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "cstruct" { >= "6.0.0" }
+  "vchan-xen" { >= "6.0.0" }
+  "mirage-xen" { >= "6.0.0" }
+  "lwt" { >= "5.7.0" }
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.08.0" }
+  "ohex" { >= "0.2.0" }
+  "fmt" {>= "0.8.5"}
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+description: """
+Implementations of various Qubes protocols:
+
+- Qubes.RExec: provide services to other VMs
+- Qubes.GUI: just enough of the GUI protocol so that Qubes accepts the AppVM
+- Qubes.DB: read and write the VM's QubesDB database"""
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.9.4/mirage-qubes-0.9.4.tbz"
+  checksum: [
+    "sha256=a214b006c7d0b1ff630138c4d7078b3f655480780a23b29c807b694bfe5bb049"
+    "sha512=2df99dec5c9b41d9e877f6773572089f410370cb5ddf4c85198d77e36d2065420e7afd38fe38a7a7dc351e7b6bc6fc739c545331b88d62744da11f70d5390b4b"
+  ]
+}
+x-commit-hash: "bf6b08bcc674a68513aac87bf24a347d36a84960"


### PR DESCRIPTION
Implementations of various Qubes protocols for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-qubes">https://github.com/mirage/mirage-qubes</a>
- Documentation: <a href="https://mirage.github.io/mirage-qubes">https://mirage.github.io/mirage-qubes</a>

##### CHANGES:

- Remove internal Cstruct.t (mirage/mirage-qubes#65, @reynir @hannesm @palainp)
