### PR TITLE
[new release] gluten (6 packages) (0.5.1)

### DIFF
--- a/packages/gluten-async/gluten-async.0.5.1/opam
+++ b/packages/gluten-async/gluten-async.0.5.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Async support for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "gluten" {= version}
+  "faraday-async" {>= "0.7.3"}
+  "async" {>= "v0.15.0"}
+  "core" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+depopts: ["async_ssl" "tls-async"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.1/gluten-0.5.1.tbz"
+  checksum: [
+    "sha256=55971b3050d1bfe4d54971b4e70518c5a59b4e70526b8dd1895c7d39eb0f9d96"
+    "sha512=5a27e7a39f375b07910575839be75c62459ee55f35dd2b511db624b48f6ba86a6b1f8e749e6b3eeb4743e0890ba1952914e4df74a76dacb3062fadd9667e29cd"
+  ]
+}
+x-commit-hash: "a2439efe4f187b8c43dee577299470660503a73d"

--- a/packages/gluten-eio/gluten-eio.0.5.1/opam
+++ b/packages/gluten-eio/gluten-eio.0.5.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "EIO runtime for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "gluten" {= version}
+  "eio" {>= "0.12"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.1/gluten-0.5.1.tbz"
+  checksum: [
+    "sha256=55971b3050d1bfe4d54971b4e70518c5a59b4e70526b8dd1895c7d39eb0f9d96"
+    "sha512=5a27e7a39f375b07910575839be75c62459ee55f35dd2b511db624b48f6ba86a6b1f8e749e6b3eeb4743e0890ba1952914e4df74a76dacb3062fadd9667e29cd"
+  ]
+}
+x-commit-hash: "a2439efe4f187b8c43dee577299470660503a73d"

--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.1/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Lwt + Unix support for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "gluten-lwt" {= version}
+  "faraday-lwt-unix" {>= "0.7.3"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "lwt_ssl" {>= "1.2.0"}
+  "tls-lwt"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.1/gluten-0.5.1.tbz"
+  checksum: [
+    "sha256=55971b3050d1bfe4d54971b4e70518c5a59b4e70526b8dd1895c7d39eb0f9d96"
+    "sha512=5a27e7a39f375b07910575839be75c62459ee55f35dd2b511db624b48f6ba86a6b1f8e749e6b3eeb4743e0890ba1952914e4df74a76dacb3062fadd9667e29cd"
+  ]
+}
+x-commit-hash: "a2439efe4f187b8c43dee577299470660503a73d"

--- a/packages/gluten-lwt/gluten-lwt.0.5.1/opam
+++ b/packages/gluten-lwt/gluten-lwt.0.5.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Lwt-specific runtime for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "gluten" {= version}
+  "lwt" {>= "5.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.1/gluten-0.5.1.tbz"
+  checksum: [
+    "sha256=55971b3050d1bfe4d54971b4e70518c5a59b4e70526b8dd1895c7d39eb0f9d96"
+    "sha512=5a27e7a39f375b07910575839be75c62459ee55f35dd2b511db624b48f6ba86a6b1f8e749e6b3eeb4743e0890ba1952914e4df74a76dacb3062fadd9667e29cd"
+  ]
+}
+x-commit-hash: "a2439efe4f187b8c43dee577299470660503a73d"

--- a/packages/gluten-mirage/gluten-mirage.0.5.1/opam
+++ b/packages/gluten-mirage/gluten-mirage.0.5.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Mirage support for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "gluten-lwt" {= version}
+  "faraday-lwt" {>= "0.7.3"}
+  "conduit-mirage" {>= "2.0.2"}
+  "mirage-flow" {>= "2.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.1/gluten-0.5.1.tbz"
+  checksum: [
+    "sha256=55971b3050d1bfe4d54971b4e70518c5a59b4e70526b8dd1895c7d39eb0f9d96"
+    "sha512=5a27e7a39f375b07910575839be75c62459ee55f35dd2b511db624b48f6ba86a6b1f8e749e6b3eeb4743e0890ba1952914e4df74a76dacb3062fadd9667e29cd"
+  ]
+}
+x-commit-hash: "a2439efe4f187b8c43dee577299470660503a73d"

--- a/packages/gluten/gluten.0.5.1/opam
+++ b/packages/gluten/gluten.0.5.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A reusable runtime library for network protocols"
+description:
+  "gluten implements platform specific runtime code for driving network libraries based on state machines, such as http/af, h2 and websocketaf."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "bigstringaf" {>= "0.4.0"}
+  "faraday" {>= "0.7.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.1/gluten-0.5.1.tbz"
+  checksum: [
+    "sha256=55971b3050d1bfe4d54971b4e70518c5a59b4e70526b8dd1895c7d39eb0f9d96"
+    "sha512=5a27e7a39f375b07910575839be75c62459ee55f35dd2b511db624b48f6ba86a6b1f8e749e6b3eeb4743e0890ba1952914e4df74a76dacb3062fadd9667e29cd"
+  ]
+}
+x-commit-hash: "a2439efe4f187b8c43dee577299470660503a73d"

--- a/packages/styled-ppx/styled-ppx.0.56.0/opam
+++ b/packages/styled-ppx/styled-ppx.0.56.0/opam
@@ -37,7 +37,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
A reusable runtime library for network protocols

- Project page: <a href="https://github.com/anmonteiro/gluten">https://github.com/anmonteiro/gluten</a>

##### CHANGES:

- gluten-lwt,gluten-eio: remove `Client.socket`
  ([anmonteiro/gluten#75](https://github.com/anmonteiro/gluten/pull/75))
- gluten-eio: don't require `Eio_unix.stream_socket_ty`, allowing the use of
  mock sockets ([anmonteiro/gluten#74](https://github.com/anmonteiro/gluten/pull/74))
