### PR TITLE
papi is not compatible with OCaml 4.14 (Toploop.use_silently changed type)

### DIFF
--- a/packages/papi/papi.0.1.1/opam
+++ b/packages/papi/papi.0.1.1/opam
@@ -13,6 +13,7 @@ build: [ [ "dune" "subst" ] {dev}
          [ "dune" "runtest" "-p" name "-j" jobs ] {with-test} ]
 
 depends: [
+  "ocaml" {< "4.14"}
   "dune" {>= "1.7"}
   "fmt" {with-test} ]
 


### PR DESCRIPTION
Upstream PR: https://github.com/pqwy/ocaml-papi/pull/2 cc @pqwy 
```
#=== ERROR while compiling papi.0.1.1 =========================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/papi.0.1.1
# command              ~/.opam/5.1/bin/dune build -p papi -j 1
# exit-code            1
# env-file             ~/.opam/log/papi-19-a79fa7.env
# output-file          ~/.opam/log/papi-19-a79fa7.out
### output ###
# (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.papi_top.objs/byte -I /home/opam/.opam/5.1/lib/ocaml/compiler-libs -I src/.papi.objs/byte -no-alias-deps -o src/.papi_top.objs/byte/papi_top.cmo -c -impl src/papi_top.ml)
# File "src/papi_top.ml", line 4, characters 50-68:
# 4 | let _ = Toploop.use_silently Format.err_formatter "papi_top_init.ml"
#                                                       ^^^^^^^^^^^^^^^^^^
# Error: This expression has type string but an expression was expected of type
#          Toploop.input
```