### PR TITLE
repo file: Warn pre-2.2.0~beta2 beta-testers of opam 2.2 about GNU patch on macOS

### DIFF
--- a/repo
+++ b/repo
@@ -10,5 +10,5 @@ announce: [
 """ {opam-version >= "2.0.10" & opam-version < "2.1.0~~"}
 """
 [WARNING] please ensure to have GNU patch installed as `patch`. Otherwise update may fail silently (since it can't remove files).
-""" {os = "macos" & opam-version < "2.1.6"}
+""" {os = "macos" & (opam-version < "2.1.6" || (opam-version >= "2.2.0~~" & opam-version < "2.2.0~beta2"))}
 ]


### PR DESCRIPTION
https://discuss.ocaml.org/t/the-compilation-of-ocaml-5-1-1-failed-at-ocaml-gen-ocaml-config-ml-5-1-1-ocaml/14731/21