### PR TITLE
conf-ghostscript: fix package name on FreeBSD

### DIFF
--- a/packages/conf-ghostscript/conf-ghostscript.1/opam
+++ b/packages/conf-ghostscript/conf-ghostscript.1/opam
@@ -15,7 +15,8 @@ depexts: [
   ["ghostscript"] {os-family = "alpine"}
   ["ghostscript"] {os-family = "suse" | os-family = "opensuse"}
   ["ghostscript"] {os-family = "arch"}
-  ["ghostscript"] {os = "freebsd"}
+  ["ghostscript10"] {os = "freebsd" & os-version >= "13"}
+  ["ghostscript"] {os = "freebsd" & os-version < "13"}
   ["ghostscript"] {os-distribution = "homebrew" & os = "macos"}
   ["ghostscript"] {os-distribution = "macports" & os = "macos"}
 ]


### PR DESCRIPTION
https://freebsd.check.ci.dev/ is showing a failure
```
[ERROR] System package install failed with exit code 1 at command:
            sudo pkg install -y ghostscript
[ERROR] These packages are still missing: ghostscript
```
https://freebsd.check.ci.dev/log/1713371636-f089d8564db935c703bea70a4b3d8335ffa1bef3/4.14.1/internal-failure/conf-ghostscript.1

Use https://www.freshports.org/print/ghostscript10/ instead