### PR TITLE
Update conf-libssl for the mingw-w64 ports

### DIFF
--- a/packages/conf-libssl/conf-libssl.1/opam
+++ b/packages/conf-libssl/conf-libssl.1/opam
@@ -38,3 +38,4 @@ extra-source "osx-build.sh" {
     "md5=faf81a6bf30e346abe94610f136c6193"
   ]
 }
+available: os != "win32" | os-distribution = "cygwinports"

--- a/packages/conf-libssl/conf-libssl.2/opam
+++ b/packages/conf-libssl/conf-libssl.2/opam
@@ -38,3 +38,4 @@ synopsis: "Virtual package relying on an OpenSSL library system installation"
 description:
   "This package can only install if the OpenSSL library is installed on the system."
 flags: conf
+available: os != "win32" | os-distribution = "cygwinports"

--- a/packages/conf-libssl/conf-libssl.3/opam
+++ b/packages/conf-libssl/conf-libssl.3/opam
@@ -45,3 +45,4 @@ extra-source "homebrew.sh" {
     "md5=a524c7b9cb12a5be63c7d5933ccd1c43"
   ]
 }
+available: os != "win32" | os-distribution = "cygwinports"

--- a/packages/conf-libssl/conf-libssl.4/opam
+++ b/packages/conf-libssl/conf-libssl.4/opam
@@ -8,7 +8,11 @@ build-env: [
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [
-  ["pkg-config" "--print-errors" "--exists" "openssl"]
+  ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution != "cygwin"}
+   "--print-errors" "--exists" "openssl"]
     {os != "freebsd" & os != "openbsd" & os != "netbsd" & # libssl is provided by base system on BSDs
      os-distribution != "homebrew"}
   ["sh" "-ex" "./homebrew.sh" "check"] {os-distribution = "homebrew"}
@@ -18,6 +22,8 @@ install: [
 ]
 depends: [
   "conf-pkg-config" {build}
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-openssl-i686" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-openssl-x86_64" {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [
   ["libssl-dev"] {os-family = "debian"}

--- a/packages/conf-mingw-w64-openssl-i686/conf-mingw-w64-openssl-i686.1/opam
+++ b/packages/conf-mingw-w64-openssl-i686/conf-mingw-w64-openssl-i686.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "libssl for i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of libssl for the mingw-w64 project is available"
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "The OpenSSL Project"
+license: "Apache-1.0"
+homepage: "https://www.openssl.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32" & os-distribution = "cygwin"
+build: ["pkgconf" "--personality=i686-w64-mingw32" "openssl"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-i686" {build}
+]
+depexts: [
+  ["mingw64-i686-openssl"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-i686-openssl"] {os = "win32" & os-distribution = "msys2"}
+]

--- a/packages/conf-mingw-w64-openssl-x86_64/conf-mingw-w64-openssl-x86_64.1/opam
+++ b/packages/conf-mingw-w64-openssl-x86_64/conf-mingw-w64-openssl-x86_64.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "libssl for x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of libssl for the mingw-w64 project is available"
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "The OpenSSL Project"
+license: "Apache-1.0"
+homepage: "https://www.openssl.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32" & os-distribution = "cygwin"
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" "openssl"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-x86_64" {build}
+]
+depexts: [
+  ["mingw64-x86_64-openssl"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-x86_64-openssl"] {os = "win32" & os-distribution = "msys2"}
+]


### PR DESCRIPTION
This commit is extracted from the [opam 2.2.0 Windows announcement](https://opam.ocaml.org/blog/opam-2-2-0-windows/) is intended in part to serve as a demonstration of the changes which need to be made to `conf-` packages to support the opam 2.2.0 depext scheme for native Windows following the merge of #25861.

The key parts:
- Constraining old versions of conf- packages
- Adding conf-mingw-w64-* packages for each architecture with MSYS2 and Cygwin package names
- Updating the latest version of the main conf- package with a dependency formula and adapting pkg-config to use `--personality`, etc.