### PR TITLE
[new release] ppx_import (1.11.0)

### DIFF
--- a/packages/ppx_import/ppx_import.1.11.0/opam
+++ b/packages/ppx_import/ppx_import.1.11.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "A syntax extension for importing declarations from interface files"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+homepage: "https://github.com/ocaml-ppx/ppx_import"
+doc: "https://ocaml-ppx.github.io/ppx_import/"
+license: "MIT"
+bug-reports: "https://github.com/ocaml-ppx/ppx_import/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
+tags: [ "syntax" ]
+
+depends: [
+   "ocaml"                   {>= "4.05.0" &  < "4.10.0"  }
+| ("ocaml"                   {>= "4.10.0"}
+   "ppx_sexp_conv" {with-test & >= "v0.13.0"})
+  "dune"                    {              >= "1.11.0"  }
+  "ppxlib"                  {              >= "0.26.0"  }
+  "ounit"                   { with-test                 }
+  "ppx_deriving"            { with-test  & >= "4.2.1"   }
+]
+
+build:      [["dune" "build"   "-p" name "-j" jobs]
+             ["dune" "runtest" "-p" name "-j" jobs] { with-test }
+            ]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_import/releases/download/v1.11.0/ppx_import-1.11.0.tbz"
+  checksum: [
+    "sha256=2667efd48910a1a4e4cb1a31a7d148d0284d112a826a80ec03b0f86546ceac1a"
+    "sha512=5259faf2c2d6e617b6ebd67aaec2258859d2438a98007dc7e672325b8bce0303946f781370fb385597e5a8c12f3e5b5f57f8f853fb90aa69fcc8e2111c97347d"
+  ]
+}
+x-commit-hash: "ff74500409bcebc37197e5b133da81b2a85884a3"


### PR DESCRIPTION
A syntax extension for importing declarations from interface files

- Project page: <a href="https://github.com/ocaml-ppx/ppx_import">https://github.com/ocaml-ppx/ppx_import</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_import/">https://ocaml-ppx.github.io/ppx_import/</a>

##### CHANGES:

  * Support for OCaml 5.2 (ocaml-ppx/ppx_import#94, @kit-ty-kate, backport to 1.x by
    @ejgallego ocaml-ppx/ppx_import#97)
