### PR TITLE
[new release] js_of_ocaml (7 packages) (5.8.1)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.8.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.8.1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08" & < "5.3"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15.0"}
+  "re" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "sedlex" {>= "2.3"}
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.8.1/js_of_ocaml-5.8.1.tbz"
+  checksum: [
+    "sha256=0e886e10b273a8c48d9f453d5c4b8769ca1f3eba5ee950e0b1885adc943f4a53"
+    "sha512=1a55c5e2ba24a31dc51179e1b797e227c810c54c1e5a39ba1a35cdbfecd5119a91febcfc269524d9c64afebb6bb84c5485a01cd1b96387e2ac06563358e91560"
+  ]
+}
+x-commit-hash: "f4d64b6fe586e20f9c6ec80fc894a6646a2fd91e"

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.5.8.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.5.8.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "lwt" {>= "2.4.4"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["graphics" "lwt_log"]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.8.1/js_of_ocaml-5.8.1.tbz"
+  checksum: [
+    "sha256=0e886e10b273a8c48d9f453d5c4b8769ca1f3eba5ee950e0b1885adc943f4a53"
+    "sha512=1a55c5e2ba24a31dc51179e1b797e227c810c54c1e5a39ba1a35cdbfecd5119a91febcfc269524d9c64afebb6bb84c5485a01cd1b96387e2ac06563358e91560"
+  ]
+}
+x-commit-hash: "f4d64b6fe586e20f9c6ec80fc894a6646a2fd91e"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.5.8.1/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.5.8.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15.0"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.8.1/js_of_ocaml-5.8.1.tbz"
+  checksum: [
+    "sha256=0e886e10b273a8c48d9f453d5c4b8769ca1f3eba5ee950e0b1885adc943f4a53"
+    "sha512=1a55c5e2ba24a31dc51179e1b797e227c810c54c1e5a39ba1a35cdbfecd5119a91febcfc269524d9c64afebb6bb84c5485a01cd1b96387e2ac06563358e91560"
+  ]
+}
+x-commit-hash: "f4d64b6fe586e20f9c6ec80fc894a6646a2fd91e"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.5.8.1/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.5.8.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.8.1/js_of_ocaml-5.8.1.tbz"
+  checksum: [
+    "sha256=0e886e10b273a8c48d9f453d5c4b8769ca1f3eba5ee950e0b1885adc943f4a53"
+    "sha512=1a55c5e2ba24a31dc51179e1b797e227c810c54c1e5a39ba1a35cdbfecd5119a91febcfc269524d9c64afebb6bb84c5485a01cd1b96387e2ac06563358e91560"
+  ]
+}
+x-commit-hash: "f4d64b6fe586e20f9c6ec80fc894a6646a2fd91e"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.5.8.1/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.5.8.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml-compiler" {= version}
+  "ocamlfind" {>= "1.5.1"}
+  "cohttp-lwt-unix" {with-test}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.8.1/js_of_ocaml-5.8.1.tbz"
+  checksum: [
+    "sha256=0e886e10b273a8c48d9f453d5c4b8769ca1f3eba5ee950e0b1885adc943f4a53"
+    "sha512=1a55c5e2ba24a31dc51179e1b797e227c810c54c1e5a39ba1a35cdbfecd5119a91febcfc269524d9c64afebb6bb84c5485a01cd1b96387e2ac06563358e91560"
+  ]
+}
+x-commit-hash: "f4d64b6fe586e20f9c6ec80fc894a6646a2fd91e"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.5.8.1/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.5.8.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "react" {>= "1.2.1"}
+  "reactiveData" {>= "0.2"}
+  "tyxml" {>= "4.6"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.8.1/js_of_ocaml-5.8.1.tbz"
+  checksum: [
+    "sha256=0e886e10b273a8c48d9f453d5c4b8769ca1f3eba5ee950e0b1885adc943f4a53"
+    "sha512=1a55c5e2ba24a31dc51179e1b797e227c810c54c1e5a39ba1a35cdbfecd5119a91febcfc269524d9c64afebb6bb84c5485a01cd1b96387e2ac06563358e91560"
+  ]
+}
+x-commit-hash: "f4d64b6fe586e20f9c6ec80fc894a6646a2fd91e"

--- a/packages/js_of_ocaml/js_of_ocaml.5.8.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.5.8.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml-compiler" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.8.1/js_of_ocaml-5.8.1.tbz"
+  checksum: [
+    "sha256=0e886e10b273a8c48d9f453d5c4b8769ca1f3eba5ee950e0b1885adc943f4a53"
+    "sha512=1a55c5e2ba24a31dc51179e1b797e227c810c54c1e5a39ba1a35cdbfecd5119a91febcfc269524d9c64afebb6bb84c5485a01cd1b96387e2ac06563358e91560"
+  ]
+}
+x-commit-hash: "f4d64b6fe586e20f9c6ec80fc894a6646a2fd91e"


### PR DESCRIPTION
Compiler from OCaml bytecode to JavaScript

- Project page: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>
- Documentation: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>

##### CHANGES 5.8.1:

## Features/Changes

* Library: new Typed_array.Bytes module.

## Bug fixes

* Compiler: fix ocsigen/js_of_ocaml#1509

##### CHANGES 5.8.0: 

## Features/Changes
* Compiler: es6 now generate consise body
* Compiler: codegen: optimize Offset_ref for negative offsets
* Compiler: codegen: change argument passing of back edges.
* Compiler: codegen: use Array destruction to assign args of back
  edges with es6.
* Compiler: codegen: specialize string equality
* Compiler: codegen: more specialization for %int_add, %int_sub
* Compiler: recognize and optimize String.concat
* Compiler: more inlining - duplicate small function.
* Compiler: Make it possible to link runtime JavaScript file
  together with OCaml libraries ocsigen/js_of_ocaml#1509
* Runtime: abort instead of exit when calling unimplemented
  js primitives in bytecode/native. It should help if one tries
  to understand the source of the call with gdb (see ocsigen/js_of_ocaml#677)
* Runtime: re-enable marshalling of floats, disabled in jsoo 2.0
* Runtime: new runtime api for channels

## Bug fixes

* Compiler: fix variable renaming for property binding and assignment target
* Compiler: fix separate compilation of toplevels (broken since 5.7.0)
* Compiler: fix assertion while checking stack compatibility (ocsigen/js_of_ocaml#1600)

