### PR TITLE
[new release] mirage-block-xen (2.1.3)

### DIFF
--- a/packages/mirage-block-xen/mirage-block-xen.2.1.3/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.2.1.3/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott" "Thomas Leonard"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-block-xen"
+doc: "https://mirage.github.io/mirage-block-xen/"
+bug-reports: "https://github.com/mirage/mirage-block-xen/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "logs"
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "6.0.0"}
+  "shared-memory-ring"
+  "shared-memory-ring-lwt"
+  "mirage-block" {>= "2.0.0"}
+  "io-page" {>= "2.0.0"}
+  "mirage-xen" {>= "7.0.0"}
+  "xenstore"
+  "fmt" {>= "0.8.7"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block-xen.git"
+synopsis: "MirageOS block driver for Xen that implements the blkfront/back protocol"
+description: """
+This library allows a Mirage OCaml application to
+
+  1. read and write blocks from any Xen "backend" (server)
+  2. service block requests from any Xen "frontend" (client)
+
+This library can be used in both kernelspace (on Xen)
+or in userspace (using libraries that come with Xen).
+
+This library depends on the
+[shared-memory-ring](https://github.com/mirage/shared-memory-ring)
+library which enables high-throughput, low-latency data
+transfers over shared memory on both x86 and ARM architectures,
+using the standard Xen RPC and event channel semantics.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block-xen/releases/download/v2.1.3/mirage-block-xen-2.1.3.tbz"
+  checksum: [
+    "sha256=03376069972d05cfa4daeb89a934faef43cfdb583838e575cbeb662bebdef451"
+    "sha512=8288e1f0e08875e5dc9a5a13c39bfd495fc0571645fa13bf6d218ff7c34e90fd665c00ebecf688e5c110c889ff1fabeae317ecf4ca975a5d05cbcc5c219a675d"
+  ]
+}
+x-commit-hash: "8411188166d7dd428ea8be8cc426f1a32312d6ea"


### PR DESCRIPTION
MirageOS block driver for Xen that implements the blkfront/back protocol

- Project page: <a href="https://github.com/mirage/mirage-block-xen">https://github.com/mirage/mirage-block-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-xen/">https://mirage.github.io/mirage-block-xen/</a>

##### CHANGES:

* Remove ppx_cstruct dependency (@hannesm, mirage/mirage-block-xen#97)
