### PR TITLE
[new release] mirage-vnetif (2 packages) (0.6.2)

### DIFF
--- a/packages/mirage-vnetif-stack/mirage-vnetif-stack.0.6.2/opam
+++ b/packages/mirage-vnetif-stack/mirage-vnetif-stack.0.6.2/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/mirage-vnetif"
+bug-reports: "https://github.com/mirage/mirage-vnetif/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-vnetif.git"
+doc: "https://mirage.github.io/mirage-vnetif/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@test/vnetif-stack/runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.9"}
+  "lwt"
+  "mirage-time" {>= "3.0.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "mirage-random"
+  "mirage-vnetif" {= version}
+  "tcpip" {>= "8.0.0"}
+  "ethernet"
+  "cstruct" {>="6.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr"
+  "arp" {>= "3.0.0"}
+  "duration"
+  "logs"
+  "mirage-time-unix" {with-test}
+  "mirage-clock-unix" {with-test & >= "4.0.0"}
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "alcotest" {>= "1.5.0" & with-test}
+  "alcotest-lwt" {>= "1.5.0" & with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+tags: ["org:mirage"]
+synopsis: "Vnetif implementation of mirage-stack for Mirage TCP/IP"
+description: """
+Provides Vnetif_stack, a mirage-stack implementation using Vnetif and the
+Mirage TCP/IP stack. The virtual stack can be used to test and record Mirage
+TCP/IP connections over a virtual network interface, as a process or VM.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-vnetif/releases/download/v0.6.2/mirage-vnetif-0.6.2.tbz"
+  checksum: [
+    "sha256=4a8adcacf4618426211dab0b4061ef4ed2e8db6f7fdf1541e9feff5ce9454522"
+    "sha512=f186bffb3701bd19817d5c6a01346fbc395f7a6986b6a5e0008f55c0833eb3b1d8bc8fb9b801f09fcde2ad4c8ad898379c0274d6cfd627cdb3780d7f8a5dc2c4"
+  ]
+}
+x-commit-hash: "9955006b1fa6ee321a159c55eb96ade4de64b4a8"

--- a/packages/mirage-vnetif/mirage-vnetif.0.6.2/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.6.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/mirage-vnetif"
+bug-reports: "https://github.com/mirage/mirage-vnetif/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-vnetif.git"
+doc: "https://mirage.github.io/mirage-vnetif/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.9"}
+  "lwt"
+  "mirage-net" {>= "3.0.0"}
+  "cstruct" {>="6.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "macaddr"
+  "duration"
+  "logs"
+]
+conflicts: [ "result" {< "1.5"} ]
+tags: ["org:mirage"]
+synopsis: "Virtual network interface and software switch for Mirage"
+description: """
+Provides the module `Vnetif` which can be used as a replacement for the regular
+`Netif` implementation in Xen and Unix. Stacks built using `Vnetif` are
+connected to a software switch that allows the stacks to communicate as if they
+were connected to the same LAN.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-vnetif/releases/download/v0.6.2/mirage-vnetif-0.6.2.tbz"
+  checksum: [
+    "sha256=4a8adcacf4618426211dab0b4061ef4ed2e8db6f7fdf1541e9feff5ce9454522"
+    "sha512=f186bffb3701bd19817d5c6a01346fbc395f7a6986b6a5e0008f55c0833eb3b1d8bc8fb9b801f09fcde2ad4c8ad898379c0274d6cfd627cdb3780d7f8a5dc2c4"
+  ]
+}
+x-commit-hash: "9955006b1fa6ee321a159c55eb96ade4de64b4a8"

--- a/packages/tcpip/tcpip.6.0.0/opam
+++ b/packages/tcpip/tcpip.6.0.0/opam
@@ -43,7 +43,7 @@ depends: [
   "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
   "alcotest" {with-test & >="0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}

--- a/packages/tcpip/tcpip.6.0.0/opam
+++ b/packages/tcpip/tcpip.6.0.0/opam
@@ -44,7 +44,7 @@ depends: [
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
-  "alcotest" {with-test & >="0.7.0" & < "1.4.0"}
+  "alcotest" {with-test & >="0.8.1" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
   "mirage-random-test" {with-test & >= "0.1.0"}

--- a/packages/tcpip/tcpip.6.1.0/opam
+++ b/packages/tcpip/tcpip.6.1.0/opam
@@ -49,7 +49,7 @@ depends: [
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
-  "alcotest" {with-test & >="0.7.0" & < "1.4.0"}
+  "alcotest" {with-test & >="0.8.1" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
   "mirage-random-test" {with-test & >= "0.1.0"}

--- a/packages/tcpip/tcpip.6.1.0/opam
+++ b/packages/tcpip/tcpip.6.1.0/opam
@@ -48,7 +48,7 @@ depends: [
   "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
   "alcotest" {with-test & >="0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}

--- a/packages/tcpip/tcpip.6.2.0/opam
+++ b/packages/tcpip/tcpip.6.2.0/opam
@@ -48,7 +48,7 @@ depends: [
   "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
   "alcotest" {with-test & >="0.7.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}

--- a/packages/tcpip/tcpip.6.2.0/opam
+++ b/packages/tcpip/tcpip.6.2.0/opam
@@ -49,7 +49,7 @@ depends: [
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
-  "alcotest" {with-test & >="0.7.0"}
+  "alcotest" {with-test & >="0.8.1"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
   "mirage-random-test" {with-test & >= "0.1.0"}

--- a/packages/tcpip/tcpip.6.3.0/opam
+++ b/packages/tcpip/tcpip.6.3.0/opam
@@ -48,7 +48,7 @@ depends: [
   "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
   "alcotest" {with-test & >="0.7.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}

--- a/packages/tcpip/tcpip.6.3.0/opam
+++ b/packages/tcpip/tcpip.6.3.0/opam
@@ -49,7 +49,7 @@ depends: [
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
-  "alcotest" {with-test & >="0.7.0"}
+  "alcotest" {with-test & >="0.8.1"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
   "mirage-random-test" {with-test & >= "0.1.0"}

--- a/packages/tcpip/tcpip.6.4.0/opam
+++ b/packages/tcpip/tcpip.6.4.0/opam
@@ -48,7 +48,7 @@ depends: [
   "randomconv" {< "0.2.0"}
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
   "alcotest" {with-test & >="0.7.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}

--- a/packages/tcpip/tcpip.6.4.0/opam
+++ b/packages/tcpip/tcpip.6.4.0/opam
@@ -49,7 +49,7 @@ depends: [
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
-  "alcotest" {with-test & >="0.7.0"}
+  "alcotest" {with-test & >="0.8.1"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
   "mirage-random-test" {with-test & >= "0.1.0"}

--- a/packages/tcpip/tcpip.7.0.0/opam
+++ b/packages/tcpip/tcpip.7.0.0/opam
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
   "alcotest" {with-test & >="1.5.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}

--- a/packages/tcpip/tcpip.7.0.1/opam
+++ b/packages/tcpip/tcpip.7.0.1/opam
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
   "alcotest" {with-test & >="1.5.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}

--- a/packages/tcpip/tcpip.7.1.0/opam
+++ b/packages/tcpip/tcpip.7.1.0/opam
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
   "alcotest" {with-test & >="1.5.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}

--- a/packages/tcpip/tcpip.7.1.1/opam
+++ b/packages/tcpip/tcpip.7.1.1/opam
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
   "alcotest" {with-test & >="1.5.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}

--- a/packages/tcpip/tcpip.7.1.2/opam
+++ b/packages/tcpip/tcpip.7.1.2/opam
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "2.0.0" & < "4.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
   "alcotest" {with-test & >="1.5.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}

--- a/packages/tcpip/tcpip.8.0.2/opam
+++ b/packages/tcpip/tcpip.8.0.2/opam
@@ -44,7 +44,7 @@ depends: [
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "4.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0" & < "0.6.2"}
   "alcotest" {with-test & >="1.5.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}


### PR DESCRIPTION
Virtual network interface and software switch for Mirage

- Project page: <a href="https://github.com/mirage/mirage-vnetif">https://github.com/mirage/mirage-vnetif</a>
- Documentation: <a href="https://mirage.github.io/mirage-vnetif/">https://mirage.github.io/mirage-vnetif/</a>

##### CHANGES:

- fewer type aliases, 'a io is Lwt.t, buffer is Cstruct.t, id is int
  (mirage/mirage-vnetif#37 @hannesm)
