### PR TITLE
release pa_ppx 0.15 w/Camlp5 8.03.00, ocaml 5.2 compatibility

### DIFF
--- a/packages/pa_ppx/pa_ppx.0.15/opam
+++ b/packages/pa_ppx/pa_ppx.0.15/opam
@@ -51,8 +51,8 @@ depends: [
   "cppo"
   "sexplib" { with-test & >= "v0.14.0" }
   "ppx_import" { with-test & >= "1.7.1"  & <= "1.11.0" }
-  "ppx_deriving" { with-test }
-  "ppx_deriving_yojson" { with-test & >= "3.5.2" }
+  "ppx_deriving" { with-test & <= "5.2.1" }
+  "ppx_deriving_yojson" { with-test & >= "3.5.2" & <= "3.7.0" }
   "ppx_here" { with-test & >= "v0.13.0" }
   "ppx_sexp_conv" { with-test & >= "v0.13.0" }
 #  "expect_test_helpers" { with-test & >= "v0.13.0" }

--- a/packages/pa_ppx/pa_ppx.0.15/opam
+++ b/packages/pa_ppx/pa_ppx.0.15/opam
@@ -48,6 +48,7 @@ depends: [
   "fmt"
   "uint" { >= "2.0.1" }
   "ounit"
+  "cppo"
   "sexplib" { with-test & >= "v0.14.0" }
   "ppx_import" { with-test & >= "1.7.1"  & <= "1.11.0" }
   "ppx_deriving" { with-test }

--- a/packages/pa_ppx/pa_ppx.0.15/opam
+++ b/packages/pa_ppx/pa_ppx.0.15/opam
@@ -71,6 +71,6 @@ install: [make "install"]
 url {
   src: "https://github.com/camlp5/pa_ppx/archive/refs/tags/0.15.tar.gz"
   checksum: [
-    "sha512=efb701c3b9c14c2ae89a8380e8f89aa340c671f4cf87e62da04a9afd4b499b747a4bc3c41286717b6397dde437f69d2f10a022c527dd803f33a156ea0db0ecfa"
+    "sha512=96a0a78b919923216569d6857ea1e6dfb9aee38c3da9439656b57249498c5d16d3b1a30a099f885fb399a9fe7b8176711ee89fea68067b587dd72b691f885db5"
   ]
 }

--- a/packages/pa_ppx/pa_ppx.0.15/opam
+++ b/packages/pa_ppx/pa_ppx.0.15/opam
@@ -51,8 +51,8 @@ depends: [
   "cppo"
   "sexplib" { with-test & >= "v0.14.0" }
   "ppx_import" { with-test & >= "1.7.1"  & <= "1.11.0" }
-  "ppx_deriving" { with-test & <= "5.2.1" }
-  "ppx_deriving_yojson" { with-test & >= "3.5.2" & <= "3.7.0" }
+  "ppx_deriving" { with-test & >= "6.0.2" }
+  "ppx_deriving_yojson" { with-test & >= "3.5.2" & >= "3.8.0" }
   "ppx_here" { with-test & >= "v0.13.0" }
   "ppx_sexp_conv" { with-test & >= "v0.13.0" }
 #  "expect_test_helpers" { with-test & >= "v0.13.0" }

--- a/packages/pa_ppx/pa_ppx.0.15/opam
+++ b/packages/pa_ppx/pa_ppx.0.15/opam
@@ -60,6 +60,7 @@ depends: [
 conflicts: [
   "base-effects"
   "ocaml-option-bytecode-only"
+  "pa_ppx_migrate" { <= "0.11" }
 ]
 build: [
   [make "get-generated"]

--- a/packages/pa_ppx/pa_ppx.0.15/opam
+++ b/packages/pa_ppx/pa_ppx.0.15/opam
@@ -1,0 +1,74 @@
+
+synopsis: "PPX Rewriters for Ocaml, written using Camlp5"
+description:
+"""
+This is a collection of PPX rewriters, re-implementing those based on ppxlib
+and other libraries, but instead based on Camlp5.  Included is also a collection
+of support libraries for writing new PPX rewriters.  Included are:
+
+pa_assert: ppx_assert
+pa_ppx.deriving, pa_ppx.deriving_plugins (enum, eq, fold, iter, make, map, ord, sexp, show, yojson):
+  ppx_deriving, plugins, ppx_sexp_conv, ppx_deriving_yojson
+pa_ppx.expect_test: ppx_expect_test
+pa_ppx.here: ppx_here
+pa_ppx.import: ppx_import
+pa_ppx.inline_test: ppx_inline_test
+
+pa_ppx.undo_deriving: pa_ppx.deriving expands [@@deriving ...] into code; this rewriter undoes that.
+pa_ppx.unmatched_vala: expands to match-cases (support library for camlp5-based PPX rewriters)
+pa_ppx.hashrecons: support for writing AST rewriters that automatically fills in hash-consing boilerplate
+pa_dock: implements doc-comment extraction for camlp5 preprocessors
+
+Many of the reimplementations in fact offer significant enhanced
+function, described in the pa_ppx documentation.  In addition, there
+is an extensive test-suite, much of it slightly modified versions of
+the tests for the respective PPX rewriters.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx.git"
+doc: "https://github.com/camlp5/pa_ppx/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "5.03.0" }
+  "conf-perl"
+  "camlp5-buildscripts" { >= "0.03" }
+  "camlp5"      { >= "8.03.00" }
+  "not-ocamlfind" { >= "0.10" }
+  "pcre2"
+  "result" { >= "1.5" }
+  "yojson" { >= "1.7.0" }
+  "sexplib0"
+  "bos" { >= "0.2.0" }
+  "fmt"
+  "uint" { >= "2.0.1" }
+  "ounit"
+  "sexplib" { with-test & >= "v0.14.0" }
+  "ppx_import" { with-test & >= "1.7.1"  & <= "1.11.0" }
+  "ppx_deriving" { with-test }
+  "ppx_deriving_yojson" { with-test & >= "3.5.2" }
+  "ppx_here" { with-test & >= "v0.13.0" }
+  "ppx_sexp_conv" { with-test & >= "v0.13.0" }
+#  "expect_test_helpers" { with-test & >= "v0.13.0" }
+]
+conflicts: [
+  "base-effects"
+  "ocaml-option-bytecode-only"
+]
+build: [
+  [make "get-generated"]
+  [make "-j%{jobs}%" "DEBUG=-g" "sys"]
+  [make "DEBUG=-g" "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx/archive/refs/tags/0.15.tar.gz"
+  checksum: [
+    "sha512=efb701c3b9c14c2ae89a8380e8f89aa340c671f4cf87e62da04a9afd4b499b747a4bc3c41286717b6397dde437f69d2f10a022c527dd803f33a156ea0db0ecfa"
+  ]
+}


### PR DESCRIPTION
very little changes except for adding AST support for OCaml 5.2