### PR TITLE
[new release] xenstore (2.3.0)

### DIFF
--- a/packages/xenstore/xenstore.2.3.0/opam
+++ b/packages/xenstore/xenstore.2.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Dave Scott"
+  "Anil Madhavapeddy"
+  "Vincent Bernardoff"
+]
+homepage: "https://github.com/mirage/ocaml-xenstore"
+doc: "https://mirage.github.io/ocaml-xenstore/"
+bug-reports: "https://github.com/mirage/ocaml-xenstore/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "lwt"
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-xenstore.git"
+synopsis: "Xenstore protocol in pure OCaml"
+description: """
+This repo contains:
+1. a xenstore client library, a merge of the Mirage and XCP ones
+2. a xenstore server library
+3. a xenstore server instance which runs under Unix with libxc
+4. a xenstore server instance which runs on mirage.
+
+The client and the server libraries have sets of unit-tests.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-xenstore/releases/download/v2.3.0/xenstore-2.3.0.tbz"
+  checksum: [
+    "sha256=d63c6bbcb2d3c297767d83c0a0f6dd46cecfd4e691f1cf5c5b6554445ec1b3f4"
+    "sha512=5cea990ab16ef708e53605172f708dde6ed15981cca6890939274db6efde1e5b2f9ec5c659d4d2f4115c5e0c3b69bcacc798a0d7fd5c1b75b83ddccd699de189"
+  ]
+}
+x-commit-hash: "0195baf7409ee6223f5821df63732e6516aa12a0"


### PR DESCRIPTION
Xenstore protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-xenstore">https://github.com/mirage/ocaml-xenstore</a>
- Documentation: <a href="https://mirage.github.io/ocaml-xenstore/">https://mirage.github.io/ocaml-xenstore/</a>

##### CHANGES:

* remove cstruct and ppx_cstruct dependency (mirage/ocaml-xenstore#52 @palainp)
* require OCaml 4.08 (for Bytes.set_int32_le) (mirage/ocaml-xenstore#52 @palainp)
