### PR TITLE
Add missing dependency on cppo that used to be included by Yojson

### DIFF
--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.09/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.09/opam
@@ -29,6 +29,7 @@ depends: [
   "pcre" { >= "7.4.3" }
   "ounit" {with-test}
   "bos" { >= "0.2.0" }
+  "cppo"
 ]
 build: [
   [make "sys"]


### PR DESCRIPTION
[Build fails](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/dd1f7a904024287a3f7f1288feb4a3694f856d28/variant/compilers,4.14,yojson.2.2.1,revdeps,pa_ppx_q_ast.0.09) with

```
/bin/sh: 1: cppo: not found
```

Which is due to Yojson not depending on CPPO anymore. Similar to #26009.