### PR TITLE
[new release] ipaddr (6 packages) (5.6.0)

### DIFF
--- a/packages/ipaddr-cstruct/ipaddr-cstruct.5.6.0/opam
+++ b/packages/ipaddr-cstruct/ipaddr-cstruct.5.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP address representations using Cstructs"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "ipaddr" {= version}
+  "cstruct" {>= "6.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Cstruct convertions for macaddr
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz"
+  checksum: [
+    "sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133"
+    "sha512=66a3bedfd91dacd6c1de9ba35abac3ef2ad3c2c8543f7b4e2a0cc6283a8d42138b48d02e904df0232ee9f320920e889bddbbda9a5148c5c6b72fd0164e0c6a34"
+  ]
+}
+x-commit-hash: "a3852099627a9f9c56d75efe1c1adf4941c6c3d4"

--- a/packages/ipaddr-sexp/ipaddr-sexp.5.6.0/opam
+++ b/packages/ipaddr-sexp/ipaddr-sexp.5.6.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP address representations using sexp"
+description: """
+Sexp convertions for ipaddr
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "ipaddr" {= version}
+  "ipaddr-cstruct" {with-test & = version}
+  "ounit2" {with-test}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz"
+  checksum: [
+    "sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133"
+    "sha512=66a3bedfd91dacd6c1de9ba35abac3ef2ad3c2c8543f7b4e2a0cc6283a8d42138b48d02e904df0232ee9f320920e889bddbbda9a5148c5c6b72fd0164e0c6a34"
+  ]
+}
+x-commit-hash: "a3852099627a9f9c56d75efe1c1adf4941c6c3d4"

--- a/packages/ipaddr/ipaddr.5.6.0/opam
+++ b/packages/ipaddr/ipaddr.5.6.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP (and MAC) address representations"
+description: """
+Features:
+ * Depends only on sexplib (conditionalization under consideration)
+ * ounit2-based tests
+ * IPv4 and IPv6 support
+ * IPv4 and IPv6 CIDR prefix support
+ * IPv4 and IPv6 [CIDR-scoped address](http://tools.ietf.org/html/rfc4291#section-2.3) support
+ * `Ipaddr.V4` and `Ipaddr.V4.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr.V6` and `Ipaddr.V6.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr` and `Ipaddr.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr_unix` in findlib subpackage `ipaddr.unix` provides compatibility with the standard library `Unix` module
+ * `Ipaddr_top` in findlib subpackage `ipaddr.top` provides top-level pretty printers (requires compiler-libs default since OCaml 4.0)
+ * IP address scope classification
+ * IPv4-mapped addresses in IPv6 (::ffff:0:0/96) are an embedding of IPv4
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "macaddr" {= version}
+  "domain-name" {>= "0.3.0"}
+  "ounit2" {with-test}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz"
+  checksum: [
+    "sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133"
+    "sha512=66a3bedfd91dacd6c1de9ba35abac3ef2ad3c2c8543f7b4e2a0cc6283a8d42138b48d02e904df0232ee9f320920e889bddbbda9a5148c5c6b72fd0164e0c6a34"
+  ]
+}
+x-commit-hash: "a3852099627a9f9c56d75efe1c1adf4941c6c3d4"

--- a/packages/macaddr-cstruct/macaddr-cstruct.5.6.0/opam
+++ b/packages/macaddr-cstruct/macaddr-cstruct.5.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations using Cstructs"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "macaddr" {= version}
+  "cstruct" {>= "6.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Cstruct convertions for macaddr
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz"
+  checksum: [
+    "sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133"
+    "sha512=66a3bedfd91dacd6c1de9ba35abac3ef2ad3c2c8543f7b4e2a0cc6283a8d42138b48d02e904df0232ee9f320920e889bddbbda9a5148c5c6b72fd0164e0c6a34"
+  ]
+}
+x-commit-hash: "a3852099627a9f9c56d75efe1c1adf4941c6c3d4"

--- a/packages/macaddr-sexp/macaddr-sexp.5.6.0/opam
+++ b/packages/macaddr-sexp/macaddr-sexp.5.6.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations using sexp"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "macaddr" {= version}
+  "macaddr-cstruct" {with-test & = version}
+  "ounit2" {with-test}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+]
+conflicts: [ "ipaddr" {< "3.0.0"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Sexp convertions for macaddr
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz"
+  checksum: [
+    "sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133"
+    "sha512=66a3bedfd91dacd6c1de9ba35abac3ef2ad3c2c8543f7b4e2a0cc6283a8d42138b48d02e904df0232ee9f320920e889bddbbda9a5148c5c6b72fd0164e0c6a34"
+  ]
+}
+x-commit-hash: "a3852099627a9f9c56d75efe1c1adf4941c6c3d4"

--- a/packages/macaddr/macaddr.5.6.0/opam
+++ b/packages/macaddr/macaddr.5.6.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "ounit2" {with-test}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+]
+conflicts: [ "ipaddr" {< "3.0.0"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+A library for manipulation of MAC address representations.
+
+Features:
+
+ * ounit2-based tests
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers optionally via the `Macaddr_sexp` library.
+ """
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz"
+  checksum: [
+    "sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133"
+    "sha512=66a3bedfd91dacd6c1de9ba35abac3ef2ad3c2c8543f7b4e2a0cc6283a8d42138b48d02e904df0232ee9f320920e889bddbbda9a5148c5c6b72fd0164e0c6a34"
+  ]
+}
+x-commit-hash: "a3852099627a9f9c56d75efe1c1adf4941c6c3d4"


### PR DESCRIPTION
A library for manipulation of IP (and MAC) address representations

- Project page: <a href="https://github.com/mirage/ocaml-ipaddr">https://github.com/mirage/ocaml-ipaddr</a>
- Documentation: <a href="https://mirage.github.io/ocaml-ipaddr/">https://mirage.github.io/ocaml-ipaddr/</a>

##### CHANGES:

* Add host and subnet Seq.t iterators for Ipaddr.V4.prefix, Ipaddr.V6.Prefix
  and Ipaddr.Prefix (mirage/ocaml-ipaddr#107 @verbosemode @dinosaure)
* Ipaddr.V4.compare: use Int32.unsigned_compare, as provided since OCaml 4.08
  (mirage/ocaml-ipaddr#118 @reynir)
* Ipaddr.V6.t is a string, not a byte vector anymore (so it is immutable)
  (mirage/ocaml-ipaddr#119 @reynir, restoring 4.08 compatibility mirage/ocaml-ipaddr#121)
* Provide Ipaddr.Prefix.address (since 5.0.0, Ipaddr.V4.Prefix.address and
  Ipaddr.V6.Prefix.address have been provided, but Ipaddr.Prefix.address was
  forgotten) (mirage/ocaml-ipaddr#122 @hannesm)
* Fix further docstrings (mirage/ocaml-ipaddr#123, fixes mirage/ocaml-ipaddr#81, @hannesm @reynir)
