### PR TITLE
[new release] mirage-solo5 (0.9.3)

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.9.3/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.9.3/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-solo5"
+bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-solo5.git"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {>= "2.7.0"}
+  "bheap" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "metrics"
+  "metrics-lwt" {>= "0.2.0"}
+  "mirage-runtime" {>= "4.0"}
+  "duration"
+]
+conflicts: [
+  "io-page" {< "2.4.0"}
+  "tcpip" {< "6.1.0"}
+]
+synopsis: "Solo5 core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+[Solo5](https://github.com/Solo5/solo5) targets, which handles the main loop
+and timers. It also provides the low level C startup code and C stubs required
+by the OCaml code.
+
+Currently this package also includes the C stubs used by the Solo5 `console`,
+`block` and `net` implementations.
+
+The OCaml runtime and C runtime required to support it are provided separately
+by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-solo5/releases/download/v0.9.3/mirage-solo5-0.9.3.tbz"
+  checksum: [
+    "sha256=af0900dcebd4f63307fcbe5f93dd178bbc22d911708c44afcb76ca039027a033"
+    "sha512=02ecf944333d555ae1e851e19f6498dc2d09f0b3a5efa568c42c3d65241b354169d8a0d19b82d66d44c95377487485db4e56c800976cfbe7784d0553ab7d8006"
+  ]
+}
+x-commit-hash: "42e6d5f4cae7458bc8edd14d5cbd6c364052c969"


### PR DESCRIPTION
Solo5 core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-solo5">https://github.com/mirage/mirage-solo5</a>

##### CHANGES:

* Time: remove Timeout exception, and unused timeout and with_timeout functions
  (mirage/mirage-solo5#95 @hannesm)
