### PR TITLE
[new release] merlin and merlin-lib v4.15-414/501

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.9/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.9/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08" & < "5.2"}
   "dune" {>= "2.9.0"}
-  "merlin-lib" {>= "4.9" & < "4.14-502"}
+  "merlin-lib" {>= "4.9" & < "5.0"}
   "ocamlfind" {>= "1.6.0"}
 ]
 description:

--- a/packages/merlin-lib/merlin-lib.4.15-414/opam
+++ b/packages/merlin-lib/merlin-lib.4.15-414/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.15-414/merlin-4.15-414.tbz"
+  checksum: [
+    "sha256=d1cc427a3d2d11ab0cf3570ae5348ace5fbd2454869df58f9320c4a5cf9f3fe3"
+    "sha512=dab52b7d002208e6b94fb20a2fb5a732e6954b951c74eb1bc5c5f81d21d8aa92bfd410a798abd261bef79f314a8e72c4f7aa9e31d62b635cae6fe1bcc6c121cc"
+  ]
+}
+x-commit-hash: "9be57bf93bc661eef8484b4dbafc102827198154"

--- a/packages/merlin-lib/merlin-lib.4.15-501/opam
+++ b/packages/merlin-lib/merlin-lib.4.15-501/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.1.1" & < "5.2"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.15-501/merlin-4.15-501.tbz"
+  checksum: [
+    "sha256=bdb6d021232c0405af17d74fca50d7b76eec7d1db4837557e5786bde59f82553"
+    "sha512=7462f3d603a158e192b06a5eb161692c1bdde68f4ccf4b382cfd7f7eebafc29f8b8e6699cfb3ec75a761b07815887f2dd70efa8611bf46f55b67971979457ae0"
+  ]
+}
+x-commit-hash: "a5c29395496e09d2cf0651a918226e52d095837b"

--- a/packages/merlin/merlin.4.15-414/opam
+++ b/packages/merlin/merlin.4.15-414/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.9"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.15-414/merlin-4.15-414.tbz"
+  checksum: [
+    "sha256=d1cc427a3d2d11ab0cf3570ae5348ace5fbd2454869df58f9320c4a5cf9f3fe3"
+    "sha512=dab52b7d002208e6b94fb20a2fb5a732e6954b951c74eb1bc5c5f81d21d8aa92bfd410a798abd261bef79f314a8e72c4f7aa9e31d62b635cae6fe1bcc6c121cc"
+  ]
+}
+x-commit-hash: "9be57bf93bc661eef8484b4dbafc102827198154"

--- a/packages/merlin/merlin.4.15-501/opam
+++ b/packages/merlin/merlin.4.15-501/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.1" & < "5.2"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.9"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.15-501/merlin-4.15-501.tbz"
+  checksum: [
+    "sha256=bdb6d021232c0405af17d74fca50d7b76eec7d1db4837557e5786bde59f82553"
+    "sha512=7462f3d603a158e192b06a5eb161692c1bdde68f4ccf4b382cfd7f7eebafc29f8b8e6699cfb3ec75a761b07815887f2dd70efa8611bf46f55b67971979457ae0"
+  ]
+}
+x-commit-hash: "a5c29395496e09d2cf0651a918226e52d095837b"


### PR DESCRIPTION
CHANGES:

Fri May 31 14:02:42 CEST 2024

  + merlin binary
    - destruct: Removal of residual patterns (ocaml/merlin#1737, fixes ocaml/merlin#1560)
    - Do not erase fields' names when destructing punned record fields (ocaml/merlin#1734,
      fixes ocaml/merlin#1661)
    - Ignore SIGPIPE in the Merlin server process (ocaml/merlin#1746)
    - Fix lexing of quoted strings in comments (ocaml/merlin#1754, fixes ocaml/merlin#1753)
    - Improve cursor position detection in longidents (ocaml/merlin#1756)