### PR TITLE
pgx_lwt_mirage: restrict to dns-client < 8.0.0

### DIFF
--- a/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.1/opam
+++ b/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.1/opam
@@ -14,7 +14,7 @@ depends: [
   "logs"
   "mirage-channel"
   "conduit-mirage" {>= "2.3.0"}
-  "dns-client" {>= "6.0.0"}
+  "dns-client" {>= "6.0.0" & < "8.0.0"}
   "mirage-random" {< "4.0.0"}
   "mirage-time"
   "mirage-clock"

--- a/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.2/opam
+++ b/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.2/opam
@@ -14,7 +14,7 @@ depends: [
   "logs"
   "mirage-channel"
   "conduit-mirage" {>= "2.3.0"}
-  "dns-client" {>= "6.0.0"}
+  "dns-client" {>= "6.0.0" & < "8.0.0"}
   "mirage-random" {< "4.0.0"}
   "mirage-time"
   "mirage-clock"


### PR DESCRIPTION
as noticed by @mseri in #26077

```
== ERROR while compiling pgx_lwt_mirage.2.1 =================================#
context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
path                 ~/.opam/4.14/.opam-switch/build/pgx_lwt_mirage.2.1
command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p pgx_lwt_mirage -j 255 @install
exit-code            1
env-file             ~/.opam/log/pgx_lwt_mirage-7-6ede53.env
output-file          ~/.opam/log/pgx_lwt_mirage-7-6ede53.out
 # output ###
(cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I pgx_lwt_mirage/src/.pgx_lwt_mirage.objs/byte -I pgx_lwt_mirage/src/.pgx_lwt_mirage.objs/native -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/asn1-combinators -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/ca-certs-nss -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-mirage -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/dns -I /home/opam/.opam/4.14/lib/dns-client -I /home/opam/.opam/4.14/lib/dns-client-mirage -I /home/opam/.opam/4.14/lib/dns/cache -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/eqaf/bigstring -I /home/opam/.opam/4.14/lib/eqaf/cstruct -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/gmap -I /home/opam/.opam/4.14/lib/happy-eyeballs -I /home/opam/.opam/4.14/lib/happy-eyeballs-mirage -I /home/opam/.opam/4.14/lib/hex -I /home/opam/.opam/4.14/lib/hkdf -I /home/opam/.opam/4.14/lib/io-page -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lru -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/metrics -I /home/opam/.opam/4.14/lib/mirage-channel -I /home/opam/.opam/4.14/lib/mirage-clock -I /home/opam/.opam/4.14/lib/mirage-crypto -I /home/opam/.opam/4.14/lib/mirage-crypto-ec -I /home/opam/.opam/4.14/lib/mirage-crypto-pk -I /home/opam/.opam/4.14/lib/mirage-crypto-rng -I /home/opam/.opam/4.14/lib/mirage-flow -I /home/opam/.opam/4.14/lib/mirage-flow-combinators -I /home/opam/.opam/4.14/lib/mirage-kv -I /home/opam/.opam/4.14/lib/mirage-random -I /home/opam/.opam/4.14/lib/mirage-time -I /home/opam/.opam/4.14/lib/optint -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/pbkdf -I /home/opam/.opam/4.14/lib/pgx -I /home/opam/.opam/4.14/lib/pgx_lwt -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/psq -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/randomconv -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/tcpip -I /home/opam/.opam/4.14/lib/tls -I /home/opam/.opam/4.14/lib/tls-mirage -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/uuidm -I /home/opam/.opam/4.14/lib/vchan -I /home/opam/.opam/4.14/lib/x509 -I /home/opam/.opam/4.14/lib/xenstore -I /home/opam/.opam/4.14/lib/xenstore/client -I /home/opam/.opam/4.14/lib/zarith -intf-suffix .ml -no-alias-deps -o pgx_lwt_mirage/src/.pgx_lwt_mirage.objs/native/pgx_lwt_mirage.cmx -c -impl pgx_lwt_mirage/src/pgx_lwt_mirage.ml)
File "pgx_lwt_mirage/src/pgx_lwt_mirage.ml", line 98, characters 14-24:
98 |     let dns = Dns.create stack in
                   ^^^^^^^^^^
Error: The module Dns is a functor, it cannot have any components
(cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I pgx_lwt_mirage/src/.pgx_lwt_mirage.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/asn1-combinators -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/ca-certs-nss -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-mirage -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/dns -I /home/opam/.opam/4.14/lib/dns-client -I /home/opam/.opam/4.14/lib/dns-client-mirage -I /home/opam/.opam/4.14/lib/dns/cache -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/eqaf/bigstring -I /home/opam/.opam/4.14/lib/eqaf/cstruct -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/gmap -I /home/opam/.opam/4.14/lib/happy-eyeballs -I /home/opam/.opam/4.14/lib/happy-eyeballs-mirage -I /home/opam/.opam/4.14/lib/hex -I /home/opam/.opam/4.14/lib/hkdf -I /home/opam/.opam/4.14/lib/io-page -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lru -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/metrics -I /home/opam/.opam/4.14/lib/mirage-channel -I /home/opam/.opam/4.14/lib/mirage-clock -I /home/opam/.opam/4.14/lib/mirage-crypto -I /home/opam/.opam/4.14/lib/mirage-crypto-ec -I /home/opam/.opam/4.14/lib/mirage-crypto-pk -I /home/opam/.opam/4.14/lib/mirage-crypto-rng -I /home/opam/.opam/4.14/lib/mirage-flow -I /home/opam/.opam/4.14/lib/mirage-flow-combinators -I /home/opam/.opam/4.14/lib/mirage-kv -I /home/opam/.opam/4.14/lib/mirage-random -I /home/opam/.opam/4.14/lib/mirage-time -I /home/opam/.opam/4.14/lib/optint -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/pbkdf -I /home/opam/.opam/4.14/lib/pgx -I /home/opam/.opam/4.14/lib/pgx_lwt -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/psq -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/randomconv -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/tcpip -I /home/opam/.opam/4.14/lib/tls -I /home/opam/.opam/4.14/lib/tls-mirage -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/uuidm -I /home/opam/.opam/4.14/lib/vchan -I /home/opam/.opam/4.14/lib/x509 -I /home/opam/.opam/4.14/lib/xenstore -I /home/opam/.opam/4.14/lib/xenstore/client -I /home/opam/.opam/4.14/lib/zarith -intf-suffix .ml -no-alias-deps -o pgx_lwt_mirage/src/.pgx_lwt_mirage.objs/byte/pgx_lwt_mirage.cmo -c -impl pgx_lwt_mirage/src/pgx_lwt_mirage.ml)
File "pgx_lwt_mirage/src/pgx_lwt_mirage.ml", line 98, characters 14-24:
98 |     let dns = Dns.create stack in
                   ^^^^^^^^^^
Error: The module Dns is a functor, it cannot have any components
```