### PR TITLE
Expand conf-rocksdb platform support

### DIFF
--- a/packages/conf-rocksdb/conf-rocksdb.1/opam
+++ b/packages/conf-rocksdb/conf-rocksdb.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["rocksdb-devel"] {os-distribution = "fedora" | os-family = "fedora"}
   ["rocksdb-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["rocksdb"] {os-distribution = "homebrew" & os = "macos"}
+  ["rocksdb"] {os = "freebsd"}
 ]
 build: [
   ["cc" "-lrocksdb" "main.c"]

--- a/packages/conf-rocksdb/conf-rocksdb.1/opam
+++ b/packages/conf-rocksdb/conf-rocksdb.1/opam
@@ -9,7 +9,7 @@ depexts: [
   ["rocksdb"] {os-distribution = "arch"}
   ["rocksdb-dev"] {os-distribution = "alpine"} # community package
   ["librocksdb-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["rocksdb-devel"] {os-distribution = "fedora" | os-family = "fedora"}
+  ["rocksdb-devel"] {os-distribution = "fedora"}
   ["rocksdb-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["rocksdb"] {os-distribution = "homebrew" & os = "macos"}
   ["rocksdb"] {os = "freebsd"}

--- a/packages/conf-rocksdb/conf-rocksdb.1/opam
+++ b/packages/conf-rocksdb/conf-rocksdb.1/opam
@@ -6,6 +6,8 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Apache-2.0"
 
 depexts: [
+  ["rocksdb"] {os-distribution = "arch"}
+  ["rocksdb-dev"] {os-distribution = "alpine"} # community package
   ["librocksdb-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["rocksdb"] {os-distribution = "homebrew" & os = "macos"}
 ]

--- a/packages/conf-rocksdb/conf-rocksdb.1/opam
+++ b/packages/conf-rocksdb/conf-rocksdb.1/opam
@@ -9,6 +9,8 @@ depexts: [
   ["rocksdb"] {os-distribution = "arch"}
   ["rocksdb-dev"] {os-distribution = "alpine"} # community package
   ["librocksdb-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["rocksdb-devel"] {os-distribution = "fedora" | os-family = "fedora"}
+  ["rocksdb-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["rocksdb"] {os-distribution = "homebrew" & os = "macos"}
 ]
 build: [

--- a/packages/conf-rocksdb/conf-rocksdb.1/opam
+++ b/packages/conf-rocksdb/conf-rocksdb.1/opam
@@ -7,6 +7,7 @@ license: "Apache-2.0"
 
 depexts: [
   ["librocksdb-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["rocksdb"] {os-distribution = "homebrew" & os = "macos"}
 ]
 build: [
   ["cc" "-lrocksdb" "main.c"]

--- a/packages/conf-rocksdb/conf-rocksdb.1/opam
+++ b/packages/conf-rocksdb/conf-rocksdb.1/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Apache-2.0"
 
 depexts: [
-  ["librocksdb-dev"] {os-family = "debian"}
+  ["librocksdb-dev"] {os-family = "debian" | os-family = "ubuntu"}
 ]
 build: [
   ["cc" "-lrocksdb" "main.c"]

--- a/packages/conf-rocksdb/conf-rocksdb.1/opam
+++ b/packages/conf-rocksdb/conf-rocksdb.1/opam
@@ -16,6 +16,11 @@ depexts: [
 build: [
   ["cc" "-lrocksdb" "main.c"]
 ]
+x-ci-accept-failures: [
+  "oraclelinux-7"
+  "oraclelinux-8"
+  "oraclelinux-9"
+]
 synopsis: "Virtual package relying on a system installation of RocksDB"
 flags: conf
 extra-source "main.c" {


### PR DESCRIPTION
This adds conf-rocksdb platform support for Arch, Alpine, Fedora, OpenSuse, Ubuntu-family, FreeBSD, and macOS.

For OpenSuse https://pkgs.org/download/rocksdb-devel only lists an entry for openSUSE Tumbleweed. The other one will probably fail.

I also expect FreeBSD and macOS to need linker path fiddling.