### PR TITLE
[new release] multicore-magic (2.2.0)

### DIFF
--- a/packages/multicore-magic/multicore-magic.2.2.0/opam
+++ b/packages/multicore-magic/multicore-magic.2.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Low-level multicore utilities for OCaml"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-magic"
+bug-reports: "https://github.com/ocaml-multicore/multicore-magic/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "4.12.0"}
+  "domain_shims" {>= "0.1.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-magic.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-magic/releases/download/2.2.0/multicore-magic-2.2.0.tbz"
+  checksum: [
+    "sha256=f38b65182a2f2819db579ee71e91f7d68b8e43b5f4cb480c976333b4f1a706a9"
+    "sha512=d50bdd90141a3dd34a251db2bb67e8ea7425ff6bbefbd39a46b38e814db082ee5910d0ac23c86fcb3b2e00715d3b7797e9412d14319b9c2c8b7262e034e170ac"
+  ]
+}
+x-commit-hash: "41deff748791dc795c034deff87d58196b8be3c7"


### PR DESCRIPTION
Low-level multicore utilities for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/multicore-magic">https://github.com/ocaml-multicore/multicore-magic</a>

##### CHANGES:

- Add (unboxed) `Atomic_array` (@polytypic)
