### PR TITLE
conduit-mirage: upper bound on vchan

### DIFF
--- a/packages/conduit-mirage/conduit-mirage.6.2.1/opam
+++ b/packages/conduit-mirage/conduit-mirage.6.2.1/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "dns-client-mirage" {>= "7.0.0"}
   "conduit-lwt" {=version}
-  "vchan" {>= "5.0.0"}
+  "vchan" {>= "5.0.0" & < "6.0.2"}
   "xenstore"
   "tls" {>= "0.11.0"}
   "tls-mirage" {>= "0.11.0"}


### PR DESCRIPTION
from [#25765](https://github.com/ocaml/opam-repository/pull/25765):


```
#=== ERROR while compiling conduit-mirage.6.2.1 ===============================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/conduit-mirage.6.2.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p conduit-mirage -j 255
# exit-code            1
# env-file             ~/.opam/log/conduit-mirage-7-9804f5.env
# output-file          ~/.opam/log/conduit-mirage-7-9804f5.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I src/conduit-mirage/.conduit_mirage.objs/byte -I /home/opam/.opam/5.1/lib/angstrom -I /home/opam/.opam/5.1/lib/asn1-combinators -I /home/opam/.opam/5.1/lib/astring -I /home/opam/.opam/5.1/lib/base64 -I /home/opam/.opam/5.1/lib/bigstringaf -I /home/opam/.opam/5.1/lib/ca-certs-nss -I /home/opam/.opam/5.1/lib/conduit -I /home/opam/.opam/5.1/lib/conduit-lwt -I /home/opam/.opam/5.1/lib/cstruct -I /home/opam/.opam/5.1/lib/dns -I /home/opam/.opam/5.1/lib/dns-client -I /home/opam/.opam/5.1/lib/dns-client-mirage -I /home/opam/.opam/5.1/lib/dns/cache -I /home/opam/.opam/5.1/lib/domain-name -I /home/opam/.opam/5.1/lib/duration -I /home/opam/.opam/5.1/lib/eqaf -I /home/opam/.opam/5.1/lib/eqaf/bigstring -I /home/opam/.opam/5.1/lib/eqaf/cstruct -I /home/opam/.opam/5.1/lib/fmt -I /home/opam/.opam/5.1/lib/gmap -I /home/opam/.opam/5.1/lib/happy-eyeballs -I /home/opam/.opam/5.1/lib/hkdf -I /home/opam/.opam/5.1/lib/io-page -I /home/opam/.opam/5.1/lib/ipaddr -I /home/opam/.opam/5.1/lib/ipaddr-sexp -I /home/opam/.opam/5.1/lib/logs -I /home/opam/.opam/5.1/lib/lru -I /home/opam/.opam/5.1/lib/lwt -I /home/opam/.opam/5.1/lib/macaddr -I /home/opam/.opam/5.1/lib/metrics -I /home/opam/.opam/5.1/lib/mirage-clock -I /home/opam/.opam/5.1/lib/mirage-crypto -I /home/opam/.opam/5.1/lib/mirage-crypto-ec -I /home/opam/.opam/5.1/lib/mirage-crypto-pk -I /home/opam/.opam/5.1/lib/mirage-crypto-rng -I /home/opam/.opam/5.1/lib/mirage-flow -I /home/opam/.opam/5.1/lib/mirage-flow-combinators -I /home/opam/.opam/5.1/lib/mirage-kv -I /home/opam/.opam/5.1/lib/mirage-random -I /home/opam/.opam/5.1/lib/mirage-time -I /home/opam/.opam/5.1/lib/optint -I /home/opam/.opam/5.1/lib/parsexp -I /home/opam/.opam/5.1/lib/pbkdf -I /home/opam/.opam/5.1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.1/lib/psq -I /home/opam/.opam/5.1/lib/ptime -I /home/opam/.opam/5.1/lib/randomconv -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/sexplib -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/stringext -I /home/opam/.opam/5.1/lib/tcpip -I /home/opam/.opam/5.1/lib/tls -I /home/opam/.opam/5.1/lib/tls-mirage -I /home/opam/.opam/5.1/lib/uri -I /home/opam/.opam/5.1/lib/uri/services -I /home/opam/.opam/5.1/lib/vchan -I /home/opam/.opam/5.1/lib/x509 -I /home/opam/.opam/5.1/lib/xenstore -I /home/opam/.opam/5.1/lib/xenstore/client -I /home/opam/.opam/5.1/lib/zarith -intf-suffix .ml -no-alias-deps -o src/conduit-mirage/.conduit_mirage.objs/byte/conduit_mirage.cmo -c -impl src/conduit-mirage/conduit_mirage.pp.ml)
# File "src/conduit-mirage/conduit_mirage.ml", line 63, characters 23-35:
# 63 |     [ `Direct of int * Vchan.Port.t | `Domain_socket of string * Vchan.Port.t ]
#                             ^^^^^^^^^^^^
# Error: Unbound value Vchan.Port.t_of_sexp
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlopt.opt -w -40 -g -I src/conduit-mirage/.conduit_mirage.objs/byte -I src/conduit-mirage/.conduit_mirage.objs/native -I /home/opam/.opam/5.1/lib/angstrom -I /home/opam/.opam/5.1/lib/asn1-combinators -I /home/opam/.opam/5.1/lib/astring -I /home/opam/.opam/5.1/lib/base64 -I /home/opam/.opam/5.1/lib/bigstringaf -I /home/opam/.opam/5.1/lib/ca-certs-nss -I /home/opam/.opam/5.1/lib/conduit -I /home/opam/.opam/5.1/lib/conduit-lwt -I /home/opam/.opam/5.1/lib/cstruct -I /home/opam/.opam/5.1/lib/dns -I /home/opam/.opam/5.1/lib/dns-client -I /home/opam/.opam/5.1/lib/dns-client-mirage -I /home/opam/.opam/5.1/lib/dns/cache -I /home/opam/.opam/5.1/lib/domain-name -I /home/opam/.opam/5.1/lib/duration -I /home/opam/.opam/5.1/lib/eqaf -I /home/opam/.opam/5.1/lib/eqaf/bigstring -I /home/opam/.opam/5.1/lib/eqaf/cstruct -I /home/opam/.opam/5.1/lib/fmt -I /home/opam/.opam/5.1/lib/gmap -I /home/opam/.opam/5.1/lib/happy-eyeballs -I /home/opam/.opam/5.1/lib/hkdf -I /home/opam/.opam/5.1/lib/io-page -I /home/opam/.opam/5.1/lib/ipaddr -I /home/opam/.opam/5.1/lib/ipaddr-sexp -I /home/opam/.opam/5.1/lib/logs -I /home/opam/.opam/5.1/lib/lru -I /home/opam/.opam/5.1/lib/lwt -I /home/opam/.opam/5.1/lib/macaddr -I /home/opam/.opam/5.1/lib/metrics -I /home/opam/.opam/5.1/lib/mirage-clock -I /home/opam/.opam/5.1/lib/mirage-crypto -I /home/opam/.opam/5.1/lib/mirage-crypto-ec -I /home/opam/.opam/5.1/lib/mirage-crypto-pk -I /home/opam/.opam/5.1/lib/mirage-crypto-rng -I /home/opam/.opam/5.1/lib/mirage-flow -I /home/opam/.opam/5.1/lib/mirage-flow-combinators -I /home/opam/.opam/5.1/lib/mirage-kv -I /home/opam/.opam/5.1/lib/mirage-random -I /home/opam/.opam/5.1/lib/mirage-time -I /home/opam/.opam/5.1/lib/optint -I /home/opam/.opam/5.1/lib/parsexp -I /home/opam/.opam/5.1/lib/pbkdf -I /home/opam/.opam/5.1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.1/lib/psq -I /home/opam/.opam/5.1/lib/ptime -I /home/opam/.opam/5.1/lib/randomconv -I /home/opam/.opam/5.1/lib/seq -I /home/opam/.opam/5.1/lib/sexplib -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/stringext -I /home/opam/.opam/5.1/lib/tcpip -I /home/opam/.opam/5.1/lib/tls -I /home/opam/.opam/5.1/lib/tls-mirage -I /home/opam/.opam/5.1/lib/uri -I /home/opam/.opam/5.1/lib/uri/services -I /home/opam/.opam/5.1/lib/vchan -I /home/opam/.opam/5.1/lib/x509 -I /home/opam/.opam/5.1/lib/xenstore -I /home/opam/.opam/5.1/lib/xenstore/client -I /home/opam/.opam/5.1/lib/zarith -intf-suffix .ml -no-alias-deps -o src/conduit-mirage/.conduit_mirage.objs/native/conduit_mirage.cmx -c -impl src/conduit-mirage/conduit_mirage.pp.ml)
# File "src/conduit-mirage/conduit_mirage.ml", line 63, characters 23-35:
# 63 |     [ `Direct of int * Vchan.Port.t | `Domain_socket of string * Vchan.Port.t ]
#                             ^^^^^^^^^^^^
# Error: Unbound value Vchan.Port.t_of_sexp
```