### PR TITLE
7 packages from zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.2.0.tar.gz

### DIFF
--- a/packages/ldp/ldp.0.2.0/opam
+++ b/packages/ldp/ldp.0.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "cohttp-lwt" {>= "4.0.0"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.3"}
+  "ocaml" {>= "4.14.0"}
+  "ocf" {>= "0.8.0"}
+  "ocf_ppx" {>= "0.8.0"}
+  "rdf" {>= "1.0.0"}
+  "rdf_ppx" {>= "1.0.0"}
+  "sedlex" {>= "2.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.2.0.tar.gz"
+  checksum: [
+    "md5=7f82ccbdcb07a75f6d2bb7ca226d02df"
+    "sha512=42f8e53d6634de4b19ac5249fcd8e3d2bde13de7a3963e6821eae9e7b46ff914458d3bfde201352fd18b6de14bb276705561d8fd09a09ddd16f001d0f25cf209"
+  ]
+}

--- a/packages/ldp_curl/ldp_curl.0.2.0/opam
+++ b/packages/ldp_curl/ldp_curl.0.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications using Curl"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "ocurl" {>= "0.9.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.2.0.tar.gz"
+  checksum: [
+    "md5=7f82ccbdcb07a75f6d2bb7ca226d02df"
+    "sha512=42f8e53d6634de4b19ac5249fcd8e3d2bde13de7a3963e6821eae9e7b46ff914458d3bfde201352fd18b6de14bb276705561d8fd09a09ddd16f001d0f25cf209"
+  ]
+}

--- a/packages/ldp_js/ldp_js.0.2.0/opam
+++ b/packages/ldp_js/ldp_js.0.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications in JS"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "js_of_ocaml" {>= "3.9.0"}
+  "js_of_ocaml-ppx" {>= "3.9.0"}
+  "cohttp-lwt-jsoo" {>= "4.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.2.0.tar.gz"
+  checksum: [
+    "md5=7f82ccbdcb07a75f6d2bb7ca226d02df"
+    "sha512=42f8e53d6634de4b19ac5249fcd8e3d2bde13de7a3963e6821eae9e7b46ff914458d3bfde201352fd18b6de14bb276705561d8fd09a09ddd16f001d0f25cf209"
+  ]
+}

--- a/packages/ldp_tls/ldp_tls.0.2.0/opam
+++ b/packages/ldp_tls/ldp_tls.0.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications using TLS"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "tls" {>= "0.16.0"}
+  "ppx_sexp_conv"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.2.0.tar.gz"
+  checksum: [
+    "md5=7f82ccbdcb07a75f6d2bb7ca226d02df"
+    "sha512=42f8e53d6634de4b19ac5249fcd8e3d2bde13de7a3963e6821eae9e7b46ff914458d3bfde201352fd18b6de14bb276705561d8fd09a09ddd16f001d0f25cf209"
+  ]
+}

--- a/packages/solid/solid.0.2.0/opam
+++ b/packages/solid/solid.0.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Library to build SOLID applications"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.2.0.tar.gz"
+  checksum: [
+    "md5=7f82ccbdcb07a75f6d2bb7ca226d02df"
+    "sha512=42f8e53d6634de4b19ac5249fcd8e3d2bde13de7a3963e6821eae9e7b46ff914458d3bfde201352fd18b6de14bb276705561d8fd09a09ddd16f001d0f25cf209"
+  ]
+}

--- a/packages/solid_server/solid_server.0.2.0/opam
+++ b/packages/solid_server/solid_server.0.2.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "SOLID server under development"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "calendar" {>= "2.04"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "cryptokit" {>= "1.16.1"}
+  "fpath" {>= "0.7.3"}
+  "git-unix" {>= "3.4.0"}
+  "ldp_curl" {= version}
+  "ldp_tls" {= version}
+  "ocaml" {>= "4.14.0"}
+  "ppx_blob" {>= "0.7.2"}
+  "solid" {= version}
+  "webmachine" {>= "0.7.0"}
+  "xtmpl" {>= "0.19.0"}
+  "xtmpl_ppx" {>= "0.19.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.2.0.tar.gz"
+  checksum: [
+    "md5=7f82ccbdcb07a75f6d2bb7ca226d02df"
+    "sha512=42f8e53d6634de4b19ac5249fcd8e3d2bde13de7a3963e6821eae9e7b46ff914458d3bfde201352fd18b6de14bb276705561d8fd09a09ddd16f001d0f25cf209"
+  ]
+}

--- a/packages/solid_tools/solid_tools.0.2.0/opam
+++ b/packages/solid_tools/solid_tools.0.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Library to build SOLID tools"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.14.0"}
+  "ldp_curl" {= version}
+  "ldp_tls" {= version}
+  "solid" {= version}
+  "ocf" {>= "0.8.0"}
+  "ocf_ppx" {>= "0.8.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.2.0.tar.gz"
+  checksum: [
+    "md5=7f82ccbdcb07a75f6d2bb7ca226d02df"
+    "sha512=42f8e53d6634de4b19ac5249fcd8e3d2bde13de7a3963e6821eae9e7b46ff914458d3bfde201352fd18b6de14bb276705561d8fd09a09ddd16f001d0f25cf209"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `ldp.0.2.0`: Library to build LDP applications
- `ldp_curl.0.2.0`: Library to build LDP applications using Curl
- `ldp_js.0.2.0`: Library to build LDP applications in JS
- `ldp_tls.0.2.0`: Library to build LDP applications using TLS
- `solid.0.2.0`: Library to build SOLID applications
- `solid_server.0.2.0`: SOLID server under development
- `solid_tools.0.2.0`: Library to build SOLID tools



---
* Homepage: https://zoggy.frama.io/ocaml-ldp/
* Source repo: git+https://framagit.org/zoggy/ocaml-ldp.git
* Bug tracker: https://framagit.org/zoggy/ocaml-ldp/issues

---
:camel: Pull-request generated by opam-publish v2.3.0