### PR TITLE
Package catala.0.10.0

### DIFF
--- a/packages/catala/catala.0.10.0/opam
+++ b/packages/catala/catala.0.10.0/opam
@@ -1,0 +1,82 @@
+opam-version: "2.0"
+synopsis:
+  "Compiler and library for the literate programming language for tax code specification"
+description:
+  "Catala is a domain-specific language for deriving faithful-by-construction algorithms from legislative texts. See https://catala-lang.org for more information"
+maintainer: "contact@catala-lang.org"
+authors: [
+  "Denis Merigoux"
+  "Nicolas Chataing"
+  "Emile Rolley"
+  "Louis Gesbert"
+  "Aymeric Fromherz"
+  "Alain Delaët-Tixeuil"
+  "Raphaël Monat"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/CatalaLang/catala"
+bug-reports: "https://github.com/CatalaLang/catala/issues"
+depends: [
+  "ocolor" {>= "1.3.0"}
+  "bindlib" {>= "6.0"}
+  "cmdliner" {>= "1.1.0"}
+  "cppo" {>= "1"}
+  "dates_calc" {>= "0.0.4"}
+  "dune" {>= "3.11"}
+  "js_of_ocaml-ppx" {= "4.1.0"}
+  "menhir" {>= "20200211"}
+  "menhirLib" {>= "20200211"}
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {!= "1.9.5"}
+  "ocamlgraph" {>= "1.8.8"}
+  "re" {>= "1.10"}
+  "sedlex" {>= "2.4"}
+  "uutf" {>= "1.0.3"}
+  "ubase" {>= "0.05"}
+  "unionFind" {>= "20220109"}
+  "visitors" {>= "20200210"}
+  "zarith" {>= "1.12"}
+  "zarith_stubs_js" {>= "v0.14.1"}
+  "crunch" {>= "3.0.0"}
+  "alcotest" {>= "1.5.0"}
+  "ninja_utils" {= "0.9.0"}
+  "odoc" {with-doc}
+  "ocamlformat" {with-dev-setup & = "0.26.0"}
+  "obelisk" {with-dev-setup}
+  "conf-npm" {with-dev-setup}
+  "conf-python-3-dev" {with-dev-setup}
+  "cpdf" {with-dev-setup}
+  "conf-diffutils" {with-dev-setup}
+  "conf-pandoc" {with-dev-setup}
+  "conf-ninja"
+]
+depopts: ["z3"]
+conflicts: [
+  "z3" {< "4.8.11"}
+  "base" {>= "v0.16.0"}
+]
+build: [
+  "dune"
+  "build"
+  "-p"
+  name
+  "-j"
+  jobs
+  "@install"
+  "@runtest" {with-test}
+  "@doc" {with-doc}
+]
+dev-repo: "git+https://github.com/CatalaLang/catala.git"
+depexts: [
+  ["groff"] { with-doc }
+  ["python3-pip"] {with-dev-setup & os-family = "debian"}
+  ["py3-pip" "py3-pygments"] {with-dev-setup & os-distribution = "alpine"}
+  ["python-pygments"] {with-dev-setup & os-family = "arch"}
+]
+url {
+  src: "https://github.com/CatalaLang/catala/archive/refs/tags/0.10.0.tar.gz"
+  checksum: [
+    "md5=5abd76e8c51a47670645e91b21b57fc5"
+    "sha512=9c6fbe50c0b5a60566e877eeddadca0a339e2ce35deb5c1beceb03bc40eb6af2d519313e71859d88645b53fad591d4fa5288c633b185c9d765603da0f5b7dd7b"
+  ]
+}

--- a/packages/catala/catala.0.10.0/opam
+++ b/packages/catala/catala.0.10.0/opam
@@ -54,6 +54,7 @@ depopts: ["z3"]
 conflicts: [
   "z3" {< "4.8.11"}
   "base" {>= "v0.16.0"}
+  "ocaml-option-bytecode-only"
 ]
 build: [
   "dune"


### PR DESCRIPTION
### `catala.0.10.0`
Compiler and library for the literate programming language for tax code specification
Catala is a domain-specific language for deriving faithful-by-construction algorithms from legislative texts. See https://catala-lang.org for more information



---
* Homepage: https://github.com/CatalaLang/catala
* Source repo: git+https://github.com/CatalaLang/catala.git
* Bug tracker: https://github.com/CatalaLang/catala/issues

---
:camel: Pull-request generated by opam-publish v2.1.0