### PR TITLE
[new release] carton (3 packages) (0.7.2)

### DIFF
--- a/packages/carton-git/carton-git.0.7.2/opam
+++ b/packages/carton-git/carton-git.0.7.2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACK file in OCaml"
+description: """\
+Carton is an implementation of the PACK file
+in OCaml. PACK file is used by Git to store Git objects. Carton is more
+abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://git.robur.coop/robur/carton"
+doc: "https://robur-coop.github.io/carton/"
+bug-reports: "https://git.robur.coop/robur/carton/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "carton" {= version}
+  "carton-lwt" {= version}
+  "bigstringaf" {>= "0.9.0"}
+  "lwt"
+  "fpath"
+  "fmt" {>= "0.8.9"}
+  "base-unix"
+  "decompress" {>= "1.4.3"}
+  "astring" {>= "0.8.5"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "cstruct" {>= "6.1.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "rresult" {>= "0.6.0" & with-test}
+  "ke" {>= "0.6" & with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/carton.git"
+url {
+  src:
+    "https://github.com/robur-coop/carton/releases/download/0.7.2/carton-0.7.2.tbz"
+  checksum: [
+    "sha256=46795855444dd8ce7cd90fc9d975516c9ea0b0f50365b25e2d672864256db692"
+    "sha512=a1a3c81cb51c61f4a85b661affd4db1aebedff678215a334fd240120622d3dbdd7d63e6cca994ec56c1a15675fe686bbf8a50233017911ce4dc44a70145fd98a"
+  ]
+}
+x-commit-hash: "25bf9b68ee8cf7804dbd80f93499fd2ca5811fe5"

--- a/packages/carton-lwt/carton-lwt.0.7.2/opam
+++ b/packages/carton-lwt/carton-lwt.0.7.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACK file in OCaml"
+description: """\
+Carton is an implementation of the PACK file
+in OCaml. PACK file is used by Git to store Git objects. Carton is more
+abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://git.robur.coop/robur/carton" 
+doc: "https://robur-coop.github.io/carton/"
+bug-reports: "https://git.robur.coop/robur/carton/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "carton" {= version}
+  "lwt"
+  "decompress" {>= "1.4.3"}
+  "optint" {>= "0.0.4"}
+  "bigstringaf" {>= "0.9.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "cstruct" {>= "6.1.0" & with-test}
+  "fmt" {>= "0.8.9" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "rresult" {>= "0.6.0" & with-test}
+  "ke" {>= "0.6" & with-test}
+  "base64" {>= "3.4.0" & with-test}
+  "bos" {>= "0.2.0" & with-test}
+  "checkseum" {>= "0.3.3" & with-test}
+  "digestif" {>= "1.1.2" & with-test}
+  "fpath" {>= "0.7.3" & with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/carton.git"
+url {
+  src:
+    "https://github.com/robur-coop/carton/releases/download/0.7.2/carton-0.7.2.tbz"
+  checksum: [
+    "sha256=46795855444dd8ce7cd90fc9d975516c9ea0b0f50365b25e2d672864256db692"
+    "sha512=a1a3c81cb51c61f4a85b661affd4db1aebedff678215a334fd240120622d3dbdd7d63e6cca994ec56c1a15675fe686bbf8a50233017911ce4dc44a70145fd98a"
+  ]
+}
+x-commit-hash: "25bf9b68ee8cf7804dbd80f93499fd2ca5811fe5"

--- a/packages/carton/carton.0.7.2/opam
+++ b/packages/carton/carton.0.7.2/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACKv2 file in OCaml"
+description: """\
+Carton is an implementation of the PACKv2 file
+in OCaml. PACKv2 file is used by Git to store Git objects.
+Carton is more abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://git.robur.coop/robur/carton"
+doc: "https://robur-coop.github.io/carton/"
+bug-reports: "https://git.robur.coop/robur/carton/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "ke" {>= "0.6"}
+  "duff" {>= "0.5"}
+  "decompress" {>= "1.4.3"}
+  "cstruct" {>= "6.1.0"}
+  "optint" {>= "0.0.4"}
+  "bigstringaf" {>= "0.9.0"}
+  "checkseum" {>= "0.3.3"}
+  "logs"
+  "cmdliner" {>= "1.1.0"}
+  "hxd" {>= "0.3.2"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "rresult" {with-test & >= "0.7.0"}
+  "fpath"
+  "base64" {with-test & >= "3.0.0"}
+  "bos"
+  "digestif" {>= "1.1.2"}
+  "base-unix" {with-test}
+  "base-threads" {with-test}
+  "alcotest" {with-test}
+  "crowbar" {with-test & >= "0.2.1"}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "lwt" {>= "5.3.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/carton.git"
+url {
+  src:
+    "https://github.com/robur-coop/carton/releases/download/0.7.2/carton-0.7.2.tbz"
+  checksum: [
+    "sha256=46795855444dd8ce7cd90fc9d975516c9ea0b0f50365b25e2d672864256db692"
+    "sha512=a1a3c81cb51c61f4a85b661affd4db1aebedff678215a334fd240120622d3dbdd7d63e6cca994ec56c1a15675fe686bbf8a50233017911ce4dc44a70145fd98a"
+  ]
+}
+x-commit-hash: "25bf9b68ee8cf7804dbd80f93499fd2ca5811fe5"


### PR DESCRIPTION
Implementation of PACKv2 file in OCaml

- Project page: <a href="https://git.robur.coop/robur/carton">https://git.robur.coop/robur/carton</a>
- Documentation: <a href="https://robur-coop.github.io/carton/">https://robur-coop.github.io/carton/</a>

##### CHANGES:

- Remove the `result` dependency (@hannesm, mirage/ocaml-git#634)
- Split out `carton` into `https://git.robur.coop/robur/carton` (@dinosaure)
