### PR TITLE
[new release] mirage-bootvar (1.0.0)

### DIFF
--- a/packages/mirage-bootvar/mirage-bootvar.1.0.0/opam
+++ b/packages/mirage-bootvar/mirage-bootvar.1.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "MirageOS Core team"
+authors: [
+  "Anil Madhavapeddy"
+  "Dan Williams"
+  "Hannes Mehnert"
+  "Jon Ludlam"
+  "Magnus Skjegstad"
+  "Martin Lucina"
+  "Mindy Preston"
+  "Thomas Gazagnaire"
+]
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-bootvar"
+doc: "https://mirage.github.io/mirage-bootvar/"
+bug-reports: "https://github.com/mirage/mirage-bootvar/issues"
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "ounit2" {with-test}
+]
+depopts: [
+  "mirage-xen"
+  "mirage-solo5"
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "mirage-solo5" {< "0.6.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-bootvar.git"
+synopsis: "Boot time arguments for MirageOS"
+description: """
+Mirage-bootvar reads and parses boot parameters for MirageOS unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-bootvar/releases/download/v1.0.0/mirage-bootvar-1.0.0.tbz"
+  checksum: [
+    "sha256=e3e4d9b3fd96fa8fe1f5e0a59e6f8a80b58505a21d3296ed08d396ed9ac905f8"
+    "sha512=817017d81b5dc0a16956ff1ef0cdaadf4b7f8572d33ce02683fdcdc95a18b0995599a8c7c3ae555ff1ef097195ebe9417f8fc1e0e23d50216c60eb5e95b7f5a8"
+  ]
+}
+x-commit-hash: "c31a256f0c46afb417cfe52871100ceb0679973c"


### PR DESCRIPTION
Boot time arguments for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-bootvar">https://github.com/mirage/mirage-bootvar</a>
- Documentation: <a href="https://mirage.github.io/mirage-bootvar/">https://mirage.github.io/mirage-bootvar/</a>

##### CHANGES:

* parse-argv, mirage-bootvar-unix, mirage-bootvar-solo5, and mirage-bootvar-xen
  have been merged into the single mirage-bootvar package. This uses dune
  variants to select the concrete implementation. The selection is done by
  the mirage tool which inspects the "target" option in `mirage configure`
  and outputs the desired ocamlfind sublibrary into the dune.build file.
* The main logic is provided by the Mirage_bootvar module, while the
  implementation to retrieve the boot parameters is provided by the dune variant
  backend, and implemented by mirage-bootvar.unix, mirage-bootvar.solo5, and
  mirage-bootvar.xen mirage/mirage-bootvar#1
