### PR TITLE
[new release] progress (2 packages) (0.4.0)

### DIFF
--- a/packages/progress/progress.0.4.0/opam
+++ b/packages/progress/progress.0.4.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "User-definable progress bars"
+description: """
+A progress bar library for OCaml, featuring a DSL for declaratively specifying
+progress bar formats. Supports rendering multiple progress bars simultaneously."""
+maintainer: ["Craig Ferguson <me@craigfe.io>"]
+authors: ["Craig Ferguson <me@craigfe.io>"]
+license: "MIT"
+homepage: "https://github.com/CraigFe/progress"
+doc: "https://CraigFe.github.io/progress/"
+bug-reports: "https://github.com/CraigFe/progress/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "terminal" {= version}
+  "fmt" {>= "0.8.5"}
+  "logs" {>= "0.7.0"}
+  "mtime" {>= "2.0.0"}
+  "uucp" {>= "2.0.0"}
+  "uutf" {>= "1.0.0"}
+  "vector"
+  "optint" {>= "0.1.0"}
+  "alcotest" {with-test & >= "1.4.0"}
+  "astring" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CraigFe/progress.git"
+url {
+  src:
+    "https://github.com/craigfe/progress/releases/download/0.4.0/progress-0.4.0.tbz"
+  checksum: [
+    "sha256=8be449553379bb2dc5e8b79805c80447690a03dca3e9aee959fecf46d8278fb7"
+    "sha512=841383e8aa7d6bd802ced5eb7feae01bd507b2914eb45e8a559140677f83d5b8ec614f1d0bc54421021b5254a1edd78dd8a2506b2dfb264af72448d76bd03ac5"
+  ]
+}
+x-commit-hash: "b4d34b7b1d9622402fca3ad8ff7ed5816c74bf8c"

--- a/packages/terminal/terminal.0.4.0/opam
+++ b/packages/terminal/terminal.0.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Basic utilities for interacting with terminals"
+description: "Basic utilities for interacting with terminals"
+maintainer: ["Craig Ferguson <me@craigfe.io>"]
+authors: ["Craig Ferguson <me@craigfe.io>"]
+license: "MIT"
+homepage: "https://github.com/CraigFe/progress"
+doc: "https://CraigFe.github.io/progress/"
+bug-reports: "https://github.com/CraigFe/progress/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.03.0"}
+  "uucp" {>= "2.0.0"}
+  "uutf" {>= "1.0.0"}
+  "stdlib-shims"
+  "alcotest" {with-test & >= "1.4.0"}
+  "fmt" {with-test}
+  "astring" {with-test}
+  "mtime" {with-test & >= "2.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CraigFe/progress.git"
+url {
+  src:
+    "https://github.com/craigfe/progress/releases/download/0.4.0/progress-0.4.0.tbz"
+  checksum: [
+    "sha256=8be449553379bb2dc5e8b79805c80447690a03dca3e9aee959fecf46d8278fb7"
+    "sha512=841383e8aa7d6bd802ced5eb7feae01bd507b2914eb45e8a559140677f83d5b8ec614f1d0bc54421021b5254a1edd78dd8a2506b2dfb264af72448d76bd03ac5"
+  ]
+}
+x-commit-hash: "b4d34b7b1d9622402fca3ad8ff7ed5816c74bf8c"

--- a/packages/terminal/terminal.0.4.0/opam
+++ b/packages/terminal/terminal.0.4.0/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/CraigFe/progress"
 doc: "https://CraigFe.github.io/progress/"
 bug-reports: "https://github.com/CraigFe/progress/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "3.0"}
   "ocaml" {>= "4.03.0"}
   "uucp" {>= "2.0.0"}
   "uutf" {>= "1.0.0"}


### PR DESCRIPTION
User-definable progress bars

- Project page: <a href="https://github.com/CraigFe/progress">https://github.com/CraigFe/progress</a>
- Documentation: <a href="https://CraigFe.github.io/progress/">https://CraigFe.github.io/progress/</a>

##### CHANGES:

- Revert the `terminal` API and keep an "happy" path to get size of a tty
  and be compatible with MirageOS (@art-w, @msprotz, CraigFe/progress#42, CraigFe/progress#43)
- Use a `float` instead of a `int` in `flow_meter per-second` (@mbarbin, CraigFe/progress#23, CraigFe/progress#27)
