### PR TITLE
cryptohash is not compatible with OCaml 5.0

### DIFF
--- a/packages/cryptohash/cryptohash.0.1/opam
+++ b/packages/cryptohash/cryptohash.0.1/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "cryptohash"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-unix" {with-test}
   "base-bigarray"
   "base-bytes"


### PR DESCRIPTION
Expects the bigarray library to be available through ocamlfind
```
#=== ERROR while compiling cryptohash.0.1 =====================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/cryptohash.0.1
# command              ~/.opam/5.1/bin/omake lib
# exit-code            2
# env-file             ~/.opam/log/cryptohash-19-90c35e.env
# output-file          ~/.opam/log/cryptohash-19-90c35e.out
### output ###
# *** omake: reading OMakefiles
# --- Checking for ocamlfind... (found /home/opam/.opam/5.1/bin/ocamlfind)
# --- Checking for ocamlc.opt... (found /home/opam/.opam/5.1/bin/ocamlc.opt)
# --- Checking for ocamlopt.opt... (found /home/opam/.opam/5.1/bin/ocamlopt.opt)
# --- Checking for ocamldep.opt... (found /home/opam/.opam/5.1/bin/ocamldep.opt)
# --- Checking for ocamllex.opt... (found /home/opam/.opam/5.1/bin/ocamllex.opt)
# --- Checking whether ocamlc understands the "z" warnings... (yes)
# --- Checking whether ocamlopt can create cmxs plugins... (yes)
# File OMakeIncludes: line 33, characters 1-17:
#    Warning: old-style foreach expression.
#    This expression should use a => binding.
# File OMakeIncludes: line 40, characters 1-17:
#    Warning: old-style foreach expression.
#    This expression should use a => binding.
# File OMakeIncludes: line 71, characters 1-18:
#    Warning: old-style foreach expression.
#    This expression should use a => binding.
# --- Checking for ocamlfind... (found /home/opam/.opam/5.1/bin/ocamlfind)
# /home/opam/.opam/5.1/lib/ocaml/dynlink
# File src/OMakefile: line 81, characters 1-20:
#    Warning: old-style foreach expression.
#    This expression should use a => binding.
# File src/OMakefile: line 94, characters 1-26:
#    Warning: old-style foreach expression.
#    This expression should use a => binding.
# File src/OMakefile: line 132, characters 1-26:
#    Warning: old-style foreach expression.
#    This expression should use a => binding.
# File src/OMakefile: line 156, characters 2-23:
#    Warning: old-style foreach expression.
#    This expression should use a => binding.
# File src/OMakefile: line 167, characters 4-24:
#    Warning: old-style foreach expression.
#    This expression should use a => binding.
# File src/OMakefile: line 423, characters 3-15:
#    Warning: old-style foreach expression.
#    This expression should use a => binding.
# --- Checking for OCaml library location... (/home/opam/.opam/5.1/lib/ocaml)
# *** omake: finished reading OMakefiles (0.16 sec)
# --- Checking if ocamldep understands -modules... (yes)
# - scan src scan-ocaml-cryptohash_sha3_256.ml
# + ocamlfind ocamldep -package bytes,bigarray -modules cryptohash_sha3_256.ml
# ocamlfind: Package `bigarray' not found
# - scan src scan-ocaml-cryptohash_sha3_384.ml
# + ocamlfind ocamldep -package bytes,bigarray -modules cryptohash_sha3_384.ml
# ocamlfind: Package `bigarray' not found
```