### PR TITLE
Package base.v0.17.0

### DIFF
--- a/packages/OCanren-ppx/OCanren-ppx.0.1.0/opam
+++ b/packages/OCanren-ppx/OCanren-ppx.0.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml"
   "dune" {>= "2.5"}
   "dune-configurator"
-  "base" { >= "v0.14.0" }
+  "base" { >= "v0.14.0" & < "v0.17" }
   "ppxlib" {< "0.22.0"}
 ]
 

--- a/packages/OCanren-ppx/OCanren-ppx.0.2.0/opam
+++ b/packages/OCanren-ppx/OCanren-ppx.0.2.0/opam
@@ -30,7 +30,7 @@ depends: [
   "dune"              { >= "2.5"  }
   "dune-configurator"
   "ppxlib"            { >= "0.22.0" }
-  "base"              { >= "v0.14.1" }
+  "base"              { >= "v0.14.1" & < "v0.17" }
 ]
 
 build: [

--- a/packages/OCanren-ppx/OCanren-ppx.0.3.0/opam
+++ b/packages/OCanren-ppx/OCanren-ppx.0.3.0/opam
@@ -34,7 +34,7 @@ depends: [
   "ocaml" { >= "4.10" }
   "dune-configurator"
   "ppxlib" { >= "0.22" }
-  "base"
+  "base" { < "v0.17" }
   "ppx_inline_test"
   "ppx_expect"
   "odoc" { with-doc }

--- a/packages/OCanren-ppx/OCanren-ppx.0.3.0~alpha1/opam
+++ b/packages/OCanren-ppx/OCanren-ppx.0.3.0~alpha1/opam
@@ -34,7 +34,7 @@ depends: [
   "ocaml" {>= "4.10"}
   "dune-configurator"
   "ppxlib" {>= "0.22" & <= "0.24"}
-  "base"
+  "base" { < "v0.17" }
   "ppx_inline_test"
   "ppx_expect"
   "OCanren" { >= "0.3.0~" }

--- a/packages/base/base.v0.17.0/opam
+++ b/packages/base/base.v0.17.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "5.1.0"}
   "ocaml_intrinsics_kernel"
-  "sexplib0"
+  "sexplib0"                {>= "v0.17" & < "0.18"}
   "dune"                    {>= "3.11.0"}
   "dune-configurator"
 ]

--- a/packages/base/base.v0.17.0/opam
+++ b/packages/base/base.v0.17.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/base"
+bug-reports: "https://github.com/janestreet/base/issues"
+dev-repo: "git+https://github.com/janestreet/base.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "ocaml_intrinsics_kernel"
+  "sexplib0"
+  "dune"                    {>= "3.11.0"}
+  "dune-configurator"
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Full standard library replacement for OCaml"
+description: "
+Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio
+"
+url {
+  src: "https://github.com/janestreet/base/archive/refs/tags/v0.17.0.tar.gz"
+  checksum: [
+    "md5=6a3504bf4179654606f2785c057981e4"
+    "sha512=5828bfdad7e80183c4aa8b52e6ab06cc17c9f15cfbffc88827db8f8973a064813236d60b01358f838e58f2fea1f4499e6a7676bf081da443c1fb8a019d9fe7be"
+  ]
+}

--- a/packages/caisar/caisar.0.1/opam
+++ b/packages/caisar/caisar.0.1/opam
@@ -17,7 +17,7 @@ depends: [
   "piqilib" {>= "0.6.14"}
   "zarith" {>= "1.7"}
   "ocplib-endian" {>= "1.0"}
-  "base" {>= "v0.14.0"}
+  "base" {>= "v0.14.0" & < "v0.17" }
   "stdio" {>= "v0.14.0"}
   "cmdliner" {>= "1.1.1"}
   "fmt" {>= "0.8.9"}

--- a/packages/caisar/caisar.0.2.1/opam
+++ b/packages/caisar/caisar.0.2.1/opam
@@ -17,7 +17,7 @@ depends: [
   "piqilib" {>= "0.6.14"}
   "zarith" {>= "1.7"}
   "ocplib-endian" {>= "1.0"}
-  "base" {>= "v0.15.1"}
+  "base" {>= "v0.15.1" & < "v0.17" }
   "stdio" {>= "v0.14.0"}
   "cmdliner" {>= "1.1.1"}
   "fmt" {>= "0.8.9"}

--- a/packages/caisar/caisar.0.2/opam
+++ b/packages/caisar/caisar.0.2/opam
@@ -17,7 +17,7 @@ depends: [
   "piqilib" {>= "0.6.14"}
   "zarith" {>= "1.7"}
   "ocplib-endian" {>= "1.0"}
-  "base" {>= "v0.14.0"}
+  "base" {>= "v0.14.0" & < "v0.17" }
   "stdio" {>= "v0.14.0"}
   "cmdliner" {>= "1.1.1"}
   "fmt" {>= "0.8.9"}

--- a/packages/caisar/caisar.1.0/opam
+++ b/packages/caisar/caisar.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "piqilib" {>= "0.6.14"}
   "zarith" {>= "1.7"}
   "ocplib-endian" {>= "1.0"}
-  "base" {>= "v0.15.1"}
+  "base" {>= "v0.15.1" & < "v0.17" }
   "stdio" {>= "v0.14.0"}
   "cmdliner" {>= "1.1.1"}
   "fmt" {>= "0.8.9"}

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.5.1.2/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.5.1.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04"}
-  "base" {>= "v0.14.0" }
+  "base" {>= "v0.14.0" & < "v0.17" }
   "dune" {>= "1.2"}
   "ppxlib" {>= "0.9.0" & < "0.15.0"}
   "ppx_sexp_conv" {with-test}

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.5.2.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.5.2.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.07"}
-  "base" {>= "v0.14.0" }
+  "base" {>= "v0.14.0" & < "v0.17" }
   "dune" {>= "1.2"}
   "ppxlib" {>= "0.9.0"}
   "ppx_sexp_conv" {with-test}

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.5.2.1/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.5.2.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.07"}
-  "base" {>= "v0.14.0" }
+  "base" {>= "v0.14.0" & < "v0.17" }
   "dune" {>= "1.2"}
   "ppxlib" {>= "0.9.0"}
   "ppx_sexp_conv" {with-test}


### PR DESCRIPTION
### `base.v0.17.0`
Full standard library replacement for OCaml
Full standard library replacement for OCaml

Base is a complete and portable alternative to the OCaml standard
library. It provides all standard functionalities one would expect
from a language standard library. It uses consistent conventions
across all of its module.

Base aims to be usable in any context. As a result system dependent
features such as I/O are not offered by Base. They are instead
provided by companion libraries such as stdio:

  https://github.com/janestreet/stdio



---
* Homepage: https://github.com/janestreet/base
* Source repo: git+https://github.com/janestreet/base.git
* Bug tracker: https://github.com/janestreet/base/issues

---
:camel: Pull-request generated by opam-publish v2.3.0