### PR TITLE
[new release] multicore-bench (0.1.3)

### DIFF
--- a/packages/multicore-bench/multicore-bench.0.1.3/opam
+++ b/packages/multicore-bench/multicore-bench.0.1.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Framework for writing multicore benchmark executables to run on current-bench"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-bench"
+bug-reports: "https://github.com/ocaml-multicore/multicore-bench/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "domain-local-await" {>= "1.0.1"}
+  "multicore-magic" {>= "2.1.0"}
+  "mtime" {>= "2.0.0"}
+  "yojson" {>= "2.1.0"}
+  "domain_shims" {>= "0.1.0"}
+  "backoff" {>= "0.1.0" & with-test}
+  "mdx" {>= "2.4.0" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
+  "ocaml" {>= "4.13.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-bench.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-bench/releases/download/0.1.3/multicore-bench-0.1.3.tbz"
+  checksum: [
+    "sha256=00bbb5501c6aad94b213b2a36261602d00dc81fc9ea1b9d74050efe8e7e9be70"
+    "sha512=faaf989e33ec0a8509fef33aeb9d3dc44378105b037dc79ecf8246925ccdadbafc576005b05703cd80bcdea374661488f1853b04a0a3adceb9bada7d798ed7f2"
+  ]
+}
+x-commit-hash: "3ea8cafaf9f36d5c425683d63e646401c97330d3"


### PR DESCRIPTION
Framework for writing multicore benchmark executables to run on current-bench

- Project page: <a href="https://github.com/ocaml-multicore/multicore-bench">https://github.com/ocaml-multicore/multicore-bench</a>

##### CHANGES:

- Add `Metric.make` to allow ad hoc metrics (@polytypic)
