### PR TITLE
[new release] shuttle_http (2 packages) (0.12.0)

### DIFF
--- a/packages/shuttle_http/shuttle_http.0.12.0/opam
+++ b/packages/shuttle_http/shuttle_http.0.12.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Async library for HTTP/1.1 servers and clients"
+description:
+  "Shuttle_http is a low level library for implementing HTTP/1.1 web services and clients in OCaml."
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["http-server" "http-client" "http" "http1.1" "async"]
+homepage: "https://github.com/anuragsoni/shuttle_http"
+bug-reports: "https://github.com/anuragsoni/shuttle_http/issues"
+depends: [
+  "dune" {>= "3.1"}
+  "async" {>= "v0.17.0"}
+  "async_log" {>= "v0.17.0"}
+  "async_ssl" {>= "v0.17.0"}
+  "core" {>= "v0.17.0"}
+  "jane_rope" {>= "v0.17.0"}
+  "ocaml" {>= "5.1.0"}
+  "ppx_jane" {>= "v0.17.0"}
+  "re2" {>= "v0.17.0"}
+  "core_unix" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle_http.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"}
+    "@doc" {with-doc}
+  ]
+]
+available: [ arch = "x86_64" | arch = "arm64" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle_http/releases/download/0.12.0/shuttle_http-0.12.0.tbz"
+  checksum: [
+    "sha256=073651dfcbe88a29856ae9568583ecece3df659aa74470ca92671e388ccc9351"
+    "sha512=78a8f4517238a7332cf5211f250aa031a3f64fcdf3617c23f072183bbbd9535e295cdef9551d24e4451ef674e0ce6845296960f66ca9c28b81430f4cf0dda563"
+  ]
+}
+x-commit-hash: "b7f2b7b1f7f018d58ae5b898293043dd77314b43"

--- a/packages/shuttle_websocket/shuttle_websocket.0.12.0/opam
+++ b/packages/shuttle_websocket/shuttle_websocket.0.12.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Websocket support for HTTP/1.1 servers using Async"
+description:
+  "Shuttle_websocket is a companion library for shuttle_http that provides a HTTP service that performs websocket negotiation for HTTP/1.1 servers."
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["http-server" "websocket"]
+homepage: "https://github.com/anuragsoni/shuttle_http"
+bug-reports: "https://github.com/anuragsoni/shuttle_http/issues"
+depends: [
+  "dune" {>= "3.1"}
+  "shuttle_http" {= version}
+  "async_websocket"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle_http.git"
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle_http/releases/download/0.12.0/shuttle_http-0.12.0.tbz"
+  checksum: [
+    "sha256=073651dfcbe88a29856ae9568583ecece3df659aa74470ca92671e388ccc9351"
+    "sha512=78a8f4517238a7332cf5211f250aa031a3f64fcdf3617c23f072183bbbd9535e295cdef9551d24e4451ef674e0ce6845296960f66ca9c28b81430f4cf0dda563"
+  ]
+}
+x-commit-hash: "b7f2b7b1f7f018d58ae5b898293043dd77314b43"

--- a/packages/shuttle_websocket/shuttle_websocket.0.12.0/opam
+++ b/packages/shuttle_websocket/shuttle_websocket.0.12.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/anuragsoni/shuttle_http/issues"
 depends: [
   "dune" {>= "3.1"}
   "shuttle_http" {= version}
-  "async_websocket"
+  "async_websocket" {>= "v0.17.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Async library for HTTP/1.1 servers and clients

- Project page: <a href="https://github.com/anuragsoni/shuttle_http">https://github.com/anuragsoni/shuttle_http</a>

##### CHANGES:

* Adapt to Janestreet's 0.17 series.
