### PR TITLE
[new release] dns (12 packages) (8.0.0)

### DIFF
--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2.3/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2.3/opam
@@ -15,7 +15,7 @@ depends: [
   "capnp-rpc-net" {= version}
   "fmt" {>= "0.8.7"}
   "logs"
-  "dns-client-mirage" {>= "7.0.0"}
+  "dns-client-mirage" {>= "7.0.0" & < "8.0.0"}
   "tls-mirage"
   "tcpip" {>= "7.0.0"}
   "alcotest" {>= "1.0.1" & with-test}

--- a/packages/conduit-mirage/conduit-mirage.6.2.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.6.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0" & < "4.0.0"}
   "mirage-time" {>= "2.0.0"}
-  "dns-client-mirage" {>= "7.0.0"}
+  "dns-client-mirage" {>= "7.0.0" & < "8.0.0"}
   "conduit-lwt" {=version}
   "vchan" {>= "5.0.0"}
   "xenstore"

--- a/packages/conduit-mirage/conduit-mirage.6.2.1/opam
+++ b/packages/conduit-mirage/conduit-mirage.6.2.1/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0" & < "4.0.0"}
   "mirage-time" {>= "2.0.0"}
-  "dns-client-mirage" {>= "7.0.0"}
+  "dns-client-mirage" {>= "7.0.0" & < "8.0.0"}
   "conduit-lwt" {=version}
   "vchan" {>= "5.0.0" & < "6.0.2"}
   "xenstore"

--- a/packages/conduit-mirage/conduit-mirage.6.2.2/opam
+++ b/packages/conduit-mirage/conduit-mirage.6.2.2/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
-  "dns-client-mirage" {>= "7.0.0"}
+  "dns-client-mirage" {>= "7.0.0" & < "8.0.0"}
   "conduit-lwt" {=version}
   "vchan" {>= "5.0.0"}
   "xenstore"

--- a/packages/dkim-mirage/dkim-mirage.0.5.0/opam
+++ b/packages/dkim-mirage/dkim-mirage.0.5.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml"             {>= "4.08.0"}
   "dune"              {>= "2.0.0"}
   "dkim"              {= version}
-  "dns-client-mirage" {>= "7.0.0"}
+  "dns-client-mirage" {>= "7.0.0" & < "8.0.0"}
   "mirage-time"
   "mirage-random" {< "4.0.0"}
   "mirage-clock"

--- a/packages/dns-certify/dns-certify.8.0.0/opam
+++ b/packages/dns-certify/dns-certify.8.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "x509" {>= "0.15.2"}
   "lwt" {>= "4.2.1"}

--- a/packages/dns-certify/dns-certify.8.0.0/opam
+++ b/packages/dns-certify/dns-certify.8.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "x509" {>= "0.15.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "logs"
+  "mirage-crypto-ec"
+  "mirage-crypto-pk" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "MirageOS let's encrypt certificate retrieval"
+description: """
+A function to retrieve a certificate when providing a hostname, TSIG key, server
+IP, and an optional key seed. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v8.0.0/dns-8.0.0.tbz"
+  checksum: [
+    "sha256=0882061bc5bfa7515ab26c84ca8062323ac5931b3f8ae2952794b0c927d8854e"
+    "sha512=1b937aea10a76aebd6b9f44e7142fb0818e17147048fc7ff99ff6f29e5b217eb75e2bc700464089ed453ced2fede4a094828bf278a555736b51fbe285d6271a4"
+  ]
+}
+x-commit-hash: "875651e2529092c639ec9a2f6cd14c37ea23137f"

--- a/packages/dns-cli/dns-cli.8.0.0/opam
+++ b/packages/dns-cli/dns-cli.8.0.0/opam
@@ -31,7 +31,7 @@ depends: [
   "fmt" {>= "0.8.8"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "alcotest" {with-test}
 ]
 

--- a/packages/dns-cli/dns-cli.8.0.0/opam
+++ b/packages/dns-cli/dns-cli.8.0.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dnssec" {= version}
+  "dns-tsig" {= version}
+  "dns-client-lwt" {= version}
+  "dns-server" {= version}
+  "dns-certify" {= version}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.0"}
+  "fpath" {>= "0.7.2"}
+  "x509" {>= "0.13.0"}
+  "mirage-crypto" {>= "0.8.0"}
+  "mirage-crypto-pk" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.11.0"}
+  "hex" {>= "1.4.0"}
+  "ptime" {>= "0.8.5"}
+  "mtime" {>= "1.2.0"}
+  "logs" {>= "0.6.3"}
+  "fmt" {>= "0.8.8"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.0.0"}
+  "randomconv"
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Unix command line utilities using uDNS"
+description: """
+'oupdate' sends a DNS update frome to a DNS server that sets 'hostname A ip'.
+For authentication via TSIG, a hmac secret needs to be provided.
+
+'ocertify' updates DNS with a certificate signing request, and polls a matching
+certificate. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v8.0.0/dns-8.0.0.tbz"
+  checksum: [
+    "sha256=0882061bc5bfa7515ab26c84ca8062323ac5931b3f8ae2952794b0c927d8854e"
+    "sha512=1b937aea10a76aebd6b9f44e7142fb0818e17147048fc7ff99ff6f29e5b217eb75e2bc700464089ed453ced2fede4a094828bf278a555736b51fbe285d6271a4"
+  ]
+}
+x-commit-hash: "875651e2529092c639ec9a2f6cd14c37ea23137f"

--- a/packages/dns-client-lwt/dns-client-lwt.8.0.0/opam
+++ b/packages/dns-client-lwt/dns-client-lwt.8.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns-client" {= version}
+  "dns" {= version}
+  "ipaddr" {>= "5.3.0"}
+  "lwt" {>= "4.2.1"}
+  "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng-lwt" {>= "0.11.0"}
+  "happy-eyeballs-lwt" {>= "1.1.0"}
+  "happy-eyeballs" {>= "1.0.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "ca-certs"
+]
+synopsis: "DNS client API using lwt"
+description: """
+A client implementation using uDNS and lwt for side effects.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v8.0.0/dns-8.0.0.tbz"
+  checksum: [
+    "sha256=0882061bc5bfa7515ab26c84ca8062323ac5931b3f8ae2952794b0c927d8854e"
+    "sha512=1b937aea10a76aebd6b9f44e7142fb0818e17147048fc7ff99ff6f29e5b217eb75e2bc700464089ed453ced2fede4a094828bf278a555736b51fbe285d6271a4"
+  ]
+}
+x-commit-hash: "875651e2529092c639ec9a2f6cd14c37ea23137f"

--- a/packages/dns-client-mirage/dns-client-mirage.8.0.0/opam
+++ b/packages/dns-client-mirage/dns-client-mirage.8.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns-client" {= version}
+  "domain-name" {>= "0.4.0"}
+  "ipaddr" {>= "5.3.0"}
+  "lwt" {>= "4.2.1"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "happy-eyeballs-mirage" {>= "1.1.0"}
+  "happy-eyeballs" {>= "1.0.0"}
+  "tls-mirage" {>= "0.16.0"}
+  "x509" {>= "0.16.0"}
+  "ca-certs-nss"
+]
+synopsis: "DNS client API for MirageOS"
+description: """
+A client implementation using uDNS using MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v8.0.0/dns-8.0.0.tbz"
+  checksum: [
+    "sha256=0882061bc5bfa7515ab26c84ca8062323ac5931b3f8ae2952794b0c927d8854e"
+    "sha512=1b937aea10a76aebd6b9f44e7142fb0818e17147048fc7ff99ff6f29e5b217eb75e2bc700464089ed453ced2fede4a094828bf278a555736b51fbe285d6271a4"
+  ]
+}
+x-commit-hash: "875651e2529092c639ec9a2f6cd14c37ea23137f"

--- a/packages/dns-client/dns-client.8.0.0/opam
+++ b/packages/dns-client/dns-client.8.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns" {= version}
+  "randomconv" {>= "0.1.2"}
+  "domain-name" {>= "0.4.0"}
+  "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng" {>= "0.11.0"}
+  "fmt" {>= "0.9.0"}
+  "ipaddr" {>= "5.5.0"}
+  "alcotest" {with-test}
+]
+synopsis: "DNS client API"
+description: """
+A client implementation using uDNS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v8.0.0/dns-8.0.0.tbz"
+  checksum: [
+    "sha256=0882061bc5bfa7515ab26c84ca8062323ac5931b3f8ae2952794b0c927d8854e"
+    "sha512=1b937aea10a76aebd6b9f44e7142fb0818e17147048fc7ff99ff6f29e5b217eb75e2bc700464089ed453ced2fede4a094828bf278a555736b51fbe285d6271a4"
+  ]
+}
+x-commit-hash: "875651e2529092c639ec9a2f6cd14c37ea23137f"

--- a/packages/dns-client/dns-client.8.0.0/opam
+++ b/packages/dns-client/dns-client.8.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>="2.0.0"}
   "ocaml" {>= "4.08.0"}
   "dns" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "domain-name" {>= "0.4.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.11.0"}

--- a/packages/dns-mirage/dns-mirage.8.0.0/opam
+++ b/packages/dns-mirage/dns-mirage.8.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "ipaddr" {>= "5.2.0"}
+  "lwt" {>= "4.2.1"}
+  "tcpip" {>= "7.0.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v8.0.0/dns-8.0.0.tbz"
+  checksum: [
+    "sha256=0882061bc5bfa7515ab26c84ca8062323ac5931b3f8ae2952794b0c927d8854e"
+    "sha512=1b937aea10a76aebd6b9f44e7142fb0818e17147048fc7ff99ff6f29e5b217eb75e2bc700464089ed453ced2fede4a094828bf278a555736b51fbe285d6271a4"
+  ]
+}
+x-commit-hash: "875651e2529092c639ec9a2f6cd14c37ea23137f"

--- a/packages/dns-resolver/dns-resolver.8.0.0/opam
+++ b/packages/dns-resolver/dns-resolver.8.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dnssec" {= version}
   "lru" {>= "0.3.0"}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-resolver/dns-resolver.8.0.0/opam
+++ b/packages/dns-resolver/dns-resolver.8.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns" {= version}
+  "dns-server" {= version}
+  "dns-mirage" {= version}
+  "dnssec" {= version}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "alcotest" {with-test}
+  "tls" "tls-mirage"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS resolver business logic"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v8.0.0/dns-8.0.0.tbz"
+  checksum: [
+    "sha256=0882061bc5bfa7515ab26c84ca8062323ac5931b3f8ae2952794b0c927d8854e"
+    "sha512=1b937aea10a76aebd6b9f44e7142fb0818e17147048fc7ff99ff6f29e5b217eb75e2bc700464089ed453ced2fede4a094828bf278a555736b51fbe285d6271a4"
+  ]
+}
+x-commit-hash: "875651e2529092c639ec9a2f6cd14c37ea23137f"

--- a/packages/dns-server/dns-server.8.0.0/opam
+++ b/packages/dns-server/dns-server.8.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-mirage" {= version}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "duration" {>= "0.1.2"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/dns-server/dns-server.8.0.0/opam
+++ b/packages/dns-server/dns-server.8.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "alcotest" {with-test}
+  "dns-tsig" {with-test}
+  "base64" {with-test & >= "3.0.0"}
+  "metrics"
+  "logs" {>= "0.7.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS server, primary and secondary"
+description: """
+Primary and secondary DNS server implemented in value-passing style. Needs an
+effectful layer to be useful.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v8.0.0/dns-8.0.0.tbz"
+  checksum: [
+    "sha256=0882061bc5bfa7515ab26c84ca8062323ac5931b3f8ae2952794b0c927d8854e"
+    "sha512=1b937aea10a76aebd6b9f44e7142fb0818e17147048fc7ff99ff6f29e5b217eb75e2bc700464089ed453ced2fede4a094828bf278a555736b51fbe285d6271a4"
+  ]
+}
+x-commit-hash: "875651e2529092c639ec9a2f6cd14c37ea23137f"

--- a/packages/dns-stub/dns-stub.8.0.0/opam
+++ b/packages/dns-stub/dns-stub.8.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}
-  "randomconv" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2" & < "0.2.0"}
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/dns-stub/dns-stub.8.0.0/opam
+++ b/packages/dns-stub/dns-stub.8.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dns-client-mirage" {= version}
+  "dns-mirage" {= version}
+  "dns-resolver" {= version}
+  "dns-tsig" {= version}
+  "dns-server" {= version}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS stub resolver"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v8.0.0/dns-8.0.0.tbz"
+  checksum: [
+    "sha256=0882061bc5bfa7515ab26c84ca8062323ac5931b3f8ae2952794b0c927d8854e"
+    "sha512=1b937aea10a76aebd6b9f44e7142fb0818e17147048fc7ff99ff6f29e5b217eb75e2bc700464089ed453ced2fede4a094828bf278a555736b51fbe285d6271a4"
+  ]
+}
+x-commit-hash: "875651e2529092c639ec9a2f6cd14c37ea23137f"

--- a/packages/dns-tsig/dns-tsig.8.0.0/opam
+++ b/packages/dns-tsig/dns-tsig.8.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "mirage-crypto"
+  "base64" {>= "3.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "TSIG support for DNS"
+description: """
+TSIG is used to authenticate nsupdate frames using a HMAC.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v8.0.0/dns-8.0.0.tbz"
+  checksum: [
+    "sha256=0882061bc5bfa7515ab26c84ca8062323ac5931b3f8ae2952794b0c927d8854e"
+    "sha512=1b937aea10a76aebd6b9f44e7142fb0818e17147048fc7ff99ff6f29e5b217eb75e2bc700464089ed453ced2fede4a094828bf278a555736b51fbe285d6271a4"
+  ]
+}
+x-commit-hash: "875651e2529092c639ec9a2f6cd14c37ea23137f"

--- a/packages/dns/dns.8.0.0/opam
+++ b/packages/dns/dns.8.0.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "logs" "ptime"
+  "fmt" {>= "0.8.8"}
+  "domain-name" {>= "0.4.0"}
+  "gmap" {>= "0.3.0"}
+  "cstruct" {>= "6.0.0"}
+  "ipaddr" {>= "5.2.0"}
+  "alcotest" {with-test}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "metrics"
+  "base64" {>= "3.3.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v8.0.0/dns-8.0.0.tbz"
+  checksum: [
+    "sha256=0882061bc5bfa7515ab26c84ca8062323ac5931b3f8ae2952794b0c927d8854e"
+    "sha512=1b937aea10a76aebd6b9f44e7142fb0818e17147048fc7ff99ff6f29e5b217eb75e2bc700464089ed453ced2fede4a094828bf278a555736b51fbe285d6271a4"
+  ]
+}
+x-commit-hash: "875651e2529092c639ec9a2f6cd14c37ea23137f"

--- a/packages/dnssec/dnssec.8.0.0/opam
+++ b/packages/dnssec/dnssec.8.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "alcotest" {with-test}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec"
+  "domain-name" {>= "0.4.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "logs" {>= "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNSSec support for OCaml-DNS"
+description: """
+DNSSec (DNS security extensions) for OCaml-DNS, including
+signing and verifying of RRSIG records.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v8.0.0/dns-8.0.0.tbz"
+  checksum: [
+    "sha256=0882061bc5bfa7515ab26c84ca8062323ac5931b3f8ae2952794b0c927d8854e"
+    "sha512=1b937aea10a76aebd6b9f44e7142fb0818e17147048fc7ff99ff6f29e5b217eb75e2bc700464089ed453ced2fede4a094828bf278a555736b51fbe285d6271a4"
+  ]
+}
+x-commit-hash: "875651e2529092c639ec9a2f6cd14c37ea23137f"


### PR DESCRIPTION
An opinionated Domain Name System (DNS) library

- Project page: <a href="https://github.com/mirage/ocaml-dns">https://github.com/mirage/ocaml-dns</a>
- Documentation: <a href="https://mirage.github.io/ocaml-dns/">https://mirage.github.io/ocaml-dns/</a>

##### CHANGES:

* dns-client (lwt, mirage): depend on happy-eyeballs-{lwt,mirage} instead of
  duplicating the code. This requires happy-eyeballs 1.1.0, and now the same
  Happy_eyeballs_{lwt,mirage}.t is used for DNS (connecting to the nameserver)
  and for the application (connecting to a remote host)
  (@dinosaure @hannesm mirage/ocaml-dns#346)
* server: improve API documentation (@hannesm
  1a80bd4080e597687152cf351d035ef5f00c5946
  000ae02dfc477d91c05891e3891a447328ae448a)
* server: add a `packet_callback` to `handle_packet` and `handle_buf`
  (@RyanGibb mirage/ocaml-dns#349)
* server: expose `update_data` (@RyanGibb mirage/ocaml-dns#350)
* resolver: b root name server IP change (@hannesm mirage/ocaml-dns#348)
* secondary server [mirage]: avoid infinite loop in connect (avoids SYN floods)
  (@hannesm @reynir mirage/ocaml-dns#347)
* resolver, dns_zone: use consistently `Log` instead of `Logs` (@palainp mirage/ocaml-dns#342)
