### PR TITLE
Add: down.0.3.0

### DIFF
--- a/packages/down/down.0.3.0/opam
+++ b/packages/down/down.0.3.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "An OCaml toplevel (REPL) upgrade"
+description: """\
+Down is an unintrusive user experience upgrade for the `ocaml`
+toplevel (REPL). 
+
+Simply load the zero dependency `Down` library in the `ocaml` toplevel
+and you get line edition, history, session support and identifier
+completion and documentation (courtesy of [`ocp-index`][ocp-index]).
+
+Add this to your `~/.ocamlinit`:
+
+    #use "down.top"
+
+![tty](doc/tty.png)
+
+Down is distributed under the ISC license.
+
+Homepage: http://erratique.ch/software/down
+
+[ocp-index]: https://github.com/OCamlPro/ocp-index"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The down programmers"
+license: "ISC"
+tags: ["dev" "toplevel" "repl" "org:erratique"]
+homepage: "https://erratique.ch/software/down"
+doc: "https://erratique.ch/software/down/doc/"
+bug-reports: "https://github.com/dbuenzli/down/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "uucp" {dev}
+]
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%" "--lib-dir" "%{lib}%"
+]
+install: [
+  ["install" "-d" "%{lib}%/ocaml/"]
+  ["install" "src/down.top" "src/down.nattop" "%{lib}%/ocaml/"]
+]
+dev-repo: "git+https://erratique.ch/repos/down.git"
+url {
+  src: "https://erratique.ch/software/down/releases/down-0.3.0.tbz"
+  checksum:
+    "sha512=03d4a5e82da97ac7814f93385d1a216976976ed7b00693c1e4fa24f6ea2e15121b39344bc599b82e1d2fea12d87663810c2aaca920af1d8b4db5682c6ec61dc6"
+}


### PR DESCRIPTION
* Add: `down.0.3.0` [home](https://erratique.ch/software/down), [doc](https://erratique.ch/software/down/doc/), [issues](https://github.com/dbuenzli/down/issues)  
  *An OCaml toplevel (REPL) upgrade*


---

#### `down` v0.3.0 2024-04-29 La Forclaz (VS)

- Windows support ([#34](https://github.com/dbuenzli/down/issues/34), [#35](https://github.com/dbuenzli/down/issues/35)). Thanks to Nicolás Ojeda Bär for
  the report and the work.

---

Use `b0 -- .opam publish down.0.3.0` to update the pull request.