### PR TITLE
[new release] mirage-net-xen (2.1.4)

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.2.1.4/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.2.1.4/opam
@@ -25,7 +25,9 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.5.0"}
 ]
-
+conflicts: [
+    "result" {< "1.5"}
+]
 tags: "org:mirage"
 synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
 description: """

--- a/packages/mirage-net-xen/mirage-net-xen.2.1.4/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.2.1.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+license:       "ISC"
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "mirage-xen" {>= "7.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "shared-memory-ring" {>="3.0.0"}
+  "macaddr" {>= "5.2.0"}
+  "lwt-dllist"
+  "logs" {>= "0.5.0"}
+]
+
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v2.1.4/mirage-net-xen-2.1.4.tbz"
+  checksum: [
+    "sha256=38218929722745ea48fc53e053d1ce66c09fd0fe774f7e80be45f88a13fb486a"
+    "sha512=581642aad70cbb7a6b46384318aaaf65a4d80419ae99bfc4cca338dfc62376d42487fda61c7e14e17b886ff95fd7ae30aeca2e79fa8442e737b768b7630c1c32"
+  ]
+}
+x-commit-hash: "23965eb9a487b08ebac6edaa3fbbf9528580496e"


### PR DESCRIPTION
Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol

- Project page: <a href="https://github.com/mirage/mirage-net-xen">https://github.com/mirage/mirage-net-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-xen/">https://mirage.github.io/mirage-net-xen/</a>

##### CHANGES:

* Remove mirage-profile dependency (mirage/mirage-net-xen#109 @hannesm)
* Remove sexplib, ppx_sexp_conv and ppx_cstruct dependency (mirage/mirage-net-xen#110 @hannesm)
* Merge netchannel and mirage-net-xen into single opam pacakge (mirage/mirage-net-xen#111 @hannesm)
