### PR TITLE
pa_monad_custom is not compatible with OCaml 5.0 (uses String.lowercase)

### DIFF
--- a/packages/pa_monad_custom/pa_monad_custom.v6.0.0/opam
+++ b/packages/pa_monad_custom/pa_monad_custom.v6.0.0/opam
@@ -5,7 +5,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 remove: [["ocamlfind" "remove" "monad-custom"]]
-depends: ["ocaml" "camlp4" "ocamlfind"]
+depends: ["ocaml" {< "5.0"} "camlp4" "ocamlfind"]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "Syntactic Sugar for Monads"
 flags: light-uninstall


### PR DESCRIPTION
```
#=== ERROR while compiling pa_monad_custom.v6.0.0 =============================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/pa_monad_custom.v6.0.0
# command              ~/.opam/5.1/bin/ocaml setup.ml -configure --prefix /home/opam/.opam/5.1
# exit-code            2
# env-file             ~/.opam/log/pa_monad_custom-20-db7fca.env
# output-file          ~/.opam/log/pa_monad_custom-20-db7fca.out
### output ###
# File "/home/gildor/programmation/oasis/src/oasis/OASISUtils.ml", line 44, characters 20-36:
# Error: Unbound value String.lowercase
```