### PR TITLE
ocamlscript < 3.0.0 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/ocamlscript/ocamlscript.2.0.2/opam
+++ b/packages/ocamlscript/ocamlscript.2.0.2/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 build: make
 remove: [["ocamlfind" "remove" "ocamlscript"]]
-depends: ["ocaml" "ocamlfind" "camlp4"]
+depends: ["ocaml" {< "5.0"} "ocamlfind" "camlp4"]
 install: [make "install"]
 synopsis: "Tool which compiles OCaml scripts into native code"
 flags: light-uninstall

--- a/packages/ocamlscript/ocamlscript.2.0.4/opam
+++ b/packages/ocamlscript/ocamlscript.2.0.4/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "martin@mjambon.com"
 build: make
 remove: [["ocamlfind" "remove" "ocamlscript"]]
-depends: ["ocaml" "ocamlfind" "camlp4"]
+depends: ["ocaml" {< "5.0"} "ocamlfind" "camlp4"]
 dev-repo: "git+https://github.com/mjambon/ocamlscript"
 install: [make "install"]
 synopsis: "Tool which compiles OCaml scripts into native code"


### PR DESCRIPTION
```
#=== ERROR while compiling ocamlscript.2.0.4 ==================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/ocamlscript.2.0.4
# command              /usr/bin/make
# exit-code            2
# env-file             ~/.opam/log/ocamlscript-20-682292.env
# output-file          ~/.opam/log/ocamlscript-20-682292.out
### output ###
# echo 'let version = "2.0.4"' > version.ml
# echo 'version = "2.0.4"' > META
# cat META.in >> META
# ocamlc -pp 'camlp4orf -loc _loc' -c \
# 	-I /home/opam/.opam/5.1/lib/ocaml/camlp4 pa_opt310.ml && \
# 	cp pa_opt310.cmo pa_opt.cmo && \
# 	cp pa_opt310.cmi pa_opt.cmi
# ocamlc -pp 'camlp4orf -loc _loc' -c \
# 	-I /home/opam/.opam/5.1/lib/ocaml/camlp4 pa_tryfinally310.ml && \
# 	cp pa_tryfinally310.cmo pa_tryfinally.cmo && \
# 	cp pa_tryfinally310.cmi pa_tryfinally.cmi
# make[1]: Entering directory '/home/opam/.opam/5.1/.opam-switch/build/ocamlscript.2.0.4'
# ocamlfind ocamldep ocaml.mli > ._bcdi/ocaml.di
# ocamlfind ocamldep utils.mli > ._bcdi/utils.di
# ocamlfind ocamldep common.mli > ._bcdi/common.di
# ocamlfind ocamldep pipeline.mli > ._bcdi/pipeline.di
# ocamlfind ocamldep ocaml.ml > ._d/ocaml.d
# ocamlfind ocamldep utils.ml > ._d/utils.d
# ocamlfind ocamldep common.ml > ._d/common.d
# ocamlfind ocamldep -pp "$PP " pipeline.ml > ._d/pipeline.d
# ocamlfind ocamldep version.ml > ._d/version.d
# ocamlfind ocamlc -package unix,str -c -dtypes -for-pack Ocamlscript version.ml
# ocamlfind ocamlc -package unix,str -c -dtypes pipeline.mli
# ocamlfind ocamlc -package unix,str -c -pp "$PP " -dtypes -for-pack Ocamlscript pipeline.ml
# ocamlfind ocamlc -package unix,str -c -dtypes common.mli
# ocamlfind ocamlc -package unix,str -c -dtypes -for-pack Ocamlscript common.ml
# ocamlfind ocamlc -package unix,str -c -dtypes utils.mli
# ocamlfind ocamlc -package unix,str -c -dtypes -for-pack Ocamlscript utils.ml
# ocamlfind ocamlc -package unix,str -c -dtypes ocaml.mli
# ocamlfind ocamlc -package unix,str -c -dtypes -for-pack Ocamlscript ocaml.ml
# ocamlfind ocamlc -pack              \
# 			  -o ocamlscript.cmo version.cmo pipeline.cmo common.cmo utils.cmo ocaml.cmo
# make[1]: Leaving directory '/home/opam/.opam/5.1/.opam-switch/build/ocamlscript.2.0.4'
# touch bc.done
# make[1]: Entering directory '/home/opam/.opam/5.1/.opam-switch/build/ocamlscript.2.0.4'
# ocamlfind ocamldep -native ocaml.mli > ._ncdi/ocaml.di
# ocamlfind ocamldep -native utils.mli > ._ncdi/utils.di
# ocamlfind ocamldep -native common.mli > ._ncdi/common.di
# ocamlfind ocamldep -native pipeline.mli > ._ncdi/pipeline.di
# ocamlfind ocamlopt -package unix,str -c -dtypes -for-pack Ocamlscript version.ml
# ocamlfind ocamlopt -package unix,str -c -pp "$PP " -dtypes -for-pack Ocamlscript pipeline.ml
# ocamlfind ocamlopt -package unix,str -c -dtypes -for-pack Ocamlscript common.ml
# ocamlfind ocamlopt -package unix,str -c -dtypes -for-pack Ocamlscript utils.ml
# ocamlfind ocamlopt -package unix,str -c -dtypes -for-pack Ocamlscript ocaml.ml
# ocamlfind ocamlopt -pack              \
# 			  -o ocamlscript.cmx version.cmx pipeline.cmx common.cmx utils.cmx ocaml.cmx
# make[1]: 'ocamlscript.o' is up to date.
# make[1]: Leaving directory '/home/opam/.opam/5.1/.opam-switch/build/ocamlscript.2.0.4'
# touch nc.done
# ocamlfind ocamlopt -o ocamlscript -pp 'camlp4o -I . -parser pa_tryfinally.cmo -parser pa_opt.cmo' \
#   -package 'unix str' -linkpkg -dtypes \
#   ocamlscript.cmx main.ml
# File "main.ml", line 329, characters 39-55:
# 329 | 	  `Stdin -> "", Text.lines_of_channel Pervasives.stdin
#       	                                      ^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# make: *** [Makefile:54: optexe] Error 2
```