### PR TITLE
Package core.v0.17.1

### DIFF
--- a/packages/core/core.v0.17.1/opam
+++ b/packages/core/core.v0.17.1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/core"
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "git+https://github.com/janestreet/core.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/core/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"               {>= "5.1.0"}
+  "base"                {>= "v0.17" & < "v0.18"}
+  "base_bigstring"      {>= "v0.17" & < "v0.18"}
+  "base_quickcheck"     {>= "v0.17" & < "v0.18"}
+  "bin_prot"            {>= "v0.17" & < "v0.18"}
+  "fieldslib"           {>= "v0.17" & < "v0.18"}
+  "jane-street-headers" {>= "v0.17" & < "v0.18"}
+  "jst-config"          {>= "v0.17" & < "v0.18"}
+  "ppx_assert"          {>= "v0.17" & < "v0.18"}
+  "ppx_base"            {>= "v0.17" & < "v0.18"}
+  "ppx_diff"            {>= "v0.17" & < "v0.18"}
+  "ppx_hash"            {>= "v0.17" & < "v0.18"}
+  "ppx_inline_test"     {>= "v0.17" & < "v0.18"}
+  "ppx_jane"            {>= "v0.17" & < "v0.18"}
+  "ppx_optcomp"         {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv"       {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_message"    {>= "v0.17" & < "v0.18"}
+  "sexplib"             {>= "v0.17" & < "v0.18"}
+  "splittable_random"   {>= "v0.17" & < "v0.18"}
+  "stdio"               {>= "v0.17" & < "v0.18"}
+  "time_now"            {>= "v0.17" & < "v0.18"}
+  "typerep"             {>= "v0.17" & < "v0.18"}
+  "variantslib"         {>= "v0.17" & < "v0.18"}
+  "dune"                {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Industrial strength alternative to OCaml's standard library"
+description: "
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+
+This is the system-independent part of Core. Unix-specific parts were moved to [core_unix].
+"
+url {
+  src: "https://github.com/janestreet/core/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=743a141234e04210e295980f7a78a6d9"
+    "sha512=61b415f4fb12c78d30649fff1aabe3a475eea926ce6edb7774031f4dc7f37ea51f5d9337ead6ec73cd93da5fd1ed0f2738c210c71ebc8fe9d7f6135a06bd176f"
+  ]
+}


### PR DESCRIPTION
### `core.v0.17.1`
Industrial strength alternative to OCaml's standard library
The Core suite of libraries is an industrial strength alternative to
OCaml's standard library that was developed by Jane Street, the
largest industrial user of OCaml.

This is the system-independent part of Core. Unix-specific parts were moved to [core_unix].



---
* Homepage: https://github.com/janestreet/core
* Source repo: git+https://github.com/janestreet/core.git
* Bug tracker: https://github.com/janestreet/core/issues

---
:camel: Pull-request generated by opam-publish v2.3.0