### PR TITLE
Release patricia-tree 0.10.0

### DIFF
--- a/packages/patricia-tree/patricia-tree.0.10.0/opam
+++ b/packages/patricia-tree/patricia-tree.0.10.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Patricia Tree data structure in OCaml for maps and sets. Supports generic key-value pairs"
+maintainer: ["Dorian Lesbre <dorian.lesbre@cea.fr>"]
+authors: [
+  "Matthieu Lemerre <matthieu.lemerre@cea.fr>"
+  "Dorian Lesbre <dorian.lesbre@cea.fr>"
+]
+license: "LGPL-2.1-only"
+homepage: "https://codex.top/api/patricia-tree/"
+doc: "https://codex.top/api/patricia-tree/"
+bug-reports:
+  "https://github.com/codex-semantics-library/patricia-tree/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0"}
+  "qcheck-core" {>= "0.21.2" & with-test}
+  "ppx_inline_test" {>= "v0.16.0" & with-test}
+  "mdx" {>= "2.4.1" & with-test}
+  "odoc" {>= "2.4.0" & with-doc}
+  "sherlodoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/codex-semantics-library/patricia-tree.git"
+url {
+  src:
+    "https://github.com/codex-semantics-library/patricia-tree/releases/download/v0.10.0/patricia-tree-0.10.0.tbz"
+  checksum: [
+    "sha256=026b9bae3a0cd20a3543a44c8b92794fd42e742ccc4651a905043015aca26044"
+    "sha512=7e57a067f0684fc6455482ad3d6af01d0c0fa015e6119566903ff9f94e9d16ac2839567e7b6f8ccb43138432501aad380e1a51b4372f5d6b25d8343431e20db8"
+  ]
+}
+x-commit-hash: "2782affd42c34f761f7846da8249430b4a064a11"


### PR DESCRIPTION
Release new version of patricia-tree (version 0.10.0).

Package documentation: https://codex.top/api/patricia-tree (this was moved from 0.9.0, which used https://codex.top/patricia-tree, but a redirection is in place to keep the url valid).

Changes:
- Added hash-consed nodes and functors to build hash-consed maps and sets.
- Added new functions fold_on_nonequal_inter and fold_on_nonequal_union to maps.
- Now support using negative keys, removed zarith dependency.
- Fixed some bugs

See the changelog for more details: https://github.com/codex-semantics-library/patricia-tree/blob/main/CHANGELOG.md