### PR TITLE
Package ocaml_intrinsics_kernel.v0.17.0

### DIFF
--- a/packages/ocaml_intrinsics_kernel/ocaml_intrinsics_kernel.v0.17.0/opam
+++ b/packages/ocaml_intrinsics_kernel/ocaml_intrinsics_kernel.v0.17.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ocaml_intrinsics_kernel"
+bug-reports: "https://github.com/janestreet/ocaml_intrinsics_kernel/issues"
+dev-repo: "git+https://github.com/janestreet/ocaml_intrinsics_kernel.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ocaml_intrinsics_kernel/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Intrinsics"
+description: "
+Provides functions to invoke amd64 instructions (such as cmov, min/maxsd, popcnt)
+     when available, or compatible software implementation on other targets.
+     See also ocaml_intrinsics library.
+"
+url {
+  src:
+    "https://github.com/janestreet/ocaml_intrinsics_kernel/archive/refs/tags/v0.17.0.tar.gz"
+  checksum: [
+    "md5=f6ce51ce6ceec9093191e6f8a1cbea97"
+    "sha512=e197202f6af364caf864efda5d7496416c30bdc3ade9bf0e81e17014f1a046daee21897fc9d47fc4fa44408b1466cf8cff38831b5df45468f3f4a15723d75aac"
+  ]
+}


### PR DESCRIPTION
### `ocaml_intrinsics_kernel.v0.17.0`
Intrinsics
Provides functions to invoke amd64 instructions (such as cmov, min/maxsd, popcnt)
     when available, or compatible software implementation on other targets.
     See also ocaml_intrinsics library.



---
* Homepage: https://github.com/janestreet/ocaml_intrinsics_kernel
* Source repo: git+https://github.com/janestreet/ocaml_intrinsics_kernel.git
* Bug tracker: https://github.com/janestreet/ocaml_intrinsics_kernel/issues

---
:camel: Pull-request generated by opam-publish v2.3.0