### PR TITLE
advi 2.0.0 is not compatible with ocaml 5

### DIFF
--- a/packages/advi/advi.2.0.0/opam
+++ b/packages/advi/advi.2.0.0/opam
@@ -25,7 +25,7 @@ dev-repo: "git+https://github.com/diremy/advi.git"
 doc: "http://advi.inria.fr"
 bug-reports: "Didier.Remy@inria.fr"
 depends: [
-  "ocaml" {>= "4.11.1"}
+  "ocaml" {>= "4.11.1" & < "5.0"}
   "dune" {>= "2.5"}
   "graphics" {>= "5.1.1"}
   "camlimages" {>= "5.0.4"}


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/25747

```
# File "src/main.ml", line 175, characters 0-14:
# 175 | Printexc.catch (Misc.handle_fatal_error main) ();;
#       ^^^^^^^^^^^^^^
# Error (alert deprecated): Stdlib.Printexc.catch
# This function is no longer needed.
```