### PR TITLE
2 packages from ocaml-mlx/mlx at 0.9

### DIFF
--- a/packages/mlx/mlx.0.9/opam
+++ b/packages/mlx/mlx.0.9/opam
@@ -8,7 +8,7 @@ doc: "https://url/to/documentation"
 bug-reports: "https://github.com/ocaml-mlx/mlx/issues"
 depends: [
   "ocaml" {>= "4.14.0"}
-  "ppxlib"
+  "ppxlib" {>= "0.32.1"}
   "dune" {>= "3.15"}
   "menhir" {= "20210419" & with-dev-setup}
   "ocamlformat" {with-dev-setup}

--- a/packages/mlx/mlx.0.9/opam
+++ b/packages/mlx/mlx.0.9/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ocaml-mlx/mlx/issues"
 depends: [
   "ocaml" {>= "4.14.0"}
   "ppxlib"
-  "dune" {>= "3.9"}
+  "dune" {>= "3.15"}
   "menhir" {= "20210419" & with-dev-setup}
   "ocamlformat" {with-dev-setup}
   "odoc" {with-doc}

--- a/packages/mlx/mlx.0.9/opam
+++ b/packages/mlx/mlx.0.9/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "OCaml syntax dialect which adds JSX syntax expressions"
+maintainer: ["Andrey Popp"]
+authors: ["Andrey Popp"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml-mlx/mlx"
+doc: "https://url/to/documentation"
+bug-reports: "https://github.com/ocaml-mlx/mlx/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ppxlib"
+  "dune" {>= "3.9"}
+  "menhir" {= "20210419" & with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-mlx/mlx.git"
+url {
+  src: "https://github.com/ocaml-mlx/mlx/archive/refs/tags/0.9.tar.gz"
+  checksum: [
+    "md5=c413c013d6c3a905e9b77cc2f65413cf"
+    "sha512=b16bcbb1e168fbc4d31b3f72f3e4d9b8d161988724a85c256f6e3f9795868fe77934ccead62b843f360da67a028f6bd484f2f4c5216d51ac9dc372439b0fc717"
+  ]
+}

--- a/packages/ocamlmerlin-mlx/ocamlmerlin-mlx.0.9/opam
+++ b/packages/ocamlmerlin-mlx/ocamlmerlin-mlx.0.9/opam
@@ -8,7 +8,7 @@ doc: "https://url/to/documentation"
 bug-reports: "https://github.com/ocaml-mlx/mlx/issues"
 depends: [
   "ocaml" {>= "4.14.0"}
-  "ppxlib"
+  "ppxlib" {>= "0.32.1"}
   "dune" {>= "3.15"}
   "merlin-lib"
   "cppo"

--- a/packages/ocamlmerlin-mlx/ocamlmerlin-mlx.0.9/opam
+++ b/packages/ocamlmerlin-mlx/ocamlmerlin-mlx.0.9/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Merlin support for MLX OCaml dialect"
+maintainer: ["Andrey Popp"]
+authors: ["Andrey Popp"]
+license: "MIT"
+homepage: "https://github.com/ocaml-mlx/mlx"
+doc: "https://url/to/documentation"
+bug-reports: "https://github.com/ocaml-mlx/mlx/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ppxlib"
+  "dune" {>= "3.9"}
+  "merlin-lib"
+  "cppo"
+  "csexp" {with-dev-setup}
+  "menhir" {= "20201216" & with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-mlx/mlx.git"
+url {
+  src: "https://github.com/ocaml-mlx/mlx/archive/refs/tags/0.9.tar.gz"
+  checksum: [
+    "md5=c413c013d6c3a905e9b77cc2f65413cf"
+    "sha512=b16bcbb1e168fbc4d31b3f72f3e4d9b8d161988724a85c256f6e3f9795868fe77934ccead62b843f360da67a028f6bd484f2f4c5216d51ac9dc372439b0fc717"
+  ]
+}

--- a/packages/ocamlmerlin-mlx/ocamlmerlin-mlx.0.9/opam
+++ b/packages/ocamlmerlin-mlx/ocamlmerlin-mlx.0.9/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ocaml-mlx/mlx/issues"
 depends: [
   "ocaml" {>= "4.14.0"}
   "ppxlib"
-  "dune" {>= "3.9"}
+  "dune" {>= "3.15"}
   "merlin-lib"
   "cppo"
   "csexp" {with-dev-setup}


### PR DESCRIPTION
This pull-request concerns:
- `mlx.0.9`: OCaml syntax dialect which adds JSX syntax expressions
- `ocamlmerlin-mlx.0.9`: Merlin support for MLX OCaml dialect



---
* Homepage: https://github.com/ocaml-mlx/mlx
* Source repo: git+https://github.com/ocaml-mlx/mlx.git
* Bug tracker: https://github.com/ocaml-mlx/mlx/issues

---
:camel: Pull-request generated by opam-publish v2.3.0