### PR TITLE
[new release] dune (15 packages) (3.16.0~alpha1)

### DIFF
--- a/packages/chrome-trace/chrome-trace.3.16.0~alpha1/opam
+++ b/packages/chrome-trace/chrome-trace.3.16.0~alpha1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Chrome trace event generation library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.16.0_alpha1/dune-3.16.0.alpha1.tbz"
+  checksum: [
+    "sha256=70a853781260253254d502fc5ba8672f607688945dadd790c5b822feed793f5c"
+    "sha512=f5d0c2f5786592fb3dd000660a267466d7401fa683666ccb095ae88ddf69d23bc48919f5b8fd8f7c522ec7218f0b14bc61f33ae9fcf88d1e22d2f76eeff78c0f"
+  ]
+}
+x-commit-hash: "9ae295e62d28a3d27a674e67fbed683c82e32bc6"

--- a/packages/dune-action-plugin/dune-action-plugin.3.16.0~alpha1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.16.0~alpha1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "dune-glob" {= version}
+  "csexp" {>= "1.5.0"}
+  "ppx_expect" {with-test}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "dune-rpc" {= version}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.16.0_alpha1/dune-3.16.0.alpha1.tbz"
+  checksum: [
+    "sha256=70a853781260253254d502fc5ba8672f607688945dadd790c5b822feed793f5c"
+    "sha512=f5d0c2f5786592fb3dd000660a267466d7401fa683666ccb095ae88ddf69d23bc48919f5b8fd8f7c522ec7218f0b14bc61f33ae9fcf88d1e22d2f76eeff78c0f"
+  ]
+}
+x-commit-hash: "9ae295e62d28a3d27a674e67fbed683c82e32bc6"

--- a/packages/dune-build-info/dune-build-info.3.16.0~alpha1/opam
+++ b/packages/dune-build-info/dune-build-info.3.16.0~alpha1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Embed build information inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.16.0_alpha1/dune-3.16.0.alpha1.tbz"
+  checksum: [
+    "sha256=70a853781260253254d502fc5ba8672f607688945dadd790c5b822feed793f5c"
+    "sha512=f5d0c2f5786592fb3dd000660a267466d7401fa683666ccb095ae88ddf69d23bc48919f5b8fd8f7c522ec7218f0b14bc61f33ae9fcf88d1e22d2f76eeff78c0f"
+  ]
+}
+x-commit-hash: "9ae295e62d28a3d27a674e67fbed683c82e32bc6"

--- a/packages/dune-configurator/dune-configurator.3.16.0~alpha1/opam
+++ b/packages/dune-configurator/dune-configurator.3.16.0~alpha1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.04.0"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.16.0_alpha1/dune-3.16.0.alpha1.tbz"
+  checksum: [
+    "sha256=70a853781260253254d502fc5ba8672f607688945dadd790c5b822feed793f5c"
+    "sha512=f5d0c2f5786592fb3dd000660a267466d7401fa683666ccb095ae88ddf69d23bc48919f5b8fd8f7c522ec7218f0b14bc61f33ae9fcf88d1e22d2f76eeff78c0f"
+  ]
+}
+x-commit-hash: "9ae295e62d28a3d27a674e67fbed683c82e32bc6"

--- a/packages/dune-glob/dune-glob.3.16.0~alpha1/opam
+++ b/packages/dune-glob/dune-glob.3.16.0~alpha1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "stdune" {= version}
+  "dyn"
+  "ordering"
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.16.0_alpha1/dune-3.16.0.alpha1.tbz"
+  checksum: [
+    "sha256=70a853781260253254d502fc5ba8672f607688945dadd790c5b822feed793f5c"
+    "sha512=f5d0c2f5786592fb3dd000660a267466d7401fa683666ccb095ae88ddf69d23bc48919f5b8fd8f7c522ec7218f0b14bc61f33ae9fcf88d1e22d2f76eeff78c0f"
+  ]
+}
+x-commit-hash: "9ae295e62d28a3d27a674e67fbed683c82e32bc6"

--- a/packages/dune-private-libs/dune-private-libs.3.16.0~alpha1/opam
+++ b/packages/dune-private-libs/dune-private-libs.3.16.0~alpha1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "csexp" {>= "1.5.0"}
+  "pp" {>= "1.1.0"}
+  "dyn" {= version}
+  "stdune" {= version}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.16.0_alpha1/dune-3.16.0.alpha1.tbz"
+  checksum: [
+    "sha256=70a853781260253254d502fc5ba8672f607688945dadd790c5b822feed793f5c"
+    "sha512=f5d0c2f5786592fb3dd000660a267466d7401fa683666ccb095ae88ddf69d23bc48919f5b8fd8f7c522ec7218f0b14bc61f33ae9fcf88d1e22d2f76eeff78c0f"
+  ]
+}
+x-commit-hash: "9ae295e62d28a3d27a674e67fbed683c82e32bc6"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.16.0~alpha1/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.16.0~alpha1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc and Lwt"
+description: "Specialization of dune-rpc to Lwt"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "dune-rpc" {= version}
+  "csexp" {>= "1.5.0"}
+  "lwt" {>= "5.6.0"}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.16.0_alpha1/dune-3.16.0.alpha1.tbz"
+  checksum: [
+    "sha256=70a853781260253254d502fc5ba8672f607688945dadd790c5b822feed793f5c"
+    "sha512=f5d0c2f5786592fb3dd000660a267466d7401fa683666ccb095ae88ddf69d23bc48919f5b8fd8f7c522ec7218f0b14bc61f33ae9fcf88d1e22d2f76eeff78c0f"
+  ]
+}
+x-commit-hash: "9ae295e62d28a3d27a674e67fbed683c82e32bc6"

--- a/packages/dune-rpc/dune-rpc.3.16.0~alpha1/opam
+++ b/packages/dune-rpc/dune-rpc.3.16.0~alpha1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.16.0_alpha1/dune-3.16.0.alpha1.tbz"
+  checksum: [
+    "sha256=70a853781260253254d502fc5ba8672f607688945dadd790c5b822feed793f5c"
+    "sha512=f5d0c2f5786592fb3dd000660a267466d7401fa683666ccb095ae88ddf69d23bc48919f5b8fd8f7c522ec7218f0b14bc61f33ae9fcf88d1e22d2f76eeff78c0f"
+  ]
+}
+x-commit-hash: "9ae295e62d28a3d27a674e67fbed683c82e32bc6"

--- a/packages/dune-site/dune-site.3.16.0~alpha1/opam
+++ b/packages/dune-site/dune-site.3.16.0~alpha1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Embed locations information inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.16.0_alpha1/dune-3.16.0.alpha1.tbz"
+  checksum: [
+    "sha256=70a853781260253254d502fc5ba8672f607688945dadd790c5b822feed793f5c"
+    "sha512=f5d0c2f5786592fb3dd000660a267466d7401fa683666ccb095ae88ddf69d23bc48919f5b8fd8f7c522ec7218f0b14bc61f33ae9fcf88d1e22d2f76eeff78c0f"
+  ]
+}
+x-commit-hash: "9ae295e62d28a3d27a674e67fbed683c82e32bc6"

--- a/packages/dune/dune.3.16.0~alpha1/opam
+++ b/packages/dune/dune.3.16.0~alpha1/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+Dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+Dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+Dune is composable; supporting multi-package development by simply
+dropping multiple repositories into the same directory.
+
+Dune also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
+  "base-unix"
+  "base-threads"
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.16.0_alpha1/dune-3.16.0.alpha1.tbz"
+  checksum: [
+    "sha256=70a853781260253254d502fc5ba8672f607688945dadd790c5b822feed793f5c"
+    "sha512=f5d0c2f5786592fb3dd000660a267466d7401fa683666ccb095ae88ddf69d23bc48919f5b8fd8f7c522ec7218f0b14bc61f33ae9fcf88d1e22d2f76eeff78c0f"
+  ]
+}
+x-commit-hash: "9ae295e62d28a3d27a674e67fbed683c82e32bc6"

--- a/packages/dyn/dyn.3.16.0~alpha1/opam
+++ b/packages/dyn/dyn.3.16.0~alpha1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.16.0_alpha1/dune-3.16.0.alpha1.tbz"
+  checksum: [
+    "sha256=70a853781260253254d502fc5ba8672f607688945dadd790c5b822feed793f5c"
+    "sha512=f5d0c2f5786592fb3dd000660a267466d7401fa683666ccb095ae88ddf69d23bc48919f5b8fd8f7c522ec7218f0b14bc61f33ae9fcf88d1e22d2f76eeff78c0f"
+  ]
+}
+x-commit-hash: "9ae295e62d28a3d27a674e67fbed683c82e32bc6"

--- a/packages/ocamlc-loc/ocamlc-loc.3.16.0~alpha1/opam
+++ b/packages/ocamlc-loc/ocamlc-loc.3.16.0~alpha1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Parse ocaml compiler output into structured form"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-lsp-server" {< "1.15.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.16.0_alpha1/dune-3.16.0.alpha1.tbz"
+  checksum: [
+    "sha256=70a853781260253254d502fc5ba8672f607688945dadd790c5b822feed793f5c"
+    "sha512=f5d0c2f5786592fb3dd000660a267466d7401fa683666ccb095ae88ddf69d23bc48919f5b8fd8f7c522ec7218f0b14bc61f33ae9fcf88d1e22d2f76eeff78c0f"
+  ]
+}
+x-commit-hash: "9ae295e62d28a3d27a674e67fbed683c82e32bc6"

--- a/packages/ordering/ordering.3.16.0~alpha1/opam
+++ b/packages/ordering/ordering.3.16.0~alpha1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.16.0_alpha1/dune-3.16.0.alpha1.tbz"
+  checksum: [
+    "sha256=70a853781260253254d502fc5ba8672f607688945dadd790c5b822feed793f5c"
+    "sha512=f5d0c2f5786592fb3dd000660a267466d7401fa683666ccb095ae88ddf69d23bc48919f5b8fd8f7c522ec7218f0b14bc61f33ae9fcf88d1e22d2f76eeff78c0f"
+  ]
+}
+x-commit-hash: "9ae295e62d28a3d27a674e67fbed683c82e32bc6"

--- a/packages/stdune/stdune.3.16.0~alpha1/opam
+++ b/packages/stdune/stdune.3.16.0~alpha1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "dyn" {= version}
+  "ordering" {= version}
+  "pp" {>= "1.2.0"}
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.16.0_alpha1/dune-3.16.0.alpha1.tbz"
+  checksum: [
+    "sha256=70a853781260253254d502fc5ba8672f607688945dadd790c5b822feed793f5c"
+    "sha512=f5d0c2f5786592fb3dd000660a267466d7401fa683666ccb095ae88ddf69d23bc48919f5b8fd8f7c522ec7218f0b14bc61f33ae9fcf88d1e22d2f76eeff78c0f"
+  ]
+}
+x-commit-hash: "9ae295e62d28a3d27a674e67fbed683c82e32bc6"

--- a/packages/xdg/xdg.3.16.0~alpha1/opam
+++ b/packages/xdg/xdg.3.16.0~alpha1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.16.0_alpha1/dune-3.16.0.alpha1.tbz"
+  checksum: [
+    "sha256=70a853781260253254d502fc5ba8672f607688945dadd790c5b822feed793f5c"
+    "sha512=f5d0c2f5786592fb3dd000660a267466d7401fa683666ccb095ae88ddf69d23bc48919f5b8fd8f7c522ec7218f0b14bc61f33ae9fcf88d1e22d2f76eeff78c0f"
+  ]
+}
+x-commit-hash: "9ae295e62d28a3d27a674e67fbed683c82e32bc6"


### PR DESCRIPTION
Fast, portable, and opinionated build system

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

### Added

- allow libraries with the same `(name ..)` in projects as long as they don't
  conflict during resolution (via `enabled_if`). (ocaml/dune#10307, @anmonteiro,
  @jchavarri)

- `dune describe pp` now finds the exact module and the stanza it belongs to,
  instead of guessing the name of the preprocessed file. (ocaml/dune#10321, @anmonteiro)

- Print the result of `dune describe pp` with the respective dialect printer.
  (ocaml/dune#10322, @anmonteiro)

- Add new flag `--context` to `dune ocaml-merlin`, which allows to select a
  Dune context when requesting Merlin config. Add `dune describe contexts`
  subcommand. Introduce a field `generate_merlin_rules` for contexts declared
  in the workspace, that allows to optionally produce Merlin rules for other
  contexts besides the one selected for Merlin (ocaml/dune#10324, @jchavarri)

- melange: add include paths for private library `.cmj` files during JS
  emission. (ocaml/dune#10416, @anmonteiro)

- `dune ocaml-merlin`: communicate additional directives `SOURCE_ROOT`,
  `UNIT_NAME` (the actual name with wrapping) and `INDEX` with the paths to the
  index(es). (ocaml/dune#10422, @voodoos)

- Add a new alias `@ocaml-index` that uses the `ocaml-index` binary to generate
  indexes that can be read by tools such as Merlin to provide project-wide
  references search. (ocaml/dune#10422, @voodoos)

- merlin: add optional `(merlin_reader CMD)` construct to `(dialect)` stanza to
  configure a merlin reader (ocaml/dune#8567, @andreypopp)

### Changed

- melange: treat private libraries with `(package ..)` as public libraries,
  fixing an issue where `import` paths were wrongly emitted. (ocaml/dune#10415,
  @anmonteiro)

- install `.glob` files for Coq theories too (ocaml/dune#10602, @ejgallego)

### Fixed

- Don't try to document non-existent libraries in doc-new target (ocaml/dune#10319, fixes
  ocaml/dune#10056, @jonludlam)

- Make `dune-site`'s `load_all` function look for `META` files so that it
  doesn't fail on empty directories in the plugin directory (ocaml/dune#10458, fixes
  ocaml/dune#10457, @shym)

- Fix incorrect warning for libraries defined inside non-existant directories
  using `(subdir ..)` and used by executables using `dune-build-info` (ocaml/dune#10525,
  @rgrinberg)

- Don't try to take build lock when running `coq top --no-build` (ocaml/dune#10547, fixes
  ocaml/dune#7671, @lzy0505)

- Make sure to truncate dune's lock file after locking and unlocking so that
  users cannot observe incorrect pid's (ocaml/dune#10575, @rgrinberg)

- mdx: link mdx binary with `byte_complete`. This fixes `(libraries)` with
  foreign archives on Linux. (ocaml/dune#10586, fixes ocaml/dune#10582, @anmonteiro)
