### PR TITLE
Package sexplib0.v0.17.0

### DIFF
--- a/packages/sexplib0/sexplib0.v0.17.0/opam
+++ b/packages/sexplib0/sexplib0.v0.17.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/sexplib0"
+bug-reports: "https://github.com/janestreet/sexplib0/issues"
+dev-repo: "git+https://github.com/janestreet/sexplib0.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib0/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Library containing the definition of S-expressions and some base converters"
+description: "
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+"
+url {
+  src:
+    "https://github.com/janestreet/sexplib0/archive/refs/tags/v0.17.0.tar.gz"
+  checksum: [
+    "md5=6cf43b43006d973191bfe61921480a12"
+    "sha512=8203086cec1617866aa6ff32c60f9a6ae52b34287d602141e33d3a180358a8bfc3e076d4a83926c91b8811a760e89d0881436d4b435be729d0a19ce135ef5481"
+  ]
+}


### PR DESCRIPTION
### `sexplib0.v0.17.0`
Library containing the definition of S-expressions and some base converters
Part of Jane Street's Core library
The Core suite of libraries is an industrial strength alternative to
OCaml's standard library that was developed by Jane Street, the
largest industrial user of OCaml.



---
* Homepage: https://github.com/janestreet/sexplib0
* Source repo: git+https://github.com/janestreet/sexplib0.git
* Bug tracker: https://github.com/janestreet/sexplib0/issues

---
:camel: Pull-request generated by opam-publish v2.3.0