### PR TITLE
[new release] ppx_deriving_yaml (0.3.0)

### DIFF
--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.3.0/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Yaml PPX Deriver"
+description:
+  "Deriving conversion functions to and from yaml for your OCaml types."
+maintainer: ["patrick@sirref.org"]
+authors: ["Patrick Ferris"]
+license: "ISC"
+homepage: "https://github.com/patricoferris/ppx_deriving_yaml"
+bug-reports: "https://github.com/patricoferris/ppx_deriving_yaml/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yaml"
+  "ppx_deriving"
+  "alcotest" {with-test}
+  "mdx" {with-test & >= "2.0.0"}
+  "ocaml" {>= "4.08.1"}
+  "ppxlib" {>= "0.25.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/patricoferris/ppx_deriving_yaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v0.3.0/ppx_deriving_yaml-0.3.0.tbz"
+  checksum: [
+    "sha256=1cb634a339b2eb36342a35e4c0fdddad3773f39ecfbcb4bf6ee3759c1fb17f5b"
+    "sha512=a0daf0f9d86a60757b9512d89ad9f5b3a93b2ba6482f225fa4f12cda8f31d52a32f81dcd69f96fdce93238d3b3cbc789d8f791a5b4545979872ae625c9e99a7d"
+  ]
+}
+x-commit-hash: "996b41ade452fdda3aed623c46d497ef2adfaa8b"


### PR DESCRIPTION
Yaml PPX Deriver

- Project page: <a href="https://github.com/patricoferris/ppx_deriving_yaml">https://github.com/patricoferris/ppx_deriving_yaml</a>

##### CHANGES:

- Fix bug with unused infix operators (patricoferris/ppx_deriving_yaml#56, @patricoferris)
- Stdlib.( = ) is also used now so other stdlibs work (patricoferris/ppx_deriving_yaml#55, @andreypopp)
