### PR TITLE
[new release] yojson and yojson-five (2.2.0)

### DIFF
--- a/packages/yojson-five/yojson-five.2.2.0/opam
+++ b/packages/yojson-five/yojson-five.2.2.0/opam
@@ -15,6 +15,7 @@ bug-reports: "https://github.com/ocaml-community/yojson/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
+  "yojson" {= version}
   "sedlex" {>= "2.5"}
   "alcotest" {with-test & >= "0.8.5"}
   "odoc" {with-doc}

--- a/packages/yojson-five/yojson-five.2.2.0/opam
+++ b/packages/yojson-five/yojson-five.2.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Yojson-five is a parsing and printing library for the JSON5 format"
+description: """
+Yojson-five is a parsing and printing library for the JSON5 format.
+It supports parsing JSON5 to Yojson.Basic.t and Yojson.Safe.t types."""
+maintainer: [
+  "paul-elliot@tarides.com" "nathan@tarides.com" "marek@tarides.com"
+]
+authors: ["Martin Jambon"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/yojson"
+doc: "https://ocaml-community.github.io/yojson"
+bug-reports: "https://github.com/ocaml-community/yojson/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "sedlex" {>= "2.5"}
+  "alcotest" {with-test & >= "0.8.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-community/yojson.git"
+url {
+  src:
+    "https://github.com/ocaml-community/yojson/releases/download/2.2.0/yojson-2.2.0.tbz"
+  checksum: [
+    "sha256=bfdc33bef3141bba9a8fa66a885b54b29f6bfab450040884dd8cf7cdec784519"
+    "sha512=0854d8ab094c8f70fdb6af7f36cac621cecfcbae4592f6e079945761460625fdb7d1bff458998dc95970990daefce57b7f4f9458fd1347a393a1d76709bc9561"
+  ]
+}
+x-commit-hash: "c0276cebe274f90241141338e7d6f13df3bd1c0e"

--- a/packages/yojson/yojson.2.2.0/opam
+++ b/packages/yojson/yojson.2.2.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "Yojson is an optimized parsing and printing library for the JSON format"
+description: """
+Yojson is an optimized parsing and printing library for the JSON format.
+
+ydump is a pretty-printing command-line program provided with the
+yojson package."""
+maintainer: [
+  "paul-elliot@tarides.com" "nathan@tarides.com" "marek@tarides.com"
+]
+authors: ["Martin Jambon"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/yojson"
+doc: "https://ocaml-community.github.io/yojson"
+bug-reports: "https://github.com/ocaml-community/yojson/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.02.3"}
+  "alcotest" {with-test & >= "0.8.5"}
+  "seq" {>= "0.2.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-community/yojson.git"
+url {
+  src:
+    "https://github.com/ocaml-community/yojson/releases/download/2.2.0/yojson-2.2.0.tbz"
+  checksum: [
+    "sha256=bfdc33bef3141bba9a8fa66a885b54b29f6bfab450040884dd8cf7cdec784519"
+    "sha512=0854d8ab094c8f70fdb6af7f36cac621cecfcbae4592f6e079945761460625fdb7d1bff458998dc95970990daefce57b7f4f9458fd1347a393a1d76709bc9561"
+  ]
+}
+x-commit-hash: "c0276cebe274f90241141338e7d6f13df3bd1c0e"


### PR DESCRIPTION
Yojson is an optimized parsing and printing library for the JSON format

- Project page: <a href="https://github.com/ocaml-community/yojson">https://github.com/ocaml-community/yojson</a>
- Documentation: <a href="https://ocaml-community.github.io/yojson">https://ocaml-community.github.io/yojson</a>

##### CHANGES:

*2024-05-31*

### Added

- Added support for JSON5 (@dhilst, @gorm-issuu, @gertsonderby, ocaml-community/yojson#152)

### Removed

- Remove CPPO dependency to make the Yojson installation lighter
  (@Leonidas-from-XIV, ocaml-community/yojson#175)
