### PR TITLE
LablTk 8.06.14 and OCamlBrowser 5.2.0

### DIFF
--- a/packages/labltk/labltk.8.06.14/opam
+++ b/packages/labltk/labltk.8.06.14/opam
@@ -7,7 +7,11 @@ dev-repo: "git+https://github.com/garrigue/labltk.git"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build: [
   ["./configure" "-use-findlib" "-verbose" "-installbindir" bin]
-  [make "library" "opt"]
+  [
+    make
+    "library"
+    "opt" {!ocaml-option-bytecode-only:installed}
+  ]
 ]
 install: [
   [make "install"]

--- a/packages/labltk/labltk.8.06.14/opam
+++ b/packages/labltk/labltk.8.06.14/opam
@@ -27,7 +27,7 @@ description: "ocamlbrowser is now a separate package.\n\
 url {
   src: "https://github.com/garrigue/labltk/archive/refs/tags/8.06.14.tar.gz"
   checksum: [
-    "sha256=e811d82754e19dd9e335cddd76bdcb7ea3fdb3d83084ae3147e90471217c0155"
-    "md5=3492160c6cc77da5f3ae2d494ff69f36"
+    "sha256=f0c1e23c1fe4f7aa78fd343b322890ed065ed0635ff83fb11365237bee0d29bf"
+    "md5=41034d1303305104750929470cc877be"
   ]
 }

--- a/packages/labltk/labltk.8.06.14/opam
+++ b/packages/labltk/labltk.8.06.14/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://garrigue.github.io/labltk/"
+bug-reports: "https://github.com/garrigue/labltk/issues"
+dev-repo: "git+https://github.com/garrigue/labltk.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+build: [
+  ["./configure" "-use-findlib" "-verbose" "-installbindir" bin]
+  [make "library" "opt"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "ocamlfind" {build}
+  "conf-tcl"
+  "conf-tk"
+]
+post-messages: [
+  "This package requires Tcl/Tk with its development packages installed on your system" {failure}
+]
+synopsis: "OCaml interface to Tcl/Tk"
+description: "ocamlbrowser is now a separate package.\n\
+             For details, see https://garrigue.github.io/labltk/"
+url {
+  src: "https://github.com/garrigue/labltk/archive/refs/tags/8.06.14.tar.gz"
+  checksum: [
+    "sha256=e811d82754e19dd9e335cddd76bdcb7ea3fdb3d83084ae3147e90471217c0155"
+    "md5=3492160c6cc77da5f3ae2d494ff69f36"
+  ]
+}

--- a/packages/ocamlbrowser/ocamlbrowser.5.2.0/opam
+++ b/packages/ocamlbrowser/ocamlbrowser.5.2.0/opam
@@ -27,7 +27,7 @@ description: "Require LablTk. For details, see https://garrigue.github.io/labltk
 url {
   src: "https://github.com/garrigue/labltk/archive/refs/tags/8.06.14.tar.gz"
   checksum: [
-    "sha256=e811d82754e19dd9e335cddd76bdcb7ea3fdb3d83084ae3147e90471217c0155"
-    "md5=3492160c6cc77da5f3ae2d494ff69f36"
+    "sha256=f0c1e23c1fe4f7aa78fd343b322890ed065ed0635ff83fb11365237bee0d29bf"
+    "md5=41034d1303305104750929470cc877be"
   ]
 }

--- a/packages/ocamlbrowser/ocamlbrowser.5.2.0/opam
+++ b/packages/ocamlbrowser/ocamlbrowser.5.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://garrigue.github.io/labltk/"
+bug-reports: "https://github.com/garrigue/labltk/issues"
+dev-repo: "git+https://github.com/garrigue/labltk.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+build: [
+  ["./configure" "-use-findlib" "-installbindir" bin]
+  [make "all"]
+]
+install: [
+  [make "install-browser"]
+]
+depends: [
+  "ocaml" {>= "5.2" & < "5.3"}
+  "labltk" {>= "8.06.14"}
+  "ocamlfind" {build}
+  "conf-tcl"
+  "conf-tk"
+]
+post-messages: [
+  "This package requires Tcl/Tk with its development packages installed on your system" {failure}
+]
+synopsis: "OCamlBrowser Library Explorer"
+description: "Require LablTk. For details, see https://garrigue.github.io/labltk/"
+url {
+  src: "https://github.com/garrigue/labltk/archive/refs/tags/8.06.14.tar.gz"
+  checksum: [
+    "sha256=e811d82754e19dd9e335cddd76bdcb7ea3fdb3d83084ae3147e90471217c0155"
+    "md5=3492160c6cc77da5f3ae2d494ff69f36"
+  ]
+}


### PR DESCRIPTION
New release for compatibility with OCaml 5.2 and C2x.
Old versions appear to be broken.