### PR TITLE
[new release] picos (0.4.0)

### DIFF
--- a/packages/picos/picos.0.4.0/opam
+++ b/packages/picos/picos.0.4.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Pico scheduler interface"
+description:
+  "A systems programming interface between effects based schedulers and concurrent abstractions."
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/picos"
+bug-reports: "https://github.com/ocaml-multicore/picos/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "backoff" {>= "0.1.0"}
+  "thread-local-storage" {>= "0.1"}
+  "mtime" {>= "2.0.0"}
+  "psq" {>= "0.2.1"}
+  "multicore-magic" {>= "2.2.0"}
+  "lwt" {>= "5.7.0"}
+  "multicore-bench" {>= "0.1.3" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "qcheck-core" {>= "0.21.2" & with-test}
+  "qcheck-stm" {>= "0.3" & with-test}
+  "qcheck-multicoretests-util" {>= "0.3" & with-test}
+  "mdx" {>= "2.4.0" & with-test}
+  "ocaml-version" {>= "3.6.4" & with-test}
+  "domain_shims" {>= "0.1.0" & with-test}
+  "js_of_ocaml" {>= "5.4.0" & with-test}
+  "conf-npm" {arch != "x86_32" & arch != "riscv64" & with-test}
+  "dscheck" {>= "0.4.0" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
+  "ocaml" {>= "4.14.0"}
+]
+depopts: [
+  "cohttp" {>= "5.3.1" & with-test}
+  "cohttp-lwt" {>= "5.3.0" & with-test}
+  "cohttp-lwt-unix" {>= "5.3.0" & with-test}
+  "conduit-lwt-unix" {>= "6.2.2" & with-test}
+  "uri" {>= "4.4.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/picos.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/picos/releases/download/0.4.0/picos-0.4.0.tbz"
+  checksum: [
+    "sha256=343a8b4759239ca0c107145b8e2cc94c14625fecc0b0887d3c40a9ab7537b8da"
+    "sha512=db22b0a5b3adc603c0e815c9011c779f892b9ace76be018b2198d3e24a7d96727c999701025fe5a5fd07d0b452cb7286fc50c939aba0e4dce809941e9ebc12a6"
+  ]
+}
+x-commit-hash: "7d85f8573163a1ff547b51bd4763b6ab7df8095a"


### PR DESCRIPTION
Pico scheduler interface

- Project page: <a href="https://github.com/ocaml-multicore/picos">https://github.com/ocaml-multicore/picos</a>

##### CHANGES:

- Renamed `Picos_mpsc_queue` to `Picos_mpscq`. (@polytypic)

- Core API changes:

  - Added `Computation.returned`. (@polytypic)

- `Lwt` interop improvements:

  - Fixed `Picos_lwt` handling of `Cancel_after` to not raise in case of
    cancelation. (@polytypic)

  - Redesigned `Picos_lwt` to take a `System` module, which must implement a
    semi thread-safe trigger mechanism to allow unblocking `Lwt` promises on the
    main thread. (@polytypic)

  - Added `Picos_lwt_unix` interface to `Lwt`, which includes an internal
    `System` module implemented using `Lwt_unix`. (@polytypic)

  - Dropped thunking from `Picos_lwt.await`. (@polytypic)

- Added a randomized multicore scheduler `Picos_randos` for testing.
  (@polytypic)

- Changed `Picos_select.check_configured` to always (re)configure signal
  handling on the current thread. (@polytypic)

- `Picos_structured`:

  - Added a minimalistic `Promise` abstraction. (@polytypic)
  - Changed to more consistently not treat `Terminate` as an error. (@polytypic)

- Changed schedulers to take `~forbid` as an optional argument. (@polytypic)

- Various minor additions, fixes, and documentation improvements. (@polytypic)
