### PR TITLE
mirage-crypto & fiat-p256 does not work with newer eqaf (requires the .cstruct package)

### DIFF
--- a/packages/fiat-p256/fiat-p256.0.2.1/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.1/opam
@@ -34,7 +34,7 @@ depends: [
   "cstruct" {>= "3.5.0" & < "6.1.0"}
   "dune" {>= "1.10.0"}
   "dune-configurator"
-  "eqaf" {>= "0.5" & < "0.10"}
+  "eqaf" {>= "0.7" & < "0.10"}
   "hex"
   "ppx_deriving_yojson" {with-test}
   "rresult" {with-test}

--- a/packages/fiat-p256/fiat-p256.0.2.1/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.1/opam
@@ -35,7 +35,7 @@ depends: [
   "dune" {>= "1.10.0"}
   "dune-configurator"
   "eqaf" {>= "0.7" & < "0.10"}
-  "hex" {>= "1.4.0}
+  "hex" {>= "1.4.0"}
   "ppx_deriving_yojson" {with-test}
   "rresult" {with-test}
   "stdlib-shims" {with-test}

--- a/packages/fiat-p256/fiat-p256.0.2.1/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.1/opam
@@ -34,7 +34,7 @@ depends: [
   "cstruct" {>= "3.5.0" & < "6.1.0"}
   "dune" {>= "1.10.0"}
   "dune-configurator"
-  "eqaf" {>= "0.5"}
+  "eqaf" {>= "0.5" & < "0.10"}
   "hex"
   "ppx_deriving_yojson" {with-test}
   "rresult" {with-test}

--- a/packages/fiat-p256/fiat-p256.0.2.1/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.1/opam
@@ -35,7 +35,7 @@ depends: [
   "dune" {>= "1.10.0"}
   "dune-configurator"
   "eqaf" {>= "0.7" & < "0.10"}
-  "hex"
+  "hex" {>= "1.4.0}
   "ppx_deriving_yojson" {with-test}
   "rresult" {with-test}
   "stdlib-shims" {with-test}

--- a/packages/fiat-p256/fiat-p256.0.2.2/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.2/opam
@@ -28,7 +28,7 @@ depends: [
   "cstruct" {>= "3.5.0" & < "6.1.0"}
   "dune-configurator"
   "eqaf" {>= "0.7" & < "0.10"}
-  "hex"
+  "hex" {>= "1.4.0"}
   "conf-pkg-config" {build}
   "ppx_deriving_yojson" {with-test}
   "rresult" {with-test}

--- a/packages/fiat-p256/fiat-p256.0.2.2/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.2/opam
@@ -27,7 +27,7 @@ depends: [
   "bigarray-compat"
   "cstruct" {>= "3.5.0" & < "6.1.0"}
   "dune-configurator"
-  "eqaf" {>= "0.5" & < "0.10"}
+  "eqaf" {>= "0.7" & < "0.10"}
   "hex"
   "conf-pkg-config" {build}
   "ppx_deriving_yojson" {with-test}

--- a/packages/fiat-p256/fiat-p256.0.2.2/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.2/opam
@@ -27,7 +27,7 @@ depends: [
   "bigarray-compat"
   "cstruct" {>= "3.5.0" & < "6.1.0"}
   "dune-configurator"
-  "eqaf" {>= "0.5"}
+  "eqaf" {>= "0.5" & < "0.10"}
   "hex"
   "conf-pkg-config" {build}
   "ppx_deriving_yojson" {with-test}

--- a/packages/fiat-p256/fiat-p256.0.2.3/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.3/opam
@@ -28,7 +28,7 @@ depends: [
   "cstruct" {>= "3.5.0" & < "6.1.0"}
   "dune-configurator"
   "eqaf" {>= "0.7" & < "0.10"}
-  "hex"
+  "hex" {>= "1.4.0"}
   "conf-pkg-config" {build}
   "ppx_deriving_yojson" {with-test}
   "rresult" {with-test}

--- a/packages/fiat-p256/fiat-p256.0.2.3/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.3/opam
@@ -27,7 +27,7 @@ depends: [
   "bigarray-compat"
   "cstruct" {>= "3.5.0" & < "6.1.0"}
   "dune-configurator"
-  "eqaf" {>= "0.5" & < "0.10"}
+  "eqaf" {>= "0.7" & < "0.10"}
   "hex"
   "conf-pkg-config" {build}
   "ppx_deriving_yojson" {with-test}

--- a/packages/fiat-p256/fiat-p256.0.2.3/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.3/opam
@@ -27,7 +27,7 @@ depends: [
   "bigarray-compat"
   "cstruct" {>= "3.5.0" & < "6.1.0"}
   "dune-configurator"
-  "eqaf" {>= "0.5"}
+  "eqaf" {>= "0.5" & < "0.10"}
   "hex"
   "conf-pkg-config" {build}
   "ppx_deriving_yojson" {with-test}

--- a/packages/mirage-crypto/mirage-crypto.0.10.0/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.10.0/opam
@@ -19,7 +19,7 @@ depends: [
   "dune-configurator" {>= "2.0.0"}
   "ounit" {with-test}
   "cstruct" {>="3.2.0" & < "6.1.0"}
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
   "bigarray-compat" # required to get eqaf.cstruct
 ]
 depopts: [

--- a/packages/mirage-crypto/mirage-crypto.0.10.1/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.10.1/opam
@@ -19,7 +19,7 @@ depends: [
   "dune-configurator" {>= "2.0.0"}
   "ounit" {with-test}
   "cstruct" {>="3.2.0" & < "6.1.0"}
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
   "bigarray-compat" # required to get eqaf.cstruct
 ]
 depopts: [

--- a/packages/mirage-crypto/mirage-crypto.0.10.2/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.10.2/opam
@@ -19,7 +19,7 @@ depends: [
   "dune-configurator" {>= "2.0.0"}
   "ounit" {with-test}
   "cstruct" {>="3.2.0" & < "6.1.0"}
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
   "bigarray-compat" # required to get eqaf.cstruct
 ]
 depopts: [

--- a/packages/mirage-crypto/mirage-crypto.0.10.3/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.10.3/opam
@@ -19,7 +19,7 @@ depends: [
   "dune-configurator" {>= "2.0.0"}
   "ounit" {with-test}
   "cstruct" {>="3.2.0" & < "6.1.0"}
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
   "bigarray-compat" # required to get eqaf.cstruct
 ]
 depopts: [

--- a/packages/mirage-crypto/mirage-crypto.0.10.4/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.10.4/opam
@@ -19,7 +19,7 @@ depends: [
   "dune-configurator" {>= "2.0.0"}
   "ounit" {with-test}
   "cstruct" {>="6.0.0"}
-  "eqaf" {>= "0.8"}
+  "eqaf" {>= "0.8" & < "0.10"}
 ]
 depopts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto/mirage-crypto.0.10.5/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.10.5/opam
@@ -19,7 +19,7 @@ depends: [
   "dune-configurator" {>= "2.0.0"}
   "ounit" {with-test}
   "cstruct" {>="6.0.0"}
-  "eqaf" {>= "0.8"}
+  "eqaf" {>= "0.8" & < "0.10"}
 ]
 depopts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto/mirage-crypto.0.10.6/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.10.6/opam
@@ -19,7 +19,7 @@ depends: [
   "dune-configurator" {>= "2.0.0"}
   "ounit2" {with-test}
   "cstruct" {>="6.0.0"}
-  "eqaf" {>= "0.8"}
+  "eqaf" {>= "0.8" & < "0.10"}
 ]
 depopts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto/mirage-crypto.0.10.7/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.10.7/opam
@@ -19,7 +19,7 @@ depends: [
   "dune-configurator" {>= "2.0.0"}
   "ounit2" {with-test}
   "cstruct" {>="6.0.0"}
-  "eqaf" {>= "0.8"}
+  "eqaf" {>= "0.8" & < "0.10"}
 ]
 depopts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto/mirage-crypto.0.11.0/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.11.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune-configurator" {>= "2.0.0"}
   "ounit2" {with-test}
   "cstruct" {>="6.0.0"}
-  "eqaf" {>= "0.8"}
+  "eqaf" {>= "0.8" & < "0.10"}
 ]
 conflicts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto/mirage-crypto.0.11.1/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.11.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dune-configurator" {>= "2.0.0"}
   "ounit2" {with-test}
   "cstruct" {>="6.0.0"}
-  "eqaf" {>= "0.8"}
+  "eqaf" {>= "0.8" & < "0.10"}
 ]
 conflicts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto/mirage-crypto.0.11.2/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.11.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dune-configurator" {>= "2.0.0"}
   "ounit2" {with-test}
   "cstruct" {>="6.0.0"}
-  "eqaf" {>= "0.8"}
+  "eqaf" {>= "0.8" & < "0.10"}
 ]
 conflicts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto/mirage-crypto.0.11.3/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.11.3/opam
@@ -18,7 +18,7 @@ depends: [
   "dune-configurator" {>= "2.0.0"}
   "ounit2" {with-test}
   "cstruct" {>="6.0.0"}
-  "eqaf" {>= "0.8"}
+  "eqaf" {>= "0.8" & < "0.10"}
 ]
 conflicts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto/mirage-crypto.0.8.1/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.1/opam
@@ -20,7 +20,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0"}
   "bigarray-compat" # required to get eqaf.cstruct
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
 ]
 depopts: [
   "mirage-xen-posix"

--- a/packages/mirage-crypto/mirage-crypto.0.8.10/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.10/opam
@@ -20,7 +20,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>= "3.2.0" & < "6.1.0"}
   "bigarray-compat" # required to get eqaf.cstruct
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
 ]
 depopts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto/mirage-crypto.0.8.2/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.2/opam
@@ -20,7 +20,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0"}
   "bigarray-compat" # required to get eqaf.cstruct
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
 ]
 depopts: [
   "mirage-xen-posix"

--- a/packages/mirage-crypto/mirage-crypto.0.8.3/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.3/opam
@@ -20,7 +20,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0"}
   "bigarray-compat" # required to get eqaf.cstruct
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
 ]
 depopts: [
   "mirage-xen-posix"

--- a/packages/mirage-crypto/mirage-crypto.0.8.4/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.4/opam
@@ -20,7 +20,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0"}
   "bigarray-compat" # required to get eqaf.cstruct
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
 ]
 depopts: [
   "mirage-xen-posix"

--- a/packages/mirage-crypto/mirage-crypto.0.8.5/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.5/opam
@@ -20,7 +20,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0" & < "6.1.0"}
   "bigarray-compat" # required to get eqaf.cstruct
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
 ]
 depopts: [
   "mirage-xen-posix"

--- a/packages/mirage-crypto/mirage-crypto.0.8.6/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.6/opam
@@ -20,7 +20,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0" & < "6.1.0"}
   "bigarray-compat" # required to get eqaf.cstruct
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
 ]
 depopts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto/mirage-crypto.0.8.7/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.7/opam
@@ -20,7 +20,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0" & < "6.1.0"}
   "bigarray-compat" # required to get eqaf.cstruct
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
 ]
 depopts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto/mirage-crypto.0.8.8/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.8/opam
@@ -20,7 +20,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0" & < "6.1.0"}
   "bigarray-compat" # required to get eqaf.cstruct
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
 ]
 depopts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto/mirage-crypto.0.8.9/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.8.9/opam
@@ -20,7 +20,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0" & < "6.1.0"}
   "bigarray-compat" # required to get eqaf.cstruct
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
 ]
 depopts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto/mirage-crypto.0.9.0/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.9.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0" & < "6.1.0"}
   "bigarray-compat" # required to get eqaf.cstruct
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
 ]
 depopts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto/mirage-crypto.0.9.1/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.9.1/opam
@@ -20,7 +20,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0" & < "6.1.0"}
   "bigarray-compat" # required to get eqaf.cstruct
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
 ]
 depopts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto/mirage-crypto.0.9.2/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.9.2/opam
@@ -20,7 +20,7 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0" & < "6.1.0"}
   "bigarray-compat" # required to get eqaf.cstruct
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
 ]
 depopts: [
   "ocaml-freestanding"


### PR DESCRIPTION
for #26094

```
=== ERROR while compiling mirage-crypto.0.11.0 ===============================#
 context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
 path                 ~/.opam/4.14/.opam-switch/build/mirage-crypto.0.11.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p mirage-crypto -j 255
 exit-code            1
 env-file             ~/.opam/log/mirage-crypto-7-db30d0.env
 output-file          ~/.opam/log/mirage-crypto-7-db30d0.out
 ## output ###
 File "src/dune", line 4, characters 20-32:
 4 |  (libraries cstruct eqaf.cstruct)
                         ^^^^^^^^^^^^
 Error: Library "eqaf.cstruct" not found.
 -> required by library "mirage-crypto" in _build/default/src
 -> required by _build/default/META.mirage-crypto
 -> required by _build/install/default/lib/mirage-crypto/META
 -> required by _build/default/mirage-crypto.install
 -> required by alias install
```