### PR TITLE
[new release] eio-ssl (0.3.0)

### DIFF
--- a/packages/eio-ssl/eio-ssl.0.3.0/opam
+++ b/packages/eio-ssl/eio-ssl.0.3.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "OpenSSL binding to EIO"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LicenseRef-LGPL-WITH-OpenSSL-linking-exception"
+homepage: "https://github.com/anmonteiro/eio-ssl"
+bug-reports: "https://github.com/anmonteiro/eio-ssl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "5.0"}
+  "ssl" {>= "0.5.13"}
+  "eio" {>= "0.12"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-re/melange-compiler-libs.git"
+url {
+  src:
+    "https://github.com/anmonteiro/eio-ssl/releases/download/0.3.0/eio-ssl-0.3.0.tbz"
+  checksum: [
+    "sha256=9b80a2510b5755231f2ed85b0ec01fb6988eb2bdb8239206894d6fbfb473f20a"
+    "sha512=2f93ba3955b5d9c5c3b8248d83f42f058e60c833a11dbf4dd0a0bf7b219fe68c531b00763c88bd24a3884d82030b1401eb141c6cd26b722843fd74eb1f68374e"
+  ]
+}
+x-commit-hash: "5444faeae017a5db35793d0d8676166e5955efd7"

--- a/packages/eio-ssl/eio-ssl.0.3.0/opam
+++ b/packages/eio-ssl/eio-ssl.0.3.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/anmonteiro/eio-ssl/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "5.0"}
-  "ssl" {>= "0.5.13"}
+  "ssl" {>= "0.7.0"}
   "eio" {>= "0.12"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
OpenSSL binding to EIO

- Project page: <a href="https://github.com/anmonteiro/eio-ssl">https://github.com/anmonteiro/eio-ssl</a>

##### CHANGES:

- Handle EOF from OpenSSL more gracefully
  ([anmonteiro/eio-ssl#23](https://github.com/anmonteiro/eio-ssl/pull/23))
