### PR TITLE
archimedes is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/archimedes/archimedes.0.4.18/opam
+++ b/packages/archimedes/archimedes.0.4.18/opam
@@ -39,7 +39,7 @@ remove: [
   ["ocaml" "%{etc}%/archimedes/_oasis_remove_.ml" "%{etc}%/archimedes"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bigarray"
   "camlp4"
   "ocamlbuild" {build}

--- a/packages/archimedes/archimedes.0.4.19/opam
+++ b/packages/archimedes/archimedes.0.4.19/opam
@@ -30,7 +30,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocaml" "%{etc}%/archimedes/_oasis_remove_.ml" "%{etc}%/archimedes"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bigarray"
   "camlp4"
   "oasis" {build & >= "0.3" & != "0.4.7"}


### PR DESCRIPTION
```
#=== ERROR while compiling archimedes.0.4.18 ==================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/archimedes.0.4.18
# command              ~/.opam/5.1/bin/ocaml setup.ml -configure --prefix /home/opam/.opam/5.1 --disable-graphics --disable-cairo2
# exit-code            2
# env-file             ~/.opam/log/archimedes-19-cd56f3.env
# output-file          ~/.opam/log/archimedes-19-cd56f3.out
### output ###
# File "./setup.ml", line 1402, characters 23-41:
# 1402 |          let compare = Pervasives.compare
#                               ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```