### PR TITLE
Add conf-libblake3 virtual package.

### DIFF
--- a/packages/conf-libblake3/conf-libblake3.1.5.1/opam
+++ b/packages/conf-libblake3/conf-libblake3.1.5.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+maintainer: "opam-repository maintainers"
+homepage: "https://blake3.io/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Jack O'Connor <oconnor663@gmail.com>"  "Samuel Neves"]
+license: "CC0-1.0 OR Apache-2.0"
+build: [
+  ["pkg-config" "--atleast-version=1.5.1" "libblake3"]
+]
+depends: ["conf-pkg-config" {build}]
+depexts: [
+  ["blake3-devel"] {os-distribution = "fedora"}
+  ["blake3"] {os-distribution = "homebrew" & os = "macos"}
+]
+synopsis: "Virtual package relying on libblake3"
+description:"
+This package can only install if the libblake3 library is installed on the system,
+and its version is at least 1.5.1
+"


### PR DESCRIPTION
Add a configuration package for the [extremely spotty support](https://repology.org/project/blake3/versions) of the `libblake3` C library. I guess that's what happens when tools get written in rust :-(