### PR TITLE
melange.4.0.0-52: require dune 3.16

### DIFF
--- a/packages/melange/melange.4.0.0-52/opam
+++ b/packages/melange/melange.4.0.0-52/opam
@@ -6,7 +6,7 @@ license: "LGPL-2.1-or-later"
 homepage: "https://github.com/melange-re/melange"
 bug-reports: "https://github.com/melange-re/melange/issues"
 depends: [
-  "dune" {>= "3.13"}
+  "dune" {>= "3.16"}
   "ocaml" {>= "5.2"}
   "cmdliner" {>= "1.1.0"}
   "dune-build-info"


### PR DESCRIPTION
When dune 3.16 uses ocaml 5.2 (or melange acting like a 5.2 compiler), it will pass `-bin-annot-occurences`, but `melange.4.0.0-52` doesn't support it (4.0.1-52 does support it). See melange-re/melange#1132 and ocaml/dune#10622.