### PR TITLE
[new release] tcpip (8.1.0)

### DIFF
--- a/packages/tcpip/tcpip.8.1.0/opam
+++ b/packages/tcpip/tcpip.8.1.0/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding"
+  "result" {< "1.5"}
+]
+depends: [
+  "dune" {>= "2.7.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "mirage-net" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0" & < "4.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "ipaddr" {>= "5.6.0"}
+  "macaddr" {>="4.0.0"}
+  "macaddr-cstruct"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv" {< "0.2.0"}
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "mirage-vnetif" {with-test & >= "0.6.2"}
+  "alcotest" {with-test & >="1.5.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "ipaddr-cstruct"
+  "macaddr-cstruct"
+  "lru" {>= "0.3.0"}
+  "metrics"
+  "cmdliner" {>= "1.1.0"}
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v8.1.0/tcpip-8.1.0.tbz"
+  checksum: [
+    "sha256=86ba5d92f9078bddc65312f63b5f4ce34fd2570d765433b23a226ab84d75a9c0"
+    "sha512=a348a597cf4ba1e19f7fc97d6d1cb980711d09b6944efacba91d23daf419fc8cb8a83a2d263bcc7b96ff5d37ad5dbfa4a3879db9ac4c0b35528b80acb87cf8f7"
+  ]
+}
+x-commit-hash: "e422baa3ba0412c3f4111d0adf6026c53e144633"

--- a/packages/tcpip/tcpip.8.1.0/opam
+++ b/packages/tcpip/tcpip.8.1.0/opam
@@ -15,7 +15,7 @@ tags: ["org:mirage"]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
 ]
 conflicts: [
   "mirage-xen" {< "6.0.0"}


### PR DESCRIPTION
OCaml TCP/IP networking stack, used in MirageOS

- Project page: <a href="https://github.com/mirage/mirage-tcpip">https://github.com/mirage/mirage-tcpip</a>
- Documentation: <a href="https://mirage.github.io/mirage-tcpip/">https://mirage.github.io/mirage-tcpip/</a>

##### CHANGES:

* adapt to mirage-vnetif 0.6.2 changes (mirage/mirage-tcpip#517 @hannesm)
* Add `type prefix = Ipaddr.Prefix.t` and `IP.configured_ips : t -> prefix`
  to the IP layers (mirage/mirage-tcpip#516 @hannesm)
* Mark `get_ips` as deprecated, use `configured_ips` instead (mirage/mirage-tcpip#516 @hannesm)
