### PR TITLE
chamo is not compatible with OCaml 5.2 (Load_path.add_dir changed its type)

### DIFF
--- a/packages/chamo/chamo.3.0/opam
+++ b/packages/chamo/chamo.3.0/opam
@@ -9,7 +9,7 @@ homepage: "https://zoggy.frama.io/chamo"
 doc: "https://zoggy.frama.io/chamo/doc.html"
 bug-reports: "https://framagit.org/zoggy/chamo/issues"
 depends: [
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "5.2"}
   "ocamlfind" {build}
   "ocf" {>= "0.7.0"}
   "pcre" {>= "7.4.6"}

--- a/packages/chamo/chamo.4.0/opam
+++ b/packages/chamo/chamo.4.0/opam
@@ -8,7 +8,7 @@ doc: "https://zoggy.frama.io/chamo/doc.html"
 bug-reports: "https://framagit.org/zoggy/chamo/issues"
 depends: [
   "dune" {>= "3.6"}
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "5.2"}
   "fmt" {>= "0.9.0"}
   "logs" {>= "0.7.0"}
   "lwt" {>= "5.4.0"}


### PR DESCRIPTION
Reported upstream in https://framagit.org/zoggy/chamo/-/issues/11 cc @zoggy 
```
#=== ERROR while compiling chamo.4.0 ==========================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/chamo.4.0
# command              ~/.opam/5.2/bin/dune build -p chamo -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/chamo-20-f1ec8d.env
# output-file          ~/.opam/log/chamo-20-f1ec8d.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -g -w -40 -bin-annot -w -6-7-9-10-27-30-32-33-34-35-36-50-52 -no-strict-sequence -g -bin-annot -I lib/.chamo.objs/byte -I /home/opam/.opam/5.2/lib/bigarray-compat -I /home/opam/.opam/5.2/lib/bytes -I /home/opam/.opam/5.2/lib/ctypes -I /home/opam/.opam/5.2/lib/ctypes-foreign -I /home/opam/.opam/5.2/lib/fmt -I /home/opam/.opam/5.2/lib/gen -I /home/opam/.opam/5.2/lib/higlo -I /home/opam/.opam/5.2/lib/integers -I /home/opam/.opam/5.2/lib/iri -I /home/opam/.opam/5.2/lib/logs -I /home/opam/.opam/5.2/lib/lwt -I /home/opam/.opam/5.2/lib/lwt/unix -I /home/opam/.opam/5.2/lib/lwt_ppx -I /home/opam/.opam/5.2/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.2/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/ocaml/str -I /home/opam/.opam/5.2/lib/ocaml/threads -I /home/opam/.opam/5.2/lib/ocaml/unix -I /home/opam/.opam/5.2/lib/ocf -I /home/opam/.opam/5.2/lib/ocplib-endian -I /home/opam/.opam/5.2/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.2/lib/pcre -I /home/opam/.opam/5.2/lib/ppx_derivers -I /home/opam/.opam/5.2/lib/ppxlib -I /home/opam/.opam/5.2/lib/ppxlib/ast -I /home/opam/.opam/5.2/lib/ppxlib/astlib -I /home/opam/.opam/5.2/lib/ppxlib/print_diff -I /home/opam/.opam/5.2/lib/ppxlib/stdppx -I /home/opam/.opam/5.2/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.2/lib/re -I /home/opam/.opam/5.2/lib/re/str -I /home/opam/.opam/5.2/lib/sedlex -I /home/opam/.opam/5.2/lib/seq -I /home/opam/.opam/5.2/lib/sexplib0 -I /home/opam/.opam/5.2/lib/stdlib-shims -I /home/opam/.opam/5.2/lib/stk -I /home/opam/.opam/5.2/lib/stk_iconv -I /home/opam/.opam/5.2/lib/tsdl -I /home/opam/.opam/5.2/lib/tsdl-image -I /home/opam/.opam/5.2/lib/tsdl-ttf -I /home/opam/.opam/5.2/lib/uunf -I /home/opam/.opam/5.2/lib/uutf -I /home/opam/.opam/5.2/lib/xmlm -I /home/opam/.opam/5.2/lib/xtmpl -I /home/opam/.opam/5.2/lib/yojson -no-alias-deps -open Chamo -o lib/.chamo.objs/byte/chamo__Binannot.cmo -c -impl lib/binannot.pp.ml)
# File "lib/binannot.ml", line 134, characters 12-29:
# 134 |   List.iter Load_path.add_dir cmt.Cmt_format.cmt_loadpath;
#                   ^^^^^^^^^^^^^^^^^
# Error: This expression has type "hidden:bool -> string -> unit"
#        but an expression was expected of type "'a -> unit"
```