### PR TITLE
volt is not compatible with OCaml 5.0 (uses Stream)

### DIFF
--- a/packages/volt/volt.1.4/opam
+++ b/packages/volt/volt.1.4/opam
@@ -18,7 +18,7 @@ build: [
   [make "all"]
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0"}
   "camlp4"
   "ocamlfind" {build}
   "ocamlbuild" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling volt.1.4 ===========================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.1.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/volt.1.4
# command              /usr/bin/make all
# exit-code            2
# env-file             ~/.opam/log/volt-20-27961f.env
# output-file          ~/.opam/log/volt-20-27961f.out
### output ###
# echo 'bolt.cma' > bolt.itarget
# (which ocamlopt && echo 'bolt.cmxa' >> bolt.itarget) || true
# /home/opam/.opam/5.1/bin/ocamlopt
# (which ocamljava && echo 'bolt.cmjo' >> bolt.itarget) || true
# WARNINGS=FALSE PATH_OCAML_PREFIX=/home/opam/.opam/5.1 ocamlbuild -classic-display -no-links bolt.cmo
# /home/opam/.opam/5.1/bin/ocamlopt.opt unix.cmxa -I /home/opam/.opam/5.1/lib/ocamlbuild /home/opam/.opam/5.1/lib/ocamlbuild/ocamlbuildlib.cmxa myocamlbuild.ml /home/opam/.opam/5.1/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# File "_tags", line 27, characters 19-27:
# Warning: the tag "warnings" is not used in any flag or dependency declaration, so it will have no effect; it may be a typo. Otherwise you can use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
# /home/opam/.opam/5.1/bin/ocamllex.opt -q src/library/configLexer.mll
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/configLexer.ml > src/library/configLexer.ml.depends
# /home/opam/.opam/5.1/bin/ocamlyacc src/library/configParser.mly
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/configParser.mli > src/library/configParser.mli.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/configuration.mli > src/library/configuration.mli.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/name.mli > src/library/name.mli.depends
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/name.cmi src/library/name.mli
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/configuration.cmi src/library/configuration.mli
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/configParser.cmi src/library/configParser.mli
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/configParser.ml > src/library/configParser.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/configuration.ml > src/library/configuration.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/configurationNew.mli > src/library/configurationNew.mli.depends
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/configurationNew.cmi src/library/configurationNew.mli
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/configurationNew.ml > src/library/configurationNew.ml.depends
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/configLexer.cmo src/library/configLexer.ml
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/configurationOld.mli > src/library/configurationOld.mli.depends
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/configurationOld.cmi src/library/configurationOld.mli
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/configurationOld.ml > src/library/configurationOld.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/utils.mli > src/library/utils.mli.depends
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/utils.cmi src/library/utils.mli
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/event.mli > src/library/event.mli.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/level.mli > src/library/level.mli.depends
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/level.cmi src/library/level.mli
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/event.cmi src/library/event.mli
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/event.ml > src/library/event.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/filter.mli > src/library/filter.mli.depends
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/filter.cmi src/library/filter.mli
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/filter.ml > src/library/filter.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/layout.mli > src/library/layout.mli.depends
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/layout.cmi src/library/layout.mli
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/layout.ml > src/library/layout.ml.depends
# cp /tmp/versionedfcc2.ml src/library/version.ml
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/version.mli > src/library/version.mli.depends
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/version.cmi src/library/version.mli
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/level.ml > src/library/level.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/logger.mli > src/library/logger.mli.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/mode.mli > src/library/mode.mli.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/output.mli > src/library/output.mli.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/signal.mli > src/library/signal.mli.depends
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/signal.cmi src/library/signal.mli
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/output.cmi src/library/output.mli
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/mode.cmi src/library/mode.mli
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/logger.cmi src/library/logger.mli
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/logger.ml > src/library/logger.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/tree.mli > src/library/tree.mli.depends
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/tree.cmi src/library/tree.mli
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/mode.ml > src/library/mode.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/name.ml > src/library/name.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/output.ml > src/library/output.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/signal.ml > src/library/signal.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/tree.ml > src/library/tree.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/utils.ml > src/library/utils.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/library/version.ml > src/library/version.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/support/daikon.mli > src/support/daikon.mli.depends
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/support -I src -I src/threads -I src/syntax -I src/library -o src/support/daikon.cmi src/support/daikon.mli
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/support/daikon.ml > src/support/daikon.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/support/log4j.mli > src/support/log4j.mli.depends
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/support -I src -I src/threads -I src/syntax -I src/library -o src/support/log4j.cmi src/support/log4j.mli
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/support/log4j.ml > src/support/log4j.ml.depends
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/support/paje.mli > src/support/paje.mli.depends
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/support -I src -I src/threads -I src/syntax -I src/library -o src/support/paje.cmi src/support/paje.mli
# /home/opam/.opam/5.1/bin/ocamldep.opt -modules src/support/paje.ml > src/support/paje.ml.depends
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/configParser.cmo src/library/configParser.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/configuration.cmo src/library/configuration.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/configurationNew.cmo src/library/configurationNew.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/configurationOld.cmo src/library/configurationOld.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/event.cmo src/library/event.ml
# + /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/event.cmo src/library/event.ml
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/filter.cmo src/library/filter.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/layout.cmo src/library/layout.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/level.cmo src/library/level.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/logger.cmo src/library/logger.ml
# + /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/logger.cmo src/library/logger.ml
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The dynlink subdirectory has
# been automatically added to the search path, but you should add -I +dynlink
# to the command-line to silence this alert (e.g. by adding dynlink to the list
# of libraries in your dune file, or adding use_dynlink to your _tags file for
# ocamlbuild, or using -package dynlink for ocamlfind).
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/mode.cmo src/library/mode.ml
# + /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/mode.cmo src/library/mode.ml
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/name.cmo src/library/name.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/output.cmo src/library/output.ml
# + /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/output.cmo src/library/output.ml
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/signal.cmo src/library/signal.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/tree.cmo src/library/tree.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/utils.cmo src/library/utils.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/version.cmo src/library/version.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/support -I src -I src/threads -I src/syntax -I src/library -o src/support/daikon.cmo src/support/daikon.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/support -I src -I src/threads -I src/syntax -I src/library -o src/support/log4j.cmo src/support/log4j.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -for-pack Bolt -I src/support -I src -I src/threads -I src/syntax -I src/library -o src/support/paje.cmo src/support/paje.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -pack src/library/utils.cmo src/library/name.cmo src/library/configuration.cmo src/library/configParser.cmo src/library/configLexer.cmo src/library/configurationNew.cmo src/library/configurationOld.cmo src/library/level.cmo src/library/event.cmo src/library/filter.cmo src/library/version.cmo src/library/layout.cmo src/library/signal.cmo src/library/output.cmo src/library/mode.cmo src/library/tree.cmo src/library/logger.cmo src/support/daikon.cmo src/support/log4j.cmo src/support/paje.cmo -o bolt.cmo
# + /home/opam/.opam/5.1/bin/ocamlopt.opt unix.cmxa -I /home/opam/.opam/5.1/lib/ocamlbuild /home/opam/.opam/5.1/lib/ocamlbuild/ocamlbuildlib.cmxa myocamlbuild.ml /home/opam/.opam/5.1/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# WARNINGS=FALSE PATH_OCAML_PREFIX=/home/opam/.opam/5.1 ocamlbuild -classic-display -no-links bolt.cmx
# File "_tags", line 27, characters 19-27:
# Warning: the tag "warnings" is not used in any flag or dependency declaration, so it will have no effect; it may be a typo. Otherwise you can use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
# cp /tmp/version5d6182.ml src/library/version.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/utils.cmx src/library/utils.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/name.cmx src/library/name.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/configuration.cmx src/library/configuration.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/configParser.cmx src/library/configParser.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/configLexer.cmx src/library/configLexer.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/level.cmx src/library/level.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/event.cmx src/library/event.ml
# + /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/event.cmx src/library/event.ml
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/version.cmx src/library/version.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/configurationNew.cmx src/library/configurationNew.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/configurationOld.cmx src/library/configurationOld.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/filter.cmx src/library/filter.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/layout.cmx src/library/layout.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/signal.cmx src/library/signal.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/output.cmx src/library/output.ml
# + /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/output.cmx src/library/output.ml
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/mode.cmx src/library/mode.ml
# + /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/mode.cmx src/library/mode.ml
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/tree.cmx src/library/tree.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/logger.cmx src/library/logger.ml
# + /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/library -I src -I src/threads -I src/syntax -I src/support -o src/library/logger.cmx src/library/logger.ml
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The dynlink subdirectory has
# been automatically added to the search path, but you should add -I +dynlink
# to the command-line to silence this alert (e.g. by adding dynlink to the list
# of libraries in your dune file, or adding use_dynlink to your _tags file for
# ocamlbuild, or using -package dynlink for ocamlfind).
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/support -I src -I src/threads -I src/syntax -I src/library -o src/support/daikon.cmx src/support/daikon.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/support -I src -I src/threads -I src/syntax -I src/library -o src/support/log4j.cmx src/support/log4j.ml
# /home/opam/.opam/5.1/bin/ocamlopt.opt -c -for-pack Bolt -I src/support -I src -I src/threads -I src/syntax -I src/library -o src/support/paje.cmx src/support/paje.ml
# touch bolt.mli  ; if  /home/opam/.opam/5.1/bin/ocamlopt.opt -pack -I src/library -I src/support src/library/utils.cmx src/library/name.cmx src/library/configuration.cmx src/library/configParser.cmx src/library/configLexer.cmx src/library/configurationNew.cmx src/library/configurationOld.cmx src/library/level.cmx src/library/event.cmx src/library/filter.cmx src/library/version.cmx src/library/layout.cmx src/library/signal.cmx src/library/output.cmx src/library/mode.cmx src/library/tree.cmx src/library/logger.cmx src/support/daikon.cmx src/support/log4j.cmx src/support/paje.cmx -o bolt.cmx  ; then  rm -f bolt.mli  ; else  rm -f bolt.mli  ; exit 1; fi
# WARNINGS=FALSE PATH_OCAML_PREFIX=/home/opam/.opam/5.1 ocamlbuild -classic-display -no-links bolt.otarget
# File "_tags", line 27, characters 19-27:
# Warning: the tag "warnings" is not used in any flag or dependency declaration, so it will have no effect; it may be a typo. Otherwise you can use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
# cp /tmp/version8e77ec.ml src/library/version.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -a bolt.cmo -o bolt.cma
# /home/opam/.opam/5.1/bin/ocamlopt.opt -a bolt.cmx -o bolt.cmxa
# WARNINGS=FALSE PATH_OCAML_PREFIX=/home/opam/.opam/5.1 ocamlbuild -classic-display -no-links bolt_pp.cmo
# File "_tags", line 27, characters 19-27:
# Warning: the tag "warnings" is not used in any flag or dependency declaration, so it will have no effect; it may be a typo. Otherwise you can use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
# /home/opam/.opam/5.1/bin/ocamldep.opt -pp /home/opam/.opam/5.1/bin/camlp4of -modules src/syntax/bolt_pp.ml > src/syntax/bolt_pp.ml.depends
# cp /tmp/versionfb53ae.ml src/library/version.ml
# /home/opam/.opam/5.1/bin/ocamlc.opt -c -I /home/opam/.opam/5.1/lib/ocaml/camlp4 -pp /home/opam/.opam/5.1/bin/camlp4of -for-pack Bolt -I src/syntax -I src -I src/threads -I src/support -I src/library -o src/syntax/bolt_pp.cmo src/syntax/bolt_pp.ml
# + /home/opam/.opam/5.1/bin/ocamlc.opt -c -I /home/opam/.opam/5.1/lib/ocaml/camlp4 -pp /home/opam/.opam/5.1/bin/camlp4of -for-pack Bolt -I src/syntax -I src -I src/threads -I src/support -I src/library -o src/syntax/bolt_pp.cmo src/syntax/bolt_pp.ml
# File "src/syntax/bolt_pp.ml", line 135, characters 13-25:
# 135 |       raise (Stream.Error "constant string or module item expected after \"LOG\"") 
#                    ^^^^^^^^^^^^
# Error: Unbound module Stream
# Command exited with code 2.
# make: *** [Makefile:58: all] Error 10
```