### PR TITLE
config-file is not compatible with OCaml 5.0 (uses Genlex)

### DIFF
--- a/packages/config-file/config-file.1.1/opam
+++ b/packages/config-file/config-file.1.1/opam
@@ -10,7 +10,7 @@ remove: [
   ["./configure" "--prefix" prefix]
   [make "uninstall"]
 ]
-depends: ["ocaml" "ocamlfind" "camlp4"]
+depends: ["ocaml" {< "5.0"} "ocamlfind" "camlp4"]
 install: [make "install"]
 synopsis: "Small library to define, load and save options files."
 url {

--- a/packages/config-file/config-file.1.2.1/opam
+++ b/packages/config-file/config-file.1.2.1/opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/MisterDA/config-file"
 bug-reports: "https://github.com/MisterDA/config-file/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "camlp4" {build}
   "cppo" {>= "1.6.7" & build}
   "odoc" {with-doc}

--- a/packages/config-file/config-file.1.2/opam
+++ b/packages/config-file/config-file.1.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "config-file"]]
 depends: [
-  "ocaml" {>= "4.00"}
+  "ocaml" {>= "4.00" & < "5.0"}
   "ocamlfind"
   "camlp4"
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling config-file.1.2.1 ==================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/config-file.1.2.1
# command              ~/.opam/5.1/bin/dune build -p config-file -j 1 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/config-file-21-796207.env
# output-file          ~/.opam/log/config-file-21-796207.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlopt.opt -w -40 -g -I .config_file.objs/byte -I .config_file.objs/native -intf-suffix .ml -no-alias-deps -o .config_file.objs/native/config_file.cmx -c -impl config_file.ml)
# File "config_file_parser.ml", line 27, characters 6-23:
# Error: Unbound module Genlex
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I .config_file.objs/byte -intf-suffix .ml -no-alias-deps -o .config_file.objs/byte/config_file.cmo -c -impl config_file.ml)
# File "config_file_parser.ml", line 27, characters 6-23:
# Error: Unbound module Genlex
```