### PR TITLE
Package vscoq-language-server.2.1.3

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.1.3/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.1.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/coq-community/vscoq"
+bug-reports: "https://github.com/coq-community/vscoq/issues"
+dev-repo: "git+https://github.com/coq-community/vscoq"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { >= "4.13.1" }
+  "dune" { >= "3.5" }
+  "coq-core" { ((>= "8.18" < "8.20") | (= "dev")) }
+  "coq-stdlib" { ((>= "8.18" < "8.20") | (= "dev")) }
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_yojson_conv" {< "v0.16.0"}
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "ppx_optcomp"
+  "result" { >= "1.5" }
+  "lsp" { >= "1.15"}
+  "sel" {>= "0.4.0"}
+]
+synopsis: "VSCoq language server"
+description: """
+LSP based language server for Coq and its VSCoq user interface
+"""
+url {
+  src:
+    "https://github.com/coq-community/vscoq/releases/download/v2.1.3/vscoq-language-server-2.1.3.tar.gz"
+  checksum: [
+    "md5=300d171d3225fac2a68ce348154ff640"
+    "sha512=65bc228d84f814cfea4b5ddcd20f365a8a8ea178bbd4474129c998e8a351a7dba8d2adbb263f7f18ed41c45c765e73c332b518834360bf3638fe2721518e1fd8"
+  ]
+}


### PR DESCRIPTION
### `vscoq-language-server.2.1.3`
VSCoq language server
LSP based language server for Coq and its VSCoq user interface



---
* Homepage: https://github.com/coq-community/vscoq
* Source repo: git+https://github.com/coq-community/vscoq
* Bug tracker: https://github.com/coq-community/vscoq/issues

---
:camel: Pull-request generated by opam-publish v2.0.3