### PR TITLE
Update E-Prover (an automated theorem prover) to version 3.1

### DIFF
--- a/packages/eprover/eprover.3.1/opam
+++ b/packages/eprover/eprover.3.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+authors: [ "Stephan Schulz" "Simon Cruanes" "Petar Vukmirovic" "Mohamed Bassem" "Martin Moehrmann" ]
+homepage: "https://www.eprover.org"
+license: ["LGPL-2.1-or-later OR GPL-2.0-or-later"]
+dev-repo: "git+https://github.com/eprover/eprover.git"
+bug-reports: "Stephan Schulz (see homepage for email)"
+build: [
+  [ "./configure" "--bindir=%{bin}%" ]
+  [ make "-j" "%{jobs}%" ]
+]
+install: [
+  [ make "install" ]
+]
+depends: [
+  "conf-gcc"
+]
+synopsis: "E Theorem Prover"
+description: "E is a theorem prover for first-order and higher-order logic with equality. It accepts a problem specification, typically consisting of a number of first-order clauses or formulas, and a conjecture, in clausal or full first-order/higher-order form. The system will then try to find a formal proof for the conjecture, assuming the axioms."
+url {
+  # Note: the main author prefers this download link over the also available github tag tarball download and expects that the link is stable over time
+  src: "http://wwwlehre.dhbw-stuttgart.de/~sschulz/WORK/E_DOWNLOAD/V_3.1/E.tgz"
+  checksum: "sha512=4258d9fbd8d32346f5c24dbf0475c98c8e325aa0dc75dacaacd0096357ced8dde4456b88b0d7094a42d317482b6fec46955a1574b0984098386703772f698459"
+}


### PR DESCRIPTION
This PR adds a new version 3.1. for the automated theorem prover E-prover.

The accuracy of the meta data has been reviewed by the main author.