### PR TITLE
Package camlp4.5.2

### DIFF
--- a/packages/camlp4/camlp4.5.2/opam
+++ b/packages/camlp4/camlp4.5.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Camlp4 is a system for writing extensible parsers for programming languages"
+description: """\
+It provides a set of OCaml libraries that are used to define grammars as well
+as loadable syntax extensions of such grammars. Camlp4 stands for Caml
+Preprocessor and Pretty-Printer and one of its most important applications is
+the definition of domain-specific extensions of the syntax of OCaml.
+
+Camlp4 was part of the official OCaml distribution until its version 4.01.0.
+Since then it has been replaced by a simpler system which is easier to maintain
+and to learn: ppx rewriters and extension points."""
+maintainer: "ygrek@autistici.org"
+authors: ["Daniel de Rauglaudre" "Nicolas Pouillard"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/camlp4/camlp4"
+bug-reports: "https://github.com/camlp4/camlp4/issues"
+depends: [
+  "ocaml" {>= "5.2" & < "5.3"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+  "camlp-streams"
+]
+build: [
+  [
+    "./configure"
+    "--bindir=%{bin}%"
+    "--libdir=%{lib}%/ocaml"
+    "--pkgdir=%{lib}%"
+    "--pinned"
+  ]
+  [make "clean"]
+  [make "all"] {ocaml:native-dynlink}
+  [make "byte"] {!ocaml:native-dynlink}
+]
+install: [make "install" "install-META"]
+dev-repo: "git+https://github.com/camlp4/camlp4.git"
+url {
+  src: "https://github.com/camlp4/camlp4/archive/refs/tags/5.2+1.tar.gz"
+  checksum: [
+    "md5=f6f680e8403117c0b0d8e4ef897bdadf"
+    "sha512=7034cf32575b6a7dc0406fea3c354068598195aa84a75e8576ea1219c38e4bffdc048c936d440bab235aea76510972a174bffba13f4f94f531b80fb4d80ca4ad"
+  ]
+}


### PR DESCRIPTION
### `camlp4.5.2`
Camlp4 is a system for writing extensible parsers for programming languages
It provides a set of OCaml libraries that are used to define grammars as well
as loadable syntax extensions of such grammars. Camlp4 stands for Caml
Preprocessor and Pretty-Printer and one of its most important applications is
the definition of domain-specific extensions of the syntax of OCaml.

Camlp4 was part of the official OCaml distribution until its version 4.01.0.
Since then it has been replaced by a simpler system which is easier to maintain
and to learn: ppx rewriters and extension points.



---
* Homepage: https://github.com/camlp4/camlp4
* Source repo: git+https://github.com/camlp4/camlp4.git
* Bug tracker: https://github.com/camlp4/camlp4/issues

---
:camel: Pull-request generated by opam-publish v2.3.1