### PR TITLE
[new release] grace (0.2.0)

### DIFF
--- a/packages/grace/grace.0.2.0/opam
+++ b/packages/grace/grace.0.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "A fancy diagnostics library that allows your compilers to exit with grace"
+maintainer: ["alistair.obrien@trili.tech"]
+authors: ["Alistair O'Brien"]
+license: "MIT"
+homepage: "https://github.com/johnyob/grace"
+bug-reports: "https://github.com/johnyob/grace/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.4"}
+  "core"
+  "ppx_jane"
+  "fmt" {>= "0.8.7"}
+  "dedent"
+  "iter"
+  "core_unix"
+  "uutf"
+  "ppx_optcomp"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/johnyob/grace.git"
+url {
+  src:
+    "https://github.com/johnyob/grace/releases/download/0.2.0/grace-0.2.0.tbz"
+  checksum: [
+    "sha256=821df54882c9253eac69f47bcf3a71ffdc61c77fdae42587c32aada5b56cfeae"
+    "sha512=007afa83251da3ddecd874e120ea89dce0253c387a64a5fece69069d3486ec5eb6c82d6bf0febaf23dd322bd9eaadc2f7882e33f05a2e1fa18a41294e7dc3ba1"
+  ]
+}
+x-commit-hash: "d15a6d7d07a2551d1a9934fa79c2cf84c918f990"


### PR DESCRIPTION
A fancy diagnostics library that allows your compilers to exit with grace

- Project page: <a href="https://github.com/johnyob/grace">https://github.com/johnyob/grace</a>

##### CHANGES:

* fix(renderer): remove uncessary underlines when printing a unique 'multi-line `Top` marker' ([johnyob/grace#31](https://github.com/johnyob/grace/pull/31))
* fix(renderer): replace unicode chars with ASCII in `Config.ascii` ([johnyob/grace#27](https://github.com/johnyob/grace/pull/27))
* feat(renderer): add `NO_COLOR` and `TERM` support to `Config` ([johnyob/grace#8](https://github.com/johnyob/grace/pull/8))
* feat(core,renderer): add support for error codes ([johnyob/grace#30](https://github.com/johnyob/grace/pull/30))
* feat(renderer): add support for UTF8 encoding 🚀 ([johnyob/grace#25](https://github.com/johnyob/grace/pull/25))
* feat(renderer): re-introduce support for compact diagnostic rendering ([johnyob/grace#28](https://github.com/johnyob/grace/pull/28))
* refactor(renderer)!: move `grace.renderer` library to `grace.ansi_renderer` ([johnyob/grace#29](https://github.com/johnyob/grace/pull/29))

### BREAKING CHANGE

* `Grace_rendering` has been removed. Use `Grace_ansi_renderer` instead.
