### PR TITLE
[new release] reason-react (2 packages) (0.14.1)

### DIFF
--- a/packages/reason-react-ppx/reason-react-ppx.0.14.1/opam
+++ b/packages/reason-react-ppx/reason-react-ppx.0.14.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "React.js JSX PPX"
+description: "ReasonReact JSX PPX"
+maintainer: [
+  "David Sancho <dsnxmoreno@gmail.com>"
+  "Antonio Monteiro <anmonteiro@gmail.com>"
+]
+authors: [
+  "Cheng Lou <chenglou92@gmail.com>" "Ricky Vetter <rickywvetter@gmail.com>"
+]
+license: "MIT"
+homepage: "https://reasonml.github.io/reason-react"
+doc: "https://reasonml.github.io/reason-react"
+bug-reports: "https://github.com/reasonml/reason-react/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml"
+  "reason" {>= "3.10.0"}
+  "ppxlib" {>= "0.28.0"}
+  "merlin" {with-test}
+  "ocamlformat" {= "0.24.0" & with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reasonml/reason-react.git"
+url {
+  src:
+    "https://github.com/reasonml/reason-react/releases/download/0.14.1/reason-react-0.14.1.tbz"
+  checksum: [
+    "sha256=e366724937fa8484473ec94b5e72132da2c9900b006142baa808cd192a2fdf3b"
+    "sha512=2225be0339506af2b7e06ccb3d7aeec69eb76472c5602046ccc4b1cce24a8e66f95e556712f4b7fe8825fc6ebb7d3e083c403ca7ea062d00294d3cfc13cbb1a4"
+  ]
+}
+x-commit-hash: "9da6b4801716b3311a4931c8b3b5c22e6c437f24"

--- a/packages/reason-react-ppx/reason-react-ppx.0.14.1/opam
+++ b/packages/reason-react-ppx/reason-react-ppx.0.14.1/opam
@@ -14,7 +14,7 @@ doc: "https://reasonml.github.io/reason-react"
 bug-reports: "https://github.com/reasonml/reason-react/issues"
 depends: [
   "dune" {>= "3.9"}
-  "ocaml"
+  "ocaml" {>= "4.14"}
   "reason" {>= "3.10.0"}
   "ppxlib" {>= "0.28.0"}
   "merlin" {with-test}
@@ -31,7 +31,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/reason-react/reason-react.0.14.1/opam
+++ b/packages/reason-react/reason-react.0.14.1/opam
@@ -36,7 +36,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/reason-react/reason-react.0.14.1/opam
+++ b/packages/reason-react/reason-react.0.14.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Reason bindings for React.js"
+description: """
+ReasonReact helps you use Reason to build React components with deeply integrated, strong, static type safety.
+
+It is designed and built by people using Reason and React in large, mission critical production React codebases."""
+maintainer: [
+  "David Sancho <dsnxmoreno@gmail.com>"
+  "Antonio Monteiro <anmonteiro@gmail.com>"
+]
+authors: [
+  "Cheng Lou <chenglou92@gmail.com>" "Ricky Vetter <rickywvetter@gmail.com>"
+]
+license: "MIT"
+homepage: "https://reasonml.github.io/reason-react"
+doc: "https://reasonml.github.io/reason-react"
+bug-reports: "https://github.com/reasonml/reason-react/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml"
+  "melange" {>= "3.0.0"}
+  "reason-react-ppx" {= version}
+  "reason" {>= "3.10.0"}
+  "ocaml-lsp-server" {with-dev-setup}
+  "opam-check-npm-deps" {= "1.0.0" & with-dev-setup}
+  "ocamlformat" {= "0.24.0" & with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reasonml/reason-react.git"
+depexts: [
+  ["react"] {npm-version = "^18.0.0"}
+  ["react-dom"] {npm-version = "^18.0.0"}
+]
+url {
+  src:
+    "https://github.com/reasonml/reason-react/releases/download/0.14.1/reason-react-0.14.1.tbz"
+  checksum: [
+    "sha256=e366724937fa8484473ec94b5e72132da2c9900b006142baa808cd192a2fdf3b"
+    "sha512=2225be0339506af2b7e06ccb3d7aeec69eb76472c5602046ccc4b1cce24a8e66f95e556712f4b7fe8825fc6ebb7d3e083c403ca7ea062d00294d3cfc13cbb1a4"
+  ]
+}
+x-commit-hash: "9da6b4801716b3311a4931c8b3b5c22e6c437f24"


### PR DESCRIPTION
Reason bindings for React.js

- Project page: <a href="https://reasonml.github.io/reason-react">https://reasonml.github.io/reason-react</a>
- Documentation: <a href="https://reasonml.github.io/reason-react">https://reasonml.github.io/reason-react</a>

##### CHANGES:

* Support JSX transform with fragments (@tatchi in
  [reasonml/reason-react#835](https://github.com/reasonml/reason-react/pull/835))
