### PR TITLE
format is not compatible with OCaml 5.0 (uses Stream)

### DIFF
--- a/packages/format/format.0.1/opam
+++ b/packages/format/format.0.1/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "philippe.veber@gmail.com"
 build: make
 remove: [make "uninstall"]
-depends: ["ocaml" "ocamlfind" "camlp4"]
+depends: ["ocaml" {< "5.0"} "ocamlfind" "camlp4"]
 install: [make "install"]
 synopsis:
   "Format is a syntax extension which defines quotations for building"


### PR DESCRIPTION
```
#=== ERROR while compiling format.0.1 =========================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/format.0.1
# command              /usr/bin/make
# exit-code            2
# env-file             ~/.opam/log/format-19-258861.env
# output-file          ~/.opam/log/format-19-258861.out
### output ###
# ocamllex formatLexer.mll
# 23 states, 271 transitions, table size 1222 bytes
# 1219 additional bytes used for bindings
# ocamlyacc formatParser.mly
# rm -f formatParser.mli
# ocamlc -I +camlp4 -c formatParser.ml
# ocamlc -I +camlp4 -c formatLexer.ml
# File "formatLexer.mll", line 35, characters 62-78:
# Error: Unbound module Stream
# make: *** [Makefile:13: formatLexer.cmo] Error 2
```