### PR TITLE
3 packages from gitlab.com/nomadic-labs/ringo/-/archive/v1.1.0/ringo-v1.1.0.tar.gz

### DIFF
--- a/packages/aches-lwt/aches-lwt.1.1.0/opam
+++ b/packages/aches-lwt/aches-lwt.1.1.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.08" }
+  "dune" { >= "1.7" }
+  "aches" { = version }
+  "lwt" { >= "5.4.0" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Caches (bounded-size stores) for Lwt promises"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v1.1.0/ringo-v1.1.0.tar.gz"
+  checksum: [
+    "md5=c9c5400e7ae19100b945279835ff3e5c"
+    "sha512=7f37b721e2ca32e5e96fbf8df1bbd72c9060b6826bd95a21ea81af5fdd0c1961d3d7fb41210966aac7c277ec7f91fd32e3e284b583cb02121dc589646642f5c0"
+  ]
+}

--- a/packages/aches/aches.1.1.0/opam
+++ b/packages/aches/aches.1.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.08" }
+  "dune" { >= "1.7" }
+  "ringo" { = version }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Caches (bounded-size stores) for in-memory values and for resources"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v1.1.0/ringo-v1.1.0.tar.gz"
+  checksum: [
+    "md5=c9c5400e7ae19100b945279835ff3e5c"
+    "sha512=7f37b721e2ca32e5e96fbf8df1bbd72c9060b6826bd95a21ea81af5fdd0c1961d3d7fb41210966aac7c277ec7f91fd32e3e284b583cb02121dc589646642f5c0"
+  ]
+}

--- a/packages/ringo/ringo.1.1.0/opam
+++ b/packages/ringo/ringo.1.1.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.08" }
+  "dune" { >= "1.7" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Bounded-length collections"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v1.1.0/ringo-v1.1.0.tar.gz"
+  checksum: [
+    "md5=c9c5400e7ae19100b945279835ff3e5c"
+    "sha512=7f37b721e2ca32e5e96fbf8df1bbd72c9060b6826bd95a21ea81af5fdd0c1961d3d7fb41210966aac7c277ec7f91fd32e3e284b583cb02121dc589646642f5c0"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`aches.1.1.0`: Caches (bounded-size stores) for in-memory values and for resources
-`aches-lwt.1.1.0`: Caches (bounded-size stores) for Lwt promises
-`ringo.1.1.0`: Bounded-length collections



---
* Homepage: https://gitlab.com/nomadic-labs/ringo
* Source repo: git+https://gitlab.com/nomadic-labs/ringo.git
* Bug tracker: https://gitlab.com/nomadic-labs/ringo/issues

---
:camel: Pull-request generated by opam-publish v2.1.0