### PR TITLE
Dream 1.0.0~alpha6

### DIFF
--- a/packages/dream-httpaf/dream-httpaf.1.0.0~alpha3/opam
+++ b/packages/dream-httpaf/dream-httpaf.1.0.0~alpha3/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+
+synopsis: "Internal: shared http/af stack for Dream (server) and Hyper (client)"
+description: "This package does not have a stable API."
+
+license: "MIT"
+homepage: "https://github.com/aantron/dream"
+doc: "https://aantron.github.io/dream"
+bug-reports: "https://github.com/aantron/dream/issues"
+dev-repo: "git+https://github.com/aantron/dream.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "dream-pure"
+  "dune" {>= "2.7.0"}  # --instrument-with.
+  "lwt"
+  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ssl"
+  "ocaml" {>= "4.08.0"}
+  "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
+
+  # Currently vendored.
+  # "gluten"
+  # "gluten-lwt-unix"
+  # "httpaf"
+  # "httpaf-lwt-unix"
+  # "h2"
+  # "h2-lwt-unix"
+  # "hpack"
+  # "websocketaf"
+
+  # Dependencies of vendored packages.
+  "angstrom" {>= "0.14.0"}
+  "base64" {>= "3.0.0"}
+  "bigstringaf" {>= "0.5.0"}  # h2.
+  "digestif" {>= "0.7.2"}  # websocket/af, sha1, default implementation.
+  "faraday" {>= "0.6.1"}
+  "faraday-lwt-unix"
+  "lwt_ssl" {>= "1.2.0"}  # Gluten.
+  "psq"  # h2.
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/dream/releases/download/1.0.0-alpha6/dream-1.0.0-alpha6.tar.gz"
+  checksum: "md5=4525b433fc9b84b153abe226628d4ef9"
+}

--- a/packages/dream/dream.1.0.0~alpha6/opam
+++ b/packages/dream/dream.1.0.0~alpha6/opam
@@ -1,0 +1,107 @@
+opam-version: "2.0"
+
+synopsis: "Tidy, feature-complete Web framework"
+tags: ["http" "web" "framework" "websocket" "graphql" "server" "http2" "tls"]
+
+description: """
+Dream is a feature-complete Web framework with a simple programming
+model and no boilerplate. It provides only two data types, request and
+response.
+
+Almost everything else is either a built-in OCaml type, or an
+abbreviation for a bare function. For example, a Web app, known in
+Dream as a handler, is just an ordinary function from requests to
+responses. And a middleware is then just a function from handlers to
+handlers.
+
+Within this model, Dream adds:
+
+- Session management with pluggable back ends.
+- A fully composable router.
+- Support for HTTP/1.1, HTTP/2, and HTTPS.
+- WebSockets.
+- GraphQL, including subscriptions and a built-in GraphiQL editor.
+- SQL connection pool helpers.
+- Server-side HTML templates.
+- Automatic secure handling of cookies and forms.
+- Unified, internationalization-friendly error handling.
+- A neat log, and OCaml runtime configuration.
+- Helpers for Web formats, such as Base64url, and a modern cipher.
+
+Because of the simple programming model, everything is optional and
+composable. It is trivailly possible to strip Dream down to just a
+bare driver of the various HTTP protocols.
+
+Dream is presented as a single module, whose API is documented on one
+page. In addition, Dream comes with a large number of examples.
+Security topics are introduced throughout, wherever they are
+applicable."""
+
+license: "MIT"
+homepage: "https://github.com/aantron/dream"
+doc: "https://aantron.github.io/dream"
+bug-reports: "https://github.com/aantron/dream/issues"
+dev-repo: "git+https://github.com/aantron/dream.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "base-unix"
+  "bigarray-compat"
+  "camlp-streams"
+  "caqti" {>= "2.0.0"}
+  "caqti-lwt" {>= "2.0.0"}
+  ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
+  "cstruct" {>= "6.0.0"}
+  "dream-httpaf" {>= "1.0.0~alpha3"}
+  "dream-pure" {>= "1.0.0~alpha2"}
+  "dune" {>= "2.7.0"}  # --instrument-with.
+  "fmt" {>= "0.8.7"}  # `Italic.
+  "graphql_parser"
+  "graphql-lwt"
+  "lambdasoup" {>= "0.6.1"}
+  "lwt"
+  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ssl"
+  "logs" {>= "0.5.0"}
+  "magic-mime"
+  "markup" {>= "1.0.2"}
+  "mirage-clock" {>= "3.0.0"}  # now_d_ps : unit -> int * int64.
+  "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
+  "mirage-crypto-rng"
+  "mirage-crypto-rng-lwt"
+  "multipart_form" {>= "0.4.0"}
+  "multipart_form-lwt"
+  "ocaml" {>= "4.08.0"}
+  "ptime" {>= "0.8.1"}  # Ptime.v.
+  "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
+  "uri" {>= "4.2.0"}
+  "yojson"  # ...
+
+  # Testing, development.
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}  # --instrument-with.
+  "caqti-driver-postgresql" {with-test}
+  "caqti-driver-sqlite3" {with-test}
+  "crunch" {with-test}
+  "js_of_ocaml" {with-test}
+  "js_of_ocaml-ppx" {with-test}
+  "ppx_expect" {with-test & >= "v0.15.0"}  # Formatting changes.
+  "ppx_yojson_conv" {with-test}
+  "reason" {with-test}
+  "tyxml" {with-test & >= "4.5.0"}
+
+  # Blocked until https://github.com/ocsigen/tyxml/pull/312.
+  # "tyxml-jsx" {with-test & >= "4.5.0"}
+  # "tyxml-ppx" {with-test & >= "4.5.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/dream/releases/download/1.0.0-alpha6/dream-1.0.0-alpha6.tar.gz"
+  checksum: "md5=4525b433fc9b84b153abe226628d4ef9"
+}


### PR DESCRIPTION
From the changelog:

Additions

- Check that response header names are non-empty strings (aantron/dream#262, Dennis Dang).
- Update [built-in GraphiQL](https://aantron.github.io/dream/#val-graphiql) to 2.4.1 (aantron/dream#271, Dennis Dang).
- Adapt to [Caqti 2.0.0](https://github.com/paurkedal/ocaml-caqti/releases/tag/v2.0.0) (aantron/dream#302, Petter Urkedal).
- Merge [`dream-livereload`](https://github.com/tmattio/dream-livereload) into Dream as [`Dream.livereload`](https://aantron.github.io/dream/#val-livereload) (aantron/dream#279, Thibaut Mattio).
- Ability for [`dream-eml`](https://github.com/aantron/dream/tree/master/example/7-template#readme) to output to STDOUT (aantron/dream#228, Thomas Coopman).
- [`Dream.drop_session_field`](https://aantron.github.io/dream/#val-drop_session_field) (aantron/dream#284, requested by @rawleyfowler).
- Docs: togglable light theme (aantron/dream#268, Tom Ekander).
- Upgrade vendored http/af stack (aantron/dream@c86e492, aantron/dream@51902fc, aantron/dream@d802548, aantron/dream@a357921).
- WebSocket: handle ping and pong payloads (aantron/dream@aaabf4d).
- WebSocket: allow non-FIN frames (aantron/dream@a2cfbf4).
- Support listening on Unix domain sockets (aantron/dream#219, Thomas Gazagnaire).

Removals

- Remove previously deprecated values `Dream.with_client`, `Dream.with_method`, `Dream.with_header`, `Dream.with_body`, `Dream.with_stream`, `Dream.write_buffer`, `Dream.form_tag`, `Dream.session`, `Dream.put_session`, `Dream.all_session_values`, `Dream.put_flash`, `Dream.local`, `Dream.new_local`, `Dream.with_local`, `Dream.first`, `Dream.last`, and deprecated type `Dream.local` (aantron/dream@e14bd91).

Fixes

- Respect log levels of custom sub-logs (aantron/dream#299, reported by Flemming Madsen).
- [`dream-eml`](https://github.com/aantron/dream/tree/master/example/7-template#readme) should not emit references to internal module `Dream_pure` (aantron/dream#291, reported by Glenn Slotte).
- Docs: replace `inria.fr` URLs with `ocaml.org` URLs (aantron/dream#309, @denver-s).
- Fix code and commands in [examples](https://github.com/aantron/dream/tree/master/example#readme) (aantron/dream#311, aantron/dream#312, aantron/dream#315, @renatillas, Valentin Gatien-Baron).

Miscellaneous

- Convert example [`w-watch`](https://github.com/aantron/dream/tree/master/example/w-watch#readme) to use the new `dune exec -w` instead of `fswatch` (aantron/dream#266, Dennis Dang).
- Rename `dream.log` log tag to `dream.logger` (aantron/dream@d135ba6).
- Deprecate `Dream.not_found` (aantron/dream@23b7406).
- Update Alpine Linux version in example (aantron/dream#300, Pedro Dias).
- Document significance of trailing slashes in the [router](https://aantron.github.io/dream/#val-router) (aantron/dream#265, @rawleyfowler).
- Adapt example [`e-json`](https://github.com/aantron/dream/tree/master/example/e-json#readme) to `ppx_yojson_conv` 0.16.0 (aantron/dream#287, Benjamin Thomas).
- Convert examples to use opam.