### PR TITLE
malfunction is not compatible with OCaml 5.2 (relies on compiler-libs)

### DIFF
--- a/packages/malfunction/malfunction.0.2.1/opam
+++ b/packages/malfunction/malfunction.0.2.1/opam
@@ -32,7 +32,7 @@ build: [
   ] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.2"}
   "ocaml-variants"
     {= "4.03.0+beta1+flambda" | = "4.03.0+beta2+flambda" | = "4.03.0+flambda" |
      = "4.03.0+fp+flambda" |

--- a/packages/malfunction/malfunction.0.2/opam
+++ b/packages/malfunction/malfunction.0.2/opam
@@ -32,7 +32,7 @@ build: [
   ] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.2"}
   "ocaml-variants"
     {= "4.03.0+beta1+flambda" | = "4.03.0+beta2+flambda" | = "4.03.0+flambda" |
      = "4.03.0+fp+flambda" |

--- a/packages/malfunction/malfunction.0.5/opam
+++ b/packages/malfunction/malfunction.0.5/opam
@@ -9,6 +9,7 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
   [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]
+conflicts: [ "ocaml-option-bytecode-only" ]
 depends: [
   "ocaml" {>= "4.08" & < "5.2"}
   "ocamlfind"

--- a/packages/malfunction/malfunction.0.5/opam
+++ b/packages/malfunction/malfunction.0.5/opam
@@ -10,7 +10,7 @@ build: [
   [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.2"}
   "ocamlfind"
   "dune" {>= "2.9.1"}
   "cppo" {build}


### PR DESCRIPTION
Reported upstream in https://github.com/stedolan/malfunction/issues/40 cc @stedolan 
```
#=== ERROR while compiling malfunction.0.5 ====================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/malfunction.0.5
# command              ~/.opam/5.2/bin/dune build -p malfunction -j 1
# exit-code            1
# env-file             ~/.opam/log/malfunction-20-6dc01d.env
# output-file          ~/.opam/log/malfunction-20-6dc01d.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.malfunction.objs/byte -I /home/opam/.opam/5.2/lib/findlib -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/ocaml/dynlink -I /home/opam/.opam/5.2/lib/ocaml/str -I /home/opam/.opam/5.2/lib/ocaml/unix -I /home/opam/.opam/5.2/lib/zarith -no-alias-deps -o src/.malfunction.objs/byte/malfunction_compat.cmo -c -impl src/malfunction_compat.ml)
# File "malfunction_compat.cppo.ml", lines 15-25, characters 13-3:
# Error: Some record fields are undefined: "may_fuse_arity"
```