### PR TITLE
hweak is not compatible with OCaml 5.0 (uses Array.create)

### DIFF
--- a/packages/hweak/hweak.1.1/opam
+++ b/packages/hweak/hweak.1.1/opam
@@ -16,7 +16,7 @@ install: [
 ]
 synopsis:
   "An hastable with weak pointer enabling the GC to collect things that are in the hashtable"
-depends: ["ocaml"]
+depends: ["ocaml" {< "5.0"}]
 url {
   src: "http://aspellfr.free.fr/hweak/hweak-1.1.tar.gz"
   checksum: "md5=980cc30c156a248bbd4e6b58d8c12a9c"


### PR DESCRIPTION
```
#=== ERROR while compiling hweak.1.1 ==========================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/hweak.1.1
# command              /usr/bin/make
# exit-code            2
# env-file             ~/.opam/log/hweak-20-35f9e3.env
# output-file          ~/.opam/log/hweak-20-35f9e3.out
### output ###
# ocamlc  -c hweak.mli
# ocamlc  -c hweak.ml
# File "hweak.ml", line 69, characters 14-26:
# 69 |       table = Array.create sz (emptybucket, em);
#                    ^^^^^^^^^^^^
# Error: Unbound value Array.create
# make: *** [Makefile:32: hweak.cmo] Error 2
```