### PR TITLE
async_ssl needs a lower bound on ctypes-foreign

### DIFF
--- a/packages/async_ssl/async_ssl.v0.15.0/opam
+++ b/packages/async_ssl/async_ssl.v0.15.0/opam
@@ -18,7 +18,7 @@ depends: [
   "stdio"             {>= "v0.15" & < "v0.16"}
   "conf-libssl"
   "ctypes"            {>= "0.18.0"}
-  "ctypes-foreign"
+  "ctypes-foreign" {>= "0.18.0"}
   "dune"              {>= "2.0.0"}
   "dune-configurator"
 ]

--- a/packages/async_ssl/async_ssl.v0.16.0/opam
+++ b/packages/async_ssl/async_ssl.v0.16.0/opam
@@ -19,7 +19,7 @@ depends: [
   "stdio"             {>= "v0.16" & < "v0.17"}
   "conf-libssl"
   "ctypes"            {>= "0.18.0"}
-  "ctypes-foreign"
+  "ctypes-foreign" {>= "0.18.0"}
   "dune"              {>= "2.0.0"}
   "dune-configurator"
 ]

--- a/packages/async_ssl/async_ssl.v0.16.1/opam
+++ b/packages/async_ssl/async_ssl.v0.16.1/opam
@@ -19,7 +19,7 @@ depends: [
   "stdio"             {>= "v0.16" & < "v0.17"}
   "conf-libssl"
   "ctypes"            {>= "0.18.0"}
-  "ctypes-foreign"
+  "ctypes-foreign" {>= "0.18.0"}
   "dune"              {>= "2.0.0"}
   "dune-configurator"
 ]

--- a/packages/async_ssl/async_ssl.v0.17.0/opam
+++ b/packages/async_ssl/async_ssl.v0.17.0/opam
@@ -19,7 +19,7 @@ depends: [
   "stdio"             {>= "v0.17" & < "v0.18"}
   "conf-libssl"
   "ctypes"            {>= "0.18.0"}
-  "ctypes-foreign"
+  "ctypes-foreign" {>= "0.18.0"}
   "dune"              {>= "3.11.0"}
   "dune-configurator"
 ]


### PR DESCRIPTION
Needed to avoid the error ctypes.foreign not found where a too old version of ctypes-foreign is installed alongside a new version of ctypes