### PR TITLE
[new release] dream-html (2 packages) (3.5.0)

### DIFF
--- a/packages/dream-html/dream-html.3.5.0/opam
+++ b/packages/dream-html/dream-html.3.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "pure-html"
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.5.0/dream-html-3.5.0.tbz"
+  checksum: [
+    "sha256=58fb17f5a549616cd9c2eb98944cb44f4554f28fa05166dab9d53b27bc92045a"
+    "sha512=3c92ddc6eb1516797af1b39f6bd42552f50abddd17871a712896f3ed709b8117eb2ed7fdf66b410a2cf46c7c79bc45fd47c1b946177f459f4bfbd89de7100cf4"
+  ]
+}
+x-commit-hash: "3ecdbf9d06c91b2fcb4a948f78ceda04695fcc9c"

--- a/packages/pure-html/pure-html.3.5.0/opam
+++ b/packages/pure-html/pure-html.3.5.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.5.0/dream-html-3.5.0.tbz"
+  checksum: [
+    "sha256=58fb17f5a549616cd9c2eb98944cb44f4554f28fa05166dab9d53b27bc92045a"
+    "sha512=3c92ddc6eb1516797af1b39f6bd42552f50abddd17871a712896f3ed709b8117eb2ed7fdf66b410a2cf46c7c79bc45fd47c1b946177f459f4bfbd89de7100cf4"
+  ]
+}
+x-commit-hash: "3ecdbf9d06c91b2fcb4a948f78ceda04695fcc9c"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
