### PR TITLE
8 packages from ocsigen/ocsipersist at 2.0.0

### DIFF
--- a/packages/ocsipersist-dbm-config/ocsipersist-dbm-config.2.0.0/opam
+++ b/packages/ocsipersist-dbm-config/ocsipersist-dbm-config.2.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+synopsis:     "Ocsigen Server configuration file extension for ocsipersist-dbm"
+description:  "Load this package from Ocsigen Server's configuration file if you want to use the DBM storage backend."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+available: [ os != "macos" ]
+depends: [
+  "dune" {>= "2.9"}
+  "xml-light"
+  "ocsigenserver" {>= "3.0.0"}
+  "ocsipersist-dbm" {>= "2.0.0" & < "2.1.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsipersist/archive/refs/tags/2.0.0.tar.gz"
+  checksum: [
+    "md5=b96e2fa070038fc9ffa9ab7551ed5637"
+    "sha512=f5aca65bee735f90047c7457d4e5a9965a71a70df14366dd7fea2d494b5397702d5d5b0d677dbe0524368e9ae9c124c281d39ec3a99b3c79ed60ae439f93ec84"
+  ]
+}

--- a/packages/ocsipersist-dbm/ocsipersist-dbm.2.0.0/opam
+++ b/packages/ocsipersist-dbm/ocsipersist-dbm.2.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage for OCaml using DBM"
+description:  "This library provides a DBM backend for the unified key/value storage frontend as defined in the ocsipersist package."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+available: [ os != "macos" ]
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_log"
+  "ocsipersist" {>= "2.0.0" & < "2.1.0"}
+  "dbm"
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsipersist/archive/refs/tags/2.0.0.tar.gz"
+  checksum: [
+    "md5=b96e2fa070038fc9ffa9ab7551ed5637"
+    "sha512=f5aca65bee735f90047c7457d4e5a9965a71a70df14366dd7fea2d494b5397702d5d5b0d677dbe0524368e9ae9c124c281d39ec3a99b3c79ed60ae439f93ec84"
+  ]
+}

--- a/packages/ocsipersist-lib/ocsipersist-lib.2.0.0/opam
+++ b/packages/ocsipersist-lib/ocsipersist-lib.2.0.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage for OCaml - support library"
+description:  "This library defines signatures and auxiliary tools for defining backends for the Ocsipersist frontent. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library. Implementations of the following backends currently exist: DBM, PostgreSQL, SQLite."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_ppx" {>= "2.0.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsipersist/archive/refs/tags/2.0.0.tar.gz"
+  checksum: [
+    "md5=b96e2fa070038fc9ffa9ab7551ed5637"
+    "sha512=f5aca65bee735f90047c7457d4e5a9965a71a70df14366dd7fea2d494b5397702d5d5b0d677dbe0524368e9ae9c124c281d39ec3a99b3c79ed60ae439f93ec84"
+  ]
+}

--- a/packages/ocsipersist-pgsql-config/ocsipersist-pgsql-config.2.0.0/opam
+++ b/packages/ocsipersist-pgsql-config/ocsipersist-pgsql-config.2.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+synopsis:     "Ocsigen Server configuration file extension for ocsipersist-pgsql"
+description:  "Load this package from Ocsigen Server's configuration file if you want to use the PostgreSQL storage backend."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.9"}
+  "xml-light"
+  "ocsigenserver" {>= "3.0.0"}
+  "ocsipersist-pgsql" {>= "2.0.0" & < "2.1.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsipersist/archive/refs/tags/2.0.0.tar.gz"
+  checksum: [
+    "md5=b96e2fa070038fc9ffa9ab7551ed5637"
+    "sha512=f5aca65bee735f90047c7457d4e5a9965a71a70df14366dd7fea2d494b5397702d5d5b0d677dbe0524368e9ae9c124c281d39ec3a99b3c79ed60ae439f93ec84"
+  ]
+}

--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.2.0.0/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.2.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage for OCaml using PostgreSQL"
+description:  "This library provides a PostgreSQL backend for the unified key/value storage frontend as defined in the ocsipersist package."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_log"
+  "ocsipersist" {>= "2.0.0" & < "2.1.0"}
+  "pgocaml"
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsipersist/archive/refs/tags/2.0.0.tar.gz"
+  checksum: [
+    "md5=b96e2fa070038fc9ffa9ab7551ed5637"
+    "sha512=f5aca65bee735f90047c7457d4e5a9965a71a70df14366dd7fea2d494b5397702d5d5b0d677dbe0524368e9ae9c124c281d39ec3a99b3c79ed60ae439f93ec84"
+  ]
+}

--- a/packages/ocsipersist-sqlite-config/ocsipersist-sqlite-config.2.0.0/opam
+++ b/packages/ocsipersist-sqlite-config/ocsipersist-sqlite-config.2.0.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+synopsis:     "Ocsigen Server configuration file extension for ocsipersist-sqlite"
+description:  "Load this package from Ocsigen Server's configuration file if you want to use the SQLite storage backend."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "xml-light"
+  "ocsigenserver" {>= "3.0.0"}
+  "ocsipersist-sqlite" {>= "2.0.0" & < "2.1.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsipersist/archive/refs/tags/2.0.0.tar.gz"
+  checksum: [
+    "md5=b96e2fa070038fc9ffa9ab7551ed5637"
+    "sha512=f5aca65bee735f90047c7457d4e5a9965a71a70df14366dd7fea2d494b5397702d5d5b0d677dbe0524368e9ae9c124c281d39ec3a99b3c79ed60ae439f93ec84"
+  ]
+}

--- a/packages/ocsipersist-sqlite/ocsipersist-sqlite.2.0.0/opam
+++ b/packages/ocsipersist-sqlite/ocsipersist-sqlite.2.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage for OCaml using SQLite"
+description:  "This library provides a SQLite backend for the unified key/value storage frontend as defined in the ocsipersist package."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_log"
+  "ocsipersist" {>= "2.0.0" & < "2.1.0"}
+  "sqlite3"
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsipersist/archive/refs/tags/2.0.0.tar.gz"
+  checksum: [
+    "md5=b96e2fa070038fc9ffa9ab7551ed5637"
+    "sha512=f5aca65bee735f90047c7457d4e5a9965a71a70df14366dd7fea2d494b5397702d5d5b0d677dbe0524368e9ae9c124c281d39ec3a99b3c79ed60ae439f93ec84"
+  ]
+}

--- a/packages/ocsipersist/ocsipersist.2.0.0/opam
+++ b/packages/ocsipersist/ocsipersist.2.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key-value storage for OCaml using multiple backends"
+description:  "This is an virtual library defining a unified frontend for a number of key-value storage implementations. Implementations of the following backends currently exist: DBM, PostgreSQL, SQLite."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "ocsipersist-lib" {>= "2.0.0" & < "3.0.0"}
+]
+conflicts: [
+	"ocsipersist-dbm" {< "2.0.0" | >= "2.1.0"}
+	"ocsipersist-pgsql" {< "2.0.0" | >= "2.1.0"}
+	"ocsipersist-sqlite" {< "2.0.0" | >= "2.1.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsipersist/archive/refs/tags/2.0.0.tar.gz"
+  checksum: [
+    "md5=b96e2fa070038fc9ffa9ab7551ed5637"
+    "sha512=f5aca65bee735f90047c7457d4e5a9965a71a70df14366dd7fea2d494b5397702d5d5b0d677dbe0524368e9ae9c124c281d39ec3a99b3c79ed60ae439f93ec84"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `ocsipersist.2.0.0`: Persistent key-value storage for OCaml using multiple backends
- `ocsipersist-dbm.2.0.0`: Persistent key/value storage for OCaml using DBM
- `ocsipersist-dbm-config.2.0.0`: Ocsigen Server configuration file extension for ocsipersist-dbm
- `ocsipersist-lib.2.0.0`: Persistent key/value storage for OCaml - support library
- `ocsipersist-pgsql.2.0.0`: Persistent key/value storage for OCaml using PostgreSQL
- `ocsipersist-pgsql-config.2.0.0`: Ocsigen Server configuration file extension for ocsipersist-pgsql
- `ocsipersist-sqlite.2.0.0`: Persistent key/value storage for OCaml using SQLite
- `ocsipersist-sqlite-config.2.0.0`: Ocsigen Server configuration file extension for ocsipersist-sqlite



---
* Homepage: https://github.com/ocsigen/ocsipersist
* Source repo: git+https://github.com/ocsigen/ocsipersist.git
* Bug tracker: https://github.com/ocsigen/ocsipersist/issues

---
:camel: Pull-request generated by opam-publish v2.3.0