### PR TITLE
secondary packages to compile the JS flambda2 compiler

### DIFF
--- a/packages/dune-secondary/dune-secondary.3.8.1/opam
+++ b/packages/dune-secondary/dune-secondary.3.8.1/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build-env: [PATH += "%{ocaml-secondary-compiler:share}%/bin"]
+build: [
+  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+install: [
+  ["./_boot/dune.exe" "install" "dune" "--prefix" "%{_:share}%"]
+]
+depends: [
+  "ocaml-secondary-compiler" {="4.14.1"}
+  "base-unix"
+  "base-threads"
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.8.1/dune-3.8.1.tbz"
+  checksum: [
+    "sha256=9413a5d6eb9d7968a0463debb9d9f1be73025345809b827978d0c14db76cf914"
+    "sha512=6857b64e7ca8ba452937539d5996c8d0941b25d82313cfad9e1e6b835a04fb86605beccdc86400cc705ad6a969171524091ab6981df87629b542cc172b38746b"
+  ]
+}

--- a/packages/menhir-secondary/menhir-secondary.20210419/opam
+++ b/packages/menhir-secondary/menhir-secondary.20210419/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+  "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
+]
+homepage: "http://gitlab.inria.fr/fpottier/menhir"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
+build-env: [ PATH += "%{ocaml-secondary-compiler:share}%/bin:%{dune-secondary:share}%/bin" ]
+build: [
+  ["dune" "build" "-j" jobs]
+]
+install: [
+  ["dune" "install" "--prefix" "%{_:share}%"]
+]
+depends: [
+  "dune-secondary"
+]
+synopsis: "Menhir secondary installation"
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/-/archive/20210419/archive.tar.gz"
+  checksum: [
+    "md5=1af2d137eb20811c74ca516500164fd4"
+    "sha512=37a88b3ea0bde6089e5fbf0c1f10c1867c4edcd033ed3d5b75e7ed93e14ddd4f4c4db96baf638a054f65e294b83411497615c7fc14c6ff3a2a007e70f9d12c98"
+  ]
+}

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.14.1/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.14.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.14.1 Secondary Switch Compiler"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+build: [
+  [
+    "./configure"
+      "--prefix=%{_:share}%"
+      "--libdir=%{_:share}%/lib"
+      "--disable-debugger"
+      "--disable-installing-bytecode-programs"
+      "--disable-debug-runtime"
+      "--disable-instrumented-runtime"
+      "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
+      "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%" {os != "cygwin"} "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.1.tar.gz"
+  checksum: "sha256=776006e6f0b9bcfb6d9d74381c588e587432ca85562fde93bb80472a5145b028"
+}
+description: "Installs an additional compiler to the opam switch in
+%{_:share}%/ocaml-secondary-compiler which can be accessed using
+`ocamlfind -toolchain secondary`."

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+flambda2/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+flambda2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+version: "5.1.1+flambda2"
+synopsis: "Jane Street compiler variant with Flambda2 backend"
+depends: [
+  "ocaml" {= "5.1.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "dune-secondary" {="3.8.1"}
+  "menhir-secondary"
+  "conf-autoconf" {build}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build-env: [ PATH += "%{ocaml-secondary-compiler:share}%/bin:%{dune-secondary:share}%/bin:%{menhir-secondary:share}%/bin" ]
+build: [
+  ["autoconf"]
+  ["./configure" "--prefix=%{prefix}%" "--enable-flambda2" "--enable-runtime5=yes"]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+maintainer: "anil@recoil.org"
+homepage: "https://github.com/ocaml-flambda/flambda-backend/"
+bug-reports: "https://github.com/ocaml-flambda/flambda-backend/issues"
+url {
+  src: "https://github.com/ocaml-flambda/flambda-backend/archive/main.tar.gz"
+}
+authors: [ "The Jane Street compiler team"
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]


### PR DESCRIPTION
This (draft) PR allows the flambda2 compiler to be installed with:

```
opam switch create flambda2 5.1.1+flambda2
```

There are some bleeding-edge limitations with the compiler, so its also helpful to add:

```
opam repo add duni https://github.com/dune-universe/opam-overlays.git
```

to get more dune overlay packages (as ocamlbuild compilation fails).