### PR TITLE
[new release] melange-recharts (4.0.3)

### DIFF
--- a/packages/melange-recharts/melange-recharts.4.0.3/opam
+++ b/packages/melange-recharts/melange-recharts.4.0.3/opam
@@ -18,7 +18,6 @@ depends: [
   "reason" {>= "3.10.0"}
   "reason-react" {>= "0.14.0"}
   "reason-react-ppx" {>= "0.14.0"}
-  "ocaml-lsp-server" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/melange-recharts/melange-recharts.4.0.3/opam
+++ b/packages/melange-recharts/melange-recharts.4.0.3/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Melange bindings for recharts"
+description: "Melange bindings for recharts JavaScript library."
+maintainer: [
+  "Liubomyr Mykhalchenko <liubomyr.mykhalchenko@ahrefs.com>"
+]
+authors: [
+  "Liubomyr Mykhalchenko <liubomyr.mykhalchenko@ahrefs.com>"
+]
+license: "MIT"
+tags: ["melange" "org:ahrefs"]
+homepage: "https://github.com/ahrefs/melange-recharts/"
+bug-reports: "https://github.com/ahrefs/melange-recharts/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml"
+  "melange" {>= "3.0.0"}
+  "reason" {>= "3.10.0"}
+  "reason-react" {>= "0.14.0"}
+  "reason-react-ppx" {>= "0.14.0"}
+  "ocaml-lsp-server" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/melange-recharts.git"
+depexts: [
+  ["recharts"] {npm-version = "^2.1.12"}
+]
+url {
+  src:
+    "https://github.com/ahrefs/melange-recharts/releases/download/4.0.3/melange-recharts-4.0.3.tbz"
+  checksum: [
+    "sha256=1295e56c252d53ca85bf814404e4bc40b02ba095b33cd48cd1b44d05514bae0c"
+    "sha512=a204b818dbc3e01dd4e8ceacabc70221844592b2e7163dfc7375051b921253285a38cf502e7c2cd8c613d04ceee9270408e572b43bdae4988fc164c35adec933"
+  ]
+}
+x-commit-hash: "83c65fa3a67ce3e8d0e4b673a3b150f65311c7f1"


### PR DESCRIPTION
Melange bindings for recharts

- Project page: <a href="https://github.com/ahrefs/melange-recharts/">https://github.com/ahrefs/melange-recharts/</a>

##### CHANGES:

- add `filterNull` to `Tooltip`
- support `melange.3.0.0` and `reason-react.0.14.0`
