### PR TITLE
lascar is not compatible with OCaml 5.0 (uses Stream)

### DIFF
--- a/packages/lascar/lascar.0.5/opam
+++ b/packages/lascar/lascar.0.5/opam
@@ -7,7 +7,7 @@ homepage: "http://cloud.ip.univ-bpclermont.fr/~serot/lascar/"
 bug-reports: "jocelyn.serot@uca.fr"
 dev-repo: "git+https://github.com/jserot/lascar.git"
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0"}
   "camlp4"
   "ocamlfind" {build}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling lascar.0.5 =========================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/lascar.0.5
# command              /usr/bin/make
# exit-code            2
# env-file             ~/.opam/log/lascar-20-a9e526.env
# output-file          ~/.opam/log/lascar-20-a9e526.out
### output ###
# (cd src/utils; make)
# make[1]: Entering directory '/home/opam/.opam/5.1/.opam-switch/build/lascar.0.5/src/utils'
# ocamlfind ocamlc  -for-pack Utils -c misc.mli
# ocamlfind ocamlc  -for-pack Utils -c misc.ml
# ocamlfind ocamlc  -for-pack Utils -c dot.mli
# ocamlfind ocamlc  -for-pack Utils -c dot.ml
# ocamlfind ocamlc  -for-pack Utils -c tree.mli
# ocamlfind ocamlc  -for-pack Utils -c tree.ml
# ocamlfind ocamlc  -for-pack Utils -c option.mli
# ocamlfind ocamlc  -for-pack Utils -c option.ml
# ocamlfind ocamlc  -for-pack Utils -c orderedTypeExt.mli
# ocamlfind ocamlc  -for-pack Utils -c orderedTypeExt.ml
# ocamlfind ocamlc  -for-pack Utils -c stringable.mli
# ocamlfind ocamlc  -for-pack Utils -c stringable.ml
# ocamlfind ocamlc  -for-pack Utils -c listExt.mli
# File "listExt.mli", line 113, characters 35-43:
# 113 | val parse: string -> (Genlex.token Stream.t -> 'a) -> Genlex.token Stream.t -> 'a list
#                                          ^^^^^^^^
# Error: Unbound module Stream
# make[1]: *** [Makefile:50: listExt.cmi] Error 2
# make[1]: Leaving directory '/home/opam/.opam/5.1/.opam-switch/build/lascar.0.5/src/utils'
# make: *** [Makefile:27: all] Error 2
```