### PR TITLE
Expand conf-nauty platform support

### DIFF
--- a/packages/conf-nauty/conf-nauty.1.0/opam
+++ b/packages/conf-nauty/conf-nauty.1.0/opam
@@ -15,6 +15,11 @@ depexts: [
   ["nauty-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["nauty"] {os = "freebsd"}
 ]
+x-ci-accept-failures: [
+  "oraclelinux-7"
+  "oraclelinux-8"
+  "oraclelinux-9"
+]
 synopsis: "Virtual package relying on nauty"
 description:
   "This package can only install if the libnauty library is installed on the system."

--- a/packages/conf-nauty/conf-nauty.1.0/opam
+++ b/packages/conf-nauty/conf-nauty.1.0/opam
@@ -17,6 +17,7 @@ depexts: [
   ["nauty"] {os = "freebsd"}
 ]
 x-ci-accept-failures: [
+  "archlinux"           # Arch is missing a devel package for nauty: https://archlinux.org/packages/extra/x86_64/nauty/
   "oraclelinux-7"
   "oraclelinux-8"
   "oraclelinux-9"

--- a/packages/conf-nauty/conf-nauty.1.0/opam
+++ b/packages/conf-nauty/conf-nauty.1.0/opam
@@ -9,8 +9,9 @@ depends: [
   "conf-pkg-config" {build & os != "macos"}
 ]
 depexts: [
-  ["libnauty2-dev"] {os-family = "debian"}
+  ["libnauty2-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libnauty-devel"] {os-distribution = "fedora"}
+  ["nauty"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on nauty"
 description:

--- a/packages/conf-nauty/conf-nauty.1.0/opam
+++ b/packages/conf-nauty/conf-nauty.1.0/opam
@@ -20,6 +20,8 @@ x-ci-accept-failures: [
   "oraclelinux-7"
   "oraclelinux-8"
   "oraclelinux-9"
+  "opensuse-15.6"       # The opensuse packages are missing a .pc file:
+  "opensuse-tumbleweed" # https://opensuse.pkgs.org/tumbleweed/opensuse-oss-x86_64/nauty-devel-2.8.8-2.1.x86_64.rpm.html
 ]
 synopsis: "Virtual package relying on nauty"
 description:

--- a/packages/conf-nauty/conf-nauty.1.0/opam
+++ b/packages/conf-nauty/conf-nauty.1.0/opam
@@ -9,8 +9,10 @@ depends: [
   "conf-pkg-config" {build & os != "macos"}
 ]
 depexts: [
+  ["nauty-dev"] {os-distribution = "alpine"}
   ["libnauty2-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libnauty-devel"] {os-distribution = "fedora"}
+  ["nauty-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["nauty"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on nauty"

--- a/packages/conf-nauty/conf-nauty.1.0/opam
+++ b/packages/conf-nauty/conf-nauty.1.0/opam
@@ -4,15 +4,16 @@ homepage: "http://pallini.di.uniroma1.it/"
 authors: "http://pallini.di.uniroma1.it/Links.html#contact"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Apache-2.0"
-build: ["pkg-config" "nauty"] {os != "macos"}
+build: ["pkg-config" "nauty"]
 depends: [
-  "conf-pkg-config" {build & os != "macos"}
+  "conf-pkg-config" {build}
 ]
 depexts: [
   ["nauty-dev"] {os-distribution = "alpine"}
   ["libnauty2-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libnauty-devel"] {os-distribution = "fedora"}
   ["nauty-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["nauty"] {os = "macos" & os-distribution = "homebrew"}
   ["nauty"] {os = "freebsd"}
 ]
 x-ci-accept-failures: [


### PR DESCRIPTION
This PR expands conf-nauty support to include Alpine, Ubuntu, Open/Suse, macOS/homebrew, and FreeBSD.

Again, I couldn't find any mention of it on the relevant Oracle 7/8/9 repos linked from https://yum.oracle.com/index.html and hence mark it an acceptable CI failure.