### PR TITLE
Package herdtools7.7.57

### DIFF
--- a/packages/herdtools7/herdtools7.7.57/opam
+++ b/packages/herdtools7/herdtools7.7.57/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "The herdtools suite for simulating and studying weak memory models"
+maintainer: "Luc Maranget <Luc.Maranget@inria.fr>"
+authors: [
+  "Luc Maranget <Luc.Maranget@inria.fr>"
+  "Jade Alglave <j.alglave@ucl.ac.uk>"
+]
+homepage: "http://diy.inria.fr/"
+bug-reports: "http://github.com/herd/herdtools7/issues/"
+doc: "http://diy.inria.fr/doc/index.html"
+dev-repo: "git+https://github.com/herd/herdtools7.git"
+license: "CECILL-B"
+build: [make "build" "PREFIX=%{prefix}%"]
+install: [make "install" "PREFIX=%{prefix}%"]
+# @todo Add "build-doc" field
+# @todo Add "build-test" field
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "2.7" }
+  "menhir" {>= "20200123"}
+  "zarith"
+]
+conflicts: ["ocaml-option-bytecode-only"]
+url {
+  src: "https://github.com/herd/herdtools7/archive/refs/tags/7.57.tar.gz"
+  checksum: [
+    "md5=94f321f138662ba84f519376b6a9ec44"
+    "sha512=08c6d99e8bcd1774f40daed2965f286401404dbf42c4871246edd5b64ce4fd89ead1f36d2c6d7bfc534d769888cf61b0c8cd6decca9434272c32cbef1bcd29ba"
+  ]
+}

--- a/packages/herdtools7/herdtools7.7.57/opam
+++ b/packages/herdtools7/herdtools7.7.57/opam
@@ -19,6 +19,7 @@ depends: [
   "dune"  {>= "2.7" }
   "menhir" {>= "20200123"}
   "zarith" {>= "1.10"}
+  "conf-which"
 ]
 conflicts: ["ocaml-option-bytecode-only"]
 url {

--- a/packages/herdtools7/herdtools7.7.57/opam
+++ b/packages/herdtools7/herdtools7.7.57/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune"  {>= "2.7" }
   "menhir" {>= "20200123"}
-  "zarith"
+  "zarith" {>= "1.10"}
 ]
 conflicts: ["ocaml-option-bytecode-only"]
 url {


### PR DESCRIPTION
### `herdtools7.7.57`
The herdtools suite for simulating and studying weak memory models



---
* Homepage: http://diy.inria.fr/
* Source repo: git+https://github.com/herd/herdtools7.git
* Bug tracker: http://github.com/herd/herdtools7/issues/

---
:camel: Pull-request generated by opam-publish v2.2.0