### PR TITLE
pa_where is not compatible with OCaml 5.0 (uses String.lowercase)

### DIFF
--- a/packages/pa_where/pa_where.0.4/opam
+++ b/packages/pa_where/pa_where.0.4/opam
@@ -8,7 +8,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "pa_where"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "camlp4"
   "ocamlbuild" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling pa_where.0.4 =======================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/pa_where.0.4
# command              ~/.opam/5.1/bin/ocaml setup.ml -configure
# exit-code            2
# env-file             ~/.opam/log/pa_where-20-2b07c7.env
# output-file          ~/.opam/log/pa_where-20-2b07c7.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```