### PR TITLE
xen-gnt-unix & xen-evtchn-unix: unavailable on FreeBSD

### DIFF
--- a/packages/xen-evtchn-unix/xen-evtchn-unix.2.0.0/opam
+++ b/packages/xen-evtchn-unix/xen-evtchn-unix.2.0.0/opam
@@ -21,6 +21,7 @@ depends: [
   "ounit" {with-test}
   "conf-xen" {build}
 ]
+available: [ os != "freebsd" ]
 synopsis: "Xen event channel bindings."
 description:
   "These are needed for building Xen device drivers (e.g. mirage-block-xen)"

--- a/packages/xen-evtchn-unix/xen-evtchn-unix.2.1.0/opam
+++ b/packages/xen-evtchn-unix/xen-evtchn-unix.2.1.0/opam
@@ -17,6 +17,7 @@ depends: [
   "ounit" {with-test}
   "conf-xen" {build}
 ]
+available: [ os != "freebsd" ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/xen-gnt-unix/xen-gnt-unix.3.0.0/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.3.0.0/opam
@@ -18,6 +18,7 @@ depends: [
   "io-page-unix"
   "conf-xen" {build}
 ]
+available: [ arch != "s390x" & arch != "ppc64" & os != "freebsd" ]
 synopsis: "Xen grant table bindings"
 description: """
 These allow your program (running either in userspace or in kernelspace

--- a/packages/xen-gnt-unix/xen-gnt-unix.3.0.1/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.3.0.1/opam
@@ -18,6 +18,7 @@ depends: [
   "io-page-unix" {>= "2.0.0"}
   "conf-xen" {build}
 ]
+available: [ arch != "s390x" & arch != "ppc64" & os != "freebsd" ]
 synopsis: "Grant table bindings for OCaml."
 description: """
 These are used to create Xen device driver "backends" (servers)

--- a/packages/xen-gnt-unix/xen-gnt-unix.3.1.0/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.3.1.0/opam
@@ -17,6 +17,7 @@ depends: [
   "io-page-unix" {>= "2.0.0"}
   "conf-xen" {build}
 ]
+available: [ arch != "s390x" & arch != "ppc64" & os != "freebsd" ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/xen-gnt-unix/xen-gnt-unix.4.0.0/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.4.0.0/opam
@@ -17,6 +17,7 @@ depends: [
   "io-page-unix" {>= "2.0.0"}
   "conf-xen" {build}
 ]
+available: [ arch != "s390x" & arch != "ppc64" & os != "freebsd" ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/xen-gnt-unix/xen-gnt-unix.4.0.1/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.4.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "xen-gnt" {= version}
   "conf-xen"
 ]
-available: [ arch != "s390x" & arch != "ppc64" ]
+available: [ arch != "s390x" & arch != "ppc64" & os != "freebsd" ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
The errors (from [#25765](https://github.com/ocaml/opam-repository/pull/25765)):

```
#=== ERROR while compiling xen-gnt-unix.4.0.1 =================================#
# context              2.2.0~beta2~dev | freebsd/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14.2/.opam-switch/build/xen-gnt-unix.4.0.1
# command              ~/.opam/4.14.2/bin/dune build -p xen-gnt-unix -j 7
# exit-code            1
# env-file             ~/.opam/log/xen-gnt-unix-93451-e2aff9.env
# output-file          ~/.opam/log/xen-gnt-unix-93451-e2aff9.out
### output ###
# File "lib/dune", line 12, characters 10-22:
# 12 |  (c_names gntshr_stubs gnttab_stubs)
#                ^^^^^^^^^^^^
# (cd _build/default/lib && /usr/bin/cc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -I /home/opam/.opam/4.14.2/lib/ocaml -I /home/opam/.opam/4.14.2/lib/bytes -I /home/opam/.opam/4.14.2/lib/lwt -I /home/opam/.opam/4.14.2/lib/lwt/unix -I /home/opam/.opam/4.14.2/lib/ocaml/threads -I /home/opam/.opam/4.14.2/lib/ocplib-endian -I /home/opam/.opam/4.14.2/lib/ocplib-endian/bigstring -o gntshr_stubs.o -c gntshr_stubs.c)
# gntshr_stubs.c:33:10: fatal error: 'xenctrl.h' file not found
# #include <xenctrl.h>
#          ^~~~~~~~~~~
# 1 error generated.
# File "lib/dune", line 12, characters 23-35:
# 12 |  (c_names gntshr_stubs gnttab_stubs)
#                             ^^^^^^^^^^^^
# (cd _build/default/lib && /usr/bin/cc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -I /home/opam/.opam/4.14.2/lib/ocaml -I /home/opam/.opam/4.14.2/lib/bytes -I /home/opam/.opam/4.14.2/lib/lwt -I /home/opam/.opam/4.14.2/lib/lwt/unix -I /home/opam/.opam/4.14.2/lib/ocaml/threads -I /home/opam/.opam/4.14.2/lib/ocplib-endian -I /home/opam/.opam/4.14.2/lib/ocplib-endian/bigstring -o gnttab_stubs.o -c gnttab_stubs.c)
# gnttab_stubs.c:34:10: fatal error: 'xenctrl.h' file not found
# #include <xenctrl.h>
#          ^~~~~~~~~~~
# 1 error generated.
```

```
#=== ERROR while compiling xen-evtchn-unix.2.1.0 ==============================#
# context              2.2.0~beta2~dev | freebsd/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14.2/.opam-switch/build/xen-evtchn-unix.2.1.0
# command              ~/.opam/4.14.2/bin/dune build -p xen-evtchn-unix -j 7
# exit-code            1
# env-file             ~/.opam/log/xen-evtchn-unix-93451-26b38e.env
# output-file          ~/.opam/log/xen-evtchn-unix-93451-26b38e.out
### output ###
# File "lib/dune", line 12, characters 10-24:
# 12 |  (c_names eventchn_stubs)
#                ^^^^^^^^^^^^^^
# (cd _build/default/lib && /usr/bin/cc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -I /home/opam/.opam/4.14.2/lib/ocaml -I /home/opam/.opam/4.14.2/lib/bytes -I /home/opam/.opam/4.14.2/lib/lwt -I /home/opam/.opam/4.14.2/lib/lwt-dllist -I /home/opam/.opam/4.14.2/lib/lwt/unix -I /home/opam/.opam/4.14.2/lib/ocaml/threads -I /home/opam/.opam/4.14.2/lib/ocplib-endian -I /home/opam/.opam/4.14.2/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14.2/lib/xen-evtchn -o eventchn_stubs.o -c eventchn_stubs.c)
# eventchn_stubs.c:27:10: fatal error: 'xenctrl.h' file not found
# #include <xenctrl.h>
#          ^~~~~~~~~~~
# 1 error generated.
```