### PR TITLE
Fix installation of Morbig 0.11.0

### DIFF
--- a/packages/morbig/morbig.0.11.0/opam
+++ b/packages/morbig/morbig.0.11.0/opam
@@ -33,6 +33,7 @@ depends: [
 ]
 
 build: [make "build"]
+install: [make "install"]
 run-test: [make "check"]
 
 url {


### PR DESCRIPTION
As first reported in https://github.com/colis-anr/morbig/issues/189, Morbig 0.11.0 does not install properly via opam-repository, while pinning [colis-anr/morbig](https://github.com/colis-anr/morbig/) does work. Previous version of Morbig are not affected.

The culprit is the change to the opam file made in https://github.com/ocaml/opam-repository/pull/23667 prior to publishing Morbig 0.11.0 in opam-repository. This change affects the `build:` field ([before](https://github.com/colis-anr/morbig/blob/52c9ded2ba1ee616dc98d7628057e11ffb833145/morbig.opam#L30-L43); [after](https://github.com/ocaml/opam-repository/blob/175a8ca8b27d9a46ed86ec5d7b1130c98a153055/packages/morbig/morbig.0.11.0/opam#L35)) in a way that makes it not install anything anymore.

The solution is _not_ to revert the change because it introduces the use of `make build` instead of `dune build`, and `make build` includes some important extra steps. However, adding a field `install: [make "install"]` seems to do the trick.

Reproduce:
- With opam pointing on opam-repository's `master` branch, install Morbig. It should succeed. However, `type morbig` should not find anything, and neither should `opam show morbig --list-files | grep libmorbig` (to look for Morbig's C library files).
- With opam pointing on this PR, install Morbig. It should succeed, and `type morbig` should report a path in the `.opam` directory. `opam show morbig --list-files | grep libmorbig` should find a `.h` and a `.o` files.