### PR TITLE
[new release] ocaml-version (3.6.7)

### DIFF
--- a/packages/ocaml-version/ocaml-version.3.6.7/opam
+++ b/packages/ocaml-version/ocaml-version.3.6.7/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """
+This library provides facilities to parse version numbers of the OCaml compiler, and enumerates the various official OCaml releases and configuration variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the `patch` and `extra` fields are optional.  This library offers the following functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under the Ecosystem category.
+- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+license: "ISC"
+tags: ["org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-version"
+doc: "https://ocurrent.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-version/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.07.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-version/releases/download/v3.6.7/ocaml-version-3.6.7.tbz"
+  checksum: [
+    "sha256=d50ffd5b669d33edb0d889c476a71de4888d90008d58336038d210ced28f810c"
+    "sha512=128c2777152d6050a1cc07e520876aa7bef380459dd6a3dbcc8e42352afcbd7ebb8f8ef1751beb865346d49ba6f0c2dc45359f2367e5d4c53906008fc51d95eb"
+  ]
+}
+x-commit-hash: "1fd32aebc48b86a81e3f825229180f530a94729a"


### PR DESCRIPTION
CHANGES:

- Add 5.2.0~beta2 (https://github.com/ocurrent/ocaml-version/pull/71, @benmandrew)