### PR TITLE
zarith*: use sha256 instead of md5 for extra-files checksums

### DIFF
--- a/packages/zarith-freestanding/zarith-freestanding.1.10/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.10/opam
@@ -23,10 +23,22 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 extra-files: [
-  ["mirage-uninstall.sh" "md5=33f0c41ca3ef941f73fc566977b32453"]
-  ["mirage-install.sh" "md5=4eb793d6246c80eacebb201694cf3a3e"]
-  ["mirage-build.sh" "md5=ccca36c5e3632bbb788bce15b4487f77"]
-  ["no-dynlink.patch" "md5=2437531740d788bbeba56241d54debc2"]
+  [
+  "mirage-build.sh"
+  "sha256=cad6be1624017213abdc0dd0603053473fc63b1747e3cf3d9743023440808fa7"
+]
+  [
+  "mirage-install.sh"
+  "sha256=b2ffcb009d8600356d8938e4695bc3bc9b88021e8c7bf862d1bf459dd42b3881"
+]
+  [
+  "mirage-uninstall.sh"
+  "sha256=27ea0c49209e386b11201a70477060cad1e2fc9200d3480c77e82d0ff381957e"
+]
+  [
+  "no-dynlink.patch"
+  "sha256=89b96237fefc9a72d4718dd190bd4314d21c4f6e207b52af4a393d251a733a49"
+]
 ]
 url {
   src: "https://github.com/ocaml/Zarith/archive/release-1.10.tar.gz"

--- a/packages/zarith-freestanding/zarith-freestanding.1.11/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.11/opam
@@ -23,10 +23,22 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 extra-files: [
-  ["mirage-uninstall.sh" "md5=33f0c41ca3ef941f73fc566977b32453"]
-  ["mirage-install.sh" "md5=4eb793d6246c80eacebb201694cf3a3e"]
-  ["mirage-build.sh" "md5=ccca36c5e3632bbb788bce15b4487f77"]
-  ["no-dynlink.patch" "md5=2437531740d788bbeba56241d54debc2"]
+  [
+  "mirage-build.sh"
+  "sha256=cad6be1624017213abdc0dd0603053473fc63b1747e3cf3d9743023440808fa7"
+]
+  [
+  "mirage-install.sh"
+  "sha256=b2ffcb009d8600356d8938e4695bc3bc9b88021e8c7bf862d1bf459dd42b3881"
+]
+  [
+  "mirage-uninstall.sh"
+  "sha256=27ea0c49209e386b11201a70477060cad1e2fc9200d3480c77e82d0ff381957e"
+]
+  [
+  "no-dynlink.patch"
+  "sha256=89b96237fefc9a72d4718dd190bd4314d21c4f6e207b52af4a393d251a733a49"
+]
 ]
 url {
   src: "https://github.com/ocaml/Zarith/archive/release-1.11.tar.gz"

--- a/packages/zarith-freestanding/zarith-freestanding.1.12/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.12/opam
@@ -23,10 +23,22 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 extra-files: [
-  ["mirage-uninstall.sh" "md5=33f0c41ca3ef941f73fc566977b32453"]
-  ["mirage-install.sh" "md5=4eb793d6246c80eacebb201694cf3a3e"]
-  ["mirage-build.sh" "md5=ccca36c5e3632bbb788bce15b4487f77"]
-  ["no-dynlink.patch" "md5=a6a99400f2d0ff50b9b4401ef6a98a4c"]
+  [
+  "mirage-build.sh"
+  "sha256=cad6be1624017213abdc0dd0603053473fc63b1747e3cf3d9743023440808fa7"
+]
+  [
+  "mirage-install.sh"
+  "sha256=b2ffcb009d8600356d8938e4695bc3bc9b88021e8c7bf862d1bf459dd42b3881"
+]
+  [
+  "mirage-uninstall.sh"
+  "sha256=27ea0c49209e386b11201a70477060cad1e2fc9200d3480c77e82d0ff381957e"
+]
+  [
+  "no-dynlink.patch"
+  "sha256=f413b0f911bb8f4931767b5ab0d102144c9a9b40984952d78ee7d709f08bb6b2"
+]
 ]
 url {
   src: "https://github.com/ocaml/Zarith/archive/release-1.12.tar.gz"

--- a/packages/zarith-freestanding/zarith-freestanding.1.4.1/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.4.1/opam
@@ -21,10 +21,22 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 extra-files: [
-  ["mirage-uninstall.sh" "md5=de37d98a1987c89bc53a7a032b7278df"]
-  ["mirage-install.sh" "md5=f195dd0b56296a61d3233389c032a03d"]
-  ["mirage-build.sh" "md5=edd32d0ccd5c79e8872af99798f37079"]
-  ["config.diff" "md5=a1b990b42e0a16b8960995096e0722c8"]
+  [
+  "config.diff"
+  "sha256=d11de57eae8cdc37046954b26f7743ce64ed9193565f3daf3d9bf858808f2a3f"
+]
+  [
+  "mirage-build.sh"
+  "sha256=7251d2433f67be818557a2b2543eebf8550c5afc593c9a76e2b055bb1e6f38f7"
+]
+  [
+  "mirage-install.sh"
+  "sha256=70eae013b69e2d6667dd5883db62baf3ab93d0fc0650ef9e0375d5a2f9f8abb8"
+]
+  [
+  "mirage-uninstall.sh"
+  "sha256=b8175f6d93e58b95356402315bcfc26b28b9af0e1127c345271f008caa38e701"
+]
 ]
 url {
   src: "https://download.ocamlcore.org/zarith/Zarith/1.4.1/zarith-1.4.1.tgz"

--- a/packages/zarith-freestanding/zarith-freestanding.1.4/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.4/opam
@@ -21,11 +21,26 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 extra-files: [
-  ["z_pp.pl.patch" "md5=91205dc2130807273fb83a00a3b54215"]
-  ["mirage-uninstall.sh" "md5=de37d98a1987c89bc53a7a032b7278df"]
-  ["mirage-install.sh" "md5=f195dd0b56296a61d3233389c032a03d"]
-  ["mirage-build.sh" "md5=edd32d0ccd5c79e8872af99798f37079"]
-  ["config.diff" "md5=a1b990b42e0a16b8960995096e0722c8"]
+  [
+  "config.diff"
+  "sha256=d11de57eae8cdc37046954b26f7743ce64ed9193565f3daf3d9bf858808f2a3f"
+]
+  [
+  "mirage-build.sh"
+  "sha256=7251d2433f67be818557a2b2543eebf8550c5afc593c9a76e2b055bb1e6f38f7"
+]
+  [
+  "mirage-install.sh"
+  "sha256=70eae013b69e2d6667dd5883db62baf3ab93d0fc0650ef9e0375d5a2f9f8abb8"
+]
+  [
+  "mirage-uninstall.sh"
+  "sha256=b8175f6d93e58b95356402315bcfc26b28b9af0e1127c345271f008caa38e701"
+]
+  [
+  "z_pp.pl.patch"
+  "sha256=64ec498df705de6e4cf915e2cee6e7b54a0b11d140a0502cdcc9155596711b5b"
+]
 ]
 url {
   src: "https://download.ocamlcore.org/zarith/Zarith/1.4/zarith-1.4.tgz"

--- a/packages/zarith-freestanding/zarith-freestanding.1.6/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.6/opam
@@ -21,10 +21,22 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 extra-files: [
-  ["mirage-uninstall.sh" "md5=de37d98a1987c89bc53a7a032b7278df"]
-  ["mirage-install.sh" "md5=f195dd0b56296a61d3233389c032a03d"]
-  ["mirage-build.sh" "md5=edd32d0ccd5c79e8872af99798f37079"]
-  ["config.diff" "md5=a1b990b42e0a16b8960995096e0722c8"]
+  [
+  "config.diff"
+  "sha256=d11de57eae8cdc37046954b26f7743ce64ed9193565f3daf3d9bf858808f2a3f"
+]
+  [
+  "mirage-build.sh"
+  "sha256=7251d2433f67be818557a2b2543eebf8550c5afc593c9a76e2b055bb1e6f38f7"
+]
+  [
+  "mirage-install.sh"
+  "sha256=70eae013b69e2d6667dd5883db62baf3ab93d0fc0650ef9e0375d5a2f9f8abb8"
+]
+  [
+  "mirage-uninstall.sh"
+  "sha256=b8175f6d93e58b95356402315bcfc26b28b9af0e1127c345271f008caa38e701"
+]
 ]
 url {
   src: "https://github.com/ocaml/Zarith/archive/release-1.6.tar.gz"

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-1/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-1/opam
@@ -22,10 +22,22 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 extra-files: [
-  ["mirage-uninstall.sh" "md5=de37d98a1987c89bc53a7a032b7278df"]
-  ["mirage-install.sh" "md5=f195dd0b56296a61d3233389c032a03d"]
-  ["mirage-build.sh" "md5=965e4b33ed871a73436223177d104876"]
-  ["no-dynlink.patch" "md5=eff128f04dd08b0e5a02e49c99dc518b"]
+  [
+  "mirage-build.sh"
+  "sha256=d9193ded9a0a4619b1535072922ef689dd4ba75d38dd7dbc7007d48562c4dbc3"
+]
+  [
+  "mirage-install.sh"
+  "sha256=70eae013b69e2d6667dd5883db62baf3ab93d0fc0650ef9e0375d5a2f9f8abb8"
+]
+  [
+  "mirage-uninstall.sh"
+  "sha256=b8175f6d93e58b95356402315bcfc26b28b9af0e1127c345271f008caa38e701"
+]
+  [
+  "no-dynlink.patch"
+  "sha256=c6326402af2c93c758ddb05e31b4bd2a0d0f9d0cd2b1d8bd9d64681dcb7079c0"
+]
 ]
 url {
   src: "https://github.com/ocaml/Zarith/archive/release-1.7.tar.gz"

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-2/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-2/opam
@@ -22,10 +22,22 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 extra-files: [
-  ["mirage-uninstall.sh" "md5=de37d98a1987c89bc53a7a032b7278df"]
-  ["mirage-install.sh" "md5=f195dd0b56296a61d3233389c032a03d"]
-  ["mirage-build.sh" "md5=d8585e00ab3353746f2fc4c15abe7cfa"]
-  ["no-dynlink.patch" "md5=eff128f04dd08b0e5a02e49c99dc518b"]
+  [
+  "mirage-build.sh"
+  "sha256=ca68cd0089ebca181e8d47c9d6a0f8e418d12c4e340203b8aa4ff9cd1213ad30"
+]
+  [
+  "mirage-install.sh"
+  "sha256=70eae013b69e2d6667dd5883db62baf3ab93d0fc0650ef9e0375d5a2f9f8abb8"
+]
+  [
+  "mirage-uninstall.sh"
+  "sha256=b8175f6d93e58b95356402315bcfc26b28b9af0e1127c345271f008caa38e701"
+]
+  [
+  "no-dynlink.patch"
+  "sha256=c6326402af2c93c758ddb05e31b4bd2a0d0f9d0cd2b1d8bd9d64681dcb7079c0"
+]
 ]
 url {
   src: "https://github.com/ocaml/Zarith/archive/release-1.7.tar.gz"

--- a/packages/zarith-freestanding/zarith-freestanding.1.7/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7/opam
@@ -21,10 +21,22 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 extra-files: [
-  ["mirage-uninstall.sh" "md5=de37d98a1987c89bc53a7a032b7278df"]
-  ["mirage-install.sh" "md5=f195dd0b56296a61d3233389c032a03d"]
-  ["mirage-build.sh" "md5=d77263aa84216efa3a80272b2603274f"]
-  ["config.diff" "md5=a1b990b42e0a16b8960995096e0722c8"]
+  [
+  "config.diff"
+  "sha256=d11de57eae8cdc37046954b26f7743ce64ed9193565f3daf3d9bf858808f2a3f"
+]
+  [
+  "mirage-build.sh"
+  "sha256=8bdce24a7ded7ae1e8237ef700cf2412cd4af762c7a322eec4cab7d140c71936"
+]
+  [
+  "mirage-install.sh"
+  "sha256=70eae013b69e2d6667dd5883db62baf3ab93d0fc0650ef9e0375d5a2f9f8abb8"
+]
+  [
+  "mirage-uninstall.sh"
+  "sha256=b8175f6d93e58b95356402315bcfc26b28b9af0e1127c345271f008caa38e701"
+]
 ]
 url {
   src: "https://github.com/ocaml/Zarith/archive/release-1.7.tar.gz"

--- a/packages/zarith-freestanding/zarith-freestanding.1.9.1/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.9.1/opam
@@ -22,10 +22,22 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 extra-files: [
-  ["mirage-uninstall.sh" "md5=de37d98a1987c89bc53a7a032b7278df"]
-  ["mirage-install.sh" "md5=f195dd0b56296a61d3233389c032a03d"]
-  ["mirage-build.sh" "md5=d8585e00ab3353746f2fc4c15abe7cfa"]
-  ["no-dynlink.patch" "md5=2437531740d788bbeba56241d54debc2"]
+  [
+  "mirage-build.sh"
+  "sha256=ca68cd0089ebca181e8d47c9d6a0f8e418d12c4e340203b8aa4ff9cd1213ad30"
+]
+  [
+  "mirage-install.sh"
+  "sha256=70eae013b69e2d6667dd5883db62baf3ab93d0fc0650ef9e0375d5a2f9f8abb8"
+]
+  [
+  "mirage-uninstall.sh"
+  "sha256=b8175f6d93e58b95356402315bcfc26b28b9af0e1127c345271f008caa38e701"
+]
+  [
+  "no-dynlink.patch"
+  "sha256=89b96237fefc9a72d4718dd190bd4314d21c4f6e207b52af4a393d251a733a49"
+]
 ]
 url {
   src: "https://github.com/ocaml/Zarith/archive/release-1.9.1.tar.gz"

--- a/packages/zarith-xen/zarith-xen.1.3/opam
+++ b/packages/zarith-xen/zarith-xen.1.3/opam
@@ -25,8 +25,14 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 extra-files: [
-  ["xen_linkopts.patch" "md5=bfcb9eba4d6790dfb6e48b7533d91ad7"]
-  ["mirage-install.sh" "md5=dc7670c682280ed402e3937d4d6fbe04"]
+  [
+  "mirage-install.sh"
+  "sha256=e3d07e49f66f6034e912b97fbbfce356bfe4feba55e82e90744e969078c2d41f"
+]
+  [
+  "xen_linkopts.patch"
+  "sha256=0926a96f7c4c38e7c8966a0d03aa9715ad3aef3dbc159d4ddbeb6d183d064afb"
+]
 ]
 url {
   src: "https://download.ocamlcore.org/zarith/Zarith/1.3/zarith-1.3.tgz"

--- a/packages/zarith-xen/zarith-xen.1.4/opam
+++ b/packages/zarith-xen/zarith-xen.1.4/opam
@@ -19,8 +19,14 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 extra-files: [
-  ["mirage-uninstall.sh" "md5=ef2f117c09b2af4341b642ed29fb2387"]
-  ["mirage-install.sh" "md5=fdda6c79ecac23b0c31852900674d7c6"]
+  [
+  "mirage-install.sh"
+  "sha256=404c2392484ce8b72776ad18f45bdb39b47d0960a5a2f9c88ea7f727a4d6e48b"
+]
+  [
+  "mirage-uninstall.sh"
+  "sha256=e5ea4b8731e4cefa8514e00eeee5290062852f229d713c78be6941e8d59c0f36"
+]
 ]
 url {
   src: "https://download.ocamlcore.org/zarith/Zarith/1.4/zarith-1.4.tgz"

--- a/packages/zarith-xen/zarith-xen.1.6/opam
+++ b/packages/zarith-xen/zarith-xen.1.6/opam
@@ -19,8 +19,14 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 extra-files: [
-  ["mirage-uninstall.sh" "md5=ef2f117c09b2af4341b642ed29fb2387"]
-  ["mirage-install.sh" "md5=fdda6c79ecac23b0c31852900674d7c6"]
+  [
+  "mirage-install.sh"
+  "sha256=404c2392484ce8b72776ad18f45bdb39b47d0960a5a2f9c88ea7f727a4d6e48b"
+]
+  [
+  "mirage-uninstall.sh"
+  "sha256=e5ea4b8731e4cefa8514e00eeee5290062852f229d713c78be6941e8d59c0f36"
+]
 ]
 url {
   src: "https://github.com/ocaml/Zarith/archive/release-1.6.tar.gz"

--- a/packages/zarith-xen/zarith-xen.1.7/opam
+++ b/packages/zarith-xen/zarith-xen.1.7/opam
@@ -19,8 +19,14 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 extra-files: [
-  ["mirage-uninstall.sh" "md5=ef2f117c09b2af4341b642ed29fb2387"]
-  ["mirage-install.sh" "md5=fdda6c79ecac23b0c31852900674d7c6"]
+  [
+  "mirage-install.sh"
+  "sha256=404c2392484ce8b72776ad18f45bdb39b47d0960a5a2f9c88ea7f727a4d6e48b"
+]
+  [
+  "mirage-uninstall.sh"
+  "sha256=e5ea4b8731e4cefa8514e00eeee5290062852f229d713c78be6941e8d59c0f36"
+]
 ]
 url {
   src: "https://github.com/ocaml/Zarith/archive/release-1.7.tar.gz"

--- a/packages/zarith/zarith.1.2/opam
+++ b/packages/zarith/zarith.1.2/opam
@@ -23,7 +23,7 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 flags: light-uninstall
-extra-files: ["install_fix.patch" "md5=b48bb873c56ca0d53bb4ea689cd02887"]
+extra-files: ["install_fix.patch" "sha256=72f10a4dc5f88263de8f017ea0d6892e8a24569d4a69c801aaa42de797d1cff8"]
 url {
   src: "https://download.ocamlcore.org/zarith/Zarith/1.2/zarith-1.2.tgz"
   checksum: "md5=077c927f337f8a19b55fa086ed35eab1"

--- a/packages/zarith/zarith.1.3/opam
+++ b/packages/zarith/zarith.1.3/opam
@@ -30,7 +30,7 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 flags: light-uninstall
-extra-files: ["z_pp.pl.patch" "md5=e138d44f86858d55c6e0911e1517ed2e"]
+extra-files: ["z_pp.pl.patch" "sha256=5fc46d48b37942942485218795c2395ca28fed6673f049fa8bc3f3db80361ab7"]
 url {
   src: "https://download.ocamlcore.org/zarith/Zarith/1.3/zarith-1.3.tgz"
   checksum: "md5=9ed8ddafdebfa8c1b673dbe91a181f66"

--- a/packages/zarith/zarith.1.4/opam
+++ b/packages/zarith/zarith.1.4/opam
@@ -31,7 +31,7 @@ arbitrary-precision integers. It uses GMP to efficiently implement
 arithmetic over big integers. Small integers are represented as Caml
 unboxed integers, for speed and space economy."""
 flags: light-uninstall
-extra-files: ["z_pp.pl.patch" "md5=91205dc2130807273fb83a00a3b54215"]
+extra-files: ["z_pp.pl.patch" "sha256=64ec498df705de6e4cf915e2cee6e7b54a0b11d140a0502cdcc9155596711b5b"]
 url {
   src: "https://download.ocamlcore.org/zarith/Zarith/1.4/zarith-1.4.tgz"
   checksum: "md5=8967de3cf9eabe1d73b663bc9916657d"

--- a/packages/zarith/zarith.1.7-1/opam
+++ b/packages/zarith/zarith.1.7-1/opam
@@ -45,4 +45,4 @@ url {
   src: "https://github.com/ocaml/Zarith/archive/release-1.7.tar.gz"
   checksum: "md5=80944e2755ebb848451a77dc2ad0651b"
 }
-extra-files: ["absolute_CC.patch" "md5=8699b1d3d9340f9443e2ce0c8677190d"]
+extra-files: ["absolute_CC.patch" "sha256=5110eaa7c7c4c403504f3cdebc555125487658c83db0a64fffcd17b312b16dbd"]


### PR DESCRIPTION
Dear opam-repository maintainers,

I'm keen to get rid of md5 checksums in the opam-repository. I hope this is a shared goal with you as well.

To keep the ball rolling, I submitted a new lint for opam-repo-ci https://github.com/ocurrent/opam-repo-ci/pull/304 which yells if only MD5 is used as checksum -- so no new md5 checksums should be accepted in this repository.

A second step is to convert the existing md5 checksums to sha256. I started with `opam admin update-extrafiles --hash=sha256` (from opam 2.2). Here is a tiny output, I can as well push a PR with all the changes (though some should be avoided where the existing checksum is sha512). Please let me know what you think about the roadmap and this specific PR. If you have other plans, we can also drop this PR and take a different ship.


Thanks,

Hannes