### PR TITLE
Fix base's upper bound on sexplib0

### DIFF
--- a/packages/base/base.v0.17.0/opam
+++ b/packages/base/base.v0.17.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "5.1.0"}
   "ocaml_intrinsics_kernel"
-  "sexplib0"                {>= "v0.17" & < "0.18"}
+  "sexplib0"                {>= "v0.17" & < "v0.18"}
   "dune"                    {>= "3.11.0"}
   "dune-configurator"
 ]


### PR DESCRIPTION
e07ba5493f0404ed6ec2859aaa2df9360cb21dc5 incorrectly added an upper bound on sexplib0 as 0.18, when it should be v0.18. This causes the base package to be unavailable for installation.

/cc @dkalinichenko-js

Previous build summary: https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/d5c972425cfc838e6e57beca8dc42616b8572b48

Previous build log for 5.1: https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/d5c972425cfc838e6e57beca8dc42616b8572b48/variant/compilers,5.1,base.v0.17.0