### PR TITLE
ocp-pack-split is not compatible with OCaml 5.0 (uses String.capitalize)

### DIFF
--- a/packages/ocp-pack-split/ocp-pack-split.1.0.1/opam
+++ b/packages/ocp-pack-split/ocp-pack-split.1.0.1/opam
@@ -9,7 +9,7 @@ synopsis: "ocp-pack and ocp-split"
 description: """
 ocp-pack packs a list of sources in the same manner as the -pack option.
 ocp-split splits a packed annot file into individual annot files."""
-depends: ["ocaml"]
+depends: ["ocaml" {< "5.0"}]
 extra-files: [
   "ocp-pack-split.install" "md5=9d28fabf6e6c72182e0e89c3cdc0b70d"
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling ocp-pack-split.1.0.1 ===============================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/ocp-pack-split.1.0.1
# command              /usr/bin/make
# exit-code            2
# env-file             ~/.opam/log/ocp-pack-split-20-0608a4.env
# output-file          ~/.opam/log/ocp-pack-split-20-0608a4.out
### output ###
# ocamlopt version.ml pack.ml -o ocp-pack
# File "pack.ml", line 151, characters 20-37:
# 151 |       let modname = String.capitalize basename in
#                           ^^^^^^^^^^^^^^^^^
# Error: Unbound value String.capitalize
# make: *** [Makefile:11: all] Error 2
```