### PR TITLE
pa_qualified is not compatible with OCaml 5.0 (uses String.lowercase)

### DIFF
--- a/packages/pa_qualified/pa_qualified.0.5/opam
+++ b/packages/pa_qualified/pa_qualified.0.5/opam
@@ -8,7 +8,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "pa_qualified"]]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind"
   "camlp4"
   "ocamlbuild" {build}

--- a/packages/pa_qualified/pa_qualified.0.6/opam
+++ b/packages/pa_qualified/pa_qualified.0.6/opam
@@ -8,7 +8,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "pa_qualified"]]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind"
   "camlp4"
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling pa_qualified.0.6 ===================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/pa_qualified.0.6
# command              ~/.opam/5.1/bin/ocaml setup.ml -configure
# exit-code            2
# env-file             ~/.opam/log/pa_qualified-19-2da607.env
# output-file          ~/.opam/log/pa_qualified-19-2da607.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```