### PR TITLE
srt.0.2.*: Add missing dependency on ocamlfind

### DIFF
--- a/packages/srt/srt.0.2.0/opam
+++ b/packages/srt/srt.0.2.0/opam
@@ -19,6 +19,7 @@ depends: [
   "ctypes"
   "integers"
   "posix-socket"
+  "ocamlfind"
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/packages/srt/srt.0.2.1/opam
+++ b/packages/srt/srt.0.2.1/opam
@@ -20,6 +20,7 @@ depends: [
   "ctypes"
   "integers"
   "posix-socket"
+  "ocamlfind"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Dependency added in 0.2.0 in https://github.com/savonet/ocaml-srt/commit/67026ec6a03cdf9c4fb51acefc4ee50871c690b7 and added to the dependency only since 0.2.2
```
#=== ERROR while compiling srt.0.2.1 ==========================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/srt.0.2.1
# command              ~/.opam/5.1/bin/dune build -p srt -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/srt-20-2fe41d.env
# output-file          ~/.opam/log/srt-20-2fe41d.out
### output ###
# File "src/generator/dune", line 79, characters 0-365:
# 79 | (rule
# 80 |  (targets gen_constants_c.exe)
# 81 |  (deps
# ....
# 94 |    -I
# 95 |    ../constants/.srt_constants.objs/byte/
# 96 |    %{lib-private:srt.constants:srt_constants.cmxa})))
# (cd _build/default/src/generator && ./build_native.sh linux gen_constants_c.ml gen_constants_c.exe -I ../constants -I ../constants/.srt_constants.objs/native/ -I ../constants/.srt_constants.objs/byte/ ../constants/srt_constants.cmxa)
# ./build_native.sh: 18: ocamlfind: not found
```