### PR TITLE
nuscr 2.0.0 is not compatible with base v0.17

### DIFF
--- a/packages/nuscr/nuscr.2.0.0/opam
+++ b/packages/nuscr/nuscr.2.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "menhir" {>= "20190924" & < "20211215"}
   "ppx_deriving" {>= "5.2"}
   "dune" {>= "2.8"}
-  "base" {>= "v0.12.0"}
+  "base" {>= "v0.12.0" & < "v0.17" }
   "stdio" {>= "v0.12.0"}
   "ppx_sexp_conv" {>= "v0.12.0"}
   "z3" {with-test}


### PR DESCRIPTION
Fails with
```
# File "lib/syntaxtree/syntax.ml", line 81, characters 24-43:
# 81 | let pp_payloadt fmt p = Caml.Format.fprintf fmt "%s" (show_payloadt p)
#                              ^^^^^^^^^^^^^^^^^^^
# Error: Unbound module "Caml.Format"

```