### PR TITLE
http-mirage-client: add an upper bound to mimic-happy-eyeballs at 0.0.7

### DIFF
--- a/packages/http-mirage-client/http-mirage-client.0.0.3/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.3/opam
@@ -15,7 +15,7 @@ depends: [
   "mirage-time" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}
   "lwt" {>= "5.5.0"}
-  "mimic-happy-eyeballs"
+  "mimic-happy-eyeballs" {< "0.0.8"}
   "httpaf"
   "alcotest-lwt" {with-test}
   "mirage-clock-unix" {with-test}

--- a/packages/http-mirage-client/http-mirage-client.0.0.4/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.4/opam
@@ -15,7 +15,7 @@ depends: [
   "mirage-time" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}
   "lwt" {>= "5.5.0"}
-  "mimic-happy-eyeballs"
+  "mimic-happy-eyeballs" {< "0.0.8"}
   "httpaf"
   "alcotest-lwt" {with-test}
   "mirage-clock-unix" {with-test & >= "4.0.0"}

--- a/packages/http-mirage-client/http-mirage-client.0.0.5/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.5/opam
@@ -15,7 +15,7 @@ depends: [
   "mirage-time" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}
   "lwt" {>= "5.5.0"}
-  "mimic-happy-eyeballs"
+  "mimic-happy-eyeballs" {< "0.0.8"}
   "httpaf"
   "alcotest-lwt" {with-test}
   "mirage-clock-unix" {with-test & >= "4.0.0"}


### PR DESCRIPTION
failure:
```
== ERROR while compiling http-mirage-client.0.0.3 ===========================#
context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
path                 ~/.opam/4.14/.opam-switch/build/http-mirage-client.0.0.3
command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p http-mirage-client -j 31 @install
exit-code            1
env-file             ~/.opam/log/http-mirage-client-7-eb3b40.env
output-file          ~/.opam/log/http-mirage-client-7-eb3b40.out
 # output ###
(cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.http_mirage_client.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/asn1-combinators -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/eqaf/bigstring -I /home/opam/.opam/4.14/lib/eqaf/cstruct -I /home/opam/.opam/4.14/lib/faraday -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/gmap -I /home/opam/.opam/4.14/lib/h2 -I /home/opam/.opam/4.14/lib/happy-eyeballs -I /home/opam/.opam/4.14/lib/happy-eyeballs-mirage -I /home/opam/.opam/4.14/lib/hpack -I /home/opam/.opam/4.14/lib/httpaf -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ke -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/mimic -I /home/opam/.opam/4.14/lib/mimic-happy-eyeballs -I /home/opam/.opam/4.14/lib/mirage-clock -I /home/opam/.opam/4.14/lib/mirage-crypto -I /home/opam/.opam/4.14/lib/mirage-crypto-ec -I /home/opam/.opam/4.14/lib/mirage-crypto-pk -I /home/opam/.opam/4.14/lib/mirage-crypto-rng -I /home/opam/.opam/4.14/lib/mirage-flow -I /home/opam/.opam/4.14/lib/mirage-time -I /home/opam/.opam/4.14/lib/paf -I /home/opam/.opam/4.14/lib/pbkdf -I /home/opam/.opam/4.14/lib/psq -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/tcpip -I /home/opam/.opam/4.14/lib/x509 -I /home/opam/.opam/4.14/lib/zarith -no-alias-deps -o src/.http_mirage_client.objs/byte/http_mirage_client.cmi -c -intf src/http_mirage_client.mli)
File "src/http_mirage_client.mli", line 27, characters 17-34:
27 |   -> ?tls_config:Tls.Config.client
                      ^^^^^^^^^^^^^^^^^
Error: Unbound module Tls
```

Now, the underlying issue is a non-declared dependency in http-mirage-client (namely tls), and mimic-happy-eyeballs 0.0.8 supports happy-eyeballs-mirage 1.1.0 which no longer depends on dns-client-mirage (which depends on tls).