### PR TITLE
[new release] picos (0.3.0)

### DIFF
--- a/packages/picos/picos.0.3.0/opam
+++ b/packages/picos/picos.0.3.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Pico scheduler framework"
+description:
+  "A framework for building interoperable elements of effects based cooperative concurrent programming models."
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/picos"
+bug-reports: "https://github.com/ocaml-multicore/picos/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "backoff" {>= "0.1.0"}
+  "thread-local-storage" {>= "0.1"}
+  "mtime" {>= "2.0.0"}
+  "psq" {>= "0.2.1"}
+  "multicore-magic" {>= "2.1.0"}
+  "lwt" {>= "5.7.0"}
+  "multicore-bench" {>= "0.1.2" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "qcheck-core" {>= "0.21.2" & with-test}
+  "qcheck-stm" {>= "0.3" & with-test}
+  "qcheck-multicoretests-util" {>= "0.3" & with-test}
+  "mdx" {>= "2.4.0" & with-test}
+  "ocaml-version" {>= "3.6.4" & with-test}
+  "domain_shims" {>= "0.1.0" & with-test}
+  "js_of_ocaml" {>= "5.4.0" & with-test}
+  "conf-npm" {arch != "x86_32" & arch != "riscv64" & with-test}
+  "dscheck" {>= "0.4.0" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
+  "ocaml" {>= "4.12.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/picos.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/picos/releases/download/0.3.0/picos-0.3.0.tbz"
+  checksum: [
+    "sha256=544804c0bde4b29764f82f04e7defed7c06bc43e5a6ce3f7fdc326cb54a7f066"
+    "sha512=4c93427e477fb52374a554a8b9c4c92836a9b5899161275d1473269ab526a1f59177209140631ed763a55be375855dea12f076e18bf4124522414986c0e257be"
+  ]
+}
+x-commit-hash: "bda364fe1205fe9ef18552395af63bafacd33df8"


### PR DESCRIPTION
Pico scheduler framework

- Project page: <a href="https://github.com/ocaml-multicore/picos">https://github.com/ocaml-multicore/picos</a>

##### CHANGES:

- Core API changes:

  - Added `Fiber.set_computation`, which represents a semantic change
  - Renamed `Fiber.computation` to `Fiber.get_computation`
  - Added `Computation.attach_canceler`
  - Added `Fiber.sleep`
  - Added `Fiber.create_packed`
  - Removed `Fiber.try_attach`
  - Removed `Fiber.detach`

  Most of the above changes were motivated by work on and requirements of the
  added structured concurrency library (@polytypic)

- Added a basic user level structured concurrent programming library
  `Picos_structured` (@polytypic)

- Added a functorized `Picos_lwt` providing direct style effects based interface
  to programming with Lwt (@polytypic)

- Added missing `Picos_stdio.Unix.select` (@polytypic)
