### PR TITLE
[new release] dream-html (2 packages) (3.6.0)

### DIFF
--- a/packages/dream-html/dream-html.3.6.0/opam
+++ b/packages/dream-html/dream-html.3.6.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.6.0/dream-html-3.6.0.tbz"
+  checksum: [
+    "sha256=f0f005c6060446c1811df081c0ec4ae4cd7367362225585a373636f38ab39913"
+    "sha512=355e081dbc51b4d3c336031a946a40d4e386be5768403932a64345716aba924a1c671a521bb8ab7ca688d9433c6e64287eb91ab37d6ff20e0e3e2aa03e197da1"
+  ]
+}
+x-commit-hash: "9abcc44ffa878e2ecd0905a28ff8a7a2a09d3514"

--- a/packages/pure-html/pure-html.3.6.0/opam
+++ b/packages/pure-html/pure-html.3.6.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.6.0/dream-html-3.6.0.tbz"
+  checksum: [
+    "sha256=f0f005c6060446c1811df081c0ec4ae4cd7367362225585a373636f38ab39913"
+    "sha512=355e081dbc51b4d3c336031a946a40d4e386be5768403932a64345716aba924a1c671a521bb8ab7ca688d9433c6e64287eb91ab37d6ff20e0e3e2aa03e197da1"
+  ]
+}
+x-commit-hash: "9abcc44ffa878e2ecd0905a28ff8a7a2a09d3514"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
