### PR TITLE
[new release] mirage (2 packages) (4.5.1)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.4.5.1/opam
+++ b/packages/mirage-runtime/mirage-runtime.4.5.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.9.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "4.0.0"}
+  "ipaddr" {>= "5.5.0"}
+  "cmdliner" {>= "1.2.0"}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "ppxlib" {= "0.29.0"} #0.29.0 provides a vendored ppx_sexp_conv
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.5.1/mirage-4.5.1.tbz"
+  checksum: [
+    "sha256=81e00be4aac00372fc246bf721c1fe1681e587b229d3a60613e93ca7f2857e0c"
+    "sha512=4eed10a76ad63064933cecee5b5a4d183cb83e794510ee10d5f9e6484f9abf296e94cb0facf21486fc0b9086e6fb8315ceffd943d48b8d84fbff56848a6151f4"
+  ]
+}
+x-commit-hash: "4fb4a3195f741395e710ec2d7315df2bc27fcabc"

--- a/packages/mirage/mirage.4.5.1/opam
+++ b/packages/mirage/mirage.4.5.1/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+available: opam-version >= "2.1.0"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.9.0"}
+  "astring"
+  "cmdliner" {>= "1.2.0"}
+  "emile" {>= "1.1"}
+  "fmt" {>= "0.8.7"}
+  "ipaddr" {>= "5.0.0"}
+  "bos"
+  "fpath"
+  "rresult" {>= "0.7.0"}
+  "uri" {>= "4.2.0"}
+  "logs" {>= "0.7.0"}
+  "opam-monorepo" {>= "0.3.2"}
+  "alcotest" {with-test}
+  "mirage-runtime" {with-test & = version}
+]
+
+conflicts: [ "jbuilder" {with-test} ]
+
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.5.1/mirage-4.5.1.tbz"
+  checksum: [
+    "sha256=81e00be4aac00372fc246bf721c1fe1681e587b229d3a60613e93ca7f2857e0c"
+    "sha512=4eed10a76ad63064933cecee5b5a4d183cb83e794510ee10d5f9e6484f9abf296e94cb0facf21486fc0b9086e6fb8315ceffd943d48b8d84fbff56848a6151f4"
+  ]
+}
+x-commit-hash: "4fb4a3195f741395e710ec2d7315df2bc27fcabc"

--- a/packages/mirage/mirage.4.5.1/opam
+++ b/packages/mirage/mirage.4.5.1/opam
@@ -19,6 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
+  "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
   "cmdliner" {>= "1.2.0"}


### PR DESCRIPTION
The MirageOS library operating system

- Project page: <a href="https://github.com/mirage/mirage">https://github.com/mirage/mirage</a>
- Documentation: <a href="https://mirage.github.io/mirage/">https://mirage.github.io/mirage/</a>

##### CHANGES:

- BREAKING: remove `~name` parameter from Mirage.Runtime_args.create
  (mirage/mirage#1541 @samoht, fixes mirage/mirage#1532)
- BREAKING: remove `~name` parameter from Mirage.runtime_arg, and use a
  string (instead of a format string) as third parameter (mirage/mirage#1541 @samoht)
- constrain the `start` function to `unit Lwt.t`. Previously, there was no
  restrictions, and lots of time was spent in debugging when a unikernel
  resulted in `unit Lwt.t Lwt.t` (@Julow mirage/mirage#1524)
- revise man page sections and ordering: ARGUMENTS, OPTIONAL, NETWORK OPTIONS,
  DISK OPTIONS, LOG AND MONITORING OPTIONS, OCAML RUNTIME OPTIONS. Previously,
  the ARGUMENTS and OPTIONS were put later, and were hard to find. These are
  the sections where unikernel-specific arguments are put by default
  (mirage/mirage#1531 @hannesm @reynir)
- add --net=host and --net=ocaml to reduce confusion. --net=host uses the
  TCP/IP socket stack, --net=ocaml the OCaml network stack (mirage/mirage#1525 @hannesm)
- quote Runtime_arg.call (mirage/mirage#1522 @Julow)
- documentation fixes (inline examples @Julow mirage/mirage#1523, @hannesm mirage/mirage#1537 (fixes
  mirage/mirage#1512 reported by @reynir), Runtime_args.create mirage/mirage#1541 @samoht)
- fix the build instructions of the generated opam file: since 4.5.0
  `mirage build` is no longer available, use `make "build"` (mirage/mirage#1527 @hannesm)
- add RELEASE.md, a guide on how to cut a mirage release (mirage/mirage#1519 @samoht)
- allow git 3.16 (mirage/mirage#1536 @hannesm)
- use mirage-bootvar (using dune variant) instead of parse-argv and
  mirage-bootvar-xen, mirage-bootvar-solo5, mirage-bootvar-unix
  (mirage/mirage#1533 @hannesm)
- BUGFIX: reset the lexer location before applying functors in generated code
  (mirage/mirage#1539 @samoht, fixes mirage/mirage#1520 @hannesm)
- BUGFIX: fix off-by-one locations for mirage/main.ml (mirage/mirage#1540 @samoht, fixes
  mirage/mirage#1528 @hannesm)
