### PR TITLE
Expand conf-sdl2-net platform support

### DIFF
--- a/packages/conf-sdl2-net/conf-sdl2-net.1/opam
+++ b/packages/conf-sdl2-net/conf-sdl2-net.1/opam
@@ -4,6 +4,7 @@ homepage: "http://www.libsdl.org/projects/SDL_net/"
 license: "Zlib"
 build: [["pkg-config" "SDL2_net"]]
 depexts: [
+  ["sdl2_net"] {os-family = "arch"}
   ["sdl2_net-dev"] {os-distribution = "alpine"}
   ["libsdl2-net-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["SDL2_net-devel"] {os-distribution = "fedora"}

--- a/packages/conf-sdl2-net/conf-sdl2-net.1/opam
+++ b/packages/conf-sdl2-net/conf-sdl2-net.1/opam
@@ -7,6 +7,7 @@ depexts: [
   ["sdl2_net-dev"] {os-distribution = "alpine"}
   ["libsdl2-net-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libsdl2_net-devel"] {os-distribution = "mageia"}
+  ["sdl2_net"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a sdl2-net system installation"
 description:

--- a/packages/conf-sdl2-net/conf-sdl2-net.1/opam
+++ b/packages/conf-sdl2-net/conf-sdl2-net.1/opam
@@ -6,6 +6,8 @@ build: [["pkg-config" "SDL2_net"]]
 depexts: [
   ["sdl2_net-dev"] {os-distribution = "alpine"}
   ["libsdl2-net-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["SDL2_net-devel"] {os-distribution = "fedora"}
+  ["libSDL2_net-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libsdl2_net-devel"] {os-distribution = "mageia"}
   ["sdl2_net"] {os = "freebsd"}
 ]

--- a/packages/conf-sdl2-net/conf-sdl2-net.1/opam
+++ b/packages/conf-sdl2-net/conf-sdl2-net.1/opam
@@ -9,6 +9,7 @@ depexts: [
   ["SDL2_net-devel"] {os-distribution = "fedora"}
   ["libSDL2_net-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libsdl2_net-devel"] {os-distribution = "mageia"}
+  ["sdl2_net"] {os-distribution = "homebrew" & os = "macos"}
   ["sdl2_net"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on a sdl2-net system installation"

--- a/packages/conf-sdl2-net/conf-sdl2-net.1/opam
+++ b/packages/conf-sdl2-net/conf-sdl2-net.1/opam
@@ -13,6 +13,11 @@ depexts: [
   ["sdl2_net"] {os-distribution = "homebrew" & os = "macos"}
   ["sdl2_net"] {os = "freebsd"}
 ]
+x-ci-accept-failures: [
+  "oraclelinux-7"
+  "oraclelinux-8"
+  "oraclelinux-9"
+]
 synopsis: "Virtual package relying on a sdl2-net system installation"
 description:
   "This package can only install if libsdl2-net is installed on the system."

--- a/packages/conf-sdl2-net/conf-sdl2-net.1/opam
+++ b/packages/conf-sdl2-net/conf-sdl2-net.1/opam
@@ -5,7 +5,7 @@ license: "Zlib"
 build: [["pkg-config" "SDL2_net"]]
 depexts: [
   ["sdl2_net-dev"] {os-distribution = "alpine"}
-  ["libsdl2-net-dev"] {os-family = "debian"}
+  ["libsdl2-net-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libsdl2_net-devel"] {os-distribution = "mageia"}
 ]
 synopsis: "Virtual package relying on a sdl2-net system installation"


### PR DESCRIPTION
This add conf-sdl2-net support for Arch, Fedora, OpenSuse, Ubuntu-family, FreeBSD, and macOS.

For OpenSuse https://pkgs.org/download/SDL2_net-devel lists some mismatch between the Tumbleweed and Leap 15.5 package names, which may require dispatching between the two... :thinking: 