### PR TITLE
dot-merlin-reader < 4.14 is not compatible with OCaml 5.2

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.6/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.6/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.2"}
   "dune" {>= "2.9.0"}
   "merlin-lib" {>= "4.6" & < "4.9"}
   "ocamlfind" {>= "1.6.0"}

--- a/packages/dot-merlin-reader/dot-merlin-reader.4.9/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.9/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.08" & < "6.0"}
+  "ocaml" {>= "4.08" & < "5.2"}
   "dune" {>= "2.9.0"}
   "merlin-lib" {>= "4.9" & < "4.14-502"}
   "ocamlfind" {>= "1.6.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling dot-merlin-reader.4.9 ==============================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/dot-merlin-reader.4.9
# command              ~/.opam/5.2/bin/dune build -p dot-merlin-reader -j 1
# exit-code            1
# env-file             ~/.opam/log/dot-merlin-reader-19-b19e9d.env
# output-file          ~/.opam/log/dot-merlin-reader-19-b19e9d.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I src/dot-merlin/.dot_merlin_reader.eobjs/byte -I /home/opam/.opam/5.2/lib/findlib -I /home/opam/.opam/5.2/lib/merlin-lib/dot_protocol -I /home/opam/.opam/5.2/lib/merlin-lib/utils -I /home/opam/.opam/5.2/lib/ocaml/str -I /home/opam/.opam/5.2/lib/ocaml/unix -no-alias-deps -o src/dot-merlin/.dot_merlin_reader.eobjs/byte/dune__exe__Dot_merlin_reader.cmo -c -impl src/dot-merlin/dot_merlin_reader.ml)
# File "src/dot-merlin/dot_merlin_reader.ml", lines 326-359, characters 4-47:
# 326 | ....match d with
# 327 |     | `B _ | `S _ | `CMI _ | `CMT _  as directive ->
# 328 |       { cfg with to_canonicalize = (cwd, directive) :: cfg.to_canonicalize }
# 329 |     | `EXT _ | `SUFFIX _ | `FLG _ | `READER _
# 330 |     | (`EXCLUDE_QUERY_DIR | `USE_PPX_CACHE | `UNKNOWN_TAG _) as directive ->
# ...
# 356 |       | Some p ->
# 357 |         log ~title:"conflicting paths for findlib toolchain" "%s\n%s" p path
# 358 |       end;
# 359 |       { cfg with findlib_toolchain = Some path}
# Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
# Here is an example of a case that is not matched:
# `H _
# 
# File "src/dot-merlin/dot_merlin_reader.ml", line 451, characters 22-41:
# 451 |     [ List.concat_map cfg.to_canonicalize ~f:(fun (dir, directive) ->
#                             ^^^^^^^^^^^^^^^^^^^
# Error: This expression has type
#          "(string * Merlin_dot_protocol.Directive.include_path) list"
#        but an expression was expected of type
#          "(string *
#           [< `B of string | `CMI of string | `CMT of string | `S of string ])
#          list"
#        Type
#          "Merlin_dot_protocol.Directive.include_path" =
#            "[ `B of string
#            | `CMI of string
#            | `CMT of string
#            | `H of string
#            | `S of string ]"
#        is not compatible with type
#          "[< `B of string | `CMI of string | `CMT of string | `S of string ]"
#        The second variant type does not allow tag(s) "`H"
```