### PR TITLE
[new release] eio-trace (0.2)

### DIFF
--- a/packages/eio-trace/eio-trace.0.2/opam
+++ b/packages/eio-trace/eio-trace.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Trace visualisation for Eio programs"
+maintainer: ["Thomas Leonard"]
+authors: ["Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio-trace"
+bug-reports: "https://github.com/ocaml-multicore/eio-trace/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "5.1.0"}
+  "eio_main" {>= "0.14"}
+  "cmdliner" {>= "1.2.0"}
+  "lablgtk3" {>= "3.1.4"}
+  "crowbar" {>= "0.2.1" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio-trace.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio-trace/releases/download/v0.2/eio-trace-0.2.tbz"
+  checksum: [
+    "sha256=8386fca77c24757382c4cd8dbf13da416994154f6d479b5115bda8687befabfb"
+    "sha512=988ffdcc504b490d687e6f1b9d1a7fde5b982947122b2b16854208ca8961130029f593acdb412c9a156e34bc5fd2fa0205b8924f4870ad9551ecd0e838d76001"
+  ]
+}
+x-commit-hash: "668a86a2175236d304c0d01fc1df7a07b0a20389"


### PR DESCRIPTION
Trace visualisation for Eio programs

- Project page: <a href="https://github.com/ocaml-multicore/eio-trace">https://github.com/ocaml-multicore/eio-trace</a>

##### CHANGES:

- Fix staircasing in layout (@talex5 ocaml-multicore/eio-trace#28).
  Instead of placing a new fiber below all overlapping fibers, place it in the first large-enough gap.

- Allow setting viewport values explicitly (@talex5 ocaml-multicore/eio-trace#29).
  Press `s` to see or edit the start time.
  Press `d` to see or edit the duration time.
  Useful to find values for command-line rendering or to ensure that images have the same scale for comparison.

- Add a popup menu (@talex5 ocaml-multicore/eio-trace#31).

- Add Reload feature (@talex5 ocaml-multicore/eio-trace#27, ocaml-multicore/eio-trace#33).
  With `eio-trace run` the window opens after 1 second. Press F5 to get further updates.

- Add Export image to GTK UI (@talex5 ocaml-multicore/eio-trace#32).

- Show GC running in red (@talex5 ocaml-multicore/eio-trace#30).
  This makes it easier to see the difference between domains actively running GC vs waiting for other domains to be ready.

- Update README now that eio-trace is released (@talex5 ocaml-multicore/eio-trace#26).

- Explain what to do about lost events (@talex5 ocaml-multicore/eio-trace#34).
