### PR TITLE
[new release] caisar (2.0)

### DIFF
--- a/packages/caisar/caisar.2.0/opam
+++ b/packages/caisar/caisar.2.0/opam
@@ -47,7 +47,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+#    "@runtest" {with-test} # tests require py-onnx
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/caisar/caisar.2.0/opam
+++ b/packages/caisar/caisar.2.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis:
+  "A platform for characterizing the safety and robustness of artificial intelligence based software"
+maintainer: ["AISER team, Software Safety and Security Laboratory, CEA-List"]
+authors: ["AISER team, Software Safety and Security Laboratory, CEA-List"]
+license: "LGPL-2.1-only"
+homepage: "https://git.frama-c.com/pub/caisar"
+doc: "https://git.frama-c.com/pub/caisar"
+bug-reports: "https://git.frama-c.com/pub/caisar/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.13"}
+  "dune-site" {>= "2.9.0"}
+  "piqi" {>= "0.7.6"}
+  "piqilib" {>= "0.6.14"}
+  "zarith" {>= "1.7"}
+  "ocplib-endian" {>= "1.0"}
+  "base" {>= "v0.15.1" & < "v0.17.0"}
+  "stdio" {>= "v0.14.0"}
+  "cmdliner" {>= "1.1.1"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "yojson" {>= "1.7.0"}
+  "menhirLib" {>= "20210310"}
+  "csv" {>= "2.4"}
+  "why3" {= "1.6.0"}
+  "re" {>= "1.10.4"}
+  "fpath" {>= "0.7.3"}
+  "yaml" {>= "3.1.0"}
+  "ocaml-protoc-plugin" {>= "4.2.0"}
+  "stdio" {>= "v0.14.0"}
+  "ocamlgraph" {>= "1.8.8"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_inline_test" {>= "0.12.0"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/caisar.git"
+url {
+  src:
+    "https://git.frama-c.com/api/v4/projects/1082/packages/generic/caisar/2.0/caisar-2.0.tbz"
+  checksum: [
+    "sha256=3d24d2940eed0921acba158a8970687743c401c6a99d0aac8ed6dcfedca1429c"
+    "sha512=0b4484c0e080b8ba22722fe9d5665f9015ebf1648ac89c566a978dd54e3e061acb63edd92e078eed310e26f3e8ad2c48f3682a24af2acb1f0633da12f7966a38"
+  ]
+}
+x-commit-hash: "5f1174cb642ca19b5ffb633de1f4e5fbce35d7f9"

--- a/packages/caisar/caisar.2.0/opam
+++ b/packages/caisar/caisar.2.0/opam
@@ -34,6 +34,7 @@ depends: [
   "ppx_inline_test" {>= "0.12.0"}
   "ppx_deriving_yojson" {>= "3.6.1"}
   "odoc" {with-doc}
+  "conf-python-3" {with-test}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
A platform for characterizing the safety and robustness of artificial intelligence based software

* Project page: https://git.frama-c.com/pub/caisar
* Documentation: https://git.frama-c.com/pub/caisar


CHANGES:

- [interpretation] Add transformations that allow the verification of several neural network at once. Within particular patterns, CAISAR will generate an ONNX file that preserve the semantic of the neural networks while encapsulating parts of the specification directly in the control flow of the neural network. This feature allow the verification of properties with multiple neural networks, including their composition.

- [interpretation] Integrate SVMs into the interpretation engine. Users can expect vector computations and applications on SVMs to be computed similarly as what exists already for neural networks.

- [interpretation] Add support for addition between vectors.

- [interpretation] Add better error reporting for interpretation errors. Users now get better guidance on how to write their specification. For instance, CAISAR now explicitly asks for a predicate constraining the length of a vector after a universal quantifier.

- [language] Unified Support Vector Machines (SVMs) theories. Previously, there was a separate theory for neural networks and SVMs datasets and models. They are now accessible under a single theory.

- [language] Add additional abstraction support for SVMs.

- [language] Simplify CAISAR Neural Intermediate Representation (NIR) and perform automatic shape inference when creating a new NIR node.

- [language] Add support for the following ONNX operators: Gather, Log, Abs, RandomNormal, ReduceSum.

- [language] Neural networks in NNet format are now parsed into a NIR.

- [examples] Rework ACAS-Xu specification with a formulation that is closer to the original. In particular, provide explicit normalization and denormalization functions in the test file. Also define explicit function contracts using Why3 pre and post-conditions.

- [examples] Add more examples displaying CAISAR ability to handle several neural networks at once.

- [cmdline] Add command line option --onnx-out-dir to output the NIR generated by CAISAR as an ONNX file.

- [logging] Add command line option --ltag for fine-grained logging. By providing a logging tag (ltag), users can control which part of CAISAR will log its outputs.

- [prover] Add support for Marabou 2.0 via its Python API. Autodetection of Marabou installed through maraboupy is now supported.

- [prover] Update AIMOS configuration to match upstream.

- [prover] Update ABCROWN configuration to match upstream.

- [doc] Clarify the supported ONNX operator set: the ONNX Intermediate Representation is version 8, the supported operator set is version 13.