### PR TITLE
[new release] git-kv (0.0.5)

### DIFF
--- a/packages/git-kv/git-kv.0.0.5/opam
+++ b/packages/git-kv/git-kv.0.0.5/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Robur Team <team@robur.coop>"
+authors: [ "Robur Team <team@robur.coop>" ]
+license: "MIT"
+homepage: "https://github.com/robur-coop/git-kv"
+dev-repo: "git+https://github.com/robur-coop/git-kv.git"
+bug-reports: "https://github.com/robur-coop/git-kv/issues"
+synopsis: "A Mirage_kv implementation using git"
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.9.0"}
+  "git"               {>= "3.10.0"}
+  "mirage-kv"         {>= "6.0.0"}
+  "carton"            {>= "0.7.0"}
+  "carton-lwt"        {>= "0.7.0"}
+  "fmt"               {>= "0.8.7"}
+  "mirage-clock"      {>= "2.0.0"}
+  "ptime"
+  "hxd"               {with-test}
+  "conf-git"          {with-test}
+  "mirage-clock-unix" {with-test}
+  "git-unix"          {>= "3.10.0" & with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/robur-coop/git-kv/releases/download/v0.0.5/git-kv-0.0.5.tbz"
+  checksum: [
+    "sha256=531a165a2b107dc38947769ffd548df47a9d6ced1608da15ff5a90a5c720a7a8"
+    "sha512=772210a21f5f6453d08902817126203ed79e2c3c56e152dfc671f07919976e171c98b8919a283657e1bd4861dca69cba12074d97a54fdf2a2c8ec5785d45cfad"
+  ]
+}
+x-commit-hash: "768b498fef0685087f1395f42cfb323bbb4f7377"


### PR DESCRIPTION
A Mirage_kv implementation using git

- Project page: <a href="https://github.com/robur-coop/git-kv">https://github.com/robur-coop/git-kv</a>

##### CHANGES:

- Return a raw representation of the hash instead of the hex representation (@hannesm, robur-coop/git-kv#35)
- Stream in & out {of,to}_octets instead of manipulating the whole PACK file (@dinosaure, robur-coop/git-kv#33)
