### PR TITLE
Update ocaml-base-compiler, ocaml-system and ocaml-variants 4.13.0+ with support for native Windows

### DIFF
--- a/packages/arch-x86_32/arch-x86_32.1/opam
+++ b/packages/arch-x86_32/arch-x86_32.1/opam
@@ -11,7 +11,9 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-flags: compiler
+# This package is marked avoid-version in order to steer the default on 64-bit
+# systems towards a 64-bit compiler.
+flags: [compiler avoid-version]
 available: os = "win32"
 depends: [
   ("ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"})

--- a/packages/arch-x86_32/arch-x86_32.1/opam
+++ b/packages/arch-x86_32/arch-x86_32.1/opam
@@ -13,5 +13,8 @@ homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: compiler
 available: os = "win32"
-depends: "ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"}
+depends: [
+  ("ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"})
+  "host-arch-x86_32" {post}
+]
 conflict-class: "ocaml-arch"

--- a/packages/arch-x86_32/arch-x86_32.1/opam
+++ b/packages/arch-x86_32/arch-x86_32.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "Build OCaml for x86 (32-bit)"
+description: """
+Installing this package causes the OCaml compiler packages to target
+32bit Intel x86 (x86_32/x86).
+
+At present, this facility is only available for the native Windows ports of
+OCaml."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: compiler
+available: os = "win32"
+depends: "ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"}
+conflict-class: "ocaml-arch"

--- a/packages/arch-x86_64/arch-x86_64.1/opam
+++ b/packages/arch-x86_64/arch-x86_64.1/opam
@@ -12,7 +12,14 @@ license: "CC0-1.0+"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: compiler
-available: os = "win32"
+# The architecture selection is somewhat belt-and-braces while this system is
+# only available for Windows. The dependency of the OCaml ecosystem on either
+# Cygwin or MSYS2 means that OCaml cannot be used on 32-bit Windows, although
+# 32-bit is fully supported as a target.
+# When these packages are extended to all platforms, the available field would
+# ensure that this package becomes unavailable on a 32-bit system, and the
+# avoid-version in arch-x86_32 will be ignored.
+available: os = "win32" & (arch = "x86_64" | arch = "arm64")
 depends: [
   ("ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"})
   "host-arch-x86_64" {post}

--- a/packages/arch-x86_64/arch-x86_64.1/opam
+++ b/packages/arch-x86_64/arch-x86_64.1/opam
@@ -13,5 +13,8 @@ homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: compiler
 available: os = "win32"
-depends: "ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"}
+depends: [
+  ("ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"})
+  "host-arch-x86_64" {post}
+]
 conflict-class: "ocaml-arch"

--- a/packages/arch-x86_64/arch-x86_64.1/opam
+++ b/packages/arch-x86_64/arch-x86_64.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "Build OCaml for amd64 (64-bit)"
+description: """
+Installing this package causes the OCaml compiler packages to target
+64-bit Intel x86 (x86_64/amd64/x64).
+
+At present, this facility is only available for the native Windows ports of
+OCaml."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: compiler
+available: os = "win32"
+depends: "ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"}
+conflict-class: "ocaml-arch"

--- a/packages/conf-c++/conf-c++.1.0/opam
+++ b/packages/conf-c++/conf-c++.1.0/opam
@@ -4,7 +4,12 @@ authors: "C++ compiler developers"
 homepage: "https://github.com/ocaml/opam-repository"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-2.0-or-later"
-build: ["c++" "--version"]
+build: [
+  "i686-w64-mingw32-c++" {os = "win32" & host-arch-x86_32:installed}
+  "x86_64-w64-mingw32-c++" {os = "win32" & host-arch-x86_64:installed}
+  "c++" {os != "win32" | (!host-arch-x86_32:installed & !host-arch-x86_64:installed)}
+  "--version"
+]
 depexts: [
   ["gcc-c++"] {os-distribution = "centos"}
   ["gcc-c++"] {os-distribution = "fedora"}
@@ -16,6 +21,9 @@ depexts: [
   ["gcc"] {os-distribution = "arch"}
   ["gcc-g++"] {os = "win32" & os-distribution = "cygwinports"}
 ]
+depends:
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-i686" {os = "win32" & os-distribution != "cygwinports"}) |
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-x86_64" {os = "win32" & os-distribution != "cygwinports"})
 synopsis: "Virtual package relying on the c++ compiler"
 description:
   "This package can only install if the c++ compiler is installed on the system."

--- a/packages/conf-c++/conf-c++.1.0/opam
+++ b/packages/conf-c++/conf-c++.1.0/opam
@@ -22,8 +22,8 @@ depexts: [
   ["gcc-g++"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 depends:
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-i686" {os = "win32" & os-distribution != "cygwinports"}) |
-  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  (("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-i686" {os = "win32" & os-distribution != "cygwinports"}) |
+   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-x86_64" {os = "win32" & os-distribution != "cygwinports"}))
 synopsis: "Virtual package relying on the c++ compiler"
 description:
   "This package can only install if the c++ compiler is installed on the system."

--- a/packages/conf-g++/conf-g++.1.0/opam
+++ b/packages/conf-g++/conf-g++.1.0/opam
@@ -4,7 +4,12 @@ authors: "Francois Berenger"
 homepage: "https://github.com/ocaml/opam-repository"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-2.0-or-later"
-build: ["g++" "--version"]
+build: [
+  "i686-w64-mingw32-g++" {os = "win32" & host-arch-x86_32:installed}
+  "x86_64-w64-mingw32-g++" {os = "win32" & host-arch-x86_64:installed}
+  "g++" {os != "win32" | (!host-arch-x86_32:installed & !host-arch-x86_64:installed)}
+  "--version"
+]
 depexts: [
   ["gcc-c++"] {os-distribution = "centos"}
   ["gcc-c++"] {os-distribution = "fedora"}
@@ -18,6 +23,9 @@ depexts: [
   ["gcc-g++"] {os = "win32" & os-distribution = "cygwinports"}
   ["gcc"] {os = "freebsd"}
 ]
+depends:
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-i686" {os = "win32" & os-distribution != "cygwinports"}) |
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-x86_64" {os = "win32" & os-distribution != "cygwinports"})
 synopsis: "Virtual package relying on the g++ compiler (for C++)"
 description:
   "This package can only install if the g++ compiler is installed on the system."

--- a/packages/conf-mingw-w64-gcc-i686/conf-mingw-w64-gcc-i686.1/opam
+++ b/packages/conf-mingw-w64-gcc-i686/conf-mingw-w64-gcc-i686.1/opam
@@ -8,6 +8,10 @@ homepage: "https://www.mingw-w64.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
+depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
+]
 build: ["i686-w64-mingw32-gcc" "--version"]
 depexts: [
   ["mingw64-i686-gcc-core"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-gcc-x86_64/conf-mingw-w64-gcc-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gcc-x86_64/conf-mingw-w64-gcc-x86_64.1/opam
@@ -8,6 +8,10 @@ homepage: "https://www.mingw-w64.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
+depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
+]
 build: ["x86_64-w64-mingw32-gcc" "--version"]
 depexts: [
   ["mingw64-x86_64-gcc-core"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-pkgconf-i686/conf-mingw-w64-pkgconf-i686.1/opam
+++ b/packages/conf-mingw-w64-pkgconf-i686/conf-mingw-w64-pkgconf-i686.1/opam
@@ -8,6 +8,10 @@ homepage: "http://pkgconf.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
+depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
+]
 build: ["i686-w64-mingw32-pkgconf" "--version"]
 depexts: [
   ["mingw-w64-i686-pkgconf"] {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-pkgconf-x86_64/conf-mingw-w64-pkgconf-x86_64.1/opam
+++ b/packages/conf-mingw-w64-pkgconf-x86_64/conf-mingw-w64-pkgconf-x86_64.1/opam
@@ -8,6 +8,10 @@ homepage: "http://pkgconf.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
+depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
+]
 build: ["x86_64-w64-mingw32-pkgconf" "--version"]
 depexts: [
   ["mingw-w64-x86_64-pkgconf"] {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-zstd-i686/conf-mingw-w64-zstd-i686.1/opam
+++ b/packages/conf-mingw-w64-zstd-i686/conf-mingw-w64-zstd-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libzstd"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-zstd-x86_64/conf-mingw-w64-zstd-x86_64.1/opam
+++ b/packages/conf-mingw-w64-zstd-x86_64/conf-mingw-w64-zstd-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libzstd"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-pkg-config/conf-pkg-config.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.3/opam
@@ -4,9 +4,13 @@ authors: ["Francois Berenger"]
 homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-1.0-or-later"
+depends: [
+  ("host-arch-x86_64" {os = "win32" & os-distribution = "msys2"} & "conf-mingw-w64-pkgconf-x86_64" {os = "win32" & os-distribution = "msys2"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution = "msys2"} & "conf-mingw-w64-pkgconf-i686" {os = "win32" & os-distribution = "msys2"})
+]
 build: [
   ["pkg-config" "--help"] {os != "openbsd" & os != "win32"}
-  ["pkgconf" "--version"] {os = "win32"}
+  ["pkgconf" "--version"] {os = "win32" & os-distribution != "msys2"}
 ]
 depexts: [
   ["pkg-config"] {os-family = "debian" | os-family = "ubuntu"}

--- a/packages/conf-zstd/conf-zstd.1.3.8/opam
+++ b/packages/conf-zstd/conf-zstd.1.3.8/opam
@@ -5,9 +5,17 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Facebook"]
 license: "BSD-3-Clause"
 build: [
-  ["pkg-config" "--atleast-version=1.3.8" "libzstd"]
+  ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution != "cygwin"}
+   "--atleast-version=1.3.8" "libzstd"]
 ]
-depends: ["conf-pkg-config" {build}]
+depends: [
+  "conf-pkg-config" {build}
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zstd-i686" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zstd-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+]
 depexts: [
   ["libzstd-dev"] {os-family = "debian"}
   ["libzstd-dev"] {os-family = "ubuntu"}

--- a/packages/conf-zstd/conf-zstd.1.3.8/opam
+++ b/packages/conf-zstd/conf-zstd.1.3.8/opam
@@ -13,8 +13,8 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zstd-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zstd-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  (("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zstd-i686" {os = "win32" & os-distribution != "cygwinports"}) |
+   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zstd-x86_64" {os = "win32" & os-distribution != "cygwinports"}))
 ]
 depexts: [
   ["libzstd-dev"] {os-family = "debian"}

--- a/packages/host-arch-arm32/host-arch-arm32.1/opam
+++ b/packages/host-arch-arm32/host-arch-arm32.1/opam
@@ -1,0 +1,16 @@
+opam-version: "2.0"
+synopsis: "OCaml on AArch32 (32-bit)"
+description: """
+This package is installed if the underlying OCaml compiler is for 32-bit ARM.
+
+Precisely, this means `ocamlopt -config-var architecture` equals `arm`.
+
+This package may be used in depends or conflicts fields of dependent packages
+to indicate either a requirement or an incompatibility with this
+architecture."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+conflict-class: "ocaml-host-arch"

--- a/packages/host-arch-arm64/host-arch-arm64.1/opam
+++ b/packages/host-arch-arm64/host-arch-arm64.1/opam
@@ -1,0 +1,16 @@
+opam-version: "2.0"
+synopsis: "OCaml on AArch64 (64-bit)"
+description: """
+This package is installed if the underlying OCaml compiler is for 64-bit ARM.
+
+Precisely, this means `ocamlopt -config-var architecture` equals `arm64`.
+
+This package may be used in depends or conflicts fields of dependent packages
+to indicate either a requirement or an incompatibility with this
+architecture."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+conflict-class: "ocaml-host-arch"

--- a/packages/host-arch-ppc64/host-arch-ppc64.1/opam
+++ b/packages/host-arch-ppc64/host-arch-ppc64.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "OCaml on 64-bit IBM POWER"
+description: """
+This package is installed if the underlying OCaml compiler is for
+64-bit IBM POWER.
+
+Precisely, this means `ocamlopt -config-var architecture` equals `power`.
+
+This package may be used in depends or conflicts fields of dependent packages
+to indicate either a requirement or an incompatibility with this
+architecture."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+conflict-class: "ocaml-host-arch"

--- a/packages/host-arch-riscv64/host-arch-riscv64.1/opam
+++ b/packages/host-arch-riscv64/host-arch-riscv64.1/opam
@@ -1,0 +1,16 @@
+opam-version: "2.0"
+synopsis: "OCaml on 64-bit RISC-V"
+description: """
+This package is installed if the underlying OCaml compiler is for 64-bit RISC-V.
+
+Precisely, this means `ocamlopt -config-var architecture` equals `riscv`.
+
+This package may be used in depends or conflicts fields of dependent packages
+to indicate either a requirement or an incompatibility with this
+architecture."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+conflict-class: "ocaml-host-arch"

--- a/packages/host-arch-s390x/host-arch-s390x.1/opam
+++ b/packages/host-arch-s390x/host-arch-s390x.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "OCaml on 64-bit IBM z/Architecture"
+description: """
+This package is installed if the underlying OCaml compiler is for
+64-bit IBM z/Architecture (s390x).
+
+Precisely, this means `ocamlopt -config-var architecture` equals `s390x`.
+
+This package may be used in depends or conflicts fields of dependent packages
+to indicate either a requirement or an incompatibility with this
+architecture."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+conflict-class: "ocaml-host-arch"

--- a/packages/host-arch-unknown/host-arch-unknown.1/opam
+++ b/packages/host-arch-unknown/host-arch-unknown.1/opam
@@ -1,0 +1,16 @@
+opam-version: "2.0"
+synopsis: "OCaml on an unknown architecture"
+description: """
+This package is installed if the underlying OCaml compiler is for an unknown
+architecture.
+
+Precisely, this means `ocamlopt -config-var architecture` equals `none`.
+
+It is not expected that this package be used in depends or conflicts fields of
+dependent packages."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+conflict-class: "ocaml-host-arch"

--- a/packages/host-arch-x86_32/host-arch-x86_32.1/opam
+++ b/packages/host-arch-x86_32/host-arch-x86_32.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "OCaml on x86 (32-bit)"
+description: """
+This package is installed if the underlying OCaml compiler is for
+32-bit Intel x86 (x86_32/x86).
+
+Precisely, this means `ocamlopt -config-var architecture` equals `i386`.
+
+This package may be used in depends or conflicts fields of dependent packages
+to indicate either a requirement or an incompatibility with this
+architecture."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+conflict-class: "ocaml-host-arch"

--- a/packages/host-arch-x86_64/host-arch-x86_64.1/opam
+++ b/packages/host-arch-x86_64/host-arch-x86_64.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "OCaml on amd64 (64-bit)"
+description: """
+This package is installed if the underlying OCaml compiler is for
+64-bit Intel x86 (x86_64/amd64/x64).
+
+Precisely, this means `ocamlopt -config-var architecture` equals `amd64`.
+
+This package may be used in depends or conflicts fields of dependent packages
+to indicate either a requirement or an incompatibility with this
+architecture."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+conflict-class: "ocaml-host-arch"

--- a/packages/host-system-mingw/host-system-mingw.1/opam
+++ b/packages/host-system-mingw/host-system-mingw.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "OCaml for mingw-w64"
+description: """
+This package is installed if the underlying OCaml compiler is one of the
+mingw-w64 native Windows ports of OCaml.
+
+Precisely, this means `ocamlopt -config-var system` is equal to either `mingw`
+or `mingw64`.
+
+This package may be used in depends or conflicts fields of dependent packages
+to indicate either a requirement or an incompatibility with this OCaml port."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+conflict-class: "ocaml-host-system"

--- a/packages/host-system-msvc/host-system-msvc.1/opam
+++ b/packages/host-system-msvc/host-system-msvc.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "OCaml for Microsoft Visual Studio"
+description: """
+This package is installed if the underlying OCaml compiler is one of the "MSVC"
+native Windows ports of OCaml.
+
+Precisely, this means `ocamlopt -config-var system` is equal to either `win32`
+or `win64`.
+
+This package may be used in depends or conflicts fields of dependent packages
+to indicate either a requirement or an incompatibility with this OCaml port."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+conflict-class: "ocaml-host-system"

--- a/packages/host-system-other/host-system-other.1/opam
+++ b/packages/host-system-other/host-system-other.1/opam
@@ -1,0 +1,15 @@
+opam-version: "2.0"
+synopsis: "OCaml on an unidentified system"
+description: """
+This package is installed if the underlying OCaml compiler's system is not
+recognised by opam-repository's compiler packaging.
+
+It is not expected that this package be used in depends or conflicts fields of
+dependent packages, given that its use may be changed if the packaging is
+subsequently enhanced to recognise the system value."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+conflict-class: "ocaml-host-system"

--- a/packages/msys2-clang32/msys2-clang32.1/opam
+++ b/packages/msys2-clang32/msys2-clang32.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "MSYS2 CLANG32 Environment"
+description: """
+This package selects the CLANG32 MSYS2 Environment.
+
+Toolchain: llvm
+Architecture: i686
+C Runtime Library: ucrt
+C++ Runtime Library: libc++"""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: compiler
+depends: "msys2" {post}
+conflict-class: "msys2-env"

--- a/packages/msys2-clang64/msys2-clang64.1/opam
+++ b/packages/msys2-clang64/msys2-clang64.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "MSYS2 CLANG64 Environment"
+description: """
+This package selects the CLANG64 MSYS2 Environment.
+
+Toolchain: llvm
+Architecture: x86_64
+C Runtime Library: ucrt
+C++ Runtime Library: libc++"""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: compiler
+depends: "msys2" {post}
+conflict-class: "msys2-env"

--- a/packages/msys2-clangarm64/msys2-clangarm64.1/opam
+++ b/packages/msys2-clangarm64/msys2-clangarm64.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "MSYS2 CLANGARM64 Environment"
+description: """
+This package selects the CLANGARM64 MSYS2 Environment.
+
+Toolchain: llvm
+Architecture: aarch64
+C Runtime Library: ucrt
+C++ Runtime Library: libc++"""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: compiler
+depends: "msys2" {post}
+conflict-class: "msys2-env"

--- a/packages/msys2-mingw32/msys2-mingw32.1/opam
+++ b/packages/msys2-mingw32/msys2-mingw32.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "MSYS2 MINGW32 Environment"
+description: """
+This package selects the MINGW32 MSYS2 Environment.
+
+Toolchain: gcc (mingw-w64)
+Architecture: i686
+C Runtime Library: msvcrt
+C++ Runtime Library: libstdc++"""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: compiler
+depends: "msys2" {post}
+conflict-class: "msys2-env"

--- a/packages/msys2-mingw64/msys2-mingw64.1/opam
+++ b/packages/msys2-mingw64/msys2-mingw64.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "MSYS2 MINGW64 Environment"
+description: """
+This package selects the MINGW64 MSYS2 Environment.
+
+Toolchain: gcc (mingw-w64)
+Architecture: x86_64
+C Runtime Library: msvcrt
+C++ Runtime Library: libstdc++"""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: compiler
+depends: "msys2" {post}
+conflict-class: "msys2-env"

--- a/packages/msys2-ucrt64/msys2-ucrt64.1/opam
+++ b/packages/msys2-ucrt64/msys2-ucrt64.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "MSYS2 UCRT64 Environment"
+description: """
+This package selects the UCRT64 MSYS2 Environment.
+
+Toolchain: gcc (mingw-w64)
+Architecture: x86_64
+C Runtime Library: ucrt
+C++ Runtime Library: libstdc++"""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: compiler
+depends: "msys2" {post}
+conflict-class: "msys2-env"

--- a/packages/msys2/msys2.0.1.0/opam
+++ b/packages/msys2/msys2.0.1.0/opam
@@ -1,0 +1,83 @@
+opam-version: "2.0"
+synopsis: "MSYS2 Environment Settings"
+description: """
+After installation, the package's variables indicate which MSYS2 Environment is
+active.
+
+- msys2:msystem (exported as MSYSTEM) is the MSYS2 Environment Name.
+- msys2:carch (exported as MSYSTEM_CARCH) is the compiler's target architecture
+  (i686, x86_64 or aarch64),
+- msys2:chost (exported as MSYSTEM_CHOST and MINGW_CHOST) is the compiler's
+  target triplet ("%{msys2:carch}%-w64-mingw32").
+- msys2:root (exported as MSYSTEM_PREFIX and MINGW_PREFIX) is the Unix path to
+  the root of the MSYS2 Environment.
+- msys2:package-prefix (exported as MINGW_PACKAGE_PREFIX) is the prefix used for
+  MSYS2 Pacman packages for this Environment.
+
+Additionally, Path, MANPATH and INFOPATH are all updated with the appropriate
+directories from msys2:root. PKG_CONFIG_PATH, PKG_CONFIG_SYSTEM_INCLUDE_PATH,
+PKG_CONFIG_SYSTEM_LIBRARY_PATH and ACLOCAL_PATH are all _set_ to the appropriate
+values for msys2:root. Finally, CONFIG_SITE is exported as /etc/config.site as
+per MSYS2's own configuration.
+
+See https://www.msys2.org/docs/environments/ for further information."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: compiler
+available: os = "win32" & os-distribution = "msys2"
+dev-repo: "git+https://github.com/dra27/msys2-opam.git"
+build: [
+  ["sh" "./gen_config.sh" name
+        "CLANG32" {msys2-clang32:installed}
+        "CLANG64" {msys2-clang64:installed}
+        "CLANGARM64" {msys2-clangarm64:installed}
+        "MINGW32" {msys2-mingw32:installed}
+        "MINGW64" {msys2-mingw64:installed}
+        "UCRT64" {msys2-ucrt64:installed}]
+]
+depends:
+  ("msys2-clang32" |
+   "msys2-clang64" |
+   "msys2-clangarm64" |
+   "msys2-mingw32" |
+   "msys2-mingw64" |
+   "msys2-ucrt64")
+setenv: [
+  [ CONFIG_SITE = "/etc/config.site" ]
+  [ MSYSTEM = "%{_:msystem}%" ]
+  [ MSYSTEM_CARCH = "%{_:carch}%" ]
+  [ MSYSTEM_CHOST = "%{_:chost}%" ]
+  [ MSYSTEM_PREFIX = "%{_:root}%" ]
+  [ MINGW_CHOST = "%{_:chost}%" ]
+  [ MINGW_PREFIX = "%{_:root}%" ]
+  [ MINGW_PACKAGE_PREFIX = "%{_:package-prefix}%" ]
+  [ PATH += "%{_:native-root}%/bin" ]
+  [ MANPATH += "%{_:root}%/local/man" ]
+  [ MANPATH += "%{_:root}%/share/man" ]
+  [ INFOPATH += "%{_:root}%/local/info" ]
+  [ INFOPATH += "%{_:root}%/share/info" ]
+  [ PKG_CONFIG_PATH = "%{_:root}%/lib/pkgconfig:%{_:root}%/share/pkgconfig" ]
+  [ PKG_CONFIG_SYSTEM_INCLUDE_PATH = "%{_:root}%/include" ]
+  [ PKG_CONFIG_SYSTEM_LIBRARY_PATH = "%{_:root}%/lib" ]
+  [ ACLOCAL_PATH = "%{_:root}%/share/aclocal:%{_:root}%/usr/share/aclocal" ]
+]
+x-env-path-rewrite: [
+  [ PATH ";" "target-quoted" ]
+  [ MANPATH ":" "host" ]
+  [ INFOPATH ":" "host" ]
+  [ PKG_CONFIG_PATH false ]
+  [ PKG_CONFIG_SYSTEM_INCLUDE_PATH false ]
+  [ PKG_CONFIG_SYSTEM_LIBRARY_PATH false ]
+  [ ACLOCAL_PATH false ]
+]
+url {
+  src:
+    "https://github.com/dra27/msys2-opam/archive/refs/tags/0.1.0.tar.gz"
+  checksum: [
+    "sha256=9532eb3711376d8437d95abbf91875755a933882ec58b4b5f2318e8a1d6f312c"
+    "sha512=bcf3adbec1dfe065785f36e27fa84a7de72dea71d0cb0a63b2fb9fd89fac9db5455caa6aafeec7ce98317438677aacb77e6e28b24ba67481b19ebe45dca98cc4"
+  ]
+}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0/opam
@@ -8,21 +8,65 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml"
+dev-repo: "git+https://github.com/ocaml/ocaml#4.13"
 depends: [
+  # This is OCaml 4.13.0
   "ocaml" {= "4.13.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post}
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # i686 mingw-w64 / MSVC
+   "arch-x86_32" {os = "win32"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
   "ocaml-options-vanilla" {post}
+
+  # Support Packages
+  "flexdll" {>= "0.36" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
+build-env: MSYS2_ARG_CONV_EXCL = "*"
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0/opam
@@ -35,13 +35,13 @@ depends: [
 
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # i686 mingw-w64 / MSVC
-   "arch-x86_32" {os = "win32"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+   ("arch-x86_32" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.1/opam
@@ -8,21 +8,65 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml"
+dev-repo: "git+https://github.com/ocaml/ocaml#4.13"
 depends: [
+  # This is OCaml 4.13.1
   "ocaml" {= "4.13.1" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post}
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # i686 mingw-w64 / MSVC
+   "arch-x86_32" {os = "win32"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
   "ocaml-options-vanilla" {post}
+
+  # Support Packages
+  "flexdll" {>= "0.36" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
+build-env: MSYS2_ARG_CONV_EXCL = "*"
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.1/opam
@@ -35,13 +35,13 @@ depends: [
 
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # i686 mingw-w64 / MSVC
-   "arch-x86_32" {os = "win32"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+   ("arch-x86_32" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
@@ -8,22 +8,66 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml"
+dev-repo: "git+https://github.com/ocaml/ocaml#4.14"
 depends: [
+  # This is OCaml 4.14.0
   "ocaml" {= "4.14.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post}
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # i686 mingw-w64 / MSVC
+   "arch-x86_32" {os = "win32"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
   "ocaml-options-vanilla" {post}
+
+  # Support Packages
+  "flexdll" {>= "0.36" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
+build-env: MSYS2_ARG_CONV_EXCL = "*"
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
@@ -35,13 +35,13 @@ depends: [
 
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # i686 mingw-w64 / MSVC
-   "arch-x86_32" {os = "win32"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+   ("arch-x86_32" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1/opam
@@ -35,13 +35,13 @@ depends: [
 
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # i686 mingw-w64 / MSVC
-   "arch-x86_32" {os = "win32"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+   ("arch-x86_32" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1/opam
@@ -8,22 +8,66 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml"
+dev-repo: "git+https://github.com/ocaml/ocaml#4.14"
 depends: [
+  # This is OCaml 4.14.1
   "ocaml" {= "4.14.1" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post}
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # i686 mingw-w64 / MSVC
+   "arch-x86_32" {os = "win32"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
   "ocaml-options-vanilla" {post}
+
+  # Support Packages
+  "flexdll" {>= "0.36" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
+build-env: MSYS2_ARG_CONV_EXCL = "*"
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.2/opam
@@ -35,13 +35,13 @@ depends: [
 
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # i686 mingw-w64 / MSVC
-   "arch-x86_32" {os = "win32"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+   ("arch-x86_32" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.2/opam
@@ -8,22 +8,66 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml"
+dev-repo: "git+https://github.com/ocaml/ocaml#4.14"
 depends: [
+  # This is OCaml 4.14.2
   "ocaml" {= "4.14.2" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post}
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # i686 mingw-w64 / MSVC
+   "arch-x86_32" {os = "win32"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
   "ocaml-options-vanilla" {post}
+
+  # Support Packages
+  "flexdll" {>= "0.36" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
+build-env: MSYS2_ARG_CONV_EXCL = "*"
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0/opam
@@ -8,25 +8,65 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: "Xavier Leroy and many contributors"
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml"
+dev-repo: "git+https://github.com/ocaml/ocaml#5.0"
 depends: [
+  # This is OCaml 5.0.0
   "ocaml" {= "5.0.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post}
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
   "ocaml-options-vanilla" {post}
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
+conflicts: "system-msvc"
 conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0/opam
@@ -37,11 +37,11 @@ depends: [
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0/opam
@@ -10,23 +10,63 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml#5.1"
 depends: [
+  # This is OCaml 5.1.0
   "ocaml" {= "5.1.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post}
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
   "ocaml-options-vanilla" {post}
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
+conflicts: "system-msvc"
 conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0/opam
@@ -37,11 +37,11 @@ depends: [
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1/opam
@@ -10,23 +10,63 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml#5.1"
 depends: [
+  # This is OCaml 5.1.1
   "ocaml" {= "5.1.1" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post}
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
   "ocaml-options-vanilla" {post}
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
+conflicts: "system-msvc"
 conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1/opam
@@ -37,11 +37,11 @@ depends: [
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0/opam
@@ -10,23 +10,63 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml#5.2"
 depends: [
+  # This is OCaml 5.2.0
   "ocaml" {= "5.2.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post}
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
   "ocaml-options-vanilla" {post}
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
+conflicts: "system-msvc"
 conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0/opam
@@ -37,11 +37,11 @@ depends: [
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~alpha1/opam
@@ -10,24 +10,65 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml#5.2"
 depends: [
+  # This is OCaml 5.2.0
   "ocaml" {= "5.2.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post}
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
   "ocaml-options-vanilla" {post}
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
-  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
+conflicts: "system-msvc"
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~alpha1/opam
@@ -39,11 +39,11 @@ depends: [
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta1/opam
@@ -10,24 +10,65 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml#5.2"
 depends: [
+  # This is OCaml 5.2.0
   "ocaml" {= "5.2.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post}
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
   "ocaml-options-vanilla" {post}
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
-  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
+conflicts: "system-msvc"
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta1/opam
@@ -39,11 +39,11 @@ depends: [
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta2/opam
@@ -10,24 +10,65 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml#5.2"
 depends: [
+  # This is OCaml 5.2.0
   "ocaml" {= "5.2.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post}
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
   "ocaml-options-vanilla" {post}
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
-  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
+conflicts: "system-msvc"
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta2/opam
@@ -39,11 +39,11 @@ depends: [
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~rc1/opam
@@ -10,24 +10,65 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml#5.2"
 depends: [
+  # This is OCaml 5.2.0
   "ocaml" {= "5.2.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post}
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
   "ocaml-options-vanilla" {post}
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
-  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
+conflicts: "system-msvc"
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~rc1/opam
@@ -39,11 +39,11 @@ depends: [
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-beta/ocaml-beta.disabled/opam
+++ b/packages/ocaml-beta/ocaml-beta.disabled/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "David Allsopp <david@tarides.com>"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml-config/ocaml-config.0/opam
+++ b/packages/ocaml-config/ocaml-config.0/opam
@@ -7,6 +7,7 @@ authors: [
   "Louis Gesbert <louis.gesbert@ocamlpro.com>"
   "David Allsopp <david.allsopp@metastack.com>"
 ]
+license: "ISC"
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
@@ -31,4 +32,4 @@ extra-source "gen_ocaml_config.ml.in" {
     "md5=6209d629171ad6ce6677de1aff759ac5"
   ]
 }
-
+available: os != "win32"

--- a/packages/ocaml-config/ocaml-config.1/opam
+++ b/packages/ocaml-config/ocaml-config.1/opam
@@ -7,6 +7,7 @@ authors: [
   "Louis Gesbert <louis.gesbert@ocamlpro.com>"
   "David Allsopp <david.allsopp@metastack.com>"
 ]
+license: "ISC"
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
@@ -31,4 +32,4 @@ extra-source "gen_ocaml_config.ml.in" {
     "md5=71f88c92be191cf4a0547f3c6196ef00"
   ]
 }
-
+available: os != "win32"

--- a/packages/ocaml-config/ocaml-config.2/opam
+++ b/packages/ocaml-config/ocaml-config.2/opam
@@ -7,6 +7,7 @@ authors: [
   "Louis Gesbert <louis.gesbert@ocamlpro.com>"
   "David Allsopp <david.allsopp@metastack.com>"
 ]
+license: "ISC"
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
@@ -31,3 +32,4 @@ extra-source "gen_ocaml_config.ml.in" {
     "md5=a4b41e3236593d8271295b84b0969172"
   ]
 }
+available: os != "win32"

--- a/packages/ocaml-env-mingw32/ocaml-env-mingw32.1/opam
+++ b/packages/ocaml-env-mingw32/ocaml-env-mingw32.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "GCC mingw-w64 OCaml Runtime Dependency (32-bit)"
+description: """
+This package is an internal part of the implementation of the OCaml compiler in
+opam-repository.
+
+This package is used to create an indirection between the OCaml compiler
+packages and conf-mingw-w64-gcc-x86_64. The compiler packages must have one of
+conf-mingw-w64-gcc-i686 or conf-mingw-w64-gcc-x86_64 depending on configuration,
+but if they directly refer to both packages in their depends fields then the
+subsequent installation of the _other_ C compiler package would trigger a
+rebuild of the OCaml compiler package, because it changes its dependency cone.
+By having the compiler packages instead depend on either ocaml-env-mingw64 or
+ocaml-env-mingw32, the installation of conf-mingw-w64-gcc-x86_64 into a switch
+already containing ocaml-env-mingw32 does not trigger a rebuild of the OCaml
+compiler, because ocaml-env-mingw64 is not installed."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+depends: [
+  "host-system-mingw" {post}
+  "host-arch-x86_32" {post}
+  "conf-mingw-w64-gcc-i686"
+]
+conflict-class: "ocaml-env-mingw"
+flags: conf

--- a/packages/ocaml-env-mingw64/ocaml-env-mingw64.1/opam
+++ b/packages/ocaml-env-mingw64/ocaml-env-mingw64.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "GCC mingw-w64 OCaml Runtime Dependency (64-bit)"
+description: """
+This package is an internal part of the implementation of the OCaml compiler in
+opam-repository.
+
+This package is used to create an indirection between the OCaml compiler
+packages and conf-mingw-w64-gcc-i686. The compiler packages must have one of
+conf-mingw-w64-gcc-i686 or conf-mingw-w64-gcc-x86_64 depending on configuration,
+but if they directly refer to both packages in their depends fields then the
+subsequent installation of the _other_ C compiler package would trigger a
+rebuild of the OCaml compiler package, because it changes its dependency cone.
+By having the compiler packages instead depend on either ocaml-env-mingw64 or
+ocaml-env-mingw32, the installation of conf-mingw-w64-gcc-i686 into a switch
+already containing ocaml-env-mingw64 does not trigger a rebuild of the OCaml
+compiler, because ocaml-env-mingw32 is not installed."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+depends: [
+  "host-system-mingw" {post}
+  "host-arch-x86_64" {post}
+  "conf-mingw-w64-gcc-x86_64"
+]
+conflict-class: "ocaml-env-mingw"
+flags: conf

--- a/packages/ocaml-env-msvc32/ocaml-env-msvc32.1/opam
+++ b/packages/ocaml-env-msvc32/ocaml-env-msvc32.1/opam
@@ -19,7 +19,10 @@ depends: [
   "conf-msvc32"
 ]
 conflict-class: "ocaml-env-msvc"
-flags: conf
+# This package is marked avoid-version because opam 2.x's depext system has no
+# way of detecting Microsoft Visual Studio, but it can install the mingw-w64
+# compilers. It is intended to address this as part of opam 3.x.
+flags: [conf avoid-version]
 build: [
   ["xcopy" "%{conf-msvc32:share}%\\conf-msvc32.config" "%{_:name}%.config*"]
 ]

--- a/packages/ocaml-env-msvc32/ocaml-env-msvc32.1/opam
+++ b/packages/ocaml-env-msvc32/ocaml-env-msvc32.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Microsoft C Compiler OCaml Runtime Dependency (32-bit)"
+description: """
+This package is an internal part of the implementation of the OCaml compiler in
+opam-repository. It is used to store the active environment variable settings
+for Microsoft Visual Studio and adds them to the environment.
+"""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+# opam-repository mandates 2.2.0+ when setenv may perform `+= ""`, since some
+# versions of 2.0.x and 2.1.x crash on these updates.
+available: opam-version >= "2.2.0~"
+depends: [
+  "host-system-msvc" {post}
+  "host-arch-x86_32" {post}
+  "conf-msvc32"
+]
+conflict-class: "ocaml-env-msvc"
+flags: conf
+build: [
+  ["xcopy" "%{conf-msvc32:share}%\\conf-msvc32.config" "%{_:name}%.config*"]
+]
+setenv: [
+  [PATH += "%{_:msvs-bin}%"]
+  [INCLUDE += "%{_:msvs-inc}%"]
+  [LIB += "%{_:msvs-lib}%"]
+]
+x-env-path-rewrite: [
+  [ PATH false ]
+  [ INCLUDE false ]
+  [ LIB false ]
+]

--- a/packages/ocaml-env-msvc64/ocaml-env-msvc64.1/opam
+++ b/packages/ocaml-env-msvc64/ocaml-env-msvc64.1/opam
@@ -19,7 +19,10 @@ depends: [
   "conf-msvc64"
 ]
 conflict-class: "ocaml-env-msvc"
-flags: conf
+# This package is marked avoid-version because opam 2.x's depext system has no
+# way of detecting Microsoft Visual Studio, but it can install the mingw-w64
+# compilers. It is intended to address this as part of opam 3.x.
+flags: [conf avoid-version]
 build: [
   ["xcopy" "%{conf-msvc64:share}%\\conf-msvc64.config" "%{_:name}%.config*"]
 ]

--- a/packages/ocaml-env-msvc64/ocaml-env-msvc64.1/opam
+++ b/packages/ocaml-env-msvc64/ocaml-env-msvc64.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Microsoft C Compiler OCaml Runtime Dependency (64-bit)"
+description: """
+This package is an internal part of the implementation of the OCaml compiler in
+opam-repository. It is used to store the active environment variable settings
+for Microsoft Visual Studio and adds them to the environment.
+"""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+# opam-repository mandates 2.2.0+ when setenv may perform `+= ""`, since some
+# versions of 2.0.x and 2.1.x crash on these updates.
+available: opam-version >= "2.2.0~"
+depends: [
+  "host-system-msvc" {post}
+  "host-arch-x86_64" {post}
+  "conf-msvc64"
+]
+conflict-class: "ocaml-env-msvc"
+flags: conf
+build: [
+  ["xcopy" "%{conf-msvc64:share}%\\conf-msvc64.config" "%{_:name}%.config*"]
+]
+setenv: [
+  [PATH += "%{_:msvs-bin}%"]
+  [INCLUDE += "%{_:msvs-inc}%"]
+  [LIB += "%{_:msvs-lib}%"]
+]
+x-env-path-rewrite: [
+  [ PATH false ]
+  [ INCLUDE false ]
+  [ LIB false ]
+]

--- a/packages/ocaml-option-32bit/ocaml-option-32bit.1/opam
+++ b/packages/ocaml-option-32bit/ocaml-option-32bit.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Set OCaml to be compiled in 32-bit mode for 64-bit Linux and OS X hosts"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depexts: [
   ["gcc-multilib" "g++-multilib"] {os-family = "debian"}
 ]

--- a/packages/ocaml-option-address-sanitizer/ocaml-option-address-sanitizer.1/opam
+++ b/packages/ocaml-option-address-sanitizer/ocaml-option-address-sanitizer.1/opam
@@ -4,6 +4,13 @@ description: """
 This configuration package enables memory leak sanitzation using
 the -fsanitize=leak gcc and clang option.
 """
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 post-messages: """
 Make sure to set ASAN_OPTIONS=detect_leaks=0,exitcode=0
 while compiling and to unset it before running compiled binaries.

--- a/packages/ocaml-option-afl/ocaml-option-afl.1/opam
+++ b/packages/ocaml-option-afl/ocaml-option-afl.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Set OCaml to be compiled with afl-fuzz instrumentation"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   "ocaml-variants" {post & >= "4.12.0~"}
 ]

--- a/packages/ocaml-option-bytecode-only/ocaml-option-bytecode-only.1/opam
+++ b/packages/ocaml-option-bytecode-only/ocaml-option-bytecode-only.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Compile OCaml without the native-code compiler"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   "ocaml-variants" {post & >= "4.12.0~"} |
   "ocaml-base-compiler" {post & >= "5.0.0~~" & arch != "arm64" & arch != "x86_64"}

--- a/packages/ocaml-option-bytecode-only/ocaml-option-bytecode-only.1/opam
+++ b/packages/ocaml-option-bytecode-only/ocaml-option-bytecode-only.1/opam
@@ -9,7 +9,13 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "CC0-1.0+"
 depends: [
   "ocaml-variants" {post & >= "4.12.0~"} |
-  "ocaml-base-compiler" {post & >= "5.0.0~~" & arch != "arm64" & arch != "x86_64"}
+  # See equivalent constraint in ocaml-options-vanilla
+  # Windows is permitted to install 32-bit versions of ocaml-base-compiler on
+  # 64-bit systems hence the (temporary) addition of the `os = "win32"` here,
+  # at least until the ocaml-option- / base- mess is fixed. Note that this puts
+  # 64-bit Windows into the same class as ppc64, riscv64 and s390x where
+  # ocaml-option-bytecode-only can be installed, but has no effect.
+  "ocaml-base-compiler" {post & >= "5.0.0~~" & arch != "arm64" & (arch != "x86_64" | os = "win32")}
 ]
 conflicts: [ "ocaml-option-afl" "ocaml-option-fp" "ocaml-option-flambda" ]
 maintainer: "David Allsopp <david@tarides.com>"

--- a/packages/ocaml-option-default-unsafe-string/ocaml-option-default-unsafe-string.1/opam
+++ b/packages/ocaml-option-default-unsafe-string/ocaml-option-default-unsafe-string.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Set OCaml to be compiled without safe strings by default"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   "ocaml-variants" {post & >= "4.12.0~" & < "5.0.0~~"}
 ]

--- a/packages/ocaml-option-flambda/ocaml-option-flambda.1/opam
+++ b/packages/ocaml-option-flambda/ocaml-option-flambda.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Set OCaml to be compiled with flambda activated"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   "ocaml-variants" {post & >= "4.12.0~"}
 ]

--- a/packages/ocaml-option-fp/ocaml-option-fp.1/opam
+++ b/packages/ocaml-option-fp/ocaml-option-fp.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Set OCaml to be compiled with frame-pointers enabled"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   "ocaml-variants" {post & >= "4.12.0~"}
 ]

--- a/packages/ocaml-option-leak-sanitizer/ocaml-option-leak-sanitizer.1/opam
+++ b/packages/ocaml-option-leak-sanitizer/ocaml-option-leak-sanitizer.1/opam
@@ -4,6 +4,13 @@ description: """
 This configuration package enables memory address sanitzation using
 the -fsanitize=address gcc and clang option.
 """
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 post-messages: """
 Make sure to set LSAN_OPTIONS=detect_leaks=0,exitcode=0
 while compiling and to unset it before running compiled binaries.

--- a/packages/ocaml-option-mingw/ocaml-option-mingw.1/opam
+++ b/packages/ocaml-option-mingw/ocaml-option-mingw.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "Select the mingw-w64 Windows port of OCaml"
+description: """
+This package simply causes system-mingw to be selected.
+
+It's a legacy package from the "temporary" packaging of the mingw-w64 port of
+OCaml provided by @dra27 during 2022 and 2023, which is why there is no -msvc
+equivalent."""
+authors: "David Allsopp"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
+depends: [
+  "ocaml-variants" {post & >= "4.12.0~"}
+  "system-mingw"
+]
+available: os = "win32"
+maintainer: "David Allsopp <david@tarides.com>"
+flags: compiler

--- a/packages/ocaml-option-musl/ocaml-option-musl.1/opam
+++ b/packages/ocaml-option-musl/ocaml-option-musl.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Set OCaml to be compiled with musl-gcc"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   "ocaml-variants" {post & >= "4.12.0~"}
 ]

--- a/packages/ocaml-option-nnp/ocaml-option-nnp.1/opam
+++ b/packages/ocaml-option-nnp/ocaml-option-nnp.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Set OCaml to be compiled with --disable-naked-pointers"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   "ocaml-variants" {post & >= "4.12.0~" & < "5.0.0~~"}
   "base-nnp" {post}

--- a/packages/ocaml-option-nnpchecker/ocaml-option-nnpchecker.1/opam
+++ b/packages/ocaml-option-nnpchecker/ocaml-option-nnpchecker.1/opam
@@ -17,6 +17,13 @@ If you spot any violations of the nnpchecker on packages, then please consider
 submitting a pull request to the ocaml/opam-repository that adds a conflict
 against the violating package against this one.
 """
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   "ocaml-variants" {post & ((>= "4.12.0~" & arch = "x86_64") | >= "4.14.0~") & < "5.0.0~~"}
 ]

--- a/packages/ocaml-option-nnpchecker/ocaml-option-nnpchecker.1/opam
+++ b/packages/ocaml-option-nnpchecker/ocaml-option-nnpchecker.1/opam
@@ -26,9 +26,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "CC0-1.0+"
 depends: [
   "ocaml-variants" {post & ((>= "4.12.0~" & arch = "x86_64") | >= "4.14.0~") & < "5.0.0~~"}
+  "system-msvc" {os = "win32"}
 ]
 available:
-    (arch = "x86_64" & (os = "linux" | os = "macos" | os = "openbsd" | os = "freebsd" | os = "sunos"))
+    (arch = "x86_64" & (os = "win32" | os = "linux" | os = "macos" | os = "openbsd" | os = "freebsd" | os = "sunos"))
   | (arch = "arm64" & (os = "linux" | os = "macos"))
 conflicts: [ "ocaml-option-nnp" "ocaml-option-32bit" ]
 maintainer: "David Allsopp <david@tarides.com>"

--- a/packages/ocaml-option-no-compression/ocaml-option-no-compression.1/opam
+++ b/packages/ocaml-option-no-compression/ocaml-option-no-compression.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Set OCaml to be compiled with --without-zstd"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   "ocaml-variants" {post & >= "5.1.0~"}
 ]

--- a/packages/ocaml-option-no-flat-float-array/ocaml-option-no-flat-float-array.1/opam
+++ b/packages/ocaml-option-no-flat-float-array/ocaml-option-no-flat-float-array.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Set OCaml to be compiled with --disable-flat-float-array"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   "ocaml-variants" {post & >= "4.12.0~"}
 ]

--- a/packages/ocaml-option-spacetime/ocaml-option-spacetime.1/opam
+++ b/packages/ocaml-option-spacetime/ocaml-option-spacetime.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Set OCaml to be compiled with spacetime activated"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   # Not available until options are ported to earlier compilers
   "ocaml-variants" {post & >= "4.12.0~" & < "4.12"}

--- a/packages/ocaml-option-static/ocaml-option-static.1/opam
+++ b/packages/ocaml-option-static/ocaml-option-static.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Set OCaml to be compiled with musl-gcc -static"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   "ocaml-option-musl"
   "ocaml-variants" {post & >= "4.12.0~"}

--- a/packages/ocaml-option-tsan/ocaml-option-tsan.1/opam
+++ b/packages/ocaml-option-tsan/ocaml-option-tsan.1/opam
@@ -18,5 +18,6 @@ conflicts: [
   "ocaml-option-leak-sanitizer"
   "ocaml-option-address-sanitier"
 ]
+available: os != "win32"
 maintainer: "David Allsopp <david@tarides.com>"
 flags: compiler

--- a/packages/ocaml-option-tsan/ocaml-option-tsan.1/opam
+++ b/packages/ocaml-option-tsan/ocaml-option-tsan.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Set OCaml to be compiled with ThreadSanitizer support"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   "ocaml-variants" {post & >= "5.2.0~"}
   "conf-unwind" {build}

--- a/packages/ocaml-options-only-afl/ocaml-options-only-afl.1/opam
+++ b/packages/ocaml-options-only-afl/ocaml-options-only-afl.1/opam
@@ -24,6 +24,7 @@ conflicts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-tsan"
+  "ocaml-option-mingw"
 ]
 maintainer: "David Allsopp <david@tarides.com>"
 flags: compiler

--- a/packages/ocaml-options-only-afl/ocaml-options-only-afl.1/opam
+++ b/packages/ocaml-options-only-afl/ocaml-options-only-afl.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Ensure that OCaml is compiled with AFL support enabled, and no other custom options"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: ["ocaml-option-afl"]
 conflicts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-options-only-flambda-fp/ocaml-options-only-flambda-fp.1/opam
+++ b/packages/ocaml-options-only-flambda-fp/ocaml-options-only-flambda-fp.1/opam
@@ -23,6 +23,7 @@ conflicts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-tsan"
+  "ocaml-option-mingw"
 ]
 maintainer: "David Allsopp <david@tarides.com>"
 flags: compiler

--- a/packages/ocaml-options-only-flambda-fp/ocaml-options-only-flambda-fp.1/opam
+++ b/packages/ocaml-options-only-flambda-fp/ocaml-options-only-flambda-fp.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Ensure that OCaml is compiled with flambda and frame-pointer enabled, and no other custom options"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: ["ocaml-option-flambda" "ocaml-option-fp"]
 conflicts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-options-only-flambda/ocaml-options-only-flambda.1/opam
+++ b/packages/ocaml-options-only-flambda/ocaml-options-only-flambda.1/opam
@@ -24,6 +24,7 @@ conflicts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-tsan"
+  "ocaml-option-mingw"
 ]
 maintainer: "David Allsopp <david@tarides.com>"
 flags: compiler

--- a/packages/ocaml-options-only-flambda/ocaml-options-only-flambda.1/opam
+++ b/packages/ocaml-options-only-flambda/ocaml-options-only-flambda.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Ensure that OCaml is compiled with flambda activated, and no other custom options"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: ["ocaml-option-flambda"]
 conflicts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-options-only-fp/ocaml-options-only-fp.1/opam
+++ b/packages/ocaml-options-only-fp/ocaml-options-only-fp.1/opam
@@ -24,6 +24,7 @@ conflicts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-tsan"
+  "ocaml-option-mingw"
 ]
 maintainer: "David Allsopp <david@tarides.com>"
 flags: compiler

--- a/packages/ocaml-options-only-fp/ocaml-options-only-fp.1/opam
+++ b/packages/ocaml-options-only-fp/ocaml-options-only-fp.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Ensure that OCaml is compiled with only frame-pointer enabled, and no other custom options"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: ["ocaml-option-fp"]
 conflicts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-options-only-nnp/ocaml-options-only-nnp.1/opam
+++ b/packages/ocaml-options-only-nnp/ocaml-options-only-nnp.1/opam
@@ -24,6 +24,7 @@ conflicts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-tsan"
+  "ocaml-option-mingw"
 ]
 maintainer: "David Allsopp <david@tarides.com>"
 flags: compiler

--- a/packages/ocaml-options-only-nnp/ocaml-options-only-nnp.1/opam
+++ b/packages/ocaml-options-only-nnp/ocaml-options-only-nnp.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Ensure that OCaml is compiled with no-naked-pointers, and no other custom options"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: ["ocaml-option-nnp"]
 conflicts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-options-only-nnpchecker/ocaml-options-only-nnpchecker.1/opam
+++ b/packages/ocaml-options-only-nnpchecker/ocaml-options-only-nnpchecker.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Ensure that OCaml is compiled with enable-naked-pointers-checker, and no other custom options"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: ["ocaml-option-nnpchecker"]
 conflicts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-options-only-nnpchecker/ocaml-options-only-nnpchecker.1/opam
+++ b/packages/ocaml-options-only-nnpchecker/ocaml-options-only-nnpchecker.1/opam
@@ -23,6 +23,7 @@ conflicts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-tsan"
+  "ocaml-option-mingw"
 ]
 maintainer: "David Allsopp <david@tarides.com>"
 flags: compiler

--- a/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1+bytecode-only/opam
+++ b/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1+bytecode-only/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Ensure that OCaml is compiled with no-flat-float-array, and no other custom options"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   "ocaml-option-no-flat-float-array"
   "ocaml-option-bytecode-only"

--- a/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1+bytecode-only/opam
+++ b/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1+bytecode-only/opam
@@ -27,6 +27,7 @@ conflicts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-tsan"
+  "ocaml-option-mingw"
 ]
 maintainer: "David Allsopp <david@tarides.com>"
 flags: compiler

--- a/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1/opam
+++ b/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1/opam
@@ -26,6 +26,7 @@ conflicts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-tsan"
+  "ocaml-option-mingw"
 ]
 maintainer: "David Allsopp <david@tarides.com>"
 flags: compiler

--- a/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1/opam
+++ b/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Ensure that OCaml is compiled with no-flat-float-array, and no other custom options"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   "ocaml-option-no-flat-float-array"
   "ocaml-variants" {post & < "5.0.0~~" & arch != "x86_64" & arch != "arm64"}

--- a/packages/ocaml-options-only-tsan/ocaml-options-only-tsan.1/opam
+++ b/packages/ocaml-options-only-tsan/ocaml-options-only-tsan.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Ensure that OCaml is compiled with ThreadSanitizer support enabled, and no other custom options"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: ["ocaml-option-tsan"]
 conflicts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-options-only-tsan/ocaml-options-only-tsan.1/opam
+++ b/packages/ocaml-options-only-tsan/ocaml-options-only-tsan.1/opam
@@ -24,6 +24,7 @@ conflicts: [
   "ocaml-option-nnpchecker"
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
+  "ocaml-option-mingw"
 ]
 maintainer: "David Allsopp <david@tarides.com>"
 flags: compiler

--- a/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
+++ b/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
@@ -29,6 +29,7 @@ conflicts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-tsan"
+  "ocaml-option-mingw"
 ]
 maintainer: "David Allsopp <david@tarides.com>"
 flags: compiler

--- a/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
+++ b/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
@@ -15,7 +15,13 @@ depends: [
 conflicts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
-  "ocaml-option-bytecode-only" {arch = "arm64" | arch = "x86_64" }
+  # See equivalent constraint in ocaml-option-bytecode-only
+  # Windows is permitted to install 32-bit versions of ocaml-base-compiler on
+  # 64-bit systems hence the (temporary) addition of the `os = "win32"` here,
+  # at least until the ocaml-option- / base- mess is fixed. Note that this puts
+  # 64-bit Windows into the same class as ppc64, riscv64 and s390x where
+  # ocaml-option-bytecode-only can be installed, but has no effect.
+  "ocaml-option-bytecode-only" {arch = "arm64" | (arch = "x86_64" & os != "win32") }
   "ocaml-option-default-unsafe-string"
   "ocaml-option-flambda"
   "ocaml-option-fp"

--- a/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
+++ b/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
@@ -1,5 +1,12 @@
 opam-version: "2.0"
 synopsis: "Ensure that OCaml is compiled with no special options enabled"
+authors: [
+  "David Allsopp"
+  "Louis Gesbert"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
 depends: [
   "ocaml-base-compiler" {post} |
   "ocaml-system" {post} |

--- a/packages/ocaml-system/ocaml-system.4.13.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.13.0/opam
@@ -10,13 +10,49 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml"
 depends: [
-  "ocaml" {post}
+  # This is OCaml 4.13.0
+  "ocaml" {= "4.13.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-threads" {post}
   "base-bigarray" {post}
+
+  # Architecture
+  "host-arch-arm32" {?sys-ocaml-arch & sys-ocaml-arch = "arm" & post}
+  "host-arch-arm64" {?sys-ocaml-arch & sys-ocaml-arch = "arm64" & post}
+  "host-arch-ppc64" {?sys-ocaml-arch & sys-ocaml-arch = "power" & post}
+  "host-arch-riscv64" {?sys-ocaml-arch & sys-ocaml-arch = "riscv" & post}
+  "host-arch-s390x" {?sys-ocaml-arch & sys-ocaml-arch = "s390x" & post}
+  "host-arch-x86_32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & post}
+  "host-arch-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & post}
+  "host-arch-unknown" {!(?sys-ocaml-arch) |
+                       sys-ocaml-arch != "arm" &
+                       sys-ocaml-arch != "arm64" &
+                       sys-ocaml-arch != "power" &
+                       sys-ocaml-arch != "riscv" &
+                       sys-ocaml-arch != "s390x" &
+                       sys-ocaml-arch != "i686" &
+                       sys-ocaml-arch != "x86_64" & post}
+
+  # System (Windows-only at present)
+  "host-system-mingw" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "host-system-msvc" {?sys-ocaml-arch & sys-ocaml-cc = "msvc" & post}
+  "host-system-other" {?sys-ocaml-arch & sys-ocaml-libc != "msvc" & post}
+
+  # Environment configuration (Windows-only)
+  # NB There are not "system" distributions of OCaml on Windows; the support
+  # here is intended for binary caching setups, choosing to install a build
+  # of OCaml external to opam, but still using opam to provide the C compiler
+  # configuration.
+  "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
+  "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]
 conflict-class: "ocaml-core-compiler"
-available: sys-ocaml-version = "4.13.0"
+available: sys-ocaml-version = "4.13.0" & (os != "win32" | sys-ocaml-libc = "msvc")
 flags: compiler
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"

--- a/packages/ocaml-system/ocaml-system.4.13.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.13.1/opam
@@ -10,13 +10,49 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml"
 depends: [
-  "ocaml" {post}
+  # This is OCaml 4.13.1
+  "ocaml" {= "4.13.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-threads" {post}
   "base-bigarray" {post}
+
+  # Architecture
+  "host-arch-arm32" {?sys-ocaml-arch & sys-ocaml-arch = "arm" & post}
+  "host-arch-arm64" {?sys-ocaml-arch & sys-ocaml-arch = "arm64" & post}
+  "host-arch-ppc64" {?sys-ocaml-arch & sys-ocaml-arch = "power" & post}
+  "host-arch-riscv64" {?sys-ocaml-arch & sys-ocaml-arch = "riscv" & post}
+  "host-arch-s390x" {?sys-ocaml-arch & sys-ocaml-arch = "s390x" & post}
+  "host-arch-x86_32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & post}
+  "host-arch-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & post}
+  "host-arch-unknown" {!(?sys-ocaml-arch) |
+                       sys-ocaml-arch != "arm" &
+                       sys-ocaml-arch != "arm64" &
+                       sys-ocaml-arch != "power" &
+                       sys-ocaml-arch != "riscv" &
+                       sys-ocaml-arch != "s390x" &
+                       sys-ocaml-arch != "i686" &
+                       sys-ocaml-arch != "x86_64" & post}
+
+  # System (Windows-only at present)
+  "host-system-mingw" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "host-system-msvc" {?sys-ocaml-arch & sys-ocaml-cc = "msvc" & post}
+  "host-system-other" {?sys-ocaml-arch & sys-ocaml-libc != "msvc" & post}
+
+  # Environment configuration (Windows-only)
+  # NB There are not "system" distributions of OCaml on Windows; the support
+  # here is intended for binary caching setups, choosing to install a build
+  # of OCaml external to opam, but still using opam to provide the C compiler
+  # configuration.
+  "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
+  "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]
 conflict-class: "ocaml-core-compiler"
-available: sys-ocaml-version = "4.13.1"
+available: sys-ocaml-version = "4.13.1" & (os != "win32" | sys-ocaml-libc = "msvc")
 flags: compiler
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"

--- a/packages/ocaml-system/ocaml-system.4.14.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.0/opam
@@ -10,13 +10,49 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml"
 depends: [
-  "ocaml" {post}
+  # This is OCaml 4.14.0
+  "ocaml" {= "4.14.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-threads" {post}
   "base-bigarray" {post}
+
+  # Architecture
+  "host-arch-arm32" {?sys-ocaml-arch & sys-ocaml-arch = "arm" & post}
+  "host-arch-arm64" {?sys-ocaml-arch & sys-ocaml-arch = "arm64" & post}
+  "host-arch-ppc64" {?sys-ocaml-arch & sys-ocaml-arch = "power" & post}
+  "host-arch-riscv64" {?sys-ocaml-arch & sys-ocaml-arch = "riscv" & post}
+  "host-arch-s390x" {?sys-ocaml-arch & sys-ocaml-arch = "s390x" & post}
+  "host-arch-x86_32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & post}
+  "host-arch-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & post}
+  "host-arch-unknown" {!(?sys-ocaml-arch) |
+                       sys-ocaml-arch != "arm" &
+                       sys-ocaml-arch != "arm64" &
+                       sys-ocaml-arch != "power" &
+                       sys-ocaml-arch != "riscv" &
+                       sys-ocaml-arch != "s390x" &
+                       sys-ocaml-arch != "i686" &
+                       sys-ocaml-arch != "x86_64" & post}
+
+  # System (Windows-only at present)
+  "host-system-mingw" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "host-system-msvc" {?sys-ocaml-arch & sys-ocaml-cc = "msvc" & post}
+  "host-system-other" {?sys-ocaml-arch & sys-ocaml-libc != "msvc" & post}
+
+  # Environment configuration (Windows-only)
+  # NB There are not "system" distributions of OCaml on Windows; the support
+  # here is intended for binary caching setups, choosing to install a build
+  # of OCaml external to opam, but still using opam to provide the C compiler
+  # configuration.
+  "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
+  "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]
 conflict-class: "ocaml-core-compiler"
-available: sys-ocaml-version = "4.14.0"
+available: sys-ocaml-version = "4.14.0" & (os != "win32" | sys-ocaml-libc = "msvc")
 flags: compiler
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"

--- a/packages/ocaml-system/ocaml-system.4.14.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.1/opam
@@ -10,13 +10,49 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml"
 depends: [
-  "ocaml" {post}
+  # This is OCaml 4.14.1
+  "ocaml" {= "4.14.1" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-threads" {post}
   "base-bigarray" {post}
+
+  # Architecture
+  "host-arch-arm32" {?sys-ocaml-arch & sys-ocaml-arch = "arm" & post}
+  "host-arch-arm64" {?sys-ocaml-arch & sys-ocaml-arch = "arm64" & post}
+  "host-arch-ppc64" {?sys-ocaml-arch & sys-ocaml-arch = "power" & post}
+  "host-arch-riscv64" {?sys-ocaml-arch & sys-ocaml-arch = "riscv" & post}
+  "host-arch-s390x" {?sys-ocaml-arch & sys-ocaml-arch = "s390x" & post}
+  "host-arch-x86_32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & post}
+  "host-arch-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & post}
+  "host-arch-unknown" {!(?sys-ocaml-arch) |
+                       sys-ocaml-arch != "arm" &
+                       sys-ocaml-arch != "arm64" &
+                       sys-ocaml-arch != "power" &
+                       sys-ocaml-arch != "riscv" &
+                       sys-ocaml-arch != "s390x" &
+                       sys-ocaml-arch != "i686" &
+                       sys-ocaml-arch != "x86_64" & post}
+
+  # System (Windows-only at present)
+  "host-system-mingw" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "host-system-msvc" {?sys-ocaml-arch & sys-ocaml-cc = "msvc" & post}
+  "host-system-other" {?sys-ocaml-arch & sys-ocaml-libc != "msvc" & post}
+
+  # Environment configuration (Windows-only)
+  # NB There are not "system" distributions of OCaml on Windows; the support
+  # here is intended for binary caching setups, choosing to install a build
+  # of OCaml external to opam, but still using opam to provide the C compiler
+  # configuration.
+  "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
+  "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]
 conflict-class: "ocaml-core-compiler"
-available: sys-ocaml-version = "4.14.1"
+available: sys-ocaml-version = "4.14.1" & (os != "win32" | sys-ocaml-libc = "msvc")
 flags: compiler
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"

--- a/packages/ocaml-system/ocaml-system.4.14.2/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.2/opam
@@ -10,13 +10,49 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml"
 depends: [
-  "ocaml" {post}
+  # This is OCaml 4.14.2
+  "ocaml" {= "4.14.2" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-threads" {post}
   "base-bigarray" {post}
+
+  # Architecture
+  "host-arch-arm32" {?sys-ocaml-arch & sys-ocaml-arch = "arm" & post}
+  "host-arch-arm64" {?sys-ocaml-arch & sys-ocaml-arch = "arm64" & post}
+  "host-arch-ppc64" {?sys-ocaml-arch & sys-ocaml-arch = "power" & post}
+  "host-arch-riscv64" {?sys-ocaml-arch & sys-ocaml-arch = "riscv" & post}
+  "host-arch-s390x" {?sys-ocaml-arch & sys-ocaml-arch = "s390x" & post}
+  "host-arch-x86_32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & post}
+  "host-arch-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & post}
+  "host-arch-unknown" {!(?sys-ocaml-arch) |
+                       sys-ocaml-arch != "arm" &
+                       sys-ocaml-arch != "arm64" &
+                       sys-ocaml-arch != "power" &
+                       sys-ocaml-arch != "riscv" &
+                       sys-ocaml-arch != "s390x" &
+                       sys-ocaml-arch != "i686" &
+                       sys-ocaml-arch != "x86_64" & post}
+
+  # System (Windows-only at present)
+  "host-system-mingw" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "host-system-msvc" {?sys-ocaml-arch & sys-ocaml-cc = "msvc" & post}
+  "host-system-other" {?sys-ocaml-arch & sys-ocaml-libc != "msvc" & post}
+
+  # Environment configuration (Windows-only)
+  # NB There are not "system" distributions of OCaml on Windows; the support
+  # here is intended for binary caching setups, choosing to install a build
+  # of OCaml external to opam, but still using opam to provide the C compiler
+  # configuration.
+  "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
+  "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]
 conflict-class: "ocaml-core-compiler"
-available: sys-ocaml-version = "4.14.2"
+available: sys-ocaml-version = "4.14.2" & (os != "win32" | sys-ocaml-libc = "msvc")
 flags: compiler
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"

--- a/packages/ocaml-system/ocaml-system.5.0.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.0.0/opam
@@ -10,15 +10,52 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml"
 depends: [
-  "ocaml" {post}
+  # This is OCaml 5.0.0
+  "ocaml" {= "5.0.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-threads" {post}
   "base-bigarray" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  # Architecture
+  "host-arch-arm32" {?sys-ocaml-arch & sys-ocaml-arch = "arm" & post}
+  "host-arch-arm64" {?sys-ocaml-arch & sys-ocaml-arch = "arm64" & post}
+  "host-arch-ppc64" {?sys-ocaml-arch & sys-ocaml-arch = "power" & post}
+  "host-arch-riscv64" {?sys-ocaml-arch & sys-ocaml-arch = "riscv" & post}
+  "host-arch-s390x" {?sys-ocaml-arch & sys-ocaml-arch = "s390x" & post}
+  "host-arch-x86_32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & post}
+  "host-arch-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & post}
+  "host-arch-unknown" {!(?sys-ocaml-arch) |
+                       sys-ocaml-arch != "arm" &
+                       sys-ocaml-arch != "arm64" &
+                       sys-ocaml-arch != "power" &
+                       sys-ocaml-arch != "riscv" &
+                       sys-ocaml-arch != "s390x" &
+                       sys-ocaml-arch != "i686" &
+                       sys-ocaml-arch != "x86_64" & post}
+
+  # System (Windows-only at present)
+  "host-system-mingw" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  # There is no official MSVC support for 5.0.0
+  "host-system-msvc" {?sys-ocaml-arch & sys-ocaml-cc = "msvc" & post}
+  "host-system-other" {?sys-ocaml-arch & sys-ocaml-libc != "msvc" & post}
+
+  # Environment configuration (Windows-only)
+  # NB There are not "system" distributions of OCaml on Windows; the support
+  # here is intended for binary caching setups, choosing to install a build
+  # of OCaml external to opam, but still using opam to provide the C compiler
+  # configuration.
+  "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
+  "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]
 conflict-class: "ocaml-core-compiler"
-available: sys-ocaml-version = "5.0.0"
+available: sys-ocaml-version = "5.0.0" & (os != "win32" | sys-ocaml-libc = "msvc")
 flags: compiler
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"

--- a/packages/ocaml-system/ocaml-system.5.1.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.1.0/opam
@@ -10,15 +10,54 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml"
 depends: [
-  "ocaml" {post}
+  # This is OCaml 5.1.0
+  "ocaml" {= "5.1.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-threads" {post}
   "base-bigarray" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  # Architecture
+  "host-arch-arm32" {?sys-ocaml-arch & sys-ocaml-arch = "arm" & post}
+  "host-arch-arm64" {?sys-ocaml-arch & sys-ocaml-arch = "arm64" & post}
+  "host-arch-ppc64" {?sys-ocaml-arch & sys-ocaml-arch = "power" & post}
+  "host-arch-riscv64" {?sys-ocaml-arch & sys-ocaml-arch = "riscv" & post}
+  "host-arch-s390x" {?sys-ocaml-arch & sys-ocaml-arch = "s390x" & post}
+  "host-arch-x86_32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & post}
+  "host-arch-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & post}
+  "host-arch-unknown" {!(?sys-ocaml-arch) |
+                       sys-ocaml-arch != "arm" &
+                       sys-ocaml-arch != "arm64" &
+                       sys-ocaml-arch != "power" &
+                       sys-ocaml-arch != "riscv" &
+                       sys-ocaml-arch != "s390x" &
+                       sys-ocaml-arch != "i686" &
+                       sys-ocaml-arch != "x86_64" & post}
+
+  # System (Windows-only at present)
+  "host-system-mingw" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  # There is no official MSVC support for 5.1.0
+  "host-system-msvc" {?sys-ocaml-arch & sys-ocaml-cc = "msvc" & post}
+  "host-system-other" {?sys-ocaml-arch & sys-ocaml-libc != "msvc" & post}
+
+  # Environment configuration (Windows-only)
+  # NB There are not "system" distributions of OCaml on Windows; the support
+  # here is intended for binary caching setups, choosing to install a build
+  # of OCaml external to opam, but still using opam to provide the C compiler
+  # configuration.
+  "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-zstd-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-zstd-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
+  "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]
 conflict-class: "ocaml-core-compiler"
-available: sys-ocaml-version = "5.1.0"
+available: sys-ocaml-version = "5.1.0" & (os != "win32" | sys-ocaml-libc = "msvc")
 flags: compiler
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"

--- a/packages/ocaml-system/ocaml-system.5.1.1/opam
+++ b/packages/ocaml-system/ocaml-system.5.1.1/opam
@@ -10,15 +10,54 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml"
 depends: [
-  "ocaml" {post}
+  # This is OCaml 5.1.1
+  "ocaml" {= "5.1.1" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-threads" {post}
   "base-bigarray" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  # Architecture
+  "host-arch-arm32" {?sys-ocaml-arch & sys-ocaml-arch = "arm" & post}
+  "host-arch-arm64" {?sys-ocaml-arch & sys-ocaml-arch = "arm64" & post}
+  "host-arch-ppc64" {?sys-ocaml-arch & sys-ocaml-arch = "power" & post}
+  "host-arch-riscv64" {?sys-ocaml-arch & sys-ocaml-arch = "riscv" & post}
+  "host-arch-s390x" {?sys-ocaml-arch & sys-ocaml-arch = "s390x" & post}
+  "host-arch-x86_32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & post}
+  "host-arch-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & post}
+  "host-arch-unknown" {!(?sys-ocaml-arch) |
+                       sys-ocaml-arch != "arm" &
+                       sys-ocaml-arch != "arm64" &
+                       sys-ocaml-arch != "power" &
+                       sys-ocaml-arch != "riscv" &
+                       sys-ocaml-arch != "s390x" &
+                       sys-ocaml-arch != "i686" &
+                       sys-ocaml-arch != "x86_64" & post}
+
+  # System (Windows-only at present)
+  "host-system-mingw" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  # There is no official MSVC support for 5.1.1
+  "host-system-msvc" {?sys-ocaml-arch & sys-ocaml-cc = "msvc" & post}
+  "host-system-other" {?sys-ocaml-arch & sys-ocaml-libc != "msvc" & post}
+
+  # Environment configuration (Windows-only)
+  # NB There are not "system" distributions of OCaml on Windows; the support
+  # here is intended for binary caching setups, choosing to install a build
+  # of OCaml external to opam, but still using opam to provide the C compiler
+  # configuration.
+  "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-zstd-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-zstd-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
+  "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]
 conflict-class: "ocaml-core-compiler"
-available: sys-ocaml-version = "5.1.1"
+available: sys-ocaml-version = "5.1.1" & (os != "win32" | sys-ocaml-libc = "msvc")
 flags: compiler
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"

--- a/packages/ocaml-system/ocaml-system.5.2.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.2.0/opam
@@ -10,15 +10,54 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml"
 depends: [
-  "ocaml" {post}
+  # This is OCaml 5.2.0
+  "ocaml" {= "5.2.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-threads" {post}
   "base-bigarray" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  # Architecture
+  "host-arch-arm32" {?sys-ocaml-arch & sys-ocaml-arch = "arm" & post}
+  "host-arch-arm64" {?sys-ocaml-arch & sys-ocaml-arch = "arm64" & post}
+  "host-arch-ppc64" {?sys-ocaml-arch & sys-ocaml-arch = "power" & post}
+  "host-arch-riscv64" {?sys-ocaml-arch & sys-ocaml-arch = "riscv" & post}
+  "host-arch-s390x" {?sys-ocaml-arch & sys-ocaml-arch = "s390x" & post}
+  "host-arch-x86_32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & post}
+  "host-arch-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & post}
+  "host-arch-unknown" {!(?sys-ocaml-arch) |
+                       sys-ocaml-arch != "arm" &
+                       sys-ocaml-arch != "arm64" &
+                       sys-ocaml-arch != "power" &
+                       sys-ocaml-arch != "riscv" &
+                       sys-ocaml-arch != "s390x" &
+                       sys-ocaml-arch != "i686" &
+                       sys-ocaml-arch != "x86_64" & post}
+
+  # System (Windows-only at present)
+  "host-system-mingw" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  # There is no official MSVC support for 5.2.0
+  "host-system-msvc" {?sys-ocaml-arch & sys-ocaml-cc = "msvc" & post}
+  "host-system-other" {?sys-ocaml-arch & sys-ocaml-libc != "msvc" & post}
+
+  # Environment configuration (Windows-only)
+  # NB There are not "system" distributions of OCaml on Windows; the support
+  # here is intended for binary caching setups, choosing to install a build
+  # of OCaml external to opam, but still using opam to provide the C compiler
+  # configuration.
+  "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-zstd-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-zstd-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
+  "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]
 conflict-class: "ocaml-core-compiler"
-available: sys-ocaml-version = "5.2.0"
+available: sys-ocaml-version = "5.2.0" & (os != "win32" | sys-ocaml-libc = "msvc")
 flags: compiler
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"

--- a/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
@@ -10,18 +10,61 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.13"
 depends: [
+  # This is OCaml 4.13.0
   "ocaml" {= "4.13.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # i686 mingw-w64 / MSVC
+   "arch-x86_32" {os = "win32"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # Support Packages
+  "flexdll" {>= "0.36" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
+build-env: MSYS2_ARG_CONV_EXCL = "*"
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}

--- a/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
@@ -30,19 +30,19 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # i686 mingw-w64 / MSVC
-   "arch-x86_32" {os = "win32"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+   ("arch-x86_32" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
@@ -10,18 +10,61 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.13"
 depends: [
+  # This is OCaml 4.13.1
   "ocaml" {= "4.13.1" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # i686 mingw-w64 / MSVC
+   "arch-x86_32" {os = "win32"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # Support Packages
+  "flexdll" {>= "0.36" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
+build-env: MSYS2_ARG_CONV_EXCL = "*"
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}

--- a/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
@@ -30,19 +30,19 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # i686 mingw-w64 / MSVC
-   "arch-x86_32" {os = "win32"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+   ("arch-x86_32" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
@@ -10,19 +10,63 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.13"
 depends: [
+  # This is OCaml 4.13.2
   "ocaml" {= "4.13.2" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+
   "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # i686 mingw-w64 / MSVC
+   "arch-x86_32" {os = "win32"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # Support Packages
+  "flexdll" {>= "0.36" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
+build-env: MSYS2_ARG_CONV_EXCL = "*"
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}

--- a/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
@@ -32,19 +32,19 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # i686 mingw-w64 / MSVC
-   "arch-x86_32" {os = "win32"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+   ("arch-x86_32" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
@@ -30,19 +30,19 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # i686 mingw-w64 / MSVC
-   "arch-x86_32" {os = "win32"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+   ("arch-x86_32" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
@@ -10,19 +10,62 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.14"
 depends: [
+  # This is OCaml 4.14.0
   "ocaml" {= "4.14.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # i686 mingw-w64 / MSVC
+   "arch-x86_32" {os = "win32"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # Support Packages
+  "flexdll" {>= "0.36" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
+build-env: MSYS2_ARG_CONV_EXCL = "*"
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+options/opam
@@ -30,19 +30,19 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # i686 mingw-w64 / MSVC
-   "arch-x86_32" {os = "win32"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+   ("arch-x86_32" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+options/opam
@@ -10,19 +10,62 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.14"
 depends: [
+  # This is OCaml 4.14.1
   "ocaml" {= "4.14.1" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # i686 mingw-w64 / MSVC
+   "arch-x86_32" {os = "win32"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # Support Packages
+  "flexdll" {>= "0.36" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
+build-env: MSYS2_ARG_CONV_EXCL = "*"
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}

--- a/packages/ocaml-variants/ocaml-variants.4.14.2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.2+options/opam
@@ -30,19 +30,19 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # i686 mingw-w64 / MSVC
-   "arch-x86_32" {os = "win32"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+   ("arch-x86_32" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.4.14.2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.2+options/opam
@@ -10,19 +10,62 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.14"
 depends: [
+  # This is OCaml 4.14.2
   "ocaml" {= "4.14.2" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # i686 mingw-w64 / MSVC
+   "arch-x86_32" {os = "win32"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # Support Packages
+  "flexdll" {>= "0.36" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
+build-env: MSYS2_ARG_CONV_EXCL = "*"
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}

--- a/packages/ocaml-variants/ocaml-variants.4.14.3+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.3+trunk/opam
@@ -10,20 +10,64 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.14"
 depends: [
+  # This is OCaml 4.14.3
   "ocaml" {= "4.14.3" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+
   "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # i686 mingw-w64 / MSVC
+   "arch-x86_32" {os = "win32"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+     "system-msvc") |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # Support Packages
+  "flexdll" {>= "0.36" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
+build-env: MSYS2_ARG_CONV_EXCL = "*"
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: [
   [
     "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}

--- a/packages/ocaml-variants/ocaml-variants.4.14.3+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.3+trunk/opam
@@ -32,19 +32,19 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # i686 mingw-w64 / MSVC
-   "arch-x86_32" {os = "win32"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
-     "system-msvc") |
+   ("arch-x86_32" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+      "system-msvc")) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
@@ -41,7 +41,7 @@ depends: [
   ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
@@ -10,17 +10,54 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.0"
 depends: [
+  # This is OCaml 5.0.0
   "ocaml" {= "5.0.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # Only amd64 and arm64 support the native compiler
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -28,8 +65,11 @@ build-env: [
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
@@ -73,14 +113,16 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-conflicts: [ "ocaml-option-fp" ]
+conflicts: [
+  "ocaml-option-fp"
+  "system-msvc"
+]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
-  "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-address-sanitizer"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
@@ -5,7 +5,14 @@ maintainer: [
   "David Allsopp <david@tarides.com>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
-authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.0"
@@ -32,17 +39,17 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
@@ -10,18 +10,56 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.0"
 depends: [
+  # This is OCaml 5.0.1
   "ocaml" {= "5.0.1" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
+
   "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # Only amd64 and arm64 support the native compiler
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -29,8 +67,11 @@ build-env: [
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
@@ -73,7 +114,10 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-conflicts: [ "ocaml-option-fp" ]
+conflicts: [
+  "ocaml-option-fp"
+  "system-msvc"
+]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
@@ -43,7 +43,7 @@ depends: [
   ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
@@ -5,7 +5,14 @@ maintainer: [
   "David Allsopp <david@tarides.com>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
-authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.0"
@@ -34,17 +41,17 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
@@ -48,7 +48,7 @@ depends: [
   ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
@@ -17,17 +17,54 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.1"
 depends: [
+  # This is OCaml 5.1.0
   "ocaml" {= "5.1.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # POWER and all the 32-bit architectures are bytecode-only
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -35,15 +72,18 @@ build-env: [
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--without-zstd"  {ocaml-option-no-compression:installed}
+    "--without-zstd" {ocaml-option-no-compression:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed}
@@ -66,6 +106,9 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/5.1.0.tar.gz"
   checksum: "sha256=43a3ac7aab7f8880f2bb6221317be55319b356e517622fdc28359fe943e6a450"
 }
+conflicts: [
+  "system-msvc"
+]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
@@ -39,17 +39,17 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
@@ -51,7 +51,7 @@ depends: [
   ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
@@ -42,17 +42,17 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
@@ -17,19 +17,57 @@ homepage: "https://github.com/ocaml/ocaml"
 bug-reports: "https://github.com/ocaml/ocaml/issues"
 dev-repo: "git+https://github.com/xavierleroy/ocaml.git#5.1.1+effect-syntax"
 depends: [
+  # This is OCaml 5.1.1
   "ocaml" {= "5.1.1" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-effects" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
+
   "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # POWER and all the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -37,8 +75,11 @@ build-env: [
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
@@ -68,6 +109,9 @@ url {
   src: "https://github.com/xavierleroy/ocaml/archive/5.1.1+effect-syntax.tar.gz"
   checksum: "sha256=300b540f60a823933af76c572e5931b502634830ea838f96bead309336c44579"
 }
+conflicts: [
+  "system-msvc"
+]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
@@ -48,7 +48,7 @@ depends: [
   ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
@@ -17,17 +17,54 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.1"
 depends: [
+  # This is OCaml 5.1.1
   "ocaml" {= "5.1.1" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # POWER and all the 32-bit architectures are bytecode-only
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -35,15 +72,18 @@ build-env: [
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--without-zstd"  {ocaml-option-no-compression:installed}
+    "--without-zstd" {ocaml-option-no-compression:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed}
@@ -66,6 +106,9 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/5.1.1.tar.gz"
   checksum: "sha256=57f7b382b3d71198413ede405d95ef3506f1cdc480cda1dca1e26b37cb090e17"
 }
+conflicts: [
+  "system-msvc"
+]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
@@ -39,17 +39,17 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
@@ -5,7 +5,14 @@ maintainer: [
   "David Allsopp <david@tarides.com>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
-authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.1"
@@ -34,17 +41,17 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
@@ -10,18 +10,56 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.1"
 depends: [
+  # This is OCaml 5.1.2
   "ocaml" {= "5.1.2" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
+
   "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # POWER and all the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -29,8 +67,11 @@ build-env: [
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
@@ -47,15 +88,9 @@ build: [
     "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
     "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
     "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
-    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
     "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
-    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
-    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
-    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
-    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
     "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
     "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
-    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
     "LIBS=-static" {ocaml-option-static:installed}
     "--disable-warn-error"
   ]
@@ -65,14 +100,8 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/5.1.tar.gz"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+conflicts: [
+  "system-msvc"
 ]
 depopts: [
   "ocaml-option-32bit"
@@ -81,8 +110,8 @@ depopts: [
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"
-  "ocaml-option-musl"
   "ocaml-option-no-compression"
+  "ocaml-option-musl"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"

--- a/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
@@ -43,7 +43,7 @@ depends: [
   ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
@@ -17,17 +17,54 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.2"
 depends: [
+  # This is OCaml 5.2.0
   "ocaml" {= "5.2.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -35,8 +72,11 @@ build-env: [
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
@@ -68,6 +108,9 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/5.2.0.tar.gz"
   checksum: "sha256=48554abfd530fcdaa08f23f801b699e4f74c320ddf7d0bd56b0e8c24e55fc911"
 }
+conflicts: [
+  "system-msvc"
+]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
@@ -48,7 +48,7 @@ depends: [
   ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
@@ -39,17 +39,17 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+statmemprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+statmemprof/opam
@@ -41,17 +41,17 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+statmemprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+statmemprof/opam
@@ -17,18 +17,56 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml-multicore/ocaml.git#5.2.0+statmemprof"
 depends: [
+  # This is OCaml 5.2.0
   "ocaml" {= "5.2.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
   "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -36,8 +74,11 @@ build-env: [
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
@@ -69,6 +110,9 @@ url {
   src: "https://github.com/ocaml-multicore/ocaml/archive/5.2.0+statmemprof.tar.gz"
   checksum: "sha256=7118bd121642cd8fc8558b26b99d62670f3f1442e43e26c05fc9b5ed77b70ca7"
 }
+conflicts: [
+  "system-msvc"
+]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+statmemprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+statmemprof/opam
@@ -50,7 +50,7 @@ depends: [
   ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~alpha1+options/opam
@@ -41,17 +41,17 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~alpha1+options/opam
@@ -17,18 +17,56 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.2"
 depends: [
+  # This is OCaml 5.2.0
   "ocaml" {= "5.2.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
   "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -36,8 +74,11 @@ build-env: [
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
@@ -69,6 +110,9 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/5.2.0-alpha1.tar.gz"
   checksum: "sha256=2664bd9175dffadfcd1ccba69d3689459202580586e12f53ca1fdd98c43431ad"
 }
+conflicts: [
+  "system-msvc"
+]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~alpha1+options/opam
@@ -50,7 +50,7 @@ depends: [
   ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/opam
@@ -41,17 +41,17 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/opam
@@ -50,7 +50,7 @@ depends: [
   ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/opam
@@ -17,18 +17,56 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.2"
 depends: [
+  # This is OCaml 5.2.0
   "ocaml" {= "5.2.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
   "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -36,8 +74,11 @@ build-env: [
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
@@ -69,6 +110,9 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/5.2.0-beta1.tar.gz"
   checksum: "sha256=8fa1101f92091dd333d9dbd101f52ea3db86b827e8f1d26e45c98f8eac7e9e28"
 }
+conflicts: [
+  "system-msvc"
+]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~beta2+options/opam
@@ -41,17 +41,17 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~beta2+options/opam
@@ -17,18 +17,56 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.2"
 depends: [
+  # This is OCaml 5.2.0
   "ocaml" {= "5.2.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
   "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -36,8 +74,11 @@ build-env: [
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
@@ -69,6 +110,9 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/5.2.0-beta2.tar.gz"
   checksum: "sha256=3d76aef8d2fc7d454e7fee201553e7f3e8298d29c4f220e82911c207d72fc982"
 }
+conflicts: [
+  "system-msvc"
+]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~beta2+options/opam
@@ -50,7 +50,7 @@ depends: [
   ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~rc1+options/opam
@@ -41,17 +41,17 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~rc1+options/opam
@@ -17,18 +17,56 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.2"
 depends: [
+  # This is OCaml 5.2.0
   "ocaml" {= "5.2.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
   "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -36,8 +74,11 @@ build-env: [
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
@@ -69,6 +110,9 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/5.2.0-rc1.tar.gz"
   checksum: "sha256=2573928dfd5399b2fdb629bfce844b12e68475bb431c2a96a9c8e72a419da029"
 }
+conflicts: [
+  "system-msvc"
+]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~rc1+options/opam
@@ -50,7 +50,7 @@ depends: [
   ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.2.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.1+trunk/opam
@@ -41,17 +41,17 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 only
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.2.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.1+trunk/opam
@@ -17,18 +17,56 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.2"
 depends: [
+  # This is OCaml 5.2.1
   "ocaml" {= "5.2.1" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
   "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # i686 mingw-w64 only
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -36,8 +74,11 @@ build-env: [
 build: [
   [
     "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
@@ -68,6 +109,9 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/5.2.tar.gz"
 }
+conflicts: [
+  "system-msvc"
+]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.5.2.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.1+trunk/opam
@@ -50,7 +50,7 @@ depends: [
   ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # i686 mingw-w64 only
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
@@ -17,27 +17,74 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
 depends: [
+  # This is OCaml 5.3.0
   "ocaml" {= "5.3.0" & post}
+
+  # General base- packages
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
   "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+      "system-msvc" & "winpthreads" & "ocaml-option-no-compression") |
+  # i686 mingw-w64 / MSVC
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
+      "system-msvc" & "winpthreads" & "ocaml-option-no-compression") |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build-env: [
+  [MSYS2_ARG_CONV_EXCL = "*"]
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
 ]
 build: [
   [
     "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
     "--prefix=%{prefix}%"
     "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
+    "--with-winpthreads-msvc=%{winpthreads:share}%" {system-msvc:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}

--- a/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
@@ -41,19 +41,19 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"} |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
-  ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
-      "system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}) |
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # i686 mingw-w64 / MSVC
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-    ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
-      "system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}) |
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
@@ -49,11 +49,11 @@ depends: [
   # amd64 mingw-w64 / MSVC
   ("arch-x86_64" {os = "win32" & arch = "x86_64"} &
     ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
-      "system-msvc" & "winpthreads" & "ocaml-option-no-compression") |
+      "system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}) |
   # i686 mingw-w64 / MSVC
-   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+   "arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
     ("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build} |
-      "system-msvc" & "winpthreads" & "ocaml-option-no-compression") |
+      "system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml/ocaml.4.13.0/opam
+++ b/packages/ocaml/ocaml.4.13.0/opam
@@ -16,6 +16,9 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"

--- a/packages/ocaml/ocaml.4.13.1/opam
+++ b/packages/ocaml/ocaml.4.13.1/opam
@@ -16,6 +16,9 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"

--- a/packages/ocaml/ocaml.4.13.2/opam
+++ b/packages/ocaml/ocaml.4.13.2/opam
@@ -16,6 +16,9 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"

--- a/packages/ocaml/ocaml.4.14.0/opam
+++ b/packages/ocaml/ocaml.4.14.0/opam
@@ -17,6 +17,9 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"

--- a/packages/ocaml/ocaml.4.14.1/opam
+++ b/packages/ocaml/ocaml.4.14.1/opam
@@ -16,6 +16,9 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"

--- a/packages/ocaml/ocaml.4.14.2/opam
+++ b/packages/ocaml/ocaml.4.14.2/opam
@@ -17,6 +17,9 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"

--- a/packages/ocaml/ocaml.4.14.3/opam
+++ b/packages/ocaml/ocaml.4.14.3/opam
@@ -17,6 +17,9 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""
 homepage: "https://ocaml.org"

--- a/packages/ocaml/ocaml.5.0.0/opam
+++ b/packages/ocaml/ocaml.5.0.0/opam
@@ -16,6 +16,9 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [
   [CAML_LD_LIBRARY_PATH = ""]

--- a/packages/ocaml/ocaml.5.0.1/opam
+++ b/packages/ocaml/ocaml.5.0.1/opam
@@ -17,6 +17,9 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [
   [CAML_LD_LIBRARY_PATH = ""]

--- a/packages/ocaml/ocaml.5.1.0/opam
+++ b/packages/ocaml/ocaml.5.1.0/opam
@@ -17,6 +17,9 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [
   [CAML_LD_LIBRARY_PATH = ""]

--- a/packages/ocaml/ocaml.5.1.1/opam
+++ b/packages/ocaml/ocaml.5.1.1/opam
@@ -17,6 +17,9 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [
   [CAML_LD_LIBRARY_PATH = ""]

--- a/packages/ocaml/ocaml.5.1.2/opam
+++ b/packages/ocaml/ocaml.5.1.2/opam
@@ -17,6 +17,9 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [
   [CAML_LD_LIBRARY_PATH = ""]

--- a/packages/ocaml/ocaml.5.2.0/opam
+++ b/packages/ocaml/ocaml.5.2.0/opam
@@ -17,6 +17,9 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [
   [CAML_LD_LIBRARY_PATH = ""]

--- a/packages/ocaml/ocaml.5.3.0/opam
+++ b/packages/ocaml/ocaml.5.3.0/opam
@@ -17,6 +17,9 @@ setenv: [
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [
   [CAML_LD_LIBRARY_PATH = ""]

--- a/packages/system-mingw/system-mingw.1/opam
+++ b/packages/system-mingw/system-mingw.1/opam
@@ -13,5 +13,8 @@ homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: compiler
 available: os = "win32"
-depends: "ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"}
+depends: [
+  ("ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"})
+  ("ocaml-env-mingw32" | "ocaml-env-mingw64")
+]
 conflict-class: "ocaml-system"

--- a/packages/system-mingw/system-mingw.1/opam
+++ b/packages/system-mingw/system-mingw.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "Build OCaml for mingw-w64"
+description: """
+This package specifies OCaml built with the mingw-w64 GCC compiler and is
+presently available for i386/x86_32 and amd64/x86_64.
+
+This package corresponds to the `mingw` and `mingw64` values given by
+`ocamlopt -config-var system`."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: compiler
+available: os = "win32"
+depends: "ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"}
+conflict-class: "ocaml-system"

--- a/packages/system-msvc/system-msvc.1/opam
+++ b/packages/system-msvc/system-msvc.1/opam
@@ -13,5 +13,8 @@ homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: compiler
 available: os = "win32"
-depends: "ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"}
+depends: [
+  ("ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"})
+  ("ocaml-env-msvc32" | "ocaml-env-msvc64")
+]
 conflict-class: "ocaml-system"

--- a/packages/system-msvc/system-msvc.1/opam
+++ b/packages/system-msvc/system-msvc.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+synopsis: "Build OCaml for Microsoft Visual Studio"
+description: """
+This package specifies OCaml built with Microsoft Visual Studio and is presently
+available for i386/x86_32 and amd64/x86_64.
+
+This package corresponds to the `win32` and `win64` values given by
+`ocamlopt -config-var system`."""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: compiler
+available: os = "win32"
+depends: "ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"}
+conflict-class: "ocaml-system"


### PR DESCRIPTION
This PR augments the three compiler packages (`ocaml-base-compiler`, `ocaml-system` and `ocaml-variants`) with support for the MSVC and mingw-w64 native Windows ports for 4.13.0+. I intend to extend this support back to 4.08 as part of an ongoing overhaul of the compiler packages, but that is beyond the scope of this PR.

## Principles

The implementation presented here stems from three underlying principles:

1. All four native Windows ports should be able to be co-installed in the same opam root (i.e. `~/.opam`) as separate switches (as with opam-repository-mingw). That is, the user should not be forced to choose permanently between MSVC/mingw-w64 and/or amd64/i686 at `opam init`.
2. The Windows ports should not be made to look like Tier 2 or alternate platforms; i.e. the instructions to create a Windows OCaml switch should not be _fundamentally_ different from other platforms.
3. Depexts requirements should be precise, so the installation of a `conf-` package should not speculatively install more dependencies than necessary for the given switch. In particular, if a switch is configured with i686 OCaml, the installation of conf-libfoo should install the required packages for i686 libfoo, not both i686 and x86_64 libfoo.

<details>
  <summary>Corollaries</summary>
    
There are some immediate observations and problems:
- The first principle matches the existing capability of [opam-repository-mingw](https://github.com/ocaml-opam/opam-repository-mingw).
- The second principle prohibits either _requiring_ `opam exec` or needing a Windows-specific wrapper (such as `with-dkml` or `ocaml-env`).
- The second principle also has implications for the `ocaml-base-compiler` package, since there is no concept of a "default" C compiler on Windows. The mingw-w64 and MSVC ports of OCaml are not interchangeable in the way that GCC or Clang-based OCaml is.
- The depext system in [OCaml for Windows](https://fdopen.github.io/opam-repository-mingw) was based on opam 2.0's opam-depext plugin, and never adopted opam 2.1's integrated support. While the use of the plugin means that it suffers from the same solving problems that caused depext to be integrated directly into the solver in opam 2.1, it did mean that `opam depext` knew which compiler was installed in the switch, because it was necessarily run _after_ the switch had been created.
- The `depexts` section of an opam file can only be filtered on _global_ variables. While we can (just about) set switch-specific global variables, this would be both awkward (users would need to know of an extra step), but would also contradict the second principle, adding a requirement to Windows-specific parts of the workflow. This means that the depexts for Windows need to be recorded in separate `conf-` packages, and the dependency graph of a switch needs to record sufficient information about the architecture and C compiler to select the correct package (in short, we require more `base-`-like packages).
</details>

<details>
    <summary>Other related work</summary>
    
This work overlaps with some considerable ongoing additional work on the compiler's opam packages:
- #17541 added the `ocaml-option-` packages to reduce the number of variants, but this applies to OCaml 4.12+ only. This facility needs extending (on principle) back to 4.11 and earlier. It makes little sense to update all the individual variants for 4.11 and earlier without first addressing this issue (it's side-stepped for now as 4.13 is the minimum version updated for a different technical reason).
- As I note in https://github.com/ocaml/opam-repository/pull/24075#issuecomment-1625271501, #22246 forged the wrong approach to fixing bytecode-only 5.x architectures started in #21510. This PR doesn't attempt to fix those issues, but the new virtual packages are added in both "input" (`ocaml-option-*`) form and "output" (`base-*`), which I believe to be the fundamental error I (/we) failed to see in #21510.

I was originally (back in September) of the opinion that it would be better to solve these two issues _first_ and then add Windows support as an extension of these fixes. However, while it's tempting to engineer things such that Windows becomes a "minor" addition, the compatibility concerns for these two fixes make them much higher risk than the Windows packages, which have no compatibility story to worry about. I've therefore restructured the changes so that the alterations are made Windows-only _for now_, with the fixes to Unix following later, lifting these "limitations".
</details>

## How it works

With opam 2.2.0 beta2, `opam init` (if pointed to this branch) will create an OCaml 5.1.1 switch. Concretely, on a clean Windows 11 system:

```
winget install Git.Git
winget install opam
```

and then in fresh terminal followed by:

```batch
rem Accept all defaults for opam init
opam init git+https://github.com/dra27/opam-repository.git#windows-initial
opam exec -- ocaml
```

will give OCaml 5.1.1! When creating a switch, an `arch-` or `system-` package can simply be added just as for the `ocaml-option-` packages. For example, assuming the user has installed Visual Studio which, amongst methods, may be done with:

```
winget install Microsoft.VisualStudio.2022.BuildTools --override "--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --passive"
```

then a 32-bit MSVC 4.14.2 switch may be created with:

```
opam switch create 4.14.2-msvc32 ocaml.4.14.2 system-msvc arch-x86_32
echo print_endline "Hello, world" > hello.ml
opam exec -- ocamlopt -o hello.exe hello.ml
```

Note that these steps do _not_ require the user to start a Visual Studio Tools Command Prompt or do anything beyond installing Visual Studio.

## Under the hood

In more detail, at present, the `ocaml.x.y.z` package encodes the version of OCaml being installed. To this, at present for Windows only, I have added two more sets of packages:
- `arch-x86_32` and `arch-x86_64` allow the choice between the i686 and amd64 architectures.
- `system-mingw` and `system-msvc` provide the choice between the mingw-w64 and Microsoft Visual Studio (MSVC) ports.

_Both_ `ocaml-base-compiler` and `ocaml-variants` use these two sets of packages. `ocaml-base-compiler` remains "OCaml in its default configuration", but it becomes possible to control exactly which C compiler configuration it's using.

The default compiler is amd64 mingw-w64 (i.e. `arch-x86_64` and `system-mingw` will be automatically added if no other `arch-` or `system-` package has been selected) for two reasons:
- We can't detect MSVC using opam's depext system at present (but we can automatically install mingw-w64), so mingw-w64 as a default means that `opam init` always builds a working OCaml
- Cygwin (and MSYS2) are not available for 32-bit systems, so users will be on 64-bit Windows.

For now, it is intentionally not possible to install the Cygwin port of OCaml using native Windows opam.

Where the _user_ installs a `system-` and an `arch-` package, there are also new sets of `host-arch-` and `host-system-` which are installed by all opam switches. The idea here is that one `host-system-` and one `host-arch-` package are _always_ installed in a switch (be that `ocaml-base-compiler`, `ocaml-variants` **or** `ocaml-system`).

<details>
  <summary>More information for users</summary>
    
The key rule is that `arch-` and `system-` should never be used in opam files because there are packages (such as `ocaml-system`) which don't use them. These are also packages which may also disappear in the future if opam gains a way to specify configuration options for to packages at installation time.

From the user's perspective, specifying `arch-x86_64` vs `host-arch-x86_64` is similar to the difference between specifying `ocaml-base-compiler.4.14.1` vs `ocaml.4.14.1`. `ocaml-base-compiler.4.14.1` instructs opam to build 4.14.1 from source, where `ocaml.4.14.1` permits the use of a system compiler.
</details>

The motivation for this change is to be able to indicate precisely where packages are not supported:
- `available: os != "win32"` is the sledgehammer: no Windows support at all
- `conflicts: "host-system-msvc"`: this package works with the mingw-w64 ports, but doesn't work with the Visual Studio ports
- `conflicts: "host-arch-x86_32"`: this package doesn't work on 32-bit Intel
- `depends: "host-system-mingw"`: this package _only_ works with the mingw-w64 ports.

## Notes

I've attempted to organise the changes into a meaningful commit series, which is slightly easier to review than the entire diff in one go. I've added missing metadata fields packages in order to pass `opam lint`.