### PR TITLE
Fix caching by running the workflow on master

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,8 @@
 name: Windows CI
 on:
+  push:
+    branches:
+      - 'master'
   pull_request:
 env:
   OPAMROOT: D:\opamroot
@@ -47,10 +50,12 @@ jobs:
 
       - name: Get changed files
         id: changed-files
+        if: github.event_name != 'push'
         uses: tj-actions/changed-files@v44
 
       - name: List all changed packages
         id: changed-packages
+        if: github.event_name != 'push'
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
@@ -69,6 +74,7 @@ jobs:
       - name: Install packages
         env:
           ALL_CHANGED_PACKAGES: ${{ steps.changed-packages.outputs.data }}
+        if: github.event_name != 'push'
         run: |
           $pkgs = $env:ALL_CHANGED_PACKAGES | ConvertFrom-Json
           $failed = $false


### PR DESCRIPTION
The caching isn't working in GHA at the moment because the master branch is never built. When a PR is opened, actions/cache will try to match the cache for the PR and then for the target branch and then for the default branch, but only the PR caches were ever built. See [the docs for further details](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key).