### PR TITLE
Make `core_unix.v0.15.x` unavailable on FreeBSD 14+

### DIFF
--- a/packages/core_unix/core_unix.v0.15.0/opam
+++ b/packages/core_unix/core_unix.v0.15.0/opam
@@ -29,6 +29,7 @@ description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
 "
 depexts: ["linux-headers"] {os-family = "alpine"}
+available: [ !(os = "freebsd" & os-version >= "14") ]
 url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.15/files/core_unix-v0.15.0.tar.gz"
 checksum: "sha256=0af9d2c0d2029a80858c730171e0bd70a1981b3e7021f8c31cd8dc54925da02d"

--- a/packages/core_unix/core_unix.v0.15.1/opam
+++ b/packages/core_unix/core_unix.v0.15.1/opam
@@ -29,6 +29,7 @@ description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
 "
 depexts: ["linux-headers"] {os-family = "alpine"}
+available: [ !(os = "freebsd" & os-version >= "14") ]
 url {
 src: "https://github.com/ocaml/opam-source-archives/raw/main/core_unix-v0.15.1.tar.gz"
 checksum: "sha256=b467c7c64616d5cc88f42f9660b447247e7a848148336e0ad0de6bd35edce9b3"

--- a/packages/core_unix/core_unix.v0.15.2/opam
+++ b/packages/core_unix/core_unix.v0.15.2/opam
@@ -29,6 +29,7 @@ description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
 "
 depexts: ["linux-headers"] {os-family = "alpine"}
+available: [ !(os = "freebsd" & os-version >= "14") ]
 url {
 src: "https://github.com/janestreet/core_unix/archive/refs/tags/v0.15.2.tar.gz"
 checksum: "sha256=486d0e954603960fa081b3fd23e3cc3e50ac0892544acd35f9c2919c4bf5f67b"


### PR DESCRIPTION
Similar to #26013 this makes `core_unix.v0.15.x` unavailable on FreeBSD 14+ ([example CI failure](https://ocaml.ci.dev/github/ocaml-community/yojson/commit/2f2f0a728ae2448d9c0aa9238150c6c5355dc425/variant/freebsd-4.14_opam-2.1), [@hannesm mentioning the same issue on v0.15.2](https://github.com/ocaml/opam-repository/pull/26013#issuecomment-2156451968). The code seems to be the same in all three releases, and the reason seems to be the same as `timerfd` detection enables it but it doesn't work. In older versions the code is slightly different so it might work, or it might not, haven't explored so far.

Failures look like this:

```
ld: error: undefined symbol: core_linux_timerfd_create
>>> referenced by linux_ext.o:(.text+0x464D) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x2E38) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_settime
>>> referenced by linux_ext.o:(.text+0x48B1) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.text+0x4B91) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x2E30) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_gettime
>>> referenced by linux_ext.o:(.text+0x4AEA) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x2E28) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_CLOCK_REALTIME
>>> referenced by linux_ext.o:(.text+0x7B6A) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x2E58) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_CLOCK_MONOTONIC
>>> referenced by linux_ext.o:(.text+0x7B84) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x2E50) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_TFD_NONBLOCK
>>> referenced by linux_ext.o:(.text+0x7C36) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x2E48) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_TFD_CLOEXEC
>>> referenced by linux_ext.o:(.text+0x7C4F) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x2E40) in archive /home/opam/.opam/4.14.2/lib/core_unix/linux_ext/linux_ext.a
```