### PR TITLE
Backport ocaml/ocaml#13100 to 5.1.x ocaml-variants

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
@@ -130,3 +130,10 @@ extra-source "ocaml-variants.install" {
     "md5=3e969b841df1f51ca448e6e6295cb451"
   ]
 }
+# Back-ported ocaml/ocaml#13100 (5.2.0) - fixes the misdetection of zstd with
+# ocaml-option-musl
+patches: ["zstd-detection.patch"]
+extra-source "zstd-detection.patch" {
+  src: "https://github.com/ocaml/ocaml/commit/baf65b91c51bb04b09ecc98b94ddd4ba3b446912.patch?full_index=1"
+  checksum: "sha256=958e061bc3b967e32a5606d5109ed7faacb9b793fe2de0e8f8697c23a178c5cf"
+}

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+tsan/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+tsan/opam
@@ -92,3 +92,4 @@ extra-source "zstd-detection.patch" {
   src: "https://github.com/ocaml/ocaml/commit/baf65b91c51bb04b09ecc98b94ddd4ba3b446912.patch?full_index=1"
   checksum: "sha256=958e061bc3b967e32a5606d5109ed7faacb9b793fe2de0e8f8697c23a178c5cf"
 }
+available: arch = "x86_64" & (os = "linux" | os = "macos")

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+tsan/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+tsan/opam
@@ -85,3 +85,10 @@ extra-source "ocaml-variants.install" {
   ]
 }
 available: os != "win32"
+# Back-ported ocaml/ocaml#13100 (5.2.0) - fixes the misdetection of zstd with
+# ocaml-option-musl
+patches: ["zstd-detection.patch"]
+extra-source "zstd-detection.patch" {
+  src: "https://github.com/ocaml/ocaml/commit/baf65b91c51bb04b09ecc98b94ddd4ba3b446912.patch?full_index=1"
+  checksum: "sha256=958e061bc3b967e32a5606d5109ed7faacb9b793fe2de0e8f8697c23a178c5cf"
+}

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
@@ -133,3 +133,10 @@ extra-source "ocaml-variants.install" {
     "md5=3e969b841df1f51ca448e6e6295cb451"
   ]
 }
+# Back-ported ocaml/ocaml#13100 (5.2.0) - fixes the misdetection of zstd with
+# ocaml-option-musl
+patches: ["zstd-detection.patch"]
+extra-source "zstd-detection.patch" {
+  src: "https://github.com/ocaml/ocaml/commit/baf65b91c51bb04b09ecc98b94ddd4ba3b446912.patch?full_index=1"
+  checksum: "sha256=958e061bc3b967e32a5606d5109ed7faacb9b793fe2de0e8f8697c23a178c5cf"
+}

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
@@ -130,3 +130,10 @@ extra-source "ocaml-variants.install" {
     "md5=3e969b841df1f51ca448e6e6295cb451"
   ]
 }
+# Back-ported ocaml/ocaml#13100 (5.2.0) - fixes the misdetection of zstd with
+# ocaml-option-musl
+patches: ["zstd-detection.patch"]
+extra-source "zstd-detection.patch" {
+  src: "https://github.com/ocaml/ocaml/commit/baf65b91c51bb04b09ecc98b94ddd4ba3b446912.patch?full_index=1"
+  checksum: "sha256=958e061bc3b967e32a5606d5109ed7faacb9b793fe2de0e8f8697c23a178c5cf"
+}

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+tsan/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+tsan/opam
@@ -92,3 +92,4 @@ extra-source "zstd-detection.patch" {
   src: "https://github.com/ocaml/ocaml/commit/baf65b91c51bb04b09ecc98b94ddd4ba3b446912.patch?full_index=1"
   checksum: "sha256=958e061bc3b967e32a5606d5109ed7faacb9b793fe2de0e8f8697c23a178c5cf"
 }
+available: arch = "x86_64" & (os = "linux" | os = "macos")

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+tsan/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+tsan/opam
@@ -85,3 +85,10 @@ extra-source "ocaml-variants.install" {
   ]
 }
 available: os != "win32"
+# Back-ported ocaml/ocaml#13100 (5.2.0) - fixes the misdetection of zstd with
+# ocaml-option-musl
+patches: ["zstd-detection.patch"]
+extra-source "zstd-detection.patch" {
+  src: "https://github.com/ocaml/ocaml/commit/baf65b91c51bb04b09ecc98b94ddd4ba3b446912.patch?full_index=1"
+  checksum: "sha256=958e061bc3b967e32a5606d5109ed7faacb9b793fe2de0e8f8697c23a178c5cf"
+}


### PR DESCRIPTION
When building with ocaml-option-musl, zstd detection in OCaml fails if pkg-config and libzstd are installed for the host. This is fixed in 5.2.0. ocaml-base-compiler is unaffected.

This PR is a draft and should not be merged until after opam 2.2.0 beta3 is released as it breaks ocaml-variants.5.1.1+effects, ocaml-variants.5.1.0+options and ocaml-variants.5.1.1+options on Windows (https://github.com/ocaml/opam/pull/5921).