### PR TITLE
Package bitv.2.0

### DIFF
--- a/packages/bitv/bitv.2.0/opam
+++ b/packages/bitv/bitv.2.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.0.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name] {with-test}
 ]

--- a/packages/bitv/bitv.2.0/opam
+++ b/packages/bitv/bitv.2.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jean-Christophe.Filliatre@cnrs.fr"
+authors: "Jean-Christophe Filliâtre"
+license: "LGPL-2.1-or-later"
+synopsis: "A bit vector library for OCaml"
+description: "A bit vector library for OCaml"
+homepage: "https://github.com/backtracking/bitv"
+bug-reports: "https://github.com/backtracking/bitv/issues"
+doc: "https://backtracking.github.io/bitv"
+depends: [
+  "ocaml" {>= "4.03"}
+  "dune" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/backtracking/bitv.git"
+url {
+  src: "https://github.com/backtracking/bitv/archive/refs/tags/2.0.tar.gz"
+  checksum: [
+    "md5=3cc19ac840f22c19508aac5063fcb43c"
+    "sha512=8a96af5d5573746b004fe018ef2b6faa0c3adf52c356e8a7b3ba97d3ba3cead685e1f3e174d46ccd3a09bb3215a4936501b08eabd36f0492a240ea20128bafae"
+  ]
+}


### PR DESCRIPTION
### `bitv.2.0`
A bit vector library for OCaml
A bit vector library for OCaml



---
* Homepage: https://github.com/backtracking/bitv
* Source repo: git+https://github.com/backtracking/bitv.git
* Bug tracker: https://github.com/backtracking/bitv/issues

---
:camel: Pull-request generated by opam-publish v2.3.0