### PR TITLE
Add csdp package & fix conf-openblas

### DIFF
--- a/packages/conf-openblas/conf-openblas.0.2.2/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.2/opam
@@ -31,7 +31,7 @@ depexts: [
   ["libopenblas-dev" "liblapacke-dev"] {os-family = "debian"}
   ["libopenblas-dev" "liblapacke-dev"] {os-family = "ubuntu"}
   ["openblas-devel"] {os-distribution = "fedora"}
-  ["openblas-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["libopenblas_openmp-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["openblas" "lapacke" "cblas"] {os-distribution = "arch"}
   ["openblas"] {os = "macos" & os-distribution = "homebrew"}
   ["openblas" "lapacke"] {os = "freebsd"}
@@ -39,6 +39,7 @@ depexts: [
 x-ci-accept-failures: [
   "oraclelinux-7"
   "oraclelinux-8"
+  "oraclelinux-9"
 ]
 synopsis: "Virtual package to install OpenBLAS and LAPACKE"
 description:

--- a/packages/csdp/csdp.6.2.0/files/csdp.install
+++ b/packages/csdp/csdp.6.2.0/files/csdp.install
@@ -1,0 +1,8 @@
+bin: [
+  "solver/csdp" 
+  "theta/theta"
+  "theta/graphtoprob"
+  "theta/complement"
+  "theta/rand_graph"
+]
+

--- a/packages/csdp/csdp.6.2.0/opam
+++ b/packages/csdp/csdp.6.2.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "Nikolay Khachatryan <i20.khachatryan.nikolay@etud.ufar.am>"
+homepage: "https://github.com/coin-or/Csdp"
+dev-repo: "git+https://github.com/coin-or/Csdp.git"
+doc: "https://github.com/coin-or/Csdp/blob/master/doc/csdpuser.pdf"
+license: "EPL-2.0"
+bug-reports: "https://github.com/coin-or/Csdp/issues"
+
+synopsis: "Solver for semidefinite programming problems"
+description: """
+CSDP is a library of routines that implements a predictor corrector variant of
+the semidefinite programming algorithm. It is written in C for efficiency and runs
+in parallel on shared memory multi-processor systems.
+See also the conf-csdp opam package (for distributions that provide csdp)
+"""
+authors: [
+  "Brian Borchers <borchers@nmt.edu>"
+  "Joseph Young <josyoun@nmt.edu>"
+  "Aaron Wilson  <wilson@nmt.edu>"
+]
+depends: [
+  "conf-gcc"
+  "conf-lapack"
+  "conf-openblas" {os != "macos"}
+]
+depexts: [
+  ["libomp"] {os = "macos" & os-distribution = "homebrew"}
+]
+build: [
+  # Add stdio.h (missing in 6.2.0 git tag)
+  # cf. https://github.com/coin-or/Csdp/blob/0dcf187a159c365b6d4e4e0ed5849f7b706da408/lib/user_exit.c#L16
+  ["sed" "-e" "16i\\\n#include <stdio.h>" "-i.bak" "lib/user_exit.c"]
+  # Use openblas (which seems available on most distributions), and remove -static
+  ["sed" "-e" "/export LIBS=/s/-lblas/-lopenblas/" "-e" "/export LIBS=/s/-static//" "-i.bak" "Makefile"]
+  # Remove -ansi to avoid "error: unknown type name 'inline'" on freebsd and macos
+  ["sed" "-e" "/export CFLAGS=/s/-ansi//" "-i.bak" "Makefile"] {os = "freebsd" | os = "macos"}
+  # Use homebrew's libomp to avoid "error: unsupported option '-fopenmp'" on macos
+  # https://github.com/Macaulay2/homebrew-tap/blob/main/Formula/csdp.rb
+  ["sed" "-e" "/export CFLAGS=/s|-fopenmp|-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include -I/usr/local/opt/libomp/include|" "-e" "/export LIBS=/s|-lopenblas|-L/opt/homebrew/opt/libomp/lib -L/usr/local/opt/libomp/lib -lomp -framework Accelerate|" "-i.bak" "Makefile"] {os = "macos" & os-distribution = "homebrew"}
+  ["sed" "-e" "/export CFLAGS=/s|-fopenmp|-fopenmp -I/usr/local/include|" "-e" "/export LIBS=/s|-lsdp|-lsdp -L/usr/local/lib|" "-i.bak" "Makefile"] {os = "freebsd"}
+  # Remove -m64 (not portable and unneeded on amd64 given -march=native)
+  ["sed" "-e" "/export CFLAGS=/s/-m64//" "-i.bak" "Makefile"]
+  # Use -mcpu=native for PowerPC, cf. https://github.com/mfem/mfem/pull/219
+  ["sed" "-e" "/export CFLAGS=/s/-march=native/-mcpu=native/" "-i.bak" "Makefile"] {arch = "ppc64"}
+  [make]
+  [make "unitTest"] {with-test}
+]
+url {
+  src: "https://github.com/coin-or/Csdp/archive/refs/tags/releases/6.2.0.tar.gz"
+  checksum: "sha256=3d341974af1f8ed70e1a37cc896e7ae4a513375875e5b46db8e8f38b7680b32f"
+}


### PR DESCRIPTION
Hello.

Csdp (Cone Semidefinite Programming) is a tool for solving large-scale convex semidefinite programs (SDPs).
It is a dependency of the [osdp](https://opam.ocaml.org/packages/osdp/) opam package and the [validsdp](https://github.com/validsdp/validsdp#readme) coq package, which aims at automatically and formally prove multivariate polynomial inequalities over the real numbers.
With @proux01 and @erikmd , we aim to integrate validsdp in the [coq platform](https://github.com/coq/platform), and the bottleneck is to make csdp available on all major distributions.

It happens the existing conf-csdp package is not enough, because csdp is not directly packaged on all distributions.
Hence the proposition to add this new package in opam-repository.

I have been trying to compile csdp in docker container based on `opensuse/leap` which depends on conf-openblas. 

During the compilation of conf-openblas I have had the following error. 
```
    [ERROR] Package conf-openblas.0.2.2 depends on the unavailable system package
    'openblas-devel'. 
    You can use '--no-depexts' to attempt installation anyway.
    680d7ec7a57d:~ # zypper install openblas-devel
    Loading repository data...
    Reading installed packages...
    'openblas-devel' not found in package names. Trying capabilities.
    'libopenblas_pthreads-devel' providing 'openblas-devel' is already installed.
    Resolving package dependencies...
    Nothing to do.

```
So openblas-devel is a virtual package and opam does not seem to support these on SUSE. Hence my suggestion is to replace openblas-devel with libopenblas_openmp-devel (more idiomatic than libopenblas_pthreads-devel).
    
CC: @erikmd @proux01