### PR TITLE
Update conf-sqlite3 for mingw-w64 ports

### DIFF
--- a/packages/conf-mingw-w64-sqlite3-i686/conf-mingw-w64-sqlite3-i686.1/opam
+++ b/packages/conf-mingw-w64-sqlite3-i686/conf-mingw-w64-sqlite3-i686.1/opam
@@ -7,7 +7,7 @@ authors: [
   "Dan Kennedy"
   "Joe Mistachkin"
 ]
-license: "PD"
+license: "blessing"
 homepage: "http://www.sqlite3.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf

--- a/packages/conf-mingw-w64-sqlite3-i686/conf-mingw-w64-sqlite3-i686.1/opam
+++ b/packages/conf-mingw-w64-sqlite3-i686/conf-mingw-w64-sqlite3-i686.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "sqlite3 for i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of sqlite3 for the mingw-w64 project is available"
+maintainer: "David Allsopp <david@tarides.com>"
+authors: [
+  "D. Richard Hipp"
+  "Dan Kennedy"
+  "Joe Mistachkin"
+]
+license: "PD"
+homepage: "http://www.sqlite3.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32" & os-distribution = "cygwin"
+build: ["pkgconf" "--personality=i686-w64-mingw32" "sqlite3"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-i686" {build}
+]
+depexts: [
+  ["mingw64-i686-sqlite3"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-i686-sqlite3"] {os = "win32" & os-distribution = "msys2"}
+]

--- a/packages/conf-mingw-w64-sqlite3-x86_64/conf-mingw-w64-sqlite3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sqlite3-x86_64/conf-mingw-w64-sqlite3-x86_64.1/opam
@@ -7,7 +7,7 @@ authors: [
   "Dan Kennedy"
   "Joe Mistachkin"
 ]
-license: "PD"
+license: "blessing"
 homepage: "http://www.sqlite3.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf

--- a/packages/conf-mingw-w64-sqlite3-x86_64/conf-mingw-w64-sqlite3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sqlite3-x86_64/conf-mingw-w64-sqlite3-x86_64.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "sqlite3 for x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of sqlite3 for the mingw-w64 project is available"
+maintainer: "David Allsopp <david@tarides.com>"
+authors: [
+  "D. Richard Hipp"
+  "Dan Kennedy"
+  "Joe Mistachkin"
+]
+license: "PD"
+homepage: "http://www.sqlite3.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32" & os-distribution = "cygwin"
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" "sqlite3"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-x86_64" {build}
+]
+depexts: [
+  ["mingw64-x86_64-sqlite3"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-x86_64-sqlite3"] {os = "win32" & os-distribution = "msys2"}
+]

--- a/packages/conf-sqlite3/conf-sqlite3.1/opam
+++ b/packages/conf-sqlite3/conf-sqlite3.1/opam
@@ -7,7 +7,7 @@ authors: [
 ]
 homepage: "http://www.sqlite3.org"
 dev-repo: "git+https://github.com/mmottl/sqlite3-ocaml.git"
-license: "PD"
+license: "blessing"
 build: [
   ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
    "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}

--- a/packages/conf-sqlite3/conf-sqlite3.1/opam
+++ b/packages/conf-sqlite3/conf-sqlite3.1/opam
@@ -8,8 +8,18 @@ authors: [
 homepage: "http://www.sqlite3.org"
 dev-repo: "git+https://github.com/mmottl/sqlite3-ocaml.git"
 license: "PD"
-build: [["pkg-config" "sqlite3"]]
-depends: ["conf-pkg-config" {build}]
+build: [
+  ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution != "cygwin"}
+  "sqlite3"]
+]
+depends: [
+  "conf-pkg-config" {build}
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sqlite3-i686" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sqlite3-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 
 depexts: [


### PR DESCRIPTION
The sqlite3 package needs to be updated to build under opam 2.2.0-rc1.  See https://github.com/mmottl/sqlite3-ocaml/pull/61.  Once the build has been updated, this PR add the support for opam-repository on Windows.