### PR TITLE
Install `num.1.5` in findlib directory as well as stdlib

### DIFF
--- a/packages/num/num.1.5-1/opam
+++ b/packages/num/num.1.5-1/opam
@@ -21,10 +21,15 @@ depends: [
 conflicts: [ "base-num" ]
 synopsis:
   "The legacy Num library for arbitrary-precision integer and rational arithmetic"
+patches: ["num-in-findlib-dir.patch"]
 url {
   src: "https://github.com/ocaml/num/archive/v1.5.tar.gz"
   checksum: [
     "md5=b1f9405dfe5f573ea187f122f789ae57"
     "sha512=110dd01140c1c96f5f067aa824bb63f74a26411dcaa65aaf04cb6c44b116ca02aaab9505f431c66964388ce4a31d86da5928b4c0e5557800e834de80bed46495"
   ]
+}
+extra-source "num-in-findlib-dir.patch" {
+  src: "https://github.com/ocaml/num/commit/f6e31b1653f32c7c425b69c2b123ab2f924a4d61.patch?full_index=1"
+  checksum: "sha256=f93880031ed823249f4aac860e0d9e5cdc2878550db13914db25b1585803cf05"
 }

--- a/packages/num/num.1.5/opam
+++ b/packages/num/num.1.5/opam
@@ -21,10 +21,15 @@ depends: [
 conflicts: [ "base-num" ]
 synopsis:
   "The legacy Num library for arbitrary-precision integer and rational arithmetic"
+patches: ["num-in-findlib-dir.patch"]
 url {
   src: "https://github.com/ocaml/num/archive/v1.5.tar.gz"
   checksum: [
     "md5=b1f9405dfe5f573ea187f122f789ae57"
     "sha512=110dd01140c1c96f5f067aa824bb63f74a26411dcaa65aaf04cb6c44b116ca02aaab9505f431c66964388ce4a31d86da5928b4c0e5557800e834de80bed46495"
   ]
+}
+extra-source "num-in-findlib-dir.patch" {
+  src: "https://github.com/ocaml/num/commit/f6e31b1653f32c7c425b69c2b123ab2f924a4d61.patch?full_index=1"
+  checksum: "sha256=f93880031ed823249f4aac860e0d9e5cdc2878550db13914db25b1585803cf05"
 }


### PR DESCRIPTION
Num does a bit of an unusual thing for findlib packages as it installs into (what it considers) the OCaml stdlib.

This works as long as the stdlib is in `%{lib_root}%/ocaml` and thus it doesn't findlib to add it to the compiler search path. In the new dune package management `%{lib_root}%/ocaml` will not point to the ocaml compiler stdlib thus `num` will not be found unless its installation directory is added to the search path (via findlib or dune or any other mechanism that evaluates META files).

In OCaml 5.0 this is the default already, `num` is never installed in the stdlib but always into its package folder.

This patch changes the behavior for OCaml 4.x where before `num` was only installed into the stdlib folder (and didn't need to be stated as dependency) but referencing it via findlib did not hurt to install it in *both* the stdlib and the package folder.

This way if a package depends on num in the stdlib without referencing num it will find num in the stdlib, but if `num` is referenced via findlib it will add the package folder to the search path and find either copy.

This patch has been merged upstream, see the discussion at https://github.com/ocaml/num/pull/40 for more details. This patch just backports the change to the latest released `num` version as future versions of `num` will come with this change. The next num release might be some time off given `num` is mostly "done" therefore this patch is meant to bridge the gap and a recommendation from @dra27 who is maintaining `num` upstream.