### PR TITLE
ppx_interact is not compatible with OCaml 5.2

### DIFF
--- a/packages/ppx_interact/ppx_interact.0.1.0/opam
+++ b/packages/ppx_interact/ppx_interact.0.1.0/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/dariusf/ppx_interact"
 bug-reports: "https://github.com/dariusf/ppx_interact/issues"
 depends: [
   "dune" {>= "3.7"}
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.14" & < "5.2"}
   "ppxlib" {>= "0.28.0"}
   "linenoise" {>= "1.4.0"}
   "odoc" {with-doc}


### PR DESCRIPTION
uses Misc.find_in_path_uncap from compiler-libs.
Reported upstream in https://github.com/dariusf/ppx_interact/issues/2 cc @dariusf 
```
#=== ERROR while compiling ppx_interact.0.1.0 =================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/ppx_interact.0.1.0
# command              ~/.opam/5.2/bin/dune build -p ppx_interact -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/ppx_interact-20-241059.env
# output-file          ~/.opam/log/ppx_interact-20-241059.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I runtime/.ppx_interact_runtime.objs/byte -I /home/opam/.opam/5.2/lib/linenoise -I /home/opam/.opam/5.2/lib/ocaml/compiler-libs -I /home/opam/.opam/5.2/lib/ocaml/unix -no-alias-deps -o runtime/.ppx_interact_runtime.objs/byte/ppx_interact_runtime.cmo -c -impl runtime/ppx_interact_runtime.ml)
# File "runtime/ppx_interact_runtime.ml", line 215, characters 8-31:
# 215 |     try Misc.find_in_path_uncap search_path (unit ^ ".cmt")
#               ^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value "Misc.find_in_path_uncap"
```