### PR TITLE
[new release] html_of_jsx (0.0.4)

### DIFF
--- a/packages/html_of_jsx/html_of_jsx.0.0.4/opam
+++ b/packages/html_of_jsx/html_of_jsx.0.0.4/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/davesnx/html_of_jsx/issues"
 depends: [
   "dune" {>= "3.12"}
   "ocaml" {>= "4.14"}
-  "ppxlib" {> "0.23.0"}
+  "ppxlib" {>= "0.25.0"}
   "alcotest" {with-test}
   "benchmark" {with-test}
   "reason" {>= "3.10.0" & with-test}

--- a/packages/html_of_jsx/html_of_jsx.0.0.4/opam
+++ b/packages/html_of_jsx/html_of_jsx.0.0.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Render HTML with JSX"
+description:
+  "html_of_jsx is a JSX transformation that allows you to write HTML declaratively."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/davesnx/html_of_jsx"
+bug-reports: "https://github.com/davesnx/html_of_jsx/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "ppxlib" {> "0.23.0"}
+  "alcotest" {with-test}
+  "benchmark" {with-test}
+  "reason" {>= "3.10.0" & with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {= "0.26.1" & (with-dev-setup | with-test)}
+  "ocaml-lsp-server" {with-dev-setup}
+  "tiny_httpd" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/html_of_jsx.git"
+url {
+  src:
+    "https://github.com/davesnx/html_of_jsx/releases/download/0.0.4/html_of_jsx-0.0.4.tbz"
+  checksum: [
+    "sha256=12c49cb44a7476921d097248540e222cb412cf49a283cc20b92775e2bf2b9c39"
+    "sha512=96748d99db49817a900ce2b310d5f496cee5e96ba1c90611d204c397549e55797eb76f0952912bcfd5be17e06cf5029fb85b19417ea47ba4543103eb0536ab55"
+  ]
+}
+x-commit-hash: "b6c86c9248d19a7eae80a3f55019ea38bd0c7384"


### PR DESCRIPTION
Render HTML with JSX

- Project page: <a href="https://github.com/davesnx/html_of_jsx">https://github.com/davesnx/html_of_jsx</a>

## 0.0.4

- [BREAKING] Handle HTML encoding for `'` (@davesnx)
- Handle HTML encoding for `"` (from `&davesnx/html_of_jsx#34;` to `&quot;`) (@davesnx)
- Improved performance of `JSX.render` (@davesnx)
- [BREAKING] Remove `Fragment` in favor of `JSX.list` (@davesnx)
- Remove unused `Component (unit -> element)` since it isn't needed (@davesnx)
- [BREAKING] Change attributes representation (@andreypopp)
- [BREAKING] Remove melange dependency (@andreypopp)
- [BREAKING] Lower the OCaml bound to 4.14 (@davesnx)
- Make lib wrapped (@andreypopp)
