### PR TITLE
[new release] ppx_deriving_yaml (0.2.3)

### DIFF
--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.3/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Yaml PPX Deriver"
+description:
+  "Deriving conversion functions to and from yaml for your OCaml types."
+maintainer: ["patrick@sirref.org"]
+authors: ["Patrick Ferris"]
+license: "ISC"
+homepage: "https://github.com/patricoferris/ppx_deriving_yaml"
+bug-reports: "https://github.com/patricoferris/ppx_deriving_yaml/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yaml"
+  "ppx_deriving"
+  "alcotest" {with-test}
+  "mdx" {with-test & >= "2.0.0"}
+  "ocaml" {>= "4.08.1"}
+  "ppxlib" {>= "0.25.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/patricoferris/ppx_deriving_yaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v0.2.3/ppx_deriving_yaml-0.2.3.tbz"
+  checksum: [
+    "sha256=a0fe9a54150be3d3f25f2ebbbdb96d0af8829e3ff65a3288884ab588e580fb43"
+    "sha512=a5dd78af2797f0cd5e27ffe0b384c712963fe97cb81cb916dbf6ff680edaa1f78db78a7a37ec16dd3cb912e08d3f998040a6314bb2ba7aefbb8fd7adeff8edb0"
+  ]
+}
+x-commit-hash: "b243771a74dc36e1de323a9874f1324ec671fee9"


### PR DESCRIPTION
Yaml PPX Deriver

- Project page: <a href="https://github.com/patricoferris/ppx_deriving_yaml">https://github.com/patricoferris/ppx_deriving_yaml</a>

##### CHANGES:

- Prefix `Stdlib.` to standard library modules so other stdlibs work (patricoferris/ppx_deriving_yaml#53, @andrepopp)
