### PR TITLE
Expand conf-vim platform support

### DIFF
--- a/packages/conf-vim/conf-vim.1/opam
+++ b/packages/conf-vim/conf-vim.1/opam
@@ -5,10 +5,13 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "charityware"
 build: ["vim" "--version"]
 depexts: [
-  ["vim-nox"] {os-family = "debian"}
+  ["vim"] {os-distribution = "arch"}
+  ["vim"] {os-distribution = "alpine"}
+  ["vim-nox"] {os-family = "debian" | os-family = "ubuntu"}
   ["vim"] {os-distribution = "centos"}
   ["vim"] {os-distribution = "rhel"}
   ["vim"] {os-distribution = "fedora"}
+  ["vim"] {os-family = "suse" | os-family = "opensuse"}
   ["vim"] {os-distribution = "ol"}
   ["vim"] {os = "freebsd"}
 ]


### PR DESCRIPTION
This adds Arch, Alpine, Ubuntu-family, and OpenSuse support.

Unsure how this useful this change is in practice, I suspect most if not all of these systems include it as part of their base systems :shrug: 