### PR TITLE
opam-graph: source is a tar.bz2

### DIFF
--- a/packages/opam-graph/opam-graph.0.1.1/opam
+++ b/packages/opam-graph/opam-graph.0.1.1/opam
@@ -29,7 +29,7 @@ build: [
 dev-repo: "git+https://git.robur.coop/robur/opam-graph.git"
 url {
   src:
-    "https://github.com/ocaml/opam-source-archives/raw/main/opam-graph-0.1.1.tar.gz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/opam-graph-0.1.1.tar.bz2"
   checksum: [
     "sha512=33e76715684b9f34f97f34a3033975beafa3cbcf88a861e937b80b6c4b08d4dd9b2aa1f7da51830a44166ae519c9a6c3f695c9b9af5583e17140359e0de1d73e"
   ]


### PR DESCRIPTION
now that https://github.com/ocaml/opam-source-archives/pull/30 is merged, this can be updated