### PR TITLE
[new release] mirage-qubes (2 packages) (0.9.5)

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.5/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.5/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "mirage-qubes" {= version}
+  "tcpip" { >= "7.0.0" }
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "ipaddr" { >= "3.0.0" }
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "lwt" { >= "5.7.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.9.5/mirage-qubes-0.9.5.tbz"
+  checksum: [
+    "sha256=5ece36cb788bcbb1933d974c0e8ff3ee8db9eac1b3755fb4a5b24cdf4fdeb0f5"
+    "sha512=67c89051f32135452582786e4f4838dccd37900987c6ed2db5347ac59c9a7a61eefc5d157515c572a47e5b6f3c2d597454ba35fc1197077efd457a481b66bfc4"
+  ]
+}
+x-commit-hash: "2d897fb0a2326362953cd3adacf10c87b4ea594e"

--- a/packages/mirage-qubes/mirage-qubes.0.9.4/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.9.4/opam
@@ -6,7 +6,7 @@ bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
 dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
 doc:          "https://mirage.github.io/mirage-qubes"
 license:      "BSD-2-Clause"
-
+available: false
 build: [
   [ "dune" "subst"] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]

--- a/packages/mirage-qubes/mirage-qubes.0.9.5/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.9.5/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "cstruct" { >= "6.0.0" }
+  "vchan-xen" { >= "6.0.0" }
+  "mirage-xen" { >= "6.0.0" }
+  "lwt" { >= "5.7.0" }
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.08.0" }
+  "ohex" { >= "0.2.0" }
+  "fmt" {>= "0.8.5"}
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+description: """
+Implementations of various Qubes protocols:
+
+- Qubes.RExec: provide services to other VMs
+- Qubes.GUI: just enough of the GUI protocol so that Qubes accepts the AppVM
+- Qubes.DB: read and write the VM's QubesDB database"""
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.9.5/mirage-qubes-0.9.5.tbz"
+  checksum: [
+    "sha256=5ece36cb788bcbb1933d974c0e8ff3ee8db9eac1b3755fb4a5b24cdf4fdeb0f5"
+    "sha512=67c89051f32135452582786e4f4838dccd37900987c6ed2db5347ac59c9a7a61eefc5d157515c572a47e5b6f3c2d597454ba35fc1197077efd457a481b66bfc4"
+  ]
+}
+x-commit-hash: "2d897fb0a2326362953cd3adacf10c87b4ea594e"


### PR DESCRIPTION
Implementations of various Qubes protocols for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-qubes">https://github.com/mirage/mirage-qubes</a>
- Documentation: <a href="https://mirage.github.io/mirage-qubes">https://mirage.github.io/mirage-qubes</a>

##### CHANGES:

- Remove leftover ppx_cstruct from lib/dune (@hannesm)
