### PR TITLE
GHA windows: do not fail when none of the packages can be installed

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -86,3 +86,4 @@ jobs:
           if ($failed) {
             throw "build failed"
           }
+          Exit


### PR DESCRIPTION
Somehow the last `$LASTEXITCODE` seems to be carried over to the whole process

Should fix the issue seen in https://github.com/ocaml/opam-repository/pull/26079