### PR TITLE
Update some Cygwin depexts

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -80,14 +80,17 @@ jobs:
           $failed = $false
           opam update
           Foreach ($pkg in $pkgs) {
-            opam install --confirm-level=unsafe-yes "$pkg"
+            Write-Host "::group::Testing `e[1;34m$pkg`e[0m"
+            opam install --color=always --confirm-level=unsafe-yes "$pkg"
+            Write-Host "::endgroup::"
             switch ($LASTEXITCODE) {
               0 { Break }
-              5 { Write-Host "$pkg is not installable. Skip."; Break } # TODO: Remove when https://github.com/ocaml/opam/issues/6017 is fixed
-              20 { Write-Host "$pkg is not installable. Skip."; Break }
-              31 { Write-Host "$pkg failed to build."; $failed = $true; Break }
+              5 { Write-Host "$pkg is not installable. `e[1;33mSkip`e[0m."; Break } # TODO: Remove when https://github.com/ocaml/opam/issues/6017 is fixed
+              20 { Write-Host "$pkg is not installable. `e[1;33mSkip`e[0m."; Break }
+              31 { Write-Host "`e[1;31m$pkg failed to build`e[0m."; $failed = $true; Break }
               default { throw "Unexpected error $_" }
             }
+            Write-Host
           }
           if ($failed) {
             throw "build failed"

--- a/packages/conf-aclocal/conf-aclocal.1.0.0/opam
+++ b/packages/conf-aclocal/conf-aclocal.1.0.0/opam
@@ -14,6 +14,7 @@ depexts: [
   ["automake"] {os-distribution = "nixos"}
   ["automake"] {os-distribution = "arch"}
   ["system:automake"] {os = "win32" & os-distribution = "cygwinports"}
+  ["automake"] {os-distribution = "cygwin"}
 ]
 depends: ["conf-which" {build}]
 synopsis: "Virtual package relying on aclocal"

--- a/packages/conf-asciidoc/conf-asciidoc.1/opam
+++ b/packages/conf-asciidoc/conf-asciidoc.1/opam
@@ -19,6 +19,7 @@ depexts: [
   ["asciidoc"] {os = "macos" & os-distribution = "homebrew"}
   ["asciidoc"] {os = "macos" & os-distribution = "macports"}
   ["system:asciidoc"] {os = "win32" & os-distribution = "cygwinports"}
+  ["asciidoc"] {os-distribution = "cygwin"}
   ["asciidoc"] {os = "freebsd"}
   ["asciidoc"] {os = "openbsd"}
   ["asciidoc"] {os = "netbsd"}

--- a/packages/conf-cairo/conf-cairo.1/opam
+++ b/packages/conf-cairo/conf-cairo.1/opam
@@ -24,7 +24,7 @@ depexts: [
   ["cairo"] {os-family = "arch"}
   ["cairo"] {os = "macos" & os-distribution = "homebrew"}
   ["cairo"] {os = "win32" & os-distribution = "cygwinports"}
-  ["libcairo-devel"] {os-distribution = "cygwin"}
+  ["libcairo-devel"] {os = "cygwin"}
 ]
 synopsis: "Virtual package relying on a Cairo system installation"
 description:

--- a/packages/conf-cmake/conf-cmake.1/opam
+++ b/packages/conf-cmake/conf-cmake.1/opam
@@ -22,6 +22,7 @@ depexts: [
   ["devel/cmake"] {os = "netbsd"}
   ["devel/cmake"] {os = "dragonfly"}
   ["system:cmake"] {os-distribution = "cygwinports"}
+  ["cmake"] {os-distribution = "cygwin"}
 ]
 synopsis: "Virtual package relying on cmake"
 description:

--- a/packages/conf-findutils/conf-findutils.1/opam
+++ b/packages/conf-findutils/conf-findutils.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["findutils"] {os-distribution = "ol"}
   ["findutils"] {os-distribution = "arch"}
   ["system:findutils"] {os = "win32" & os-distribution = "cygwinports"}
+  ["findutils"] {os-distribution = "cygwin"}
   # ["findutils"] {os = "freebsd"} # this installs g* packges, e.g., gfind. Unless code looks for those specific names, it is not necessary to install on freebsd
 ]
 synopsis: "Virtual package relying on findutils"

--- a/packages/conf-git/conf-git.1.0/opam
+++ b/packages/conf-git/conf-git.1.0/opam
@@ -17,6 +17,10 @@ depexts: [
   ["git"] {os-distribution = "arch"}
   ["git"] {os = "macos" & os-distribution = "homebrew"}
   ["system:git"] {os = "win32" & os-distribution = "cygwinports"}
+  # This is intentionally os = "cygwin" and *not* os-distribution = "cygwin"
+  # For native Windows, opam 2.2 recommends Git for Windows, so for native
+  # Windows there's no need for depext support.
+  ["git"] {os = "cygwin"}
 ]
 synopsis: "Virtual package relying on git"
 description:

--- a/packages/conf-git/conf-git.1.1/opam
+++ b/packages/conf-git/conf-git.1.1/opam
@@ -16,6 +16,10 @@ depexts: [
   ["git"] {os-family = "arch"}
   ["git"] {os-family = "alpine"}
   ["system:git"] {os = "win32" & os-distribution = "cygwinports"}
+  # This is intentionally os = "cygwin" and *not* os-distribution = "cygwin"
+  # For native Windows, opam 2.2 recommends Git for Windows, so for native
+  # Windows there's no need for depext support.
+  ["git"] {os = "cygwin"}
   ["git"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on git"

--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -16,7 +16,7 @@ depexts: [
   ["gtk3-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gtk3"] {os-family = "arch"}
   ["gtk3"] {os = "win32" & os-distribution = "cygwinports"}
-  ["libgtk3-devel"] {os-distribution = "cygwin"}
+  ["libgtk3-devel"] {os = "cygwin"}
   ["gtk3"] {os = "freebsd"}
 ]
 post-messages: [

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
@@ -18,6 +18,7 @@ depexts: [
   ["gtksourceview3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
   ["gtksourceview3 +quartz" "libxml2"] {os = "macos" & os-distribution = "macports"}
   ["gtksourceview3.0"] {os = "win32" & os-distribution = "cygwinports"}
+  ["libgtksourceview3.0-devel"] { os = "cygwin"}
 ]
 x-ci-accept-failures: [
   "oraclelinux-7"

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
@@ -17,7 +17,7 @@ depexts: [
   ["gtksourceview3-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gtksourceview3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
   ["gtksourceview3.0"] {os = "win32" & os-distribution = "cygwinports"}
-  ["libgtksourceview3.0-devel"] { os-distribution = "cygwin"}
+  ["libgtksourceview3.0-devel"] { os = "cygwin"}
 ]
 synopsis: "Virtual package relying on a GtkSourceView-3 system installation"
 description:

--- a/packages/conf-jq/conf-jq.1/opam
+++ b/packages/conf-jq/conf-jq.1/opam
@@ -18,6 +18,7 @@ depexts: [
   ["jq"] {os = "freebsd"}
   ["jq"] {os = "macos" & os-distribution = "homebrew"}
   ["system:jq"] {os = "win32" & os-distribution = "cygwinports"}
+  ["jq"] {os-distribution = "cygwin"}
 ]
 synopsis: "Virtual package relying on jq"
 description:

--- a/packages/conf-libX11/conf-libX11.1/opam
+++ b/packages/conf-libX11/conf-libX11.1/opam
@@ -17,7 +17,7 @@ depexts: [
   ["libX11-devel"] {os-distribution = "centos" | os-distribution = "ol" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["libx11-dev"] {os-distribution = "alpine"}
   ["libx11"] {os-distribution = "arch"}
-  ["libX11-dev"] {os-distribution = "cygwin"}
+  ["libX11-dev"] {os = "cygwin"}
   ["xquartz"] {os = "macos" & os-distribution = "homebrew"}
   ["xorg-libX11"] {os = "macos" & os-distribution = "macports"}
   ["libX11"] {os = "freebsd"}

--- a/packages/conf-libtool/conf-libtool.1/opam
+++ b/packages/conf-libtool/conf-libtool.1/opam
@@ -25,6 +25,7 @@ depexts: [
   ["libtool"] {os-distribution = "ol"}
   ["libtool"] {os-distribution = "rhel"}
   ["system:libtool"] {os = "win32" & os-distribution = "cygwinports"}
+  ["libtool"] {os-distribution = "cygwin"}
 ]
 synopsis: "Virtual package relying on libtool installation"
 description: """

--- a/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.1/opam
+++ b/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.1/opam
@@ -20,6 +20,7 @@ depexts: [
   ["perl-IPC-System-Simple"] {os-distribution = "fedora"}
   ["perl-ipc-system-simple"] {os-family = "arch"}
   ["system:perl-IPC-System-Simple"] {os = "win32" & os-distribution = "cygwinports"}
+  ["perl-IPC-System-Simple"] {os-distribution = "cygwin"}
 ]
 x-ci-accept-failures: [
   "oraclelinux-7"

--- a/packages/conf-pkg-config/conf-pkg-config.1.0/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.0/opam
@@ -21,6 +21,7 @@ depexts: [
   ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconf"] {os = "freebsd"}
   ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
+  ["pkgconf"] {os = "cygwin"}
 ]
 available: os != "openbsd" & (os != "win32" | os-distribution = "cygwinports")
 synopsis: "Virtual package relying on pkg-config installation"

--- a/packages/conf-pkg-config/conf-pkg-config.1.1/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.1/opam
@@ -31,6 +31,7 @@ depexts: [
   ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconf"] {os = "freebsd"}
   ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
+  ["pkgconf"] {os = "cygwin"}
 ]
 synopsis: "Virtual package relying on pkg-config installation"
 description: """

--- a/packages/conf-pkg-config/conf-pkg-config.1.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.2/opam
@@ -33,6 +33,7 @@ depexts: [
   ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
   ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
   ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
+  ["pkgconf"] {os = "cygwin"}
 ]
 synopsis: "Virtual package relying on pkg-config installation"
 description: """

--- a/packages/conf-pkg-config/conf-pkg-config.1.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.3/opam
@@ -34,6 +34,7 @@ depexts: [
   ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
   ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
   ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
+  ["pkgconf"] {os = "cygwin"}
 ]
 synopsis: "Virtual package relying on pkg-config installation"
 description: """

--- a/packages/conf-pkg-config/conf-pkg-config.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.2/opam
@@ -35,6 +35,7 @@ depexts: [
   ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
   ["pkgconf-pkg-config"] {os-distribution = "ol" & os-version >= "8"}
   ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
+  ["pkgconf"] {os = "cygwin"}
 ]
 synopsis: "Check if pkg-config is installed and create an opam switch local pkgconfig folder"
 description: """

--- a/packages/conf-pkg-config/conf-pkg-config.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.3/opam
@@ -29,7 +29,7 @@ depexts: [
   ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
   ["pkgconf-pkg-config"] {os-distribution = "ol" & os-version >= "8"}
   ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
-  ["pkgconf"] {os = "win32" & os-distribution = "cygwin"}
+  ["pkgconf"] {os-distribution = "cygwin"}
 ]
 synopsis: "Check if pkg-config is installed and create an opam switch local pkgconfig folder"
 description: """

--- a/packages/conf-python-3-7/conf-python-3-7.1.0.0/opam
+++ b/packages/conf-python-3-7/conf-python-3-7.1.0.0/opam
@@ -27,6 +27,7 @@ depexts: [
   ["python37"] {os-distribution = "macports" & os = "macos"}
   ["python@3"] {os-distribution = "homebrew" & os = "macos"}
   ["system:python3"] {os-distribution = "cygwinports"}
+  ["python3"] {os-distribution = "cygwin"}
 ]
 x-ci-accept-failures: [
   "opensuse-15.3" # python >=3.7 not packaged

--- a/packages/conf-python-3/conf-python-3.1.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.1.0.0/opam
@@ -21,6 +21,7 @@ depexts: [
   ["python36"] {os-distribution = "macports" & os = "macos"}
   ["python@3"] {os-distribution = "homebrew" & os = "macos"}
   ["system:python3"] {os-distribution = "cygwinports"}
+  ["python3"] {os-distribution = "cygwin"}
 ]
 synopsis: "Virtual package relying on Python-3 installation"
 description: """

--- a/packages/conf-python-3/conf-python-3.9.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.9.0.0/opam
@@ -21,6 +21,7 @@ depexts: [
   ["python39"] {os-distribution = "macports" & os = "macos"}  # this will not result in a python3 command but only a python3.9 command
   ["python@3.9"] {os-distribution = "homebrew" & os = "macos"}
   ["system:python3"] {os-distribution = "cygwinports"}
+  ["python3"] {os-distribution = "cygwin"}
 ]
 synopsis: "Virtual package relying on Python-3 installation"
 description: """

--- a/packages/conf-time/conf-time.1/opam
+++ b/packages/conf-time/conf-time.1/opam
@@ -8,6 +8,7 @@ build: [["which" "time"]]
 depends: ["conf-which" {build}]
 depexts: [
   ["system:time"] {os = "win32" & os-distribution = "cygwinports"}
+  ["time"] {os-distribution = "cygwin"}
   ["time"] {os-family = "debian"}
   ["time"] {os-family = "ubuntu"}
   ["time"] {os-distribution = "centos"}

--- a/packages/conf-zig/conf-zig.1/opam
+++ b/packages/conf-zig/conf-zig.1/opam
@@ -17,6 +17,7 @@ depexts: [
   ["zig"] {os = "freebsd"}
   ["zig"] {os = "macos" & os-distribution = "homebrew"}
   ["system:zig"] {os = "win32" & os-distribution = "cygwinports"}
+  ["zig"] {os-distribution = "cygwin"}
 ]
 synopsis: "Virtual package relying on zig"
 description:

--- a/packages/conf-zig/conf-zig.1/opam
+++ b/packages/conf-zig/conf-zig.1/opam
@@ -16,8 +16,6 @@ depexts: [
   ["zig"] {os-distribution = "arch"}
   ["zig"] {os = "freebsd"}
   ["zig"] {os = "macos" & os-distribution = "homebrew"}
-  ["system:zig"] {os = "win32" & os-distribution = "cygwinports"}
-  ["zig"] {os-distribution = "cygwin"}
 ]
 synopsis: "Virtual package relying on zig"
 description:

--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -18,7 +18,7 @@ depexts: [
   ["zlib"] {os-distribution = "homebrew" & os = "macos"}
   ["zlib"] {os-family = "arch"}
   ["zlib"] {os = "win32" & os-distribution = "cygwinports"}
-  ["zlib-devel"] {os-distribution = "cygwin"}
+  ["zlib-devel"] {os = "cygwin"}
 ]
 synopsis: "Virtual package relying on zlib"
 description:


### PR DESCRIPTION
Spotted while reviewing #26115 and to expand on https://github.com/ocaml/opam-repository/pull/24432#issuecomment-2183879312.

Cygwin provides two things in the Windows OCaml ecosystem:
1. It's an entire distribution of Unix built on top of Windows. In this context, it has GCC, libraries and so forth and from OCaml's perspective behaves like a BSD flavour with some Linuxisms. opam running in this context has `os = "cygwin"` and `os-distribution = "cygwin"`
2. It's a provider of both cross-compilers and cross-compiled libraries for the mingw-w64 native port of OCaml. opam running in this context has `os = "win32"` and `os-distribution = "cygwin"`.

opam for native Windows also uses tooling from Cygwin (for example, `make`). This means that there are two possible filters we can need for depexts:
- `os = "cygwin"` is for things _specific_ to opam running in Cygwin itself. This will generally by C libraries only.
- `os-distribution = "cygwin"` is generally for tools used by both opam running in Cygwin but also by native Windows opam when building packages.

The latter correspond to depexts prefixed `system:` for `os-distribution = "cygwinports"`. This PR updates depexts presently in opam-repository for Cygwin and was based on a search for `"system:` (to catch existing opam-repository-mingw depexts) and `os-distribution = "cygwin"` (to catch incorrectly tagged Cygwin-only depexts).

The commit messages contain further explanations, as conf-pkg-config and conf-git are both exceptions to the rules above.