### PR TITLE
ocamlbuild for windows OCaml 5.2

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.14.3+win/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.14.3+win/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "OCamlbuild is a build system with builtin rules to easily build most OCaml projects"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+authors: ["Nicolas Pouillard" "Berke Durak"]
+license: "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/ocamlbuild/"
+doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
+bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+depends: [
+  "ocaml" {>= "4.03"}
+]
+conflicts: [
+  "base-ocamlbuild"
+  "ocamlfind" {< "1.6.2"}
+]
+build: [
+  [make "all"]
+]
+install: [
+  [make "install"]
+  ["mkdir" "-p" "%{lib}%/ocamlbuild"]
+  ["install" "-m" "0644" "META" "%{lib}%/ocamlbuild"]
+]
+dev-repo: "git+https://github.com/ocaml/ocamlbuild.git"
+url {
+  src: "https://github.com/ocaml/ocamlbuild/archive/refs/tags/0.14.3.tar.gz"
+  checksum: [
+    "md5=220df59060c916e8aac2eb471c870485"
+    "sha512=def8fa1d5488905fda31f72b7f6f0ebdccefa55a8e984a6ea4a7c1e0856e8ea1f7814410202e0f7f7d5e72aca7e8ae0d6623f7f2bade78b0dd82155de76ec4e5"
+  ]
+}
+extra-source "ocamlbuild-0.14.2.patch" {
+  src: "https://raw.githubusercontent.com/ocaml-opam/opam-repository-mingw/354a87b397856f2a70024c5c83fc5001074935b6/packages/ocamlbuild/ocamlbuild.0.14.2/files/ocamlbuild-0.14.2.patch"
+  checksum: "sha256=a9b7e1829a3304e5a073d8ddea29d3d8272698e93b7e1ee659ae5e31e5cfb6b9"
+}
+patches: "ocamlbuild-0.14.2.patch"
+available: os = "win32"


### PR DESCRIPTION
This PR provides a windows variant of ocamlbuild.0.14.3.
It re-uses the patch used to fix ocamlbuild.0.14.2 for windows and make ocamlbuild.0.14.3 available on windows with OCaml 5.02.