### PR TITLE
[new release] ocaml-protoc-plugin and conf-protoc-dev (6.1.0)

### DIFF
--- a/packages/conf-protoc-dev/conf-protoc-dev.6.1.0/opam
+++ b/packages/conf-protoc-dev/conf-protoc-dev.6.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann"
+authors: "Google"
+license: "BSD-3-Clause"
+homepage: "https://developers.google.com/protocol-buffers/"
+bug-reports: "https://github.com/protocolbuffers/protobuf/issues"
+dev-repo: "git+https://github.com/protocolbuffers/protobuf.git"
+
+depends: [
+  "conf-pkg-config"
+]
+
+depexts: [
+  ["libprotoc-dev"]       {os-family = "debian"}
+  ["libprotoc-dev"]       {os-family = "ubuntu"}
+  ["lib64protobuf-devel"] {os-distribution = "mageia"}
+  ["protobuf-devel"]      {os-distribution = "centos"}
+  ["protobuf-devel"]      {os-distribution = "fedora"}
+  ["protobuf-devel"]      {os-distribution = "rhel"}
+  ["protobuf-dev"]        {os-family = "alpine"}
+  ["protobuf"]            {os-family = "arch"}
+  ["protobuf-devel"]      {os-family = "suse"}
+  ["protobuf"]            {os = "freebsd"}
+  ["protobuf"]            {os = "macos" & os-distribution = "homebrew"}
+]
+
+x-ci-accept-failures: [
+  "oraclelinux-7" # Package not available by default
+  "oraclelinux-8" # Package not available by default
+  "oraclelinux-9" # Package not available by default
+]
+
+available: (os-distribution != "ubuntu" | os-version >= "18.04") & (os-distribution != "centos" | os-version >= "8")
+synopsis: "Virtual package to install protobuf cpp headers"
+description:
+  "This package will install c header files and libaries for google protocol buffers via `opam depext`"
+flags: conf
+url {
+  src:
+    "https://github.com/andersfugmann/ocaml-protoc-plugin/releases/download/6.1.0/ocaml-protoc-plugin-6.1.0.tbz"
+  checksum: [
+    "sha256=6254d1c7bf9e41f5fd52c1cf53f3dea93d302ed38cfaf604e8360601a368c57b"
+    "sha512=aa81ac6eacbf0dd6fea07c3e9e2eb0aebc8031853ef1cad770497501a2222794c61a1dca9f6b6711039fb49474e55daebf4ad73be9191d6a585f57de3e2d816b"
+  ]
+}
+x-commit-hash: "59227ab995faca3db2b98b9b95f71a6b55a051ec"

--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.6.1.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.6.1.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann"
+authors: "Anders Fugmann <anders@fugmann.net>"
+license: "APACHE-2.0"
+homepage: "https://github.com/andersfugmann/ocaml-protoc-plugin"
+dev-repo: "git+https://github.com/andersfugmann/ocaml-protoc-plugin"
+bug-reports: "https://github.com/andersfugmann/ocaml-protoc-plugin/issues"
+doc: "https://andersfugmann.github.io/ocaml-protoc-plugin/"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "arm32" & arch != "x86_32"}
+]
+
+depends: [
+  "conf-protoc" {>= "1.0.0"}
+  "conf-pkg-config"
+  "conf-protoc-dev" {with-test}
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_deriving" {with-test}
+  "bisect_ppx" {with-test}
+  "odoc" {with-doc}
+  "conf-pkg-config" {build}
+  "dune-configurator" {with-test}
+  "yojson" {with-test}
+  "base64" {>= "3.1.0"}
+  "ptime"
+]
+
+
+synopsis: "Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file"
+
+description: """ The plugin generates ocaml type definitions,
+serialization and deserialization functions from a protobuf file.
+The types generated aims to create ocaml idiomatic types;
+- messages are mapped into modules
+- oneof constructs are mapped to polymorphic variants
+- enums are mapped to adt's
+- map types are mapped to assoc lists
+- all integer types are mapped to int by default (exact mapping is also possible)
+- all floating point types are mapped to float.
+- packages are mapped to nested modules
+
+The package aims to be a 100% compliant protobuf implementation.
+It also includes serializing to and from json (Yojson format) based on
+protobuf json specification
+"""
+url {
+  src:
+    "https://github.com/andersfugmann/ocaml-protoc-plugin/releases/download/6.1.0/ocaml-protoc-plugin-6.1.0.tbz"
+  checksum: [
+    "sha256=6254d1c7bf9e41f5fd52c1cf53f3dea93d302ed38cfaf604e8360601a368c57b"
+    "sha512=aa81ac6eacbf0dd6fea07c3e9e2eb0aebc8031853ef1cad770497501a2222794c61a1dca9f6b6711039fb49474e55daebf4ad73be9191d6a585f57de3e2d816b"
+  ]
+}
+x-commit-hash: "59227ab995faca3db2b98b9b95f71a6b55a051ec"


### PR DESCRIPTION
Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file

- Project page: <a href="https://github.com/andersfugmann/ocaml-protoc-plugin">https://github.com/andersfugmann/ocaml-protoc-plugin</a>
- Documentation: <a href="https://andersfugmann.github.io/ocaml-protoc-plugin/">https://andersfugmann.github.io/ocaml-protoc-plugin/</a>

##### CHANGES:

- Fix name resolution leading to wrongly mapped named
- Fix codegen bug causing the plugin to reject valid protobuf
- Add preliminary support for melange though disabling eager
  evaluation of serialize and deserialize functions when not using
  native or bytecode backends
- Fix missing cflags when compiling test c stub
- Make Map tests compatible with older versions of protoc
- Fix negative integer test failues due to a bug in older versions of protobuf (google) c lib
