### PR TITLE
Allow opam-state 2.2.0 instead of 2.2.0~beta3 upper bound

### DIFF
--- a/packages/odep/odep.0.2.0/opam
+++ b/packages/odep/odep.0.2.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.13"}
   "parsexp"
   "opam-core" {>= "2.1.0"}
-  "opam-state" {>= "2.1.0" & < "2.2.0~beta3"}
+  "opam-state" {>= "2.1.0" & (< "2.2.0~beta3" | >= "2.2.0")}
   "opam-format"
   "ocamlfind" {>= "1.8.1"}
   "cmdliner" {>= "1.1.0"}

--- a/packages/odep/odep.0.2.1/opam
+++ b/packages/odep/odep.0.2.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.13"}
   "parsexp"
   "opam-core" {>= "2.1.0"}
-  "opam-state" {>= "2.1.0" & < "2.2.0~beta3"}
+  "opam-state" {>= "2.1.0" & (< "2.2.0~beta3" | >= "2.2.0")}
   "opam-format"
   "ocamlfind" {>= "1.8.1"}
   "cmdliner" {>= "1.1.0"}

--- a/packages/opam-0install/opam-0install.0.4.2/opam
+++ b/packages/opam-0install/opam-0install.0.4.2/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "2.7"}
   "fmt"
   "cmdliner"
-  "opam-state" {>= "2.1.0~rc" & < "2.2.0~beta3"}
+  "opam-state" {>= "2.1.0~rc" & (< "2.2.0~beta3" | >= "2.2.0")}
   "ocaml" {>= "4.08.0"}
   "0install-solver"
   "opam-file-format" {>= "2.1.1"}

--- a/packages/opam-0install/opam-0install.0.4.3/opam
+++ b/packages/opam-0install/opam-0install.0.4.3/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "2.7"}
   "fmt" {>= "0.8.7"}
   "cmdliner" {>= "1.1.0"}
-  "opam-state" {>= "2.1.0~rc" & < "2.2.0~beta3"}
+  "opam-state" {>= "2.1.0~rc" & (< "2.2.0~beta3" | >= "2.2.0")}
   "ocaml" {>= "4.08.0"}
   "0install-solver"
   "opam-file-format" {>= "2.1.1"}

--- a/packages/opam-dune-lint/opam-dune-lint.0.3/opam
+++ b/packages/opam-dune-lint/opam-dune-lint.0.3/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "bos" {>= "0.2.0"}
   "fmt" {>= "0.8.9"}
-  "opam-state" {>= "2.1.0" & < "2.2.0~beta3"}
+  "opam-state" {>= "2.1.0" & (< "2.2.0~beta3" | >= "2.2.0")}
   "opam-format"
   "odoc" {with-doc}
 ]

--- a/packages/opam-dune-lint/opam-dune-lint.0.4/opam
+++ b/packages/opam-dune-lint/opam-dune-lint.0.4/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "bos" {>= "0.2.0"}
   "fmt" {>= "0.8.9"}
-  "opam-state" {>= "2.1.0" & < "2.2.0~beta3"}
+  "opam-state" {>= "2.1.0" & (< "2.2.0~beta3" | >= "2.2.0")}
   "opam-format"
   "odoc" {with-doc}
 ]

--- a/packages/opam-dune-lint/opam-dune-lint.0.5/opam
+++ b/packages/opam-dune-lint/opam-dune-lint.0.5/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "bos" {>= "0.2.0"}
   "fmt" {>= "0.8.9"}
-  "opam-state" {>= "2.1.0" & < "2.2.0~beta3"}
+  "opam-state" {>= "2.1.0" & (< "2.2.0~beta3" | >= "2.2.0")}
   "opam-format"
   "odoc" {with-doc}
 ]

--- a/packages/opam-dune-lint/opam-dune-lint.0.6/opam
+++ b/packages/opam-dune-lint/opam-dune-lint.0.6/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "bos" {>= "0.2.0"}
   "fmt" {>= "0.8.9"}
-  "opam-state" {>= "2.1.0" & < "2.2.0~beta3"}
+  "opam-state" {>= "2.1.0" & (< "2.2.0~beta3" | >= "2.2.0")}
   "opam-format"
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
These were added in PR #26066 due to opam-state API change in 2.2.0~beta3.

However, the final version of opam-state 2.2.0 undid the API change: https://github.com/ocaml/opam/pull/6058. This allows the final version to be used by these packages again.

opam-dune-lint 0.{1,2} are excluded because they were made entirely incompatible in 364f7dd34e8e6bf87f393e507093d0b21cde7a98.

I hope `>= "2.2.0"` means anything newer than alpha/beta/rc. If not, then please suggest the correct bound.

It would have make more sense (at least to me) to just replace the upper bound with a conflict for
```
"opam-state" {>= "2.2.0~beta3" & < "2.2.0"}
```
but according to `opam lint`, conjunctions are not allowed in conflicts apparently.