### PR TITLE
heptagon is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/heptagon/heptagon.1.00.06/opam
+++ b/packages/heptagon/heptagon.1.00.06/opam
@@ -7,7 +7,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "menhir" {< "20141215"}
   "ocamlgraph"

--- a/packages/heptagon/heptagon.1.03.03/opam
+++ b/packages/heptagon/heptagon.1.03.03/opam
@@ -8,7 +8,7 @@ build: [
    [make]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "menhir" {build & >= "20141215"}
   "ocamlgraph" {build}

--- a/packages/heptagon/heptagon.1.03.04/opam
+++ b/packages/heptagon/heptagon.1.03.04/opam
@@ -8,7 +8,7 @@ build: [
    [make]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "menhir" {build & >= "20141215"}
   "ocamlgraph" {build}

--- a/packages/heptagon/heptagon.1.04.00/opam
+++ b/packages/heptagon/heptagon.1.04.00/opam
@@ -8,7 +8,7 @@ build: [
    [make]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "menhir" {build & >= "20141215"}
   "ocamlgraph" {build}

--- a/packages/heptagon/heptagon.1.05.00/opam
+++ b/packages/heptagon/heptagon.1.05.00/opam
@@ -20,7 +20,7 @@ build: [
    [make]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "menhir" {build & >= "20141215"}
   "ocamlgraph" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling heptagon.1.05.00 ===================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/heptagon.1.05.00
# command              /usr/bin/make
# exit-code            2
# env-file             ~/.opam/log/heptagon-19-617d48.env
# output-file          ~/.opam/log/heptagon-19-617d48.out
### output ###
# (cd compiler/; /usr/bin/make)
# make[1]: Entering directory '/home/opam/.opam/5.1/.opam-switch/build/heptagon.1.05.00/compiler'
# STDLIB=/home/opam/.opam/5.1/lib/heptagon ocamlbuild -use-ocamlfind heptc.byte
# ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/5.1/lib/ocamlbuild /home/opam/.opam/5.1/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild_config.ml myocamlbuild.ml /home/opam/.opam/5.1/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# ocamlfind ocamldep -package ocamlgraph -modules main/heptc.ml > main/heptc.ml.depends
# ocamlfind ocamldep -package ocamlgraph -package camlp4 -pp camlp4of -modules preproc.ml > preproc.ml.depends
# ocamlfind ocamlc -c -g -dtypes -annot -bin-annot -w Ae -warn-error PU -w -9-48 -package ocamlgraph -package camlp4 -pp camlp4of -I utilities -I obc -I heptagon -I minils -I main -I global -I utilities/ctrln -I utilities/minils -I utilities/global -I obc/java -I obc/c -I obc/main -I obc/transformations -I heptagon/ctrln -I heptagon/parsing -I heptagon/main -I heptagon/transformations -I heptagon/analysis -I minils/ctrln -I minils/main -I minils/transformations -I minils/analysis -I minils/sigali -o preproc.cmo preproc.ml
# + ocamlfind ocamlc -c -g -dtypes -annot -bin-annot -w Ae -warn-error PU -w -9-48 -package ocamlgraph -package camlp4 -pp camlp4of -I utilities -I obc -I heptagon -I minils -I main -I global -I utilities/ctrln -I utilities/minils -I utilities/global -I obc/java -I obc/c -I obc/main -I obc/transformations -I heptagon/ctrln -I heptagon/parsing -I heptagon/main -I heptagon/transformations -I heptagon/analysis -I minils/ctrln -I minils/main -I minils/transformations -I minils/analysis -I minils/sigali -o preproc.cmo preproc.ml
# File "_none_", line 1:
# Alert ocaml_deprecated_cli: Setting a warning with a sequence of lowercase or uppercase letters,
# like 'Ae', is deprecated.
# Use the equivalent signed form: +A-e.
# Hint: Enabling or disabling a warning by its mnemonic name requires a + or - prefix.
# 
# File "utilities/global/compiler_utils.ml", line 42, characters 27-54:
# 42 |     | Illegal_character -> Pervasives.format_of_string "%aIllegal character.@."
#                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
# + ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/5.1/lib/ocamlbuild /home/opam/.opam/5.1/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild_config.ml myocamlbuild.ml /home/opam/.opam/5.1/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# make[1]: *** [Makefile:21: byte] Error 10
# make[1]: Leaving directory '/home/opam/.opam/5.1/.opam-switch/build/heptagon.1.05.00/compiler'
# make: *** [Makefile:6: all] Error 2
```