### PR TITLE
Fixes for +options packages for 4.13+

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
@@ -30,7 +30,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
@@ -30,8 +30,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
@@ -30,7 +30,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
@@ -30,8 +30,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
@@ -32,7 +32,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
@@ -32,8 +32,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
@@ -30,7 +30,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
@@ -30,8 +30,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+options/opam
@@ -30,7 +30,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+options/opam
@@ -30,8 +30,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.4.14.2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.2+options/opam
@@ -30,7 +30,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.4.14.2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.2+options/opam
@@ -30,8 +30,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.4.14.3+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.3+trunk/opam
@@ -32,7 +32,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.4.14.3+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.3+trunk/opam
@@ -32,8 +32,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
@@ -39,7 +39,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
@@ -39,8 +39,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
@@ -41,7 +41,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
@@ -41,8 +41,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
@@ -39,7 +39,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
@@ -39,8 +39,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
@@ -42,8 +42,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
@@ -42,7 +42,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
@@ -39,7 +39,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
@@ -39,8 +39,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
@@ -41,7 +41,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
@@ -41,8 +41,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
@@ -39,7 +39,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
@@ -39,8 +39,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+statmemprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+statmemprof/opam
@@ -41,7 +41,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+statmemprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+statmemprof/opam
@@ -41,8 +41,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~alpha1+options/opam
@@ -41,7 +41,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~alpha1+options/opam
@@ -41,8 +41,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/opam
@@ -41,7 +41,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/opam
@@ -41,8 +41,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~beta2+options/opam
@@ -41,7 +41,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~beta2+options/opam
@@ -41,8 +41,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~rc1+options/opam
@@ -41,7 +41,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~rc1+options/opam
@@ -41,8 +41,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.5.2.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.1+trunk/opam
@@ -41,7 +41,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.5.2.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.1+trunk/opam
@@ -41,8 +41,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)

--- a/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
@@ -41,7 +41,7 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32"}) |
+  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
    "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 

--- a/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
@@ -41,8 +41,8 @@ depends: [
   # The Windows ports explicitly select the architecture (see below) this
   # facility is not yet available for other platforms.
   "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  (("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}) |
-   "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post})
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
   "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
 
   # Port selection (Windows)


### PR DESCRIPTION
Two fixes following the report by @MSoegtropIMC in https://github.com/ocaml/opam-repository/pull/25861#issuecomment-2151803041 that macOS arm hardware was broken when using `ocaml-option-flambda` and also a fix for ocaml-ci also with flambda reported by @polytypic.

The macOS issue is unfortunate mistake in the conjunction which handles `ocaml-option-32bit` which had `os != "win32"` and was missing the `& arch != "x86_64"`). This meant that on non-Windows and non-x84 hardware, the +options required both `ocaml-option-32bit` to be installed (which is impossible) and even if they had, it would have tried to install two host-arch- packages, which is also impossible.

The ocaml-ci issue is down to the different solver it uses. opam's solver (including when using 0install) seeks to minimise the number of package installations, which means that `"host-arch-x86_32" "ocaml-option-32bit"` never looks as good to opam as `"host-arch-x86_64"`. The 0install solver explores the disjunction differently, and is content with either, as they both result in latest versions of packages being installed. It's content with the first one it encounters, so my workaround here is simply to flip the disjunction and have the x86_64 case first. The future work mentioned in #25861 seeks to make these option packages more explicit which should provide a more robust solution for this in future.