### PR TITLE
Update the 'out-of-date warning' after the release of opam 2.1.6

### DIFF
--- a/repo
+++ b/repo
@@ -4,7 +4,7 @@ upstream: "https://github.com/ocaml/opam-repository/tree/master/"
 announce: [
 """
 [WARNING] opam is out-of-date. Please consider updating it (https://opam.ocaml.org/doc/Install.html)
-""" {(opam-version >= "2.1.0~~" & opam-version < "2.1.5") | opam-version < "2.0.10"}
+""" {(opam-version >= "2.1.0~~" & opam-version < "2.1.6") | opam-version < "2.0.10"}
 """
 [INFO] opam 2.1 includes many performance improvements over 2.0; please consider upgrading (https://opam.ocaml.org/doc/Install.html)
 """ {opam-version >= "2.0.10" & opam-version < "2.1.0~~"}


### PR DESCRIPTION
To merge once the blog posts are up.