### PR TITLE
conf-cuda: CUDA libraries -- configure installation path, offer install tips, validate

### DIFF
--- a/packages/conf-cuda-config/conf-cuda-config.1/opam
+++ b/packages/conf-cuda-config/conf-cuda-config.1/opam
@@ -10,15 +10,24 @@ build: [
     if [ -z "$CUDA_PATH" ]; then
       if [ -d "/usr/local/cuda" ]; then
         CUDA_PATH="/usr/local/cuda"
-        HAS_CUDA="true"
+        CUDA_PREINSTALLED="true"
       elif [ -d "/opt/cuda" ]; then
         CUDA_PATH="/opt/cuda"
-        HAS_CUDA="true"
+        CUDA_PREINSTALLED="true"
+      elif [ -d "/usr/cuda" ]; then
+        CUDA_PATH="/usr/cuda"
+        CUDA_PREINSTALLED="true"
+      elif [ "arch" = %{os-family}% ]; then
+        CUDA_PATH="/opt/cuda"
+        CUDA_PREINSTALLED="false"
       else
-        HAS_CUDA="false"
+        CUDA_PATH="/usr/local/cuda"
+        CUDA_PREINSTALLED="false"
       fi
     else
-      HAS_CUDA="false"
+      if [ -d "$CUDA_PATH" ]; then
+        CUDA_PREINSTALLED="true"
+      fi
     fi
     if [ -z "$WSL_DISTRO_NAME" ]; then
       IS_WSL="false"
@@ -28,13 +37,17 @@ build: [
     cat <<EOF > conf-cuda-config.config
 opam-version: "2.0"
 variables {
-  has_cuda: "$HAS_CUDA"
+  cuda_preinstalled: "$CUDA_PREINSTALLED"
   cuda_path: "$CUDA_PATH"
   is_wsl: "$IS_WSL"
   wsl_distro_name: "$WSL_DISTRO_NAME"
 }
 EOF
     """]
+]
+post-message: [
+  [ "NOTE: assuming CUDA will be installed under %{conf-cuda-config:cuda_path}%" ]
+  { !conf-cuda-path:cuda_preinstalled }
 ]
 synopsis: "Preparatory steps for the conf-cuda package"
 description:

--- a/packages/conf-cuda-config/conf-cuda-config.1/opam
+++ b/packages/conf-cuda-config/conf-cuda-config.1/opam
@@ -48,10 +48,6 @@ EOF
     """]
 ]
 post-messages: [
-  "NOTE: Add the multiverse repository `sudo add-apt-repository multiverse; sudo apt update`. Or manually install CUDA, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html"
-  {!conf-cuda-config:cuda_preinstalled & !conf-cuda-config:is_wsl & os-family = "debian" & os-distribution != "ubuntu"}
-  "NOTE: under WSL, manually install CUDA, this package will not install it. See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl"
-  {!conf-cuda-config:cuda_preinstalled & conf-cuda-config:is_wsl}
   "NOTE: assuming CUDA will be installed under %{conf-cuda-config:cuda_path}%"
   {!conf-cuda-config:cuda_preinstalled}
 ]

--- a/packages/conf-cuda-config/conf-cuda-config.1/opam
+++ b/packages/conf-cuda-config/conf-cuda-config.1/opam
@@ -34,7 +34,7 @@ build: [
     if [ -z "$WSL_DISTRO_NAME" ]; then
       IS_WSL="false"
     else
-      IS_WSL="false"
+      IS_WSL="true"
     fi
     cat <<EOF > conf-cuda-config.config
 opam-version: "2.0"
@@ -53,7 +53,7 @@ post-messages: [
   "NOTE: under WSL, manually install CUDA, this package will not install it. See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl"
   {!conf-cuda-config:cuda_preinstalled & conf-cuda-config:is_wsl}
   "NOTE: assuming CUDA will be installed under %{conf-cuda-config:cuda_path}%"
-  { !conf-cuda-config:cuda_preinstalled }
+  {!conf-cuda-config:cuda_preinstalled}
 ]
 synopsis: "Preparatory steps for the conf-cuda package"
 description:

--- a/packages/conf-cuda-config/conf-cuda-config.1/opam
+++ b/packages/conf-cuda-config/conf-cuda-config.1/opam
@@ -45,13 +45,13 @@ variables {
 EOF
     """]
 ]
-post-message: [
+post-messages: [
   "NOTE: Add the multiverse repository `sudo add-apt-repository multiverse; sudo apt update`. Or manually install CUDA, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html"
   {!conf-cuda-config:cuda_preinstalled & !conf-cuda-config:is_wsl & os-family = "debian" & os-distribution != "ubuntu"}
   "NOTE: under WSL, manually install CUDA, this package will not install it. See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl"
   {!conf-cuda-config:cuda_preinstalled & conf-cuda-config:is_wsl}
-  [ "NOTE: assuming CUDA will be installed under %{conf-cuda-config:cuda_path}%" ]
-  { !conf-cuda-path:cuda_preinstalled }
+  "NOTE: assuming CUDA will be installed under %{conf-cuda-config:cuda_path}%"
+  { !conf-cuda-config:cuda_preinstalled }
 ]
 synopsis: "Preparatory steps for the conf-cuda package"
 description:

--- a/packages/conf-cuda-config/conf-cuda-config.1/opam
+++ b/packages/conf-cuda-config/conf-cuda-config.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Lukasz Stafiniak <lukstafi@gmail.com>"
+authors: [
+    "Lukasz Stafiniak <lukstafi@gmail.com>"
+]
+homepage: "https://docs.nvidia.com/cuda/"
+license: "MIT"
+build: [
+  ["sh" "-exc" """
+    if [ -z "$CUDA_PATH" ]; then
+      if [ -d "/usr/local/cuda" ]; then
+        CUDA_PATH="/usr/local/cuda"
+        HAS_CUDA="true"
+      elif [ -d "/opt/cuda" ]; then
+        CUDA_PATH="/opt/cuda"
+        HAS_CUDA="true"
+      else
+        HAS_CUDA="false"
+      fi
+    else
+      HAS_CUDA="false"
+    fi
+    if [ -z "$WSL_DISTRO_NAME" ]; then
+      IS_WSL="false"
+    else
+      IS_WSL="false"
+    fi
+    cat <<EOF > conf-cuda-config.config
+opam-version: "2.0"
+variables {
+  has_cuda: "$HAS_CUDA"
+  cuda_path: "$CUDA_PATH"
+  is_wsl: "$IS_WSL"
+  wsl_distro_name: "$WSL_DISTRO_NAME"
+}
+EOF
+    """]
+]
+synopsis: "Preparatory steps for the conf-cuda package"
+description:
+  "This package checks if CUDA is already installed on the system, and if the OS runs under WSL."
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-cuda-config/conf-cuda-config.1/opam
+++ b/packages/conf-cuda-config/conf-cuda-config.1/opam
@@ -27,6 +27,8 @@ build: [
     else
       if [ -d "$CUDA_PATH" ]; then
         CUDA_PREINSTALLED="true"
+      else
+        CUDA_PREINSTALLED="false"
       fi
     fi
     if [ -z "$WSL_DISTRO_NAME" ]; then

--- a/packages/conf-cuda-config/conf-cuda-config.1/opam
+++ b/packages/conf-cuda-config/conf-cuda-config.1/opam
@@ -46,6 +46,10 @@ EOF
     """]
 ]
 post-message: [
+  "NOTE: Add the multiverse repository `sudo add-apt-repository multiverse; sudo apt update`. Or manually install CUDA, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html"
+  {!conf-cuda-config:cuda_preinstalled & !conf-cuda-config:is_wsl & os-family = "debian" & os-distribution != "ubuntu"}
+  "NOTE: under WSL, manually install CUDA, this package will not install it. See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl"
+  {!conf-cuda-config:cuda_preinstalled & conf-cuda-config:is_wsl}
   [ "NOTE: assuming CUDA will be installed under %{conf-cuda-config:cuda_path}%" ]
   { !conf-cuda-path:cuda_preinstalled }
 ]

--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -16,17 +16,20 @@ build: [
 # Note: the minimal set of packages directly from NVidia repositories, e.g. for cudajit:
 # "cuda-cudart-X-Y" "cuda-cudart-dev-X-Y" "cuda-runtime-X-Y" "cuda-nvrtc-X-Y" "cuda-nvrtc-dev-X-Y"
 # where e.g. X=12, Y=4 is the CUDA version.
+depends: [ "conf-cuda-config" ]
 depexts: [
-  ["nvidia-cuda-dev" "nvidia-cuda-toolkit"] {os-family = "debian"}
-  ["CUDA" "CUDA-tools"] {os-family = "opensuse" | os-distribution = "opensuse-leap" | 
-                         os-distribution = "opensuse-tumbleweed"}
-  ["cuda"] {os-family = "arch"}
+  ["nvidia-cuda-dev" "nvidia-cuda-toolkit"]
+  {!conf-cuda-config:is_wsl & !conf-cuda-config:has_cuda & os-family = "debian"}
+  ["CUDA" "CUDA-tools"]
+  {!conf-cuda-config:is_wsl & !conf-cuda-config:has_cuda &
+   (os-family = "opensuse" | os-distribution = "opensuse-leap" | os-distribution = "opensuse-tumbleweed")}
+  ["cuda"] {!conf-cuda-config:is_wsl & !conf-cuda-config:has_cuda & os-family = "arch"}
 ]
 setenv: [
-  [CUDA_PATH = "/opt/cuda"] {os-family = "arch"}
+  [ CUDA_PATH = "%{conf-cuda-config:cuda_path}%" ]
 ]
 build-env: [
-  [CUDA_PATH = "/opt/cuda"] {os-family = "arch"}
+  [ CUDA_PATH = "%{conf-cuda-config:cuda_path}%" ]
 ]
 messages: [
   "WARNING: under WSL, manually install CUDA, when installing this package ignore request for external dependencies if any (answer 3, or nny). See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl"

--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Lukasz Stafiniak <lukstafi@gmail.com>"
+authors: [
+    "NVidia"
+]
+homepage: "https://docs.nvidia.com/cuda/"
+license: "CUDA Toolkit End User License Agreement <https://docs.nvidia.com/cuda/eula/index.html>"
+# We do not restrict availability to let users install CUDA themselves.
+build: [
+  ["sh" "-exc" "echo \"#include  \\\"cuda.h\\\"\\n#include  \\\"nvrtc.h\\\"\" > test.c"]
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/cuda/include test.c"]
+]
+# Note: the minimal set of packages directly from NVidia repositories, e.g. for cudajit:
+# "cuda-cudart-X-Y" "cuda-cudart-dev-X-Y" "cuda-runtime-X-Y" "cuda-nvrtc-X-Y" "cuda-nvrtc-dev-X-Y"
+# where e.g. X=12, Y=4 is the CUDA version.
+depexts: [
+  ["nvidia-cuda-dev" "nvidia-cuda-toolkit"] {os-family = "debian"}
+  ["CUDA" "CUDA-tools"] {os-family = "opensuse" | os-distribution = "opensuse-leap" | 
+                         os-distribution = "opensuse-tumbleweed"}
+  ["cuda"] {os-family = "arch"}
+]
+messages: [
+  "WARNING: under WSL, manually install CUDA before installing this package, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl"
+  {os = "linux"}
+]
+synopsis: "Virtual package relying on a CUDA system installation"
+description:
+  "This package can only install if CUDA is installed on the system."
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -26,15 +26,15 @@ build-env: [
   [CUDA_PATH = "/opt/cuda"] {os-family = "arch"}
 ]
 messages: [
-  "WARNING: under WSL, manually install CUDA before installing this package, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl"
+  "WARNING: under WSL, manually install CUDA, when installing this package ignore request for external dependencies if any (answer 3). See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl"
   {os = "linux"}
 ]
 post-messages: [
-  "Add the multiverse repository; or manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, when installing this package ignore request for external dependencies if any. See: https://docs.nvidia.com/cuda/"
+  "Add the multiverse repository; or manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, when installing this package ignore request for external dependencies if any (answer 3). See: https://docs.nvidia.com/cuda/"
   {failure & os-family = "debian" & os-distribution != "ubuntu"}
-  "Manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, when installing this package ignore request for external dependencies if any. See: https://docs.nvidia.com/cuda/"
+  "Manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, when installing this package ignore request for external dependencies if any (answer 3). See: https://docs.nvidia.com/cuda/"
   {failure & os-family != "arch" & (os-distribution = "ubuntu" | os-family != "debian")}
-  "Manually install CUDA ensuring headers are under /opt/cuda/include and library objects under /opt/cuda/lib64, when installing this package ignore request for external dependencies. See: https://docs.nvidia.com/cuda/"
+  "Manually install CUDA ensuring headers are under /opt/cuda/include and library objects under /opt/cuda/lib64, when installing this package ignore request for external dependencies (answer 3). See: https://docs.nvidia.com/cuda/"
   {failure & os-family = "arch"}
 ]
 synopsis: "Virtual package relying on a CUDA system installation"

--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -29,9 +29,24 @@ setenv: [
   [ CUDA_PATH = "%{conf-cuda-config:cuda_path}%" ]
 ]
 post-messages: [
-  "NOTE: under WSL, manually install CUDA, this package will not install it. See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl Failing configuration: cuda preinstalled %{conf-cuda-config:cuda_preinstalled}%, CUDA_PATH=%{conf-cuda-config:cuda_path}%, is-WSL %{conf-cuda-config:is_wsl}%"
+  "DEBUG: [1] {!conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os-family = debian}"
+  {!conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os-family = "debian"}
+  "DEBUG: [2] {!conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os-family = arch}"
+  {!conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os-family = "arch"}
+  "DEBUG: [3] {!conf-cuda-config:is_wsl}"
+  {!conf-cuda-config:is_wsl}
+  "DEBUG: [4] {!conf-cuda-config:cuda_preinstalled}"
+  {!conf-cuda-config:cuda_preinstalled}
+  "DEBUG: [5] {conf-cuda-config:is_wsl}"
+  {conf-cuda-config:is_wsl}
+  "DEBUG: [6] {conf-cuda-config:cuda_preinstalled}"
+  {conf-cuda-config:cuda_preinstalled}
+  "DEBUG: [7] {os-family = debian}"
+  {os-family = "debian"}
+
+  "NOTE: under WSL, manually install CUDA, this package will not install it. See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl Failing configuration: cuda preinstalled %{conf-cuda-config:cuda_preinstalled}%, CUDA_PATH=%{conf-cuda-config:cuda_path}%, is-WSL %{conf-cuda-config:is_wsl}%, OS family %{os-family}%"
   {failure & conf-cuda-config:is_wsl}
-  "Manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, re-install opam package conf-cuda-config, when installing this package ignore request for external dependencies if any (answer 3, or nny). See: https://docs.nvidia.com/cuda/ Failing configuration: cuda preinstalled %{conf-cuda-config:cuda_preinstalled}%, CUDA_PATH=%{conf-cuda-config:cuda_path}%, is-WSL %{conf-cuda-config:is_wsl}%"
+  "Manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, re-install opam package conf-cuda-config, when installing this package ignore request for external dependencies if any (answer 3, or nny). See: https://docs.nvidia.com/cuda/ Failing configuration: cuda preinstalled %{conf-cuda-config:cuda_preinstalled}%, CUDA_PATH=%{conf-cuda-config:cuda_path}%, is-WSL %{conf-cuda-config:is_wsl}%, OS family %{os-family}%"
   {failure & !conf-cuda-config:is_wsl}
 ]
 synopsis: "Virtual package relying on a CUDA system installation"

--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -29,10 +29,12 @@ setenv: [
   [ CUDA_PATH = "%{conf-cuda-config:cuda_path}%" ]
 ]
 post-messages: [
-  "NOTE: under WSL, manually install CUDA, this package will not install it. See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl Failing configuration: cuda preinstalled %{conf-cuda-config:cuda_preinstalled}%, CUDA_PATH=%{conf-cuda-config:cuda_path}%, is-WSL %{conf-cuda-config:is_wsl}%, OS family %{os-family}%"
+  "Under WSL, manually install CUDA, this package will not install it. See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl Failing configuration: cuda preinstalled %{conf-cuda-config:cuda_preinstalled}%, CUDA_PATH=%{conf-cuda-config:cuda_path}%, is-WSL %{conf-cuda-config:is_wsl}%, OS family %{os-family}%"
   {failure & conf-cuda-config:is_wsl}
   "Manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, re-install opam package conf-cuda-config, when installing this package ignore request for external dependencies if any (answer 3, or nny). See: https://docs.nvidia.com/cuda/ Failing configuration: cuda preinstalled %{conf-cuda-config:cuda_preinstalled}%, CUDA_PATH=%{conf-cuda-config:cuda_path}%, is-WSL %{conf-cuda-config:is_wsl}%, OS family %{os-family}%"
   {failure & !conf-cuda-config:is_wsl}
+  "NOTE: CUDA drivers are outside the scope of conf-cuda and should be installed manually."
+  {!conf-cuda-config:is_wsl}
 ]
 synopsis: "Virtual package relying on a CUDA system installation"
 description:

--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -29,21 +29,6 @@ setenv: [
   [ CUDA_PATH = "%{conf-cuda-config:cuda_path}%" ]
 ]
 post-messages: [
-  "DEBUG: [1] {!conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os-family = debian}"
-  {!conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os-family = "debian"}
-  "DEBUG: [2] {!conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os-family = arch}"
-  {!conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os-family = "arch"}
-  "DEBUG: [3] {!conf-cuda-config:is_wsl}"
-  {!conf-cuda-config:is_wsl}
-  "DEBUG: [4] {!conf-cuda-config:cuda_preinstalled}"
-  {!conf-cuda-config:cuda_preinstalled}
-  "DEBUG: [5] {conf-cuda-config:is_wsl}"
-  {conf-cuda-config:is_wsl}
-  "DEBUG: [6] {conf-cuda-config:cuda_preinstalled}"
-  {conf-cuda-config:cuda_preinstalled}
-  "DEBUG: [7] {os-family = debian}"
-  {os-family = "debian"}
-
   "NOTE: under WSL, manually install CUDA, this package will not install it. See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl Failing configuration: cuda preinstalled %{conf-cuda-config:cuda_preinstalled}%, CUDA_PATH=%{conf-cuda-config:cuda_path}%, is-WSL %{conf-cuda-config:is_wsl}%, OS family %{os-family}%"
   {failure & conf-cuda-config:is_wsl}
   "Manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, re-install opam package conf-cuda-config, when installing this package ignore request for external dependencies if any (answer 3, or nny). See: https://docs.nvidia.com/cuda/ Failing configuration: cuda preinstalled %{conf-cuda-config:cuda_preinstalled}%, CUDA_PATH=%{conf-cuda-config:cuda_path}%, is-WSL %{conf-cuda-config:is_wsl}%, OS family %{os-family}%"

--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -23,17 +23,23 @@ setenv: [
 post-messages: [
   "Make sure that CUDA is properly installed under the path %{conf-cuda-config:cuda_path}%; or properly set the CUDA_PATH environment variable and re-install opam package conf-cuda-config. See: https://docs.nvidia.com/cuda/ Failing configuration: CUDA_PATH=%{conf-cuda-config:cuda_path}%, is-WSL %{conf-cuda-config:is_wsl}%, OS family %{os-family}%"
   {failure & conf-cuda-config:cuda_preinstalled}
-  "Do: `sudo add-apt-repository multiverse; sudo apt update; sudo apt-get install nvidia-cuda-dev nvidia-cuda-toolkit`. Or manually install CUDA, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html"
+  "Execute: $ sudo add-apt-repository multiverse; sudo apt update; sudo apt-get install nvidia-cuda-dev nvidia-cuda-toolkit"
   {failure & !conf-cuda-config:cuda_preinstalled & !conf-cuda-config:is_wsl & os-family = "debian" & os-distribution != "ubuntu"}
-  "Do: `sudo apt-get install nvidia-cuda-dev nvidia-cuda-toolkit`. Or manually install CUDA, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html"
+  "Execute: $ sudo apt-get install nvidia-cuda-dev nvidia-cuda-toolkit"
   {failure & !conf-cuda-config:cuda_preinstalled & !conf-cuda-config:is_wsl & os-distribution = "ubuntu"}
   "Under WSL, manually install CUDA. See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl"
   {failure & !conf-cuda-config:cuda_preinstalled & conf-cuda-config:is_wsl}
-  "Do: `sudo zypper in CUDA CUDA-tools`. Or manually install CUDA, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html"
+  "Execute: $ sudo zypper in CUDA CUDA-tools"
   {failure & !conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled &
    (os-family = "opensuse" | os-distribution = "opensuse-leap" | os-distribution = "opensuse-tumbleweed")}
-  "Do: `sudo pacman -Sy cuda`. Or manually install CUDA, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html"
+  "Execute: $ sudo pacman -Sy cuda"
    {failure & !conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os-family = "arch"}
+   "Alternatively: manually install CUDA or verify that CUDA_PATH is set properly, and re-install opam package conf-cuda-config. See: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html"
+   {failure & !conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os = "linux"}
+   "Manually install CUDA or verify that CUDA_PATH is set properly, and re-install opam package conf-cuda-config. See: https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html"
+   {failure & !conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os = "windows"}
+   "If CUDA is supported on your system, manually install CUDA or verify that CUDA_PATH is set properly, and re-install opam package conf-cuda-config. See: https://docs.nvidia.com/cuda/"
+   {failure & !conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os != "linux" & os != "windows"}
 ]
 synopsis: "Virtual package relying on a CUDA system installation"
 description:

--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -7,7 +7,10 @@ homepage: "https://docs.nvidia.com/cuda/"
 license: "CUDA Toolkit End User License Agreement <https://docs.nvidia.com/cuda/eula/index.html>"
 # We do not restrict availability to let users install CUDA themselves.
 build: [
-  ["sh" "-exc" "echo \"#include  \\\"cuda.h\\\"\\n#include  \\\"nvrtc.h\\\"\" > test.c"]
+  ["sh" "-exc" "cat <<EOF > test.c
+   #include  \\\"cuda.h\\\"
+   #include  \\\"nvrtc.h\\\"
+   EOF"]
   ["sh" "-exc" "cc -c $CFLAGS -I$(CUDA_PATH)/include -I/usr/local/cuda/include test.c"]
 ]
 # Note: the minimal set of packages directly from NVidia repositories, e.g. for cudajit:

--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -31,17 +31,11 @@ setenv: [
 build-env: [
   [ CUDA_PATH = "%{conf-cuda-config:cuda_path}%" ]
 ]
-messages: [
-  "WARNING: under WSL, manually install CUDA, when installing this package ignore request for external dependencies if any (answer 3, or nny). See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl"
-  {os = "linux"}
-  "NOTE: Add the multiverse repository `sudo add-apt-repository multiverse; sudo apt update`. Or manually install CUDA, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html"
-  {os-family = "debian" & os-distribution != "ubuntu"}
-]
 post-messages: [
-  "Manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, when installing this package ignore request for external dependencies if any (answer 3, or nny). See: https://docs.nvidia.com/cuda/"
-  {failure & os-family != "arch"}
-  "Manually install CUDA ensuring headers are under /opt/cuda/include and library objects under /opt/cuda/lib64, when installing this package ignore request for external dependencies (answer 3, or nny). See: https://docs.nvidia.com/cuda/"
-  {failure & os-family = "arch"}
+  "NOTE: under WSL, manually install CUDA, this package will not install it. See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl Failing configuration: cuda preinstalled %{conf-cuda-config:cuda_preinstalled}%, CUDA_PATH=%{conf-cuda-config:cuda_path}%, is-WSL %{conf-cuda-config:is_wsl}%"
+  {failure & conf-cuda-config:is_wsl}
+  "Manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, re-install opam package conf-cuda-config, when installing this package ignore request for external dependencies if any (answer 3, or nny). See: https://docs.nvidia.com/cuda/ Failing configuration: cuda preinstalled %{conf-cuda-config:cuda_preinstalled}%, CUDA_PATH=%{conf-cuda-config:cuda_path}%, is-WSL %{conf-cuda-config:is_wsl}%"
+  {failure & !conf-cuda-config:is_wsl}
 ]
 synopsis: "Virtual package relying on a CUDA system installation"
 description:

--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -8,9 +8,9 @@ license: "CUDA Toolkit End User License Agreement <https://docs.nvidia.com/cuda/
 # We do not restrict availability to let users install CUDA themselves.
 build: [
   ["sh" "-exc" "cat <<EOF > test.c
-   #include  \\\"cuda.h\\\"
-   #include  \\\"nvrtc.h\\\"
-   EOF"]
+   #include  \"cuda.h\"
+   #include  \"nvrtc.h\"
+   "]
   ["sh" "-exc" "cc -c $CFLAGS -I$(CUDA_PATH)/include -I/usr/local/cuda/include test.c"]
 ]
 # Note: the minimal set of packages directly from NVidia repositories, e.g. for cudajit:
@@ -29,15 +29,15 @@ build-env: [
   [CUDA_PATH = "/opt/cuda"] {os-family = "arch"}
 ]
 messages: [
-  "WARNING: under WSL, manually install CUDA, when installing this package ignore request for external dependencies if any (answer 3). See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl"
+  "WARNING: under WSL, manually install CUDA, when installing this package ignore request for external dependencies if any (answer 3, or nny). See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl"
   {os = "linux"}
+  "NOTE: Add the multiverse repository `sudo add-apt-repository multiverse; sudo apt update`. Or manually install CUDA, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html"
+  {os-family = "debian" & os-distribution != "ubuntu"}
 ]
 post-messages: [
-  "Add the multiverse repository; or manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, when installing this package ignore request for external dependencies if any (answer 3). See: https://docs.nvidia.com/cuda/"
-  {failure & os-family = "debian" & os-distribution != "ubuntu"}
-  "Manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, when installing this package ignore request for external dependencies if any (answer 3). See: https://docs.nvidia.com/cuda/"
-  {failure & os-family != "arch" & (os-distribution = "ubuntu" | os-family != "debian")}
-  "Manually install CUDA ensuring headers are under /opt/cuda/include and library objects under /opt/cuda/lib64, when installing this package ignore request for external dependencies (answer 3). See: https://docs.nvidia.com/cuda/"
+  "Manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, when installing this package ignore request for external dependencies if any (answer 3, or nny). See: https://docs.nvidia.com/cuda/"
+  {failure & os-family != "arch"}
+  "Manually install CUDA ensuring headers are under /opt/cuda/include and library objects under /opt/cuda/lib64, when installing this package ignore request for external dependencies (answer 3, or nny). See: https://docs.nvidia.com/cuda/"
   {failure & os-family = "arch"}
 ]
 synopsis: "Virtual package relying on a CUDA system installation"

--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -8,7 +8,7 @@ license: "CUDA Toolkit End User License Agreement <https://docs.nvidia.com/cuda/
 # We do not restrict availability to let users install CUDA themselves.
 build: [
   ["sh" "-exc" "echo \"#include  \\\"cuda.h\\\"\\n#include  \\\"nvrtc.h\\\"\" > test.c"]
-  ["sh" "-exc" "cc -c $CFLAGS -I$CUDA_PATH/include -I/usr/local/cuda/include test.c"]
+  ["sh" "-exc" "cc -c $CFLAGS -I$(CUDA_PATH)/include -I/usr/local/cuda/include test.c"]
 ]
 # Note: the minimal set of packages directly from NVidia repositories, e.g. for cudajit:
 # "cuda-cudart-X-Y" "cuda-cudart-dev-X-Y" "cuda-runtime-X-Y" "cuda-nvrtc-X-Y" "cuda-nvrtc-dev-X-Y"

--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -8,7 +8,7 @@ license: "CUDA Toolkit End User License Agreement <https://docs.nvidia.com/cuda/
 # We do not restrict availability to let users install CUDA themselves.
 build: [
   ["sh" "-exc" "echo \"#include  \\\"cuda.h\\\"\\n#include  \\\"nvrtc.h\\\"\" > test.c"]
-  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/cuda/include test.c"]
+  ["sh" "-exc" "cc -c $CFLAGS -I$CUDA_PATH/include -I/usr/local/cuda/include test.c"]
 ]
 # Note: the minimal set of packages directly from NVidia repositories, e.g. for cudajit:
 # "cuda-cudart-X-Y" "cuda-cudart-dev-X-Y" "cuda-runtime-X-Y" "cuda-nvrtc-X-Y" "cuda-nvrtc-dev-X-Y"
@@ -19,9 +19,23 @@ depexts: [
                          os-distribution = "opensuse-tumbleweed"}
   ["cuda"] {os-family = "arch"}
 ]
+setenv: [
+  [CUDA_PATH = "/opt/cuda"] {os-family = "arch"}
+]
+build-env: [
+  [CUDA_PATH = "/opt/cuda"] {os-family = "arch"}
+]
 messages: [
   "WARNING: under WSL, manually install CUDA before installing this package, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl"
   {os = "linux"}
+]
+post-messages: [
+  "Add the multiverse repository; or manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, when installing this package ignore request for external dependencies if any. See: https://docs.nvidia.com/cuda/"
+  {failure & os-family = "debian" & os-distribution != "ubuntu"}
+  "Manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, when installing this package ignore request for external dependencies if any. See: https://docs.nvidia.com/cuda/"
+  {failure & os-family != "arch" & (os-distribution = "ubuntu" | os-family != "debian")}
+  "Manually install CUDA ensuring headers are under /opt/cuda/include and library objects under /opt/cuda/lib64, when installing this package ignore request for external dependencies. See: https://docs.nvidia.com/cuda/"
+  {failure & os-family = "arch"}
 ]
 synopsis: "Virtual package relying on a CUDA system installation"
 description:

--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -11,7 +11,7 @@ build: [
    #include  \"cuda.h\"
    #include  \"nvrtc.h\"
    "]
-  ["sh" "-exc" "cc -c $CFLAGS -I$(CUDA_PATH)/include -I/usr/local/cuda/include test.c"]
+  ["sh" "-exc" "cc -c $CFLAGS -I$(CUDA_PATH)/include test.c"]
 ]
 # Note: the minimal set of packages directly from NVidia repositories, e.g. for cudajit:
 # "cuda-cudart-X-Y" "cuda-cudart-dev-X-Y" "cuda-runtime-X-Y" "cuda-nvrtc-X-Y" "cuda-nvrtc-dev-X-Y"
@@ -19,11 +19,11 @@ build: [
 depends: [ "conf-cuda-config" ]
 depexts: [
   ["nvidia-cuda-dev" "nvidia-cuda-toolkit"]
-  {!conf-cuda-config:is_wsl & !conf-cuda-config:has_cuda & os-family = "debian"}
+  {!conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os-family = "debian"}
   ["CUDA" "CUDA-tools"]
-  {!conf-cuda-config:is_wsl & !conf-cuda-config:has_cuda &
+  {!conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled &
    (os-family = "opensuse" | os-distribution = "opensuse-leap" | os-distribution = "opensuse-tumbleweed")}
-  ["cuda"] {!conf-cuda-config:is_wsl & !conf-cuda-config:has_cuda & os-family = "arch"}
+  ["cuda"] {!conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os-family = "arch"}
 ]
 setenv: [
   [ CUDA_PATH = "%{conf-cuda-config:cuda_path}%" ]

--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -17,24 +17,23 @@ build: [
 # "cuda-cudart-X-Y" "cuda-cudart-dev-X-Y" "cuda-runtime-X-Y" "cuda-nvrtc-X-Y" "cuda-nvrtc-dev-X-Y"
 # where e.g. X=12, Y=4 is the CUDA version.
 depends: [ "conf-cuda-config" ]
-depexts: [
-  ["nvidia-cuda-dev" "nvidia-cuda-toolkit"]
-  {!conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os-family = "debian"}
-  ["CUDA" "CUDA-tools"]
-  {!conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled &
-   (os-family = "opensuse" | os-distribution = "opensuse-leap" | os-distribution = "opensuse-tumbleweed")}
-  ["cuda"] {!conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os-family = "arch"}
-]
 setenv: [
   [ CUDA_PATH = "%{conf-cuda-config:cuda_path}%" ]
 ]
 post-messages: [
-  "Under WSL, manually install CUDA, this package will not install it. See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl Failing configuration: cuda preinstalled %{conf-cuda-config:cuda_preinstalled}%, CUDA_PATH=%{conf-cuda-config:cuda_path}%, is-WSL %{conf-cuda-config:is_wsl}%, OS family %{os-family}%"
-  {failure & conf-cuda-config:is_wsl}
-  "Manually install CUDA, set the CUDA_PATH environment variable if different from /usr/local/cuda, re-install opam package conf-cuda-config, when installing this package ignore request for external dependencies if any (answer 3, or nny). See: https://docs.nvidia.com/cuda/ Failing configuration: cuda preinstalled %{conf-cuda-config:cuda_preinstalled}%, CUDA_PATH=%{conf-cuda-config:cuda_path}%, is-WSL %{conf-cuda-config:is_wsl}%, OS family %{os-family}%"
-  {failure & !conf-cuda-config:is_wsl}
-  "NOTE: CUDA drivers are outside the scope of conf-cuda and should be installed manually."
-  {!conf-cuda-config:is_wsl}
+  "Make sure that CUDA is properly installed under the path %{conf-cuda-config:cuda_path}%; or properly set the CUDA_PATH environment variable and re-install opam package conf-cuda-config. See: https://docs.nvidia.com/cuda/ Failing configuration: CUDA_PATH=%{conf-cuda-config:cuda_path}%, is-WSL %{conf-cuda-config:is_wsl}%, OS family %{os-family}%"
+  {failure & conf-cuda-config:cuda_preinstalled}
+  "Do: `sudo add-apt-repository multiverse; sudo apt update; sudo apt-get install nvidia-cuda-dev nvidia-cuda-toolkit`. Or manually install CUDA, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html"
+  {failure & !conf-cuda-config:cuda_preinstalled & !conf-cuda-config:is_wsl & os-family = "debian" & os-distribution != "ubuntu"}
+  "Do: `sudo apt-get install nvidia-cuda-dev nvidia-cuda-toolkit`. Or manually install CUDA, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html"
+  {failure & !conf-cuda-config:cuda_preinstalled & !conf-cuda-config:is_wsl & os-distribution = "ubuntu"}
+  "Under WSL, manually install CUDA. See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-wsl"
+  {failure & !conf-cuda-config:cuda_preinstalled & conf-cuda-config:is_wsl}
+  "Do: `sudo zypper in CUDA CUDA-tools`. Or manually install CUDA, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html"
+  {failure & !conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled &
+   (os-family = "opensuse" | os-distribution = "opensuse-leap" | os-distribution = "opensuse-tumbleweed")}
+  "Do: `sudo pacman -Sy cuda`. Or manually install CUDA, see https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html"
+   {failure & !conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os-family = "arch"}
 ]
 synopsis: "Virtual package relying on a CUDA system installation"
 description:

--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -11,7 +11,7 @@ build: [
    #include  \"cuda.h\"
    #include  \"nvrtc.h\"
    "]
-  ["sh" "-exc" "cc -c $CFLAGS -I$(CUDA_PATH)/include test.c"]
+  ["sh" "-exc" "cc -c $CFLAGS -I%{conf-cuda-config:cuda_path}%/include test.c"]
 ]
 # Note: the minimal set of packages directly from NVidia repositories, e.g. for cudajit:
 # "cuda-cudart-X-Y" "cuda-cudart-dev-X-Y" "cuda-runtime-X-Y" "cuda-nvrtc-X-Y" "cuda-nvrtc-dev-X-Y"
@@ -26,9 +26,6 @@ depexts: [
   ["cuda"] {!conf-cuda-config:is_wsl & !conf-cuda-config:cuda_preinstalled & os-family = "arch"}
 ]
 setenv: [
-  [ CUDA_PATH = "%{conf-cuda-config:cuda_path}%" ]
-]
-build-env: [
   [ CUDA_PATH = "%{conf-cuda-config:cuda_path}%" ]
 ]
 post-messages: [


### PR DESCRIPTION
The package `conf-cuda-config` collects information, and then the package `conf-cuda` verifies that the CUDA library headers are installed. `conf-cuda` provides instructions to the user on how to install the CUDA headers and library objects, if the headers are missing. NVidia drivers are out of scope for `conf-cuda`.