### PR TITLE
Add upper bounds to ppx_deriving 6

### DIFF
--- a/packages/archetype/archetype.0.1.10/opam
+++ b/packages/archetype/archetype.0.1.10/opam
@@ -28,7 +28,7 @@ depends: [
   "digestif" {>= "0.7.2"}
   "num"
   "yojson"
-  "ppx_deriving"
+  "ppx_deriving" {< "6"}
   "ppx_deriving_yojson"
 ]
 conflicts: [

--- a/packages/archetype/archetype.0.1.3/opam
+++ b/packages/archetype/archetype.0.1.3/opam
@@ -27,7 +27,7 @@ depends: [
   "digestif"            { >= "0.7.2" }
   "why3"                { >= "1.2.0" & < "1.3.0" }
   "yojson"
-  "ppx_deriving"
+  "ppx_deriving" {< "6"}
   "ppx_deriving_yojson"
 ]
 

--- a/packages/archetype/archetype.0.1.4/opam
+++ b/packages/archetype/archetype.0.1.4/opam
@@ -27,7 +27,7 @@ depends: [
   "digestif"            { >= "0.7.2" }
   "num"
   "yojson"
-  "ppx_deriving"
+  "ppx_deriving" {< "6"}
   "ppx_deriving_yojson"
 ]
 

--- a/packages/archetype/archetype.0.1.5/opam
+++ b/packages/archetype/archetype.0.1.5/opam
@@ -27,7 +27,7 @@ depends: [
   "digestif"            { >= "0.7.2" }
   "num"
   "yojson"
-  "ppx_deriving"
+  "ppx_deriving" {< "6"}
   "ppx_deriving_yojson"
 ]
 

--- a/packages/archetype/archetype.0.1.6/opam
+++ b/packages/archetype/archetype.0.1.6/opam
@@ -27,7 +27,7 @@ depends: [
   "digestif"            { >= "0.7.2" }
   "num"
   "yojson"
-  "ppx_deriving"
+  "ppx_deriving" {< "6"}
   "ppx_deriving_yojson"
 ]
 

--- a/packages/archetype/archetype.0.1.8/opam
+++ b/packages/archetype/archetype.0.1.8/opam
@@ -27,7 +27,7 @@ depends: [
   "digestif"            { >= "0.7.2" }
   "num"
   "yojson"
-  "ppx_deriving"
+  "ppx_deriving" {< "6"}
   "ppx_deriving_yojson"
 ]
 

--- a/packages/archetype/archetype.0.1.9/opam
+++ b/packages/archetype/archetype.0.1.9/opam
@@ -28,7 +28,7 @@ depends: [
   "digestif" {>= "0.7.2"}
   "num"
   "yojson"
-  "ppx_deriving"
+  "ppx_deriving" {< "6"}
   "ppx_deriving_yojson"
 ]
 conflicts: [

--- a/packages/coq-serapi/coq-serapi.8.10.0+0.7.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.10.0+0.7.0/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.11.0" & < "v0.15" }
   "dune"                {           >= "1.2.0"             }
   "ppx_import" {build & >= "1.5-3" & < "2.0"}
-  "ppx_deriving"        {           >= "4.2.1"             }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.11.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"             }
   "ppx_deriving_yojson" {           >= "3.4"               }

--- a/packages/coq-serapi/coq-serapi.8.10.0+0.7.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.10.0+0.7.1/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.11.0"           }
   "dune"                {           >= "1.4.0"             }
   "ppx_import" {build & >= "1.5-3" & < "2.0"}
-  "ppx_deriving"        {           >= "4.2.1"             }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.11.0"           }
   "yojson"              {           >= "1.7.0"             }
   "ppx_deriving_yojson" {           >= "3.4"               }

--- a/packages/coq-serapi/coq-serapi.8.10.0+0.7.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.10.0+0.7.2/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.11.0"           }
   "dune"                {           >= "1.4.0"             }
   "ppx_import" {build & >= "1.5-3" & < "2.0"}
-  "ppx_deriving"        {           >= "4.2.1"             }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.11.0"           }
   "yojson"              {           >= "1.7.0"             }
   "ppx_deriving_yojson" {           >= "3.4"               }

--- a/packages/coq-serapi/coq-serapi.8.11.0+0.11.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.11.0+0.11.0/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.11.0"             }
   "dune"                {           >= "1.2.0"               }
   "ppx_import" {build & >= "1.5-3" & < "2.0"}
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.11.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"               }
   "ppx_deriving_yojson" {           >= "3.4"                 }

--- a/packages/coq-serapi/coq-serapi.8.11.0+0.11.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.11.0+0.11.1/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import" {build & >= "1.5-3" & < "2.0"}
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.14" }
   "yojson"              {           >= "1.7.0"               }
   "ppx_deriving_yojson" {           >= "3.4"                 }

--- a/packages/coq-serapi/coq-serapi.8.12.0+0.12.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.12.0+0.12.0/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import" {build & >= "1.5-3" & < "2.0"}
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.14" }
   "yojson"              {           >= "1.7.0"               }
   "ppx_deriving_yojson" {           >= "3.4"                 }

--- a/packages/coq-serapi/coq-serapi.8.12.0+0.12.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.12.0+0.12.1/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import" {build & >= "1.5-3" & < "2.0"}
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"               }
   "ppx_deriving_yojson" {           >= "3.4"                 }

--- a/packages/coq-serapi/coq-serapi.8.13.0+0.13.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.13.0+0.13.0/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import" {build & >= "1.5-3" & < "2.0"}
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"               }
   "ppx_deriving_yojson" {           >= "3.4"                 }

--- a/packages/coq-serapi/coq-serapi.8.13.0+0.13.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.13.0+0.13.1/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import" {build & >= "1.5-3" & < "2.0"}
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"               }
   "ppx_deriving_yojson" {           >= "3.4"                 }

--- a/packages/coq-serapi/coq-serapi.8.14.0+0.14.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.14.0+0.14.0/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import" {build & >= "1.5-3" & < "2.0"}
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"               }
   "ppx_deriving_yojson" {           >= "3.4"                 }

--- a/packages/coq-serapi/coq-serapi.8.15.0+0.15.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.15.0+0.15.0/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import" {build & >= "1.5-3" & < "2.0"}
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"               }
   "ppx_deriving_yojson" {           >= "3.4"                 }

--- a/packages/coq-serapi/coq-serapi.8.15.0+0.15.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.15.0+0.15.1/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import" {build & >= "1.5-3" & < "2.0"}
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"               }
   "ppx_deriving_yojson" {           >= "3.4"                 }

--- a/packages/coq-serapi/coq-serapi.8.15.0+0.15.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.15.0+0.15.2/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import" {build & >= "1.5-3" & < "2.0"}
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv" {>= "v0.13.0" & < "v0.16.0"}
   "yojson"              {           >= "1.7.0"               }
   "ppx_deriving_yojson" {           >= "3.4"                 }

--- a/packages/coq-serapi/coq-serapi.8.15.0+0.15.3/opam
+++ b/packages/coq-serapi/coq-serapi.8.15.0+0.15.3/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             { >= "v0.13.0"             }
   "dune"                { >= "2.0.1"               }
   "ppx_import"          { >= "1.5-3"               }
-  "ppx_deriving"        { >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       { >= "v0.13.0" & < "v0.16" }
   "ppx_compare"         { >= "v0.13.0" & < "v0.16" }
   "ppx_hash"            { >= "v0.13.0" & < "v0.16" }

--- a/packages/coq-serapi/coq-serapi.8.15.0+0.15.4/opam
+++ b/packages/coq-serapi/coq-serapi.8.15.0+0.15.4/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {  >= "v0.13.0"             }
   "dune"                {  >= "2.0.1"               }
   "ppx_import"          {  >= "1.5-3"               }
-  "ppx_deriving"        {  >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {  >= "v0.13.0" & < "v0.16" }
   "ppx_compare"         {  >= "v0.13.0" & < "v0.16" }
   "ppx_hash"            {  >= "v0.13.0" & < "v0.16" }

--- a/packages/coq-serapi/coq-serapi.8.16.0+0.16.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.16.0+0.16.0/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv" {>= "v0.13.0" & < "v0.16.0"}
   "ppx_compare"         {           >= "v0.13.0"             }
   "ppx_hash"            {           >= "v0.13.0"             }

--- a/packages/coq-serapi/coq-serapi.8.16.0+0.16.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.16.0+0.16.1/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv" {>= "v0.13.0" & < "v0.16.0"}
   "ppx_compare"         {           >= "v0.13.0"             }
   "ppx_hash"            {           >= "v0.13.0"             }

--- a/packages/coq-serapi/coq-serapi.8.16.0+0.16.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.16.0+0.16.2/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv" {>= "v0.13.0" & < "v0.16.0"}
   "ppx_compare"         {           >= "v0.13.0"             }
   "ppx_hash"            {           >= "v0.13.0"             }

--- a/packages/coq-serapi/coq-serapi.8.16.0+0.16.3/opam
+++ b/packages/coq-serapi/coq-serapi.8.16.0+0.16.3/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv" {>= "v0.13.0" & < "v0.16.0"}
   "ppx_compare"         {           >= "v0.13.0"             }
   "ppx_hash"            {           >= "v0.13.0"             }

--- a/packages/coq-serapi/coq-serapi.8.17.0+0.17.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.17.0+0.17.0/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             { >= "v0.13.0"             }
   "dune"                { >= "2.0.1"               }
   "ppx_import"          { >= "1.5-3" & < "2.0"     }
-  "ppx_deriving"        { >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv" {>= "v0.13.0" & < "v0.16.0"}
   "ppx_compare"         { >= "v0.13.0"             }
   "ppx_hash"            { >= "v0.13.0"             }

--- a/packages/coq-serapi/coq-serapi.8.17.0+0.17.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.17.0+0.17.1/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0"             }
   "ppx_compare"         {           >= "v0.13.0"             }
   "ppx_hash"            {           >= "v0.13.0"             }

--- a/packages/coq-serapi/coq-serapi.8.17.0+0.17.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.17.0+0.17.2/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0"             }
   "ppx_compare"         {           >= "v0.13.0"             }
   "ppx_hash"            {           >= "v0.13.0"             }

--- a/packages/coq-serapi/coq-serapi.8.17.0+0.17.3/opam
+++ b/packages/coq-serapi/coq-serapi.8.17.0+0.17.3/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0"             }
   "ppx_compare"         {           >= "v0.13.0"             }
   "ppx_hash"            {           >= "v0.13.0"             }

--- a/packages/coq-serapi/coq-serapi.8.18.0+0.18.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.18.0+0.18.1/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0"             }
   "ppx_compare"         {           >= "v0.13.0"             }
   "ppx_hash"            {           >= "v0.13.0"             }

--- a/packages/coq-serapi/coq-serapi.8.18.0+0.18.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.18.0+0.18.2/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0"             }
   "ppx_compare"         {           >= "v0.13.0"             }
   "ppx_hash"            {           >= "v0.13.0"             }

--- a/packages/coq-serapi/coq-serapi.8.18.0+0.18.3/opam
+++ b/packages/coq-serapi/coq-serapi.8.18.0+0.18.3/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0"             }
   "ppx_compare"         {           >= "v0.13.0"             }
   "ppx_hash"            {           >= "v0.13.0"             }

--- a/packages/coq-serapi/coq-serapi.8.19.0+0.19.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.19.0+0.19.0/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0"             }
   "ppx_compare"         {           >= "v0.13.0"             }
   "ppx_hash"            {           >= "v0.13.0"             }

--- a/packages/coq-serapi/coq-serapi.8.19.0+0.19.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.19.0+0.19.1/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0"             }
   "ppx_compare"         {           >= "v0.13.0"             }
   "ppx_hash"            {           >= "v0.13.0"             }

--- a/packages/coq-serapi/coq-serapi.8.19.0+0.19.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.19.0+0.19.2/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0"             }
   "ppx_compare"         {           >= "v0.13.0"             }
   "ppx_hash"            {           >= "v0.13.0"             }

--- a/packages/coq-serapi/coq-serapi.8.19.0+0.19.3/opam
+++ b/packages/coq-serapi/coq-serapi.8.19.0+0.19.3/opam
@@ -30,7 +30,7 @@ depends: [
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
-  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_deriving" {>= "4.2.1" & < "6"}
   "ppx_sexp_conv"       {           >= "v0.13.0"             }
   "ppx_compare"         {           >= "v0.13.0"             }
   "ppx_hash"            {           >= "v0.13.0"             }

--- a/packages/current/current.0.2/opam
+++ b/packages/current/current.0.2/opam
@@ -26,7 +26,7 @@ depends: [
   "current_incr" {= version}
   "fmt" {>= "0.8.7"}
   "bos"
-  "ppx_deriving"
+  "ppx_deriving" {< "6"}
   "lwt" {>= "4.3.0"}
   "cmdliner"
   "sqlite3"

--- a/packages/current/current.0.3/opam
+++ b/packages/current/current.0.3/opam
@@ -26,7 +26,7 @@ depends: [
   "current_incr" {= version}
   "fmt" {>= "0.8.7"}
   "bos"
-  "ppx_deriving"
+  "ppx_deriving" {< "6"}
   "lwt" {>= "4.3.0"}
   "cmdliner"
   "sqlite3"

--- a/packages/pkcs11/pkcs11.0.1.0/opam
+++ b/packages/pkcs11/pkcs11.0.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ctypes-foreign" {>= "0.4.0"}
   "hex" {>= "1.0.0"}
   "key-parsers" {>= "0.5.0"}
-  "ppx_deriving" {>= "4.0"}
+  "ppx_deriving" {>= "4.0" & < "6"}
   "ppx_deriving_yojson" {>= "3.0"}
   "records" {>= "0.6.0"}
   "ocamlbuild" {build}

--- a/packages/pkcs11/pkcs11.0.10.0/opam
+++ b/packages/pkcs11/pkcs11.0.10.0/opam
@@ -37,7 +37,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "hex" {>= "1.0.0"}
   "integers" {< "0.5.0"}
-  "ppx_deriving" {>= "4.0"}
+  "ppx_deriving" {>= "4.0" & < "6"}
   "ppx_deriving_yojson" {>= "3.0"}
   "yojson" {< "2.0.0"}
   "zarith"

--- a/packages/pkcs11/pkcs11.0.11.0/opam
+++ b/packages/pkcs11/pkcs11.0.11.0/opam
@@ -37,7 +37,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "hex" {>= "1.0.0"}
   "integers" {< "0.5.0"}
-  "ppx_deriving" {>= "4.0"}
+  "ppx_deriving" {>= "4.0" & < "6"}
   "ppx_deriving_yojson" {>= "3.0"}
   "yojson" {< "2.0.0"}
   "zarith"

--- a/packages/pkcs11/pkcs11.0.12.0/opam
+++ b/packages/pkcs11/pkcs11.0.12.0/opam
@@ -37,7 +37,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "hex" {>= "1.0.0"}
   "integers" {< "0.5.0"}
-  "ppx_deriving" {>= "4.0"}
+  "ppx_deriving" {>= "4.0" & < "6"}
   "ppx_deriving_yojson" {>= "3.0"}
   "yojson" {< "2.0.0"}
   "zarith"

--- a/packages/pkcs11/pkcs11.0.13.0/opam
+++ b/packages/pkcs11/pkcs11.0.13.0/opam
@@ -37,7 +37,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "hex" {>= "1.0.0"}
   "integers" {< "0.5.0"}
-  "ppx_deriving" {>= "4.0"}
+  "ppx_deriving" {>= "4.0" & < "6"}
   "ppx_deriving_yojson" {>= "3.0"}
   "yojson" {< "2.0.0"}
   "zarith"

--- a/packages/pkcs11/pkcs11.0.14.0/opam
+++ b/packages/pkcs11/pkcs11.0.14.0/opam
@@ -37,7 +37,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "hex" {>= "1.0.0"}
   "integers" {< "0.5.0"}
-  "ppx_deriving" {>= "4.0"}
+  "ppx_deriving" {>= "4.0" & < "6"}
   "ppx_deriving_yojson" {>= "3.0"}
   "yojson" {< "2.0.0"}
   "zarith"

--- a/packages/pkcs11/pkcs11.0.15.0/opam
+++ b/packages/pkcs11/pkcs11.0.15.0/opam
@@ -37,7 +37,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "hex" {>= "1.0.0"}
   "integers" {< "0.5.0"}
-  "ppx_deriving" {>= "4.0"}
+  "ppx_deriving" {>= "4.0" & < "6"}
   "ppx_deriving_yojson" {>= "3.0"}
   "yojson" {< "2.0.0"}
   "zarith"

--- a/packages/pkcs11/pkcs11.0.16.0/opam
+++ b/packages/pkcs11/pkcs11.0.16.0/opam
@@ -37,7 +37,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "hex" {>= "1.0.0"}
   "integers" {< "0.5.0"}
-  "ppx_deriving" {>= "4.0"}
+  "ppx_deriving" {>= "4.0" & < "6"}
   "ppx_deriving_yojson" {>= "3.0"}
   "yojson" {< "2.0.0"}
   "zarith"

--- a/packages/pkcs11/pkcs11.0.17.0/opam
+++ b/packages/pkcs11/pkcs11.0.17.0/opam
@@ -37,7 +37,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "hex" {>= "1.0.0"}
   "integers" {< "0.5.0"}
-  "ppx_deriving" {>= "4.0"}
+  "ppx_deriving" {>= "4.0" & < "6"}
   "ppx_deriving_yojson" {>= "3.0"}
   "yojson" {< "2.0.0"}
   "zarith"

--- a/packages/pkcs11/pkcs11.0.17.1/opam
+++ b/packages/pkcs11/pkcs11.0.17.1/opam
@@ -25,7 +25,7 @@ run-test: [
 depends: [
   "hex" { >= "1.0.0" }
   "integers" {< "0.5.0"}
-  "ppx_deriving" { >= "4.0" }
+  "ppx_deriving" {>= "4.0" & < "6"}
   "ppx_deriving_yojson" { >= "3.0" }
   "yojson" {< "2.0.0"}
   "ppx_variants_conv"

--- a/packages/pkcs11/pkcs11.0.18.0/opam
+++ b/packages/pkcs11/pkcs11.0.18.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "1.3.0"}
   "hex" { >= "1.0.0" }
   "integers" {< "0.5.0"}
-  "ppx_deriving" { >= "4.2" }
+  "ppx_deriving" {>= "4.2" & < "6"}
   "ppx_deriving_yojson" { >= "3.2" }
   "yojson" {< "2.0.0"}
   "ppx_variants_conv"

--- a/packages/pkcs11/pkcs11.1.0.0/opam
+++ b/packages/pkcs11/pkcs11.1.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "1.3.0"}
   "hex" { >= "1.0.0" }
   "integers" {< "0.5.0"}
-  "ppx_deriving" { >= "4.2" }
+  "ppx_deriving" {>= "4.2" & < "6"}
   "ppx_deriving_yojson" { >= "3.4" }
   "ppx_variants_conv"
   "zarith"

--- a/packages/pkcs11/pkcs11.1.0.1/opam
+++ b/packages/pkcs11/pkcs11.1.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "hex" { >= "1.0.0" }
   "integers"
-  "ppx_deriving" { >= "4.2" }
+  "ppx_deriving" {>= "4.2" & < "6"}
   "ppx_deriving_yojson" { >= "3.4" }
   "ppx_variants_conv"
   "zarith"


### PR DESCRIPTION
These packages were explicitly using the implicit
dependence on the result compatibility package
inherited from ppx_deriving