### PR TITLE
pgx_async 2.2 is not compatible with async v0.17

### DIFF
--- a/packages/pgx_async/pgx_async.2.2/opam
+++ b/packages/pgx_async/pgx_async.2.2/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/arenadotio/pgx/issues"
 depends: [
   "dune" {>= "3.2"}
   "alcotest-async" {with-test & >= "1.0.0"}
-  "async_kernel" {>= "v0.13.0"}
+  "async_kernel" {>= "v0.13.0" & < "v0.17"}
   "async_unix" {>= "v0.13.0"}
   "async_ssl"
   "base64" {with-test & >= "3.0.0"}


### PR DESCRIPTION
Fails with
```
#=== ERROR while compiling pgx_async.2.2 ======================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.5.2.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/pgx_async.2.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p pgx_async -j 39 @install
# exit-code            1
# env-file             ~/.opam/log/pgx_async-7-2c98e7.env
# output-file          ~/.opam/log/pgx_async-7-2c98e7.out
### output ###
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlopt.opt -w -40 -g -I pgx_async/src/.pgx_async.objs/byte -I pgx_async/src/.pgx_async.objs/native -I /home/opam/.opam/5.2/lib/angstrom -I /home/opam/.opam/5.2/lib/astring -I /home/opam/.opam/5.2/lib/async -I /home/opam/.opam/5.2/lib/async/async_command -I /home/opam/.opam/5.2/lib/async/async_quickcheck -I /home/opam/.opam/5.2/lib/async/async_rpc -I /home/opam/.opam/5.2/lib/async_kernel -I /home/opam/.opam/5.2/lib/async_kernel/config -I /home/opam/.opam/5.2/lib/async_kernel/eager_deferred -I /home/opam/.opam/5.2/lib/async_kernel/persistent_connection_kernel -I /home/opam/.opam/5.2/lib/async_kernel/read_write_pair -I /home/opam/.opam/5.2/lib/async_log -I /home/opam/.opam/5.2/lib/async_log/kernel -I /home/opam/.opam/5.2/lib/async_rpc_kernel -I /home/opam/.opam/5.2/lib/async_ssl -I /home/opam/.opam/5.2/lib/async_ssl/bindings -I /home/opam/.opam/5.2/lib/async_unix -I /home/opam/.opam/5.2/lib/async_unix/thread_pool -I /home/opam/.opam/5.2/lib/async_unix/thread_safe_ivar -I /home/opam/.opam/5.2/lib/base -I /home/opam/.opam/5.2/lib/base/base_internalhash_types -I /home/opam/.opam/5.2/lib/base/md5 -I /home/opam/.opam/5.2/lib/base/shadow_stdlib -I /home/opam/.opam/5.2/lib/base_bigstring -I /home/opam/.opam/5.2/lib/base_quickcheck -I /home/opam/.opam/5.2/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.2/lib/bigarray-compat -I /home/opam/.opam/5.2/lib/bigstringaf -I /home/opam/.opam/5.2/lib/bin_prot -I /home/opam/.opam/5.2/lib/bin_prot/shape -I /home/opam/.opam/5.2/lib/bytes -I /home/opam/.opam/5.2/lib/camlp-streams -I /home/opam/.opam/5.2/lib/conduit -I /home/opam/.opam/5.2/lib/conduit-async -I /home/opam/.opam/5.2/lib/core -I /home/opam/.opam/5.2/lib/core/base_for_tests -I /home/opam/.opam/5.2/lib/core/command -I /home/opam/.opam/5.2/lib/core/filename_base -I /home/opam/.opam/5.2/lib/core/heap_block -I /home/opam/.opam/5.2/lib/core/univ_map -I /home/opam/.opam/5.2/lib/core/validate -I /home/opam/.opam/5.2/lib/core_kernel -I /home/opam/.opam/5.2/lib/core_kernel/bounded_int_table -I /home/opam/.opam/5.2/lib/core_kernel/bus -I /home/opam/.opam/5.2/lib/core_kernel/caml_threads -I /home/opam/.opam/5.2/lib/core_kernel/caml_unix -I /home/opam/.opam/5.2/lib/core_kernel/flags -I /home/opam/.opam/5.2/lib/core_kernel/iobuf -I /home/opam/.opam/5.2/lib/core_kernel/moption -I /home/opam/.opam/5.2/lib/core_kernel/pairing_heap -I /home/opam/.opam/5.2/lib/core_kernel/reversed_list -I /home/opam/.opam/5.2/lib/core_kernel/sexp_hidden_in_test -I /home/opam/.opam/5.2/lib/core_kernel/thread_pool_cpu_affinity -I /home/opam/.opam/5.2/lib/core_kernel/thread_safe_queue -I /home/opam/.opam/5.2/lib/core_kernel/timing_wheel -I /home/opam/.opam/5.2/lib/core_kernel/tuple_pool -I /home/opam/.opam/5.2/lib/core_kernel/univ -I /home/opam/.opam/5.2/lib/core_kernel/uuid -I /home/opam/.opam/5.2/lib/core_kernel/version_util -I /home/opam/.opam/5.2/lib/core_unix -I /home/opam/.opam/5.2/lib/core_unix/bigstring_unix -I /home/opam/.opam/5.2/lib/core_unix/command_unix -I /home/opam/.opam/5.2/lib/core_unix/core_thread -I /home/opam/.opam/5.2/lib/core_unix/error_checking_mutex -I /home/opam/.opam/5.2/lib/core_unix/filename_unix -I /home/opam/.opam/5.2/lib/core_unix/iobuf_unix -I /home/opam/.opam/5.2/lib/core_unix/linux_ext -I /home/opam/.opam/5.2/lib/core_unix/nano_mutex -I /home/opam/.opam/5.2/lib/core_unix/ocaml_c_utils -I /home/opam/.opam/5.2/lib/core_unix/signal_unix -I /home/opam/.opam/5.2/lib/core_unix/squeue -I /home/opam/.opam/5.2/lib/core_unix/sys_unix -I /home/opam/.opam/5.2/lib/core_unix/time_float_unix -I /home/opam/.opam/5.2/lib/core_unix/time_ns_unix -I /home/opam/.opam/5.2/lib/core_unix/time_stamp_counter -I /home/opam/.opam/5.2/lib/cstruct -I /home/opam/.opam/5.2/lib/ctypes -I /home/opam/.opam/5.2/lib/ctypes-foreign -I /home/opam/.opam/5.2/lib/ctypes/stubs -I /home/opam/.opam/5.2/lib/domain-name -I /home/opam/.opam/5.2/lib/fieldslib -I /home/opam/.opam/5.2/lib/gel -I /home/opam/.opam/5.2/lib/hex -I /home/opam/.opam/5.2/lib/int_repr -I /home/opam/.opam/5.2/lib/integers -I /home/opam/.opam/5.2/lib/ipaddr -I /home/opam/.opam/5.2/lib/ipaddr-sexp -I /home/opam/.opam/5.2/lib/ipaddr/unix -I /home/opam/.opam/5.2/lib/jane-street-headers -I /home/opam/.opam/5.2/lib/macaddr -I /home/opam/.opam/5.2/lib/ocaml/str -I /home/opam/.opam/5.2/lib/ocaml/threads -I /home/opam/.opam/5.2/lib/ocaml/unix -I /home/opam/.opam/5.2/lib/ocaml_intrinsics_kernel -I /home/opam/.opam/5.2/lib/parsexp -I /home/opam/.opam/5.2/lib/pgx -I /home/opam/.opam/5.2/lib/pgx_value_core -I /home/opam/.opam/5.2/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_diff/diffable -I /home/opam/.opam/5.2/lib/ppx_diff/diffable_cinaps -I /home/opam/.opam/5.2/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_expect/config -I /home/opam/.opam/5.2/lib/ppx_expect/config_types -I /home/opam/.opam/5.2/lib/ppx_expect/make_corrected_file -I /home/opam/.opam/5.2/lib/ppx_expect/runtime -I /home/opam/.opam/5.2/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_inline_test/config -I /home/opam/.opam/5.2/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_log/syntax -I /home/opam/.opam/5.2/lib/ppx_log/types -I /home/opam/.opam/5.2/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.2/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_stable_witness/runtime -I /home/opam/.opam/5.2/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/5.2/lib/ppx_string/runtime -I /home/opam/.opam/5.2/lib/ppxlib/print_diff -I /home/opam/.opam/5.2/lib/protocol_version_header -I /home/opam/.opam/5.2/lib/re -I /home/opam/.opam/5.2/lib/seq -I /home/opam/.opam/5.2/lib/sexplib -I /home/opam/.opam/5.2/lib/sexplib/unix -I /home/opam/.opam/5.2/lib/sexplib0 -I /home/opam/.opam/5.2/lib/spawn -I /home/opam/.opam/5.2/lib/splittable_random -I /home/opam/.opam/5.2/lib/stdio -I /home/opam/.opam/5.2/lib/stdlib-shims -I /home/opam/.opam/5.2/lib/stringext -I /home/opam/.opam/5.2/lib/time_now -I /home/opam/.opam/5.2/lib/timezone -I /home/opam/.opam/5.2/lib/typerep -I /home/opam/.opam/5.2/lib/uopt -I /home/opam/.opam/5.2/lib/uri -I /home/opam/.opam/5.2/lib/uri/services -I /home/opam/.opam/5.2/lib/uuidm -I /home/opam/.opam/5.2/lib/variantslib -intf-suffix .ml -no-alias-deps -o pgx_async/src/.pgx_async.objs/native/pgx_async.cmx -c -impl pgx_async/src/pgx_async.ml)
# File "pgx_async/src/pgx_async.ml", line 1, characters 5-16:
# 1 | open Core_kernel
#          ^^^^^^^^^^^
# Alert deprecated: module Core_kernel
# [since 2021-05] Use [Core] -- [Core_kernel] was renamed as [Core]
# 
# File "pgx_async/src/pgx_async.ml", line 37, characters 14-27:
# 37 |     let chr = Caml.Char.chr in
#                    ^^^^^^^^^^^^^
# Alert deprecated: module Core_kernel.Caml
# [since 2023-01] use Stdlib instead of Caml
# 
# File "pgx_async/src/pgx_async.ml", line 37, characters 14-27:
# 37 |     let chr = Caml.Char.chr in
#                    ^^^^^^^^^^^^^
# Error: Unbound module "Caml.Char"
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I pgx_async/src/.pgx_async.objs/byte -I /home/opam/.opam/5.2/lib/angstrom -I /home/opam/.opam/5.2/lib/astring -I /home/opam/.opam/5.2/lib/async -I /home/opam/.opam/5.2/lib/async/async_command -I /home/opam/.opam/5.2/lib/async/async_quickcheck -I /home/opam/.opam/5.2/lib/async/async_rpc -I /home/opam/.opam/5.2/lib/async_kernel -I /home/opam/.opam/5.2/lib/async_kernel/config -I /home/opam/.opam/5.2/lib/async_kernel/eager_deferred -I /home/opam/.opam/5.2/lib/async_kernel/persistent_connection_kernel -I /home/opam/.opam/5.2/lib/async_kernel/read_write_pair -I /home/opam/.opam/5.2/lib/async_log -I /home/opam/.opam/5.2/lib/async_log/kernel -I /home/opam/.opam/5.2/lib/async_rpc_kernel -I /home/opam/.opam/5.2/lib/async_ssl -I /home/opam/.opam/5.2/lib/async_ssl/bindings -I /home/opam/.opam/5.2/lib/async_unix -I /home/opam/.opam/5.2/lib/async_unix/thread_pool -I /home/opam/.opam/5.2/lib/async_unix/thread_safe_ivar -I /home/opam/.opam/5.2/lib/base -I /home/opam/.opam/5.2/lib/base/base_internalhash_types -I /home/opam/.opam/5.2/lib/base/md5 -I /home/opam/.opam/5.2/lib/base/shadow_stdlib -I /home/opam/.opam/5.2/lib/base_bigstring -I /home/opam/.opam/5.2/lib/base_quickcheck -I /home/opam/.opam/5.2/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.2/lib/bigarray-compat -I /home/opam/.opam/5.2/lib/bigstringaf -I /home/opam/.opam/5.2/lib/bin_prot -I /home/opam/.opam/5.2/lib/bin_prot/shape -I /home/opam/.opam/5.2/lib/bytes -I /home/opam/.opam/5.2/lib/camlp-streams -I /home/opam/.opam/5.2/lib/conduit -I /home/opam/.opam/5.2/lib/conduit-async -I /home/opam/.opam/5.2/lib/core -I /home/opam/.opam/5.2/lib/core/base_for_tests -I /home/opam/.opam/5.2/lib/core/command -I /home/opam/.opam/5.2/lib/core/filename_base -I /home/opam/.opam/5.2/lib/core/heap_block -I /home/opam/.opam/5.2/lib/core/univ_map -I /home/opam/.opam/5.2/lib/core/validate -I /home/opam/.opam/5.2/lib/core_kernel -I /home/opam/.opam/5.2/lib/core_kernel/bounded_int_table -I /home/opam/.opam/5.2/lib/core_kernel/bus -I /home/opam/.opam/5.2/lib/core_kernel/caml_threads -I /home/opam/.opam/5.2/lib/core_kernel/caml_unix -I /home/opam/.opam/5.2/lib/core_kernel/flags -I /home/opam/.opam/5.2/lib/core_kernel/iobuf -I /home/opam/.opam/5.2/lib/core_kernel/moption -I /home/opam/.opam/5.2/lib/core_kernel/pairing_heap -I /home/opam/.opam/5.2/lib/core_kernel/reversed_list -I /home/opam/.opam/5.2/lib/core_kernel/sexp_hidden_in_test -I /home/opam/.opam/5.2/lib/core_kernel/thread_pool_cpu_affinity -I /home/opam/.opam/5.2/lib/core_kernel/thread_safe_queue -I /home/opam/.opam/5.2/lib/core_kernel/timing_wheel -I /home/opam/.opam/5.2/lib/core_kernel/tuple_pool -I /home/opam/.opam/5.2/lib/core_kernel/univ -I /home/opam/.opam/5.2/lib/core_kernel/uuid -I /home/opam/.opam/5.2/lib/core_kernel/version_util -I /home/opam/.opam/5.2/lib/core_unix -I /home/opam/.opam/5.2/lib/core_unix/bigstring_unix -I /home/opam/.opam/5.2/lib/core_unix/command_unix -I /home/opam/.opam/5.2/lib/core_unix/core_thread -I /home/opam/.opam/5.2/lib/core_unix/error_checking_mutex -I /home/opam/.opam/5.2/lib/core_unix/filename_unix -I /home/opam/.opam/5.2/lib/core_unix/iobuf_unix -I /home/opam/.opam/5.2/lib/core_unix/linux_ext -I /home/opam/.opam/5.2/lib/core_unix/nano_mutex -I /home/opam/.opam/5.2/lib/core_unix/ocaml_c_utils -I /home/opam/.opam/5.2/lib/core_unix/signal_unix -I /home/opam/.opam/5.2/lib/core_unix/squeue -I /home/opam/.opam/5.2/lib/core_unix/sys_unix -I /home/opam/.opam/5.2/lib/core_unix/time_float_unix -I /home/opam/.opam/5.2/lib/core_unix/time_ns_unix -I /home/opam/.opam/5.2/lib/core_unix/time_stamp_counter -I /home/opam/.opam/5.2/lib/cstruct -I /home/opam/.opam/5.2/lib/ctypes -I /home/opam/.opam/5.2/lib/ctypes-foreign -I /home/opam/.opam/5.2/lib/ctypes/stubs -I /home/opam/.opam/5.2/lib/domain-name -I /home/opam/.opam/5.2/lib/fieldslib -I /home/opam/.opam/5.2/lib/gel -I /home/opam/.opam/5.2/lib/hex -I /home/opam/.opam/5.2/lib/int_repr -I /home/opam/.opam/5.2/lib/integers -I /home/opam/.opam/5.2/lib/ipaddr -I /home/opam/.opam/5.2/lib/ipaddr-sexp -I /home/opam/.opam/5.2/lib/ipaddr/unix -I /home/opam/.opam/5.2/lib/jane-street-headers -I /home/opam/.opam/5.2/lib/macaddr -I /home/opam/.opam/5.2/lib/ocaml/str -I /home/opam/.opam/5.2/lib/ocaml/threads -I /home/opam/.opam/5.2/lib/ocaml/unix -I /home/opam/.opam/5.2/lib/ocaml_intrinsics_kernel -I /home/opam/.opam/5.2/lib/parsexp -I /home/opam/.opam/5.2/lib/pgx -I /home/opam/.opam/5.2/lib/pgx_value_core -I /home/opam/.opam/5.2/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_diff/diffable -I /home/opam/.opam/5.2/lib/ppx_diff/diffable_cinaps -I /home/opam/.opam/5.2/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_expect/config -I /home/opam/.opam/5.2/lib/ppx_expect/config_types -I /home/opam/.opam/5.2/lib/ppx_expect/make_corrected_file -I /home/opam/.opam/5.2/lib/ppx_expect/runtime -I /home/opam/.opam/5.2/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_inline_test/config -I /home/opam/.opam/5.2/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_log/syntax -I /home/opam/.opam/5.2/lib/ppx_log/types -I /home/opam/.opam/5.2/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.2/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_stable_witness/runtime -I /home/opam/.opam/5.2/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/5.2/lib/ppx_string/runtime -I /home/opam/.opam/5.2/lib/ppxlib/print_diff -I /home/opam/.opam/5.2/lib/protocol_version_header -I /home/opam/.opam/5.2/lib/re -I /home/opam/.opam/5.2/lib/seq -I /home/opam/.opam/5.2/lib/sexplib -I /home/opam/.opam/5.2/lib/sexplib/unix -I /home/opam/.opam/5.2/lib/sexplib0 -I /home/opam/.opam/5.2/lib/spawn -I /home/opam/.opam/5.2/lib/splittable_random -I /home/opam/.opam/5.2/lib/stdio -I /home/opam/.opam/5.2/lib/stdlib-shims -I /home/opam/.opam/5.2/lib/stringext -I /home/opam/.opam/5.2/lib/time_now -I /home/opam/.opam/5.2/lib/timezone -I /home/opam/.opam/5.2/lib/typerep -I /home/opam/.opam/5.2/lib/uopt -I /home/opam/.opam/5.2/lib/uri -I /home/opam/.opam/5.2/lib/uri/services -I /home/opam/.opam/5.2/lib/uuidm -I /home/opam/.opam/5.2/lib/variantslib -intf-suffix .ml -no-alias-deps -o pgx_async/src/.pgx_async.objs/byte/pgx_async.cmo -c -impl pgx_async/src/pgx_async.ml)
# File "pgx_async/src/pgx_async.ml", line 1, characters 5-16:
# 1 | open Core_kernel
#          ^^^^^^^^^^^
# Alert deprecated: module Core_kernel
# [since 2021-05] Use [Core] -- [Core_kernel] was renamed as [Core]
# 
# File "pgx_async/src/pgx_async.ml", line 37, characters 14-27:
# 37 |     let chr = Caml.Char.chr in
#                    ^^^^^^^^^^^^^
# Alert deprecated: module Core_kernel.Caml
# [since 2023-01] use Stdlib instead of Caml
# 
# File "pgx_async/src/pgx_async.ml", line 37, characters 14-27:
# 37 |     let chr = Caml.Char.chr in
#                    ^^^^^^^^^^^^^
# Error: Unbound module "Caml.Char"
# (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -I pgx_async/src/.pgx_async.objs/byte -I /home/opam/.opam/5.2/lib/angstrom -I /home/opam/.opam/5.2/lib/astring -I /home/opam/.opam/5.2/lib/async -I /home/opam/.opam/5.2/lib/async/async_command -I /home/opam/.opam/5.2/lib/async/async_quickcheck -I /home/opam/.opam/5.2/lib/async/async_rpc -I /home/opam/.opam/5.2/lib/async_kernel -I /home/opam/.opam/5.2/lib/async_kernel/config -I /home/opam/.opam/5.2/lib/async_kernel/eager_deferred -I /home/opam/.opam/5.2/lib/async_kernel/persistent_connection_kernel -I /home/opam/.opam/5.2/lib/async_kernel/read_write_pair -I /home/opam/.opam/5.2/lib/async_log -I /home/opam/.opam/5.2/lib/async_log/kernel -I /home/opam/.opam/5.2/lib/async_rpc_kernel -I /home/opam/.opam/5.2/lib/async_ssl -I /home/opam/.opam/5.2/lib/async_ssl/bindings -I /home/opam/.opam/5.2/lib/async_unix -I /home/opam/.opam/5.2/lib/async_unix/thread_pool -I /home/opam/.opam/5.2/lib/async_unix/thread_safe_ivar -I /home/opam/.opam/5.2/lib/base -I /home/opam/.opam/5.2/lib/base/base_internalhash_types -I /home/opam/.opam/5.2/lib/base/md5 -I /home/opam/.opam/5.2/lib/base/shadow_stdlib -I /home/opam/.opam/5.2/lib/base_bigstring -I /home/opam/.opam/5.2/lib/base_quickcheck -I /home/opam/.opam/5.2/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.2/lib/bigarray-compat -I /home/opam/.opam/5.2/lib/bigstringaf -I /home/opam/.opam/5.2/lib/bin_prot -I /home/opam/.opam/5.2/lib/bin_prot/shape -I /home/opam/.opam/5.2/lib/bytes -I /home/opam/.opam/5.2/lib/camlp-streams -I /home/opam/.opam/5.2/lib/conduit -I /home/opam/.opam/5.2/lib/conduit-async -I /home/opam/.opam/5.2/lib/core -I /home/opam/.opam/5.2/lib/core/base_for_tests -I /home/opam/.opam/5.2/lib/core/command -I /home/opam/.opam/5.2/lib/core/filename_base -I /home/opam/.opam/5.2/lib/core/heap_block -I /home/opam/.opam/5.2/lib/core/univ_map -I /home/opam/.opam/5.2/lib/core/validate -I /home/opam/.opam/5.2/lib/core_kernel -I /home/opam/.opam/5.2/lib/core_kernel/bounded_int_table -I /home/opam/.opam/5.2/lib/core_kernel/bus -I /home/opam/.opam/5.2/lib/core_kernel/caml_threads -I /home/opam/.opam/5.2/lib/core_kernel/caml_unix -I /home/opam/.opam/5.2/lib/core_kernel/flags -I /home/opam/.opam/5.2/lib/core_kernel/iobuf -I /home/opam/.opam/5.2/lib/core_kernel/moption -I /home/opam/.opam/5.2/lib/core_kernel/pairing_heap -I /home/opam/.opam/5.2/lib/core_kernel/reversed_list -I /home/opam/.opam/5.2/lib/core_kernel/sexp_hidden_in_test -I /home/opam/.opam/5.2/lib/core_kernel/thread_pool_cpu_affinity -I /home/opam/.opam/5.2/lib/core_kernel/thread_safe_queue -I /home/opam/.opam/5.2/lib/core_kernel/timing_wheel -I /home/opam/.opam/5.2/lib/core_kernel/tuple_pool -I /home/opam/.opam/5.2/lib/core_kernel/univ -I /home/opam/.opam/5.2/lib/core_kernel/uuid -I /home/opam/.opam/5.2/lib/core_kernel/version_util -I /home/opam/.opam/5.2/lib/core_unix -I /home/opam/.opam/5.2/lib/core_unix/bigstring_unix -I /home/opam/.opam/5.2/lib/core_unix/command_unix -I /home/opam/.opam/5.2/lib/core_unix/core_thread -I /home/opam/.opam/5.2/lib/core_unix/error_checking_mutex -I /home/opam/.opam/5.2/lib/core_unix/filename_unix -I /home/opam/.opam/5.2/lib/core_unix/iobuf_unix -I /home/opam/.opam/5.2/lib/core_unix/linux_ext -I /home/opam/.opam/5.2/lib/core_unix/nano_mutex -I /home/opam/.opam/5.2/lib/core_unix/ocaml_c_utils -I /home/opam/.opam/5.2/lib/core_unix/signal_unix -I /home/opam/.opam/5.2/lib/core_unix/squeue -I /home/opam/.opam/5.2/lib/core_unix/sys_unix -I /home/opam/.opam/5.2/lib/core_unix/time_float_unix -I /home/opam/.opam/5.2/lib/core_unix/time_ns_unix -I /home/opam/.opam/5.2/lib/core_unix/time_stamp_counter -I /home/opam/.opam/5.2/lib/cstruct -I /home/opam/.opam/5.2/lib/ctypes -I /home/opam/.opam/5.2/lib/ctypes-foreign -I /home/opam/.opam/5.2/lib/ctypes/stubs -I /home/opam/.opam/5.2/lib/domain-name -I /home/opam/.opam/5.2/lib/fieldslib -I /home/opam/.opam/5.2/lib/gel -I /home/opam/.opam/5.2/lib/hex -I /home/opam/.opam/5.2/lib/int_repr -I /home/opam/.opam/5.2/lib/integers -I /home/opam/.opam/5.2/lib/ipaddr -I /home/opam/.opam/5.2/lib/ipaddr-sexp -I /home/opam/.opam/5.2/lib/ipaddr/unix -I /home/opam/.opam/5.2/lib/jane-street-headers -I /home/opam/.opam/5.2/lib/macaddr -I /home/opam/.opam/5.2/lib/ocaml/str -I /home/opam/.opam/5.2/lib/ocaml/threads -I /home/opam/.opam/5.2/lib/ocaml/unix -I /home/opam/.opam/5.2/lib/ocaml_intrinsics_kernel -I /home/opam/.opam/5.2/lib/parsexp -I /home/opam/.opam/5.2/lib/pgx -I /home/opam/.opam/5.2/lib/pgx_value_core -I /home/opam/.opam/5.2/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_diff/diffable -I /home/opam/.opam/5.2/lib/ppx_diff/diffable_cinaps -I /home/opam/.opam/5.2/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_expect/config -I /home/opam/.opam/5.2/lib/ppx_expect/config_types -I /home/opam/.opam/5.2/lib/ppx_expect/make_corrected_file -I /home/opam/.opam/5.2/lib/ppx_expect/runtime -I /home/opam/.opam/5.2/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_inline_test/config -I /home/opam/.opam/5.2/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_log/syntax -I /home/opam/.opam/5.2/lib/ppx_log/types -I /home/opam/.opam/5.2/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.2/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.2/lib/ppx_stable_witness/runtime -I /home/opam/.opam/5.2/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/5.2/lib/ppx_string/runtime -I /home/opam/.opam/5.2/lib/ppxlib/print_diff -I /home/opam/.opam/5.2/lib/protocol_version_header -I /home/opam/.opam/5.2/lib/re -I /home/opam/.opam/5.2/lib/seq -I /home/opam/.opam/5.2/lib/sexplib -I /home/opam/.opam/5.2/lib/sexplib/unix -I /home/opam/.opam/5.2/lib/sexplib0 -I /home/opam/.opam/5.2/lib/spawn -I /home/opam/.opam/5.2/lib/splittable_random -I /home/opam/.opam/5.2/lib/stdio -I /home/opam/.opam/5.2/lib/stdlib-shims -I /home/opam/.opam/5.2/lib/stringext -I /home/opam/.opam/5.2/lib/time_now -I /home/opam/.opam/5.2/lib/timezone -I /home/opam/.opam/5.2/lib/typerep -I /home/opam/.opam/5.2/lib/uopt -I /home/opam/.opam/5.2/lib/uri -I /home/opam/.opam/5.2/lib/uri/services -I /home/opam/.opam/5.2/lib/uuidm -I /home/opam/.opam/5.2/lib/variantslib -intf-suffix .ml -no-alias-deps -o pgx_async/src/.pgx_async.objs/byte/pgx_async_test.cmo -c -impl pgx_async/src/pgx_async_test.ml)
# File "pgx_async/src/pgx_async_test.ml", line 1, characters 5-16:
# 1 | open Core_kernel
#          ^^^^^^^^^^^
# Alert deprecated: module Core_kernel
# [since 2021-05] Use [Core] -- [Core_kernel] was renamed as [Core]
```