### PR TITLE
[new release] mirage-crypto (9 packages) (1.0.0)

### DIFF
--- a/packages/git-mirage/git-mirage.3.16.1/opam
+++ b/packages/git-mirage/git-mirage.3.16.1/opam
@@ -24,7 +24,7 @@ depends: [
   "happy-eyeballs-mirage" {>= "0.1.2"}
   "happy-eyeballs" {>= "0.1.2"}
   "ca-certs-nss"
-  "mirage-crypto"
+  "mirage-crypto" {< "1.0.0"}
   "ptime"
   "x509" {>= "0.16.2"}
   "cstruct"

--- a/packages/git-unix/git-unix.3.16.1/opam
+++ b/packages/git-unix/git-unix.3.16.1/opam
@@ -40,7 +40,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "mirage-flow" {>= "4.0.0"}
   "ke" {>= "0.4" & with-test}
-  "mirage-crypto-rng" {>= "0.11.0" & with-test}
+  "mirage-crypto-rng" {with-test & >= "0.11.0" & < "1.0.0"}
   "mimic" {>= "0.0.8"}
   "tls" {>= "0.14.0"}
 ]

--- a/packages/git/git.3.16.1/opam
+++ b/packages/git/git.3.16.1/opam
@@ -40,7 +40,7 @@ depends: [
   "encore" {>= "0.8"}
   "alcotest" {with-test & >= "1.1.0"}
   "alcotest-lwt" {with-test & >= "1.1.0"}
-  "mirage-crypto-rng" {with-test & >= "0.8.0"}
+  "mirage-crypto-rng" {with-test & >= "0.8.0" & < "1.0.0"}
   "cmdliner" {with-test & >= "1.1.0"}
   "base-unix" {with-test}
   "hxd" {>= "0.3.2"}

--- a/packages/mirage-crypto-ec/mirage-crypto-ec.1.0.0/opam
+++ b/packages/mirage-crypto-ec/mirage-crypto-ec.1.0.0/opam
@@ -37,6 +37,8 @@ depends: [
   "ppx_deriving" {with-test}
   "yojson" {with-test & >= "1.6.0"}
   "asn1-combinators" {with-test & >= "0.3.1"}
+  "ohex" {with-test & >= "0.2.0"}
+  "ounit2" {with-test}
 ]
 conflicts: [
   "ocaml-freestanding"

--- a/packages/mirage-crypto-ec/mirage-crypto-ec.1.0.0/opam
+++ b/packages/mirage-crypto-ec/mirage-crypto-ec.1.0.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Elliptic Curve Cryptography with primitives taken from Fiat"
+description: """
+An implementation of key exchange (ECDH) and digital signature (ECDSA/EdDSA)
+algorithms using code from Fiat (<https://github.com/mit-plv/fiat-crypto>).
+
+The curves P256 (SECP256R1), P384 (SECP384R1),
+P521 (SECP521R1), and 25519 (X25519, Ed25519) are implemented by this package.
+"""
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "Nathan Rebours <nathan.p.rebours@gmail.com>"
+  "Clément Pascutto <clement@tarides.com>"
+  "Etienne Millon <me@emillon.org>"
+  "Virgile Robles <virgile.robles@protonmail.ch>"
+# and from the fiat-crypto AUTHORS file
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+  "Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mirage/mirage-crypto"
+doc: "https://mirage.github.io/mirage-crypto/doc"
+bug-reports: "https://github.com/mirage/mirage-crypto/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.13.0"}
+  "dune-configurator"
+  "eqaf" {>= "0.7"}
+  "mirage-crypto-rng" {=version}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "ppx_deriving_yojson" {with-test}
+  "ppx_deriving" {with-test}
+  "yojson" {with-test & >= "1.6.0"}
+  "asn1-combinators" {with-test & >= "0.3.1"}
+]
+conflicts: [
+  "ocaml-freestanding"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
+tags: ["org:mirage"]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.0/mirage-crypto-1.0.0.tbz"
+  checksum: [
+    "sha256=4f9b06af4f6440eee85e5645c01184ca10cd30a8127864e80fc5f206cf864769"
+    "sha512=73855eeea482b6ba4b7e095a92af2322e97a6da67bee79ef2b3b05449d7ed522712dd11e825759e812eec21281083ef8422429a156851930078aad41215ecdfc"
+  ]
+}
+x-commit-hash: "28e9cc96492b43a994652c25ab8db4f265f51165"

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.1.0.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.1.0.0/opam
@@ -18,6 +18,7 @@ depends: [
   "dune" {>= "2.7"}
   "ounit2" {with-test}
   "randomconv" {with-test & >= "0.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
   "mirage-crypto" {=version}
   "mirage-crypto-rng" {=version}
   "digestif" {>= "1.2.0"}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.1.0.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.1.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "ounit2" {with-test}
+  "randomconv" {with-test & >= "0.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "digestif" {>= "1.2.0"}
+  "zarith" {>= "1.13"}
+  "eqaf" {>= "0.8"}
+]
+conflicts: [
+  "ocaml-freestanding"
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.0/mirage-crypto-1.0.0.tbz"
+  checksum: [
+    "sha256=4f9b06af4f6440eee85e5645c01184ca10cd30a8127864e80fc5f206cf864769"
+    "sha512=73855eeea482b6ba4b7e095a92af2322e97a6da67bee79ef2b3b05449d7ed522712dd11e825759e812eec21281083ef8422429a156851930078aad41215ecdfc"
+  ]
+}
+x-commit-hash: "28e9cc96492b43a994652c25ab8db4f265f51165"

--- a/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.1.0.0/opam
+++ b/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an Async-friendly way"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "async" {>= "v0.14"}
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "ohex" {with-test & >= "0.2.0"}
+]
+available: os != "win32"
+description: """
+
+Mirage-crypto-rng-async feeds the entropy source for Mirage_crypto_rng-based
+random number generator implementations, in an Async-friendly way.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.0/mirage-crypto-1.0.0.tbz"
+  checksum: [
+    "sha256=4f9b06af4f6440eee85e5645c01184ca10cd30a8127864e80fc5f206cf864769"
+    "sha512=73855eeea482b6ba4b7e095a92af2322e97a6da67bee79ef2b3b05449d7ed522712dd11e825759e812eec21281083ef8422429a156851930078aad41215ecdfc"
+  ]
+}
+x-commit-hash: "28e9cc96492b43a994652c25ab8db4f265f51165"
+

--- a/packages/mirage-crypto-rng-eio/mirage-crypto-rng-eio.1.0.0/opam
+++ b/packages/mirage-crypto-rng-eio/mirage-crypto-rng-eio.1.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["Bikal Gurung <gbikal@gmail.com>" ]
+maintainer:   "Bikal Gurung <gbikal@gmail.com>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an eio-friendly way"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7"}
+  "eio" {>= "0.12"}
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "mtime"
+  "eio_main" {with-test}
+  "ohex" {with-test & >= "0.2.0"}
+]
+description: """
+Mirage-crypto-rng-eio feeds the entropy source for Mirage_crypto_rng-based
+random number generator implementations, in an eio-friendly way.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.0/mirage-crypto-1.0.0.tbz"
+  checksum: [
+    "sha256=4f9b06af4f6440eee85e5645c01184ca10cd30a8127864e80fc5f206cf864769"
+    "sha512=73855eeea482b6ba4b7e095a92af2322e97a6da67bee79ef2b3b05449d7ed522712dd11e825759e812eec21281083ef8422429a156851930078aad41215ecdfc"
+  ]
+}
+x-commit-hash: "28e9cc96492b43a994652c25ab8db4f265f51165"

--- a/packages/mirage-crypto-rng-lwt/mirage-crypto-rng-lwt.1.0.0/opam
+++ b/packages/mirage-crypto-rng-lwt/mirage-crypto-rng-lwt.1.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "duration"
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "mtime" {>= "1.0.0"}
+  "lwt" {>= "4.0.0"}
+]
+description: """
+Mirage-crypto-rng-lwt provides entropy collection code for the RNG using Lwt.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.0/mirage-crypto-1.0.0.tbz"
+  checksum: [
+    "sha256=4f9b06af4f6440eee85e5645c01184ca10cd30a8127864e80fc5f206cf864769"
+    "sha512=73855eeea482b6ba4b7e095a92af2322e97a6da67bee79ef2b3b05449d7ed522712dd11e825759e812eec21281083ef8422429a156851930078aad41215ecdfc"
+  ]
+}
+x-commit-hash: "28e9cc96492b43a994652c25ab8db4f265f51165"

--- a/packages/mirage-crypto-rng-miou-unix/mirage-crypto-rng-miou-unix.1.0.0/opam
+++ b/packages/mirage-crypto-rng-miou-unix/mirage-crypto-rng-miou-unix.1.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "logs"
   "mirage-crypto-rng" {=version}
   "duration"
-  "mtime"
+  "mtime" {>= "1.0.0"}
   "digestif" {>= "1.2.0"}
   "ohex" {with-test & >= "0.2.0"}
 ]

--- a/packages/mirage-crypto-rng-miou-unix/mirage-crypto-rng-miou-unix.1.0.0/opam
+++ b/packages/mirage-crypto-rng-miou-unix/mirage-crypto-rng-miou-unix.1.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an miou.unix-friendly way"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7"}
+  "miou" {>= "0.2.0"}
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "mtime"
+  "digestif" {>= "1.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+description: """
+Mirage-crypto-rng-miou-unix feeds the entropy source for Mirage_crypto_rng-based
+random number generator implementations, in an miou.unix-friendly way.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.0/mirage-crypto-1.0.0.tbz"
+  checksum: [
+    "sha256=4f9b06af4f6440eee85e5645c01184ca10cd30a8127864e80fc5f206cf864769"
+    "sha512=73855eeea482b6ba4b7e095a92af2322e97a6da67bee79ef2b3b05449d7ed522712dd11e825759e812eec21281083ef8422429a156851930078aad41215ecdfc"
+  ]
+}
+x-commit-hash: "28e9cc96492b43a994652c25ab8db4f265f51165"

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.1.0.0/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.1.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "BSD-2-Clause"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "logs"
+  "lwt" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.8.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-unix" {with-test & >= "5.0.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.0/mirage-crypto-1.0.0.tbz"
+  checksum: [
+    "sha256=4f9b06af4f6440eee85e5645c01184ca10cd30a8127864e80fc5f206cf864769"
+    "sha512=73855eeea482b6ba4b7e095a92af2322e97a6da67bee79ef2b3b05449d7ed522712dd11e825759e812eec21281083ef8422429a156851930078aad41215ecdfc"
+  ]
+}
+x-commit-hash: "28e9cc96492b43a994652c25ab8db4f265f51165"

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.1.0.0/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.1.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "duration"
+  "logs"
+  "mirage-crypto" {=version}
+  "digestif" {>= "1.1.4"}
+  "ounit2" {with-test}
+  "randomconv" {with-test & >= "0.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.0/mirage-crypto-1.0.0.tbz"
+  checksum: [
+    "sha256=4f9b06af4f6440eee85e5645c01184ca10cd30a8127864e80fc5f206cf864769"
+    "sha512=73855eeea482b6ba4b7e095a92af2322e97a6da67bee79ef2b3b05449d7ed522712dd11e825759e812eec21281083ef8422429a156851930078aad41215ecdfc"
+  ]
+}
+x-commit-hash: "28e9cc96492b43a994652c25ab8db4f265f51165"

--- a/packages/mirage-crypto/mirage-crypto.1.0.0/opam
+++ b/packages/mirage-crypto/mirage-crypto.1.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit2" {with-test}
+  "ohex" {with-test & >= "0.2.0"}
+  "eqaf" {>= "0.8"}
+]
+conflicts: [
+  "ocaml-freestanding"
+  "result" {< "1.5"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.0/mirage-crypto-1.0.0.tbz"
+  checksum: [
+    "sha256=4f9b06af4f6440eee85e5645c01184ca10cd30a8127864e80fc5f206cf864769"
+    "sha512=73855eeea482b6ba4b7e095a92af2322e97a6da67bee79ef2b3b05449d7ed522712dd11e825759e812eec21281083ef8422429a156851930078aad41215ecdfc"
+  ]
+}
+x-commit-hash: "28e9cc96492b43a994652c25ab8db4f265f51165"


### PR DESCRIPTION
Simple symmetric cryptography for the modern age

- Project page: <a href="https://github.com/mirage/mirage-crypto">https://github.com/mirage/mirage-crypto</a>
- Documentation: <a href="https://mirage.github.io/mirage-crypto/doc">https://mirage.github.io/mirage-crypto/doc</a>

##### CHANGES:

### Breaking changes

* mirage-crypto: Poly1305 API now uses string (mirage/mirage-crypto#203 @hannesm)
* mirage-crypto: Poly1305 no longer has type alias "type mac = string"
  (mirage/mirage-crypto#232 @hannesm)
* mirage-crypto: the API uses string instead of cstruct (mirage/mirage-crypto#214 @reynir @hannesm)
* mirage-crypto: Hash module has been removed. Use digestif if you need hash
  functions (mirage/mirage-crypto#213 @hannesm)
* mirage-crypto: the Cipher_block and Cipher_stream modules have been removed,
  its contents is inlined:
  Mirage_crypto.Cipher_block.S -> Mirage_crypto.Block
  Mirage_crypto.Cipher_stream.S -> Mirage_crypto.Stream
  Mirage_crypto.Cipher_block.AES.CTR -> Mirage_crypto.AES.CTR
  (mirage/mirage-crypto#225 @hannesm, suggested in mirage/mirage-crypto#224 by @reynir)
* mirage-crypto-pk: s-expression conversions for private and public keys (Dh,
  Dsa, Rsa) have been removed. You can use PKCS8 for encoding and decoding
  `X509.{Private,Public}_key.{en,de}code_{der,pem}` (mirage/mirage-crypto#208 @hannesm)
* mirage-crypto-pk: in the API, Cstruct.t is no longer present. Instead,
  string is used (mirage/mirage-crypto#211 @reynir @hannesm)
* mirage-crypto-rng: the API uses string instead of Cstruct.t. A new function
  `generate_into : ?g -> bytes -> ?off:int -> int -> unit` is provided
  (mirage/mirage-crypto#212 @hannesm @reynir)
* mirage-crypto-ec: remove NIST P224 support (mirage/mirage-crypto#209 @hannesm @Firobe)
* mirage-crypto: in Uncommon.xor_into the arguments ~src_off and ~dst_off are
  required now (mirage/mirage-crypto#232 @hannesm), renamed to unsafe_xor_into
  (98f01b14f5ebf98ba0e7e9c2ba97ec518f90fddc)
* mirage-crypto-pk, mirage-crypto-rng: remove type alias "type bits = int"
  (mirage/mirage-crypto#236 @hannesm)

### Bugfixes

* mirage-crypto (32 bit systems): CCM with long adata (mirage/mirage-crypto#207 @reynir)
* mirage-crypto-ec: fix K_gen for bitlen mod 8 != 0 (reported in mirage/mirage-crypto#105 that
  P521 test vectors don't pass, re-reported mirage/mirage-crypto#228, fixed mirage/mirage-crypto#230 @Firobe)
* mirage-crypto-ec: zero out bytes allocated for Field_element.zero (reported
  mirleft/ocaml-x509#167, fixed mirage/mirage-crypto#226 @dinosaure)

### Data race free

* mirage-crypto (3DES): avoid global state in key derivation (mirage/mirage-crypto#223 @hannesm)
* mirage-crypto-rng: use atomic instead of reference to be domain-safe (mirage/mirage-crypto#221
  @dinosaure @reynir @hannesm)
* mirage-crypto, mirage-crypto-rng, mirage-crypto-pk, mirage-crypto-ec:
  avoid global buffers, use freshly allocated strings/bytes instead, avoids
  data races (mirage/mirage-crypto#186 mirage/mirage-crypto#219 @dinosaure @reynir @hannesm)

### Other changes

* mirage-crypto: add {de,en}crypt_into functions (and unsafe variants) to allow
  less buffer allocations (mirage/mirage-crypto#231 @hannesm)
* mirage-crypto-rng-miou: new package which adds rng support with miou
  (mirage/mirage-crypto#227 @dinosaure)
* PERFORMANCE mirage-crypto: ChaCha20/Poly1305 use string instead of Cstruct.t,
  ChaCha20 interface unchanged, performance improvement roughly 2x
  (mirage/mirage-crypto#203 @hannesm @reynir)
* mirage-crypto-ec, mirage-crypto-pk, mirage-crypto-rng: use digestif for
  hashes (mirage/mirage-crypto#212 mirage/mirage-crypto#215 @reynir @hannesm)
* mirage-crypto-rng: use a set for entropy sources instead of a list
  (mirage/mirage-crypto#218 @hannesm)
* mirage-crypto-rng-mirage: provide a module type S (for use instead of
  mirage-random in mirage) (mirage/mirage-crypto#234 @hannesm)
