### PR TITLE
[new release] mirage-bootvar (1.0.1)

### DIFF
--- a/packages/mirage-bootvar/mirage-bootvar.1.0.1/opam
+++ b/packages/mirage-bootvar/mirage-bootvar.1.0.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "MirageOS Core team"
+authors: [
+  "Anil Madhavapeddy"
+  "Dan Williams"
+  "Hannes Mehnert"
+  "Jon Ludlam"
+  "Magnus Skjegstad"
+  "Martin Lucina"
+  "Mindy Preston"
+  "Thomas Gazagnaire"
+]
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-bootvar"
+doc: "https://mirage.github.io/mirage-bootvar/"
+bug-reports: "https://github.com/mirage/mirage-bootvar/issues"
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "ounit2" {with-test}
+]
+depopts: [
+  "mirage-xen"
+  "mirage-solo5"
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "mirage-solo5" {< "0.6.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-bootvar.git"
+synopsis: "Boot time arguments for MirageOS"
+description: """
+Mirage-bootvar reads and parses boot parameters for MirageOS unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-bootvar/releases/download/v1.0.1/mirage-bootvar-1.0.1.tbz"
+  checksum: [
+    "sha256=12e5efb6dda76a9dc1ee363b9d831e9cea9a98b4d0aeec8527c2b6b5167806ad"
+    "sha512=306decf2278ca021c71934c9a99036d7b958698a3fe5b618fa7618e0b89d9e8ea901db0e2ff0ac31bf1a939a22105a9bf6240649b2e63ce6230e75dbf75c3449"
+  ]
+}
+x-commit-hash: "4a5483b5d32b5a5de018d46e3d19bbe06e3c08ea"


### PR DESCRIPTION
Boot time arguments for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-bootvar">https://github.com/mirage/mirage-bootvar</a>
- Documentation: <a href="https://mirage.github.io/mirage-bootvar/">https://mirage.github.io/mirage-bootvar/</a>

##### CHANGES:

* Prefix all modules (backend / parse_argv) with Mirage_bootvar to avoid
  potential conflicts (mirage/mirage-bootvar#2 @hannesm) -- observed while building
  qubes-mirage-firewall which also depends on mirage-net-xen which provides
  a module named Backend.
