### PR TITLE
Relaxes the compiler constraint in reason-react-ppx

### DIFF
--- a/packages/reason-react-ppx/reason-react-ppx.0.14.1/opam
+++ b/packages/reason-react-ppx/reason-react-ppx.0.14.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "React.js JSX PPX"
+description: "ReasonReact JSX PPX"
+maintainer: [
+  "David Sancho <dsnxmoreno@gmail.com>"
+  "Antonio Monteiro <anmonteiro@gmail.com>"
+]
+authors: [
+  "Cheng Lou <chenglou92@gmail.com>" "Ricky Vetter <rickywvetter@gmail.com>"
+]
+license: "MIT"
+homepage: "https://reasonml.github.io/reason-react"
+doc: "https://reasonml.github.io/reason-react"
+bug-reports: "https://github.com/reasonml/reason-react/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "5.1.1" & < "5.3.0"}
+  "reason" {>= "3.10.0"}
+  "ppxlib" {>= "0.28.0"}
+  "merlin" {= "4.13.1-501" & with-test}
+  "ocamlformat" {= "0.24.0" & with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reasonml/reason-react.git"
+url {
+  src:
+    "https://github.com/reasonml/reason-react/releases/download/0.14.0/reason-react-0.14.0.tbz"
+  checksum: [
+    "sha256=beea06b4a02111b5e46804e359d168d357f278267c5cb4faf3f5d66e7cfe60a8"
+    "sha512=072cb9184e6a3c963fc27220f52ded0b3cb5b21a2f62770f08eb261682ea9c4faf7de2f281f82816e17d19d6b806513cd51dfe69e9928eba4eef162867a06560"
+  ]
+}
+x-commit-hash: "7856cb0c3fdad99c9d4e6f1453e53aeb0e737c3b"

--- a/packages/reason-react/reason-react.0.14.1/opam
+++ b/packages/reason-react/reason-react.0.14.1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Reason bindings for React.js"
+description: """
+ReasonReact helps you use Reason to build React components with deeply integrated, strong, static type safety.
+
+It is designed and built by people using Reason and React in large, mission critical production React codebases."""
+maintainer: [
+  "David Sancho <dsnxmoreno@gmail.com>"
+  "Antonio Monteiro <anmonteiro@gmail.com>"
+]
+authors: [
+  "Cheng Lou <chenglou92@gmail.com>" "Ricky Vetter <rickywvetter@gmail.com>"
+]
+license: "MIT"
+homepage: "https://reasonml.github.io/reason-react"
+doc: "https://reasonml.github.io/reason-react"
+bug-reports: "https://github.com/reasonml/reason-react/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml"
+  "melange" {>= "3.0.0"}
+  "reason-react-ppx" {= version}
+  "reason" {>= "3.10.0"}
+  "ocaml-lsp-server" {with-test}
+  "opam-check-npm-deps" {= "1.0.0" & with-dev-setup}
+  "ocamlformat" {= "0.24.0" & with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reasonml/reason-react.git"
+depexts: [
+  ["react"] {npm-version = "^18.0.0"}
+  ["react-dom"] {npm-version = "^18.0.0"}
+]
+url {
+  src:
+    "https://github.com/reasonml/reason-react/releases/download/0.14.0/reason-react-0.14.0.tbz"
+  checksum: [
+    "sha256=beea06b4a02111b5e46804e359d168d357f278267c5cb4faf3f5d66e7cfe60a8"
+    "sha512=072cb9184e6a3c963fc27220f52ded0b3cb5b21a2f62770f08eb261682ea9c4faf7de2f281f82816e17d19d6b806513cd51dfe69e9928eba4eef162867a06560"
+  ]
+}
+x-commit-hash: "7856cb0c3fdad99c9d4e6f1453e53aeb0e737c3b"


### PR DESCRIPTION
Also,
1. Bumps the version so that users received the fixed metadata
2. Bump reason-react since it's meant to work with sibling packages of same version