### PR TITLE
[new release] multicore-bench (0.1.4)

### DIFF
--- a/packages/multicore-bench/multicore-bench.0.1.4/opam
+++ b/packages/multicore-bench/multicore-bench.0.1.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Framework for writing multicore benchmark executables to run on current-bench"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-bench"
+bug-reports: "https://github.com/ocaml-multicore/multicore-bench/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "domain-local-await" {>= "1.0.1"}
+  "multicore-magic" {>= "2.1.0"}
+  "mtime" {>= "2.0.0"}
+  "yojson" {>= "2.1.0"}
+  "domain_shims" {>= "0.1.0"}
+  "backoff" {>= "0.1.0" & with-test}
+  "mdx" {>= "2.4.0" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
+  "ocaml" {>= "4.13.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-bench.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-bench/releases/download/0.1.4/multicore-bench-0.1.4.tbz"
+  checksum: [
+    "sha256=882c7942f858a3f7b9ddc5b6dd2cdad9ab3869ecf81de11256f2cf1750d6f390"
+    "sha512=cce4aa2fe85166a29b22ad22130b6ea6ce046f142821ff0159b6b010eb49316237ddc79ddee448c24022f530ec841c54360d85bdb997114a0b2355555078eb07"
+  ]
+}
+x-commit-hash: "3f59d03733bb7c7d05f7ea013d5ac37bd51732d5"


### PR DESCRIPTION
Framework for writing multicore benchmark executables to run on current-bench

- Project page: <a href="https://github.com/ocaml-multicore/multicore-bench">https://github.com/ocaml-multicore/multicore-bench</a>

##### CHANGES:

- Automatically filter benchmarks by given diff base file (@polytypic)
- Randomize suites to expose variation from effects on runtime (@polytypic)
