### PR TITLE
Fix 5.2.0 release packages for ppc64 and tsan

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "base-domains" {post}
   "base-nnp" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
@@ -43,8 +43,10 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--without-zstd"  {ocaml-option-no-compression:installed}
+    "--without-zstd" {ocaml-option-no-compression:installed}
+    "--enable-tsan" {ocaml-option-tsan:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed}
     "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
@@ -79,4 +81,5 @@ depopts: [
   "ocaml-option-leak-sanitizer"
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
+  "ocaml-option-tsan"
 ]

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
@@ -23,7 +23,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler


### PR DESCRIPTION
Looks like the template was taken from 5.1.1, rather than 5.2.0~rc