### PR TITLE
Package vscoq-language-server.2.1.4

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.1.4/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.1.4/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/coq-community/vscoq"
+bug-reports: "https://github.com/coq-community/vscoq/issues"
+dev-repo: "git+https://github.com/coq-community/vscoq"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { >= "4.13.1" }
+  "dune" { >= "3.5" }
+  "coq-core" { ((>= "8.18" < "8.20") | (= "dev")) }
+  "coq-stdlib" { ((>= "8.18" < "8.20") | (= "dev")) }
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_yojson_conv" {< "v0.16.0"}
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "ppx_optcomp"
+  "result" { >= "1.5" }
+  "lsp" { >= "1.15"}
+  "sel" {>= "0.4.0"}
+]
+synopsis: "VSCoq language server"
+description: """
+LSP based language server for Coq and its VSCoq user interface
+"""
+url {
+  src:
+    "https://github.com/coq-community/vscoq/releases/download/v2.1.4/vscoq-language-server-2.1.4.tar.gz"
+  checksum: [
+    "md5=a7d0911ab8c12221c5fecc73ecc67d1b"
+    "sha512=194b144b3bac35f3ef7d1b92715b7260267817c01b1855113799c6055b1510aa18dbeb03ceced0bcaf9e5d92f6c1aca2c21d858bef53ec5b0d6c12cf73860664"
+  ]
+}


### PR DESCRIPTION
### `vscoq-language-server.2.1.4`
VSCoq language server
LSP based language server for Coq and its VSCoq user interface



---
* Homepage: https://github.com/coq-community/vscoq
* Source repo: git+https://github.com/coq-community/vscoq
* Bug tracker: https://github.com/coq-community/vscoq/issues

---
:camel: Pull-request generated by opam-publish v2.0.3