### PR TITLE
[new release] dream-html (2 packages) (3.5.2)

### DIFF
--- a/packages/dream-html/dream-html.3.5.2/opam
+++ b/packages/dream-html/dream-html.3.5.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.5.2/dream-html-3.5.2.tbz"
+  checksum: [
+    "sha256=a7326b67750b7658283235f5c2b8483f7633785d0e4e8060f8745353edb925b1"
+    "sha512=74c10a8b55b5c90fd1b87cf4ce9ed8af6a514a4d56d874b219207ff75316cbcdebb8aefe6b4fb858d46eaa2374fe289b7ce4885ca17d9e6052b46d4842da43c7"
+  ]
+}
+x-commit-hash: "c9832418d2216079bf796354e0c1eec97c5007cf"

--- a/packages/pure-html/pure-html.3.5.2/opam
+++ b/packages/pure-html/pure-html.3.5.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.5.2/dream-html-3.5.2.tbz"
+  checksum: [
+    "sha256=a7326b67750b7658283235f5c2b8483f7633785d0e4e8060f8745353edb925b1"
+    "sha512=74c10a8b55b5c90fd1b87cf4ce9ed8af6a514a4d56d874b219207ff75316cbcdebb8aefe6b4fb858d46eaa2374fe289b7ce4885ca17d9e6052b46d4842da43c7"
+  ]
+}
+x-commit-hash: "c9832418d2216079bf796354e0c1eec97c5007cf"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
