### PR TITLE
add constraints for cmdliner dependency in pecu

### DIFF
--- a/packages/pecu/pecu.0.1/opam
+++ b/packages/pecu/pecu.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "fmt"
   "uutf"
   "rresult" {>= "0.3.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "1.1.0"}
 ]
 synopsis: "Pecu (PQ/QP - Quoted Printable)"
 description: """

--- a/packages/pecu/pecu.0.2/opam
+++ b/packages/pecu/pecu.0.2/opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "1.4"}
   "fmt"
   "rresult" {>= "0.3.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "1.1.0"}
   "alcotest" {with-test}
 ]
 url {

--- a/packages/pecu/pecu.0.3/opam
+++ b/packages/pecu/pecu.0.3/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.4"}
   "fmt"
   "rresult" {>= "0.3.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "1.1.0"}
   "alcotest" {with-test}
 ]
 url {


### PR DESCRIPTION
Error from recent cndliner release PR (https://github.com/ocaml/opam-repository/pull/25924):

```
#=== ERROR while compiling pecu.0.3 ===========================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/pecu.0.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p pecu -j 255
# exit-code            1
# env-file             ~/.opam/log/pecu-8-af4d5b.env
# output-file          ~/.opam/log/pecu-8-af4d5b.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I bin/.to_raw.eobjs/byte -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/rresult -I lib/.pecu.objs/byte -no-alias-deps -o bin/.to_raw.eobjs/byte/to_raw.cmo -c -impl bin/to_raw.ml)
# File "bin/to_raw.ml", line 109, characters 14-32:
# 109 |   let exits = Term.default_exits in
#                     ^^^^^^^^^^^^^^^^^^
# Alert deprecated: Cmdliner.Term.default_exits
# Use Cmd.Exit.defaults or Cmd.info's defaults ~exits value instead.
# File "bin/to_raw.ml", line 114, characters 22-27:
# 114 |   ( Term.(const map $ input $ output)
#                             ^^^^^
# Error: This expression has type [ `File of string | `Std ] Cmdliner.Term.t
#        but an expression was expected of type ('a -> 'b) Cmdliner.Term.t
#        Type [ `File of string | `Std ] is not compatible with type 'a -> 'b 
```

ping @dinosaure 