### PR TITLE
Expand conf-ode platform support

### DIFF
--- a/packages/conf-ode/conf-ode.1/opam
+++ b/packages/conf-ode/conf-ode.1/opam
@@ -5,8 +5,20 @@ homepage: "http://www.ode.org/"
 license: ["BSD-3-Clause" "LGPL-2.1-or-later"]
 build: [["pkg-config" "ode"]]
 depexts: [
-  ["libode-dev"] {os-family = "debian"}
+  ["libode-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["ode-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["ode"] {os-distribution = "arch"}
+  ["ode-devel"] {os-distribution = "fedora"}
   ["libode-devel"] {os-distribution = "mageia"}
+  ["ode"] {os-distribution = "homebrew" & os = "macos"}
+  ["ode"] {os = "freebsd"}
+]
+x-ci-accept-failures: [ #ode-dev on Alpine is under way: https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/60122
+  "alpine-3.18"
+  "alpine-3.19"
+  "oraclelinux-7"
+  "oraclelinux-8"
+  "oraclelinux-9"
 ]
 synopsis: "Virtual package relying on a ODE system installation"
 description:


### PR DESCRIPTION
This adds conf-ode support for Ubuntu, Open/Suse, Arch, Fedora, macOS-homebrew, and FreeBSD.

Alpine is under way it seems: https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/60122