### PR TITLE
Add: cmdliner.1.3.0

### DIFF
--- a/packages/cmdliner/cmdliner.1.3.0/opam
+++ b/packages/cmdliner/cmdliner.1.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Declarative definition of command line interfaces for OCaml"
+description: """\
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+
+Home page: http://erratique.ch/software/cmdliner"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The cmdliner programmers"
+license: "ISC"
+tags: ["cli" "system" "declarative" "org:erratique"]
+homepage: "https://erratique.ch/software/cmdliner"
+doc: "https://erratique.ch/software/cmdliner/doc"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+]
+build: [make "all" "PREFIX=%{prefix}%"]
+install: [
+  [make "install" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%"]
+  [make "install-doc" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%"]
+]
+dev-repo: "git+https://erratique.ch/repos/cmdliner.git"
+url {
+  src: "https://erratique.ch/software/cmdliner/releases/cmdliner-1.3.0.tbz"
+  checksum:
+    "sha512=4c46bc334444ff772637deae2f5ba03645d7a1b7db523470a1246acfce79b971c764d964cbb02388639b3161b279700d9ade95da550446fb32aa4849c8a8f283"
+}


### PR DESCRIPTION
* Add: `cmdliner.1.3.0` [home](https://erratique.ch/software/cmdliner), [doc](https://erratique.ch/software/cmdliner/doc), [issues](https://github.com/dbuenzli/cmdliner/issues)  
  *Declarative definition of command line interfaces for OCaml*


---

#### `cmdliner` v1.3.0 2024-05-23 La Forclaz (VS)

- Add let operators in `Cmdliner.Term.Syntax` ([#173](https://github.com/dbuenzli/cmdliner/issues/173)). Thanks to Benoit
  Montagu for suggesting, Gabriel Scherer for reminding us of language
  punning obscurities and Sebastien Mondet for strengthening the case
  to add them.
- Pager. Support full path command lookups on Windows.
  ([#185](https://github.com/dbuenzli/cmdliner/issues/185)). Thanks to @kit-ty-kate for the report.
- In manpage specifications use `$(iname)` in the default 
  introduction of the `ENVIRONMENT` section. Follow up to 
  [#168](https://github.com/dbuenzli/cmdliner/issues/168).
- Add `Cmd.eval_value'` a variation on `Cmd.eval_value`.

---

Use `b0 -- .opam publish cmdliner.1.3.0` to update the pull request.