### PR TITLE
bisect is not compatible with OCaml 5.0 (uses String.capitalize)

### DIFF
--- a/packages/bisect/bisect.1.3.1/opam
+++ b/packages/bisect/bisect.1.3.1/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "bisect"]]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind"
   "camlp4"
   "ocamlbuild" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling bisect.1.3.1 =======================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/bisect.1.3.1
# command              /usr/bin/make all
# exit-code            2
# env-file             ~/.opam/log/bisect-19-c34f21.env
# output-file          ~/.opam/log/bisect-19-c34f21.out
### output ###
# echo 'bisect.cma' > bisect.itarget
# (which ocamlopt && echo 'bisect.cmxa' >> bisect.itarget) || true
# /home/opam/.opam/5.1/bin/ocamlopt
# (which ocamljava && echo 'bisect.cmja' >> bisect.itarget) || true
# WARNINGS=FALSE PATH_OCAML_PREFIX=/home/opam/.opam/5.1 ocamlbuild -classic-display -no-links bisect.otarget
# /home/opam/.opam/5.1/bin/ocamlopt.opt unix.cmxa -I /home/opam/.opam/5.1/lib/ocamlbuild /home/opam/.opam/5.1/lib/ocamlbuild/ocamlbuildlib.cmxa myocamlbuild.ml /home/opam/.opam/5.1/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# + /home/opam/.opam/5.1/bin/ocamlopt.opt unix.cmxa -I /home/opam/.opam/5.1/lib/ocamlbuild /home/opam/.opam/5.1/lib/ocamlbuild/ocamlbuildlib.cmxa myocamlbuild.ml /home/opam/.opam/5.1/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# File "myocamlbuild.ml", line 45, characters 25-42:
# 45 |         let modulename = String.capitalize modulename in
#                               ^^^^^^^^^^^^^^^^^
# Error: Unbound value String.capitalize
# Command exited with code 2.
# make: *** [Makefile:55: all] Error 10
```