### PR TITLE
eliom < 10.4.1 is not compatible with OCaml 5.2 (relies on the parsetree)

### DIFF
--- a/packages/eliom/eliom.10.1.0/opam
+++ b/packages/eliom/eliom.10.1.0/opam
@@ -15,7 +15,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2"}
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}

--- a/packages/eliom/eliom.10.1.2/opam
+++ b/packages/eliom/eliom.10.1.2/opam
@@ -17,7 +17,7 @@ homepage: "https://ocsigen.org/eliom/"
 bug-reports: "https://github.com/ocsigen/eliom/issues"
 depends: [
   "dune" {>= "3.6"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2"}
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}

--- a/packages/eliom/eliom.10.2.0/opam
+++ b/packages/eliom/eliom.10.2.0/opam
@@ -17,7 +17,7 @@ homepage: "https://ocsigen.org/eliom/"
 bug-reports: "https://github.com/ocsigen/eliom/issues"
 depends: [
   "dune" {>= "3.6"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2"}
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}

--- a/packages/eliom/eliom.10.3.0/opam
+++ b/packages/eliom/eliom.10.3.0/opam
@@ -17,7 +17,7 @@ homepage: "https://ocsigen.org/eliom/"
 bug-reports: "https://github.com/ocsigen/eliom/issues"
 depends: [
   "dune" {>= "3.6"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2"}
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}

--- a/packages/eliom/eliom.10.3.1/opam
+++ b/packages/eliom/eliom.10.3.1/opam
@@ -17,7 +17,7 @@ homepage: "https://ocsigen.org/eliom/"
 bug-reports: "https://github.com/ocsigen/eliom/issues"
 depends: [
   "dune" {>= "3.6"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2"}
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}

--- a/packages/eliom/eliom.10.4.0/opam
+++ b/packages/eliom/eliom.10.4.0/opam
@@ -17,7 +17,7 @@ homepage: "https://ocsigen.org/eliom/"
 bug-reports: "https://github.com/ocsigen/eliom/issues"
 depends: [
   "dune" {>= "3.6"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2"}
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling eliom.10.4.0 =======================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/eliom.10.4.0
# command              ~/.opam/5.2/bin/dune build -p eliom -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/eliom-19-e16a7f.env
# output-file          ~/.opam/log/eliom-19-e16a7f.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlopt.opt -w -40 -g -I src/ppx/.ppx_utils.objs/byte -I src/ppx/.ppx_utils.objs/native -I /home/opam/.opam/5.2/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.2/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/ppx_derivers -I /home/opam/.opam/5.2/lib/ppxlib -I /home/opam/.opam/5.2/lib/ppxlib/ast -I /home/opam/.opam/5.2/lib/ppxlib/astlib -I /home/opam/.opam/5.2/lib/ppxlib/print_diff -I /home/opam/.opam/5.2/lib/ppxlib/stdppx -I /home/opam/.opam/5.2/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.2/lib/sexplib0 -I /home/opam/.opam/5.2/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -o src/ppx/.ppx_utils.objs/native/ppx_eliom_utils.cmx -c -impl src/ppx/ppx_eliom_utils.pp.ml)
# File "src/ppx/ppx_eliom_utils.ml", line 355, characters 37-40:
# 355 |           Typ.arrow (label_of_string lab) (type_of_out_type ty1)
#                                            ^^^
# Error: This expression has type "Asttypes.arg_label"
#        but an expression was expected of type "string"
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I src/ppx/.ppx_utils.objs/byte -I /home/opam/.opam/5.2/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.2/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/ppx_derivers -I /home/opam/.opam/5.2/lib/ppxlib -I /home/opam/.opam/5.2/lib/ppxlib/ast -I /home/opam/.opam/5.2/lib/ppxlib/astlib -I /home/opam/.opam/5.2/lib/ppxlib/print_diff -I /home/opam/.opam/5.2/lib/ppxlib/stdppx -I /home/opam/.opam/5.2/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.2/lib/sexplib0 -I /home/opam/.opam/5.2/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -o src/ppx/.ppx_utils.objs/byte/ppx_eliom_utils.cmo -c -impl src/ppx/ppx_eliom_utils.pp.ml)
# File "src/ppx/ppx_eliom_utils.ml", line 355, characters 37-40:
# 355 |           Typ.arrow (label_of_string lab) (type_of_out_type ty1)
#                                            ^^^
# Error: This expression has type "Asttypes.arg_label"
#        but an expression was expected of type "string"
```