### PR TITLE
bin_prot v0.17 is not compatible with freebsd

### DIFF
--- a/packages/bin_prot/bin_prot.v0.17.0/opam
+++ b/packages/bin_prot/bin_prot.v0.17.0/opam
@@ -24,7 +24,7 @@ depends: [
 depopts: [
   "mirage-xen-ocaml"
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "arm32" & arch != "x86_32" & os != "freebsd"
 synopsis: "A binary protocol generator"
 description: "
 Part of Jane Street's Core library


### PR DESCRIPTION
```

#=== ERROR while compiling bin_prot.v0.17.0 ===================================#
# context              2.2.0~beta3~dev | freebsd/x86_64 | ocaml-base-compiler.5.2.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.2.0/.opam-switch/build/bin_prot.v0.17.0
# command              ~/.opam/5.2.0/bin/dune build -p bin_prot -j 15
# exit-code            1
# env-file             ~/.opam/log/bin_prot-22577-03b560.env
# output-file          ~/.opam/log/bin_prot-22577-03b560.out
### output ###
# File "xen/dune", line 1, characters 0-111:
# 1 | (rule
# 2 |  (targets cflags.sexp)
# 3 |  (deps
# 4 |   (:first_dep cflags.sh))
# 5 |  (action
# 6 |   (bash "./%{first_dep} > %{targets}")))
# (cd _build/default/xen && /usr/local/bin/bash -e -u -o pipefail -c './cflags.sh > cflags.sexp')
# /usr/local/bin/bash: line 1: ./cflags.sh: cannot execute: required file not found
```