### PR TITLE
[new release] mirage-net-xen (2.1.5)

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.2.1.5/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.2.1.5/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+license:       "ISC"
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "mirage-xen" {>= "7.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "shared-memory-ring" {>="3.0.0"}
+  "macaddr" {>= "5.2.0"}
+  "lwt-dllist"
+  "logs" {>= "0.5.0"}
+]
+conflicts: [
+    "result" {< "1.5"}
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v2.1.5/mirage-net-xen-2.1.5.tbz"
+  checksum: [
+    "sha256=1399dfa90e79a485efdf61b480ef801d202bb10cf2d63b0c9b7b12631586d1f9"
+    "sha512=ecc85ea1cbdd17750198ed7b3ccb1d3f3d3cde5fb949d01099a8838660ffa997ab848bfd622ee323c6635246c9643b945792a60fbcee717bdc66eba4c403acf5"
+  ]
+}
+x-commit-hash: "11815dcad78e039df8656e4802f82198fe5630b3"


### PR DESCRIPTION
Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol

- Project page: <a href="https://github.com/mirage/mirage-net-xen">https://github.com/mirage/mirage-net-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-xen/">https://mirage.github.io/mirage-net-xen/</a>

##### CHANGES:

* Fix TX.Request structure decoding and encoding (introduced in 2.1.4, mirage/mirage-net-xen#110 --
  fixed by @palainp mirage/mirage-net-xen#112) -- due to this bug, 2.1.4 is marked as unavailable
  in opam-repository
