### PR TITLE
orun is not compatible with dune 3.0

### DIFF
--- a/packages/orun/orun.0.0.1/opam
+++ b/packages/orun/orun.0.0.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/ocaml-bench/orun/issues"
 dev-repo: "git+https://github.com/shakthimaan/orun"
 depends: [
   "ocaml" {>= "4.07"}
-  "dune" {>= "1.2"}
+  "dune" {>= "1.2" & < "3.0"}
   "conf-libdw" {build}
   "re"
   "cmdliner"


### PR DESCRIPTION
See https://github.com/ocaml-bench/orun/issues/6
```
#=== ERROR while compiling orun.0.0.1 =========================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/orun.0.0.1
# command              ~/.opam/5.2/bin/dune build -p orun -j 1
# exit-code            1
# env-file             ~/.opam/log/orun-20-7e4e8a.env
# output-file          ~/.opam/log/orun-20-7e4e8a.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -w -49 -nopervasives -nostdlib -g -bin-annot -I .profiler.objs/byte -no-alias-deps -o .profiler.objs/byte/profiler.cmo -c -impl profiler.ml-gen)
# File "profiler.ml-gen", line 1:
# Error: Could not find the .cmi file for interface profiler.mli.
```