### PR TITLE
Expand conf-numa platform support

### DIFF
--- a/packages/conf-numa/conf-numa.0.1.0/opam
+++ b/packages/conf-numa/conf-numa.0.1.0/opam
@@ -9,6 +9,7 @@ depexts: [
   ["libnuma-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["numactl-libs" "numactl-devel"] {os-distribution = "centos"}
   ["numactl-libs" "numactl-devel"] {os-distribution = "fedora"}
+  ["numactl-devel"] {os-distribution = "ol"}
   ["libnuma-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libnuma-dev"] {os-distribution = "alpine"}
   ["linux-c7-numactl-libs"] {os = "freebsd"}

--- a/packages/conf-numa/conf-numa.0.1.0/opam
+++ b/packages/conf-numa/conf-numa.0.1.0/opam
@@ -11,8 +11,9 @@ depexts: [
   ["numactl-libs" "numactl-devel"] {os-distribution = "fedora"}
   ["libnuma-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libnuma-dev"] {os-distribution = "alpine"}
+  ["linux-c7-numactl-libs"] {os = "freebsd"}
 ]
-available: os != "macos" & os != "freebsd" & os != "openbsd"
+available: os != "macos" & os != "openbsd"
 synopsis: "Package relying on libnuma"
 description: """
 Virtual package relying on a libnuma system installation.

--- a/packages/conf-numa/conf-numa.0.1.0/opam
+++ b/packages/conf-numa/conf-numa.0.1.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://www.github.com/stevebleazard/ocaml-conf-numa/issues"
 license: "MIT"
 dev-repo: "git+https://www.github.com/stevebleazard/ocaml-conf-numa.git"
 depexts: [
-  ["libnuma-dev"] {os-family = "debian"}
+  ["libnuma-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["numactl-libs" "numactl-devel"] {os-distribution = "centos"}
   ["numactl-libs" "numactl-devel"] {os-distribution = "fedora"}
   ["libnuma-devel"] {os-family = "suse" | os-family = "opensuse"}


### PR DESCRIPTION
This PR expands conf-numa support to include Ubuntu, Oracle, and FreeBSD.

Because of the relatively loose `build` check (ha!) I expect this to be all green...