### PR TITLE
intrinsics v0.17 doesn't build on arm64

### DIFF
--- a/packages/ocaml_intrinsics/ocaml_intrinsics.v0.17.0/opam
+++ b/packages/ocaml_intrinsics/ocaml_intrinsics.v0.17.0/opam
@@ -20,7 +20,7 @@ description: "
 Provides functions to invoke amd64 instructions (such as clz,popcnt,rdtsc,rdpmc)
      when available, or compatible software implementation on other targets.
 "
-available: (arch = "x86_64" | arch = "arm64") & os != "win32"
+available: (arch = "x86_64") & os != "win32"
 url {
 src: "https://github.com/janestreet/ocaml_intrinsics/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=d42b21dc49a05be658391e63fe64c055d52ec67c0812cf6801f1de0f22733ce2"


### PR DESCRIPTION
/cc @d-kalinichenko -- this might break a lot of macOS machines for v0.17 of Core

```
#=== ERROR while compiling ocaml_intrinsics.v0.17.0 ===========================#
# context              2.2.0~beta3~dev | linux/arm64 | ocaml-base-compiler.5.2.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/ocaml_intrinsics.v0.17.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ocaml_intrinsics -j 79
# exit-code            1
# env-file             ~/.opam/log/ocaml_intrinsics-7-91eef4.env
# output-file          ~/.opam/log/ocaml_intrinsics-7-91eef4.out
### output ###
# File "src/dune", line 4, characters 58-67:
# 4 |   (names atomic_stubs int_stubs float_stubs perfmon_stubs crc_stubs
#                                                               ^^^^^^^^^
# (cd _build/default/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -pthread -D_FILE_OFFSET_BITS=64 -g -I /home/opam/.opam/5.2/lib/ocaml -I /home/opam/.opam/5.2/lib/ocaml_intrinsics_kernel -o crc_stubs.o -c crc_stubs.c)
# crc_stubs.c:41:2: error: #error "Target not supported"
#    41 | #error "Target not supported"
#       |  ^~~~~
# (cd _build/default/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -pthread -D_FILE_OFFSET_BITS=64 -g -I /home/opam/.opam/5.2/lib/ocaml -I /home/opam/.opam/5.2/lib/ocaml_intrinsics_kernel -o prefetch_stubs.o -c prefetch_stubs.c)
# prefetch_stubs.c: In function 'caml_pause_hint':
# prefetch_stubs.c:332:2: warning: #warning "This target does not support PAUSE hints, emit NOP instead." [-Wcpp]
#   332 | #warning "This target does not support PAUSE hints, emit NOP instead."
#       |  ^~~~~~~
```