### PR TITLE
metaquot is not compatible with OCaml 5.2 (relies on compiler-libs)

### DIFF
--- a/packages/metaquot/metaquot.0.5.1/opam
+++ b/packages/metaquot/metaquot.0.5.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/thierry-martinez/metaquot"
 doc: "https://github.com/thierry-martinez/metaquot"
 bug-reports: "https://github.com/thierry-martinez/metaquot"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2"}
   "stdcompat" {>= "12"}
   "ppxlib" {>= "0.22.0"}
   "ocamlfind" {>= "1.8.1"}

--- a/packages/metaquot/metaquot.0.5.2/opam
+++ b/packages/metaquot/metaquot.0.5.2/opam
@@ -12,7 +12,7 @@ doc: "https://github.com/thierry-martinez/metaquot"
 bug-reports: "https://github.com/thierry-martinez/metaquot"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2"}
   "stdcompat" {>= "12"}
   "ppxlib" {>= "0.22.0"}
   "ocamlfind" {>= "1.8.1"}


### PR DESCRIPTION
```
#=== ERROR while compiling metaquot.0.5.2 =====================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/metaquot.0.5.2
# command              ~/.opam/5.2/bin/dune build -p metaquot -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/metaquot-19-ed893a.env
# output-file          ~/.opam/log/metaquot-19-ed893a.out
### output ###
# (cd _build/default && .ppx/f04423e293bc7238bf6fa2027578cb58/ppx.exe --cookie 'library-name="metaquot"' -o metaquot/metaquot.pp.ml --impl metaquot/metaquot.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "metaquot/metaquot.ml", line 244, characters 6-19:
# 244 |     | Type_abstract ->
#             ^^^^^^^^^^^^^
# Error: The constructor "Type_abstract" expects 1 argument(s),
#        but is applied here to 0 argument(s)
# File "_none_", line 1:
# Error: Unable to compile preprocessor: command-line
#        "'ocamlfind' 'ocamlopt' '-package' 'metapp.preutils,metapp.api,ppxlib,metapp,findlib' '-open' 'Stdcompat' '-I' '+compiler-libs' '-w' '-40' '-shared' '/tmp/build_959d67_dune/metapp7bb14e.ml' '-o' '/tmp/build_959d67_dune/metapp7bb14e.cmxs'"
#        failed with exit-code 2
# 
```