### PR TITLE
Mark `core_unix.v0.17.0` as unavailable on more architectures

### DIFF
--- a/packages/core_unix/core_unix.v0.17.0/opam
+++ b/packages/core_unix/core_unix.v0.17.0/opam
@@ -25,7 +25,7 @@ depends: [
   "dune"                     {>= "3.11.0"}
   "spawn"                    {>= "v0.15"}
 ]
-available: arch != "arm32" & arch != "x86_32" & arch != "ppc64" & arch != "s390x"
+available: arch = "x86_64" | arch = "arm64"
 synopsis: "Unix-specific portions of Core"
 description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].

--- a/packages/core_unix/core_unix.v0.17.0/opam
+++ b/packages/core_unix/core_unix.v0.17.0/opam
@@ -25,7 +25,7 @@ depends: [
   "dune"                     {>= "3.11.0"}
   "spawn"                    {>= "v0.15"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "arm32" & arch != "x86_32" & arch != "ppc64" & arch != "s390x"
 synopsis: "Unix-specific portions of Core"
 description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].


### PR DESCRIPTION
The build failure on ppc64 ([example](https://ocaml.ci.dev/github/ocaml-community/yojson/commit/1df1df5483a8cc25247d53215de8cf7d686f8824/variant/debian-12-5.2_ppc64_opam-2.1)) and s390x ([example](https://ocaml.ci.dev/github/ocaml-community/yojson/commit/1df1df5483a8cc25247d53215de8cf7d686f8824/variant/debian-12-5.2_s390x_opam-2.1)) is the following:

```
/usr/bin/ld: /home/opam/.opam/5.2/lib/core_unix/time_stamp_counter/libtime_stamp_counter_stubs.a(time_stamp_counter_stubs.o): in function `caml_rdtsc_unboxed':
/home/opam/.opam/5.2/.opam-switch/build/core_unix.v0.17.0/_build/default/time_stamp_counter/src/time_stamp_counter_stubs.c:51: undefined reference to `rdtsc'
/usr/bin/ld: /home/opam/.opam/5.2/lib/core_unix/time_stamp_counter/libtime_stamp_counter_stubs.a(time_stamp_counter_stubs.o): in function `caml_rdtsc':
/home/opam/.opam/5.2/.opam-switch/build/core_unix.v0.17.0/_build/default/time_stamp_counter/src/time_stamp_counter_stubs.c:56: undefined reference to `rdtsc'
collect2: error: ld returned 1 exit status
```

Looking at the relevant code (as I wanted to know whether this is also the case in v0.16 - the code is quite different so it probably isn't) in https://github.com/janestreet/core_unix/blob/v0.17/time_stamp_counter/src/time_stamp_counter_stubs.c#L33-L47 this is due to the function only defined on x86, amd64 and arm64, so maybe it would make even more sense flip the availability condition to these three architectures instead?