### PR TITLE
ocamlnet does not work on OCaml 5 so far

### DIFF
--- a/packages/ocamlnet/ocamlnet.4.1.8/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.8/opam
@@ -22,8 +22,8 @@ build: [
   [make "opt"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
-  "ocaml" {< "4.12" & os = "macos"}
+  "ocaml" {>= "4.02" & < "5"}
+  "ocaml" {os = "macos" & < "4.12"}
   "ocamlfind"
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/ocamlnet/ocamlnet.4.1.9-1/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.9-1/opam
@@ -23,7 +23,7 @@ build: [
   [make "opt"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5"}
   "ocamlfind"
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/ocamlnet/ocamlnet.4.1.9-2/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.9-2/opam
@@ -23,7 +23,7 @@ build: [
   [make "opt"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5"}
   "ocamlfind"
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/ocamlnet/ocamlnet.4.1.9/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.9/opam
@@ -22,7 +22,7 @@ build: [
   [make "opt"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5"}
   "ocamlfind"
   "ocamlbuild" {build}
   "base-bytes"


### PR DESCRIPTION
ocamlnet does not support OCaml 5 at the moment. There is a [PR on the repo](https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/merge_requests/21) but so far it is not merged.

Thus I used opam admin add-constraint to constrain the existing versions to `< 5` where necessary. Some conditions have been thus reshuffled.