### PR TITLE
conf-postgresql: fix package name on FreeBSD

### DIFF
--- a/packages/conf-postgresql/conf-postgresql.1/opam
+++ b/packages/conf-postgresql/conf-postgresql.1/opam
@@ -4,7 +4,10 @@ authors: "Markus Mottl <markus.mottl@gmail.com>"
 homepage: "https://www.postgresql.org"
 dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
 license: "PD"
-build: [["pg_config"]]
+build: [
+  ["pg_config"] {os != "macos" | os-distribution != "homebrew"}
+  ["$(brew --prefix postgresql@15)/bin/pg_config"] {os = "macos" & os-distribution = "homebrew"}
+]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 
 depexts: [

--- a/packages/conf-postgresql/conf-postgresql.1/opam
+++ b/packages/conf-postgresql/conf-postgresql.1/opam
@@ -14,7 +14,8 @@ depexts: [
   ["libpq-devel"] {os-distribution = "rhel" & os-version >= "8"}
   ["libpq-devel"] {os-distribution = "ol" & os-version >= "8"}
   ["libpq-devel"] {os-distribution = "fedora" & os-version >= "30"}
-  ["postgresql96-client"] {os-distribution = "freebsd"}
+  ["postgresql15-client"] {os-distribution = "freebsd" & os-version >= "13"}
+  ["postgresql96-client"] {os-distribution = "freebsd" & os-version < "13"}
   ["postgresql96-client"] {os-distribution = "openbsd"}
   ["postgresql-devel"] {os-distribution = "centos" & os-version < "8"}
   ["postgresql-devel"] {os-distribution = "rhel" & os-version < "8"}

--- a/packages/conf-postgresql/conf-postgresql.1/opam
+++ b/packages/conf-postgresql/conf-postgresql.1/opam
@@ -6,7 +6,7 @@ dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
 license: "PD"
 build: [
   ["pg_config"] {os != "macos" | os-distribution != "homebrew"}
-  ["$(brew --prefix postgresql@15)/bin/pg_config"] {os = "macos" & os-distribution = "homebrew"}
+  ["sh" "-c" "\"$(brew --prefix postgresql@15)\"/bin/pg_config"] {os = "macos" & os-distribution = "homebrew"}
 ]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 


### PR DESCRIPTION
I spotted in https://freebsd.check.ci.dev/ that the FreeBSD package name (version, really) was off.

According to https://www.freshports.org/databases/postgresql15-client/
`postgresql15-client`
- contains `bin/pg_config`
- has been the default version since 2023-09-08