### PR TITLE
[new release] git-kv (0.0.4)

### DIFF
--- a/packages/git-kv/git-kv.0.0.4/opam
+++ b/packages/git-kv/git-kv.0.0.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Robur Team <team@robur.coop>"
+authors: [ "Robur Team <team@robur.coop>" ]
+license: "MIT"
+homepage: "https://github.com/robur-coop/git-kv"
+dev-repo: "git+https://github.com/robur-coop/git-kv.git"
+bug-reports: "https://github.com/robur-coop/git-kv/issues"
+synopsis: "A Mirage_kv implementation using git"
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.9.0"}
+  "git"               {>= "3.10.0"}
+  "mirage-kv"         {>= "6.0.0"}
+  "carton"            {>= "0.7.0"}
+  "carton-lwt"        {>= "0.7.0"}
+  "fmt"               {>= "0.8.7"}
+  "mirage-clock"      {>= "2.0.0"}
+  "ptime"
+  "hxd"               {with-test}
+  "conf-git"          {with-test}
+  "mirage-clock-unix" {with-test}
+  "git-unix"          {>= "3.10.0" & with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/robur-coop/git-kv/releases/download/v0.0.4/git-kv-0.0.4.tbz"
+  checksum: [
+    "sha256=e191269066e19ec1b6115970bf05ccf601baac0e327e724f14509c6af23530de"
+    "sha512=b3baff9b76b1eb58e965a83db3bb475ecfd6c9471d168731fb4724e823c3610c3340ffdc2e9ccf11b1ac6bc61e6e38949bfca36198652a5d7dfd5aeec65964d0"
+  ]
+}
+x-commit-hash: "085df792453c524524117ad9ef52ed4e56394bbf"


### PR DESCRIPTION
A Mirage_kv implementation using git

- Project page: <a href="https://github.com/robur-coop/git-kv">https://github.com/robur-coop/git-kv</a>

##### CHANGES:

- Add a branch accessor (@dinosaure, robur-coop/git-kv#30)
- Add the compression level argument into `to_octets` (@hannesm, @dinosaure, robur-coop/git-kv#31)
- Add few `Lwt.pause` to be cooperative with processes (@hannesm, @dinosaure, robur-coop/git-kv#32)
