### PR TITLE
[new release] multicont (1.0.3)

### DIFF
--- a/packages/multicont/multicont.1.0.3/opam
+++ b/packages/multicont/multicont.1.0.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Multi-shot continuations in OCaml"
+description:
+  "This library provides facilities for programming with multi-shot continuations in OCaml"
+maintainer: ["Daniel Hillerström"]
+authors: ["Daniel Hillerström"]
+license: "MIT"
+tags: ["multi-shot continuations" "effect handlers"]
+homepage: "https://github.com/dhil/ocaml-multicont"
+bug-reports: "https://github.com/dhil/ocaml-multicont/issues"
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.14"}
+  "dune-configurator" {>= "3.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dhil/ocaml-multicont.git"
+url {
+  src:
+    "https://github.com/dhil/ocaml-multicont/releases/download/v1.0.3/multicont-1.0.3.tbz"
+  checksum: [
+    "sha256=12eaa68f681d6484eb53c72fabe2b880664435b1f94c09ff0c2b48e9d0084103"
+    "sha512=0fabeced43326ce09b6d010fc477caf9b593b00c40e22826caa1c7ddc956d8a505591bb683c31539f02d29208792c015ad5a2d3806a40ae47d2ec46f0122018d"
+  ]
+}
+x-commit-hash: "40826d1aa661ddc8177f6acac1d8b5f440c1feab"


### PR DESCRIPTION
Multi-shot continuations in OCaml

- Project page: <a href="https://github.com/dhil/ocaml-multicont">https://github.com/dhil/ocaml-multicont</a>

##### CHANGES:

This release restores compatibility with macOS (14.4.1) when using
clang 15 or greater.

Changes:

* Patch dhil/ocaml-multicont#8: Explicit declaration of `memcpy` to fix compilation error
  when using clang on macOS (thanks to @tmcgilchrist).
* Fixed a regression where enabling feature flag `UNIQUE_FIBERS`
  caused compilation to fail.
* Spring cleaning: Removed unused header imports.
* Added an example illustrating how to use the power of multishot
  continuation to simulate the `return` operator (e.g. as found in
  C/C++/Rust/etc) using a single handler.
