### PR TITLE
re_parser needs re 1.10.0

### DIFF
--- a/packages/re_parser/re_parser.v0.17.0/opam
+++ b/packages/re_parser/re_parser.v0.17.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"              {>= "v0.17" & < "v0.18"}
   "regex_parser_intf" {>= "v0.17" & < "v0.18"}
   "dune"              {>= "3.11.0"}
-  "re"                {>= "1.8.0"}
+  "re"                {>= "1.10.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Typed parsing using regular expressions."


### PR DESCRIPTION
Uses Re.Group.get_opt (See https://github.com/ocaml/opam-repository/pull/25930)