### PR TITLE
[new release] happy-eyeballs (3 packages) (1.0.0)

### DIFF
--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.1.0.0/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.1.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/happy-eyeballs"
+dev-repo: "git+https://github.com/robur-coop/happy-eyeballs.git"
+bug-reports: "https://github.com/robur-coop/happy-eyeballs/issues"
+doc: "https://robur-coop.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner" {>= "1.1.0"}
+  "duration"
+  "dns" {>= "7.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/robur-coop/happy-eyeballs/releases/download/v1.0.0/happy-eyeballs-1.0.0.tbz"
+  checksum: [
+    "sha256=5ea47f841ab2b70c65e861f2aebf85231e5581be5344e0e34e8564d5a500fdad"
+    "sha512=0819413dfe7fccacdfd9c4b2832f2a88b074d3d7ce419e0050a5f5fd104202c8757fe9d4a7133f592b9b2452cae0581d257853f339563c6a133500e5fab77316"
+  ]
+}
+x-commit-hash: "627874b8abdd690b612f6883e6fa58d245b9e6b7"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.1.0.0/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.1.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/happy-eyeballs"
+dev-repo: "git+https://github.com/robur-coop/happy-eyeballs.git"
+bug-reports: "https://github.com/robur-coop/happy-eyeballs/issues"
+doc: "https://robur-coop.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-time" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/robur-coop/happy-eyeballs/releases/download/v1.0.0/happy-eyeballs-1.0.0.tbz"
+  checksum: [
+    "sha256=5ea47f841ab2b70c65e861f2aebf85231e5581be5344e0e34e8564d5a500fdad"
+    "sha512=0819413dfe7fccacdfd9c4b2832f2a88b074d3d7ce419e0050a5f5fd104202c8757fe9d4a7133f592b9b2452cae0581d257853f339563c6a133500e5fab77316"
+  ]
+}
+x-commit-hash: "627874b8abdd690b612f6883e6fa58d245b9e6b7"

--- a/packages/happy-eyeballs/happy-eyeballs.1.0.0/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.1.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/happy-eyeballs"
+dev-repo: "git+https://github.com/robur-coop/happy-eyeballs.git"
+bug-reports: "https://github.com/robur-coop/happy-eyeballs/issues"
+doc: "https://robur-coop.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/robur-coop/happy-eyeballs/releases/download/v1.0.0/happy-eyeballs-1.0.0.tbz"
+  checksum: [
+    "sha256=5ea47f841ab2b70c65e861f2aebf85231e5581be5344e0e34e8564d5a500fdad"
+    "sha512=0819413dfe7fccacdfd9c4b2832f2a88b074d3d7ce419e0050a5f5fd104202c8757fe9d4a7133f592b9b2452cae0581d257853f339563c6a133500e5fab77316"
+  ]
+}
+x-commit-hash: "627874b8abdd690b612f6883e6fa58d245b9e6b7"

--- a/packages/mimic-happy-eyeballs/mimic-happy-eyeballs.0.0.5/opam
+++ b/packages/mimic-happy-eyeballs/mimic-happy-eyeballs.0.0.5/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8"}
   "mimic" {= version}
-  "happy-eyeballs-mirage" {>= "0.3.0"}
+  "happy-eyeballs-mirage" {>= "0.3.0" & < "1.0.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/mimic-happy-eyeballs/mimic-happy-eyeballs.0.0.6/opam
+++ b/packages/mimic-happy-eyeballs/mimic-happy-eyeballs.0.0.6/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8"}
   "mimic" {= version}
-  "happy-eyeballs-mirage" {>= "0.3.0"}
+  "happy-eyeballs-mirage" {>= "0.3.0" & < "1.0.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/mimic-happy-eyeballs/mimic-happy-eyeballs.0.0.7/opam
+++ b/packages/mimic-happy-eyeballs/mimic-happy-eyeballs.0.0.7/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8"}
   "mimic" {= version}
-  "happy-eyeballs-mirage" {>= "0.3.0"}
+  "happy-eyeballs-mirage" {>= "0.3.0" & < "1.0.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/robur-coop/happy-eyeballs">https://github.com/robur-coop/happy-eyeballs</a>
- Documentation: <a href="https://robur-coop.github.io/happy-eyeballs/">https://robur-coop.github.io/happy-eyeballs/</a>

##### CHANGES:

* Reverse dependency between dns-client-lwt and happy-eyeballs-lwt,
  dns-client-mirage and happy-eyeballs-mirage (robur-coop/happy-eyeballs#38 @dinosaure)
  This now has a new function `inject` to put a name resolver `getaddrinfo`
  into action. The default for happy-eyeballs-lwt is Lwt_unix.getaddrinfo.
  For happy-eyeballs-mirage, there is no default.
* Update timestamp when a fresh connection attempt is done (robur-coop/happy-eyeballs#37 @hannesm)
* Log message: prepend with counter to distinguish multiple happy-eyeballs
  instaces (robur-coop/happy-eyeballs#36 @hannesm)
