### PR TITLE
Update bitstring sources

### DIFF
--- a/packages/bitstring/bitstring.2.1.0/opam
+++ b/packages/bitstring/bitstring.2.1.0/opam
@@ -31,7 +31,7 @@ You can use this module to both parse and generate binary formats, files and pro
 Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful."""
 flags: light-uninstall
 url {
-  src: "https://github.com/xguerin/bitstring/archive/v2.1.0.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/bitstring.2.1.0.tar.gz"
   checksum: [
     "sha256=a848f15787709e88bf97a81d5e7dc0115ad83b3cf36bbaec6a69fdf3d102f7bd"
     "md5=70f7acebe337072bff03a1f7a3fb1d3a"

--- a/packages/bitstring/bitstring.2.1.0/opam
+++ b/packages/bitstring/bitstring.2.1.0/opam
@@ -31,7 +31,7 @@ You can use this module to both parse and generate binary formats, files and pro
 Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful."""
 flags: light-uninstall
 url {
-  src: "https://bitbucket.org/thanatonauts/bitstring/get/v2.1.0.tar.gz"
+  src: "https://github.com/xguerin/bitstring/archive/v2.1.0.tar.gz"
   checksum: [
     "sha256=a848f15787709e88bf97a81d5e7dc0115ad83b3cf36bbaec6a69fdf3d102f7bd"
     "md5=70f7acebe337072bff03a1f7a3fb1d3a"

--- a/packages/bitstring/bitstring.2.1.1/opam
+++ b/packages/bitstring/bitstring.2.1.1/opam
@@ -31,7 +31,7 @@ You can use this module to both parse and generate binary formats, files and pro
 Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful."""
 flags: light-uninstall
 url {
-  src: "https://bitbucket.org/thanatonauts/bitstring/get/v2.1.1.tar.gz"
+  src: "https://github.com/xguerin/bitstring/archive/v2.1.1.tar.gz"
   checksum: [
     "sha256=c442b091dc41a65359a3a04ae0cadd2b241ec123b71a207fe88e15f1296f7f50"
     "md5=69797ac391a4c4a106bbde2a2bc8d9ab"

--- a/packages/bitstring/bitstring.2.1.1/opam
+++ b/packages/bitstring/bitstring.2.1.1/opam
@@ -31,7 +31,7 @@ You can use this module to both parse and generate binary formats, files and pro
 Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful."""
 flags: light-uninstall
 url {
-  src: "https://github.com/xguerin/bitstring/archive/v2.1.1.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/bitstring.2.1.1.tar.gz"
   checksum: [
     "sha256=c442b091dc41a65359a3a04ae0cadd2b241ec123b71a207fe88e15f1296f7f50"
     "md5=69797ac391a4c4a106bbde2a2bc8d9ab"

--- a/packages/bitstring/bitstring.3.0.0/opam
+++ b/packages/bitstring/bitstring.3.0.0/opam
@@ -29,7 +29,7 @@ The ocaml-bitstring project adds Erlang-style bitstrings and matching over bitst
 You can use this module to both parse and generate binary formats, files and protocols. 
 Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful."""
 url {
-  src: "https://github.com/xguerin/bitstring/archive/v3.0.0.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/bitstring.3.0.0.tar.gz"
   checksum: [
     "sha256=ee066207521c925e1f24467dc33f0af8fb2f7623ec149fff927df5b45723d8e4"
     "md5=ce1d3b99ed9d4ff98af1fafd9274d897"

--- a/packages/bitstring/bitstring.3.0.0/opam
+++ b/packages/bitstring/bitstring.3.0.0/opam
@@ -29,7 +29,7 @@ The ocaml-bitstring project adds Erlang-style bitstrings and matching over bitst
 You can use this module to both parse and generate binary formats, files and protocols. 
 Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful."""
 url {
-  src: "https://bitbucket.org/thanatonauts/bitstring/get/v3.0.0.tar.gz"
+  src: "https://github.com/xguerin/bitstring/archive/v3.0.0.tar.gz"
   checksum: [
     "sha256=ee066207521c925e1f24467dc33f0af8fb2f7623ec149fff927df5b45723d8e4"
     "md5=ce1d3b99ed9d4ff98af1fafd9274d897"

--- a/packages/bitstring/bitstring.3.1.0/opam
+++ b/packages/bitstring/bitstring.3.1.0/opam
@@ -29,7 +29,7 @@ The ocaml-bitstring project adds Erlang-style bitstrings and matching over bitst
 You can use this module to both parse and generate binary formats, files and protocols. 
 Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful."""
 url {
-  src: "https://bitbucket.org/thanatonauts/bitstring/get/v3.1.0.tar.gz"
+  src: "https://github.com/xguerin/bitstring/archive/v3.1.0.tar.gz"
   checksum: [
     "sha256=fa6248c6c022cff30ef8e5f0323a2906f8d2cd534527425f08a3ef80af985296"
     "md5=22807a9517ede34823ebdb36d6bacef8"

--- a/packages/bitstring/bitstring.3.1.0/opam
+++ b/packages/bitstring/bitstring.3.1.0/opam
@@ -29,7 +29,7 @@ The ocaml-bitstring project adds Erlang-style bitstrings and matching over bitst
 You can use this module to both parse and generate binary formats, files and protocols. 
 Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful."""
 url {
-  src: "https://github.com/xguerin/bitstring/archive/v3.1.0.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/bitstring.3.1.0.tar.gz"
   checksum: [
     "sha256=fa6248c6c022cff30ef8e5f0323a2906f8d2cd534527425f08a3ef80af985296"
     "md5=22807a9517ede34823ebdb36d6bacef8"

--- a/packages/bitstring/bitstring.3.1.1/opam
+++ b/packages/bitstring/bitstring.3.1.1/opam
@@ -30,7 +30,7 @@ The ocaml-bitstring project adds Erlang-style bitstrings and matching over bitst
 You can use this module to both parse and generate binary formats, files and protocols. 
 Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful."""
 url {
-  src: "https://github.com/xguerin/bitstring/archive/v3.1.1.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/bitstring.3.1.1.tar.gz"
   checksum: [
     "sha256=867299a702784ca8ac59bb50dcf4c2cdec49fba2c4ed89f8de40c60ac671b22f"
     "md5=ebf52fe55946c70aa7cb3fe51905b830"

--- a/packages/bitstring/bitstring.3.1.1/opam
+++ b/packages/bitstring/bitstring.3.1.1/opam
@@ -30,7 +30,7 @@ The ocaml-bitstring project adds Erlang-style bitstrings and matching over bitst
 You can use this module to both parse and generate binary formats, files and protocols. 
 Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful."""
 url {
-  src: "https://bitbucket.org/thanatonauts/bitstring/get/v3.1.1.tar.gz"
+  src: "https://github.com/xguerin/bitstring/archive/v3.1.1.tar.gz"
   checksum: [
     "sha256=867299a702784ca8ac59bb50dcf4c2cdec49fba2c4ed89f8de40c60ac671b22f"
     "md5=ebf52fe55946c70aa7cb3fe51905b830"


### PR DESCRIPTION
Old versions of the `bitstring` package pointed their source to a now-defunct Bitbucket repository. This PR updates the sources to the currently-maintained Github repository https://github.com/xguerin/bitstring