### PR TITLE
[new release] shared-memory-ring (2 packages) (3.2.1)

### DIFF
--- a/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.3.2.1/opam
+++ b/packages/shared-memory-ring-lwt/shared-memory-ring-lwt.3.2.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/shared-memory-ring"
+doc: "https://mirage.github.io/shared-memory-ring/"
+bug-reports: "https://github.com/mirage/shared-memory-ring/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "cstruct" {>= "2.4.1"}
+  "shared-memory-ring" {= version}
+  "lwt"
+  "lwt-dllist"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/shared-memory-ring.git"
+synopsis: "Shared memory rings for RPC and bytestream communications using Lwt"
+description: """
+This package contains a set of libraries for creating shared memory
+producer/consumer rings, using the Lwt concurrency library to handle blocking.
+The rings follow the Xen ABI and may be used to create or implement Xen virtual
+devices.
+"""
+url {
+  src:
+    "https://github.com/mirage/shared-memory-ring/releases/download/v3.2.1/shared-memory-ring-3.2.1.tbz"
+  checksum: [
+    "sha256=a92767b6c3d0a34ffc2656cea0ee8d018b686bce87272e7258752c5a2fcf1833"
+    "sha512=190be12ded34e209d13608a609d9f3c9e657644cac4cdc829f475444efe69fcad9da0a4e2dbd503a682b196cc14b311e60cce3fbc68cdaf4fb15524a4252e7f1"
+  ]
+}
+x-commit-hash: "ed0e8fa13b35bddce6de1b65dbfb6eb215050bee"

--- a/packages/shared-memory-ring/shared-memory-ring.3.2.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.3.2.1/opam
@@ -17,7 +17,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-available: [ arch != "s390x" & arch != "ppc64" ]
+available: [ arch != "s390x" & arch != "ppc64" & arch != "riscv64" ]
 dev-repo: "git+https://github.com/mirage/shared-memory-ring.git"
 synopsis: "Shared memory rings for RPC and bytestream communications"
 description: """

--- a/packages/shared-memory-ring/shared-memory-ring.3.2.1/opam
+++ b/packages/shared-memory-ring/shared-memory-ring.3.2.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/shared-memory-ring"
+doc: "https://mirage.github.io/shared-memory-ring/"
+bug-reports: "https://github.com/mirage/shared-memory-ring/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "cstruct" {>= "6.0.0"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+available: [ arch != "s390x" & arch != "ppc64" ]
+dev-repo: "git+https://github.com/mirage/shared-memory-ring.git"
+synopsis: "Shared memory rings for RPC and bytestream communications"
+description: """
+This package contains a set of libraries for creating shared memory
+producer/consumer rings. The rings follow the Xen ABI and may be used
+to create or implement Xen virtual devices.
+
+Example use:
+
+One program wishes to create data records and push them efficiently
+to a second process on the same physical machine for
+sampling/analysis/archiving.
+
+Example use:
+
+A Xen virtual machine wishes to send and receive network packets to
+and from a backend driver domain.
+"""
+url {
+  src:
+    "https://github.com/mirage/shared-memory-ring/releases/download/v3.2.1/shared-memory-ring-3.2.1.tbz"
+  checksum: [
+    "sha256=a92767b6c3d0a34ffc2656cea0ee8d018b686bce87272e7258752c5a2fcf1833"
+    "sha512=190be12ded34e209d13608a609d9f3c9e657644cac4cdc829f475444efe69fcad9da0a4e2dbd503a682b196cc14b311e60cce3fbc68cdaf4fb15524a4252e7f1"
+  ]
+}
+x-commit-hash: "ed0e8fa13b35bddce6de1b65dbfb6eb215050bee"


### PR DESCRIPTION
Shared memory rings for RPC and bytestream communications

- Project page: <a href="https://github.com/mirage/shared-memory-ring">https://github.com/mirage/shared-memory-ring</a>
- Documentation: <a href="https://mirage.github.io/shared-memory-ring/">https://mirage.github.io/shared-memory-ring/</a>

##### CHANGES:

* move lwt tests to shared-memory-ring-lwt (@hannesm)
