### PR TITLE
ocamldsort is not compatible with OCaml 5.0 (uses Stream)

### DIFF
--- a/packages/ocamldsort/ocamldsort.0.15.0/opam
+++ b/packages/ocamldsort/ocamldsort.0.15.0/opam
@@ -16,7 +16,7 @@ build: [
   ]
   [make]
 ]
-depends: ["ocaml" "camlp4"]
+depends: ["ocaml" {< "5.0"} "camlp4"]
 install: [make "install"]
 synopsis: "Sorts a set of OCaml source files according to their dependencies"
 extra-files: ["ocamldsort.install" "md5=2559d16061178a281cd65ffc5af98243"]

--- a/packages/ocamldsort/ocamldsort.0.15.0/opam
+++ b/packages/ocamldsort/ocamldsort.0.15.0/opam
@@ -16,7 +16,7 @@ build: [
   ]
   [make]
 ]
-depends: ["ocaml" {< "5.0"} "camlp4"]
+depends: ["ocaml" {< "5.0"} "camlp4" "conf-autoconf"]
 install: [make "install"]
 synopsis: "Sorts a set of OCaml source files according to their dependencies"
 extra-files: ["ocamldsort.install" "md5=2559d16061178a281cd65ffc5af98243"]

--- a/packages/ocamldsort/ocamldsort.0.16.0/opam
+++ b/packages/ocamldsort/ocamldsort.0.16.0/opam
@@ -16,7 +16,7 @@ build: [
   ]
   [make]
 ]
-depends: ["ocaml" "camlp4" "conf-autoconf"]
+depends: ["ocaml" {< "5.0"} "camlp4" "conf-autoconf"]
 install: [make "install"]
 synopsis: "Sorts a set of OCaml source files according to their dependencies"
 extra-files: ["ocamldsort.install" "md5=2559d16061178a281cd65ffc5af98243"]


### PR DESCRIPTION
```
#=== ERROR while compiling ocamldsort.0.16.0 ==================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/ocamldsort.0.16.0
# command              /usr/bin/make
# exit-code            2
# env-file             ~/.opam/log/ocamldsort-19-e79c63.env
# output-file          ~/.opam/log/ocamldsort-19-e79c63.out
### output ###
# /home/opam/.opam/5.1/bin/ocamlc.opt  -pp camlp4o -c files.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt  -pp camlp4o -c dep_debug.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt  -pp camlp4o -c dep_error.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt  -pp camlp4o -c dep_parse.ml
# File "dep_parse.ml", lines 29-32, characters 23-15:
# 29 | .......................parser
# 30 |   | [< '' ' >] -> ""
# 31 |   | [< 'a when a <> '\n';  d = parse_source >] -> concat a d
# 32 |   | [< >] -> ""
# Error: Unbound module Stream
# make: *** [Makefile:73: dep_parse.cmo] Error 2
```