### PR TITLE
mirage-qubes 0.8 0.9: does not work with tcpip 8.1.0

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.3/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.8.3/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "mirage-qubes" {= version}
-  "tcpip" { >= "5.0.0" }
+  "tcpip" { >= "5.0.0" & < "8.1.0"}
   "ipaddr" { >= "3.0.0" }
   "mirage-random" {>= "2.0.0" & < "4.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.0/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "mirage-qubes" {= version}
-  "tcpip" { >= "5.0.0" }
+  "tcpip" { >= "5.0.0" & < "8.1.0"}
   "ipaddr" { >= "3.0.0" }
   "mirage-random" {>= "2.0.0" & < "4.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.1/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.1/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "mirage-qubes" {= version}
-  "tcpip" { >= "5.0.0" }
+  "tcpip" { >= "5.0.0" & < "8.1.0"}
   "ipaddr" { >= "3.0.0" }
   "mirage-random" {>= "2.0.0" & < "4.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.2/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.2/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "mirage-qubes" {= version}
-  "tcpip" { >= "7.0.0" }
+  "tcpip" { >= "7.0.0" & < "8.1.0"}
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "ipaddr" { >= "3.0.0" }

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.3/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.3/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "mirage-qubes" {= version}
-  "tcpip" { >= "7.0.0" }
+  "tcpip" { >= "7.0.0" & < "8.1.0"}
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "ipaddr" { >= "3.0.0" }

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.4/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.4/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "mirage-qubes" {= version}
-  "tcpip" { >= "7.0.0" }
+  "tcpip" { >= "7.0.0" & < "8.1.0"}
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "ipaddr" { >= "3.0.0" }

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.5/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.5/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "mirage-qubes" {= version}
-  "tcpip" { >= "7.0.0" }
+  "tcpip" { >= "7.0.0" & < "8.1.0"}
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "ipaddr" { >= "3.0.0" }


### PR DESCRIPTION
the compilation works, but using it does not:

```
478.127s:# File "mirage/main.ml", line 133, characters 39-102: 478.127s:# Error: The functor application is ill-typed.
478.127s:#        These arguments:
478.127s:#          Qubesdb_ipv4_make__16 Ipv6_make__17
478.127s:#        do not match these parameters:
478.127s:#          functor (Ipv4 : $T1) (Ipv6 : ...) -> ...
478.127s:#        1. Modules do not match:
478.127s:#             Qubesdb_ipv4_make__16 :
478.127s:#             sig
478.127s:#               type nonrec error =
478.127s:#                   Qubesdb_ipv4.Make(Qubes.DB)(Mirage_crypto_rng_mirage_make__11)(Mclock)(Ethernet_make__14)(Arp_make__15).error
478.127s:#               val pp_error : error Fmt.t
478.127s:#               type ipaddr = Ipaddr.V4.t
478.127s:#               val pp_ipaddr : ipaddr Fmt.t
478.127s:#               type prefix =
478.127s:#                   Qubesdb_ipv4.Make(Qubes.DB)(Mirage_crypto_rng_mirage_make__11)(Mclock)(Ethernet_make__14)(Arp_make__15).prefix
478.127s:#               val pp_prefix : prefix Fmt.t
478.127s:#               type t =
478.127s:#                   Qubesdb_ipv4.Make(Qubes.DB)(Mirage_crypto_rng_mirage_make__11)(Mclock)(Ethernet_make__14)(Arp_make__15).t
478.127s:#               val disconnect : t -> unit Lwt.t
478.127s:#               type callback =
478.127s:#                   src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
478.127s:#               val input :
478.127s:#                 t ->
478.127s:#                 tcp:callback ->
478.127s:#                 udp:callback ->
478.127s:#                 default:(proto:int -> callback) -> Cstruct.t -> unit Lwt.t
478.127s:#               val write :
478.127s:#                 t ->
478.127s:#                 ?fragment:bool ->
478.127s:#                 ?ttl:int ->
478.127s:#                 ?src:ipaddr ->
478.127s:#                 ipaddr ->
478.127s:#                 Tcpip__Ip.proto ->
478.127s:#                 ?size:int ->
478.127s:#                 (Cstruct.t -> int) ->
478.127s:#                 Cstruct.t list -> (unit, error) result Lwt.t
478.127s:#               val pseudoheader :
478.127s:#                 t ->
478.127s:#                 ?src:ipaddr -> ipaddr -> Tcpip__Ip.proto -> int -> Cstruct.t
478.127s:#               val src : t -> dst:ipaddr -> ipaddr
478.127s:#               val get_ip : t -> ipaddr list
478.127s:#               val configured_ips : t -> prefix list
478.127s:#               val mtu : t -> dst:ipaddr -> int
478.127s:#               val connect :
478.127s:#                 Qubes.DB.t ->
478.127s:#                 Ethernet_make__14.t -> Arp_make__15.t -> t Lwt.t
478.127s:#             end
478.127s:#           is not included in
478.127s:#             $T1 =
478.127s:#             sig
478.127s:#               type nonrec error = private [> Tcpip__Ip.error ]
478.127s:#               val pp_error : error Fmt.t
478.127s:#               type ipaddr = Ipaddr.V4.t
478.127s:#               val pp_ipaddr : ipaddr Fmt.t
478.127s:#               type prefix = Ipaddr.V4.Prefix.t
478.127s:#               val pp_prefix : prefix Fmt.t
478.127s:#               type t
478.127s:#               val disconnect : t -> unit Lwt.t
478.127s:#               type callback =
478.127s:#                   src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
478.127s:#               val input :
478.127s:#                 t ->
478.127s:#                 tcp:callback ->
478.127s:#                 udp:callback ->
478.127s:#                 default:(proto:int -> callback) -> Cstruct.t -> unit Lwt.t
478.127s:#               val write :
478.127s:#                 t ->
478.127s:#                 ?fragment:bool ->
478.127s:#                 ?ttl:int ->
478.127s:#                 ?src:ipaddr ->
478.127s:#                 ipaddr ->
478.127s:#                 Tcpip__Ip.proto ->
478.127s:#                 ?size:int ->
478.127s:#                 (Cstruct.t -> int) ->
478.127s:#                 Cstruct.t list -> (unit, error) result Lwt.t
478.127s:#               val pseudoheader :
478.127s:#                 t ->
478.127s:#                 ?src:ipaddr -> ipaddr -> Tcpip__Ip.proto -> int -> Cstruct.t
478.127s:#               val src : t -> dst:ipaddr -> ipaddr
478.127s:#               val get_ip : t -> ipaddr list
478.127s:#               val configured_ips : t -> prefix list
478.127s:#               val mtu : t -> dst:ipaddr -> int
478.127s:#             end
478.127s:#           Type declarations do not match:
478.127s:#             type prefix =
478.127s:#                 Qubesdb_ipv4.Make(Qubes.DB)(Mirage_crypto_rng_mirage_make__11)(Mclock)(Ethernet_make__14)(Arp_make__15).prefix
478.127s:#           is not included in
478.127s:#             type prefix = Ipaddr.V4.Prefix.t
478.127s:#           The type
478.127s:#             Qubesdb_ipv4.Make(Qubes.DB)(Mirage_crypto_rng_mirage_make__11)(Mclock)(Ethernet_make__14)(Arp_make__15).prefix
478.127s:#           is not equal to the type Ipaddr.V4.Prefix.t
478.127s:#           File "duniverse/mirage-tcpip/src/stack-direct/tcpip_stack_direct.mli", line 18, characters 58-90:
478.127s:#             Expected declaration
478.127s:#           File "duniverse/mirage-tcpip/src/core/ip.mli", line 31, characters 2-13:
478.127s:#             Actual declaration
478.127s:#        2. Module Ipv6_make__17 matches the expected module type
478.127s:# gmake: *** [Makefile:43: build] Error 1
```