### PR TITLE
[new release] asn1-combinators (0.3.1)

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.3.1/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.3.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+authors: "David Kaloper Meršinjak"
+maintainer: "David Kaloper Meršinjak <dk505@cam.ac.uk>"
+homepage: "https://github.com/mirleft/ocaml-asn1-combinators"
+doc: "https://mirleft.github.io/ocaml-asn1-combinators/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/mirleft/ocaml-asn1-combinators.git"
+bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
+synopsis: "Embed typed ASN.1 grammars in OCaml"
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+depends: [
+  "ocaml" {>="4.08.0"}
+  "dune" {>= "1.2.0"}
+  "ptime" {>= "0.8.6"}
+  "alcotest" {with-test & >= "0.8.1"}
+]
+description: """
+asn1-combinators is a library for expressing ASN.1 in OCaml. Skip the notation
+part of ASN.1, and embed the abstract syntax directly in the language. These
+abstract syntax representations can be used for parsing, serialization, or
+random testing.
+
+The only ASN.1 encodings currently supported are BER and DER.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.3.1/asn1-combinators-0.3.1.tbz"
+  checksum: [
+    "sha256=fa2984c6ea6e1e1c4fe2033f0165af611963c2400ce2ba051004b77dfc557c4e"
+    "sha512=710f6916e792d4134bf72cc1aa4696e1ba63cf472177439dfc17cee840f11c541287c00f923e9235c9c93825ca5570807ddd0b725738a657c4d5f2c230692c30"
+  ]
+}
+x-commit-hash: "08f16ede0c5787ed6a859f8ed8687b1803c7261e"


### PR DESCRIPTION
Embed typed ASN.1 grammars in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-asn1-combinators">https://github.com/mirleft/ocaml-asn1-combinators</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-asn1-combinators/doc">https://mirleft.github.io/ocaml-asn1-combinators/doc</a>

##### CHANGES:

* Introduce Asn.S.unsigned_integer - useful for e.g. ECDSA signatures where the
  user code expects an unsigned integer and shouldn't worry about the ASN.1
  encoding (mirleft/ocaml-asn1-combinators#44 @reynir @hannesm)
* Provide custom random generators for int and unsigned_integer
  (mirleft/ocaml-asn1-combinators#44 @hannesm @reynir)
