### PR TITLE
mirage/functoria: restrict to cmdliner < 1.3.0 for tests:

### DIFF
--- a/packages/functoria/functoria.4.4.0/opam
+++ b/packages/functoria/functoria.4.4.0/opam
@@ -27,7 +27,7 @@ depends: [
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
   "cmdliner" {>= "1.1.1"}
-  "cmdliner" {with-test & >= "1.2.0"}
+  "cmdliner" {with-test & >= "1.2.0" & < "1.3.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/packages/functoria/functoria.4.4.1/opam
+++ b/packages/functoria/functoria.4.4.1/opam
@@ -27,7 +27,7 @@ depends: [
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
   "cmdliner" {>= "1.1.1"}
-  "cmdliner" {with-test & >= "1.2.0"}
+  "cmdlinere" {with-test & >= "1.2.0" & < "1.3.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/packages/functoria/functoria.4.4.2/opam
+++ b/packages/functoria/functoria.4.4.2/opam
@@ -27,7 +27,7 @@ depends: [
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
   "cmdliner" {>= "1.1.1"}
-  "cmdliner" {with-test & >= "1.2.0"}
+  "cmdliner" {with-test & >= "1.2.0" & < "1.3.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/packages/mirage/mirage.4.4.0/opam
+++ b/packages/mirage/mirage.4.4.0/opam
@@ -30,6 +30,7 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "cmdliner" {< "1.3.0" & with-test}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.4.1/opam
+++ b/packages/mirage/mirage.4.4.1/opam
@@ -30,6 +30,7 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "cmdliner" {< "1.3.0" & with-test}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.4.2/opam
+++ b/packages/mirage/mirage.4.4.2/opam
@@ -30,6 +30,7 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "cmdliner" {< "1.3.0" & with-test}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.5.0/opam
+++ b/packages/mirage/mirage.4.5.0/opam
@@ -33,6 +33,7 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "mirage-runtime" {with-test & = version}
+  "cmdliner" {< "1.3.0" & with-test}
 ]
 
 conflicts: [ "jbuilder" {with-test} ]

--- a/packages/mirage/mirage.4.5.1/opam
+++ b/packages/mirage/mirage.4.5.1/opam
@@ -34,6 +34,7 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "mirage-runtime" {with-test & = version}
+  "cmdliner" {< "1.3.0" & with-test}
 ]
 
 conflicts: [ "jbuilder" {with-test} ]


### PR DESCRIPTION
fixes some revdeps of #25924

the error is as follows (man page rendering expect tests):

```
File "test/functoria/help/configure-o.t", line 1, characters 0-0: /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/222042f3cbc55e478b7756ba232487bb/default/test/functoria/help/configure-o.t _build/.sandbox/222042f3cbc55e478b7756ba232487bb/default/test/functoria/help/configure-o.t.corrected diff --git a/_build/.sandbox/222042f3cbc55e478b7756ba232487bb/default/test/functoria/help/configure-o.t b/_build/.sandbox/222042f3cbc55e478b7756ba232487bb/default/test/functoria/help/configure-o.t.corrected index d7b8439..3783c7d 100644
--- a/_build/.sandbox/222042f3cbc55e478b7756ba232487bb/default/test/functoria/help/configure-o.t +++ b/_build/.sandbox/222042f3cbc55e478b7756ba232487bb/default/test/functoria/help/configure-o.t.corrected @@ -84,7 +84,7 @@ Help configure -o --man-format=plain
          125 on unexpected internal errors (bugs).

   ENVIRONMENT
-         These environment variables affect the execution of configure:
+         These environment variables affect the execution of test configure:

          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
@@ -179,7 +179,7 @@ Help configure -o --help=plain
          125 on unexpected internal errors (bugs).

   ENVIRONMENT
-         These environment variables affect the execution of configure:
+         These environment variables affect the execution of test configure:

          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
File "test/functoria/help/query.t", line 1, characters 0-0: /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/b27020446267f046d4dfe54f3729efb7/default/test/functoria/help/query.t _build/.sandbox/b27020446267f046d4dfe54f3729efb7/default/test/functoria/help/query.t.corrected diff --git a/_build/.sandbox/b27020446267f046d4dfe54f3729efb7/default/test/functoria/help/query.t b/_build/.sandbox/b27020446267f046d4dfe54f3729efb7/default/test/functoria/help/query.t.corrected index 11b7d9d..b6684c1 100644
--- a/_build/.sandbox/b27020446267f046d4dfe54f3729efb7/default/test/functoria/help/query.t +++ b/_build/.sandbox/b27020446267f046d4dfe54f3729efb7/default/test/functoria/help/query.t.corrected @@ -90,7 +90,7 @@ Help query --man-format=plain
          125 on unexpected internal errors (bugs).

   ENVIRONMENT
-         These environment variables affect the execution of query:
+         These environment variables affect the execution of test query:

          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
@@ -191,7 +191,7 @@ Help query --help=plain
          125 on unexpected internal errors (bugs).

   ENVIRONMENT
-         These environment variables affect the execution of query:
+         These environment variables affect the execution of test query:

          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
File "test/functoria/e2e/help.t", line 1, characters 0-0: /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/594c2ca92cd3024bbee545fafa3fc7d5/default/test/functoria/e2e/help.t _build/.sandbox/594c2ca92cd3024bbee545fafa3fc7d5/default/test/functoria/e2e/help.t.corrected diff --git a/_build/.sandbox/594c2ca92cd3024bbee545fafa3fc7d5/default/test/functoria/e2e/help.t b/_build/.sandbox/594c2ca92cd3024bbee545fafa3fc7d5/default/test/functoria/e2e/help.t.corrected index 6d1b73c..712a082 100644
--- a/_build/.sandbox/594c2ca92cd3024bbee545fafa3fc7d5/default/test/functoria/e2e/help.t +++ b/_build/.sandbox/594c2ca92cd3024bbee545fafa3fc7d5/default/test/functoria/e2e/help.t.corrected @@ -108,7 +108,7 @@ Test that the help command works without config file:
          125 on unexpected internal errors (bugs).

   ENVIRONMENT
-         These environment variables affect the execution of help:
+         These environment variables affect the execution of test help:

          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
File "test/functoria/help/configure.t", line 1, characters 0-0: /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/97f9243b5fe020e8f09beb14bd36b103/default/test/functoria/help/configure.t _build/.sandbox/97f9243b5fe020e8f09beb14bd36b103/default/test/functoria/help/configure.t.corrected diff --git a/_build/.sandbox/97f9243b5fe020e8f09beb14bd36b103/default/test/functoria/help/configure.t b/_build/.sandbox/97f9243b5fe020e8f09beb14bd36b103/default/test/functoria/help/configure.t.corrected index 5513021..f99e5f7 100644
--- a/_build/.sandbox/97f9243b5fe020e8f09beb14bd36b103/default/test/functoria/help/configure.t +++ b/_build/.sandbox/97f9243b5fe020e8f09beb14bd36b103/default/test/functoria/help/configure.t.corrected @@ -84,7 +84,7 @@ Help configure --man-format=plain
          125 on unexpected internal errors (bugs).

   ENVIRONMENT
-         These environment variables affect the execution of configure:
+         These environment variables affect the execution of test configure:

          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
@@ -179,7 +179,7 @@ Configure help --help=plain
          125 on unexpected internal errors (bugs).

   ENVIRONMENT
-         These environment variables affect the execution of configure:
+         These environment variables affect the execution of test configure:

          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
File "test/functoria/lib/run.t", line 1, characters 0-0: /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/09cd2b9d77c5d6fdfc74b226ef3ae1d9/default/test/functoria/lib/run.t _build/.sandbox/09cd2b9d77c5d6fdfc74b226ef3ae1d9/default/test/functoria/lib/run.t.corrected diff --git a/_build/.sandbox/09cd2b9d77c5d6fdfc74b226ef3ae1d9/default/test/functoria/lib/run.t b/_build/.sandbox/09cd2b9d77c5d6fdfc74b226ef3ae1d9/default/test/functoria/lib/run.t.corrected index e115e9a..7fff559 100644
--- a/_build/.sandbox/09cd2b9d77c5d6fdfc74b226ef3ae1d9/default/test/functoria/lib/run.t +++ b/_build/.sandbox/09cd2b9d77c5d6fdfc74b226ef3ae1d9/default/test/functoria/lib/run.t.corrected @@ -206,7 +206,7 @@ Help configure
          125 on unexpected internal errors (bugs).

   ENVIRONMENT
-         These environment variables affect the execution of configure:
+         These environment variables affect the execution of test configure:

          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
```