### PR TITLE
[new release] euler (0.3)

### DIFF
--- a/packages/euler/euler.0.3/opam
+++ b/packages/euler/euler.0.3/opam
@@ -21,7 +21,7 @@ depends: [
   "containers" {>= "3.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/euler/euler.0.3/opam
+++ b/packages/euler/euler.0.3/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "An arithmetic library for OCaml's native integers "
+description: """
+Euler is a library for doing arithmetic with OCaml’s native integers (31 or 63 bits). It provides:
+
+* overflow-detecting arithmetic, that can be susbstituted for Stdlib arithmetic;
+* advanced arithmetic functions;
+* solvers for some forms of integer equations;
+* modular arithmetic, with a nice functorial interface.
+"""
+maintainer: ["Glen Mével <glen.mevel@crans.org>"]
+authors: ["Glen Mével <glen.mevel@crans.org>"]
+license: "WTFPL"
+homepage: "https://github.com/gmevel/euler-lib"
+doc: "https://gmevel.github.io/euler-lib/index.html"
+bug-reports: "https://github.com/gmevel/euler-lib/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.07"}
+  "stdcompat" {>= "18"}
+  "containers" {>= "3.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/gmevel/euler-lib.git"
+available: arch != "x86_32" & arch != "arm32"
+url {
+  src:
+    "https://github.com/gmevel/euler-lib/releases/download/0.3/euler-0.3.tbz"
+  checksum: [
+    "sha256=b6e887239f69177c121b9b88a48d27abc6b5dd597e5416c16bb2871f29a390ff"
+    "sha512=3627c597a6976e88cabceebf501be9f3bc52f26f233a9cac9c1967ad3d385d59c46a803251e265710d665ef949d057733e67cc57458c570288bad33c7445a63b"
+  ]
+}
+x-commit-hash: "e2dcea58b50aec0903466a16dc77537fe602aca2"


### PR DESCRIPTION
An arithmetic library for OCaml's native integers

- Project page: <a href="https://github.com/gmevel/euler-lib">https://github.com/gmevel/euler-lib</a>
- Documentation: <a href="https://gmevel.github.io/euler-lib/index.html">https://gmevel.github.io/euler-lib/index.html</a>

##### CHANGES:

- optimize several functions in Arith:
  + `mul`
  + `pow` for small bases
  + `log2` and `log2sup` (5x faster)
  + `log` and `logsup` for bases 2, 16, 64, 10, 60
  + `valuation_of_2`
  + `number_of_bits_set` (7x faster)
- fix overflow in `Arith.mul_quo` (renamed to `mul_equo`) and `Arith.gcdext`
- let `Arith.gcdext` return minimal coefficients
- add `Arith.sdiv`
- add `Arith.mul_{ediv,erem}`
- add `Arith.{gcd,gcdext,lcm}_of_seq`
- add functions related to integer powers and roots:
  + `Arith.isqrt_if_square`
  + `Arith.is_pow`
  + `Arith.is_pow2`
  + `Arith.kth_root`
  + `Arith.is_kth_pow`
  + `Arith.smallest_root`
- add some classical arithmetic functions whose computation uses factorization:
  + `Primes.divisor_pairs`
  + `Primes.sum_of_divisors`
  + `Primes.jordan`
  + `Primes.carmichael`
  + `Primes.mobius`
  + `Primes.derivative`
- add `Primes.order`, `Primes.order_with_known_multiple`, `Primes.order_mod_prime_pow`
- `Primes.factors` now performs some iterations of Fermat’s factor searching
- BREAKING: rename sequence-related functions:
  + `Arith.sum_seq` -> `sum_of_seq`
  + `Arith.prod_seq` -> `prod_of_seq`
  + `Primes.prime_seq` -> `gen_primes`
  + `Primes.primes` -> `iter_primes`
- BREAKING: rename logarithm functions:
  + `Arith.log` -> `Arith.ilog`
  + `Arith.log2` -> `Arith.ilog2`
  + `Arith.logsup` -> `Arith.ilogsup`
  + `Arith.log2sup` -> `Arith.ilog2sup`
- BREAKING: rename `Arith.mul_quo` to `mul_equo`
- BREAKING: add notation `Arith.( ** )` for integer exponentiation
- fix `Arith.range_down` not being exposed in the interface
