### PR TITLE
[new release] melange-moment (0.4.0)

### DIFF
--- a/packages/melange-moment/melange-moment.0.4.0/opam
+++ b/packages/melange-moment/melange-moment.0.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Melange bindings for Moment.js"
+maintainer: "Ahrefs"
+authors: "Jiayu Liu <jimexist@gmail.com>"
+license: "MIT"
+tags: ["melange" "org:ahrefs"]
+homepage: "https://github.com/ahrefs/melange-moment"
+bug-reports: "https://github.com/ahrefs/melange-moment"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml"
+  "melange" {>= "3.0.0"}
+  "reason"
+  "melange-jest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/melange-moment.git"
+depexts: [
+  ["moment"] {npm-version = "^2.26.0"}
+]
+url {
+  src:
+    "https://github.com/ahrefs/melange-moment/releases/download/0.4.0/melange-moment-0.4.0.tbz"
+  checksum: [
+    "sha256=b065d855d6dbf504b1b2064e3fc370389a103fd3f081f206de5a80c253b5e73f"
+    "sha512=d0dafe0c788e2206f92616ad868192b8a3abcc411786c41df6837b26f0f21d4597d64289dd061c3c854b15b653b8781013bd3b8862eae8235f567b98a8867bd2"
+  ]
+}
+x-commit-hash: "e30fa0576fe18a14ed451e06dbc86ee3b280603e"


### PR DESCRIPTION
Melange bindings for Moment.js

- Project page: <a href="https://github.com/ahrefs/melange-moment">https://github.com/ahrefs/melange-moment</a>

##### CHANGES:

- Fix tests to work with melange v3: [ahrefs/melange-moment#7](https://github.com/ahrefs/melange-moment/pull/7/).
- Add support for ES6, place CommonJS support under `melange-moment.cjs`: [ahrefs/melange-moment#6](https://github.com/ahrefs/melange-moment/pull/6).
