### PR TITLE
[new release] git (7 packages) (3.16.0)

### DIFF
--- a/packages/git-mirage/git-mirage.3.16.0/opam
+++ b/packages/git-mirage/git-mirage.3.16.0/opam
@@ -36,7 +36,7 @@ depends: [
   "mirage-clock" {>= "3.1.0"}
   "mirage-flow" {>= "4.0.0"}
   "mirage-time" {>= "2.0.1"}
-  "rresult" {>= "0.6.0"}
+  "rresult" {>= "0.7.0"}
   "alcotest" {>= "1.2.3" & with-test}
   "alcotest-lwt" {>= "1.2.3" & with-test}
   "bigstringaf" {>= "0.9.0" & with-test}

--- a/packages/git-mirage/git-mirage.3.16.0/opam
+++ b/packages/git-mirage/git-mirage.3.16.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "A package to use ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "mimic"
+  "mimic-happy-eyeballs" {>= "0.0.5"}
+  "base64" {>= "3.5.0"}
+  "git" {= version}
+  "git-paf" {= version}
+  "awa" {>= "0.2.0"}
+  "awa-mirage" {>= "0.2.0"}
+  "dns" {>= "6.1.3"}
+  "dns-client" {>= "6.1.3"}
+  "tls"
+  "tls-mirage"
+  "uri"
+  "happy-eyeballs-mirage" {>= "0.1.2"}
+  "happy-eyeballs" {>= "0.1.2"}
+  "ca-certs-nss"
+  "mirage-crypto"
+  "ptime"
+  "x509" {>= "0.16.2"}
+  "cstruct"
+  "tcpip" {>= "7.0.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "5.0.1"}
+  "lwt" {>= "5.3.0"}
+  "mirage-clock" {>= "3.1.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "mirage-time" {>= "2.0.1"}
+  "rresult" {>= "0.6.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.9.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.16.0/git-3.16.0.tbz"
+  checksum: [
+    "sha256=29415dd6eb78cd01810ecf2f8e565f8033cf98373b902e48918b777d8d80e492"
+    "sha512=762f0ec2dda6a20de92c87c1b06459247eb70f0230bf1cb6c8a68641e59eda997166522f5a4f16fd159db87afe5ef3a33e7ada6da2c05fe5902c1372bc9455ee"
+  ]
+}
+x-commit-hash: "d7171f86454b927dab93bd85e15ffc5fb0ed00b5"

--- a/packages/git-paf/git-paf.3.16.0/opam
+++ b/packages/git-paf/git-paf.3.16.0/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-clock"
   "tcpip" {>= "7.0.0"}
   "mirage-time"
-  "rresult"
+  "rresult" {>= "0.7.0"}
   "tls" {>= "0.14.0"}
   "uri"
   "bigstringaf"

--- a/packages/git-paf/git-paf.3.16.0/opam
+++ b/packages/git-paf/git-paf.3.16.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "mimic" {>= "0.0.4"}
+  "paf" {>= "0.2.0"}
+  "ca-certs-nss"
+  "fmt"
+  "ipaddr"
+  "logs"
+  "lwt"
+  "mirage-clock"
+  "tcpip" {>= "7.0.0"}
+  "mirage-time"
+  "rresult"
+  "tls" {>= "0.14.0"}
+  "uri"
+  "bigstringaf"
+  "domain-name"
+  "httpaf"
+  "mirage-flow" {>= "4.0.0"}
+  "tls-mirage"
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.16.0/git-3.16.0.tbz"
+  checksum: [
+    "sha256=29415dd6eb78cd01810ecf2f8e565f8033cf98373b902e48918b777d8d80e492"
+    "sha512=762f0ec2dda6a20de92c87c1b06459247eb70f0230bf1cb6c8a68641e59eda997166522f5a4f16fd159db87afe5ef3a33e7ada6da2c05fe5902c1372bc9455ee"
+  ]
+}
+x-commit-hash: "d7171f86454b927dab93bd85e15ffc5fb0ed00b5"

--- a/packages/git-unix/git-unix.3.16.0/opam
+++ b/packages/git-unix/git-unix.3.16.0/opam
@@ -12,7 +12,7 @@ depends: [
   "git" {= version}
   "git-mirage" {= version}
   "happy-eyeballs-lwt" {>= "0.1.2"}
-  "rresult"
+  "rresult" {>= "0.7.0"}
   "bigstringaf" {>= "0.9.0"}
   "fmt" {>= "0.8.7"}
   "bos"

--- a/packages/git-unix/git-unix.3.16.0/opam
+++ b/packages/git-unix/git-unix.3.16.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install and configure ocaml-git's Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "git-mirage" {= version}
+  "happy-eyeballs-lwt" {>= "0.1.2"}
+  "rresult"
+  "bigstringaf" {>= "0.9.0"}
+  "fmt" {>= "0.8.7"}
+  "bos"
+  "fpath"
+  "uri" {with-test}
+  "digestif" {>= "1.1.2"}
+  "logs"
+  "lwt" {>= "5.6.0"}
+  "base-unix"
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "mirage-clock" {>= "4.1.0"}
+  "mirage-clock-unix" {>= "4.1.0"}
+  "astring" {>= "0.8.5"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-unix" {>= "5.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "decompress" {>= "1.4.0"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "5.0.1"}
+  "mtime" {>= "1.2.0"}
+  "tcpip" {>= "7.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "ke" {>= "0.4" & with-test}
+  "mirage-crypto-rng" {>= "0.11.0" & with-test}
+  "mimic"
+  "tls" {>= "0.14.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test & os != "macos"}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.16.0/git-3.16.0.tbz"
+  checksum: [
+    "sha256=29415dd6eb78cd01810ecf2f8e565f8033cf98373b902e48918b777d8d80e492"
+    "sha512=762f0ec2dda6a20de92c87c1b06459247eb70f0230bf1cb6c8a68641e59eda997166522f5a4f16fd159db87afe5ef3a33e7ada6da2c05fe5902c1372bc9455ee"
+  ]
+}
+x-commit-hash: "d7171f86454b927dab93bd85e15ffc5fb0ed00b5"

--- a/packages/git/git.3.16.0/opam
+++ b/packages/git/git.3.16.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
   "digestif" {>= "1.1.2"}
-  "rresult"
+  "rresult" {>= "0.7.0"}
   "base64" {>= "3.0.0"}
   "bigstringaf" {>= "0.9.0"}
   "optint"

--- a/packages/git/git.3.16.0/opam
+++ b/packages/git/git.3.16.0/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis: "Git format and protocol in pure OCaml"
+description: """\
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects."""
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "digestif" {>= "1.1.2"}
+  "rresult"
+  "base64" {>= "3.0.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "optint"
+  "decompress" {>= "1.4.0"}
+  "logs"
+  "lwt"
+  "mimic" {>= "0.0.6"}
+  "cstruct" {>= "6.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "carton" {>= "0.7.2"}
+  "carton-lwt" {>= "0.7.2"}
+  "carton-git" {>= "0.7.2"}
+  "ke" {>= "0.4"}
+  "fmt" {>= "0.8.7"}
+  "checkseum" {>= "0.3.3"}
+  "ocamlgraph" {>= "1.8.8"}
+  "astring"
+  "fpath"
+  "encore" {>= "0.8"}
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "mirage-crypto-rng" {with-test & >= "0.8.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "base-unix" {with-test}
+  "hxd" {>= "0.3.2"}
+  "mirage-flow" {>= "4.0.0"}
+  "domain-name" {>= "0.3.0"}
+  "emile" {>= "1.1"}
+  "ipaddr" {>= "5.0.1"}
+  "psq" {>= "0.2.0"}
+  "uri" {>= "4.1.0"}
+  "crowbar" {>= "0.2.1" & with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.16.0/git-3.16.0.tbz"
+  checksum: [
+    "sha256=29415dd6eb78cd01810ecf2f8e565f8033cf98373b902e48918b777d8d80e492"
+    "sha512=762f0ec2dda6a20de92c87c1b06459247eb70f0230bf1cb6c8a68641e59eda997166522f5a4f16fd159db87afe5ef3a33e7ada6da2c05fe5902c1372bc9455ee"
+  ]
+}
+x-commit-hash: "d7171f86454b927dab93bd85e15ffc5fb0ed00b5"


### PR DESCRIPTION
Git format and protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Adapt `ocaml-git` to `mirage-flow.4.0.0` (@hannesm, mirage/ocaml-git#634)
- Improve the documentation (@Leonidas-from-XIV, mirage/ocaml-git#635)
- Explicitely add `unix` as a dependency of some ocaml-git's targets (@dinosaure, b2288c2)
