### PR TITLE
omod < 0.0.4 is not compatible with OCaml 5.2 (uses compiler-libs)

### DIFF
--- a/packages/omod/omod.0.0.3/opam
+++ b/packages/omod/omod.0.0.3/opam
@@ -16,7 +16,7 @@ homepage: "https://erratique.ch/software/omod"
 doc: "https://erratique.ch/software/omod/doc/"
 bug-reports: "https://github.com/dbuenzli/omod/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "1.0.3"}


### PR DESCRIPTION
```
#=== ERROR while compiling omod.0.0.3 =========================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/omod.0.0.3
# command              ~/.opam/5.2/bin/ocaml pkg/pkg.ml build --dev-pkg false --lib-dir /home/opam/.opam/5.2/lib
# exit-code            1
# env-file             ~/.opam/log/omod-20-98bb5c.env
# output-file          ~/.opam/log/omod-20-98bb5c.out
### output ###
# ocamlfind ocamldep -package compiler-libs.toplevel -modules src/omod.ml > src/omod.ml.depends
# ocamlfind ocamldep -package compiler-libs.toplevel -modules src/omod.mli > src/omod.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/omod.cmi src/omod.mli
# ocamlfind ocamldep -package compiler-libs.toplevel -modules src/omod_top.ml > src/omod_top.ml.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/omod_top.cmo src/omod_top.ml
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/omod_top.cmo src/omod_top.ml
# File "src/omod_top.ml", line 9, characters 28-51:
# 9 |   let is_utop = Hashtbl.mem Toploop.directive_table "utop_help" in
#                                 ^^^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: Toploop.directive_table
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/omod.cmx src/omod.ml
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/omod_top.cmx src/omod_top.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/omod_top.cmx src/omod_top.ml
# File "src/omod_top.ml", line 9, characters 28-51:
# 9 |   let is_utop = Hashtbl.mem Toploop.directive_table "utop_help" in
#                                 ^^^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: Toploop.directive_table
# ocamlfind ocamlopt -a -package compiler-libs.toplevel -I src src/omod.cmx src/omod_top.cmx -o src/omod.cmxa
# ocamlfind ocamlopt -shared -linkall -package compiler-libs.toplevel -I src src/omod.cmxa -o src/omod.cmxs
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/omod.cmo src/omod.ml
# ocamlfind ocamlc -a -package compiler-libs.toplevel -I src src/omod.cmo src/omod_top.cmo -o src/omod.cma
# ocamlfind ocamldep -package compiler-libs.common -modules src/omod_ocamlc.ml > src/omod_ocamlc.ml.depends
# ocamlfind ocamldep -package compiler-libs.common -modules src/omod_ocamlc.mli > src/omod_ocamlc.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package compiler-libs.common -I src -I test -o src/omod_ocamlc.cmi src/omod_ocamlc.mli
# ocamlfind ocamldep -package 'compiler-libs.common unix' -modules src/omod_support.ml > src/omod_support.ml.depends
# ocamlfind ocamldep -package 'compiler-libs.common unix' -modules src/omod_support.mli > src/omod_support.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package 'compiler-libs.common unix' -I src -I test -o src/omod_support.cmi src/omod_support.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -package compiler-libs.common -I src -I test -o src/omod_ocamlc.cmx src/omod_ocamlc.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -package compiler-libs.common -I src -I test -o src/omod_ocamlc.cmx src/omod_ocamlc.ml
# File "src/omod_ocamlc.ml", line 145, characters 45-49:
# 145 |     let iface_digest, iface_deps = split_dep name cu.Cmo_format.cu_imports in
#                                                    ^^^^
# Error: This expression has type "Cmo_format.compunit"
#        but an expression was expected of type "string"
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/omod.a' 'src/omod.cmxs' 'src/omod.cmxa' 'src/omod.cma'
#      'src/omod_top.cmx' 'src/omod.cmx' 'src/omod.cmi' 'src/omod.mli'
#      'src/omod_support.a' 'src/omod_support.cmxs' 'src/omod_support.cmxa'
#      'src/omod_support.cma' 'src/omod_support.cmx' 'src/omod_support.cmi'
#      'src/omod_support.mli' 'src/omod_ocamlc.cmx' 'src/omod_ocamlc.cmi'
#      'src/omod_ocamlc.mli' 'src/omod.top' 'src/omod_bin.native'
#      'doc/index.mld' 'doc/tutorial.mld']: exited with 10
```