### PR TITLE
Make `yojson-bench` unavailable

### DIFF
--- a/packages/yojson-bench/yojson-bench.2.0.0/opam
+++ b/packages/yojson-bench/yojson-bench.2.0.0/opam
@@ -32,3 +32,4 @@ url {
   ]
 }
 x-commit-hash: "9c5cee131ae0ec79713e62397076d597486844ed"
+available: false

--- a/packages/yojson-bench/yojson-bench.2.0.1/opam
+++ b/packages/yojson-bench/yojson-bench.2.0.1/opam
@@ -32,3 +32,4 @@ url {
   ]
 }
 x-commit-hash: "b67669eaa82d56663dc042246787d18789457cfc"
+available: false

--- a/packages/yojson-bench/yojson-bench.2.0.2/opam
+++ b/packages/yojson-bench/yojson-bench.2.0.2/opam
@@ -32,3 +32,4 @@ url {
   ]
 }
 x-commit-hash: "17ca03c5877a4346f0691443f35ed9678f99962f"
+available: false


### PR DESCRIPTION
There is no point in ever installing this package, it's just a hack to be able to install development dependencies and set ocaml versions (`core_bench` which includes a lot of dependencies that we don't want to have in `yojson`). In new releases like in #25994 I try not to submit the package in the first place.

Another option is to just delete it from opam-repository altogether which is probably more useful as it then doesn't clog up search results etc. but I'll refer to the maintainers.