### PR TITLE
[new release] vchan (3 packages) (6.0.2)

### DIFF
--- a/packages/vchan-unix/vchan-unix.6.0.2/opam
+++ b/packages/vchan-unix/vchan-unix.6.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "vchan" {= version}
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "io-page"
+  "mirage-flow" {>= "2.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "xenstore_transport" {>= "1.0.0"}
+  "xen-evtchn-unix"
+  "xen-gnt-unix"
+  "xen-evtchn"
+  "xen-gnt"
+  "fmt" {>= "0.8.7"}
+  "cmdliner" {with-test & >= "1.1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v6.0.2/vchan-6.0.2.tbz"
+  checksum: [
+    "sha256=7e48b5da5ad6b88c1e197fef483da06cc5fda9a3382ad8620d92de25859c5fe5"
+    "sha512=b2f107bf7384908e786dc45f1c5c3796662ea01032fe6639047151d5b3b30e46e82d4f6592548ee085fc1409f93986ff75e446812206122ffdd12da8f82b6e44"
+  ]
+}
+x-commit-hash: "78071e55bad05aabeb9c317c7198e961f7947a48"

--- a/packages/vchan-xen/vchan-xen.6.0.2/opam
+++ b/packages/vchan-xen/vchan-xen.6.0.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "vchan" {=version}
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "io-page"
+  "mirage-flow" {>= "2.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "mirage-xen" {>= "7.0.0"}
+  "xenstore_transport" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v6.0.2/vchan-6.0.2.tbz"
+  checksum: [
+    "sha256=7e48b5da5ad6b88c1e197fef483da06cc5fda9a3382ad8620d92de25859c5fe5"
+    "sha512=b2f107bf7384908e786dc45f1c5c3796662ea01032fe6639047151d5b3b30e46e82d4f6592548ee085fc1409f93986ff75e446812206122ffdd12da8f82b6e44"
+  ]
+}
+x-commit-hash: "78071e55bad05aabeb9c317c7198e961f7947a48"

--- a/packages/vchan/vchan.6.0.2/opam
+++ b/packages/vchan/vchan.6.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+description: """
+This is an implementation of the Xen "libvchan" or "vchan" communication
+protocol in OCaml. It allows fast inter-domain communication using shared
+memory.
+"""
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "6.0.0"}
+  "io-page"
+  "mirage-flow" {>= "4.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "xenstore_transport" {>= "1.0.0"}
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v6.0.2/vchan-6.0.2.tbz"
+  checksum: [
+    "sha256=7e48b5da5ad6b88c1e197fef483da06cc5fda9a3382ad8620d92de25859c5fe5"
+    "sha512=b2f107bf7384908e786dc45f1c5c3796662ea01032fe6639047151d5b3b30e46e82d4f6592548ee085fc1409f93986ff75e446812206122ffdd12da8f82b6e44"
+  ]
+}
+x-commit-hash: "78071e55bad05aabeb9c317c7198e961f7947a48"


### PR DESCRIPTION
Xen Vchan implementation

- Project page: <a href="https://github.com/mirage/ocaml-vchan">https://github.com/mirage/ocaml-vchan</a>
- Documentation: <a href="https://mirage.github.io/ocaml-vchan">https://mirage.github.io/ocaml-vchan</a>

##### CHANGES:

* adapt to mirage-flow 4 changes (add shutdown, alias to close) (mirage/ocaml-vchan#143 @hannesm)
* remove ppx_cstruct and sexplib and ppx_sexp_conv dependencies (mirage/ocaml-vchan#143 @hannesm)
* update to cmdliner 1.1.0 changes (mirage/ocaml-vchan#143 @hannesm)
* use oUnit2 (mirage/ocaml-vchan#141 @Alessandro-Barbieri)
