### PR TITLE
[new release] hol2dk (2.0.0)

### DIFF
--- a/packages/hol2dk/hol2dk.2.0.0/opam
+++ b/packages/hol2dk/hol2dk.2.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "HOL-Light to Dedukti/Lambdapi and Coq translator"
+description: "HOL-Light to Dedukti/Lambdapi and Coq translator"
+maintainer: ["Frédéric Blanqui"]
+authors: ["Frédéric Blanqui" "Anthony Bordg"]
+license: "CeCILL-2.1"
+homepage: "https://github.com/Deducteam/hol2dk"
+doc: "https://github.com/Deducteam/hol2dk/blob/master/README.md"
+bug-reports: "https://github.com/Deducteam/hol2dk/issues"
+depends: [
+  "ocaml" {>= "4.13"}
+  "dune" {>= "3.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Deducteam/hol2dk.git"
+url {
+  src:
+    "https://github.com/Deducteam/hol2dk/releases/download/2.0.0/hol2dk-2.0.0.tbz"
+  checksum: [
+    "sha256=1a91f3c3743575506c7e727a8615586182d7a7a40e756da2908890b5e4310fb2"
+    "sha512=14d15456d36a399c8842581bf111575a16c5d64c162b31e9b0f5b57a0ce35ae9cd560ff5164997525f5737bd66a117c1977a6d07302c318c46c6b65be2629e3b"
+  ]
+}
+x-commit-hash: "0059a181e647ba00b2aa8806966fa3b61724ae1b"


### PR DESCRIPTION
HOL-Light to Dedukti/Lambdapi and Coq translator

- Project page: <a href="https://github.com/Deducteam/hol2dk">https://github.com/Deducteam/hol2dk</a>
- Documentation: <a href="https://github.com/Deducteam/hol2dk/blob/master/README.md">https://github.com/Deducteam/hol2dk/blob/master/README.md</a>

##### CHANGES:

Big improvements in Lambdapi and Coq file generation time, and Coq checking time.

### Added

- hol2dk can now generate term abbreviations and proofs in several files
in parallel:
  * The option --max-size-abbrev allows to fix the maximum size for term abbreviations files.
  * The option --max-size-proof allows to fix the maximum size for proof files.
- optimization of lp file dependencies in generated lp files.
- generation of Makefile lpo dependencies at the same time as lp files.
- Makefile: lpo and vo dependencies are recomputed automatically.

### Changed

- FILES_WITH_SHARING renamed into BIG_FILES and not added by add-links anymore
- command dump[-simp]-use renamed into dump[-simp]-before-hol
- for each theorem, two files are generated: one with the proof, and one declaring the theorem as an axiom
