### PR TITLE
[new release] html_of_jsx (0.0.2)

### DIFF
--- a/packages/html_of_jsx/html_of_jsx.0.0.2/opam
+++ b/packages/html_of_jsx/html_of_jsx.0.0.2/opam
@@ -12,8 +12,8 @@ depends: [
   "ppxlib" {> "0.23.0"}
   "alcotest" {with-test}
   "odoc" {with-doc}
-  "ocamlformat" {= "0.26.1" & with-test}
-  "ocaml-lsp-server" {with-test}
+  "ocamlformat" {= "0.26.1" & with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
   "tiny_httpd" {with-test}
 ]
 build: [

--- a/packages/html_of_jsx/html_of_jsx.0.0.2/opam
+++ b/packages/html_of_jsx/html_of_jsx.0.0.2/opam
@@ -12,7 +12,7 @@ depends: [
   "ppxlib" {> "0.23.0"}
   "alcotest" {with-test}
   "odoc" {with-doc}
-  "ocamlformat" {= "0.26.1" & with-dev-setup}
+  "ocamlformat" {= "0.26.1" & with-test}
   "ocaml-lsp-server" {with-dev-setup}
   "tiny_httpd" {with-test}
 ]

--- a/packages/html_of_jsx/html_of_jsx.0.0.2/opam
+++ b/packages/html_of_jsx/html_of_jsx.0.0.2/opam
@@ -9,7 +9,7 @@ depends: [
   "dune" {>= "3.8"}
   "ocaml" {>= "5.0.0"}
   "reason" {>= "3.10.0"}
-  "ppxlib" {> "0.23.0" & <= "0.31.0"}
+  "ppxlib" {> "0.23.0"}
   "alcotest" {with-test}
   "odoc" {with-doc}
   "ocamlformat" {= "0.26.1" & with-test}

--- a/packages/html_of_jsx/html_of_jsx.0.0.2/opam
+++ b/packages/html_of_jsx/html_of_jsx.0.0.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Render HTML writing JSX"
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/davesnx/html_of_jsx"
+bug-reports: "https://github.com/davesnx/html_of_jsx/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "5.0.0"}
+  "reason" {>= "3.10.0"}
+  "ppxlib" {> "0.23.0" & <= "0.31.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {= "0.26.1" & with-test}
+  "ocaml-lsp-server" {with-test}
+  "tiny_httpd" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/html_of_jsx.git"
+url {
+  src:
+    "https://github.com/davesnx/html_of_jsx/releases/download/0.0.2/html_of_jsx-0.0.2.tbz"
+  checksum: [
+    "sha256=24dc2b9e3726b99d9b0d218289222e7ca66a7250432dc202ecc1b8da4efba0e7"
+    "sha512=c06d87f7e9208dcd7e0ff054c4f2c69d89711474d0da8a43496e3da46c3978a85471e750183fb423e7531efb9fbe5fa432a6729853e49d3226d5eb5ac39b459f"
+  ]
+}
+x-commit-hash: "01b3eabb38996779d11a5ad0b87251bc264ca678"


### PR DESCRIPTION
Render HTML writing JSX

- Project page: <a href="https://github.com/davesnx/html_of_jsx">https://github.com/davesnx/html_of_jsx</a>

##### CHANGES:

## 0.0.2

- Add `Jsx.unsafe` to allow unsafe HTML as children
- Fix HTML attributes formatting (charset, autocomplete, tabindex, inputmode, etc...)
- Enable HTMX attributes via `html_of_jsx.ppx -htmx`
