### PR TITLE
[new release] mirage-vnetif (2 packages) (0.6.1), tcpip (8.0.2)

### DIFF
--- a/packages/mirage-vnetif-stack/mirage-vnetif-stack.0.6.1/opam
+++ b/packages/mirage-vnetif-stack/mirage-vnetif-stack.0.6.1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/mirage-vnetif"
+bug-reports: "https://github.com/mirage/mirage-vnetif/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-vnetif.git"
+doc: "https://mirage.github.io/mirage-vnetif/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@test/vnetif-stack/runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.9"}
+  "lwt"
+  "mirage-time" {>= "3.0.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "mirage-random"
+  "mirage-vnetif" {= version}
+  "tcpip" {>= "8.0.0"}
+  "ethernet"
+  "cstruct" {>="6.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr"
+  "arp" {>= "3.0.0"}
+  "duration"
+  "logs"
+  "mirage-time-unix" {with-test}
+  "mirage-clock-unix" {with-test & >= "4.0.0"}
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "alcotest" {>= "1.5.0" & with-test}
+  "alcotest-lwt" {>= "1.5.0" & with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+tags: ["org:mirage"]
+synopsis: "Vnetif implementation of mirage-stack for Mirage TCP/IP"
+description: """
+Provides Vnetif_stack, a mirage-stack implementation using Vnetif and the
+Mirage TCP/IP stack. The virtual stack can be used to test and record Mirage
+TCP/IP connections over a virtual network interface, as a process or VM.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-vnetif/releases/download/v0.6.1/mirage-vnetif-0.6.1.tbz"
+  checksum: [
+    "sha256=a6ae3c5298b82316007174c2ba92b8f935a2f15be9d6e023e32bfde716b8dab6"
+    "sha512=022e7c847c75cb550367cc91772d5e3b1a970192a9983ba8a3ba12ca2ec3594fe25ebcddcff60c57452f00157de31f32dec3d4e9feee6020aaf25a39fa5a17e2"
+  ]
+}
+x-commit-hash: "9ad448d6dca9ea76c9eac9abfb90899c5c95bbcc"

--- a/packages/mirage-vnetif/mirage-vnetif.0.6.1/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.6.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/mirage-vnetif"
+bug-reports: "https://github.com/mirage/mirage-vnetif/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-vnetif.git"
+doc: "https://mirage.github.io/mirage-vnetif/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.9"}
+  "lwt"
+  "mirage-net" {>= "3.0.0"}
+  "cstruct" {>="6.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "macaddr"
+  "duration"
+  "logs"
+]
+conflicts: [ "result" {< "1.5"} ]
+tags: ["org:mirage"]
+synopsis: "Virtual network interface and software switch for Mirage"
+description: """
+Provides the module `Vnetif` which can be used as a replacement for the regular
+`Netif` implementation in Xen and Unix. Stacks built using `Vnetif` are
+connected to a software switch that allows the stacks to communicate as if they
+were connected to the same LAN.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-vnetif/releases/download/v0.6.1/mirage-vnetif-0.6.1.tbz"
+  checksum: [
+    "sha256=a6ae3c5298b82316007174c2ba92b8f935a2f15be9d6e023e32bfde716b8dab6"
+    "sha512=022e7c847c75cb550367cc91772d5e3b1a970192a9983ba8a3ba12ca2ec3594fe25ebcddcff60c57452f00157de31f32dec3d4e9feee6020aaf25a39fa5a17e2"
+  ]
+}
+x-commit-hash: "9ad448d6dca9ea76c9eac9abfb90899c5c95bbcc"

--- a/packages/tcpip/tcpip.8.0.0/opam
+++ b/packages/tcpip/tcpip.8.0.0/opam
@@ -44,7 +44,7 @@ depends: [
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.1"}
   "alcotest" {with-test & >="1.5.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}

--- a/packages/tcpip/tcpip.8.0.0/opam
+++ b/packages/tcpip/tcpip.8.0.0/opam
@@ -15,7 +15,7 @@ tags: ["org:mirage"]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
 ]
 conflicts: [
   "mirage-xen" {< "6.0.0"}

--- a/packages/tcpip/tcpip.8.0.1/opam
+++ b/packages/tcpip/tcpip.8.0.1/opam
@@ -44,7 +44,7 @@ depends: [
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "4.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.1"}
   "alcotest" {with-test & >="1.5.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}

--- a/packages/tcpip/tcpip.8.0.1/opam
+++ b/packages/tcpip/tcpip.8.0.1/opam
@@ -15,7 +15,7 @@ tags: ["org:mirage"]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
 ]
 conflicts: [
   "mirage-xen" {< "6.0.0"}

--- a/packages/tcpip/tcpip.8.0.2/opam
+++ b/packages/tcpip/tcpip.8.0.2/opam
@@ -15,7 +15,7 @@ tags: ["org:mirage"]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
 ]
 conflicts: [
   "mirage-xen" {< "6.0.0"}

--- a/packages/tcpip/tcpip.8.0.2/opam
+++ b/packages/tcpip/tcpip.8.0.2/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding"
+  "result" {< "1.5"}
+]
+depends: [
+  "dune" {>= "2.7.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "mirage-net" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0" & < "4.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>="4.0.0"}
+  "macaddr-cstruct"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv" {< "0.2.0"}
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "alcotest" {with-test & >="1.5.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "ipaddr-cstruct"
+  "macaddr-cstruct"
+  "lru" {>= "0.3.0"}
+  "metrics"
+  "cmdliner" {>= "1.1.0"}
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v8.0.2/tcpip-8.0.2.tbz"
+  checksum: [
+    "sha256=d452e23f4e62c8b32c977f742e72c50fe673b82e23dc80b29d8263be764d2c72"
+    "sha512=9a4aeb5c7ec0392524d1d261026e5de047dec09054f2dca63d9743aed1d27ccfd655ae693554091b4ef7d9eabfeef218e71e8bf13ea8304ebedd8e8a7d4f484a"
+  ]
+}
+x-commit-hash: "463b0c2af2703de4124bb565007f33086e3cfab3"


### PR DESCRIPTION
# Virtual network interface and software switch for Mirage

- Project page: <a href="https://github.com/mirage/mirage-vnetif">https://github.com/mirage/mirage-vnetif</a>
- Documentation: <a href="https://mirage.github.io/mirage-vnetif/">https://mirage.github.io/mirage-vnetif/</a>

##### CHANGES:

- support newer tcp releases (mirage/mirage-vnetif#35, @hannesm)
- remove mirage-profile and result dependency (mirage/mirage-vnetif#35, @hannesm)
- use mirage-crypto-rng instead of mirage-random-test (mirage/mirage-vnetif#35, @hannesm)
- adapt lower bounds (mirage/mirage-vnetif#35, @hannesm)

# TCP 8.0.2

* remove mirage-random-test dependency
* remove calls to mirage-profile in tests, now support mirage-vnetif 0.6.1