### PR TITLE
[new release] mirage-xen (8.0.3)

### DIFF
--- a/packages/mirage-xen/mirage-xen.8.0.3/opam
+++ b/packages/mirage-xen/mirage-xen.8.0.3/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "lwt-dllist"
+  "io-page" {>= "2.4.0"}
+  "mirage-runtime" {>= "4.0"}
+  "logs"
+  "fmt" {>= "0.8.5"}
+  "bheap" {>= "2.0.0"}
+  "duration"
+  "metrics"
+  "metrics-lwt" {>= "0.2.0"}
+]
+available: [
+  (arch = "x86_64" ) &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-xen/releases/download/v8.0.3/mirage-xen-8.0.3.tbz"
+  checksum: [
+    "sha256=4eb68d3cea8ee3db3a4132d9759e510f123ec734e8eb1d1ece75b236fb4ee505"
+    "sha512=4cce966b0d1d723806166334250a6136f77c569ca2d81cdbb306c404b35183096ab6f04055152142d7ea0167558928c6f47650450c7db2b08b8a6c74a5d054c0"
+  ]
+}
+x-commit-hash: "6de3bb31c1b51818986da0ae32a9068ac65efa1e"


### PR DESCRIPTION
Xen core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-xen">https://github.com/mirage/mirage-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-xen/">https://mirage.github.io/mirage-xen/</a>

##### CHANGES:

* Time: remove Timeout exception, and unused timeout and with_timeout functions
  (mirage/mirage-xen#52 @hannesm)
* Remove mirage-profile dependency (mirage/mirage-xen#53 @hannesm)
