### PR TITLE
[new release] dream-html (2 packages) (3.5.1)

### DIFF
--- a/packages/dream-html/dream-html.3.5.1/opam
+++ b/packages/dream-html/dream-html.3.5.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "pure-html"
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.5.1/dream-html-3.5.1.tbz"
+  checksum: [
+    "sha256=a76654a6b18dd08d3779763a1132bf1d6d36ff6aac08bff24836371a9a7f16ac"
+    "sha512=85897f19316bd93e2ef768b428169cc3a73c325781ae1a4ccba339562b5aea625222af19bf54ea115a48e6026a5b9a76c549e2e4f8b3e16f46af86778ed57646"
+  ]
+}
+x-commit-hash: "31d8c28cc162758ef278b6c6ffa81afaa5dd9a90"

--- a/packages/pure-html/pure-html.3.5.1/opam
+++ b/packages/pure-html/pure-html.3.5.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.5.1/dream-html-3.5.1.tbz"
+  checksum: [
+    "sha256=a76654a6b18dd08d3779763a1132bf1d6d36ff6aac08bff24836371a9a7f16ac"
+    "sha512=85897f19316bd93e2ef768b428169cc3a73c325781ae1a4ccba339562b5aea625222af19bf54ea115a48e6026a5b9a76c549e2e4f8b3e16f46af86778ed57646"
+  ]
+}
+x-commit-hash: "31d8c28cc162758ef278b6c6ffa81afaa5dd9a90"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
