### PR TITLE
ocaml-lsp-server.1.18.0~5.2preview: fix breakage after the merge of merlin 5.0 and removal of the merlin preview

### DIFF
--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0~5.2preview/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0~5.2preview/opam
@@ -42,7 +42,7 @@ depends: [
   "ocamlformat-rpc-lib" {>= "0.21.0"}
   "odoc" {with-doc}
   "ocaml" {>= "5.2" & < "5.3"}
-  "merlin-lib" {>= "4.9"}
+  "merlin-lib" {>= "5.0"}
 ]
 flags: avoid-version
 available: opam-version >= "2.1.0"
@@ -60,9 +60,9 @@ build: [
 ]
 url {
   src:
-    "https://github.com/ocaml/ocaml-lsp/archive/ceae461fe87a18bae2f7fe5bb54ed79579421b68.tar.gz"
+    "https://github.com/ocaml/ocaml-lsp/archive/3d84dc42c468d03ce36291985573b87767b6f670.tar.gz"
   checksum: [
-    "sha256=528e71864af63c791a0221ec40f5b84362778aa2f0b6cedede047d9d54f5d24c"
-    "sha512=1d2301c9faab8381951843cf74e5f3f8564197f3235e1fac28c52dd6625be843126f8efbd81bf0096abc56a7441fbaac95f1923f95372a4b1ed5415b537d773c"
+    "sha256=f6a54286923b9ec019748a258b40e0b889d155427c262a3ab69ddb02c48409a8"
+    "sha512=1efd7fbdd381b17df7be998200ad6b44c48a8b886e2ffc0a16a618a0f2019d5e0350446c10359a4d32072e943ecad9a6c706b437478bd5773a0b479925ff5596"
   ]
 }

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0~5.2preview/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0~5.2preview/opam
@@ -20,6 +20,7 @@ bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
   "dune" {>= "3.0"}
   "yojson"
+  "base" {>= "v0.14"}
   "re" {>= "1.5.0"}
   "ppx_yojson_conv_lib" {>= "v0.14"}
   "dune-rpc" {>= "3.4.0"}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0~5.2preview/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0~5.2preview/opam
@@ -42,7 +42,7 @@ depends: [
   "ocamlformat-rpc-lib" {>= "0.21.0"}
   "odoc" {with-doc}
   "ocaml" {>= "5.2" & < "5.3"}
-  "merlin-lib" {>= "4.9" & < "5.0"}
+  "merlin-lib" {>= "4.9"}
 ]
 flags: avoid-version
 available: opam-version >= "2.1.0"


### PR DESCRIPTION
Breakage done in https://github.com/ocaml/opam-repository/pull/25913
The preview doesn't have the same version number as the release: https://github.com/ocaml/opam-repository/pull/25902