### PR TITLE
[new release] mirage (2 packages) (4.6.0)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.4.6.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.4.6.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.9.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "4.0.0"}
+  "ipaddr" {>= "5.5.0"}
+  "cmdliner" {>= "1.2.0"}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "ppxlib" {= "0.29.0"} #0.29.0 provides a vendored ppx_sexp_conv
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.6.0/mirage-4.6.0.tbz"
+  checksum: [
+    "sha256=6cc3f6427bee658e75958974ee638f87ca4dd2214a5857e82719043f981b8bdf"
+    "sha512=7008a67d9fcf3929ace179c95ace8c95653edb7d630e3cc703f30019a8091baaf6575fbb7dedd90b908f8390ea8589e460afdec2e82f4c72edfa602e60cbf9b8"
+  ]
+}
+x-commit-hash: "481a2e75e2473f10a3d2fb18bc18c647086343f7"

--- a/packages/mirage/mirage.4.6.0/opam
+++ b/packages/mirage/mirage.4.6.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+available: opam-version >= "2.1.0"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.9.0"}
+  "astring"
+  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {with-test & >= "1.3.0"}
+  "emile" {>= "1.1"}
+  "fmt" {>= "0.8.7"}
+  "ipaddr" {>= "5.0.0"}
+  "bos"
+  "fpath"
+  "rresult" {>= "0.7.0"}
+  "uri" {>= "4.2.0"}
+  "logs" {>= "0.7.0"}
+  "opam-monorepo" {>= "0.3.2"}
+  "alcotest" {with-test}
+  "mirage-runtime" {with-test & = version}
+]
+
+conflicts: [ "jbuilder" {with-test} ]
+
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.6.0/mirage-4.6.0.tbz"
+  checksum: [
+    "sha256=6cc3f6427bee658e75958974ee638f87ca4dd2214a5857e82719043f981b8bdf"
+    "sha512=7008a67d9fcf3929ace179c95ace8c95653edb7d630e3cc703f30019a8091baaf6575fbb7dedd90b908f8390ea8589e460afdec2e82f4c72edfa602e60cbf9b8"
+  ]
+}
+x-commit-hash: "481a2e75e2473f10a3d2fb18bc18c647086343f7"

--- a/packages/mirage/mirage.4.6.0/opam
+++ b/packages/mirage/mirage.4.6.0/opam
@@ -19,6 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
+  "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
   "cmdliner" {>= "1.2.0"}


### PR DESCRIPTION
The MirageOS library operating system

- Project page: <a href="https://github.com/mirage/mirage">https://github.com/mirage/mirage</a>
- Documentation: <a href="https://mirage.github.io/mirage/">https://mirage.github.io/mirage/</a>

##### CHANGES:

- BREAKING adapt to happy-eyeballs and dns-client devices where dependencies
  got reversed (mirage/mirage#1543 @dinosaure @hannesm)

  Adapting unikernels requires to notice that the generic_dns_client now
  takes a happy_eyeballs, and happy_eyeballs does no longer take a dns_client:

  -let dns_client = generic_dns_client ~nameservers stackv4v6
  -let happy_eyeballs = generic_happy_eyeballs stackv4v6 dns_client
  +let happy_eyeballs = generic_happy_eyeballs stackv4v6
  +let dns_client = generic_dns_client ~nameservers stackv4v6 happy_eyeballs

- allow mirage-qubes 0.10 series (mirage/mirage#1548 @dinosaure)
- revise "job without arguments" to take runtime arguments into consideration
  (mirage/mirage#1544 @hannesm)
- provide Mirage.ethif (alias to Mirage.etif - which is now deprecated)
  (mirage/mirage#1546 @reynir @hannesm)
- update tests for cmdliner 1.3.0 (mirage/mirage#1545 @hannesm)
- allow paf 0.6.0 (mirage/mirage#1542 @hannesm)
