### PR TITLE
pa_comprehension is not compatible with OCaml 5.0 (uses String.lowercase)

### DIFF
--- a/packages/pa_comprehension/pa_comprehension.0.4/opam
+++ b/packages/pa_comprehension/pa_comprehension.0.4/opam
@@ -7,7 +7,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "camlp4"
   "batteries"


### PR DESCRIPTION
```
#=== ERROR while compiling pa_comprehension.0.4 ===============================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/pa_comprehension.0.4
# command              ~/.opam/5.1/bin/ocaml setup.ml -configure
# exit-code            2
# env-file             ~/.opam/log/pa_comprehension-20-91a083.env
# output-file          ~/.opam/log/pa_comprehension-20-91a083.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```