### PR TITLE
[new release] html_of_jsx (0.0.3)

### DIFF
--- a/packages/html_of_jsx/html_of_jsx.0.0.3/opam
+++ b/packages/html_of_jsx/html_of_jsx.0.0.3/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Render HTML with JSX"
+description:
+  "html_of_jsx is a JSX transformation that allows you to write HTML declaratively."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/davesnx/html_of_jsx"
+bug-reports: "https://github.com/davesnx/html_of_jsx/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "5.0.0"}
+  "reason" {>= "3.10.0"}
+  "ppxlib" {> "0.23.0"}
+  "rope" {>= "0.6.3"}
+  "alcotest" {with-test}
+  "benchmark" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {= "0.26.1" & with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "tiny_httpd" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/html_of_jsx.git"
+url {
+  src:
+    "https://github.com/davesnx/html_of_jsx/releases/download/0.0.3/html_of_jsx-0.0.3.tbz"
+  checksum: [
+    "sha256=c9427679a424a5c4fa5b0547c01af15bc00960df838858c4eb3124acdca301cb"
+    "sha512=354f8168d2ab9c7e3b4821dfe01c430be80d9610e764c96259f5edfc52d47fe2e3abbc6600a1d423df8e5d4b4b4ae09637050fa430f12623a5ff07c15b8c1461"
+  ]
+}
+x-commit-hash: "773029db72e9186e591f2eefd031e2e05d828a19"

--- a/packages/html_of_jsx/html_of_jsx.0.0.3/opam
+++ b/packages/html_of_jsx/html_of_jsx.0.0.3/opam
@@ -16,7 +16,7 @@ depends: [
   "alcotest" {with-test}
   "benchmark" {with-test}
   "odoc" {with-doc}
-  "ocamlformat" {= "0.26.1" & with-dev-setup}
+  "ocamlformat" {= "0.26.1" & (with-dev-setup |with-test)}
   "ocaml-lsp-server" {with-dev-setup}
   "tiny_httpd" {with-dev-setup}
 ]


### PR DESCRIPTION
Render HTML with JSX

- Project page: <a href="https://github.com/davesnx/html_of_jsx">https://github.com/davesnx/html_of_jsx</a>

##### CHANGES:

## 0.0.3

- [BREAKING] `Html_of_jsx.render` lives under `JSX.render` (removing the `Html_of_jsx` module entirely) (@lessp)
- [BREAKING] Module `Jsx` is turned into `JSX` (@lessp)
- [BREAKING] dune's library is now `html_of_jsx` instead of (`html_of_jsx.lib`) (@lessp)
- [BREAKING] `JSX.element` is opaque (can't see the type from outside), but we have a `JSX.Debug` module to inspect and re-construct `JSX.element` (cc @leostera) (@lessp)
- Improved performance of `JSX.render` (@lessp)
- add hx-trigger to htmx ppx #13 (@lessp)
- htmlFor -> for_ (@lessp)
- Fix aria-autocomplete (@davesnx)

## 0.0.2

- Add `Jsx.unsafe` to allow unsafe HTML as children
- Fix HTML attributes formatting (charset, autocomplete, tabindex, inputmode, etc...)
- Enable HTMX attributes via `html_of_jsx.ppx -htmx`

## 0.0.1

- First working version of the ppx and library
- Supports most of features from [JSX](https://reasonml.github.io/docs/en/jsx) (uppercase components, fragments, optional attributes, punning)
- but with a few improvements (lowercase components, no need to add annotations)
- No React idioms (no `className`, no `htmlFor`, no `onChange`, etc...)
- Type-safe, validates attributes and their types ([it can be better thought](https://github.com/davesnx/html_of_jsx/issues/2))
- Minimal
  - `Html_of_jsx.render` to render an element to HTML
  - `Jsx.*` to construct DOM Elements and DOM nodes (`Jsx.text`, `Jsx.int`, `Jsx.null`, `Jsx.list`)
- Works with [Reason](https://reasonml.github.io) and [mlx](https://github.com/andreypopp/mlx)
- Supports some htmx under the ppx (`html_of_jsx.ppx -htmx`)
