### PR TITLE
[new release] hilite (0.5.0)

### DIFF
--- a/packages/hilite/hilite.0.5.0/opam
+++ b/packages/hilite/hilite.0.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Build time syntax highlighting"
+description:
+  "A library for adding syntax highlighting to OCaml-related code and outputing to HTML"
+maintainer: ["patrick@sirref.org"]
+authors: ["Patrick Ferris"]
+license: "ISC"
+tags: ["syntax" "highlighting"]
+homepage: "https://github.com/patricoferris/hilite"
+bug-reports: "https://github.com/patricoferris/hilite/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "mdx" {>= "2.4.1" & with-test}
+  "cmarkit" {>= "0.3.0" & with-test}
+  "textmate-language" {>= "0.3.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/patricoferris/hilite.git"
+url {
+  src:
+    "https://github.com/patricoferris/hilite/releases/download/v0.5.0/hilite-0.5.0.tbz"
+  checksum: [
+    "sha256=498a550bbf10bfc4c7b6de71b0f10b3917f799049ba60bbf4e7b497917055824"
+    "sha512=c2a6ad8d4c8fd372bfab73deea1a07f0262574adfa51bb5c04cf4388dc49d231c81c77cc6a49525985d1ad47a0ccf3173345446738082a6c52c05487082b32b1"
+  ]
+}
+x-commit-hash: "4c0408d5f612794e337753e89313c2f3034061ca"

--- a/packages/hilite/hilite.0.5.0/opam
+++ b/packages/hilite/hilite.0.5.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/patricoferris/hilite/issues"
 depends: [
   "dune" {>= "3.8"}
   "mdx" {>= "2.4.1" & with-test}
-  "cmarkit" {>= "0.3.0" & with-test}
+  "cmarkit" {>= "0.3.0"}
   "textmate-language" {>= "0.3.3"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Build time syntax highlighting

- Project page: <a href="https://github.com/patricoferris/hilite">https://github.com/patricoferris/hilite</a>

##### CHANGES:

- Allow users to supply their own grammars and bypass the built-in ones (patricoferris/hilite#19, @patricoferris)
- Separate markdown package into an optional `hilite.markdown` package (patricoferris/hilite#18, @patricoferris)
