### PR TITLE
release not-ocamlfind 0.13

### DIFF
--- a/packages/camlp5/camlp5.8.00.05/opam
+++ b/packages/camlp5/camlp5.8.00.05/opam
@@ -34,7 +34,7 @@ depends: [
   "conf-diffutils" { with-test & os-distribution = "alpine" }
   "re"
   "pcre"
-  "ounit" { with-test }
+  "ounit2" { with-test }
   "rresult"
   "bos"
   "fmt"

--- a/packages/camlp5/camlp5.8.00.05/opam
+++ b/packages/camlp5/camlp5.8.00.05/opam
@@ -51,6 +51,7 @@ install: [make "install"]
 conflicts: [
    "ocaml-option-bytecode-only"
 ]
+x-ci-accept-failures: ["freebsd"]
 dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.00.05.tar.gz"

--- a/packages/camlp5/camlp5.8.01.00/opam
+++ b/packages/camlp5/camlp5.8.01.00/opam
@@ -35,7 +35,7 @@ depends: [
   "conf-diffutils" { with-test & os-distribution = "alpine" }
   "re"
   "pcre"
-  "ounit" { with-test }
+  "ounit2" { with-test }
   "rresult"
   "bos"
   "fmt"

--- a/packages/camlp5/camlp5.8.01.00/opam
+++ b/packages/camlp5/camlp5.8.01.00/opam
@@ -52,6 +52,7 @@ install: [make "install"]
 conflicts: [
    "ocaml-option-bytecode-only"
 ]
+x-ci-accept-failures: ["freebsd"]
 dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.01.00.tar.gz"

--- a/packages/camlp5/camlp5.8.02.00/opam
+++ b/packages/camlp5/camlp5.8.02.00/opam
@@ -35,7 +35,7 @@ depends: [
   "conf-diffutils" { with-test & os-distribution = "alpine" }
   "re"
   "pcre"
-  "ounit" { with-test }
+  "ounit2" { with-test }
   "rresult"
   "bos"
   "fmt"

--- a/packages/camlp5/camlp5.8.02.00/opam
+++ b/packages/camlp5/camlp5.8.02.00/opam
@@ -52,6 +52,7 @@ install: [make "install"]
 conflicts: [
    "ocaml-option-bytecode-only"
 ]
+x-ci-accept-failures: ["freebsd"]
 dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.02.00.tar.gz"

--- a/packages/camlp5/camlp5.8.02.01/opam
+++ b/packages/camlp5/camlp5.8.02.01/opam
@@ -34,7 +34,7 @@ depends: [
   "camlp5-buildscripts" { >= "0.02" }
   "conf-diffutils" { with-test & os-distribution = "alpine" }
   "re" { >= "1.11.0" }
-  "ounit" { with-test }
+  "ounit2" { with-test }
   "pcre2" { with-test }
   "rresult"
   "bos"

--- a/packages/camlp5/camlp5.8.02.01/opam
+++ b/packages/camlp5/camlp5.8.02.01/opam
@@ -52,6 +52,7 @@ install: [make "install"]
 conflicts: [
    "ocaml-option-bytecode-only"
 ]
+x-ci-accept-failures: ["freebsd"]
 dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.02.01.tar.gz"

--- a/packages/not-ocamlfind/not-ocamlfind.0.13/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.13/opam
@@ -32,6 +32,6 @@ dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
 url {
   src: "https://github.com/chetmurthy/not-ocamlfind/archive/refs/tags/0.13.tar.gz"
   checksum: [
-    "sha512=f1435823a2ed16a512cafa5250726d5bc0ad6a81348b561aea4ead825a6ed590d76acac64064957c8c7873f44e77b13d4527fd5331a99c16dbe46cdfb385eaa7"
+    "sha512=cbac79e3b6801ad64d6842506f0ba29a6eddc5d92d9c6375a2057ff3d0ee0c12937694fbd27db79c90095d2b98cf275d3203335107fa44b876b1386b2ad83ea3"
   ]
 }

--- a/packages/not-ocamlfind/not-ocamlfind.0.13/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.13/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A small frontend for ocamlfind that adds a few useful commands"
+license: "MIT"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+
+(* Gerd wrote most of this code; I just modified it (and probably
+introduced bugs.  This is to silence opam *)
+
+authors: "Chet Murthy <chetsky@gmail.com>"
+homepage: "https://github.com/chetmurthy/not-ocamlfind"
+bug-reports: "Chet Murthy <chetsky@gmail.com>"
+depends: [
+  "ocamlfind" {>= "1.8.0"}
+  "camlp-streams"
+  "conf-m4" {build}
+  "fmt" {>= "0.8.8"}
+  "rresult" {>= "0.6.0"}
+  "ocamlgraph" {>= "2.0.0"}
+  "conf-which"
+]
+depexts: [
+  [
+    "xdot"
+  ] {os-family = "debian"}
+]
+build: [
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-custom" "-no-topfind" {preinstalled}]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
+url {
+  src: "https://github.com/chetmurthy/not-ocamlfind/archive/refs/tags/0.13.tar.gz"
+  checksum: [
+    "sha512=f1435823a2ed16a512cafa5250726d5bc0ad6a81348b561aea4ead825a6ed590d76acac64064957c8c7873f44e77b13d4527fd5331a99c16dbe46cdfb385eaa7"
+  ]
+}


### PR DESCRIPTION
add "-impl", "-intf" to "preprocess" command (pass thru to camlp5).
Also fix Freebsd build process.