### PR TITLE
sqlgg < 2020 needs upper bound on mybuild

### DIFF
--- a/packages/sqlgg/sqlgg.0.4.3/opam
+++ b/packages/sqlgg/sqlgg.0.4.3/opam
@@ -31,7 +31,7 @@ depends: [
   "ocaml" {>= "4.02.0" & < "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "mybuild" {build}
+  "mybuild" {build & < "7"}
   "menhir"
   "deriving"
   ("extlib" | "extlib-compat")

--- a/packages/sqlgg/sqlgg.0.4.4/opam
+++ b/packages/sqlgg/sqlgg.0.4.4/opam
@@ -29,7 +29,7 @@ depends: [
   "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "mybuild" {build}
+  "mybuild" {build & < "7"}
   "menhir" {< "20211215"}
   "ppx_deriving"
   ("extlib" | "extlib-compat")

--- a/packages/sqlgg/sqlgg.0.4.5/opam
+++ b/packages/sqlgg/sqlgg.0.4.5/opam
@@ -29,7 +29,7 @@ depends: [
   "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "mybuild" {build}
+  "mybuild" {build & < "7"}
   "menhir" {< "20211215"}
   "ppx_deriving"
   ("extlib" | "extlib-compat")


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/26039

Failure:
```
+ ocamlfind ocamlopt -package unix -package ocamlbuild -linkpkg -package mybuild myocamlbuild_config.ml myocamlbuild.ml /home/opam/.opam/4.14/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# File "myocamlbuild_config.ml", line 4, characters 2-13:
# 4 |   OCaml.setup();
#       ^^^^^^^^^^^
# Error: Unbound module OCaml
```