### PR TITLE
OCamlbuild.0.15.0

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.15.0/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.15.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+authors: ["Nicolas Pouillard" "Berke Durak"]
+homepage: "https://github.com/ocaml/ocamlbuild/"
+bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+license: "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
+doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
+dev-repo: "git+https://github.com/ocaml/ocamlbuild.git"
+synopsis:
+  "OCamlbuild is a build system with builtin rules to easily build most OCaml projects"
+
+build: [
+  [
+    make
+    "-f"
+    "configure.make"
+    "all"
+    "OCAMLBUILD_PREFIX=%{prefix}%"
+    "OCAMLBUILD_BINDIR=%{bin}%"
+    "OCAMLBUILD_LIBDIR=%{lib}%"
+    "OCAMLBUILD_MANDIR=%{man}%"
+    "OCAML_NATIVE=%{ocaml:native}%"
+    "OCAML_NATIVE_TOOLS=%{ocaml:native}%"
+  ]
+  [make "check-if-preinstalled" "all" "opam-install"]
+]
+
+conflicts: [
+  "base-ocamlbuild"
+  "ocamlfind" {< "1.6.2"}
+]
+
+depends: [
+  "ocaml" {>= "4.08"}
+  "ocamlfind" {with-test}
+  "menhirLib" {with-test}
+]
+
+url {
+  src: "https://github.com/ocaml/ocamlbuild/archive/refs/tags/0.15.0.tar.gz"
+  checksum: [
+    "sha512=c8311a9a78491bf759eb27153d6ba4692d27cd935759a145f96a8ba8f3c2e97cef54e7d654ed1c2c07c74f60482a4fef5224e26d0f04450e69cdcb9418c762d3"
+  ]
+}


### PR DESCRIPTION
OCamlbuild 0.15.0 comes with first class support for native Windows ports of OCaml
(MinGW64-w64 and MSVC). This support was historically provided by
[opam-repository-mingw](https://fdopen.github.io/opam-repository-mingw/).

- Misc: restore CI (unix, macos, windows)
  (https://github.com/ocaml/ocamlbuild/pull/328, https://github.com/ocaml/ocamlbuild/pull/329, https://github.com/ocaml/ocamlbuild/pull/336, https://github.com/ocaml/ocamlbuild/pull/349 by Hugo Heuzard)
* Remove degraded mode for windows
  (https://github.com/ocaml/ocamlbuild/pull/333 by Hugo Heuzard)
- Remove light mode (https://github.com/ocaml/ocamlbuild/pull/332 by Hugo Heuzard)
- Make the codebase work on windows native
  (https://github.com/ocaml/ocamlbuild/pull/329, https://github.com/ocaml/ocamlbuild/pull/333, https://github.com/ocaml/ocamlbuild/pull/334, https://github.com/ocaml/ocamlbuild/pull/338, https://github.com/ocaml/ocamlbuild/pull/339, https://github.com/ocaml/ocamlbuild/pull/342, https://github.com/ocaml/ocamlbuild/pull/343, https://github.com/ocaml/ocamlbuild/pull/344 by Hugo Heuzard)
* No longer treat empty path in PATH env variable as the current working directory
  (https://github.com/ocaml/ocamlbuild/pull/339 by Hugo Heuzard)
- Emit a warning if several calls are made to
   `Ocamlbuild_plugin.dispatch` -- all calls before the last one are
   ignored, which may not be what users expect.
  (https://github.com/ocaml/ocamlbuild/pull/30 by Gabriel Scherer, review by whitequark)
- Rename user-rebindable {LINK,COMP}FLAGS into OCB_{LINK,COMP}FLAGS
  (https://github.com/ocaml/ocamlbuild/pull/303 by Gabriel Scherer)

