### PR TITLE
Add MacPorts support for conf-autoconf and conf-libtool

### DIFF
--- a/packages/conf-autoconf/conf-autoconf.0.1/opam
+++ b/packages/conf-autoconf/conf-autoconf.0.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["sys-devel/autoconf"] {os-distribution = "gentoo"}
   ["autoconf"] {os-distribution = "nixos"}
   ["autoconf"] {os = "macos" & os-distribution = "homebrew"}
+  ["autoconf"] {os = "macos" & os-distribution = "macports"}
   ["devel/autoconf"] {os = "openbsd"}
   ["autoconf"] {os = "freebsd"}
   ["autoconf"] {os = "netbsd"}

--- a/packages/conf-libtool/conf-libtool.1/opam
+++ b/packages/conf-libtool/conf-libtool.1/opam
@@ -17,6 +17,7 @@ depexts: [
   ["sys-devel/libtool"] {os-distribution = "gentoo"}
   ["libtool"] {os-distribution = "nixos"}
   ["libtool"] {os = "macos" & os-distribution = "homebrew"}
+  ["libtool"] {os = "macos" & os-distribution = "macports"}
   ["devel/libtool"] {os = "openbsd"}
   ["libtool"] {os = "freebsd"}
   ["libtool"] {os = "netbsd"}


### PR DESCRIPTION
This PR adds MacPorts depext entries to conf-autoconf and conf-libtool.

I did not increase the version numbers because this doesn't change anything on OS variants where it did work before, so there is no need to recompile something on such platforms.