### PR TITLE
[new release] shared-memory-ring (2 packages) (3.2.1)

### DIFF
--- a/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.3.2.1/opam
+++ b/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.3.2.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/shared-memory-ring"
+doc: "https://mirage.github.io/shared-memory-ring/"
+bug-reports: "https://github.com/mirage/shared-memory-ring/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "cstruct" {>= "2.4.1"}
+  "shared-memory-ring" {= version}
+  "lwt"
+  "lwt-dllist"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/shared-memory-ring.git"
+synopsis: "Shared memory rings for RPC and bytestream communications using Lwt"
+description: """
+This package contains a set of libraries for creating shared memory
+producer/consumer rings, using the Lwt concurrency library to handle blocking.
+The rings follow the Xen ABI and may be used to create or implement Xen virtual
+devices.
+"""
+url {
+  src:
+    "https://github.com/mirage/shared-memory-ring/releases/download/v3.2.1/shared-memory-ring-3.2.1.tbz"
+  checksum: [
+    "sha256=d9a1d1530389d173f5bd887e808138c1c3d50d8d0a2bb62173f91276816512d2"
+    "sha512=10ab2d5e32903cecb3f3b52250f125dbfc5a352c993f9da97b4c54b9c38c30552935d7abc2ee460ac0e916a26f9aa9548b880fb216a710127b23143078125dac"
+  ]
+}
+x-commit-hash: "655e47a94d8a8e5550f6e3e5e7948a0c01d5c748"

--- a/packages/shared-memory-ring/shared-memory-ring.3.2.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.3.2.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/shared-memory-ring"
+doc: "https://mirage.github.io/shared-memory-ring/"
+bug-reports: "https://github.com/mirage/shared-memory-ring/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "cstruct" {>= "6.0.0"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+available: [ arch != "s390x" & arch != "ppc64" ]
+dev-repo: "git+https://github.com/mirage/shared-memory-ring.git"
+synopsis: "Shared memory rings for RPC and bytestream communications"
+description: """
+This package contains a set of libraries for creating shared memory
+producer/consumer rings. The rings follow the Xen ABI and may be used
+to create or implement Xen virtual devices.
+
+Example use:
+
+One program wishes to create data records and push them efficiently
+to a second process on the same physical machine for
+sampling/analysis/archiving.
+
+Example use:
+
+A Xen virtual machine wishes to send and receive network packets to
+and from a backend driver domain.
+"""
+url {
+  src:
+    "https://github.com/mirage/shared-memory-ring/releases/download/v3.2.1/shared-memory-ring-3.2.1.tbz"
+  checksum: [
+    "sha256=d9a1d1530389d173f5bd887e808138c1c3d50d8d0a2bb62173f91276816512d2"
+    "sha512=10ab2d5e32903cecb3f3b52250f125dbfc5a352c993f9da97b4c54b9c38c30552935d7abc2ee460ac0e916a26f9aa9548b880fb216a710127b23143078125dac"
+  ]
+}
+x-commit-hash: "655e47a94d8a8e5550f6e3e5e7948a0c01d5c748"


### PR DESCRIPTION
Shared memory rings for RPC and bytestream communications

- Project page: <a href="https://github.com/mirage/shared-memory-ring">https://github.com/mirage/shared-memory-ring</a>
- Documentation: <a href="https://mirage.github.io/shared-memory-ring/">https://mirage.github.io/shared-memory-ring/</a>

##### CHANGES:

* move lwt tests to shared-memory-ring-lwt (@hannesm)
