### PR TITLE
[new release] coq-serapi (8.19.0+0.19.3)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.19.0+0.19.3/opam
+++ b/packages/coq-serapi/coq-serapi.8.19.0+0.19.3/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "LGPL-2.1-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.09.0"              }
+  "coq"                 {           >= "8.19" & < "8.20"     }
+  "cmdliner"            {           >= "1.1.0"               }
+  "ocamlfind"           {           >= "1.8.0"               }
+  "sexplib"             {           >= "v0.13.0"             }
+  "dune"                {           >= "2.0.1"               }
+  "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
+  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_sexp_conv"       {           >= "v0.13.0"             }
+  "ppx_compare"         {           >= "v0.13.0"             }
+  "ppx_hash"            {           >= "v0.13.0"             }
+  "yojson"              {           >= "1.7.0"               }
+  "ppx_deriving_yojson" {           >= "3.4"                 }
+]
+
+conflicts: [
+  "result" {< "1.5"}
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ [ "dune" "runtest" "-p" name "-j" jobs ] ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.19.0%2B0.19.3/coq-serapi-8.19.0.0.19.3.tbz"
+  checksum: [
+    "sha256=f09de562d1f8cef423444d09212863fd54d02a907f15c0e409825a1126051939"
+    "sha512=5ba51cdbb9a75aaf42085677b8fd4eb68efe89d32d9e216d82f79a5fd742556968cf3fcb1a6316f01058d169f0fcc0cbf8fb03d007b9ab79e06ff8f5a7d17de0"
+  ]
+}
+x-commit-hash: "53d3168f56cc1a811e5e9bfb65ffc50c26e4a6ff"


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

 - [test] Don't require math-comp to run genarg tests (@ejgallego, ejgallego/coq-serapi#399 ,
          fixes ejgallego/coq-serapi#395 , thanks to @SnarkBoojum for the report)
