### PR TITLE
OCaml compiler patches for GCC 14

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
@@ -35,7 +35,7 @@ url {
     "md5=fa11560a45793bd9fa45c1295a6f4a91"
   ]
 }
-patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch" "fix-gcc14.patch"]
 available: arch != "arm64" & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch?full_index=1"
@@ -44,4 +44,8 @@ extra-source "alt-signal-stack.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/6ad69bdd9de36c8d15a37af443d4391656c6afb1.patch?full_index=1"
   checksum: "sha256=04188b3e4c30d8d1640104f65c9abd36f3c65df34d6c0e9161ae8a2fab3987f7"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/0c6a4415de783ca9ace0f96107b2c6971f52fd92.patch?full_index=1"
+  checksum: "sha256=2763807ba3d55847d0889e9a704e288bf453366a808d6aebd18372041b1e89c9"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
@@ -35,17 +35,13 @@ url {
     "md5=fa11560a45793bd9fa45c1295a6f4a91"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: arch != "arm64" & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch?full_index=1"
   checksum: "sha256=bb0e0e736ecc55c9f8cd8f74ca00a920bfe46e4200b82c5a45da952053b374da"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.00.0"
-  checksum: [
-    "sha256=370060ddde27410c3957851d2213f0734f9250f1d5735077b57e9e4676656980"
-    "md5=eb8555e57846757138861e14d2665ed1"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/6ad69bdd9de36c8d15a37af443d4391656c6afb1.patch?full_index=1"
+  checksum: "sha256=04188b3e4c30d8d1640104f65c9abd36f3c65df34d6c0e9161ae8a2fab3987f7"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
@@ -32,6 +32,7 @@ patches: [
   "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
   "alt-signal-stack.patch"
   "fix-gcc10.patch"
+  "fix-gcc14.patch"
 ]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
@@ -56,4 +57,8 @@ extra-source "alt-signal-stack.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/6ad69bdd9de36c8d15a37af443d4391656c6afb1.patch?full_index=1"
   checksum: "sha256=04188b3e4c30d8d1640104f65c9abd36f3c65df34d6c0e9161ae8a2fab3987f7"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/0c6a4415de783ca9ace0f96107b2c6971f52fd92.patch?full_index=1"
+  checksum: "sha256=2763807ba3d55847d0889e9a704e288bf453366a808d6aebd18372041b1e89c9"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
@@ -30,8 +30,8 @@ build: [
 install: [make "install"]
 patches: [
   "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
-  "fix-gcc10.patch"
   "alt-signal-stack.patch"
+  "fix-gcc10.patch"
 ]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz"
@@ -54,10 +54,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=bb0e0e736ecc55c9f8cd8f74ca00a920bfe46e4200b82c5a45da952053b374da"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.00.1"
-  checksum: [
-    "sha256=370060ddde27410c3957851d2213f0734f9250f1d5735077b57e9e4676656980"
-    "md5=eb8555e57846757138861e14d2665ed1"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/6ad69bdd9de36c8d15a37af443d4391656c6afb1.patch?full_index=1"
+  checksum: "sha256=04188b3e4c30d8d1640104f65c9abd36f3c65df34d6c0e9161ae8a2fab3987f7"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
@@ -42,8 +42,8 @@ build: [
 install: [make "install"]
 patches: [
   "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
-  "fix-gcc10.patch"
   "alt-signal-stack.patch"
+  "fix-gcc10.patch"
 ]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
@@ -66,10 +66,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=cadeb58478a5ca998fdfa54dc99fbb31235a0ce7689a740338a8fdb391e9b436"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.01.0"
-  checksum: [
-    "sha256=3c85e1e94a848576aa3bb86e300f4534324c21067248c4daf739004017a81cac"
-    "md5=a5ee5f90499987223ca8c13896fa2c4c"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/b0f41206e4bde69380a4dc78f4e921e8a2ff0325.patch?full_index=1"
+  checksum: "sha256=2138764eeb6714c2c5ab2fce0d5e23820a19b08a172c8f842dabfd5f658c281d"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
@@ -44,6 +44,7 @@ patches: [
   "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
   "alt-signal-stack.patch"
   "fix-gcc10.patch"
+  "fix-gcc14.patch"
 ]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
@@ -68,4 +69,8 @@ extra-source "alt-signal-stack.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/b0f41206e4bde69380a4dc78f4e921e8a2ff0325.patch?full_index=1"
   checksum: "sha256=2138764eeb6714c2c5ab2fce0d5e23820a19b08a172c8f842dabfd5f658c281d"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/a4cdfb000614f66dbe0ce4c81c0ae5d0698c6bed.patch?full_index=1"
+  checksum: "sha256=dfa245cb36f3aa6b19318016734d17b6710c782b78e1f9a440b2093da28740bd"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
@@ -47,7 +47,12 @@ url {
     "md5=8bba7e7d872083af1723dd450e07a5f4"
   ]
 }
-patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
+patches: [
+  "gpr1330.patch"
+  "alt-signal-stack.patch"
+  "fix-gcc10.patch"
+  "fix-gcc14.patch"
+]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
@@ -60,4 +65,8 @@ extra-source "gpr1330.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
   checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/a859b81e07f17387ecccc259b27f7ca474d93afb.patch?full_index=1"
+  checksum: "sha256=09f5508124ae97fb5e039cba8591230df856acb5aad1e532eef206d72c3a6cc1"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
@@ -47,7 +47,7 @@ url {
     "md5=8bba7e7d872083af1723dd450e07a5f4"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
@@ -58,10 +58,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.0"
-  checksum: [
-    "sha256=b4e7fce997e004099d9611d2726e9ee9af9c8c68cfeff07289251c63897ff75f"
-    "md5=91a4a258611302bc57f4d9fadb7fc14d"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
@@ -47,7 +47,12 @@ url {
     "md5=3c35318eefd201f96797c093c920b343"
   ]
 }
-patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
+patches: [
+  "gpr1330.patch"
+  "alt-signal-stack.patch"
+  "fix-gcc10.patch"
+  "fix-gcc14.patch"
+]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
@@ -61,4 +66,8 @@ extra-source "gpr1330.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
   checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/a859b81e07f17387ecccc259b27f7ca474d93afb.patch?full_index=1"
+  checksum: "sha256=09f5508124ae97fb5e039cba8591230df856acb5aad1e532eef206d72c3a6cc1"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
@@ -47,7 +47,7 @@ url {
     "md5=3c35318eefd201f96797c093c920b343"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
@@ -57,12 +57,8 @@ extra-source "gpr1330.patch" {
   src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
-extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.1"
-  checksum: [
-    "sha256=70a506f8f44a472fc27cf4d7097d5fa47d15ea584dd956a39b73c0e8cf1e35b4"
-    "md5=4afa0ebb0a06b65e95e4906e1dced628"
-  ]
-}
 
+extra-source "fix-gcc10.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
+}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
@@ -47,7 +47,7 @@ url {
     "md5=359ad0ef89717341767142f2a4d050b2"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
@@ -57,12 +57,8 @@ extra-source "gpr1330.patch" {
   src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
-extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.2"
-  checksum: [
-    "sha256=4eb8e39b4dc1fcd05f5ae4311b64fa53c369ba733961a7fa4305afdaf9666b85"
-    "md5=d40cd243f53876ba0b7e181ac16836a9"
-  ]
-}
 
+extra-source "fix-gcc10.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
+}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
@@ -47,7 +47,12 @@ url {
     "md5=359ad0ef89717341767142f2a4d050b2"
   ]
 }
-patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
+patches: [
+  "gpr1330.patch"
+  "alt-signal-stack.patch"
+  "fix-gcc10.patch"
+  "fix-gcc14.patch"
+]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
@@ -61,4 +66,8 @@ extra-source "gpr1330.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
   checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/a859b81e07f17387ecccc259b27f7ca474d93afb.patch?full_index=1"
+  checksum: "sha256=09f5508124ae97fb5e039cba8591230df856acb5aad1e532eef206d72c3a6cc1"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
@@ -46,7 +46,7 @@ url {
     "md5=01e76397e6861773df73b84c5c6c9e8e"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
@@ -56,12 +56,8 @@ extra-source "gpr1330.patch" {
   src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
-extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.3"
-  checksum: [
-    "sha256=7f66fe8a08dbb4f63f927b864576d15ab6062787d19ffe6dfa5c36b733c9e330"
-    "md5=4516183897da9033f49dd291fa198b8c"
-  ]
-}
 
+extra-source "fix-gcc10.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
+}

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
@@ -46,7 +46,12 @@ url {
     "md5=01e76397e6861773df73b84c5c6c9e8e"
   ]
 }
-patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
+patches: [
+  "gpr1330.patch"
+  "alt-signal-stack.patch"
+  "fix-gcc10.patch"
+  "fix-gcc14.patch"
+]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
@@ -60,4 +65,8 @@ extra-source "gpr1330.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
   checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/a859b81e07f17387ecccc259b27f7ca474d93afb.patch?full_index=1"
+  checksum: "sha256=09f5508124ae97fb5e039cba8591230df856acb5aad1e532eef206d72c3a6cc1"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
@@ -46,7 +46,12 @@ url {
     "md5=4ddf4977de7708f11adad692c63e87ec"
   ]
 }
-patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
+patches: [
+  "gpr1330.patch"
+  "alt-signal-stack.patch"
+  "fix-gcc10.patch"
+  "fix-gcc14.patch"
+]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch?full_index=1"
@@ -59,4 +64,8 @@ extra-source "gpr1330.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/ebbcb0d6c4a0788642879965b3470997f77c5c5d.patch?full_index=1"
   checksum: "sha256=0d7df14ccdd2778b45840c5f5bc6cbcc10e9273886d411eea00fa551666c0cfa"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/e0e35af947dc61861e257a4e113c6980c4a863d0.patch?full_index=1"
+  checksum: "sha256=0445733b4b632f7963fff649452c2095ae87877ae2e01c23dd14fc5ee6d7caa6"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
@@ -46,7 +46,7 @@ url {
     "md5=4ddf4977de7708f11adad692c63e87ec"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch?full_index=1"
@@ -57,10 +57,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=a82eee28f3d10161010283267322c5779fcb7077ead14287d7b9e436ac16b730"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
-  checksum: [
-    "sha256=10e3a14312ee405af8ada0f14d9dddebbbc9d936ef7e2389dfb71e9cf1f49d6a"
-    "md5=4370afea8ee2dea768b0fcba52394a2f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/ebbcb0d6c4a0788642879965b3470997f77c5c5d.patch?full_index=1"
+  checksum: "sha256=0d7df14ccdd2778b45840c5f5bc6cbcc10e9273886d411eea00fa551666c0cfa"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
@@ -46,7 +46,12 @@ url {
     "md5=dbf5f869bf0621d2922547b671b36566"
   ]
 }
-patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
+patches: [
+  "gpr1330.patch"
+  "alt-signal-stack.patch"
+  "fix-gcc10.patch"
+  "fix-gcc14.patch"
+]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
@@ -59,4 +64,8 @@ extra-source "gpr1330.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
   checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/8343e7800f4ee433ff8f0c6b0d676dfc20354c15.patch?full_index=1"
+  checksum: "sha256=dfeab98379c0a36bc6e4cdb4de5546ce93670c002b4b04a4b43076da9270916c"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
@@ -46,7 +46,7 @@ url {
     "md5=dbf5f869bf0621d2922547b671b36566"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
@@ -57,10 +57,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
@@ -46,7 +46,7 @@ url {
     "md5=ca6f8d941c4c86c43cccb29ae2a9cd0e"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
@@ -57,10 +57,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.1"
-  checksum: [
-    "sha256=ca5ea3fb78daac1c3899abfddb7bda4680255e6364e53e63d651392e669ab73a"
-    "md5=c59d1ac3de4c892f4aa74d8d1112de00"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
@@ -46,7 +46,12 @@ url {
     "md5=ca6f8d941c4c86c43cccb29ae2a9cd0e"
   ]
 }
-patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
+patches: [
+  "gpr1330.patch"
+  "alt-signal-stack.patch"
+  "fix-gcc10.patch"
+  "fix-gcc14.patch"
+]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
@@ -59,4 +64,8 @@ extra-source "gpr1330.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
   checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/8343e7800f4ee433ff8f0c6b0d676dfc20354c15.patch?full_index=1"
+  checksum: "sha256=dfeab98379c0a36bc6e4cdb4de5546ce93670c002b4b04a4b43076da9270916c"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
@@ -46,7 +46,12 @@ url {
     "md5=5ce661a2d8b760dc77c2facf46ccddd1"
   ]
 }
-patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
+patches: [
+  "gpr1330.patch"
+  "alt-signal-stack.patch"
+  "fix-gcc10.patch"
+  "fix-gcc14.patch"
+]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
@@ -59,4 +64,8 @@ extra-source "gpr1330.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
   checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/8343e7800f4ee433ff8f0c6b0d676dfc20354c15.patch?full_index=1"
+  checksum: "sha256=dfeab98379c0a36bc6e4cdb4de5546ce93670c002b4b04a4b43076da9270916c"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
@@ -46,7 +46,7 @@ url {
     "md5=5ce661a2d8b760dc77c2facf46ccddd1"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
@@ -57,10 +57,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.2"
-  checksum: [
-    "sha256=490a8001ba239bd233d10a4b458926316d4b72e800a286a977f553cef668bfbe"
-    "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
@@ -46,7 +46,7 @@ url {
     "md5=7e0079162134336a24b9028349c756bb"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch?full_index=1"
@@ -57,10 +57,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
@@ -46,7 +46,12 @@ url {
     "md5=7e0079162134336a24b9028349c756bb"
   ]
 }
-patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
+patches: [
+  "gpr1330.patch"
+  "alt-signal-stack.patch"
+  "fix-gcc10.patch"
+  "fix-gcc14.patch"
+]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch?full_index=1"
@@ -59,4 +64,8 @@ extra-source "gpr1330.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
   checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/750fbd93c1c0ec5ca7a22c02ca86b41319281dc5.patch?full_index=1"
+  checksum: "sha256=630e61f8de7b99a556e9a91cc7aa9f0c8945bf4aa09f4e0414985aee1c2c478a"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.0/opam
@@ -46,17 +46,13 @@ url {
     "md5=4f3906e581181c5435078ffe3e485e3f"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.0/opam
@@ -46,7 +46,7 @@ url {
     "md5=4f3906e581181c5435078ffe3e485e3f"
   ]
 }
-patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch" "fix-gcc14.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
@@ -55,4 +55,8 @@ extra-source "alt-signal-stack.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
   checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/1be3b85f9352425ffbe3a8ff7d1260e1aa7547df.patch?full_index=1"
+  checksum: "sha256=3a0f3285926281d3d4cf21e4baa33714e524d81d5bde1a06689265000688ab51"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.1/opam
@@ -46,7 +46,7 @@ url {
     "md5=d02eb67b828de22c3f97d94b3c46acba"
   ]
 }
-patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch" "fix-gcc14.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
@@ -55,4 +55,8 @@ extra-source "alt-signal-stack.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
   checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/1be3b85f9352425ffbe3a8ff7d1260e1aa7547df.patch?full_index=1"
+  checksum: "sha256=3a0f3285926281d3d4cf21e4baa33714e524d81d5bde1a06689265000688ab51"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.1/opam
@@ -46,17 +46,13 @@ url {
     "md5=d02eb67b828de22c3f97d94b3c46acba"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.1"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
@@ -55,17 +55,13 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
@@ -55,7 +55,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch" "fix-gcc14.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
@@ -64,4 +64,8 @@ extra-source "alt-signal-stack.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
   checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/1b4ba340185d9c71cc90b8338f7fa3c68c8d85c2.patch?full_index=1"
+  checksum: "sha256=f5fec83972ab82f9e9008cb516d720379554847f28767a9d54f1f9445a17d779"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
@@ -55,17 +55,13 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
@@ -55,7 +55,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch" "fix-gcc14.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
@@ -64,4 +64,8 @@ extra-source "alt-signal-stack.patch" {
 extra-source "fix-gcc10.patch" {
   src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
   checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
+}
+extra-source "fix-gcc14.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/1b4ba340185d9c71cc90b8338f7fa3c68c8d85c2.patch?full_index=1"
+  checksum: "sha256=f5fec83972ab82f9e9008cb516d720379554847f28767a9d54f1f9445a17d779"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
@@ -46,7 +46,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
@@ -61,10 +61,6 @@ extra-source "ocaml-base-compiler.install" {
   ]
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/opam
@@ -46,7 +46,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
@@ -61,10 +61,6 @@ extra-source "ocaml-base-compiler.install" {
   ]
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.1"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/opam
@@ -37,7 +37,7 @@ url {
     "md5=76ac39570fc88b16fda2a94db7cd5cf3"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
@@ -61,10 +61,6 @@ extra-source "ocaml-base-compiler.install" {
   ]
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.09.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/2f5c210940a9f69e1997a9be616f4816ed67a95c.patch?full_index=1"
+  checksum: "sha256=9f431f56f3ad5789cc035384020fa0b9c57f30d158ec7c726feaab3a4827f759"
 }

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/opam
@@ -36,8 +36,8 @@ extra-source "alt-signal-stack.patch" {
 patches: [
   "0001-Don-t-build-manpages-for-stdlib-docs.patch"
   "0001-Fix-failure-to-install-tools-links.patch"
+  "alt-signal-stack.patch"
   "fix-gcc10.patch"
-   "alt-signal-stack.patch"
 ]
 available: !(os = "macos" & arch = "arm64")
 post-messages: [
@@ -52,14 +52,6 @@ post-messages: [
 description: "Installs an additional compiler to the opam switch in
 %{_:share}%/ocaml-secondary-compiler which can be accessed using
 `ocamlfind -toolchain secondary`."
-extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-secondary-compiler/fix-gcc10.patch"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
-}
 extra-source "0001-Fix-failure-to-install-tools-links.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-secondary-compiler/0001-Fix-failure-to-install-tools-links.patch"
@@ -75,4 +67,8 @@ extra-source "0001-Don-t-build-manpages-for-stdlib-docs.patch" {
     "sha256=08a213cff3a58007e223d341335e2bf1d1cace9ebd04fec9b9dd121c5f9aaf52"
     "md5=6caa580fe6031c109d2dc96b19bd40cd"
   ]
+}
+extra-source "fix-gcc10.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1/opam
@@ -35,8 +35,8 @@ extra-source "alt-signal-stack.patch" {
 patches: [
   "0001-Don-t-build-manpages-for-stdlib-docs.patch"
   "0001-Fix-failure-to-install-tools-links.patch"
-  "fix-gcc10.patch"
   "alt-signal-stack.patch"
+  "fix-gcc10.patch"
 ]
 available: !(os = "macos" & arch = "arm64")
 post-messages: [
@@ -51,14 +51,6 @@ post-messages: [
 description: "Installs an additional compiler to the opam switch in
 %{_:share}%/ocaml-secondary-compiler which can be accessed using
 `ocamlfind -toolchain secondary`."
-extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-secondary-compiler/fix-gcc10.patch"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
-}
 extra-source "0001-Fix-failure-to-install-tools-links.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-secondary-compiler/0001-Fix-failure-to-install-tools-links.patch"
@@ -74,4 +66,8 @@ extra-source "0001-Don-t-build-manpages-for-stdlib-docs.patch" {
     "sha256=08a213cff3a58007e223d341335e2bf1d1cace9ebd04fec9b9dd121c5f9aaf52"
     "md5=6caa580fe6031c109d2dc96b19bd40cd"
   ]
+}
+extra-source "fix-gcc10.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.0+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.0+PIC/opam
@@ -40,7 +40,7 @@ url {
     "md5=8bba7e7d872083af1723dd450e07a5f4"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -63,10 +63,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.0"
-  checksum: [
-    "sha256=b4e7fce997e004099d9611d2726e9ee9af9c8c68cfeff07289251c63897ff75f"
-    "md5=91a4a258611302bc57f4d9fadb7fc14d"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.0+improved-errors/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.0+improved-errors/opam
@@ -27,7 +27,12 @@ build: [
   ["%{make}%" "world.opt"]
 ]
 install: ["%{make}%" "install"]
-patches: ["fix-gcc10.patch" "improved-error.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: [
+  "improved-error.patch"
+  "gpr1330.patch"
+  "alt-signal-stack.patch"
+  "fix-gcc10.patch"
+]
 url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0.tar.gz"
   checksum: [
@@ -65,10 +70,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.02.0+improved-errors"
-  checksum: [
-    "sha256=70a506f8f44a472fc27cf4d7097d5fa47d15ea584dd956a39b73c0e8cf1e35b4"
-    "md5=4afa0ebb0a06b65e95e4906e1dced628"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+32bit/opam
@@ -60,7 +60,7 @@ url {
     "md5=3c35318eefd201f96797c093c920b343"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -79,10 +79,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.1"
-  checksum: [
-    "sha256=70a506f8f44a472fc27cf4d7097d5fa47d15ea584dd956a39b73c0e8cf1e35b4"
-    "md5=4afa0ebb0a06b65e95e4906e1dced628"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+BER/opam
@@ -50,7 +50,7 @@ url {
     "md5=b6e16e26ae3220a4cf7d0056bc1cb539"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
@@ -61,10 +61,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.1"
-  checksum: [
-    "sha256=70a506f8f44a472fc27cf4d7097d5fa47d15ea584dd956a39b73c0e8cf1e35b4"
-    "md5=4afa0ebb0a06b65e95e4906e1dced628"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+PIC/opam
@@ -40,7 +40,7 @@ url {
     "md5=3c35318eefd201f96797c093c920b343"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -63,10 +63,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.1"
-  checksum: [
-    "sha256=70a506f8f44a472fc27cf4d7097d5fa47d15ea584dd956a39b73c0e8cf1e35b4"
-    "md5=4afa0ebb0a06b65e95e4906e1dced628"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+fp/opam
@@ -48,7 +48,7 @@ url {
     "md5=3c35318eefd201f96797c093c920b343"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -67,10 +67,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.1"
-  checksum: [
-    "sha256=70a506f8f44a472fc27cf4d7097d5fa47d15ea584dd956a39b73c0e8cf1e35b4"
-    "md5=4afa0ebb0a06b65e95e4906e1dced628"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits-ber/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits-ber/opam
@@ -38,7 +38,7 @@ url {
     "md5=092638ee80c1a982b341b66edcc15c18"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
@@ -49,10 +49,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.1"
-  checksum: [
-    "sha256=70a506f8f44a472fc27cf4d7097d5fa47d15ea584dd956a39b73c0e8cf1e35b4"
-    "md5=4afa0ebb0a06b65e95e4906e1dced628"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits/opam
@@ -36,7 +36,7 @@ url {
     "md5=8238edd794d5043f9a28170a8d5dcf32"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -60,10 +60,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.1"
-  checksum: [
-    "sha256=70a506f8f44a472fc27cf4d7097d5fa47d15ea584dd956a39b73c0e8cf1e35b4"
-    "md5=4afa0ebb0a06b65e95e4906e1dced628"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+musl+static/opam
@@ -52,7 +52,7 @@ url {
     "md5=3c35318eefd201f96797c093c920b343"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -75,10 +75,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.1"
-  checksum: [
-    "sha256=70a506f8f44a472fc27cf4d7097d5fa47d15ea584dd956a39b73c0e8cf1e35b4"
-    "md5=4afa0ebb0a06b65e95e4906e1dced628"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+musl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+musl/opam
@@ -43,7 +43,7 @@ url {
     "md5=3c35318eefd201f96797c093c920b343"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -66,10 +66,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.1"
-  checksum: [
-    "sha256=70a506f8f44a472fc27cf4d7097d5fa47d15ea584dd956a39b73c0e8cf1e35b4"
-    "md5=4afa0ebb0a06b65e95e4906e1dced628"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.2+improved-errors/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.2+improved-errors/opam
@@ -56,7 +56,7 @@ authors: [
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch" "gpr1330.patch"]
+patches: ["alt-signal-stack.patch" "gpr1330.patch" "fix-gcc10.patch"]
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
   checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
@@ -66,10 +66,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.02.2+improved-errors"
-  checksum: [
-    "sha256=70a506f8f44a472fc27cf4d7097d5fa47d15ea584dd956a39b73c0e8cf1e35b4"
-    "md5=4afa0ebb0a06b65e95e4906e1dced628"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+32bit/opam
@@ -61,7 +61,7 @@ url {
     "md5=ef1a324608c97031cbd92a442d685ab7"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -80,10 +80,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.3"
-  checksum: [
-    "sha256=7f66fe8a08dbb4f63f927b864576d15ab6062787d19ffe6dfa5c36b733c9e330"
-    "md5=4516183897da9033f49dd291fa198b8c"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+PIC/opam
@@ -40,7 +40,7 @@ url {
     "md5=ef1a324608c97031cbd92a442d685ab7"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -63,10 +63,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=a82eee28f3d10161010283267322c5779fcb7077ead14287d7b9e436ac16b730"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.3"
-  checksum: [
-    "sha256=7f66fe8a08dbb4f63f927b864576d15ab6062787d19ffe6dfa5c36b733c9e330"
-    "md5=4516183897da9033f49dd291fa198b8c"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-1/opam
@@ -45,7 +45,7 @@ url {
     "md5=081dd8b58ef668a77c74ec910ae06a39"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -68,10 +68,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.3"
-  checksum: [
-    "sha256=7f66fe8a08dbb4f63f927b864576d15ab6062787d19ffe6dfa5c36b733c9e330"
-    "md5=4516183897da9033f49dd291fa198b8c"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-master/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-master/opam
@@ -54,7 +54,7 @@ authors: [
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch" "gpr1330.patch"]
+patches: ["alt-signal-stack.patch" "gpr1330.patch" "fix-gcc10.patch"]
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
   checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
@@ -64,10 +64,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.3"
-  checksum: [
-    "sha256=7f66fe8a08dbb4f63f927b864576d15ab6062787d19ffe6dfa5c36b733c9e330"
-    "md5=4516183897da9033f49dd291fa198b8c"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+bytecode-only/opam
@@ -41,7 +41,7 @@ url {
     "md5=ef1a324608c97031cbd92a442d685ab7"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -60,10 +60,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.3"
-  checksum: [
-    "sha256=7f66fe8a08dbb4f63f927b864576d15ab6062787d19ffe6dfa5c36b733c9e330"
-    "md5=4516183897da9033f49dd291fa198b8c"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+curried-constr/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+curried-constr/opam
@@ -109,7 +109,7 @@ url {
     "md5=754cb6ef120d90273610ab5f860b99e7"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -132,10 +132,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.3"
-  checksum: [
-    "sha256=7f66fe8a08dbb4f63f927b864576d15ab6062787d19ffe6dfa5c36b733c9e330"
-    "md5=4516183897da9033f49dd291fa198b8c"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+fp/opam
@@ -48,7 +48,7 @@ url {
     "md5=ef1a324608c97031cbd92a442d685ab7"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -67,10 +67,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.3"
-  checksum: [
-    "sha256=7f66fe8a08dbb4f63f927b864576d15ab6062787d19ffe6dfa5c36b733c9e330"
-    "md5=4516183897da9033f49dd291fa198b8c"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+musl+static/opam
@@ -52,7 +52,7 @@ url {
     "md5=ef1a324608c97031cbd92a442d685ab7"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -75,10 +75,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.3"
-  checksum: [
-    "sha256=7f66fe8a08dbb4f63f927b864576d15ab6062787d19ffe6dfa5c36b733c9e330"
-    "md5=4516183897da9033f49dd291fa198b8c"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+musl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+musl/opam
@@ -43,7 +43,7 @@ url {
     "md5=ef1a324608c97031cbd92a442d685ab7"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -66,10 +66,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.02.3"
-  checksum: [
-    "sha256=7f66fe8a08dbb4f63f927b864576d15ab6062787d19ffe6dfa5c36b733c9e330"
-    "md5=4516183897da9033f49dd291fa198b8c"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.4+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.4+trunk/opam
@@ -44,13 +44,9 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.02.tar.gz"
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.02.4+trunk"
-  checksum: [
-    "sha256=b4e7fce997e004099d9611d2726e9ee9af9c8c68cfeff07289251c63897ff75f"
-    "md5=91a4a258611302bc57f4d9fadb7fc14d"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/180e6fa62b71d0502a8994de9d4160b64733ec84.patch?full_index=1"
+  checksum: "sha256=16af284d35d2d517e6760d93869cd5d8de145f3749396aac064d99037166bfae"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+32bit/opam
@@ -60,7 +60,7 @@ url {
     "md5=4ddf4977de7708f11adad692c63e87ec"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -79,10 +79,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dea675165192cbac93aa89e43e22ad47f7e99b5ba118f27ad7e1846aa7a2a8d4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
-  checksum: [
-    "sha256=10e3a14312ee405af8ada0f14d9dddebbbc9d936ef7e2389dfb71e9cf1f49d6a"
-    "md5=4370afea8ee2dea768b0fcba52394a2f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/ebbcb0d6c4a0788642879965b3470997f77c5c5d.patch?full_index=1"
+  checksum: "sha256=0d7df14ccdd2778b45840c5f5bc6cbcc10e9273886d411eea00fa551666c0cfa"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta1+flambda/opam
@@ -42,13 +42,9 @@ url {
     "md5=4b771c8088b3e25444975df68e4cdba5"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
-  checksum: [
-    "sha256=10e3a14312ee405af8ada0f14d9dddebbbc9d936ef7e2389dfb71e9cf1f49d6a"
-    "md5=4370afea8ee2dea768b0fcba52394a2f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/ebbcb0d6c4a0788642879965b3470997f77c5c5d.patch?full_index=1"
+  checksum: "sha256=0d7df14ccdd2778b45840c5f5bc6cbcc10e9273886d411eea00fa551666c0cfa"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta1-no-debug/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta1-no-debug/opam
@@ -41,13 +41,9 @@ url {
     "md5=4b771c8088b3e25444975df68e4cdba5"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
-  checksum: [
-    "sha256=10e3a14312ee405af8ada0f14d9dddebbbc9d936ef7e2389dfb71e9cf1f49d6a"
-    "md5=4370afea8ee2dea768b0fcba52394a2f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/ebbcb0d6c4a0788642879965b3470997f77c5c5d.patch?full_index=1"
+  checksum: "sha256=0d7df14ccdd2778b45840c5f5bc6cbcc10e9273886d411eea00fa551666c0cfa"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta1/opam
@@ -41,13 +41,9 @@ url {
     "md5=4b771c8088b3e25444975df68e4cdba5"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
-  checksum: [
-    "sha256=10e3a14312ee405af8ada0f14d9dddebbbc9d936ef7e2389dfb71e9cf1f49d6a"
-    "md5=4370afea8ee2dea768b0fcba52394a2f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/ebbcb0d6c4a0788642879965b3470997f77c5c5d.patch?full_index=1"
+  checksum: "sha256=0d7df14ccdd2778b45840c5f5bc6cbcc10e9273886d411eea00fa551666c0cfa"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta2+flambda/opam
@@ -42,13 +42,9 @@ url {
     "md5=05e760a3b08b649d115bcd39b64bccab"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
-  checksum: [
-    "sha256=10e3a14312ee405af8ada0f14d9dddebbbc9d936ef7e2389dfb71e9cf1f49d6a"
-    "md5=4370afea8ee2dea768b0fcba52394a2f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/ebbcb0d6c4a0788642879965b3470997f77c5c5d.patch?full_index=1"
+  checksum: "sha256=0d7df14ccdd2778b45840c5f5bc6cbcc10e9273886d411eea00fa551666c0cfa"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta2-no-debug/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta2-no-debug/opam
@@ -41,13 +41,9 @@ url {
     "md5=05e760a3b08b649d115bcd39b64bccab"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
-  checksum: [
-    "sha256=10e3a14312ee405af8ada0f14d9dddebbbc9d936ef7e2389dfb71e9cf1f49d6a"
-    "md5=4370afea8ee2dea768b0fcba52394a2f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/ebbcb0d6c4a0788642879965b3470997f77c5c5d.patch?full_index=1"
+  checksum: "sha256=0d7df14ccdd2778b45840c5f5bc6cbcc10e9273886d411eea00fa551666c0cfa"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta2/opam
@@ -41,13 +41,9 @@ url {
     "md5=05e760a3b08b649d115bcd39b64bccab"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
-  checksum: [
-    "sha256=10e3a14312ee405af8ada0f14d9dddebbbc9d936ef7e2389dfb71e9cf1f49d6a"
-    "md5=4370afea8ee2dea768b0fcba52394a2f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/ebbcb0d6c4a0788642879965b3470997f77c5c5d.patch?full_index=1"
+  checksum: "sha256=0d7df14ccdd2778b45840c5f5bc6cbcc10e9273886d411eea00fa551666c0cfa"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+fPIC/opam
@@ -39,7 +39,7 @@ url {
     "md5=4ddf4977de7708f11adad692c63e87ec"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -62,10 +62,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=a82eee28f3d10161010283267322c5779fcb7077ead14287d7b9e436ac16b730"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
-  checksum: [
-    "sha256=10e3a14312ee405af8ada0f14d9dddebbbc9d936ef7e2389dfb71e9cf1f49d6a"
-    "md5=4370afea8ee2dea768b0fcba52394a2f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/ebbcb0d6c4a0788642879965b3470997f77c5c5d.patch?full_index=1"
+  checksum: "sha256=0d7df14ccdd2778b45840c5f5bc6cbcc10e9273886d411eea00fa551666c0cfa"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+flambda/opam
@@ -42,7 +42,7 @@ url {
     "md5=4ddf4977de7708f11adad692c63e87ec"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -65,10 +65,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=a82eee28f3d10161010283267322c5779fcb7077ead14287d7b9e436ac16b730"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
-  checksum: [
-    "sha256=10e3a14312ee405af8ada0f14d9dddebbbc9d936ef7e2389dfb71e9cf1f49d6a"
-    "md5=4370afea8ee2dea768b0fcba52394a2f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/ebbcb0d6c4a0788642879965b3470997f77c5c5d.patch?full_index=1"
+  checksum: "sha256=0d7df14ccdd2778b45840c5f5bc6cbcc10e9273886d411eea00fa551666c0cfa"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+fp+flambda/opam
@@ -49,7 +49,7 @@ url {
     "md5=4ddf4977de7708f11adad692c63e87ec"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -68,10 +68,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dea675165192cbac93aa89e43e22ad47f7e99b5ba118f27ad7e1846aa7a2a8d4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
-  checksum: [
-    "sha256=10e3a14312ee405af8ada0f14d9dddebbbc9d936ef7e2389dfb71e9cf1f49d6a"
-    "md5=4370afea8ee2dea768b0fcba52394a2f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/ebbcb0d6c4a0788642879965b3470997f77c5c5d.patch?full_index=1"
+  checksum: "sha256=0d7df14ccdd2778b45840c5f5bc6cbcc10e9273886d411eea00fa551666c0cfa"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+fp/opam
@@ -47,7 +47,7 @@ url {
     "md5=4ddf4977de7708f11adad692c63e87ec"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -66,10 +66,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dea675165192cbac93aa89e43e22ad47f7e99b5ba118f27ad7e1846aa7a2a8d4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
-  checksum: [
-    "sha256=10e3a14312ee405af8ada0f14d9dddebbbc9d936ef7e2389dfb71e9cf1f49d6a"
-    "md5=4370afea8ee2dea768b0fcba52394a2f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/ebbcb0d6c4a0788642879965b3470997f77c5c5d.patch?full_index=1"
+  checksum: "sha256=0d7df14ccdd2778b45840c5f5bc6cbcc10e9273886d411eea00fa551666c0cfa"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+statistical-memprof/opam
@@ -40,7 +40,7 @@ url {
   checksum:
     "sha256=e1d434f28a6331cc12c6ffdd37d76aa198e4c4ebb14dad0b41417326cff955b9"
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -59,10 +59,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dea675165192cbac93aa89e43e22ad47f7e99b5ba118f27ad7e1846aa7a2a8d4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
-  checksum: [
-    "sha256=10e3a14312ee405af8ada0f14d9dddebbbc9d936ef7e2389dfb71e9cf1f49d6a"
-    "md5=4370afea8ee2dea768b0fcba52394a2f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/ebbcb0d6c4a0788642879965b3470997f77c5c5d.patch?full_index=1"
+  checksum: "sha256=0d7df14ccdd2778b45840c5f5bc6cbcc10e9273886d411eea00fa551666c0cfa"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.1+trunk/opam
@@ -44,13 +44,9 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.03.tar.gz"
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.03.1+trunk"
-  checksum: [
-    "sha256=10e3a14312ee405af8ada0f14d9dddebbbc9d936ef7e2389dfb71e9cf1f49d6a"
-    "md5=4370afea8ee2dea768b0fcba52394a2f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/ebbcb0d6c4a0788642879965b3470997f77c5c5d.patch?full_index=1"
+  checksum: "sha256=0d7df14ccdd2778b45840c5f5bc6cbcc10e9273886d411eea00fa551666c0cfa"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+32bit/opam
@@ -60,7 +60,7 @@ url {
     "md5=dbf5f869bf0621d2922547b671b36566"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -79,10 +79,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+BER/opam
@@ -50,7 +50,7 @@ url {
     "md5=e6b1da1b34a207c4995ce7123475a3b6"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
@@ -61,10 +61,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+afl/opam
@@ -41,7 +41,7 @@ url {
     "md5=2ac30a9a3f014c2dab4ef1a1d365b72c"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -64,10 +64,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta1+flambda/opam
@@ -42,13 +42,9 @@ url {
     "md5=1f612e3daf7e0c7f5435e9643a531843"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta1/opam
@@ -41,13 +41,9 @@ url {
     "md5=1f612e3daf7e0c7f5435e9643a531843"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta2+flambda/opam
@@ -42,13 +42,9 @@ url {
     "md5=532aa308d2030ae62797037548950e71"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta2/opam
@@ -41,13 +41,9 @@ url {
     "md5=532aa308d2030ae62797037548950e71"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+bytecode-only/opam
@@ -42,7 +42,7 @@ url {
     "md5=dbf5f869bf0621d2922547b671b36566"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -61,10 +61,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+fPIC/opam
@@ -39,7 +39,7 @@ url {
     "md5=dbf5f869bf0621d2922547b671b36566"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -62,10 +62,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+flambda/opam
@@ -42,7 +42,7 @@ url {
     "md5=dbf5f869bf0621d2922547b671b36566"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -65,10 +65,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+fp+flambda/opam
@@ -49,7 +49,7 @@ url {
     "md5=dbf5f869bf0621d2922547b671b36566"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -68,10 +68,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+fp/opam
@@ -47,7 +47,7 @@ url {
     "md5=dbf5f869bf0621d2922547b671b36566"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -66,10 +66,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+safe-string/opam
@@ -42,7 +42,7 @@ url {
     "md5=dbf5f869bf0621d2922547b671b36566"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -65,10 +65,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+spacetime/opam
@@ -42,7 +42,7 @@ url {
     "md5=dbf5f869bf0621d2922547b671b36566"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -65,10 +65,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+32bit/opam
@@ -60,7 +60,7 @@ url {
     "md5=ca6f8d941c4c86c43cccb29ae2a9cd0e"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -79,10 +79,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.1"
-  checksum: [
-    "sha256=ca5ea3fb78daac1c3899abfddb7bda4680255e6364e53e63d651392e669ab73a"
-    "md5=c59d1ac3de4c892f4aa74d8d1112de00"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+bytecode-only/opam
@@ -42,7 +42,7 @@ url {
     "md5=ca6f8d941c4c86c43cccb29ae2a9cd0e"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -61,10 +61,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.1"
-  checksum: [
-    "sha256=ca5ea3fb78daac1c3899abfddb7bda4680255e6364e53e63d651392e669ab73a"
-    "md5=c59d1ac3de4c892f4aa74d8d1112de00"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+copatterns/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+copatterns/opam
@@ -42,7 +42,7 @@ url {
     "md5=5d581256d7258234edcddab0ac5211b5"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -65,10 +65,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.04.1+copatterns"
-  checksum: [
-    "sha256=595b914548bec578fc1b6f55abad62d18a9d707dc7dbcf9775b09f0781b1f203"
-    "md5=8b0606a5733be21ee8ae2a19ce67059e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+fPIC/opam
@@ -39,7 +39,7 @@ url {
     "md5=ca6f8d941c4c86c43cccb29ae2a9cd0e"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -62,10 +62,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.1"
-  checksum: [
-    "sha256=ca5ea3fb78daac1c3899abfddb7bda4680255e6364e53e63d651392e669ab73a"
-    "md5=c59d1ac3de4c892f4aa74d8d1112de00"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+flambda/opam
@@ -42,7 +42,7 @@ url {
     "md5=ca6f8d941c4c86c43cccb29ae2a9cd0e"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -65,10 +65,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.1"
-  checksum: [
-    "sha256=ca5ea3fb78daac1c3899abfddb7bda4680255e6364e53e63d651392e669ab73a"
-    "md5=c59d1ac3de4c892f4aa74d8d1112de00"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+fp+flambda/opam
@@ -49,7 +49,7 @@ url {
     "md5=ca6f8d941c4c86c43cccb29ae2a9cd0e"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -68,10 +68,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.1"
-  checksum: [
-    "sha256=ca5ea3fb78daac1c3899abfddb7bda4680255e6364e53e63d651392e669ab73a"
-    "md5=c59d1ac3de4c892f4aa74d8d1112de00"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+fp/opam
@@ -47,7 +47,7 @@ url {
     "md5=ca6f8d941c4c86c43cccb29ae2a9cd0e"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -66,10 +66,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.1"
-  checksum: [
-    "sha256=ca5ea3fb78daac1c3899abfddb7bda4680255e6364e53e63d651392e669ab73a"
-    "md5=c59d1ac3de4c892f4aa74d8d1112de00"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+safe-string/opam
@@ -42,7 +42,7 @@ url {
     "md5=ca6f8d941c4c86c43cccb29ae2a9cd0e"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -65,10 +65,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.1"
-  checksum: [
-    "sha256=ca5ea3fb78daac1c3899abfddb7bda4680255e6364e53e63d651392e669ab73a"
-    "md5=c59d1ac3de4c892f4aa74d8d1112de00"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+spacetime/opam
@@ -42,7 +42,7 @@ url {
     "md5=ca6f8d941c4c86c43cccb29ae2a9cd0e"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -65,10 +65,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.1"
-  checksum: [
-    "sha256=ca5ea3fb78daac1c3899abfddb7bda4680255e6364e53e63d651392e669ab73a"
-    "md5=c59d1ac3de4c892f4aa74d8d1112de00"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+32bit/opam
@@ -60,7 +60,7 @@ url {
     "md5=5ce661a2d8b760dc77c2facf46ccddd1"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -79,10 +79,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.2"
-  checksum: [
-    "sha256=490a8001ba239bd233d10a4b458926316d4b72e800a286a977f553cef668bfbe"
-    "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+bytecode-only/opam
@@ -42,7 +42,7 @@ url {
     "md5=5ce661a2d8b760dc77c2facf46ccddd1"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -61,10 +61,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.2"
-  checksum: [
-    "sha256=490a8001ba239bd233d10a4b458926316d4b72e800a286a977f553cef668bfbe"
-    "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+fPIC/opam
@@ -39,7 +39,7 @@ url {
     "md5=5ce661a2d8b760dc77c2facf46ccddd1"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -62,10 +62,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.2"
-  checksum: [
-    "sha256=490a8001ba239bd233d10a4b458926316d4b72e800a286a977f553cef668bfbe"
-    "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+flambda/opam
@@ -42,7 +42,7 @@ url {
     "md5=5ce661a2d8b760dc77c2facf46ccddd1"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -65,10 +65,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.2"
-  checksum: [
-    "sha256=490a8001ba239bd233d10a4b458926316d4b72e800a286a977f553cef668bfbe"
-    "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+fp+flambda/opam
@@ -49,7 +49,7 @@ url {
     "md5=5ce661a2d8b760dc77c2facf46ccddd1"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -68,10 +68,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.2"
-  checksum: [
-    "sha256=490a8001ba239bd233d10a4b458926316d4b72e800a286a977f553cef668bfbe"
-    "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+fp/opam
@@ -47,7 +47,7 @@ url {
     "md5=5ce661a2d8b760dc77c2facf46ccddd1"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -66,10 +66,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.2"
-  checksum: [
-    "sha256=490a8001ba239bd233d10a4b458926316d4b72e800a286a977f553cef668bfbe"
-    "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+safe-string/opam
@@ -42,7 +42,7 @@ url {
     "md5=5ce661a2d8b760dc77c2facf46ccddd1"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -65,10 +65,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.2"
-  checksum: [
-    "sha256=490a8001ba239bd233d10a4b458926316d4b72e800a286a977f553cef668bfbe"
-    "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+spacetime/opam
@@ -42,7 +42,7 @@ url {
     "md5=5ce661a2d8b760dc77c2facf46ccddd1"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -65,10 +65,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.2"
-  checksum: [
-    "sha256=490a8001ba239bd233d10a4b458926316d4b72e800a286a977f553cef668bfbe"
-    "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+statistical-memprof/opam
@@ -45,7 +45,7 @@ url {
     "md5=5a86f86039623ea089add7c29c8da4f7"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -64,10 +64,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.2"
-  checksum: [
-    "sha256=490a8001ba239bd233d10a4b458926316d4b72e800a286a977f553cef668bfbe"
-    "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.3+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.3+trunk/opam
@@ -44,13 +44,9 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.04.tar.gz"
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.04.3+trunk"
-  checksum: [
-    "sha256=490a8001ba239bd233d10a4b458926316d4b72e800a286a977f553cef668bfbe"
-    "md5=3ee8aabe0c34cbe746dacc17d8ef9b7e"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/5e5ca851e4ec2c732acc228fb257ac9eaaf9ca56.patch?full_index=1"
+  checksum: "sha256=50274c014fea64ecf9d254b2ba7a325168299b9117033f2f98bb1ffeb6b9abeb"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+32bit/opam
@@ -60,7 +60,7 @@ url {
     "md5=7e0079162134336a24b9028349c756bb"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -79,10 +79,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=22f9244e4d91c2a939594b79c41707acd75a4fc7c63feb0cb5528b43949844f8"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+afl/opam
@@ -41,7 +41,7 @@ url {
     "md5=7e0079162134336a24b9028349c756bb"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -64,10 +64,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta1+flambda/opam
@@ -42,13 +42,9 @@ url {
     "md5=5cda3f2a3be4aaa8753e74eee73a15dc"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta1/opam
@@ -41,13 +41,9 @@ url {
     "md5=5cda3f2a3be4aaa8753e74eee73a15dc"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta2+flambda/opam
@@ -42,13 +42,9 @@ url {
     "md5=51564e3df8fd777c25a3ed205ce8e38f"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta2/opam
@@ -41,13 +41,9 @@ url {
     "md5=51564e3df8fd777c25a3ed205ce8e38f"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta3/opam
@@ -41,13 +41,9 @@ url {
     "md5=4684ee312c2c599aee760e93d589ea6b"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+bytecode-only/opam
@@ -42,7 +42,7 @@ url {
     "md5=7e0079162134336a24b9028349c756bb"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -61,10 +61,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=22f9244e4d91c2a939594b79c41707acd75a4fc7c63feb0cb5528b43949844f8"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+flambda/opam
@@ -42,7 +42,7 @@ url {
     "md5=7e0079162134336a24b9028349c756bb"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -65,10 +65,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+lto/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+lto/opam
@@ -43,7 +43,7 @@ url {
     "md5=3be9b0feafd90acebbbe730ab3882699"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -66,10 +66,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+musl+flambda/opam
@@ -45,7 +45,7 @@ url {
     "md5=7e0079162134336a24b9028349c756bb"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -68,10 +68,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+musl+static+flambda/opam
@@ -54,7 +54,7 @@ url {
     "md5=7e0079162134336a24b9028349c756bb"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -77,10 +77,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+safe-string/opam
@@ -42,7 +42,7 @@ url {
     "md5=7e0079162134336a24b9028349c756bb"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -65,10 +65,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+spacetime/opam
@@ -42,7 +42,7 @@ url {
     "md5=7e0079162134336a24b9028349c756bb"
   ]
 }
-patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
+patches: ["gpr1330.patch" "alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -65,10 +65,6 @@ extra-source "gpr1330.patch" {
   checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+statistical-memprof/opam
@@ -29,7 +29,7 @@ url {
   checksum:
     "sha256=b8ee056fafa0f020e9c7f472367ce21f7b0bb237b275a41f1043aa1e83648eb5"
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -48,10 +48,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=22f9244e4d91c2a939594b79c41707acd75a4fc7c63feb0cb5528b43949844f8"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+afl/opam
@@ -43,13 +43,9 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.05.tar.gz"
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.05.1"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+flambda/opam
@@ -44,13 +44,9 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.05.tar.gz"
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.05.1"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+fp+flambda/opam
@@ -51,13 +51,9 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.05.tar.gz"
 }
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.05.1"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+fp/opam
@@ -49,13 +49,9 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.05.tar.gz"
 }
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.05.1"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+safe-string/opam
@@ -44,13 +44,9 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.05.tar.gz"
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.05.1"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk/opam
@@ -44,13 +44,9 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.05.tar.gz"
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.05.1"
-  checksum: [
-    "sha256=7a4645db04d32520f59e2676219d5626d361dbd7d55cf509b7839f3613a51028"
-    "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/0f7650d9df9a5eb6cca9b0f17dc2538042cf881b.patch?full_index=1"
+  checksum: "sha256=0df33983e8ae4b0cd4ac7d18343089ce21b56357d386ccea026da291d1a80f9f"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+32bit/opam
@@ -60,7 +60,7 @@ url {
     "md5=4f3906e581181c5435078ffe3e485e3f"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -79,10 +79,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+afl/opam
@@ -41,7 +41,7 @@ url {
     "md5=4f3906e581181c5435078ffe3e485e3f"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -60,10 +60,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+afl/opam
@@ -41,13 +41,9 @@ url {
     "md5=150d27e8c053e1f2794be668895fcf1f"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+default-unsafe-string/opam
@@ -47,13 +47,9 @@ url {
     "md5=150d27e8c053e1f2794be668895fcf1f"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+flambda/opam
@@ -42,13 +42,9 @@ url {
     "md5=150d27e8c053e1f2794be668895fcf1f"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp+flambda/opam
@@ -49,13 +49,9 @@ url {
     "md5=150d27e8c053e1f2794be668895fcf1f"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp/opam
@@ -47,13 +47,9 @@ url {
     "md5=150d27e8c053e1f2794be668895fcf1f"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1/opam
@@ -41,13 +41,9 @@ url {
     "md5=150d27e8c053e1f2794be668895fcf1f"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+afl/opam
@@ -41,13 +41,9 @@ url {
     "md5=d3beca2a7d12c42c6b2585557ba59c4a"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+default-unsafe-string/opam
@@ -47,13 +47,9 @@ url {
     "md5=d3beca2a7d12c42c6b2585557ba59c4a"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+flambda/opam
@@ -42,13 +42,9 @@ url {
     "md5=d3beca2a7d12c42c6b2585557ba59c4a"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp+flambda/opam
@@ -49,13 +49,9 @@ url {
     "md5=d3beca2a7d12c42c6b2585557ba59c4a"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp/opam
@@ -47,13 +47,9 @@ url {
     "md5=d3beca2a7d12c42c6b2585557ba59c4a"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2/opam
@@ -41,13 +41,9 @@ url {
     "md5=d3beca2a7d12c42c6b2585557ba59c4a"
   ]
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+bytecode-only/opam
@@ -42,7 +42,7 @@ url {
     "md5=4f3906e581181c5435078ffe3e485e3f"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -61,10 +61,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+default-unsafe-string/opam
@@ -47,7 +47,7 @@ url {
     "md5=4f3906e581181c5435078ffe3e485e3f"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -66,10 +66,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+flambda+no-flat-float-array/opam
@@ -50,7 +50,7 @@ url {
     "md5=4f3906e581181c5435078ffe3e485e3f"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -69,10 +69,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+flambda/opam
@@ -42,7 +42,7 @@ url {
     "md5=4f3906e581181c5435078ffe3e485e3f"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -61,10 +61,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+fp+flambda/opam
@@ -49,7 +49,7 @@ url {
     "md5=4f3906e581181c5435078ffe3e485e3f"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -68,10 +68,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+fp/opam
@@ -47,7 +47,7 @@ url {
     "md5=4f3906e581181c5435078ffe3e485e3f"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -66,10 +66,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+musl+flambda/opam
@@ -45,7 +45,7 @@ url {
     "md5=4f3906e581181c5435078ffe3e485e3f"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -64,10 +64,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+musl+static+flambda/opam
@@ -54,7 +54,7 @@ url {
     "md5=4f3906e581181c5435078ffe3e485e3f"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -73,10 +73,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+no-flat-float-array/opam
@@ -47,7 +47,7 @@ url {
     "md5=4f3906e581181c5435078ffe3e485e3f"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -66,10 +66,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+spacetime/opam
@@ -42,7 +42,7 @@ url {
     "md5=4f3906e581181c5435078ffe3e485e3f"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -61,10 +61,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+statistical-memprof/opam
@@ -41,7 +41,7 @@ url {
   checksum:
     "sha256=23043ac729f494716bedfd4f9cfb42760a83314774b4f999e7f35ac49cc1f73e"
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -60,10 +60,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
-  checksum: [
-    "sha256=89aa25371decacc2e091327b43e25d4e63c9f3b34bde8a3031b01a6b6d2e6598"
-    "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+32bit/opam
@@ -60,7 +60,7 @@ url {
     "md5=d02eb67b828de22c3f97d94b3c46acba"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -79,10 +79,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.1"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+afl/opam
@@ -41,7 +41,7 @@ url {
     "md5=d02eb67b828de22c3f97d94b3c46acba"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -60,10 +60,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.1"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+bytecode-only/opam
@@ -42,7 +42,7 @@ url {
     "md5=d02eb67b828de22c3f97d94b3c46acba"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -61,10 +61,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.1"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+default-unsafe-string/opam
@@ -47,7 +47,7 @@ url {
     "md5=d02eb67b828de22c3f97d94b3c46acba"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -66,10 +66,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.1"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+flambda/opam
@@ -42,7 +42,7 @@ url {
     "md5=d02eb67b828de22c3f97d94b3c46acba"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -61,10 +61,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.1"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+fp+flambda/opam
@@ -50,7 +50,7 @@ url {
     "md5=d02eb67b828de22c3f97d94b3c46acba"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -69,10 +69,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.1"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+fp/opam
@@ -47,7 +47,7 @@ url {
     "md5=d02eb67b828de22c3f97d94b3c46acba"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -66,10 +66,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.1"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+lto/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+lto/opam
@@ -45,7 +45,7 @@ url {
     "md5=6a59dedfb4d6194b2272d861df86cd17"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -64,10 +64,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.1"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+musl+flambda/opam
@@ -45,7 +45,7 @@ url {
     "md5=d02eb67b828de22c3f97d94b3c46acba"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -64,10 +64,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.1"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+musl+static+flambda/opam
@@ -54,7 +54,7 @@ url {
     "md5=d02eb67b828de22c3f97d94b3c46acba"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -73,10 +73,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.1"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+no-flat-float-array/opam
@@ -47,7 +47,7 @@ url {
     "md5=d02eb67b828de22c3f97d94b3c46acba"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -66,10 +66,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.1"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+no-naked-pointers+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+no-naked-pointers+flambda/opam
@@ -51,7 +51,7 @@ url {
     "md5=d02eb67b828de22c3f97d94b3c46acba"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -70,10 +70,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.1"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rescript/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rescript/opam
@@ -46,9 +46,9 @@ url {
   ]
 }
 patches: [
-  "fix-gcc10.patch"
   "add-conditional-compilation.patch"
   "alt-signal-stack.patch"
+  "fix-gcc10.patch"
 ]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
@@ -67,14 +67,6 @@ extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
-extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.1"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
-}
 extra-source "add-conditional-compilation.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/add-conditional-compilation.patch.4.06.1+rescript"
@@ -82,4 +74,8 @@ extra-source "add-conditional-compilation.patch" {
     "sha256=b5f02e0d312cb2a27b8f5a60513ff6e8c15b5e8de39d01e8719078af6015179a"
     "md5=0d4f23c1c71a232e3e7fecf991f45162"
   ]
+}
+extra-source "fix-gcc10.patch" {
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+statistical-memprof/opam
@@ -44,7 +44,7 @@ url {
     "md5=e4ea4634c9fb3bf180d51d426e1bc9dc"
   ]
 }
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -63,10 +63,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.1"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+afl/opam
@@ -43,13 +43,9 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.tar.gz"
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.06.2"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+flambda/opam
@@ -44,13 +44,9 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.tar.gz"
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.06.2"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+fp+flambda/opam
@@ -51,13 +51,9 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.tar.gz"
 }
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.06.2"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+fp/opam
@@ -49,13 +49,9 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.tar.gz"
 }
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.06.2"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk/opam
@@ -44,13 +44,9 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.06.tar.gz"
 }
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.06.2"
-  checksum: [
-    "sha256=860a3e47b86a11a71e75d18d46f17f8343c58ee9297342d6ea885128f393dac6"
-    "md5=171b510547baa777839b2ad50608a3ee"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/33dae40a872c23cdaaaa2bfc15c0fcf3668dab03.patch?full_index=1"
+  checksum: "sha256=31815be3d89bf2c1a54f282f5032614eab5ab4fdf2ea3989c21ca1f5d49b6d70"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
@@ -69,7 +69,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -88,10 +88,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
@@ -50,7 +50,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -69,10 +69,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
@@ -50,13 +50,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
@@ -56,13 +56,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
@@ -51,13 +51,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
@@ -58,13 +58,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
@@ -56,13 +56,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
@@ -50,13 +50,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
@@ -51,7 +51,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -70,10 +70,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
@@ -56,7 +56,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -75,10 +75,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
@@ -59,7 +59,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -78,10 +78,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
@@ -51,7 +51,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -70,10 +70,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
@@ -58,7 +58,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -77,10 +77,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
@@ -56,7 +56,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -75,10 +75,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
@@ -57,7 +57,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -76,10 +76,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+spacetime/opam
@@ -51,7 +51,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -70,10 +70,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
@@ -69,7 +69,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -88,10 +88,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
@@ -59,17 +59,13 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
@@ -50,7 +50,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -69,10 +69,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
@@ -51,7 +51,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -70,10 +70,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
@@ -57,7 +57,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -76,10 +76,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
@@ -59,7 +59,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -78,10 +78,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
@@ -51,7 +51,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -70,10 +70,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
@@ -52,7 +52,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -71,10 +71,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
@@ -59,7 +59,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -78,10 +78,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
@@ -56,7 +56,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -75,10 +75,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/opam
@@ -56,7 +56,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -75,10 +75,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
@@ -65,7 +65,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -84,10 +84,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
@@ -57,7 +57,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -76,10 +76,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
@@ -69,13 +69,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
@@ -50,13 +50,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
@@ -57,13 +57,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
@@ -59,13 +59,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
@@ -51,13 +51,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
@@ -52,13 +52,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
@@ -59,13 +59,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
@@ -56,13 +56,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
@@ -50,13 +50,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
@@ -51,7 +51,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -70,10 +70,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
@@ -49,7 +49,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 authors: [
@@ -68,10 +68,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
-  checksum: [
-    "sha256=efe1f8687fb54de7d0a21877615396d91d977686dc93aecf0a8832691b8237a9"
-    "md5=7f467849e5a4714f49a11517b187184f"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+afl/opam
@@ -52,13 +52,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.07.2"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+default-unsafe-string/opam
@@ -60,13 +60,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.07.2"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+flambda/opam
@@ -53,13 +53,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.07.2"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+fp+flambda/opam
@@ -60,13 +60,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.07.2"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+fp/opam
@@ -58,13 +58,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.07.2"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk/opam
@@ -53,13 +53,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.07.2"
-  checksum: [
-    "sha256=f0a7ee630046ffb83fb2a78ca5a81e288e817fbda6b12692dadb79ab93a8737d"
-    "md5=b054fa6b6651763edc8e16b6bc4c58f6"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/1baea9c99a8351213e4bb48ded3e918223083dd7.patch?full_index=1"
+  checksum: "sha256=2f2f9e94233c2e089a5e79da34137320fad6e5088b827175a659274c91e4bf8b"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+32bit/opam
@@ -56,7 +56,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -64,10 +64,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+afl/opam
@@ -47,7 +47,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -55,10 +55,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
@@ -45,13 +45,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
@@ -49,13 +49,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
@@ -44,13 +44,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
@@ -49,13 +49,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
@@ -47,13 +47,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
@@ -43,13 +43,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
@@ -45,13 +45,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
@@ -49,13 +49,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
@@ -44,13 +44,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp+flambda/opam
@@ -49,13 +49,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp/opam
@@ -47,13 +47,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
@@ -43,13 +43,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
@@ -43,13 +43,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
@@ -49,13 +49,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
@@ -44,13 +44,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp+flambda/opam
@@ -49,13 +49,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp/opam
@@ -47,13 +47,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
@@ -43,13 +43,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64" | os = "win32")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+bytecode-only/opam
@@ -46,7 +46,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -54,10 +54,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+default-unsafe-string/opam
@@ -48,7 +48,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -56,10 +56,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+flambda+no-flat-float-array/opam
@@ -50,7 +50,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -58,10 +58,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+flambda/opam
@@ -47,7 +47,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -55,10 +55,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+fp+flambda/opam
@@ -50,7 +50,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -58,10 +58,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+fp/opam
@@ -47,7 +47,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -55,10 +55,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+musl+flambda/opam
@@ -51,7 +51,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -59,10 +59,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
@@ -58,7 +58,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -66,10 +66,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+no-flat-float-array/opam
@@ -48,7 +48,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -56,10 +56,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+spacetime/opam
@@ -47,7 +47,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -55,10 +55,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
-  checksum: [
-    "sha256=f658efe87952165713affe6f1653ab94ca85a8d6bb77ff665b1de43074aa5b00"
-    "md5=f406119ae0091835cdf158d7d0ff53f7"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+32bit/opam
@@ -59,7 +59,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -67,10 +67,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.1"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+afl/opam
@@ -47,7 +47,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -55,10 +55,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.1"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+bytecode-only/opam
@@ -46,7 +46,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -54,10 +54,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.1"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+default-unsafe-string/opam
@@ -48,7 +48,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -56,10 +56,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.1"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+flambda+no-flat-float-array/opam
@@ -50,7 +50,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -58,10 +58,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.1"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+flambda/opam
@@ -47,7 +47,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -55,10 +55,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.1"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+fp+flambda/opam
@@ -50,7 +50,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -58,10 +58,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.1"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+fp/opam
@@ -47,7 +47,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -55,10 +55,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.1"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+musl+flambda/opam
@@ -55,7 +55,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -63,10 +63,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.1"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+musl+static+flambda/opam
@@ -58,7 +58,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -66,10 +66,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.1"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+no-flat-float-array/opam
@@ -48,7 +48,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -56,10 +56,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.1"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+spacetime/opam
@@ -47,7 +47,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
+patches: ["alt-signal-stack.patch" "fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
@@ -55,10 +55,6 @@ extra-source "alt-signal-stack.patch" {
   checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.1"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+afl/opam
@@ -45,13 +45,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.08.2"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+default-unsafe-string/opam
@@ -46,13 +46,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.08.2"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+flambda/opam
@@ -45,13 +45,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.08.2"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+fp+flambda/opam
@@ -50,13 +50,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.08.2"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+fp/opam
@@ -48,13 +48,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: os = "linux" & arch = "x86_64"
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.08.2"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk/opam
@@ -45,13 +45,9 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-patches: ["fix-gcc10.patch"]
 available: !(os = "macos" & arch = "arm64")
+patches: ["fix-gcc10.patch"]
 extra-source "fix-gcc10.patch" {
-  src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/fix-gcc10.patch.4.08.2"
-  checksum: [
-    "sha256=e5a116608a20558fcd6c70c05978dc0c0b792f8dc10cfff119ddd6cce4b7dda1"
-    "md5=17ecd696a8f5647a4c543280599f6974"
-  ]
+  src: "https://github.com/ocaml-opam/ocaml/commit/4ba8d8a8c084c237b9a1bc4926edff90a8f7f11f.patch?full_index=1"
+  checksum: "sha256=30453beb92acfd37eb834d60dda82215ad070b27e86947542985e477e2e602b6"
 }


### PR DESCRIPTION
With the release of GCC 14, which is included in Fedora 40 and the latest Arch Linux releases, we are seeing a number of failures to build older releases of OCaml, specifically < 4.08.  See https://github.com/ocurrent/docker-base-images/issues/279.  The configuration scripts for the compiler prior to 4.08 test for the presence of various library functions by attempting to compile minimal C programs using these functions.  These test builds now fail because GCC 14 makes implicit function declarations an error rather than a warning.  The additional compiler flag `-Wno-implicit-function-declaration` is needed.

This is not the first example of a patch being necessary to support the old compiler.  Previously, we have had the `-fno-common` patch required for GCC 10 compatibility.

Working on this issue with @dra27, and accepting that future patches will be required to maintain the older compilers, this PR set a precedence for holding compiler patches in [ocaml-opam/ocaml](https://github.com/ocaml-opam/ocaml) using the branches `x.yy-patches`.

The first commit updates the existing GCC 10 patch into this format, and the second commit adds the GCC 14 patch.