### PR TITLE
spoc is not compatible with OCaml 5.0

### DIFF
--- a/packages/spoc/spoc.20210823/opam
+++ b/packages/spoc/spoc.20210823/opam
@@ -6,7 +6,7 @@ license: "Cecill-B"
 homepage: "https://github.com/mathiasbourgoin/SPOC"
 bug-reports: "https://github.com/mathiasbourgoin/SPOC/issues"
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "re"
   "dune" {>= "2.9"}
   "cppo"


### PR DESCRIPTION
Uses the non-prefixed version of the C API
```
#=== ERROR while compiling spoc.20210823 ======================================#
# context     2.2.0 | linux/arm64 | kit-ty-kate-platform.1 ocaml-base-compiler.5.2.0 | https://opam.ocaml.org#f11abb65
# path        ~/.opam/5.2/.opam-switch/build/spoc.20210823
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p spoc -j 9 --promote-install-files false @install
# exit-code   1
# env-file    ~/.opam/log/spoc-11999-460040.env
# output-file ~/.opam/log/spoc-11999-460040.out
### output ###
# [...]
# (cd _build/default/Spoc && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -pthread -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -pthread -I/opt/cuda/targets/x86_64-linux/lib/ -lnvrtc -g -I /home/kit_ty_kate/.opam/5.2/lib/ocaml -I /home/kit_ty_kate/.opam/5.2/lib/ocaml/str -I dependencies/Cuda -I dependencies/CL -o Kernel_opencl.o -c Kernel_opencl.c)
# In file included from Kernel_opencl.c:49:
# Kernel_opencl.c: In function ‘spoc_opencl_compile’:
# Spoc.h:217:42: error: implicit declaration of function ‘raise_constant’; did you mean ‘caml_raise_constant’? [-Wimplicit-function-declaration]
#   217 |                 case CL_INVALID_CONTEXT: raise_constant(*caml_named_value("opencl_invalid_context")) ; \
#       |                                          ^~~~~~~~~~~~~~
# Spoc.h:269:25: note: in expansion of macro ‘RAISE_OPENCL_ERROR’
#   269 |                         RAISE_OPENCL_ERROR \
#       |                         ^~~~~~~~~~~~~~~~~~
# Kernel_opencl.c:73:9: note: in expansion of macro ‘OPENCL_CHECK_CALL1’
#    73 |         OPENCL_CHECK_CALL1(hProgram, clCreateProgramWithSource(ctx, 1, (const char**)&cl_source, 0, &opencl_error));
#       |         ^~~~~~~~~~~~~~~~~~
```