### PR TITLE
objsize is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/objsize/objsize.0.18/opam
+++ b/packages/objsize/objsize.0.18/opam
@@ -12,7 +12,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "objsize"]]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0"}
   "ocamlfind"
   "camlp4"
   "ocamlbuild" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling objsize.0.18 =======================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/objsize.0.18
# command              /usr/bin/make
# exit-code            2
# env-file             ~/.opam/log/objsize-20-8f2424.env
# output-file          ~/.opam/log/objsize-20-8f2424.out
### output ###
# make: oasis: No such file or directory
# make: oasis: No such file or directory
# ocaml setup.ml -configure 
# File "./setup.ml", line 1404, characters 23-41:
# 1404 |          let compare = Pervasives.compare
#                               ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# make: *** [Makefile:34: setup.data] Error 2
```