### PR TITLE
[new release] twirp (4 packages) (0.1)

### DIFF
--- a/packages/twirp_cohttp_lwt_unix/twirp_cohttp_lwt_unix.0.1/opam
+++ b/packages/twirp_cohttp_lwt_unix/twirp_cohttp_lwt_unix.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Twirp client using cohttp-lwt-unix"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["twirp" "protobuf" "client" "rpc" "curl"]
+homepage: "https://github.com/c-cube/ocaml-twirp"
+bug-reports: "https://github.com/c-cube/ocaml-twirp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "twirp_core" {= version}
+  "dune" {>= "2.9"}
+  "cohttp-lwt-unix" {>= "5.0"}
+  "lwt"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-twirp.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-twirp/releases/download/v0.1/twirp-0.1.tbz"
+  checksum: [
+    "sha256=40a20849cadaa41d0b870a8b0f3894ab560a27a7dda821cf14e1c67bfa81b08b"
+    "sha512=1fd0a0851da62c24f3c64b487dd7e877c5da0edb19a1234cd822d997067e6b7afbe6764e790f32a850e0cc7a860f9d5787e3766bfafe756c46fc062db96dad43"
+  ]
+}
+x-commit-hash: "c9fc476881e11971c24021dc2b80438eaee4d6e9"

--- a/packages/twirp_core/twirp_core.0.1/opam
+++ b/packages/twirp_core/twirp_core.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Twirp core library"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["twirp" "protobuf" "client" "rpc" "curl"]
+homepage: "https://github.com/c-cube/ocaml-twirp"
+bug-reports: "https://github.com/c-cube/ocaml-twirp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.9"}
+  "ocaml-protoc" {>= "3.0" & with-dev}
+  "logs"
+  "pbrt" {>= "3.0"}
+  "pbrt_yojson" {>= "3.0"}
+  "pbrt_services" {>= "3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-twirp.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-twirp/releases/download/v0.1/twirp-0.1.tbz"
+  checksum: [
+    "sha256=40a20849cadaa41d0b870a8b0f3894ab560a27a7dda821cf14e1c67bfa81b08b"
+    "sha512=1fd0a0851da62c24f3c64b487dd7e877c5da0edb19a1234cd822d997067e6b7afbe6764e790f32a850e0cc7a860f9d5787e3766bfafe756c46fc062db96dad43"
+  ]
+}
+x-commit-hash: "c9fc476881e11971c24021dc2b80438eaee4d6e9"

--- a/packages/twirp_ezcurl/twirp_ezcurl.0.1/opam
+++ b/packages/twirp_ezcurl/twirp_ezcurl.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Twirp client using Ezcurl"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["twirp" "protobuf" "client" "rpc" "curl"]
+homepage: "https://github.com/c-cube/ocaml-twirp"
+bug-reports: "https://github.com/c-cube/ocaml-twirp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "twirp_core" {= version}
+  "dune" {>= "2.9"}
+  "ezcurl"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-twirp.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-twirp/releases/download/v0.1/twirp-0.1.tbz"
+  checksum: [
+    "sha256=40a20849cadaa41d0b870a8b0f3894ab560a27a7dda821cf14e1c67bfa81b08b"
+    "sha512=1fd0a0851da62c24f3c64b487dd7e877c5da0edb19a1234cd822d997067e6b7afbe6764e790f32a850e0cc7a860f9d5787e3766bfafe756c46fc062db96dad43"
+  ]
+}
+x-commit-hash: "c9fc476881e11971c24021dc2b80438eaee4d6e9"

--- a/packages/twirp_tiny_httpd/twirp_tiny_httpd.0.1/opam
+++ b/packages/twirp_tiny_httpd/twirp_tiny_httpd.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Host Twirp services using Tiny_httpd"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["twirp" "protobuf" "services" "rpc"]
+homepage: "https://github.com/c-cube/ocaml-twirp"
+bug-reports: "https://github.com/c-cube/ocaml-twirp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "twirp_core" {= version}
+  "dune" {>= "2.9"}
+  "tiny_httpd" {>= "0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-twirp.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-twirp/releases/download/v0.1/twirp-0.1.tbz"
+  checksum: [
+    "sha256=40a20849cadaa41d0b870a8b0f3894ab560a27a7dda821cf14e1c67bfa81b08b"
+    "sha512=1fd0a0851da62c24f3c64b487dd7e877c5da0edb19a1234cd822d997067e6b7afbe6764e790f32a850e0cc7a860f9d5787e3766bfafe756c46fc062db96dad43"
+  ]
+}
+x-commit-hash: "c9fc476881e11971c24021dc2b80438eaee4d6e9"


### PR DESCRIPTION
Host Twirp services using Tiny_httpd

- Project page: <a href="https://github.com/c-cube/ocaml-twirp">https://github.com/c-cube/ocaml-twirp</a>

##### CHANGES:

initial release, with ezcurl and cohttp-lwt backends
