### PR TITLE
[new release] eqaf (2 packages) (0.10)

### DIFF
--- a/packages/eqaf-cstruct/eqaf-cstruct.0.10/opam
+++ b/packages/eqaf-cstruct/eqaf-cstruct.0.10/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/eqaf"
+bug-reports:  "https://github.com/mirage/eqaf/issues"
+dev-repo:     "git+https://github.com/mirage/eqaf.git"
+doc:          "https://mirage.github.io/eqaf/"
+license:      "MIT"
+synopsis:     "Constant-time equal function on string"
+description: """
+This package provides an equal function on string in constant-time to avoid timing-attack with crypto stuff.
+"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml"          {>= "4.07.0"}
+  "dune"           {>= "2.0"}
+  "cstruct"        {>= "1.1.0"}
+  "eqaf"           {= version}
+]
+url {
+  src: "https://github.com/mirage/eqaf/releases/download/v0.10/eqaf-0.10.tbz"
+  checksum: [
+    "sha256=67d1369c57c4d2d14a10d02632d45e355224abeb98aec08979c0bae5843092ee"
+    "sha512=7f75b5d5667e3605f8d95e2d6fda40953129033e6a342ee2c98ee4135c2428e1db87547971868605ab989374757c47c21c5397d4c3da578952d716826a156979"
+  ]
+}
+x-commit-hash: "7bec047f8bfa1a233d24fc4a4b77e8eb18988155"

--- a/packages/eqaf/eqaf.0.10/opam
+++ b/packages/eqaf/eqaf.0.10/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/eqaf"
+bug-reports:  "https://github.com/mirage/eqaf/issues"
+dev-repo:     "git+https://github.com/mirage/eqaf.git"
+doc:          "https://mirage.github.io/eqaf/"
+license:      "MIT"
+synopsis:     "Constant-time equal function on string"
+description: """
+This package provides an equal function on string in constant-time to avoid timing-attack with crypto stuff.
+"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" "1" "--no-buffer" "--verbose" ] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.07.0"}
+  "dune"           {>= "2.0"}
+  "base64"         {with-test & >= "3.0.0"}
+  "alcotest"       {with-test}
+  "crowbar"        {with-test}
+  "fmt"            {with-test & >= "0.8.7"}
+  "bechamel"       {with-test}
+]
+url {
+  src: "https://github.com/mirage/eqaf/releases/download/v0.10/eqaf-0.10.tbz"
+  checksum: [
+    "sha256=67d1369c57c4d2d14a10d02632d45e355224abeb98aec08979c0bae5843092ee"
+    "sha512=7f75b5d5667e3605f8d95e2d6fda40953129033e6a342ee2c98ee4135c2428e1db87547971868605ab989374757c47c21c5397d4c3da578952d716826a156979"
+  ]
+}
+x-commit-hash: "7bec047f8bfa1a233d24fc4a4b77e8eb18988155"


### PR DESCRIPTION
Constant-time equal function on string

- Project page: <a href="https://github.com/mirage/eqaf">https://github.com/mirage/eqaf</a>
- Documentation: <a href="https://mirage.github.io/eqaf/">https://mirage.github.io/eqaf/</a>

##### CHANGES:

- Implement functions provided by `eqaf` on bytes (@FantomeBeignet, mirage/eqaf#41)
- Choose the right clock on MSVC systems (@dra27, mirage/eqaf#40)
- Fix the lower bounds about base64 (@hannesm, mirage/eqaf#45)
- Split `eqaf` and `eqaf-cstruct` (@dinosaure, @hannesm, mirage/eqaf#43)
