### PR TITLE
[new release] paf (2 packages) (0.6.0)

### DIFF
--- a/packages/git-mirage/git-mirage.3.13.0/opam
+++ b/packages/git-mirage/git-mirage.3.13.0/opam
@@ -35,7 +35,7 @@ depends: [
   "ipaddr" {>= "5.0.1"}
   "lwt" {>= "5.3.0"}
   "mirage-clock" {>= "3.1.0"}
-  "mirage-flow" {>= "2.0.1"}
+  "mirage-flow" {>= "2.0.1" & < "4.0.0"}
   "mirage-random" {>= "2.0.0" & < "4.0.0"}
   "mirage-time" {>= "2.0.1"}
   "result" {>= "1.5"}

--- a/packages/git-mirage/git-mirage.3.14.0/opam
+++ b/packages/git-mirage/git-mirage.3.14.0/opam
@@ -35,7 +35,7 @@ depends: [
   "ipaddr" {>= "5.0.1"}
   "lwt" {>= "5.3.0"}
   "mirage-clock" {>= "3.1.0"}
-  "mirage-flow" {>= "2.0.1"}
+  "mirage-flow" {>= "2.0.1" & < "4.0.0"}
   "mirage-random" {>= "2.0.0" & < "4.0.0"}
   "mirage-time" {>= "2.0.1"}
   "result" {>= "1.5"}

--- a/packages/git-mirage/git-mirage.3.15.0/opam
+++ b/packages/git-mirage/git-mirage.3.15.0/opam
@@ -35,7 +35,7 @@ depends: [
   "ipaddr" {>= "5.0.1"}
   "lwt" {>= "5.3.0"}
   "mirage-clock" {>= "3.1.0"}
-  "mirage-flow" {>= "2.0.1"}
+  "mirage-flow" {>= "2.0.1" & < "4.0.0"}
   "mirage-random" {>= "2.0.0" & < "4.0.0"}
   "mirage-time" {>= "2.0.1"}
   "result" {>= "1.5"}

--- a/packages/paf-cohttp/paf-cohttp.0.6.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.6.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "cohttp-lwt" {< "6.0.0"}
+  "domain-name"
+  "httpaf"
+  "ipaddr"
+  "alcotest-lwt"      {with-test & >= "1.1.0"}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "mirage-time-unix"  {with-test}
+  "tcpip"             {with-test & >= "6.0.0"}
+  "uri"               {with-test}
+  "lwt"               {with-test}
+  "astring"           {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {os != "macos"}
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.6.0/paf-0.6.0.tbz"
+  checksum: [
+    "sha256=baf35eceec745789b06f1534ef309f0985ce80260a3f1b2138a8a20232de7fd9"
+    "sha512=5d359537b27571f1ad407722f05d2d1fae9bfa104e235fc1f9dfddb9215cbf1ddf5c983860ba8f3d73f172490b33466ff228deee840cd472c3031fe17b921bd2"
+  ]
+}
+x-commit-hash: "f13dc389f6ef53276546aa8074066a2a68254008"

--- a/packages/paf-cohttp/paf-cohttp.0.6.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.6.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
   "paf" {= version}
-  "cohttp-lwt" {< "6.0.0"}
+  "cohttp-lwt" {< "6.0.0~"}
   "domain-name"
   "httpaf"
   "ipaddr"

--- a/packages/paf/paf.0.6.0/opam
+++ b/packages/paf/paf.0.6.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "tcpip" {>= "8.0.1"}
+  "mirage-time" {>= "2.0.0"}
+  "tls-mirage" {>= "0.17.4"}
+  "mimic" {>= "0.0.7"}
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "bigstringaf" {>= "0.7.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.10.0"}
+  "faraday" {>= "0.7.2"}
+  "tls" {>= "0.17.4"}
+  "cstruct" {>= "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {os != "macos"}
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.6.0/paf-0.6.0.tbz"
+  checksum: [
+    "sha256=baf35eceec745789b06f1534ef309f0985ce80260a3f1b2138a8a20232de7fd9"
+    "sha512=5d359537b27571f1ad407722f05d2d1fae9bfa104e235fc1f9dfddb9215cbf1ddf5c983860ba8f3d73f172490b33466ff228deee840cd472c3031fe17b921bd2"
+  ]
+}
+x-commit-hash: "f13dc389f6ef53276546aa8074066a2a68254008"


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Fix typographie on errors (@hannesm, dinosaure/paf-le-chien#91)
- Introduce and use the new `shutdown` function (@hannesm, @dinosaure, dinosaure/paf-le-chien#92)
- Update to ocamlformat.0.26.1 (@dinosaure, dinosaure/paf-le-chien#94)
