### PR TITLE
`core_unix.v0.16` does not work properly on FreeBSD

### DIFF
--- a/packages/core_unix/core_unix.v0.16.0/opam
+++ b/packages/core_unix/core_unix.v0.16.0/opam
@@ -30,6 +30,7 @@ description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
 "
 depexts: ["linux-headers"] {os-family = "alpine"}
+available: [ os != "freebsd" ]
 url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/core_unix-v0.16.0.tar.gz"
 checksum: "sha256=4f70a9d3a761799d00c0a207942b4abd9f1a144bbcb19df98021d9fb7bfa9e5f"

--- a/packages/core_unix/core_unix.v0.16.0/opam
+++ b/packages/core_unix/core_unix.v0.16.0/opam
@@ -30,7 +30,7 @@ description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
 "
 depexts: ["linux-headers"] {os-family = "alpine"}
-available: [ os != "freebsd" ]
+available: [ !(os = "freebsd" & os-version >= "14") ]
 url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/core_unix-v0.16.0.tar.gz"
 checksum: "sha256=4f70a9d3a761799d00c0a207942b4abd9f1a144bbcb19df98021d9fb7bfa9e5f"


### PR DESCRIPTION
When [building yojson in the CI](https://ocaml.ci.dev/github/ocaml-community/yojson/commit/e201639f68bb983c50ac3a9af10630fa78ef07f0/variant/freebsd-4.14_opam-2.1) I noticed the FreeBSD workers always fail and this is due to the dependency on `core_unix` which doesn't seem to work on FreeBSD, presumably because the stubs don't generate the symbols on FreeBSD:

```
ld: error: undefined symbol: core_linux_timerfd_create
>>> referenced by linux_ext.o:(.text+0x39FD) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x32D0) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_settime
>>> referenced by linux_ext.o:(.text+0x3C61) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.text+0x3F41) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x32C8) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_gettime
>>> referenced by linux_ext.o:(.text+0x3E9A) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x32C0) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_CLOCK_REALTIME
>>> referenced by linux_ext.o:(.text+0x7364) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x32F0) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_CLOCK_MONOTONIC
>>> referenced by linux_ext.o:(.text+0x737E) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x32E8) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_TFD_NONBLOCK
>>> referenced by linux_ext.o:(.text+0x7430) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x32E0) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_TFD_CLOEXEC
>>> referenced by linux_ext.o:(.text+0x7449) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x32D8) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
cc: error: linker command failed with exit code 1 (use -v to see invocation) File "caml_startup", line 1:
Error: Error during linking (exit code 1)
```