### PR TITLE
alt-ergo build requires native compiler

### DIFF
--- a/packages/alt-ergo/alt-ergo.2.4.2/opam
+++ b/packages/alt-ergo/alt-ergo.2.4.2/opam
@@ -33,6 +33,9 @@ build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 url {
   src: "https://github.com/OCamlPro/alt-ergo/archive/refs/tags/2.4.2.tar.gz"
   checksum: [


### PR DESCRIPTION
The following error showed up on the CI of https://github.com/ocaml/opam-repository/pull/25873

```
#=== ERROR while compiling alt-ergo.2.4.2 =====================================#
# context              2.2.0~beta3~dev | linux/arm32 | ocaml-base-compiler.5.2.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/alt-ergo.2.4.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p alt-ergo -j 79
# exit-code            1
# env-file             ~/.opam/log/alt-ergo-6-c6418a.env
# output-file          ~/.opam/log/alt-ergo-6-c6418a.out
### output ###
# File "src/plugins/fm-simplex/dune", line 17, characters 5-25:
# 17 |     (FmSimplexPlugin.cmxs as plugins/fm-simplex-plugin.cmxs)
#           ^^^^^^^^^^^^^^^^^^^^
# Error: No rule found for src/plugins/fm-simplex/FmSimplexPlugin.cmxs
# File "src/plugins/AB-Why3/dune", line 24, characters 5-22:
# 24 |     (ABWhy3Plugin.cmxs as plugins/AB-Why3-plugin.cmxs)
#           ^^^^^^^^^^^^^^^^^
# Error: No rule found for src/plugins/AB-Why3/ABWhy3Plugin.cmxs
```

IIRC, cmxs files are produced by ocamlopt and so it seems that the build is incompatible with bytecode-only installs.

It's likely that other versions of alt-ergo should get the same change. I'll try to investigate which ones or maybe we can just apply a blanket change? (ping @Stevendeo ?)