### PR TITLE
wryd.1.4.6: fix missing archive by using opam-source-archives

### DIFF
--- a/packages/wyrd/wyrd.1.4.6/opam
+++ b/packages/wyrd/wyrd.1.4.6/opam
@@ -17,14 +17,21 @@ build: [
   ]
   [make]
 ]
-depends: ["ocaml" "camlp4" "conf-ncurses"]
+depends: [
+  "ocaml"
+  "camlp4"
+  "conf-ncurses"
+]
 x-ci-accept-failures: ["debian-unstable"]
 install: [make "install"]
 synopsis:
   "Text-based front-end to Remind, a sophisticated calendar and alarm program"
 url {
-  src: "ftp://ftp.netbsd.org/pub/pkgsrc/distfiles/wyrd-1.4.6.tar.gz"
-  checksum: "md5=2fc561482fdac4daac0cb6735d934ebe"
+  src: "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/wyrd-1.4.6.tar.gz"
+  checksum: [
+    "md5=2fc561482fdac4daac0cb6735d934ebe"
+    "sha256=b2b51d6fb38f8b8b3ec30ee72093f791ba9b6fe35418191bc2011d2c8079997e"
+  ]
 }
 extra-source "wyrd.install" {
   src:


### PR DESCRIPTION
Depends on https://github.com/ocaml/opam-source-archives/pull/31