### PR TITLE
Add configuration for autoconf under cygwin

### DIFF
--- a/packages/conf-autoconf/conf-autoconf.0.2/opam
+++ b/packages/conf-autoconf/conf-autoconf.0.2/opam
@@ -5,7 +5,8 @@ authors: "https://www.gnu.org/software/autoconf/autoconf.html#maintainer"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-3.0-only"
 build: [
-  ["autoconf" "-V"]
+  ["sh" "-exc" "autoconf -V"] {os = "win32" & os-distribution != "cygwinports"}
+  ["autoconf" "-V"] {os != "win32" | os-distribution = "cygwinports"}
 ]
 depexts: [
   ["autoconf"] {os-family = "debian" | os-family = "ubuntu"}


### PR DESCRIPTION
On Windows, `conf-autoconf` cannot directly call `autoconf` (a sh script) in Cygwin. I was able to fix the package by explicitely calling `autoconf` from `sh`, but I am not sure if that's the right solution or if something should be done inside of opam instead.