### PR TITLE
[new-release] melange (4.0.0)

### DIFF
--- a/packages/melange/melange.4.0.0-414/opam
+++ b/packages/melange/melange.4.0.0-414/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "4.14" & < "5.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {with-test & >= "3.9.0"}
+  "ppxlib" {>= "0.30.0"}
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/4.0.0-414/melange-4.0.0-414.tbz"
+  checksum: [
+    "sha256=3c82c3397608c8bbdfbf5b12c0fe9649d0a25dfa5876772ded6330de31c12c93"
+    "sha512=7abf9eab5dacac169ac82698685c3f46ff6c5219cba6b6d14abf915029d89559f38ce7f74ef04055fb31805f5d5aeeb74613a65d1d892a40b585153b95725fea"
+  ]
+}
+x-commit-hash: "fb58cb9a8e870187b5be2a6b09924cfa79996401"

--- a/packages/melange/melange.4.0.0-51/opam
+++ b/packages/melange/melange.4.0.0-51/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "5.1" & < "5.2"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {with-test & >= "3.9.0"}
+  "ppxlib" {>= "0.30.0"}
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/4.0.0-51/melange-4.0.0-51.tbz"
+  checksum: [
+    "sha256=f78d18ce9d595e737a98a55663e9ea2a39f8aad054251e5e1c4e793938c6bdd5"
+    "sha512=d4b7c18bb1d1e7af529ea49fe1ce28b0debf64056ba65108768ed28dc920e4b92a61cdb279c52b7140206e816eb484fd87d21572021b4ef983c54ddbc4907034"
+  ]
+}
+x-commit-hash: "3a953fa32ed26449e5e8304c12d6ba18a4f08438"

--- a/packages/melange/melange.4.0.0-52/opam
+++ b/packages/melange/melange.4.0.0-52/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "5.2"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {with-test & >= "3.9.0"}
+  "ppxlib" {>= "0.30.0"}
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/4.0.0-52/melange-4.0.0-52.tbz"
+  checksum: [
+    "sha256=f85c70663900460e645d5fa626f3143488106eba622611a19d721d9de6b921da"
+    "sha512=6b1a2d6678ca282eb1bd22df78984d1c03e563c0f5633dda4e453fefe1de54b734bfb61a2890d2d97e2aadc1680c9a2fa2997a9282b9cd5a7b9330c7602ac0e4"
+  ]
+}
+x-commit-hash: "e077cafc06c30c0af23b0a60c614f7f9270a3cc3"


### PR DESCRIPTION
Toolchain to produce JS from Reason/OCaml

Project page: https://github.com/melange-re/melange

This release includes a version for each of the following OCaml compiler versions: 4.14, 5.1 and the freshly released 5.2.

