### PR TITLE
[new release] miou (0.2.0)

### DIFF
--- a/packages/miou/miou.0.2.0/opam
+++ b/packages/miou/miou.0.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://git.robur.coop/robur/miou"
+bug-reports:  "https://git.robur.coop/robur/miou/issues"
+dev-repo:     "git+https://github.com/robur-coop/miou.git"
+doc:          "https://docs.osau.re/miou/"
+license:      "MIT"
+synopsis:     "Composable concurrency primitives for OCaml"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"             {>= "5.0.0"}
+  "dune"              {>= "2.8.0"}
+  "dscheck"           {with-test & >= "0.4.0"}
+  "digestif"          {with-test}
+  "happy-eyeballs"    {with-test & >= "0.6.0"}
+  "dns-client"        {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test}
+  "ipaddr"            {with-test}
+  "logs"              {with-test & >= "0.7.0"}
+  "dns"               {with-test}
+  "dns-client"        {with-test}
+  "mtime"             {with-test & >= "2.0.0"}
+]
+url {
+  src:
+    "https://github.com/robur-coop/miou/releases/download/v0.2.0/miou-0.2.0.tbz"
+  checksum: [
+    "sha256=8716021b53640c46d5c83bcdf1e4bf163eacd746324bb3511a5c8d3a42f2eac0"
+    "sha512=dd2c488e22552a05cf66e88eaf7e55d9980a442c603edd047182707ab87036974aa03c9139754321ab736b42439cb28738a18cb2f568a8429b653a5d89e60c5f"
+  ]
+}
+x-commit-hash: "bedc462649427b2dc26471850592e1191108f60e"


### PR DESCRIPTION
Composable concurrency primitives for OCaml

- Project page: <a href="https://git.robur.coop/robur/miou">https://git.robur.coop/robur/miou</a>
- Documentation: <a href="https://docs.osau.re/miou/">https://docs.osau.re/miou/</a>

##### CHANGES:

- Don't try to abusively fill the pipe to interrupt a domain

  Interrupting a domain involves writing to a pipe to interrupt the `select(2)`
  if it is running. The pipe has a limited memory, depending on the system, and
  if you ask to interrupt a domain too much, you end up blocking the `write`.
  This patch prevents writing to the pipe if it has not yet been read.

  (@dinosaure, robur-coop/miou#46)

- Expose the Sequence module
  (@dinosaure, robur-coop/miou#47)
- Be able to add a hook (effect free) into the scheduler

  It is possible to add a hook to the scheduler. If the user wants to execute a
  function to a domain each time the domain is busy with a task, they can do so.
  However, the effects are not managed in the passed function.

  (@dinosaure, robur-coop/miou#48)

- Add `Miou.Lazy`, a domain-safe `Lazy` module like `Stdlib.Lazy`
  (@dinosaure, initially implemented by @polytypic, robur-coop/miou#49)
- Raise an exception if the user uses syscalls (from `Miou_unix`) and `Miou.run`
  instead of `Miou_unix.run`

  If a user uses a suspend function offered by `Miou_unix` but does not use
  `Miou_unix.run`, the programme may block indefinitely. This patch prevents
  such an error by raising an exception if we want to add a suspension point and
  we haven't specified how to handle it (if we use `Miou.run` instead of
  `Miou_unix.run`).

  (@dinosaure, reported by @kit-ty-kate, robur-coop/miou#51)

- Rename `Miou.set_signal` to `Miou.sys_signal`
  (@dinosaure, robur-coop/miou#50)

- Improve `Miou_unix.{read,write}`
  (@kit-ty-kate, @dinosaure, robur-coop/miou#52, 2f552a6, robur-coop/miou#54)
- Fix an issue related to the dom0 and pending tasks locked by mutexes

  Tasks may have been transmitted to dom0 while it was executing a task and
  before the `select(2)`. This patch resynchronises the pending tasks in dom0's
  TODO-list before making the `select(2)`: specifically to find out whether the
  `select(2)` can block indefinitely or not. This patch also cleans up the old
  states of the tables used by `Miou_unix` if it is used on an ongoing basis (as
  in the case of tests).

  (@dinosaure, robur-coop/miou#53)

- Add `Miou.Domain.available`
  (@dinosaure, robur-coop/miou#53)
- Fix a race condition (observed with TSan) when we wait the cancellation of a
  children

  This patch changes Miou's behaviour a little when waiting for a task to be
  cancelled and prevents invalid access to a value that does not belong to the
  current domain (and which can be modified by another domain). Thanks
  @OlivierNicole and @fabbing for their advice on using TSan.

  (@dinosaure, robur-coop/miou#56)

- Update the layout of Miou to avoid conflicts with other packages (like `backoff`)
  (@dinosaure, reported by @patricoferris, robur-coop/miou#57)
- OCaml 5.3 support
  (@kit-ty-kate, github#22)
- Rename `Miou.call_cc` to `Miou.async`
  (@dinosaure, @kit-ty-kate, @Armael, github#23)
