### PR TITLE
Package base.v0.17.1

### DIFF
--- a/packages/base/base.v0.17.1/opam
+++ b/packages/base/base.v0.17.1/opam
@@ -11,8 +11,8 @@ build: [
 ]
 depends: [
   "ocaml" {>= "5.1.0"}
-  "ocaml_intrinsics_kernel"
-  "sexplib0"
+  "ocaml_intrinsics_kernel" {>= "v0.17" & < "v0.18"}
+  "sexplib0"                {>= "v0.17" & < "v0.18"}
   "dune"                    {>= "3.11.0"}
   "dune-configurator"
 ]

--- a/packages/base/base.v0.17.1/opam
+++ b/packages/base/base.v0.17.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/base"
+bug-reports: "https://github.com/janestreet/base/issues"
+dev-repo: "git+https://github.com/janestreet/base.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "ocaml_intrinsics_kernel"
+  "sexplib0"
+  "dune"                    {>= "3.11.0"}
+  "dune-configurator"
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Full standard library replacement for OCaml"
+description: "
+Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio
+"
+url {
+  src: "https://github.com/janestreet/base/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=9ad01b82a1013ca72b9b7628c9a5d954"
+    "sha512=ed5eb5e83d8085fc06f111862d609b393e394bbdcc6e25bab50030a250ffa2e540dbee02169b6f28ec220f10f61d189cd7b5646eece910c63620f5174fb5a655"
+  ]
+}


### PR DESCRIPTION
### `base.v0.17.1`
Full standard library replacement for OCaml
Full standard library replacement for OCaml

Base is a complete and portable alternative to the OCaml standard
library. It provides all standard functionalities one would expect
from a language standard library. It uses consistent conventions
across all of its module.

Base aims to be usable in any context. As a result system dependent
features such as I/O are not offered by Base. They are instead
provided by companion libraries such as stdio:

  https://github.com/janestreet/stdio



---
* Homepage: https://github.com/janestreet/base
* Source repo: git+https://github.com/janestreet/base.git
* Bug tracker: https://github.com/janestreet/base/issues

---
:camel: Pull-request generated by opam-publish v2.3.0