### PR TITLE
[new release] mirage-qubes (2 packages) (0.10.0)

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.10.0/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.10.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "mirage-qubes" {= version}
+  "tcpip" { >= "8.1.0" }
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "ipaddr" { >= "3.0.0" }
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "lwt" { >= "5.7.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.10.0/mirage-qubes-0.10.0.tbz"
+  checksum: [
+    "sha256=8a3354e2c34d5d30dfc78a0255719926f76ad9c273e818a6855547dbfc109f9f"
+    "sha512=6d16e26eab01439f731ca330c919296324e1a26b8203ff25512fb3ec73770efd612a906890ed89eb384a71b6c3506939a8f08286359a48533e094d8774dede73"
+  ]
+}
+x-commit-hash: "1be2286c8383410384db76eb3282a097413827a1"

--- a/packages/mirage-qubes/mirage-qubes.0.10.0/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.10.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"  {>= "1.0"}
   "cstruct" { >= "6.0.0" }
   "vchan-xen" { >= "6.0.0" }
-  "mirage-xen" { >= "6.0.0" }
+  "mirage-xen" { >= "8.0.0" }
   "lwt" { >= "5.7.0" }
   "logs" { >= "0.5.0" }
   "ocaml" { >= "4.08.0" }

--- a/packages/mirage-qubes/mirage-qubes.0.10.0/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.10.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "cstruct" { >= "6.0.0" }
+  "vchan-xen" { >= "6.0.0" }
+  "mirage-xen" { >= "6.0.0" }
+  "lwt" { >= "5.7.0" }
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.08.0" }
+  "ohex" { >= "0.2.0" }
+  "fmt" {>= "0.8.5"}
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+description: """
+Implementations of various Qubes protocols:
+
+- Qubes.RExec: provide services to other VMs
+- Qubes.GUI: just enough of the GUI protocol so that Qubes accepts the AppVM
+- Qubes.DB: read and write the VM's QubesDB database"""
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.10.0/mirage-qubes-0.10.0.tbz"
+  checksum: [
+    "sha256=8a3354e2c34d5d30dfc78a0255719926f76ad9c273e818a6855547dbfc109f9f"
+    "sha512=6d16e26eab01439f731ca330c919296324e1a26b8203ff25512fb3ec73770efd612a906890ed89eb384a71b6c3506939a8f08286359a48533e094d8774dede73"
+  ]
+}
+x-commit-hash: "1be2286c8383410384db76eb3282a097413827a1"


### PR DESCRIPTION
Implementations of various Qubes protocols for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-qubes">https://github.com/mirage/mirage-qubes</a>
- Documentation: <a href="https://mirage.github.io/mirage-qubes">https://mirage.github.io/mirage-qubes</a>

##### CHANGES:

- Update the package with `tcpip.8.1.0` (mirage/mirage-qubes#67, @palainp, @dinosaure)
