### PR TITLE
[new release] hkdf (2.0.0)

### DIFF
--- a/packages/hkdf/hkdf.2.0.0/opam
+++ b/packages/hkdf/hkdf.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-Clause"
+homepage: "https://github.com/hannesm/ocaml-hkdf"
+doc: "https://hannesm.github.io/ocaml-hkdf/doc"
+bug-reports: "https://github.com/hannesm/ocaml-hkdf/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test}
+  "ohex" {with-test & >= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/ocaml-hkdf.git"
+synopsis: "HMAC-based Extract-and-Expand Key Derivation Function (RFC 5869)"
+description: """
+An implementation of [HKDF](https://tools.ietf.org/html/rfc5869) using
+[digestif](https://github.com/mirage/digestif).
+"""
+url {
+  src:
+    "https://github.com/hannesm/ocaml-hkdf/releases/download/v2.0.0/hkdf-2.0.0.tbz"
+  checksum: [
+    "sha256=54b071279be24d39f59cad10348006abff3deb5c74fd118764dfc2ffb21358d3"
+    "sha512=a240ecfbdebb7e0552f59ba67a723a2ed8eacfbd6691c23cbacc763ff8f8c4e40367343ff0093db2c4c5479b9f61927011691677ddccafd0722023b3b30e6885"
+  ]
+}
+x-commit-hash: "c7e22ff344722e21b8e66a9bcc8838c7ab79f73a"

--- a/packages/tls/tls.0.12.0/opam
+++ b/packages/tls/tls.0.12.0/opam
@@ -32,7 +32,7 @@ depends: [
   "ptime" {>= "0.8.1"}
   "hacl_x25519"
   "fiat-p256"
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "alcotest" {with-test}
 ]

--- a/packages/tls/tls.0.12.1/opam
+++ b/packages/tls/tls.0.12.1/opam
@@ -33,7 +33,7 @@ depends: [
   "ptime" {>= "0.8.1"}
   "hacl_x25519"
   "fiat-p256"
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "alcotest" {with-test}
 ]

--- a/packages/tls/tls.0.12.2/opam
+++ b/packages/tls/tls.0.12.2/opam
@@ -32,7 +32,7 @@ depends: [
   "ptime" {>= "0.8.1"}
   "hacl_x25519"
   "fiat-p256"
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "alcotest" {with-test}
 ]

--- a/packages/tls/tls.0.12.3/opam
+++ b/packages/tls/tls.0.12.3/opam
@@ -32,7 +32,7 @@ depends: [
   "ptime" {>= "0.8.1"}
   "hacl_x25519"
   "fiat-p256"
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "alcotest" {with-test}
 ]

--- a/packages/tls/tls.0.12.4/opam
+++ b/packages/tls/tls.0.12.4/opam
@@ -32,7 +32,7 @@ depends: [
   "ptime" {>= "0.8.1"}
   "hacl_x25519"
   "fiat-p256"
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "alcotest" {with-test}
 ]

--- a/packages/tls/tls.0.12.5/opam
+++ b/packages/tls/tls.0.12.5/opam
@@ -32,7 +32,7 @@ depends: [
   "ptime" {>= "0.8.1"}
   "hacl_x25519"
   "fiat-p256"
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "alcotest" {with-test}
 ]

--- a/packages/tls/tls.0.12.6/opam
+++ b/packages/tls/tls.0.12.6/opam
@@ -32,7 +32,7 @@ depends: [
   "ptime" {>= "0.8.1"}
   "hacl_x25519"
   "fiat-p256"
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "alcotest" {with-test}
 ]

--- a/packages/tls/tls.0.12.7/opam
+++ b/packages/tls/tls.0.12.7/opam
@@ -32,7 +32,7 @@ depends: [
   "ptime" {>= "0.8.1"}
   "hacl_x25519"
   "fiat-p256"
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "alcotest" {with-test}
 ]

--- a/packages/tls/tls.0.12.8/opam
+++ b/packages/tls/tls.0.12.8/opam
@@ -32,7 +32,7 @@ depends: [
   "ptime" {>= "0.8.1"}
   "hacl_x25519"
   "fiat-p256"
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "alcotest" {with-test}
 ]

--- a/packages/tls/tls.0.13.0/opam
+++ b/packages/tls/tls.0.13.0/opam
@@ -32,7 +32,7 @@ depends: [
   "ounit2" {with-test & >= "2.2.0"}
   "lwt" {>= "3.0.0"}
   "ptime" {>= "0.8.1"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "alcotest" {with-test}
 ]

--- a/packages/tls/tls.0.13.1/opam
+++ b/packages/tls/tls.0.13.1/opam
@@ -32,7 +32,7 @@ depends: [
   "ounit2" {with-test & >= "2.2.0"}
   "lwt" {>= "3.0.0"}
   "ptime" {>= "0.8.1"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "alcotest" {with-test}
 ]

--- a/packages/tls/tls.0.13.2/opam
+++ b/packages/tls/tls.0.13.2/opam
@@ -32,7 +32,7 @@ depends: [
   "ounit2" {with-test & >= "2.2.0"}
   "lwt" {>= "3.0.0"}
   "ptime" {>= "0.8.1"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "alcotest" {with-test}
   "randomconv" {with-test & < "0.2.0"}

--- a/packages/tls/tls.0.14.0/opam
+++ b/packages/tls/tls.0.14.0/opam
@@ -32,7 +32,7 @@ depends: [
   "ounit2" {with-test & >= "2.2.0"}
   "lwt" {>= "3.0.0"}
   "ptime" {>= "0.8.1"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "alcotest" {with-test}
   "randomconv" {with-test & < "0.2.0"}

--- a/packages/tls/tls.0.14.1/opam
+++ b/packages/tls/tls.0.14.1/opam
@@ -32,7 +32,7 @@ depends: [
   "ounit2" {with-test & >= "2.2.0"}
   "lwt" {>= "3.0.0"}
   "ptime" {>= "0.8.1"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "alcotest" {with-test}
   "randomconv" {with-test & < "0.2.0"}

--- a/packages/tls/tls.0.15.0/opam
+++ b/packages/tls/tls.0.15.0/opam
@@ -32,7 +32,7 @@ depends: [
   "ounit2" {with-test & >= "2.2.0"}
   "lwt" {>= "3.0.0"}
   "ptime" {>= "0.8.1"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "ipaddr"
   "ipaddr-sexp"

--- a/packages/tls/tls.0.15.1/opam
+++ b/packages/tls/tls.0.15.1/opam
@@ -31,7 +31,7 @@ depends: [
   "ounit2" {with-test & >= "2.2.0"}
   "lwt" {>= "3.0.0"}
   "ptime" {>= "0.8.1"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "ipaddr"
   "ipaddr-sexp"

--- a/packages/tls/tls.0.15.2/opam
+++ b/packages/tls/tls.0.15.2/opam
@@ -31,7 +31,7 @@ depends: [
   "ounit2" {with-test & >= "2.2.0"}
   "lwt" {>= "3.0.0"}
   "ptime" {>= "0.8.1"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "ipaddr"
   "ipaddr-sexp"

--- a/packages/tls/tls.0.15.3/opam
+++ b/packages/tls/tls.0.15.3/opam
@@ -31,7 +31,7 @@ depends: [
   "ounit2" {with-test & >= "2.2.0"}
   "lwt" {>= "3.0.0"}
   "ptime" {>= "0.8.1"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "ipaddr"
   "ipaddr-sexp"

--- a/packages/tls/tls.0.15.4/opam
+++ b/packages/tls/tls.0.15.4/opam
@@ -31,7 +31,7 @@ depends: [
   "ounit2" {with-test & >= "2.2.0"}
   "lwt" {>= "3.0.0"}
   "ptime" {>= "0.8.1"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "ipaddr"
   "ipaddr-sexp"

--- a/packages/tls/tls.0.16.0/opam
+++ b/packages/tls/tls.0.16.0/opam
@@ -29,7 +29,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "cstruct-unix" {with-test & >= "3.0.0"}
   "ounit2" {with-test & >= "2.2.0"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "ipaddr"
   "ipaddr-sexp"

--- a/packages/tls/tls.0.17.0/opam
+++ b/packages/tls/tls.0.17.0/opam
@@ -25,7 +25,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "cstruct-unix" {with-test & >= "3.0.0"}
   "ounit2" {with-test & >= "2.2.0"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "ipaddr"
   "alcotest" {with-test}

--- a/packages/tls/tls.0.17.1/opam
+++ b/packages/tls/tls.0.17.1/opam
@@ -25,7 +25,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "cstruct-unix" {with-test & >= "3.0.0"}
   "ounit2" {with-test & >= "2.2.0"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "ipaddr"
   "alcotest" {with-test}

--- a/packages/tls/tls.0.17.3/opam
+++ b/packages/tls/tls.0.17.3/opam
@@ -25,7 +25,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "cstruct-unix" {with-test & >= "3.0.0"}
   "ounit2" {with-test & >= "2.2.0"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "ipaddr"
   "alcotest" {with-test}

--- a/packages/tls/tls.0.17.4/opam
+++ b/packages/tls/tls.0.17.4/opam
@@ -25,7 +25,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "cstruct-unix" {with-test & >= "3.0.0"}
   "ounit2" {with-test & >= "2.2.0"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "ipaddr"
   "alcotest" {with-test}

--- a/packages/tls/tls.0.17.5/opam
+++ b/packages/tls/tls.0.17.5/opam
@@ -25,7 +25,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "cstruct-unix" {with-test & >= "3.0.0"}
   "ounit2" {with-test & >= "2.2.0"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "ipaddr"
   "alcotest" {with-test}


### PR DESCRIPTION
HMAC-based Extract-and-Expand Key Derivation Function (RFC 5869)

- Project page: <a href="https://github.com/hannesm/ocaml-hkdf">https://github.com/hannesm/ocaml-hkdf</a>
- Documentation: <a href="https://hannesm.github.io/ocaml-hkdf/doc">https://hannesm.github.io/ocaml-hkdf/doc</a>

##### CHANGES:

* use digestif instead of mirage-crypto (@dinosaure @hannesm)
