### PR TITLE
provider 0.0.4: allow base & etc >= v0.16

### DIFF
--- a/packages/provider/provider.0.0.4/opam
+++ b/packages/provider/provider.0.0.4/opam
@@ -10,13 +10,13 @@ bug-reports: "https://github.com/mbarbin/provider/issues"
 depends: [
   "dune" {>= "3.14"}
   "ocaml" {>= "5.1"}
-  "base" {>= "v0.16" & < "v0.17"}
+  "base" {>= "v0.16"}
   "bisect_ppx" {dev & >= "2.8.3"}
-  "ppx_compare" {>= "v0.16" & < "v0.17"}
-  "ppx_hash" {>= "v0.16" & < "v0.17"}
-  "ppx_js_style" {dev & >= "v0.16" & < "v0.17"}
-  "ppx_sexp_conv" {>= "v0.16" & < "v0.17"}
-  "ppx_sexp_value" {>= "v0.16" & < "v0.17"}
+  "ppx_compare" {>= "v0.16"}
+  "ppx_hash" {>= "v0.16"}
+  "ppx_js_style" {dev & >= "v0.16"}
+  "ppx_sexp_conv" {>= "v0.16"}
+  "ppx_sexp_value" {>= "v0.16"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
I wasn't aware of a workflow in use in the opam-repository by which when new js packages versions are released, bounds are added if/where needed (upon witnessing actual breaks).

In light of this, I think the dependency setup that I initially set for provider may be relaxed.

In particular, I have checked that this package is compatible with the `v0.17` suite that was recently released, and I'd like to allow this combination.

Thank you!