### PR TITLE
[new release] dream-html (3.4.1)

### DIFF
--- a/packages/dream-html/dream-html.3.4.1/opam
+++ b/packages/dream-html/dream-html.3.4.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.4.1/dream-html-3.4.1.tbz"
+  checksum: [
+    "sha256=8e6217568995d98de70be1d2f9616fed4d50f645bc71759dbbca9ed4176fe4dc"
+    "sha512=f671f026b00a402883b3fbc3d74482b01b6343d542d5a14ba90c2fc3eba095f0b02ff8b2d788299041560c87d5529ea11396297c0a5cfe1f05f354c340046872"
+  ]
+}
+x-commit-hash: "01bd7981e3e2527589e04286cb9ca1ed297bd06d"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
