### PR TITLE
[new release] merlin (5.1-502) and ocaml-index (1.0) and ocaml-lsp-server preview update

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.5.0-502/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.0-502/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "5.2" }
   "dune" {>= "2.9.0"}
-  "merlin-lib" {>= "5.0"}
+  "merlin-lib" {>= "5.0" && < "5.1"}
   "ocamlfind" {>= "1.6.0"}
 ]
 description:

--- a/packages/dot-merlin-reader/dot-merlin-reader.5.0-502/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.0-502/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "5.2" }
   "dune" {>= "2.9.0"}
-  "merlin-lib" {>= "5.0" && < "5.1"}
+  "merlin-lib" {>= "5.0" & < "5.1"}
   "ocamlfind" {>= "1.6.0"}
 ]
 description:

--- a/packages/dot-merlin-reader/dot-merlin-reader.5.1/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "5.0" }
-  "dune" {>= "2.9.0"}
+  "dune" {>= "3.0.0"}
   "merlin-lib" {>= "5.1"}
   "ocamlfind" {>= "1.6.0"}
 ]

--- a/packages/dot-merlin-reader/dot-merlin-reader.5.1/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.0" }
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {>= "5.1"}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.1-502/merlin-5.1-502.tbz"
+  checksum: [
+    "sha256=4fd808bc26929cffcca8ea06344790159c10e3eaf9c914cf46ef79e917fcae15"
+    "sha512=1e582c8d3de6784a036b930136a568eb0cedf213a01041acfcff4eda9c6f74adab9a55c4c0d806b8fccbd882b14a984c9fba480f6c5950146b842d6c100a8d1f"
+  ]
+}
+x-commit-hash: "ce00b5bc2bc813bd1b0e2a49438b095042ff7727"

--- a/packages/merlin-lib/merlin-lib.5.1-502/opam
+++ b/packages/merlin-lib/merlin-lib.5.1-502/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" & < "5.3"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.1-502/merlin-5.1-502.tbz"
+  checksum: [
+    "sha256=4fd808bc26929cffcca8ea06344790159c10e3eaf9c914cf46ef79e917fcae15"
+    "sha512=1e582c8d3de6784a036b930136a568eb0cedf213a01041acfcff4eda9c6f74adab9a55c4c0d806b8fccbd882b14a984c9fba480f6c5950146b842d6c100a8d1f"
+  ]
+}
+x-commit-hash: "ce00b5bc2bc813bd1b0e2a49438b095042ff7727"

--- a/packages/merlin-lib/merlin-lib.5.1-502/opam
+++ b/packages/merlin-lib/merlin-lib.5.1-502/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "5.2" & < "5.3"}
-  "dune" {>= "2.9.0"}
+  "dune" {>= "3.0.0"}
   "csexp" {>= "1.5.1"}
   "menhir"    {dev & >= "20201216"}
   "menhirLib" {dev & >= "20201216"}

--- a/packages/merlin/merlin.5.1-502/opam
+++ b/packages/merlin/merlin.5.1-502/opam
@@ -1,0 +1,82 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.2" & < "5.3"}
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "5.0"}
+  "ocaml-index" {>= "1.0" & post}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.1-502/merlin-5.1-502.tbz"
+  checksum: [
+    "sha256=4fd808bc26929cffcca8ea06344790159c10e3eaf9c914cf46ef79e917fcae15"
+    "sha512=1e582c8d3de6784a036b930136a568eb0cedf213a01041acfcff4eda9c6f74adab9a55c4c0d806b8fccbd882b14a984c9fba480f6c5950146b842d6c100a8d1f"
+  ]
+}
+x-commit-hash: "ce00b5bc2bc813bd1b0e2a49438b095042ff7727"

--- a/packages/ocaml-index/ocaml-index.1.0/opam
+++ b/packages/ocaml-index/ocaml-index.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A tool that indexes value usages from cmt files"
+description:
+  "ocaml-index should integrate with the build system to index codebase and allow tools such as Merlin to perform project-wide occurrences queries."
+maintainer: ["ulysse@tarides.com"]
+authors: ["ulysse@tarides.com"]
+license: "MIT"
+homepage: "https://github.com/voodoos/ocaml-index"
+bug-reports: "https://github.com/voodoos/ocaml-index/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.2"}
+  "merlin-lib" {>= "5.1-502"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/voodoos/ocaml-index.git"
+url {
+  src:
+    "https://github.com/voodoos/ocaml-index/releases/download/v1.0/ocaml-index-1.0.tbz"
+  checksum: [
+    "sha256=01e39ca310d561f7012f5dad47905173747466c5c9f7dfe14833db5c72871e1c"
+    "sha512=3fa40158d20a9da66d6e10d4ff566457f9279f6e6b5012275ad30c11678a4516922f940817d4d70c9eec68dc2458848d09e75b5bd7f3f08aee01e82a063f0c1f"
+  ]
+}
+x-commit-hash: "0f9ffbbc9d1b4def495d3d2c7aa135a486bbcc9d"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0~5.2preview/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0~5.2preview/opam
@@ -43,7 +43,8 @@ depends: [
   "ocamlformat-rpc-lib" {>= "0.21.0"}
   "odoc" {with-doc}
   "ocaml" {>= "5.2" & < "5.3"}
-  "merlin-lib" {>= "5.0"}
+  "merlin-lib" {>= "5.1"}
+  "ocaml-index" {>= "1.0" & post}
 ]
 flags: avoid-version
 available: opam-version >= "2.1.0"
@@ -61,9 +62,9 @@ build: [
 ]
 url {
   src:
-    "https://github.com/ocaml/ocaml-lsp/archive/3d84dc42c468d03ce36291985573b87767b6f670.tar.gz"
+    "https://github.com/ocaml/ocaml-lsp/archive/0573158a2bdbe891d6d0026c922d9cfdca55bcf8.tar.gz"
   checksum: [
-    "sha256=f6a54286923b9ec019748a258b40e0b889d155427c262a3ab69ddb02c48409a8"
-    "sha512=1efd7fbdd381b17df7be998200ad6b44c48a8b886e2ffc0a16a618a0f2019d5e0350446c10359a4d32072e943ecad9a6c706b437478bd5773a0b479925ff5596"
+    "sha256=dbf43e82a01b2999db6b5df009b3f285b04265b81ec34edc25604b72e1613a2c"
+    "sha512=51bbf98dd4cd2c9d35cc3a515fff74a7d10ed736febb8ff2683739aab818e578ca16e9f126aa774a492a7141e0d34977fc1558f5feac71b8db3c1e1843fd213f"
   ]
 }


### PR DESCRIPTION
## [new release] merlin (3 packages) (5.1-502)

CHANGES:

Tue Jun 18 12:00:42 CEST 2024

  + merlin binary
    - Support project-wide occurrences queries using index files (ocaml/merlin#1766)
      - The file format is described in library `Merlin_lib.index_format`
      - Two new configuration directives are introduced:
        - `SOURCE_ROOT` that is used to resolve relative paths found in the
          indexes.
        - `INDEX` that is used to declare the list of index files Merlin should
          use when looking for occurrences.
    - A new `UNIT_NAME` configuration directive that can be used to tell Merlin
      the correct name of the current unit in the presence of wrapping (ocaml/merlin#1776)
    - Perform incremental indexation of the buffer when typing. (ocaml/merlin#1777)
    - `merlin-lib.commands`: Add a `find_command_opt` alternative to
      `find_command` that does not raise (ocaml/merlin#1778)
    - Prevent uid clashes by not returning PWO for defs located in the current
      interface file (ocaml/merlin#1781)
    - Reset uid counters when restoring the typer cache so that uids are stable
      across re-typing (ocaml/merlin#1779)
    - Improve the behavior on occurrences when the cursor is on a label /
      constructor declaration (ocaml/merlin#1785)
  + editor modes
    - emacs: add basic support for project-wide occurrences (ocaml/merlin#1766)
    - vim: add basic support for project-wide occurrences (ocaml/merlin#1767, @Julow)

## [new release] ocaml-index (1.0)

CHANGES:

### Added

- Initial release.
- The `aggregate` command that finishes reduction of shapes in cmt files and
  store the output in a single index file.
- The `stats` command that prints information about an index file.
- The `dump` command that prints all locs of an index.