### PR TITLE
docteur 0.0.4,5,6: require mimic < 0.0.7

### DIFF
--- a/packages/docteur/docteur.0.0.4/opam
+++ b/packages/docteur/docteur.0.0.4/opam
@@ -27,6 +27,7 @@ depends: [
   "rresult" {>= "0.6.0"}
   "carton" {>= "0.4.0"}
   "art" {>= "0.1.1"}
+  "mimic" {< "0.0.7"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]

--- a/packages/docteur/docteur.0.0.5/opam
+++ b/packages/docteur/docteur.0.0.5/opam
@@ -26,6 +26,7 @@ depends: [
   "carton" {>= "0.4.0"}
   "art" {>= "0.1.1"}
   "mmap"
+  "mimic" {< "0.0.7"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]

--- a/packages/docteur/docteur.0.0.6/opam
+++ b/packages/docteur/docteur.0.0.6/opam
@@ -26,6 +26,7 @@ depends: [
   "carton" {>= "0.4.0"}
   "art" {>= "0.1.1"}
   "mmap"
+  "mimic" {< "0.0.7"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]


### PR DESCRIPTION
as observed in https://github.com/ocaml/opam-repository/pull/25893

```
=== ERROR while compiling docteur.0.0.6 ======================================#
 context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.2.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.2/.opam-switch/build/docteur.0.0.6
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p docteur -j 39
 exit-code            1
 env-file             ~/.opam/log/docteur-7-85f234.env
 output-file          ~/.opam/log/docteur-7-85f234.out
=## output ###
 (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I bin/.make.eobjs/byte -I /home/opam/.opam/5.2/lib/angstrom -I /home/opam/.opam/5.2/lib/asn1-combinators -I /home/opam/.opam/5.2/lib/astring -I /home/opam/.opam/5.2/lib/awa -I /home/opam/.opam/5.2/lib/awa-mirage -I /home/opam/.opam/5.2/lib/base64 -I /home/opam/.opam/5.2/lib/bigarray-compat -I /home/opam/.opam/5.2/lib/bigstringaf -I /home/opam/.opam/5.2/lib/bos -I /home/opam/.opam/5.2/lib/bytes -I /home/opam/.opam/5.2/lib/ca-certs -I /home/opam/.opam/5.2/lib/ca-certs-nss -I /home/opam/.opam/5.2/lib/carton -I /home/opam/.opam/5.2/lib/carton-git -I /home/opam/.opam/5.2/lib/carton-lwt -I /home/opam/.opam/5.2/lib/carton/thin -I /home/opam/.opam/5.2/lib/checkseum/c -I /home/opam/.opam/5.2/lib/cmdliner -I /home/opam/.opam/5.2/lib/cstruct -I /home/opam/.opam/5.2/lib/decompress/de -I /home/opam/.opam/5.2/lib/decompress/zl -I /home/opam/.opam/5.2/lib/digestif/c -I /home/opam/.opam/5.2/lib/dns -I /home/opam/.opam/5.2/lib/dns-client -I /home/opam/.opam/5.2/lib/dns-client-lwt -I /home/opam/.opam/5.2/lib/dns-client-mirage -I /home/opam/.opam/5.2/lib/dns-client/resolvconf -I /home/opam/.opam/5.2/lib/dns/cache -I /home/opam/.opam/5.2/lib/domain-name -I /home/opam/.opam/5.2/lib/duff -I /home/opam/.opam/5.2/lib/duration -I /home/opam/.opam/5.2/lib/emile -I /home/opam/.opam/5.2/lib/encore -I /home/opam/.opam/5.2/lib/eqaf -I /home/opam/.opam/5.2/lib/eqaf/bigstring -I /home/opam/.opam/5.2/lib/eqaf/cstruct -I /home/opam/.opam/5.2/lib/faraday -I /home/opam/.opam/5.2/lib/fmt -I /home/opam/.opam/5.2/lib/fpath -I /home/opam/.opam/5.2/lib/git -I /home/opam/.opam/5.2/lib/git-mirage/http -I /home/opam/.opam/5.2/lib/git-mirage/ssh -I /home/opam/.opam/5.2/lib/git-mirage/tcp -I /home/opam/.opam/5.2/lib/git-paf -I /home/opam/.opam/5.2/lib/git-unix -I /home/opam/.opam/5.2/lib/git/loose -I /home/opam/.opam/5.2/lib/git/loose-git -I /home/opam/.opam/5.2/lib/git/nss -I /home/opam/.opam/5.2/lib/git/nss/git -I /home/opam/.opam/5.2/lib/git/nss/hkt -I /home/opam/.opam/5.2/lib/git/nss/neg -I /home/opam/.opam/5.2/lib/git/nss/pck -I /home/opam/.opam/5.2/lib/git/nss/pkt-line -I /home/opam/.opam/5.2/lib/git/nss/sigs -I /home/opam/.opam/5.2/lib/git/nss/smart -I /home/opam/.opam/5.2/lib/git/nss/smart-flow -I /home/opam/.opam/5.2/lib/git/nss/unixiz -I /home/opam/.opam/5.2/lib/gmap -I /home/opam/.opam/5.2/lib/happy-eyeballs -I /home/opam/.opam/5.2/lib/happy-eyeballs-lwt -I /home/opam/.opam/5.2/lib/happy-eyeballs-mirage -I /home/opam/.opam/5.2/lib/hkdf -I /home/opam/.opam/5.2/lib/httpaf -I /home/opam/.opam/5.2/lib/hxd/core -I /home/opam/.opam/5.2/lib/hxd/string -I /home/opam/.opam/5.2/lib/ipaddr -I /home/opam/.opam/5.2/lib/ipaddr/unix -I /home/opam/.opam/5.2/lib/ke -I /home/opam/.opam/5.2/lib/logs -I /home/opam/.opam/5.2/lib/lru -I /home/opam/.opam/5.2/lib/lwt -I /home/opam/.opam/5.2/lib/lwt/unix -I /home/opam/.opam/5.2/lib/macaddr -I /home/opam/.opam/5.2/lib/metrics -I /home/opam/.opam/5.2/lib/mimic -I /home/opam/.opam/5.2/lib/mimic-happy-eyeballs -I /home/opam/.opam/5.2/lib/mirage-clock -I /home/opam/.opam/5.2/lib/mirage-clock-unix -I /home/opam/.opam/5.2/lib/mirage-crypto -I /home/opam/.opam/5.2/lib/mirage-crypto-ec -I /home/opam/.opam/5.2/lib/mirage-crypto-pk -I /home/opam/.opam/5.2/lib/mirage-crypto-rng -I /home/opam/.opam/5.2/lib/mirage-crypto-rng-lwt -I /home/opam/.opam/5.2/lib/mirage-crypto-rng/unix -I /home/opam/.opam/5.2/lib/mirage-flow -I /home/opam/.opam/5.2/lib/mirage-kv -I /home/opam/.opam/5.2/lib/mirage-random -I /home/opam/.opam/5.2/lib/mirage-runtime -I /home/opam/.opam/5.2/lib/mirage-runtime/functoria -I /home/opam/.opam/5.2/lib/mirage-time -I /home/opam/.opam/5.2/lib/mirage-unix -I /home/opam/.opam/5.2/lib/mmap -I /home/opam/.opam/5.2/lib/mtime -I /home/opam/.opam/5.2/lib/mtime/clock/os -I /home/opam/.opam/5.2/lib/ocaml/threads -I /home/opam/.opam/5.2/lib/ocaml/unix -I /home/opam/.opam/5.2/lib/ocamlgraph -I /home/opam/.opam/5.2/lib/ocplib-endian -I /home/opam/.opam/5.2/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.2/lib/optint -I /home/opam/.opam/5.2/lib/paf -I /home/opam/.opam/5.2/lib/pbkdf -I /home/opam/.opam/5.2/lib/pecu -I /home/opam/.opam/5.2/lib/psq -I /home/opam/.opam/5.2/lib/ptime -I /home/opam/.opam/5.2/lib/ptime/clock/os -I /home/opam/.opam/5.2/lib/randomconv -I /home/opam/.opam/5.2/lib/result -I /home/opam/.opam/5.2/lib/rresult -I /home/opam/.opam/5.2/lib/seq -I /home/opam/.opam/5.2/lib/sexplib0 -I /home/opam/.opam/5.2/lib/stdlib-shims -I /home/opam/.opam/5.2/lib/stringext -I /home/opam/.opam/5.2/lib/tcpip -I /home/opam/.opam/5.2/lib/tls -I /home/opam/.opam/5.2/lib/tls-lwt -I /home/opam/.opam/5.2/lib/tls-mirage -I /home/opam/.opam/5.2/lib/uri -I /home/opam/.opam/5.2/lib/uutf -I /home/opam/.opam/5.2/lib/x509 -I /home/opam/.opam/5.2/lib/zarith -no-alias-deps -open Dune__exe -o bin/.make.eobjs/byte/dune__exe__Make.cmo -c -impl bin/make.ml)
 File "bin/make.ml", line 314, characters 63-66:
 314 | let ssh_edn, ssh_protocol = Mimic.register ~name:"ssh" (module SSH)
                                                                      ^^^
 Error: Signature mismatch:
        ...
        The value "shutdown" is required but not provided
        File "src/mirage_flow.mli", line 98, characters 2-71:
          Expected declaration
 (cd _build/default && /home/opam/.opam/5.2/bin/ocamlopt.opt -w -40 -g -o bin/verify.exe /home/opam/.opam/5.2/lib/eqaf/eqaf.cmxa /home/opam/.opam/5.2/lib/digestif/c/digestif_c.cmxa -I /home/opam/.opam/5.2/lib/digestif/c /home/opam/.opam/5.2/lib/bigstringaf/bigstringaf.cmxa -I /home/opam/.opam/5.2/lib/bigstringaf /home/opam/.opam/5.2/lib/result/result.cmxa /home/opam/.opam/5.2/lib/astring/astring.cmxa /home/opam/.opam/5.2/lib/fpath/fpath.cmxa /home/opam/.opam/5.2/lib/cmdliner/cmdliner.cmxa /home/opam/.opam/5.2/lib/rresult/rresult.cmxa /home/opam/.opam/5.2/lib/logs/logs.cmxa /home/opam/.opam/5.2/lib/logs/logs_cli.cmxa /home/opam/.opam/5.2/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.2/lib/fmt/fmt.cmxa /home/opam/.opam/5.2/lib/fmt/fmt_tty.cmxa /home/opam/.opam/5.2/lib/fmt/fmt_cli.cmxa /home/opam/.opam/5.2/lib/mtime/mtime.cmxa /home/opam/.opam/5.2/lib/mtime/clock/os/mtime_clock.cmxa -I /home/opam/.opam/5.2/lib/mtime/clock/os /home/opam/.opam/5.2/lib/lwt/lwt.cmxa /home/opam/.opam/5.2/lib/ocplib-endian/ocplib_endian.cmxa /home/opam/.opam/5.2/lib/ocplib-endian/bigstring/ocplib_endian_bigstring.cmxa /home/opam/.opam/5.2/lib/ocaml/threads/threads.cmxa /home/opam/.opam/5.2/lib/lwt/unix/lwt_unix.cmxa -I /home/opam/.opam/5.2/lib/lwt/unix /home/opam/.opam/5.2/lib/cstruct/cstruct.cmxa -I /home/opam/.opam/5.2/lib/cstruct /home/opam/.opam/5.2/lib/macaddr/macaddr.cmxa /home/opam/.opam/5.2/lib/domain-name/domain_name.cmxa /home/opam/.opam/5.2/lib/ipaddr/ipaddr.cmxa /home/opam/.opam/5.2/lib/mirage-flow/mirage_flow.cmxa /home/opam/.opam/5.2/lib/duration/duration.cmxa /home/opam/.opam/5.2/lib/tcpip/tcpip.cmxa /home/opam/.opam/5.2/lib/ptime/ptime.cmxa /home/opam/.opam/5.2/lib/gmap/gmap.cmxa /home/opam/.opam/5.2/lib/metrics/metrics.cmxa /home/opam/.opam/5.2/lib/base64/base64.cmxa /home/opam/.opam/5.2/lib/dns/dns.cmxa /home/opam/.opam/5.2/lib/psq/psq.cmxa /home/opam/.opam/5.2/lib/lru/lru.cmxa /home/opam/.opam/5.2/lib/dns/cache/dns_cache.cmxa /home/opam/.opam/5.2/lib/randomconv/randomconv.cmxa /home/opam/.opam/5.2/lib/dns-client/dns_client.cmxa /home/opam/.opam/5.2/lib/mirage-random/mirage_random.cmxa /home/opam/.opam/5.2/lib/mirage-time/mirage_time.cmxa /home/opam/.opam/5.2/lib/mirage-clock/mirage_clock.cmxa /home/opam/.opam/5.2/lib/happy-eyeballs/happy_eyeballs.cmxa /home/opam/.opam/5.2/lib/eqaf/bigstring/eqaf_bigstring.cmxa /home/opam/.opam/5.2/lib/eqaf/cstruct/eqaf_cstruct.cmxa /home/opam/.opam/5.2/lib/mirage-crypto/mirage_crypto.cmxa -I /home/opam/.opam/5.2/lib/mirage-crypto /home/opam/.opam/5.2/lib/hkdf/hkdf.cmxa /home/opam/.opam/5.2/lib/mirage-crypto-rng/mirage_crypto_rng.cmxa /home/opam/.opam/5.2/lib/zarith/zarith.cmxa -I /home/opam/.opam/5.2/lib/zarith /home/opam/.opam/5.2/lib/sexplib0/sexplib0.cmxa /home/opam/.opam/5.2/lib/mirage-crypto-pk/mirage_crypto_pk.cmxa /home/opam/.opam/5.2/lib/asn1-combinators/asn1_combinators.cmxa /home/opam/.opam/5.2/lib/mirage-crypto-ec/mirage_crypto_ec.cmxa -I /home/opam/.opam/5.2/lib/mirage-crypto-ec /home/opam/.opam/5.2/lib/pbkdf/pbkdf.cmxa /home/opam/.opam/5.2/lib/x509/x509.cmxa /home/opam/.opam/5.2/lib/tls/tls.cmxa /home/opam/.opam/5.2/lib/optint/optint.cmxa /home/opam/.opam/5.2/lib/mirage-kv/mirage_kv.cmxa /home/opam/.opam/5.2/lib/tls-mirage/tls_mirage.cmxa /home/opam/.opam/5.2/lib/ca-certs-nss/ca_certs_nss.cmxa /home/opam/.opam/5.2/lib/dns-client-mirage/dns_client_mirage.cmxa /home/opam/.opam/5.2/lib/happy-eyeballs-mirage/happy_eyeballs_mirage.cmxa /home/opam/.opam/5.2/lib/mimic/mimic.cmxa /home/opam/.opam/5.2/lib/mimic-happy-eyeballs/mimic_happy_eyeballs.cmxa /home/opam/.opam/5.2/lib/git/nss/sigs/sigs.cmxa /home/opam/.opam/5.2/lib/ke/ke.cmxa /home/opam/.opam/5.2/lib/git/nss/unixiz/unixiz.cmxa /home/opam/.opam/5.2/lib/checkseum/c/checkseum_c.cmxa -I /home/opam/.opam/5.2/lib/checkseum/c /home/opam/.opam/5.2/lib/decompress/de/de.cmxa /home/opam/.opam/5.2/lib/decompress/zl/zl.cmxa /home/opam/.opam/5.2/lib/angstrom/angstrom.cmxa /home/opam/.opam/5.2/lib/uutf/uutf.cmxa /home/opam/.opam/5.2/lib/pecu/pecu.cmxa /home/opam/.opam/5.2/lib/emile/emile.cmxa /home/opam/.opam/5.2/lib/stringext/stringext.cmxa /home/opam/.opam/5.2/lib/uri/uri.cmxa /home/opam/.opam/5.2/lib/git/nss/pkt-line/pkt_line.cmxa /home/opam/.opam/5.2/lib/git/nss/smart/smart.cmxa /home/opam/.opam/5.2/lib/git/nss/pck/pck.cmxa /home/opam/.opam/5.2/lib/git/nss/smart-flow/smart_flow.cmxa /home/opam/.opam/5.2/lib/git/nss/neg/neg.cmxa /home/opam/.opam/5.2/lib/git/nss/nss.cmxa /home/opam/.opam/5.2/lib/duff/duff.cmxa /home/opam/.opam/5.2/lib/carton/carton.cmxa /home/opam/.opam/5.2/lib/carton/thin/thin.cmxa /home/opam/.opam/5.2/lib/carton-lwt/carton_lwt.cmxa /home/opam/.opam/5.2/lib/git/nss/git/smart_git.cmxa /home/opam/.opam/5.2/lib/git-mirage/tcp/git_mirage_tcp.cmxa /home/opam/.opam/5.2/lib/awa/awa.cmxa /home/opam/.opam/5.2/lib/awa-mirage/awa_mirage.cmxa /home/opam/.opam/5.2/lib/git-mirage/ssh/git_mirage_ssh.cmxa /home/opam/.opam/5.2/lib/faraday/faraday.cmxa /home/opam/.opam/5.2/lib/paf/paf.cmxa /home/opam/.opam/5.2/lib/httpaf/httpaf.cmxa /home/opam/.opam/5.2/lib/git-paf/git_paf.cmxa /home/opam/.opam/5.2/lib/git-mirage/http/git_mirage_http.cmxa /home/opam/.opam/5.2/lib/mirage-clock-unix/mirage_clock_unix.cmxa -I /home/opam/.opam/5.2/lib/mirage-clock-unix /home/opam/.opam/5.2/lib/mirage-runtime/functoria/functoria_runtime.cmxa /home/opam/.opam/5.2/lib/mirage-runtime/mirage_runtime.cmxa /home/opam/.opam/5.2/lib/mirage-unix/unix_os.cmxa /home/opam/.opam/5.2/lib/dns-client/resolvconf/dns_resolvconv.cmxa /home/opam/.opam/5.2/lib/mirage-crypto-rng/unix/mirage_crypto_rng_unix.cmxa -I /home/opam/.opam/5.2/lib/mirage-crypto-rng/unix /home/opam/.opam/5.2/lib/mirage-crypto-rng-lwt/mirage_crypto_rng_lwt.cmxa /home/opam/.opam/5.2/lib/ipaddr/unix/ipaddr_unix.cmxa /home/opam/.opam/5.2/lib/ptime/clock/os/ptime_clock.cmxa -I /home/opam/.opam/5.2/lib/ptime/clock/os /home/opam/.opam/5.2/lib/tls-lwt/tls_lwt.cmxa /home/opam/.opam/5.2/lib/bos/bos.cmxa /home/opam/.opam/5.2/lib/ca-certs/ca_certs.cmxa -I /home/opam/.opam/5.2/lib/ca-certs /home/opam/.opam/5.2/lib/dns-client-lwt/dns_client_lwt.cmxa /home/opam/.opam/5.2/lib/happy-eyeballs-lwt/happy_eyeballs_lwt.cmxa /home/opam/.opam/5.2/lib/hxd/core/hxd.cmxa /home/opam/.opam/5.2/lib/hxd/string/hxd_string.cmxa /home/opam/.opam/5.2/lib/git/loose/loose.cmxa /home/opam/.opam/5.2/lib/git/nss/hkt/hkt.cmxa /home/opam/.opam/5.2/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/5.2/lib/ocamlgraph/graph.cmxa /home/opam/.opam/5.2/lib/git/loose-git/loose_git.cmxa /home/opam/.opam/5.2/lib/carton-git/carton_git.cmxa /home/opam/.opam/5.2/lib/encore/encore.cmxa /home/opam/.opam/5.2/lib/git/git.cmxa /home/opam/.opam/5.2/lib/git-unix/git_unix.cmxa /home/opam/.opam/5.2/lib/bigarray-compat/bigarray_compat.cmxa /home/opam/.opam/5.2/lib/mmap/mmap.cmxa bin/.verify.eobjs/native/dune__exe__Verify.cmx)
 File "_none_", line 1:
 Error: No implementations provided for the following modules:
          "Logs_fmt" referenced from "bin/.verify.eobjs/native/dune__exe__Verify.cmx"
```