### PR TITLE
[new release] ppx_deriving_variant_string (1.0.1)

### DIFF
--- a/packages/ppx_deriving_variant_string/ppx_deriving_variant_string.1.0.1/opam
+++ b/packages/ppx_deriving_variant_string/ppx_deriving_variant_string.1.0.1/opam
@@ -15,7 +15,7 @@ dev-repo: "git+https://github.com/ahrefs/ppx_deriving_variant_string.git"
 depends: [
   "ocaml"
   "dune" {>= "3.8"}
-  "ppxlib"
+  "ppxlib" {>= "0.23.0"}
   "ounit" {with-test}
   "ocaml-lsp-server" {with-test}
   "ocamlformat" {with-test}

--- a/packages/ppx_deriving_variant_string/ppx_deriving_variant_string.1.0.1/opam
+++ b/packages/ppx_deriving_variant_string/ppx_deriving_variant_string.1.0.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "OCaml PPX deriver that generates converters between variants and strings"
+description: "OCaml PPX deriver that generates converters between regular or polymorphic variants and strings. Supports both OCaml and Reason casing."
+maintainer: [
+  "Javier Chávarri <javier.chavarri@ahrefs.com>"
+]
+authors: [
+  "Javier Chávarri <javier.chavarri@ahrefs.com>"
+]
+tags: ["syntax" "org:ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/ppx_deriving_variant_string"
+bug-reports: "https://github.com/ahrefs/ppx_deriving_variant_string/issues"
+dev-repo: "git+https://github.com/ahrefs/ppx_deriving_variant_string.git"
+depends: [
+  "ocaml"
+  "dune" {>= "3.8"}
+  "ppxlib"
+  "ounit" {with-test}
+  "ocaml-lsp-server" {with-test}
+  "ocamlformat" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+  ]
+]
+url {
+  src:
+    "https://github.com/ahrefs/ppx_deriving_variant_string/releases/download/1.0.1/ppx_deriving_variant_string-1.0.1.tbz"
+  checksum: [
+    "sha256=9d253d2c4c0f38e42e0a93405508011ae707ba4e708c9ddd0c88fbd3c7632f07"
+    "sha512=25bf3725bfab353f3b6f5d67ff55cc4186419bfd537b0824ad5bd26f456470995376fe7b4f3d9eabac2105a5878f168a9a31da1e33d5cb8ea3e2b3a43cdf97b7"
+  ]
+}
+x-commit-hash: "c35d8925ed5f147da9c2d8a6303a77045bf26ad3"

--- a/packages/ppx_deriving_variant_string/ppx_deriving_variant_string.1.0.1/opam
+++ b/packages/ppx_deriving_variant_string/ppx_deriving_variant_string.1.0.1/opam
@@ -17,8 +17,6 @@ depends: [
   "dune" {>= "3.8"}
   "ppxlib" {>= "0.23.0"}
   "ounit" {with-test}
-  "ocaml-lsp-server" {with-test}
-  "ocamlformat" {with-test}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
OCaml PPX deriver that generates converters between variants and strings

- Project page: <a href="https://github.com/ahrefs/ppx_deriving_variant_string">https://github.com/ahrefs/ppx_deriving_variant_string</a>

##### CHANGES:

- Fix public name, ahrefs/ppx_deriving_variant_string#2 by @anmonteiro
