### PR TITLE
Expand conf-pam platform support

### DIFF
--- a/packages/conf-pam/conf-pam.1/opam
+++ b/packages/conf-pam/conf-pam.1/opam
@@ -4,9 +4,12 @@ maintainer: "Jane Street developers"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "BSD-3-Clause"
 depexts: [
-  ["libpam0g-dev"] {os-family = "debian"}
+  ["libpam0g-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["pam-devel"] {os-distribution = "centos"}
   ["pam-devel"] {os-distribution = "fedora"}
+  ["pam-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["pam-devel"] {os-distribution = "ol"}
+  ["pam"] {os-distribution = "arch"}
   ["linux-pam-dev"] {os-distribution = "alpine"}
 ]
 build: [


### PR DESCRIPTION
This adds conf-pam support for Ubuntu-family, Open/Suse, Oracle, and Arch