### PR TITLE
[new release] styled-ppx (0.57.0)

### DIFF
--- a/packages/styled-ppx/styled-ppx.0.57.0/opam
+++ b/packages/styled-ppx/styled-ppx.0.57.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Type-safe styled components for ReScript and Melange"
+description:
+  "styled-ppx is the ppx that brings styled components to ReScript and Melange, allowing you to create React Components with type-safe style definitions using CSS."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://styled-ppx.vercel.app"
+bug-reports: "https://github.com/davesnx/styled-ppx/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "5.1.0"}
+  "reason" {>= "3.11.0"}
+  "menhir" {>= "20220210"}
+  "ppx_deriving" {>= "5.0"}
+  "ppx_deriving_yojson" {>= "3.7.0"}
+  "ppxlib" {>= "0.27.0"}
+  "sedlex" {>= "3.2"}
+  "melange" {>= "3.0.0"}
+  "server-reason-react"
+  "reason-react" {>= "0.14.0"}
+  "alcotest" {with-test}
+  "conf-npm" {with-test}
+  "reason-react-ppx" {with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+  "utop" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/styled-ppx.git"
+depexts: [
+  ["@emotion/css"] {npm-version = ">=11.0.0"}
+]
+url {
+  src:
+    "https://github.com/davesnx/styled-ppx/releases/download/0.57.0/styled-ppx-0.57.0.tbz"
+  checksum: [
+    "sha256=9db556084c15bc1a9c96fb2a4ce2ae5cf9c05732ebebe6a82cead05a10d5fcaa"
+    "sha512=853c7989b34b30cb8711256f372c6c2d721dfc9dec73ace6aa6f74c4c555b719c5ecb1f5ed665050895f8ac997ba92d315db819b51c5e3e462f59c25a81b2ad4"
+  ]
+}
+x-commit-hash: "4b80cb6bf390d32a5c95bce56407b9cf558746bd"


### PR DESCRIPTION
Type-safe styled components for ReScript and Melange

- Project page: <a href="https://styled-ppx.vercel.app">https://styled-ppx.vercel.app</a>

##### CHANGES:

## 0.57.0

- Improvement for locations in both code-gen and error reporting by @davesnx in https://github.com/davesnx/styled-ppx/pull/456
- Support css min and max functions by @lubegasimon in https://github.com/davesnx/styled-ppx/pull/411
- Update docs by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/457
- update server-reason-react pin to main branch by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/460
- Native support for styled.{{tag}} by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/461
- Fix linear-gradient and radial-gradient  by @davesnx in https://github.com/davesnx/styled-ppx/pull/464
- Add getting started docs by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/459
- escape curly on remote markdown content by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/466
- Add Melange and native instructions by @davesnx in https://github.com/davesnx/styled-ppx/pull/465
- Global styles for native server on emotion by @pedrobslisboa in https://github.com/davesnx/styled-ppx/pull/468
- Style HTML tag by @pedrobslisboa in https://github.com/davesnx/styled-ppx/pull/467
- [emotion native] Fix nested pseudoelements by @davesnx in https://github.com/davesnx/styled-ppx/pull/470
- Transform with variable handle unsafe interpolation by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/471
- Add depext for @emotion/css >= 11.0.0 by @feihong in https://github.com/davesnx/styled-ppx/pull/473
- Add support for transition by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/472
- Fix animation codegen by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/475
- Fix error line number coming from parser by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/478
- Polish emotion-native by @davesnx in https://github.com/davesnx/styled-ppx/pull/481
- Rename `render_style_tag` to `get_stylesheet` (@davesnx)
- Docs: Explain show server rendered stylesheets work natively by @ManasJayanth in https://github.com/davesnx/styled-ppx/pull/480

## 0.56.0

- Improvement for locations in both code-gen and error reporting (davesnx/styled-ppx#456) by @davesnx
- Support css min and max functions (davesnx/styled-ppx#411) by @lubegasimon
- Update docs (davesnx/styled-ppx#457) by @zakybilfagih
- Native support for styled.{{tag}} (davesnx/styled-ppx#461) by @zakybilfagih
- background-clip: text support by @davesnx
- Fix linear-gradient and radial-gradient (davesnx/styled-ppx#464) by @davesnx
- Rename emotion-hash into murmur2 and remove public testing cli by @davesnx
- Use server-reason-react from opam by @davesnx
