### PR TITLE
`bin_prot` FTBFS on OpenSUSE

### DIFF
--- a/packages/bin_prot/bin_prot.v0.17.0/opam
+++ b/packages/bin_prot/bin_prot.v0.17.0/opam
@@ -24,7 +24,7 @@ depends: [
 depopts: [
   "mirage-xen-ocaml"
 ]
-available: arch != "arm32" & arch != "x86_32" & os != "freebsd"
+available: arch != "arm32" & arch != "x86_32" & os != "freebsd" & os-family != "opensuse"
 synopsis: "A binary protocol generator"
 description: "
 Part of Jane Street's Core library

--- a/packages/bin_prot/bin_prot.v0.17.0/opam
+++ b/packages/bin_prot/bin_prot.v0.17.0/opam
@@ -24,7 +24,7 @@ depends: [
 depopts: [
   "mirage-xen-ocaml"
 ]
-available: arch != "arm32" & arch != "x86_32" & os != "freebsd" & os-family != "opensuse"
+available: arch != "arm32" & arch != "x86_32" & os != "freebsd" & os-family != "opensuse" & os-family != "suse"
 synopsis: "A binary protocol generator"
 description: "
 Part of Jane Street's Core library


### PR DESCRIPTION
When I run the Yojson tests, bin_prot on opensuse + ocaml 5.2 [fails](https://ocaml.ci.dev/github/ocaml-community/yojson/commit/47964459af7c8fef4e3c231adde34b1a2a560f19/variant/opensuse-15.5-5.2_opam-2.1). On OCaml 4.x `bin_prot.v0.16` is picked by the solver which compiles fine.

The error message looks like this and is 100% reproducible.
```
/usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: xen/blit_stubs.o: warning: relocation against `caml_leave_blocking_section' in read-only section `.text'
/usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: xen/blit_stubs.o: relocation R_X86_64_PC32 against symbol `memcpy@@GLIBC_2.14' can not be used when making a shared object; recompile with -fPIC
/usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
```

Probably due to a missing `-fPIC` flag. Upstream fix submitted in https://github.com/janestreet/bin_prot/pull/27 and obsoleted by an even more complete solution in https://github.com/janestreet/bin_prot/pull/29.