### PR TITLE
[new release] happy-eyeballs (3 packages) (1.1.0)

### DIFF
--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.1.1.0/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.1.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/happy-eyeballs"
+dev-repo: "git+https://github.com/robur-coop/happy-eyeballs.git"
+bug-reports: "https://github.com/robur-coop/happy-eyeballs/issues"
+doc: "https://robur-coop.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner" {>= "1.1.0"}
+  "duration"
+  "dns" {>= "7.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/robur-coop/happy-eyeballs/releases/download/v1.1.0/happy-eyeballs-1.1.0.tbz"
+  checksum: [
+    "sha256=ce6670b9e1ecf5b7bc339c7c666dab8cf25be9baf20cd4c0784f12105b4fdcc1"
+    "sha512=2c391824694d18b4c5c6695540b6bdaf63ec7f5accb868312c06dafab9f0ab888e2cb46d1afc94fa897747bbe3a0223f9701eb709bf3ed4f45ed3899cf9abf15"
+  ]
+}
+x-commit-hash: "9cc0b513b521b1409405c471f144f717e134f6f0"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.1.1.0/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.1.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/happy-eyeballs"
+dev-repo: "git+https://github.com/robur-coop/happy-eyeballs.git"
+bug-reports: "https://github.com/robur-coop/happy-eyeballs/issues"
+doc: "https://robur-coop.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-time" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/robur-coop/happy-eyeballs/releases/download/v1.1.0/happy-eyeballs-1.1.0.tbz"
+  checksum: [
+    "sha256=ce6670b9e1ecf5b7bc339c7c666dab8cf25be9baf20cd4c0784f12105b4fdcc1"
+    "sha512=2c391824694d18b4c5c6695540b6bdaf63ec7f5accb868312c06dafab9f0ab888e2cb46d1afc94fa897747bbe3a0223f9701eb709bf3ed4f45ed3899cf9abf15"
+  ]
+}
+x-commit-hash: "9cc0b513b521b1409405c471f144f717e134f6f0"

--- a/packages/happy-eyeballs/happy-eyeballs.1.1.0/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.1.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/happy-eyeballs"
+dev-repo: "git+https://github.com/robur-coop/happy-eyeballs.git"
+bug-reports: "https://github.com/robur-coop/happy-eyeballs/issues"
+doc: "https://robur-coop.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/robur-coop/happy-eyeballs/releases/download/v1.1.0/happy-eyeballs-1.1.0.tbz"
+  checksum: [
+    "sha256=ce6670b9e1ecf5b7bc339c7c666dab8cf25be9baf20cd4c0784f12105b4fdcc1"
+    "sha512=2c391824694d18b4c5c6695540b6bdaf63ec7f5accb868312c06dafab9f0ab888e2cb46d1afc94fa897747bbe3a0223f9701eb709bf3ed4f45ed3899cf9abf15"
+  ]
+}
+x-commit-hash: "9cc0b513b521b1409405c471f144f717e134f6f0"


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/robur-coop/happy-eyeballs">https://github.com/robur-coop/happy-eyeballs</a>
- Documentation: <a href="https://robur-coop.github.io/happy-eyeballs/">https://robur-coop.github.io/happy-eyeballs/</a>

##### CHANGES:

* Allow timeouts and delays in `connect`, `connect_ip`, `connect_host` to
  overwrite the default from `create` (robur-coop/happy-eyeballs#42 @hannesm)
