### PR TITLE
conf-snappy: add include dir on FreeBSD

### DIFF
--- a/packages/conf-snappy/conf-snappy.1/opam
+++ b/packages/conf-snappy/conf-snappy.1/opam
@@ -16,6 +16,10 @@ depexts: [
   ["snappy"] {os-family = "suse" | os-family = "opensuse"}
   ["snappy"] {os = "freebsd"}
 ]
+x-ci-accept-failures: [
+  "oraclelinux-8"
+  "oraclelinux-9"
+]
 synopsis: "Virtual package relying on snappy"
 description:
   "This package can only install if the snappy library is installed on the system."

--- a/packages/conf-snappy/conf-snappy.1/opam
+++ b/packages/conf-snappy/conf-snappy.1/opam
@@ -3,7 +3,8 @@ maintainer: "gabriel.scherer@inria.fr"
 homepage: "https://google.github.io/snappy/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
-  ["c++" "test.cpp" "-lsnappy" "-std=c++11"]
+  ["c++" "test.cpp" "-lsnappy" "-std=c++11"] {os != "freebsd"}
+  ["c++" "test.cpp" "-I/usr/local/include" "-lsnappy" "-std=c++11"] {os = "freebsd"}
 ]
 depexts: [
   ["snappy"] {os-distribution = "arch"}

--- a/packages/conf-snappy/conf-snappy.1/opam
+++ b/packages/conf-snappy/conf-snappy.1/opam
@@ -4,7 +4,7 @@ homepage: "https://google.github.io/snappy/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
   ["c++" "test.cpp" "-lsnappy" "-std=c++11"] {os != "freebsd"}
-  ["c++" "test.cpp" "-I/usr/local/include" "-lsnappy" "-std=c++11"] {os = "freebsd"}
+  ["c++" "test.cpp" "-I/usr/local/include" "-L/usr/local/lib" "-lsnappy" "-std=c++11"] {os = "freebsd"}
 ]
 depexts: [
   ["snappy"] {os-distribution = "arch"}

--- a/packages/conf-snappy/conf-snappy.1/opam
+++ b/packages/conf-snappy/conf-snappy.1/opam
@@ -3,8 +3,9 @@ maintainer: "gabriel.scherer@inria.fr"
 homepage: "https://google.github.io/snappy/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
-  ["c++" "test.cpp" "-lsnappy" "-std=c++11"] {os != "freebsd"}
+  ["c++" "test.cpp" "-lsnappy" "-std=c++11"] {os = "linux"}
   ["c++" "test.cpp" "-I/usr/local/include" "-L/usr/local/lib" "-lsnappy" "-std=c++11"] {os = "freebsd"}
+  ["c++" "test.cpp" "-I$(brew --prefix snappy)/include" "-L$(brew --prefix snappy)/lib"  "-lsnappy" "-std=c++11"] {os = "macos" & os-distribution = "homebrew"}
 ]
 depexts: [
   ["snappy"] {os-distribution = "arch"}

--- a/packages/conf-snappy/conf-snappy.1/opam
+++ b/packages/conf-snappy/conf-snappy.1/opam
@@ -5,7 +5,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
   ["c++" "test.cpp" "-lsnappy" "-std=c++11"] {os = "linux"}
   ["c++" "test.cpp" "-I/usr/local/include" "-L/usr/local/lib" "-lsnappy" "-std=c++11"] {os = "freebsd"}
-  ["c++" "test.cpp" "-I$(brew --prefix snappy)/include" "-L$(brew --prefix snappy)/lib"  "-lsnappy" "-std=c++11"] {os = "macos" & os-distribution = "homebrew"}
+  ["sh" "-c" "c++ test.cpp -I\"$(brew --prefix snappy)/include\" -L\"$(brew --prefix snappy)/lib\" -lsnappy -std=c++11"] {os = "macos" & os-distribution = "homebrew"}
 ]
 depexts: [
   ["snappy"] {os-distribution = "arch"}


### PR DESCRIPTION
On FreeBSD this fails with https://freebsd.check.ci.dev/log/1713371636-f089d8564db935c703bea70a4b3d8335ffa1bef3/4.14.1/bad/conf-snappy.1
```
# test.cpp:1:10: fatal error: 'snappy.h' file not found
# #include <snappy.h>
#          ^~~~~~~~~~
# 1 error generated.
```

The PR therefore adds a (standard) FreeBSD include directory.