### PR TITLE
javalib < 3.2.2 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/javalib/javalib.2.2.2/opam
+++ b/packages/javalib/javalib.2.2.2/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "ptrees"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "camlzip" {= "1.04"}
   ("extlib" {<= "1.6.0"} | "extlib-compat" {< "1.7.0"})

--- a/packages/javalib/javalib.2.3.1/opam
+++ b/packages/javalib/javalib.2.3.1/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "ptrees"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "camlzip" {= "1.05"}
   "extlib" {>= "1.5.1" & <= "1.6.0"}

--- a/packages/javalib/javalib.2.3.2/opam
+++ b/packages/javalib/javalib.2.3.2/opam
@@ -17,7 +17,7 @@ remove: [
 ]
 homepage: "http://sawja.inria.fr"
 depends: [
-  "ocaml" {>= "4.00"}
+  "ocaml" {>= "4.00" & < "5.0"}
   "ocamlfind"
   "camlzip" {>= "1.05"}
   "camlp4"

--- a/packages/javalib/javalib.2.3.4/opam
+++ b/packages/javalib/javalib.2.3.4/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "ptrees"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "camlzip" {>= "1.05"}
   "camlp4"

--- a/packages/javalib/javalib.2.3.5/opam
+++ b/packages/javalib/javalib.2.3.5/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "ptrees"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "camlzip" {>= "1.05"}
   "camlp4"

--- a/packages/javalib/javalib.2.3.6/opam
+++ b/packages/javalib/javalib.2.3.6/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "javalib"]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "conf-which" {build}
   "ocamlfind" {build}
   "camlzip" {>= "1.05"}

--- a/packages/javalib/javalib.2.3/opam
+++ b/packages/javalib/javalib.2.3/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "ptrees"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "camlzip" {= "1.05"}
   ("extlib" {>= "1.5.1" & <= "1.6.0"} | "extlib-compat" {< "1.7.0"})

--- a/packages/javalib/javalib.2.3a/opam
+++ b/packages/javalib/javalib.2.3a/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "ptrees"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "camlzip" {= "1.05"}
   ("extlib" {>= "1.5.1" & <= "1.6.0"} | "extlib-compat" {< "1.7.0"})

--- a/packages/javalib/javalib.3.0/opam
+++ b/packages/javalib/javalib.3.0/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "javalib"]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "conf-which" {build}
   "ocamlfind" {build}
   "camlzip" {>= "1.05"}

--- a/packages/javalib/javalib.3.1/opam
+++ b/packages/javalib/javalib.3.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "ocaml" {>= "4.04"}
+  "ocaml" {>= "4.04" & < "5.0"}
   "conf-which" {build}
   "ocamlfind" {build}
   "camlzip" {>= "1.05"}


### PR DESCRIPTION
```
#=== ERROR while compiling javalib.3.1 ========================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/javalib.3.1
# command              /usr/bin/make
# exit-code            2
# env-file             ~/.opam/log/javalib-19-6abb7f.env
# output-file          ~/.opam/log/javalib-19-6abb7f.out
### output ###
# /usr/bin/make -C src
# make[1]: Entering directory '/home/opam/.opam/5.1/.opam-switch/build/javalib.3.1/src'
# ocamllex jManifest.mll
# 13 states, 340 transitions, table size 1438 bytes
# /home/opam/.opam/5.1/bin/ocamlfind ocamldep -I ptrees ../Makefile.config ptrees/ptset.mli ptrees/ptmap.mli ptrees/genericSet.mli ptrees/genericMap.mli jLib.mli jBasics.mli jBasicsLow.mli jSignature.mli jCode.mli jClassLow.mli jClass.mli jDumpBasics.mli jUnparseSignature.mli jDumpLow.mli jParseCode.mli jInstruction.mli jUnparse.mli jParseSignature.mli jParse.mli jLow2High.mli jHigh2Low.mli jFile.mli jManifest.mli javalib.mli ptrees/ptset.ml ptrees/ptmap.ml ptrees/genericSet.ml ptrees/genericMap.ml jLib.ml jBasics.ml jBasicsLow.ml jSignature.ml jCode.ml jClass.ml jDumpBasics.ml jParseCode.ml jInstruction.ml jUnparseSignature.ml jDumpLow.ml jHigh2Low.ml jUnparse.ml jParseSignature.ml jLow2High.ml jParse.ml jFile.ml jManifest.ml jPrint.ml javalib.ml > .depend
# /home/opam/.opam/5.1/bin/ocamlfind ocamlc -g -w Aer -annot -package unix,str,extlib,zip -I ptrees -c ptrees/ptset.mli
# File "_none_", line 1:
# Alert ocaml_deprecated_cli: Setting a warning with a sequence of lowercase or uppercase letters,
# like 'Aer', is deprecated.
# Use the equivalent signed form: +A-e-r.
# Hint: Enabling or disabling a warning by its mnemonic name requires a + or - prefix.
# /home/opam/.opam/5.1/bin/ocamlfind ocamlc -g -w Aer -annot -package unix,str,extlib,zip -I ptrees -c ptrees/ptmap.mli
# File "_none_", line 1:
# Alert ocaml_deprecated_cli: Setting a warning with a sequence of lowercase or uppercase letters,
# like 'Aer', is deprecated.
# Use the equivalent signed form: +A-e-r.
# Hint: Enabling or disabling a warning by its mnemonic name requires a + or - prefix.
# 
# File "ptrees/ptset.ml", line 338, characters 12-30:
# 338 |   List.sort Pervasives.compare (elements_aux [] s)
#                   ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# make[1]: *** [Makefile:61: ptrees/ptset.cmo] Error 2
# make[1]: Leaving directory '/home/opam/.opam/5.1/.opam-switch/build/javalib.3.1/src'
# make: *** [Makefile:9: javalib] Error 2
```