### PR TITLE
Expand conf-neko platform support

### DIFF
--- a/packages/conf-neko/conf-neko.1/opam
+++ b/packages/conf-neko/conf-neko.1/opam
@@ -14,6 +14,11 @@ depexts: [
   ["neko"] {os-distribution = "arch"}
   ["neko"] {os = "freebsd"}
 ]
+x-ci-accept-failures: [
+  "oraclelinux-7"
+  "oraclelinux-8"
+  "oraclelinux-9"
+]
 synopsis: "Virtual package relying on a Neko system installation"
 description:
   "This package can only install if Neko is installed on the system."

--- a/packages/conf-neko/conf-neko.1/opam
+++ b/packages/conf-neko/conf-neko.1/opam
@@ -7,6 +7,7 @@ build: [["neko" "-version"]]
 depexts: [
   ["neko-dev"] {os-distribution = "alpine"}
   ["neko" "neko-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["neko"] {os-family = "suse" | os-family = "opensuse"}
   ["nekovm-devel"] {os-distribution = "fedora"}
   ["neko"] {os-distribution = "nixos"}
   ["neko"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/conf-neko/conf-neko.1/opam
+++ b/packages/conf-neko/conf-neko.1/opam
@@ -6,11 +6,12 @@ license: ["MIT"]
 build: [["neko" "-version"]]
 depexts: [
   ["neko-dev"] {os-distribution = "alpine"}
-  ["neko" "neko-dev"] {os-family = "debian"}
+  ["neko" "neko-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["nekovm-devel"] {os-distribution = "fedora"}
   ["neko"] {os-distribution = "nixos"}
   ["neko"] {os-distribution = "homebrew" & os = "macos"}
   ["neko"] {os-distribution = "arch"}
+  ["neko"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a Neko system installation"
 description:


### PR DESCRIPTION
This PR expands conf-neko support to include Ubuntu, Open/Suse, and FreeBSD.

Again, I mark Oracle as an acceptable CI failure.