### PR TITLE
[new release] merlin (3 packages) (5.0-502)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.5.0-502/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.0-502/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" }
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {>= "5.0"}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/5.0-502/merlin-5.0-502.tbz"
+  checksum: [
+    "sha256=ca084c2e2e08d1e9ce1b50fc2a5787b2acc534c5fde0ddfd453b3e0e2cf74faa"
+    "sha512=e0aa85553324596a77e1f68ce39cd29ce6bb548a4a9faa32f49bf227cf8289a766477b8a2b0529b39bc8a8f4aea09515b0debaf585c0c750194e4d274311403f"
+  ]
+}
+x-commit-hash: "a7e8e6ec378a5496c6b913ec7304dc223aa182f8"

--- a/packages/merlin-lib/merlin-lib.5.0-502/opam
+++ b/packages/merlin-lib/merlin-lib.5.0-502/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" & < "5.3"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/5.0-502/merlin-5.0-502.tbz"
+  checksum: [
+    "sha256=ca084c2e2e08d1e9ce1b50fc2a5787b2acc534c5fde0ddfd453b3e0e2cf74faa"
+    "sha512=e0aa85553324596a77e1f68ce39cd29ce6bb548a4a9faa32f49bf227cf8289a766477b8a2b0529b39bc8a8f4aea09515b0debaf585c0c750194e4d274311403f"
+  ]
+}
+x-commit-hash: "a7e8e6ec378a5496c6b913ec7304dc223aa182f8"

--- a/packages/merlin/merlin.5.0-502/opam
+++ b/packages/merlin/merlin.5.0-502/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.2" & < "5.3"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "5.0"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/5.0-502/merlin-5.0-502.tbz"
+  checksum: [
+    "sha256=ca084c2e2e08d1e9ce1b50fc2a5787b2acc534c5fde0ddfd453b3e0e2cf74faa"
+    "sha512=e0aa85553324596a77e1f68ce39cd29ce6bb548a4a9faa32f49bf227cf8289a766477b8a2b0529b39bc8a8f4aea09515b0debaf585c0c750194e4d274311403f"
+  ]
+}
+x-commit-hash: "a7e8e6ec378a5496c6b913ec7304dc223aa182f8"


### PR DESCRIPTION
CHANGES:

Fri May 17 19:59:42 CET 2024

+ merlin binary
  - Support for OCaml 5.2 (ocaml/merlin#1757)
  - destruct: Removal of residual patterns (ocaml/merlin#1737, fixes ocaml/merlin#1560) 
  - Do not erase fields' names when destructing punned record fields (ocaml/merlin#1734, fixes ocaml/merlin#1661) 
  - Ignore SIGPIPE in the Merlin server process (ocaml/merlin#1746) - Fix lexing of quoted strings in comments (ocaml/merlin#1754, fixes ocaml/merlin#1753) 
  - Improve cursor position detection in longidents (ocaml/merlin#1756) 
  - Addition of a `merlin-lib.commands` library which disassociates the execution of commands from the `new_protocol`, from the binary, allowing it to be invoked from other projects (ocaml/merlin#1758) 
  - New occurrences backend: Don't index occurrences when `merlin.hide` attribute is present. (ocaml/merlin#1768) 
  - Use the new `uid_to_decl` table in 5.2's cmt files to get documentation. (ocaml/merlin#1773)