### PR TITLE
3 packages from gitlab.com/nomadic-labs/ringo/-/archive/v1.1.0/ringo-v1.1.0.tar.gz

### DIFF
--- a/packages/aches-lwt/aches-lwt.1.0.0/opam
+++ b/packages/aches-lwt/aches-lwt.1.0.0/opam
@@ -17,9 +17,9 @@ build: [
 synopsis: "Caches (bounded-size stores) for Lwt promises"
 url {
   src:
-    "https://gitlab.com/nomadic-labs/ringo/-/archive/v1.0.0/ringo-v1.0.0.tar.gz"
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v1.1.0/ringo-v1.1.0.tar.gz"
   checksum: [
-    "md5=c4bfe8506ee67b82bf5a4f5a989711d3"
-    "sha512=4c06df137173a605f14d1bf06193e591b02bd61518669f2d77513e7cd9ad7b660d5ea913cbb079eef8ac17246a71422827594dfe5ffaec032284e0de7e660305"
+    "md5=88f83ccdabc7052fbc761b406a545354"
+    "sha512=49d096bac7fd88df890bbc5ea9016805fcd3a50049d0a7b5afa36e9515035ec5ecbd1ace569cca4a07330249babd5952e21e6641824554b24547e33d9a30ac2d"
   ]
 }

--- a/packages/aches/aches.1.0.0/opam
+++ b/packages/aches/aches.1.0.0/opam
@@ -16,9 +16,9 @@ build: [
 synopsis: "Caches (bounded-size stores) for in-memory values and for resources"
 url {
   src:
-    "https://gitlab.com/nomadic-labs/ringo/-/archive/v1.0.0/ringo-v1.0.0.tar.gz"
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v1.1.0/ringo-v1.1.0.tar.gz"
   checksum: [
-    "md5=c4bfe8506ee67b82bf5a4f5a989711d3"
-    "sha512=4c06df137173a605f14d1bf06193e591b02bd61518669f2d77513e7cd9ad7b660d5ea913cbb079eef8ac17246a71422827594dfe5ffaec032284e0de7e660305"
+    "md5=88f83ccdabc7052fbc761b406a545354"
+    "sha512=49d096bac7fd88df890bbc5ea9016805fcd3a50049d0a7b5afa36e9515035ec5ecbd1ace569cca4a07330249babd5952e21e6641824554b24547e33d9a30ac2d"
   ]
 }

--- a/packages/ringo/ringo.1.0.0/opam
+++ b/packages/ringo/ringo.1.0.0/opam
@@ -15,9 +15,9 @@ build: [
 synopsis: "Bounded-length collections"
 url {
   src:
-    "https://gitlab.com/nomadic-labs/ringo/-/archive/v1.0.0/ringo-v1.0.0.tar.gz"
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v1.1.0/ringo-v1.1.0.tar.gz"
   checksum: [
-    "md5=c4bfe8506ee67b82bf5a4f5a989711d3"
-    "sha512=4c06df137173a605f14d1bf06193e591b02bd61518669f2d77513e7cd9ad7b660d5ea913cbb079eef8ac17246a71422827594dfe5ffaec032284e0de7e660305"
+    "md5=88f83ccdabc7052fbc761b406a545354"
+    "sha512=49d096bac7fd88df890bbc5ea9016805fcd3a50049d0a7b5afa36e9515035ec5ecbd1ace569cca4a07330249babd5952e21e6641824554b24547e33d9a30ac2d"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
-`aches.1.0.0`: Caches (bounded-size stores) for in-memory values and for resources
-`aches-lwt.1.0.0`: Caches (bounded-size stores) for Lwt promises
-`ringo.1.0.0`: Bounded-length collections



---
* Homepage: https://gitlab.com/nomadic-labs/ringo
* Source repo: git+https://gitlab.com/nomadic-labs/ringo.git
* Bug tracker: https://gitlab.com/nomadic-labs/ringo/issues

---
:camel: Pull-request generated by opam-publish v2.1.0