### PR TITLE
Add a basic Github Action CI for Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,7 +27,6 @@ jobs:
         if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
           Invoke-Expression "& { $(Invoke-RestMethod https://raw.githubusercontent.com/kit-ty-kate/opam/windows-installer.debug/shell/install.ps1) } -OpamBinDir 'D:\opam\bin' -NoSetPath -NoAdmin"
-          "D:\opam\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Init opam
         if: steps.cache-opam.outputs.cache-hit != 'true'
@@ -41,6 +40,10 @@ jobs:
             D:\opam\bin
             D:\opamroot
           key: ${{ steps.cache-opam.outputs.cache-primary-key }}
+
+      - name: Add opam to PATH
+        run: |
+          "D:\opam\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Init opam
         if: steps.cache-opam.outputs.cache-hit != 'true'
-        run: opam init -yn .
+        run: opam init --yes --no-setup .
 
       - name: Save opam cache
         if: steps.cache-opam.outputs.cache-hit != 'true'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,9 +14,9 @@ jobs:
       - name: Checkout tree
         uses: actions/checkout@v4
 
-      - name: Cache opam
+      - name: Restore opam cache
         id: cache-opam
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             D:\opam\bin
@@ -32,6 +32,15 @@ jobs:
       - name: Init opam
         if: steps.cache-opam.outputs.cache-hit != 'true'
         run: opam init -yn .
+
+      - name: Save opam cache
+        if: steps.cache-opam.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            D:\opam\bin
+            D:\opamroot
+          key: ${{ steps.cache-opam.outputs.cache-primary-key }}
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           $pkgs = $env:ALL_CHANGED_PACKAGES | ConvertFrom-Json
           $failed = $false
+          opam update
           Foreach ($pkg in $pkgs) {
             opam install --confirm-level=unsafe-yes "$pkg"
             switch ($LASTEXITCODE) {

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,72 @@
+name: Windows CI
+on:
+  pull_request:
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout tree
+        uses: actions/checkout@v4
+
+      - name: Cache opam
+        id: cache-opam
+        uses: actions/cache@v4
+        with:
+          path: |
+            C:\Program Files\opam\bin
+            C:\Users\runneradmin\AppData\Local\opam
+          key: ${{ runner.os }}-opam
+
+      - name: Install opam
+        if: steps.cache-opam.outputs.cache-hit != 'true'
+        run: |
+          Invoke-Expression "& { $(Invoke-RestMethod https://raw.githubusercontent.com/kit-ty-kate/opam/windows-installer.debug/shell/install.ps1) } -OpamBinDir 'C:\Program Files\opam\bin' -NoSetPath -NoAdmin"
+          "C:\Program Files\opam\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Init opam
+        if: steps.cache-opam.outputs.cache-hit != 'true'
+        run: opam init -yn .
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+
+      - name: List all changed packages
+        id: changed-packages
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          $output = @()
+          Foreach ($file in ($env:ALL_CHANGED_FILES).Split(" ")) {
+            switch -Regex ($file) {
+              '^packages\\[^\\]*\\([^\\]*)\\.*' { $output += "$($matches[1])"; Break }
+              default { Write-Host "$file skipped"; Break }
+            }
+          }
+          $outputJson = $output | ConvertTo-Json
+          "data<<@@@" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          $outputJson | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "@@@" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Install packages
+        env:
+          ALL_CHANGED_PACKAGES: ${{ steps.changed-packages.outputs.data }}
+        run: |
+          $pkgs = $env:ALL_CHANGED_PACKAGES | ConvertFrom-Json
+          $failed = $false
+          Foreach ($pkg in $pkgs) {
+            opam install --confirm-level=unsafe-yes "$pkg"
+            switch ($LASTEXITCODE) {
+              0 { Break }
+              20 { Write-Host "$pkg is not installable. Skip."; Break }
+              31 { Write-Host "$pkg failed to build."; $failed = $true; Break }
+              default { throw "Unexpected error $_" }
+            }
+          }
+          if ($failed) {
+            throw "build failed"
+          }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,8 @@
 name: Windows CI
 on:
   pull_request:
+env:
+  OPAMROOT: D:\opamroot
 jobs:
   build:
     strategy:
@@ -17,15 +19,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            C:\Program Files\opam\bin
-            C:\Users\runneradmin\AppData\Local\opam
+            D:\opam\bin
+            D:\opamroot
           key: ${{ runner.os }}-opam
 
       - name: Install opam
         if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
-          Invoke-Expression "& { $(Invoke-RestMethod https://raw.githubusercontent.com/kit-ty-kate/opam/windows-installer.debug/shell/install.ps1) } -OpamBinDir 'C:\Program Files\opam\bin' -NoSetPath -NoAdmin"
-          "C:\Program Files\opam\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          Invoke-Expression "& { $(Invoke-RestMethod https://raw.githubusercontent.com/kit-ty-kate/opam/windows-installer.debug/shell/install.ps1) } -OpamBinDir 'D:\opam\bin' -NoSetPath -NoAdmin"
+          "D:\opam\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Init opam
         if: steps.cache-opam.outputs.cache-hit != 'true'


### PR DESCRIPTION
On behalf of the opam team, this PR brings Windows to the platforms tested by opam-repository, as opam 2.2.0 is nearing its final release.

For now it only checks the last compiler version (you'll need to remove the cache to update it) and might timeout for large enough PRs due to the fact that it tests all changed packages iteratively. It is also not clever and will also test even minor changes that do not affect the build (e.g. metadata changes), but i think it is better than nothing to start with