### PR TITLE
scid is not compatible with OCaml 5.0

### DIFF
--- a/packages/scid/scid.1.0/opam
+++ b/packages/scid/scid.1.0/opam
@@ -10,7 +10,7 @@ build: [
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}


### PR DESCRIPTION
Expects the bigarray library to be available through ocamlfind
```
#=== ERROR while compiling scid.1.0 ===========================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/scid.1.0
# command              ~/.opam/5.1/bin/ocaml pkg/pkg.ml build --pinned false
# exit-code            1
# env-file             ~/.opam/log/scid-19-d2c10d.env
# output-file          ~/.opam/log/scid-19-d2c10d.out
### output ###
# ocamlfind ocamldep -package result -package ocplib-endian -package bigarray -package bytes -modules src/scid.ml > src/scid.ml.depends
# + ocamlfind ocamldep -package result -package ocplib-endian -package bigarray -package bytes -modules src/scid.ml > src/scid.ml.depends
# ocamlfind: Package `bigarray' not found
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/scid.a' 'src/scid.cmxs' 'src/scid.cmxa' 'src/scid.cma'
#      'src/scid.cmx' 'src/scid.cmi' 'src/scid.mli']: exited with 10
```