### PR TITLE
[new release] ppx_deriving_variant_string (1.0.0)

### DIFF
--- a/packages/ppx_deriving_variant_string/ppx_deriving_variant_string.1.0.0/opam
+++ b/packages/ppx_deriving_variant_string/ppx_deriving_variant_string.1.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "OCaml PPX deriver that generates converters between variants and strings"
+description: "OCaml PPX deriver that generates converters between regular or polymorphic variants and strings. Supports both OCaml and Reason casing."
+maintainer: [
+  "Javier Chávarri <javier.chavarri@ahrefs.com>"
+]
+authors: [
+  "Javier Chávarri <javier.chavarri@ahrefs.com>"
+]
+tags: ["syntax" "org:ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/ppx_deriving_variant_string"
+bug-reports: "https://github.com/ahrefs/ppx_deriving_variant_string/issues"
+dev-repo: "git+https://github.com/ahrefs/ppx_deriving_variant_string.git"
+depends: [
+  "ocaml"
+  "dune"
+  "ppxlib"
+  "ounit" {with-test}
+  "ocaml-lsp-server" {with-test}
+  "ocamlformat" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+  ]
+]
+url {
+  src:
+    "https://github.com/ahrefs/ppx_deriving_variant_string/releases/download/1.0.0/ppx_deriving_variant_string-1.0.0.tbz"
+  checksum: [
+    "sha256=be0b4c2dbafd3b408e4cd03be8b7bec4eee16b4fbe67f93c52dced14fcb8a089"
+    "sha512=6d818e92333a8ddc7f9280c9fc1fc2ab9a19e971586d60b42ba6a0461e2933aee7d7b22f0043e2129724e6c7208fe568e53c1aea80a788e0652bc339c841f95c"
+  ]
+}
+x-commit-hash: "397080f969b2ab87d07accfaa66ba676f21816a5"

--- a/packages/ppx_deriving_variant_string/ppx_deriving_variant_string.1.0.0/opam
+++ b/packages/ppx_deriving_variant_string/ppx_deriving_variant_string.1.0.0/opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/ahrefs/ppx_deriving_variant_string/issues"
 dev-repo: "git+https://github.com/ahrefs/ppx_deriving_variant_string.git"
 depends: [
   "ocaml"
-  "dune"
+  "dune" {>= "3.8"}
   "ppxlib"
   "ounit" {with-test}
   "ocaml-lsp-server" {with-test}


### PR DESCRIPTION
OCaml PPX deriver that generates converters between variants and strings

- Project page: <a href="https://github.com/ahrefs/ppx_deriving_variant_string">https://github.com/ahrefs/ppx_deriving_variant_string</a>

##### CHANGES:

- Initial release, support for `toString`, `fromString`, `to_string` and
  `of_string` derivers
