### PR TITLE
[new release] dream-html (3.4.0)

### DIFF
--- a/packages/dream-html/dream-html.3.4.0/opam
+++ b/packages/dream-html/dream-html.3.4.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.4.0/dream-html-3.4.0.tbz"
+  checksum: [
+    "sha256=3ac94d3b9919be8b5bb50946ad4cb01fbb3c12fc1c8ca52735f7f2b25fe6322b"
+    "sha512=71225b4e6eba39cda45784544e8d6f35c68d24642cc2947321fec7a1f3f390c103c819963b5b7d70b6f131438acf23283e28f80601eaf5f6a46f59d5da2cf8b4"
+  ]
+}
+x-commit-hash: "8b7c862d93cca78d71ae45b3f4c7fba850446b60"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
