### PR TITLE
Retry release camlp5 8.03.00 for ocaml 5.2.0 compat

### DIFF
--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -34,7 +34,7 @@ depends: [
   "camlp5-buildscripts" { >= "0.02" }
   "conf-diffutils" { with-test & os-distribution = "alpine" }
   "re" { >= "1.11.0" }
-  "ounit" { with-test }
+  "ounit2" { with-test }
   "pcre2" { with-test }
   "rresult"
   "bos"

--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -57,6 +57,7 @@ conflicts: [
    "matita" { <= "0.99.5" }
    "lablgl" { <= "1.07" }
 ]
+x-ci-accept-failures: [ "opensuse" ]
 dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.03.00.tar.gz"

--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -1,0 +1,61 @@
+
+opam-version: "2.0"
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description: """
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel."""
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+license: "BSD-3-Clause"
+homepage: "https://camlp5.github.io"
+doc: "https://camlp5.github.io/doc/html"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+depends: [
+  "ocaml" {>= "4.10" & < "5.03.0"}
+  "ocamlfind"
+  "camlp-streams" { >= "5.0" }
+  "conf-perl"
+  "camlp5-buildscripts" { >= "0.02" }
+  "conf-diffutils" { with-test & os-distribution = "alpine" }
+  "re" { >= "1.11.0" }
+  "ounit" { with-test }
+  "pcre2" { with-test }
+  "rresult"
+  "bos"
+  "fmt"
+]
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "-j%{jobs}%" "DEBUG=-g" "world.opt"]
+  [make "-j%{jobs}%" "DEBUG=-g" "all"]
+  [make "-C" "testsuite" "clean" "all-tests"] { with-test }
+  [make "-C" "test" "clean" "all"] { with-test & os != "macos" }
+#  [make "-C" "scripts" "clean" "test"] { with-test }
+]
+install: [make "install"]
+conflicts: [
+   "ocaml-option-bytecode-only"
+]
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+url {
+  src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.03.00.tar.gz"
+  checksum: [
+    "sha512=8fce4d3df9d35a832ef172f7751deb5995f004cb0f1e09464a3b92aaacc9fb8bc93dbe12b452af05ca81397338c6157593ba484b019200302af33b2f54deb708"
+  ]
+}

--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -31,6 +31,7 @@ depends: [
   "ocamlfind"
   "camlp-streams" { >= "5.0" }
   "conf-perl"
+  "conf-bash" { with-test }
   "camlp5-buildscripts" { >= "0.02" }
   "conf-diffutils" { with-test & (os-distribution = "alpine" | os-distribution = "freebsd") }
   "re" { >= "1.11.0" }

--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -60,6 +60,6 @@ dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.03.00.tar.gz"
   checksum: [
-    "sha512=736a2d820a48ffcf79e88e47f59e4d78e335695885a839790ccd6d916ba151362440be63de9c28bae021be2453b5d9f445b88790ed1d96986bb1fbc502ab2416"
+    "sha512=2e595aba439e9e2ce8e87d21a79e7e71e17ff460bd83ee2484dc38f171bb3d146f3ae2475b4d48f163f193c347b4485478f62a527503172d1210bb7ce9571664"
   ]
 }

--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -32,7 +32,7 @@ depends: [
   "camlp-streams" { >= "5.0" }
   "conf-perl"
   "camlp5-buildscripts" { >= "0.02" }
-  "conf-diffutils" { with-test & os-distribution = "alpine" }
+  "conf-diffutils" { with-test & (os-distribution = "alpine" | os-distribution = "freebsd") }
   "re" { >= "1.11.0" }
   "ounit2" { with-test }
   "pcre2" { with-test }

--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -51,6 +51,7 @@ build: [
 install: [make "install"]
 conflicts: [
    "ocaml-option-bytecode-only"
+   "pa_ppx" { < "0.15" }
 ]
 dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {

--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -61,6 +61,6 @@ dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.03.00.tar.gz"
   checksum: [
-    "sha512=32d59472e903593b0184e590b30b8ae8ad85acb8b0362ab56651d4e9c5ae2fd03e90e8e6566cef482f24d65163727fa5734fd0334fae9519bd9b27b8ed285ab6"
+    "sha512=04c8d8bf00d20d44cca7b2b13e312139f1e36239f7f9abeac49900578e3f7476f11932aa4cd8738f11fdf65d5985d960143cce432723f0d32f21343e7637322a"
   ]
 }

--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -55,12 +55,11 @@ conflicts: [
    "pa_ppx" { < "0.15" }
    "p5scm" { <= "0.3.1" }
    "matita" { <= "0.99.5" }
-   "ocaml" { = "5.2.0~beta2" }
 ]
 dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.03.00.tar.gz"
   checksum: [
-    "sha512=04c8d8bf00d20d44cca7b2b13e312139f1e36239f7f9abeac49900578e3f7476f11932aa4cd8738f11fdf65d5985d960143cce432723f0d32f21343e7637322a"
+    "sha512=e5fa8fd7b4f93414f14fc70b5fd3c68a74ef799515e99cc911a1786562abc6f7d21295bf182ac3f977eb6b9894623ff6136273d6e06687114e03058cbb1b0a9c"
   ]
 }

--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -57,7 +57,7 @@ conflicts: [
    "matita" { <= "0.99.5" }
    "lablgl" { <= "1.07" }
 ]
-x-ci-accept-failures: [ "opensuse" ]
+x-ci-accept-failures: [ "opensuse-tumbleweed" ]
 dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.03.00.tar.gz"

--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -33,7 +33,7 @@ depends: [
   "conf-perl"
   "conf-bash" { with-test }
   "camlp5-buildscripts" { >= "0.02" }
-  "conf-diffutils" { with-test & (os-distribution = "alpine" | os-distribution = "freebsd" | os-distribution = "opensuse") }
+  "conf-diffutils" { with-test & (os-distribution = "alpine" | os-distribution = "freebsd" | os-family = "opensuse") }
   "re" { >= "1.11.0" }
   "ounit2" { with-test }
   "pcre2" { with-test }

--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -33,7 +33,7 @@ depends: [
   "conf-perl"
   "conf-bash" { with-test }
   "camlp5-buildscripts" { >= "0.02" }
-  "conf-diffutils" { with-test & (os-distribution = "alpine" | os-distribution = "freebsd") }
+  "conf-diffutils" { with-test & (os-distribution = "alpine" | os-distribution = "freebsd" | os-distribution = "opensuse") }
   "re" { >= "1.11.0" }
   "ounit2" { with-test }
   "pcre2" { with-test }
@@ -60,6 +60,6 @@ dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.03.00.tar.gz"
   checksum: [
-    "sha512=c01b971ce9744bf0dc66007df9184e038fde1076ee3fba14dfcb93353e63b39186f87c8f7cc4d430afda037dc238d6fd9249ca231fcaed755f4e1ccee158e67b"
+    "sha512=736a2d820a48ffcf79e88e47f59e4d78e335695885a839790ccd6d916ba151362440be63de9c28bae021be2453b5d9f445b88790ed1d96986bb1fbc502ab2416"
   ]
 }

--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -27,7 +27,7 @@ homepage: "https://camlp5.github.io"
 doc: "https://camlp5.github.io/doc/html"
 bug-reports: "https://github.com/camlp5/camlp5/issues"
 depends: [
-  "ocaml" {>= "4.10" & < "5.03.0"}
+  "ocaml" {>= "4.10" & < "5.03.0" }
   "ocamlfind"
   "camlp-streams" { >= "5.0" }
   "conf-perl"
@@ -52,11 +52,14 @@ install: [make "install"]
 conflicts: [
    "ocaml-option-bytecode-only"
    "pa_ppx" { < "0.15" }
+   "p5scm" { <= "0.3.1" }
+   "matita" { <= "0.99.5" }
+   "ocaml" { = "5.2.0~beta2" }
 ]
 dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.03.00.tar.gz"
   checksum: [
-    "sha512=8fce4d3df9d35a832ef172f7751deb5995f004cb0f1e09464a3b92aaacc9fb8bc93dbe12b452af05ca81397338c6157593ba484b019200302af33b2f54deb708"
+    "sha512=76cf7550571c6c16dc5e600c3b710f158441e30d436b9c4a8b28150165cdd88e050414adfa1d615af51a5ddf067d107afef1346480147e75ea7f530b46998bf5"
   ]
 }

--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -55,6 +55,7 @@ conflicts: [
    "pa_ppx" { < "0.15" }
    "p5scm" { <= "0.3.1" }
    "matita" { <= "0.99.5" }
+   "lablgl" { <= "1.07" }
 ]
 dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {

--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -60,6 +60,6 @@ dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.03.00.tar.gz"
   checksum: [
-    "sha512=76cf7550571c6c16dc5e600c3b710f158441e30d436b9c4a8b28150165cdd88e050414adfa1d615af51a5ddf067d107afef1346480147e75ea7f530b46998bf5"
+    "sha512=32d59472e903593b0184e590b30b8ae8ad85acb8b0362ab56651d4e9c5ae2fd03e90e8e6566cef482f24d65163727fa5734fd0334fae9519bd9b27b8ed285ab6"
   ]
 }

--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -60,6 +60,6 @@ dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.03.00.tar.gz"
   checksum: [
-    "sha512=e5fa8fd7b4f93414f14fc70b5fd3c68a74ef799515e99cc911a1786562abc6f7d21295bf182ac3f977eb6b9894623ff6136273d6e06687114e03058cbb1b0a9c"
+    "sha512=c01b971ce9744bf0dc66007df9184e038fde1076ee3fba14dfcb93353e63b39186f87c8f7cc4d430afda037dc238d6fd9249ca231fcaed755f4e1ccee158e67b"
   ]
 }


### PR DESCRIPTION
The changes are pretty minimal, *except* that [these changes are documented in the CHANGES file]:

1. the "pr_o.cmo" printer module requires that the "o_keywords.cmo" module be loaded first.  If you instead use the Findlib module "camlp5.pr_o", this is done automatically, but there are some users of Camlp5 who do it the old low-level way.

2. there's a new field "kwds" in the "lexer" record-type.  This is to support pretty-printing raw-identifiers.  Since Camlp5 supports multiple syntaxes, different syntaxes can have different sets of keywords.  There are a couple of projects that create their own lexers, so those need to be updated.

I've sent PRs/emails to the affected projects, and put them in the "conflicts" stanza of the opam file, so users will not be able to install this new Camlp5 with those backlevel projects until they're updated.