### PR TITLE
[new release] pyre-ast (0.1.10)

### DIFF
--- a/packages/pyre-ast/pyre-ast.0.1.10/opam
+++ b/packages/pyre-ast/pyre-ast.0.1.10/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Full-fidelity Python parser in OCaml"
+description:
+  "pyre-ast is an OCaml library to parse Python source files into abstract syntax trees. Under the hood, it relies on the CPython parser to do the parsing work and therefore the result is always 100% compatible with the official CPython implementation."
+maintainer: ["grievejia@gmail.com"]
+authors: ["Jia Chen"]
+license: "MIT"
+homepage: "https://github.com/grievejia/pyre-ast"
+doc: "https://grievejia.github.io/pyre-ast/doc"
+bug-reports: "https://github.com/grievejia/pyre-ast/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "base" {>= "v0.14.1"}
+  "ppx_sexp_conv" {>= "v0.14.0"}
+  "ppx_compare" {>= "v0.14.0"}
+  "ppx_hash" {>= "v0.14.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "ppx_make" {>= "0.2.1"}
+  "stdio" {with-test & >= "v0.14.0"}
+  "sexplib" {with-test & >= "v0.14.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/grievejia/pyre-ast.git"
+available: [ os-family != "windows" ]
+url {
+  src:
+    "https://github.com/grievejia/pyre-ast/releases/download/0.1.10/pyre-ast-0.1.10.tbz"
+  checksum: [
+    "sha256=999bfd6a49e65b318ba091bdb7240312bb9c5f1322da291fa1684b66deb5d26b"
+    "sha512=646f1bd678127b4f0b5a3b74302d16404b46b3bb2e5562ab5fbcc03e420fa48e1a767e7e020833edc9c75624aa47baf4fa746f3769e8b481a6473c60a020882b"
+  ]
+}
+x-commit-hash: "3179623fa5ed4495e5a26ab392570710cf5d1b83"


### PR DESCRIPTION
Full-fidelity Python parser in OCaml

- Project page: <a href="https://github.com/grievejia/pyre-ast">https://github.com/grievejia/pyre-ast</a>
- Documentation: <a href="https://grievejia.github.io/pyre-ast/doc">https://grievejia.github.io/pyre-ast/doc</a>

##### CHANGES:

- Bump the bundled CPython version to 3.12.3
