### PR TITLE
Expand conf-nanomsg platform support

### DIFF
--- a/packages/conf-nanomsg/conf-nanomsg.0/opam
+++ b/packages/conf-nanomsg/conf-nanomsg.0/opam
@@ -11,6 +11,11 @@ depexts: [
   ["nanomsg"] {os = "macos" & os-distribution = "homebrew"}
   ["nanomsg"] {os = "freebsd"}
 ]
+x-ci-accept-failures: [
+  "oraclelinux-7"
+  "oraclelinux-8"
+  "oraclelinux-9"
+]
 synopsis: "Virtual package relying on a nanomsg system installation"
 description:
   "This package can only install if the nanomsg lib is installed on the system."

--- a/packages/conf-nanomsg/conf-nanomsg.0/opam
+++ b/packages/conf-nanomsg/conf-nanomsg.0/opam
@@ -7,6 +7,7 @@ build: [["pkg-config" "nanomsg"]]
 depexts: [
   ["libnanomsg-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["nanomsg"] {os-distribution = "arch"}
+  ["nanomsg-devel"] {os-distribution = "fedora"}
   ["nanomsg-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["nanomsg"] {os = "macos" & os-distribution = "homebrew"}
   ["nanomsg"] {os = "freebsd"}

--- a/packages/conf-nanomsg/conf-nanomsg.0/opam
+++ b/packages/conf-nanomsg/conf-nanomsg.0/opam
@@ -7,6 +7,7 @@ build: [["pkg-config" "nanomsg"]]
 depexts: [
   ["libnanomsg-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["nanomsg"] {os-distribution = "arch"}
+  ["nanomsg-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["nanomsg"] {os = "macos" & os-distribution = "homebrew"}
   ["nanomsg"] {os = "freebsd"}
 ]

--- a/packages/conf-nanomsg/conf-nanomsg.0/opam
+++ b/packages/conf-nanomsg/conf-nanomsg.0/opam
@@ -5,7 +5,7 @@ homepage: "http://nanomsg.org/"
 license: ["MIT" "X11"]
 build: [["pkg-config" "nanomsg"]]
 depexts: [
-  ["libnanomsg-dev"] {os-family = "debian"}
+  ["libnanomsg-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["nanomsg"] {os-distribution = "arch"}
   ["nanomsg"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-nanomsg/conf-nanomsg.0/opam
+++ b/packages/conf-nanomsg/conf-nanomsg.0/opam
@@ -8,6 +8,7 @@ depexts: [
   ["libnanomsg-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["nanomsg"] {os-distribution = "arch"}
   ["nanomsg"] {os = "macos" & os-distribution = "homebrew"}
+  ["nanomsg"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a nanomsg system installation"
 description:

--- a/packages/conf-nanomsg/conf-nanomsg.0/opam
+++ b/packages/conf-nanomsg/conf-nanomsg.0/opam
@@ -6,6 +6,7 @@ license: ["MIT" "X11"]
 build: [["pkg-config" "nanomsg"]]
 depexts: [
   ["libnanomsg-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["nanomsg-dev"] {os-distribution = "alpine"}
   ["nanomsg"] {os-distribution = "arch"}
   ["nanomsg-devel"] {os-distribution = "fedora"}
   ["nanomsg-devel"] {os-family = "suse" | os-family = "opensuse"}


### PR DESCRIPTION
This PR expands conf-nanomsg support to include Alpine, Fedora, Ubuntu, Open/Suse, and FreeBSD.
I couldn't find any mention of it on the relevant Oracle 7/8/9 repos linked from https://yum.oracle.com/index.html and hence mark it an acceptable CI failure.