### PR TITLE
mirage-crypto-pk 0.6* 0.7* 0.8.0: restrict to eqaf < 0.10

### DIFF
--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.0/opam
@@ -24,7 +24,7 @@ depends: [
   "sexplib"
   "ppx_sexp_conv"
   "zarith" {>= "1.4"}
-  "eqaf" {>= "0.6"}
+  "eqaf" {>= "0.6" & < "0.10"}
   "bigarray-compat" # required to get eqaf.cstruct
   "rresult" {>= "0.6.0"}
   ("mirage-no-xen" | "zarith-xen")

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.1/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.1/opam
@@ -24,7 +24,7 @@ depends: [
   "sexplib"
   "ppx_sexp_conv"
   "zarith" {>= "1.4"}
-  "eqaf" {>= "0.6"}
+  "eqaf" {>= "0.6" & < "0.10"}
   "bigarray-compat" # required to get eqaf.cstruct
   "rresult" {>= "0.6.0"}
   ("mirage-no-xen" | "zarith-xen")

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.2/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.6.2/opam
@@ -24,7 +24,7 @@ depends: [
   "sexplib"
   "ppx_sexp_conv"
   "zarith" {>= "1.4"}
-  "eqaf" {>= "0.6"}
+  "eqaf" {>= "0.6" & < "0.10"}
   "bigarray-compat" # required to get eqaf.cstruct
   "rresult" {>= "0.6.0"}
   ("mirage-no-xen" | "zarith-xen")

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.7.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.7.0/opam
@@ -24,7 +24,7 @@ depends: [
   "sexplib"
   "ppx_sexp_conv"
   "zarith" {>= "1.4"}
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
   "bigarray-compat" # required to get eqaf.cstruct
   "rresult" {>= "0.6.0"}
   ("mirage-no-xen" | "zarith-xen")

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.8.0/opam
@@ -24,7 +24,7 @@ depends: [
   "sexplib"
   "ppx_sexp_conv"
   "zarith" {>= "1.4"}
-  "eqaf" {>= "0.7"}
+  "eqaf" {>= "0.7" & < "0.10"}
   "bigarray-compat" # required to get eqaf.cstruct
   "rresult" {>= "0.6.0"}
   ("mirage-no-xen" | "zarith-xen")


### PR DESCRIPTION
this is a second part of fixing the revdeps of #26094 

I didn't bother restricting mirage-crypto-pk (or mirage-crypto-ec) > 0.8.0, since mirage-crypto itself is adjusted to require eqaf < 0.10 from that version on, and the mirage-crypto-{pk,ec} require mirage-crypto with =version.

```
=== ERROR while compiling mirage-crypto-pk.0.8.0 =============================#
 context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
 path                 ~/.opam/4.14/.opam-switch/build/mirage-crypto-pk.0.8.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p mirage-crypto-pk -j 255
 exit-code            1
 env-file             ~/.opam/log/mirage-crypto-pk-7-5cecb4.env
 output-file          ~/.opam/log/mirage-crypto-pk-7-5cecb4.out
 ## output ###
 File "pk/dune", line 4, characters 68-80:
 4 |   (libraries cstruct zarith mirage-crypto mirage-crypto-rng sexplib eqaf.cstruct rresult)
                                                                         ^^^^^^^^^^^^
 Error: Library "eqaf.cstruct" not found.
 -> required by library "mirage-crypto-pk" in _build/default/pk
 -> required by _build/default/META.mirage-crypto-pk
 -> required by _build/install/default/lib/mirage-crypto-pk/META
 -> required by _build/default/mirage-crypto-pk.install
 -> required by alias install
```