### PR TITLE
[new release] slipshow (0.0.32)

### DIFF
--- a/packages/slipshow/slipshow.0.0.32/opam
+++ b/packages/slipshow/slipshow.0.0.32/opam
@@ -41,6 +41,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+conflicts: [ "ocaml-option-bytecode-only" ]
 dev-repo: "git+https://github.com/panglesd/slipshow.git"
 url {
   src:

--- a/packages/slipshow/slipshow.0.0.32/opam
+++ b/packages/slipshow/slipshow.0.0.32/opam
@@ -37,7 +37,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & os = "linux"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/slipshow/slipshow.0.0.32/opam
+++ b/packages/slipshow/slipshow.0.0.32/opam
@@ -23,7 +23,7 @@ depends: [
   "dream"
   "fpath"
   "brr"
-  "ppx_blob"
+  "ppx_blob" {>= "0.7.2"}
   "odoc" {with-doc}
   "ocamlformat" {with-dev-setup & = "0.26.1"}
 ]

--- a/packages/slipshow/slipshow.0.0.32/opam
+++ b/packages/slipshow/slipshow.0.0.32/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "A compiler from markdown to slipshow"
+description: "A longer description"
+maintainer: ["Paul-Elliot"]
+authors: ["Paul-Elliot"]
+license: "MIT"
+tags: ["slipsow" "presentation" "slideshow" "beamer"]
+homepage: "https://github.com/panglesd/slipshow"
+doc: "https://slipshow.readthedocs.io"
+bug-reports: "https://github.com/panglesd/slipshow/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.6"}
+  "crunch" {with-dev-setup}
+  "cmdliner"
+  "base64"
+  "bos"
+  "lwt"
+  "inotify"
+  "js_of_ocaml-compiler"
+  "js_of_ocaml-lwt"
+  "magic-mime"
+  "dream"
+  "fpath"
+  "brr"
+  "ppx_blob"
+  "odoc" {with-doc}
+  "ocamlformat" {with-dev-setup & = "0.26.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/panglesd/slipshow.git"
+url {
+  src:
+    "https://github.com/panglesd/slipshow/releases/download/v0.0.32/slipshow-0.0.32.tbz"
+  checksum: [
+    "sha256=ec9251271a4b9ae11ce7ab18ce3f977af59ed962f473be8ccdf163b21f35f78d"
+    "sha512=6d0a4e9bc35b718c08c74a17dc684c1e279ceb88ef963193e2de37fbc0b4e731bd8dafbeec0608cc13ddc4cc228af50ba9e4f84ac671bb17d70bc6933248e629"
+  ]
+}
+x-commit-hash: "ad3df09e9b95259db4b58ab8539e26bfcbe62732"

--- a/packages/slipshow/slipshow.0.0.32/opam
+++ b/packages/slipshow/slipshow.0.0.32/opam
@@ -20,7 +20,7 @@ depends: [
   "js_of_ocaml-compiler"
   "js_of_ocaml-lwt"
   "magic-mime"
-  "dream"
+  "dream" {>= "1.0.0~alpha5"}
   "fpath"
   "brr" {>= "0.0.6"}
   "ppx_blob" {>= "0.7.2"}

--- a/packages/slipshow/slipshow.0.0.32/opam
+++ b/packages/slipshow/slipshow.0.0.32/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/panglesd/slipshow"
 doc: "https://slipshow.readthedocs.io"
 bug-reports: "https://github.com/panglesd/slipshow/issues"
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.14"}
   "dune" {>= "3.6"}
   "crunch" {with-dev-setup}
   "cmdliner"

--- a/packages/slipshow/slipshow.0.0.32/opam
+++ b/packages/slipshow/slipshow.0.0.32/opam
@@ -47,8 +47,8 @@ url {
   src:
     "https://github.com/panglesd/slipshow/releases/download/v0.0.32/slipshow-0.0.32.tbz"
   checksum: [
-    "sha256=a7e4238af43dffd7c29487009306d89af7cfe9df73255c1696f50bb3760521c4"
-    "sha512=c8c8b4a0bb5f903331fc84dc3587a13568d07f0a4397971bd450c012486c2f0dd54beddcc5ec724e54a8c790c604402f007d887984176d616875db509b8c81f3"
+    "sha256=f1f386112cb04ad2284f6ade60c35b52dc380bda6bdaff7158bc729322f1fa93"
+    "sha512=9ef7b3fd72861edf6a31e777af805254b59d7d97b126688dca7ae7c7ef52a3b4ec49d2300ff3b5d6f13df41791e83c7a5c1f32cadf76dbaf3896305bdb5ff265"
   ]
 }
-x-commit-hash: "2bb5663d0dfb117b8a4142063f2ce82979f2b16f"
+x-commit-hash: "32b86bb81ec574f493b0f3eabfdda786ba6c8955"

--- a/packages/slipshow/slipshow.0.0.32/opam
+++ b/packages/slipshow/slipshow.0.0.32/opam
@@ -22,7 +22,7 @@ depends: [
   "magic-mime"
   "dream"
   "fpath"
-  "brr"
+  "brr" {>= "0.0.6"}
   "ppx_blob" {>= "0.7.2"}
   "odoc" {with-doc}
   "ocamlformat" {with-dev-setup & = "0.26.1"}

--- a/packages/slipshow/slipshow.0.0.32/opam
+++ b/packages/slipshow/slipshow.0.0.32/opam
@@ -4,7 +4,7 @@ description: "A longer description"
 maintainer: ["Paul-Elliot"]
 authors: ["Paul-Elliot"]
 license: "MIT"
-tags: ["slipsow" "presentation" "slideshow" "beamer"]
+tags: ["slipshow" "presentation" "slideshow" "beamer"]
 homepage: "https://github.com/panglesd/slipshow"
 doc: "https://slipshow.readthedocs.io"
 bug-reports: "https://github.com/panglesd/slipshow/issues"
@@ -47,8 +47,8 @@ url {
   src:
     "https://github.com/panglesd/slipshow/releases/download/v0.0.32/slipshow-0.0.32.tbz"
   checksum: [
-    "sha256=ec9251271a4b9ae11ce7ab18ce3f977af59ed962f473be8ccdf163b21f35f78d"
-    "sha512=6d0a4e9bc35b718c08c74a17dc684c1e279ceb88ef963193e2de37fbc0b4e731bd8dafbeec0608cc13ddc4cc228af50ba9e4f84ac671bb17d70bc6933248e629"
+    "sha256=a7e4238af43dffd7c29487009306d89af7cfe9df73255c1696f50bb3760521c4"
+    "sha512=c8c8b4a0bb5f903331fc84dc3587a13568d07f0a4397971bd450c012486c2f0dd54beddcc5ec724e54a8c790c604402f007d887984176d616875db509b8c81f3"
   ]
 }
-x-commit-hash: "ad3df09e9b95259db4b58ab8539e26bfcbe62732"
+x-commit-hash: "2bb5663d0dfb117b8a4142063f2ce82979f2b16f"


### PR DESCRIPTION
A compiler from markdown to slipshow

- Project page: <a href="https://github.com/panglesd/slipshow">https://github.com/panglesd/slipshow</a>
- Documentation: <a href="https://slipshow.readthedocs.io">https://slipshow.readthedocs.io</a>

##### CHANGES:


