### PR TITLE
[new release] h2 (7 packages) (0.12.0)

### DIFF
--- a/packages/h2-async/h2-async.0.12.0/opam
+++ b/packages/h2-async/h2-async.0.12.0/opam
@@ -26,7 +26,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/h2-async/h2-async.0.12.0/opam
+++ b/packages/h2-async/h2-async.0.12.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Async support for h2"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-async provides an Async runtime implementation for h2."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "h2" {= version}
+  "faraday-async"
+  "gluten-async" {>= "0.4.0"}
+  "odoc" {with-doc}
+]
+depopts: ["async_ssl" "tls-async"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.12.0/h2-0.12.0.tbz"
+  checksum: [
+    "sha256=36e40b113d90ea383619a8c7bd993f866131c3c5d957619b6849eb32af8c53c6"
+    "sha512=a71670c0db439e26c65b7565c1e55f7714b4ebdacac47ba1cfc66a6eddccc4ddef583ee353b19d83a662d95d7878db5e93c75b8a38745a92860655ba0a2c1840"
+  ]
+}
+x-commit-hash: "471c7ae2e56d6c00123d60eec9d7ed68dae4d019"

--- a/packages/h2-eio/h2-eio.0.12.0/opam
+++ b/packages/h2-eio/h2-eio.0.12.0/opam
@@ -24,7 +24,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/h2-eio/h2-eio.0.12.0/opam
+++ b/packages/h2-eio/h2-eio.0.12.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "EIO support for h2"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-eio provides an EIO runtime implementation for h2."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "h2" {= version}
+  "gluten-eio" {>= "0.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.12.0/h2-0.12.0.tbz"
+  checksum: [
+    "sha256=36e40b113d90ea383619a8c7bd993f866131c3c5d957619b6849eb32af8c53c6"
+    "sha512=a71670c0db439e26c65b7565c1e55f7714b4ebdacac47ba1cfc66a6eddccc4ddef583ee353b19d83a662d95d7878db5e93c75b8a38745a92860655ba0a2c1840"
+  ]
+}
+x-commit-hash: "471c7ae2e56d6c00123d60eec9d7ed68dae4d019"

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.12.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.12.0/opam
@@ -26,7 +26,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.12.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.12.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Lwt + UNIX support for h2"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-lwt-unix provides an Lwt runtime implementation for h2 that targets UNIX binaries."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "h2-lwt" {= version}
+  "faraday-lwt-unix"
+  "gluten-lwt-unix" {>= "0.2.1"}
+  "odoc" {with-doc}
+]
+depopts: ["tls-lwt" "lwt_ssl"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.12.0/h2-0.12.0.tbz"
+  checksum: [
+    "sha256=36e40b113d90ea383619a8c7bd993f866131c3c5d957619b6849eb32af8c53c6"
+    "sha512=a71670c0db439e26c65b7565c1e55f7714b4ebdacac47ba1cfc66a6eddccc4ddef583ee353b19d83a662d95d7878db5e93c75b8a38745a92860655ba0a2c1840"
+  ]
+}
+x-commit-hash: "471c7ae2e56d6c00123d60eec9d7ed68dae4d019"

--- a/packages/h2-lwt/h2-lwt.0.12.0/opam
+++ b/packages/h2-lwt/h2-lwt.0.12.0/opam
@@ -25,7 +25,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/h2-lwt/h2-lwt.0.12.0/opam
+++ b/packages/h2-lwt/h2-lwt.0.12.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Lwt support for h2"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-lwt provides an Lwt runtime implementation for h2."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "h2" {= version}
+  "lwt" {>= "5.1.1"}
+  "gluten-lwt" {>= "0.2.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.12.0/h2-0.12.0.tbz"
+  checksum: [
+    "sha256=36e40b113d90ea383619a8c7bd993f866131c3c5d957619b6849eb32af8c53c6"
+    "sha512=a71670c0db439e26c65b7565c1e55f7714b4ebdacac47ba1cfc66a6eddccc4ddef583ee353b19d83a662d95d7878db5e93c75b8a38745a92860655ba0a2c1840"
+  ]
+}
+x-commit-hash: "471c7ae2e56d6c00123d60eec9d7ed68dae4d019"

--- a/packages/h2-mirage/h2-mirage.0.12.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.12.0/opam
@@ -28,7 +28,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/h2-mirage/h2-mirage.0.12.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.12.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Lwt support for h2"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-mirage provides an Lwt runtime implementation for h2 that targets MirageOS unikernels."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "h2-lwt" {= version}
+  "faraday-lwt"
+  "lwt"
+  "gluten-mirage" {>= "0.3.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "cstruct"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.12.0/h2-0.12.0.tbz"
+  checksum: [
+    "sha256=36e40b113d90ea383619a8c7bd993f866131c3c5d957619b6849eb32af8c53c6"
+    "sha512=a71670c0db439e26c65b7565c1e55f7714b4ebdacac47ba1cfc66a6eddccc4ddef583ee353b19d83a662d95d7878db5e93c75b8a38745a92860655ba0a2c1840"
+  ]
+}
+x-commit-hash: "471c7ae2e56d6c00123d60eec9d7ed68dae4d019"

--- a/packages/h2/h2.0.12.0/opam
+++ b/packages/h2/h2.0.12.0/opam
@@ -33,7 +33,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/h2/h2.0.12.0/opam
+++ b/packages/h2/h2.0.12.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "A high-performance, memory-efficient, and scalable HTTP/2 library for OCaml"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. It is based on the concepts in httpun, and therefore uses the Angstrom and Faraday libraries to implement the parsing and serialization layers of the HTTP/2 standard as a state machine that is agnostic to the underlying I/O specifics. It also preserves the same API as httpun wherever possible."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "base64" {>= "3.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "faraday" {>= "0.7.3"}
+  "bigstringaf" {>= "0.5.0"}
+  "psq"
+  "hpack" {= version}
+  "httpun-types"
+  "alcotest" {with-test}
+  "yojson" {with-test}
+  "hex" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.12.0/h2-0.12.0.tbz"
+  checksum: [
+    "sha256=36e40b113d90ea383619a8c7bd993f866131c3c5d957619b6849eb32af8c53c6"
+    "sha512=a71670c0db439e26c65b7565c1e55f7714b4ebdacac47ba1cfc66a6eddccc4ddef583ee353b19d83a662d95d7878db5e93c75b8a38745a92860655ba0a2c1840"
+  ]
+}
+x-commit-hash: "471c7ae2e56d6c00123d60eec9d7ed68dae4d019"

--- a/packages/hpack/hpack.0.12.0/opam
+++ b/packages/hpack/hpack.0.12.0/opam
@@ -26,7 +26,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/hpack/hpack.0.12.0/opam
+++ b/packages/hpack/hpack.0.12.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "An HPACK (Header Compression for HTTP/2) implementation in OCaml"
+description:
+  "hpack is an implementation of the HPACK: Header Compression for HTTP/2 specification (RFC7541) written in OCaml. It uses Angstrom and Faraday for parsing and serialization, respectively."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "angstrom"
+  "faraday" {>= "0.7.3"}
+  "yojson" {with-test}
+  "hex" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.12.0/h2-0.12.0.tbz"
+  checksum: [
+    "sha256=36e40b113d90ea383619a8c7bd993f866131c3c5d957619b6849eb32af8c53c6"
+    "sha512=a71670c0db439e26c65b7565c1e55f7714b4ebdacac47ba1cfc66a6eddccc4ddef583ee353b19d83a662d95d7878db5e93c75b8a38745a92860655ba0a2c1840"
+  ]
+}
+x-commit-hash: "471c7ae2e56d6c00123d60eec9d7ed68dae4d019"


### PR DESCRIPTION
A high-performance, memory-efficient, and scalable HTTP/2 library for OCaml

- Project page: <a href="https://github.com/anmonteiro/ocaml-h2">https://github.com/anmonteiro/ocaml-h2</a>

##### CHANGES:

- hpack: fix huffman encoding for codes > 24bit
  ([anmonteiro/ocaml-h2#229](https://github.com/anmonteiro/ocaml-h2/pull/229))
- h2-eio: don't require `Eio_unix.stream_socket_ty`, allowing the use of mock
  sockets ([anmonteiro/ocaml-h2#236](https://github.com/anmonteiro/gluten/pull/236))
- h2: drop the dependency on `httpaf`, use
  [`httpun-types`](https://ocaml.org/p/httpun-types/latest) instead
([anmonteiro/ocaml-h2#243](https://github.com/anmonteiro/ocaml-h2/pull/243))
- hpack: use `String.unsafe_get` when the string length is known
  ([anmonteiro/ocaml-h2#244](https://github.com/anmonteiro/ocaml-h2/pull/244))
