### PR TITLE
goblint and apronext are not compatible with new apron

### DIFF
--- a/packages/apronext/apronext.1.0.1/opam
+++ b/packages/apronext/apronext.1.0.1/opam
@@ -14,7 +14,7 @@ run-test: [
 depends: [
   "dune"  {>= "2.1"}
   "ocaml" {>= "4.08"}
-  "apron"
+  "apron" {< "0.9.15"}
 ]
 synopsis: "Apron extension"
 description: "An extension for the OCaml interface of the Apron library"

--- a/packages/apronext/apronext.1.0.2/opam
+++ b/packages/apronext/apronext.1.0.2/opam
@@ -14,7 +14,7 @@ run-test: [
 depends: [
   "dune"  {>= "2.1"}
   "ocaml" {>= "4.08"}
-  "apron"
+  "apron" {< "0.9.15"}
 ]
 synopsis: "Apron extension"
 description: "An extension for the OCaml interface of the Apron library"

--- a/packages/apronext/apronext.1.0.3/opam
+++ b/packages/apronext/apronext.1.0.3/opam
@@ -14,7 +14,7 @@ run-test: [
 depends: [
   "dune"  {>= "2.1"}
   "ocaml" {>= "4.08"}
-  "apron"
+  "apron" {< "0.9.15"}
 ]
 synopsis: "Apron extension"
 description: "An extension for the OCaml interface of the Apron library"

--- a/packages/apronext/apronext.1.0.4/opam
+++ b/packages/apronext/apronext.1.0.4/opam
@@ -14,7 +14,7 @@ run-test: [
 depends: [
   "dune"  {>= "2.1"}
   "ocaml" {>= "4.08"}
-  "apron"
+  "apron" {< "0.9.15"}
 ]
 synopsis: "Apron extension"
 description: "An extension for the OCaml interface of the Apron library"

--- a/packages/apronext/apronext.1.0/opam
+++ b/packages/apronext/apronext.1.0/opam
@@ -14,7 +14,7 @@ run-test: [
 depends: [
   "dune" {>= "2.1"}
   "ocaml" {>= "4.08"}
-  "apron"
+  "apron" {< "0.9.15"}
 ]
 synopsis: "Apron extension"
 description: "An extension for the OCaml interface of the Apron library"

--- a/packages/goblint/goblint.1.1.1/opam
+++ b/packages/goblint/goblint.1.1.1/opam
@@ -64,6 +64,9 @@ url {
   ]
 }
 x-commit-hash: "c35cb34d985a98308e65666cfb547f2447045ce9"
+conflicts: [
+  "apron" {>= "0.9.15"}
+]
 # on `dune build` goblint.opam will be generated from goblint.opam.template and dune-project
 # also remember to generate/adjust goblint.opam.locked!
 # pin-depends: [

--- a/packages/goblint/goblint.2.0.0/opam
+++ b/packages/goblint/goblint.2.0.0/opam
@@ -51,6 +51,7 @@ depopts: ["apron"]
 conflicts: [
   "result" {< "1.5"}
   "z3"
+  "apron" {>= "0.9.15"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/goblint/goblint.2.0.1/opam
+++ b/packages/goblint/goblint.2.0.1/opam
@@ -50,6 +50,7 @@ depends: [
 depopts: ["apron" "z3"]
 conflicts: [
   "result" {< "1.5"}
+  "apron" {>= "0.9.15"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/goblint/goblint.2.1.0/opam
+++ b/packages/goblint/goblint.2.1.0/opam
@@ -52,6 +52,7 @@ depends: [
 depopts: ["apron" "z3"]
 conflicts: [
   "result" {< "1.5"}
+  "apron" {>= "0.9.15"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/goblint/goblint.2.2.1/opam
+++ b/packages/goblint/goblint.2.2.1/opam
@@ -52,6 +52,7 @@ depends: [
 depopts: ["apron" "z3"]
 conflicts: [
   "result" {< "1.5"}
+  "apron" {>= "0.9.15"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/goblint/goblint.2.3.0/opam
+++ b/packages/goblint/goblint.2.3.0/opam
@@ -52,6 +52,7 @@ depends: [
 depopts: ["apron" "z3"]
 conflicts: [
   "result" {< "1.5"}
+  "apron" {>= "0.9.15"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Failures:
```
=== ERROR while compiling goblint.2.3.0 ======================================#
 context              2.2.0~rc1 | linux/x86_64 | ocaml-base-compiler.5.2.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.2/.opam-switch/build/goblint.2.3.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p goblint -j 39 --promote-install-files=false @install
 exit-code            1
 env-file             ~/.opam/log/goblint-8-30d430.env
 output-file          ~/.opam/log/goblint-8-30d430.out
 (cd _build/default/src/build-info && /usr/bin/bash -e -u -o pipefail -c 'git describe --all --long --dirty || echo "n/a"') > /opam-tmp/build_4386d2_dune/dune-pipe-action-_3826e7_.stdout
 fatal: not a git repository (or any parent up to mount point /)
 Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
 (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -warn-error -A -w -unused-var-strict -w -unused-functor-parameter -w +9 -open Goblint_std -g -bin-annot -bin-annot-occurrences -I src/.goblint_lib.objs/byte -I /home/opam/.opam/5.2/lib/angstrom -I /home/opam/.opam/5.2/lib/apron -I /home/opam/.opam/5.2/lib/arg-complete -I /home/opam/.opam/5.2/lib/astring -I /home/opam/.opam/5.2/lib/batteries/unthreaded -I /home/opam/.opam/5.2/lib/bigarray-compat -I /home/opam/.opam/5.2/lib/bigstringaf -I /home/opam/.opam/5.2/lib/bos -I /home/opam/.opam/5.2/lib/bytes -I /home/opam/.opam/5.2/lib/camlp-streams -I /home/opam/.opam/5.2/lib/catapult -I /home/opam/.opam/5.2/lib/catapult-file -I /home/opam/.opam/5.2/lib/catapult/utils -I /home/opam/.opam/5.2/lib/cpu -I /home/opam/.opam/5.2/lib/cstruct -I /home/opam/.opam/5.2/lib/ctypes -I /home/opam/.opam/5.2/lib/ctypes/stubs -I /home/opam/.opam/5.2/lib/fileutils -I /home/opam/.opam/5.2/lib/findlib -I /home/opam/.opam/5.2/lib/fmt -I /home/opam/.opam/5.2/lib/fpath -I /home/opam/.opam/5.2/lib/gmp -I /home/opam/.opam/5.2/lib/goblint-cil -I /home/opam/.opam/5.2/lib/goblint-cil/dataslicing -I /home/opam/.opam/5.2/lib/goblint-cil/liveness -I /home/opam/.opam/5.2/lib/goblint-cil/makecfg -I /home/opam/.opam/5.2/lib/goblint-cil/pta -I /home/opam/.opam/5.2/lib/goblint-cil/syntacticsearch -I /home/opam/.opam/5.2/lib/goblint-cil/zrapp -I /home/opam/.opam/5.2/lib/hex -I /home/opam/.opam/5.2/lib/integers -I /home/opam/.opam/5.2/lib/json-data-encoding -I /home/opam/.opam/5.2/lib/json-data-encoding/stdlib -I /home/opam/.opam/5.2/lib/jsonrpc -I /home/opam/.opam/5.2/lib/logs -I /home/opam/.opam/5.2/lib/num -I /home/opam/.opam/5.2/lib/ocaml/dynlink -I /home/opam/.opam/5.2/lib/ocaml/str -I /home/opam/.opam/5.2/lib/ocaml/threads -I /home/opam/.opam/5.2/lib/ocaml/unix -I /home/opam/.opam/5.2/lib/ppx_deriving/runtime -I /home/opam/.opam/5.2/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.2/lib/qcheck-core -I /home/opam/.opam/5.2/lib/qcheck-core/runner -I /home/opam/.opam/5.2/lib/rresult -I /home/opam/.opam/5.2/lib/seq -I /home/opam/.opam/5.2/lib/sha -I /home/opam/.opam/5.2/lib/stdlib-shims -I /home/opam/.opam/5.2/lib/stringext -I /home/opam/.opam/5.2/lib/uri -I /home/opam/.opam/5.2/lib/uuidm -I /home/opam/.opam/5.2/lib/yaml -I /home/opam/.opam/5.2/lib/yaml/bindings -I /home/opam/.opam/5.2/lib/yaml/bindings/types -I /home/opam/.opam/5.2/lib/yaml/c -I /home/opam/.opam/5.2/lib/yaml/ffi -I /home/opam/.opam/5.2/lib/yaml/types -I /home/opam/.opam/5.2/lib/yaml/unix -I /home/opam/.opam/5.2/lib/yojson -I /home/opam/.opam/5.2/lib/zarith -I src/build-info/.goblint_build_info.objs/byte -I src/common/.goblint_common.objs/byte -I src/sites/.goblint_sites.objs/byte -I src/util/backtrace/.goblint_backtrace.objs/byte -I src/util/std/.goblint_std.objs/byte -I src/util/timing/.goblint_timing.objs/byte -I src/vendor/zarith/.zarith_mlgmpidl.objs/byte -no-alias-deps -open Goblint_lib__ -o src/.goblint_lib.objs/byte/goblint_lib__AffineEqualityDomain.cmo -c -impl src/affineEqualityDomain.pp.ml)
 File "src/affineEqualityDomain.ml", line 1:
 Error: Unbound value "Environment.compare"
```
and
```
=== ERROR while compiling apronext.1.0.4 =====================================#
 context              2.2.0~rc1 | linux/x86_64 | ocaml-base-compiler.5.2.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.2/.opam-switch/build/apronext.1.0.4
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p apronext -j 255
 exit-code            1
 env-file             ~/.opam/log/apronext-7-be8a71.env
 output-file          ~/.opam/log/apronext-7-be8a71.out
 (cd _build/default && /home/opam/.opam/5.2/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/.apronext.objs/byte -I /home/opam/.opam/5.2/lib/apron -I /home/opam/.opam/5.2/lib/bigarray-compat -I /home/opam/.opam/5.2/lib/gmp -intf-suffix .ml -no-alias-deps -open Apronext__ -o src/.apronext.objs/byte/apronext__Environmentext.cmo -c -impl src/environmentext.ml)
 File "src/environmentext.ml", line 1:
 Error: The implementation "src/environmentext.ml"
        does not match the interface "src/environmentext.ml":
        The value "compare" is required but not provided
        File "src/environmentext.mli", line 64, characters 0-79:
          Expected declaration
 (cd _build/default && /home/opam/.opam/5.2/bin/ocamlopt.opt -w -40 -g -I src/.apronext.objs/byte -I src/.apronext.objs/native -I /home/opam/.opam/5.2/lib/apron -I /home/opam/.opam/5.2/lib/bigarray-compat -I /home/opam/.opam/5.2/lib/gmp -intf-suffix .ml -no-alias-deps -open Apronext__ -o src/.apronext.objs/native/apronext__Environmentext.cmx -c -impl src/environmentext.ml)
 File "src/environmentext.ml", line 1:
 Error: The implementation "src/environmentext.ml"
        does not match the interface "src/environmentext.ml":
        The value "compare" is required but not provided
        File "src/environmentext.mli", line 64, characters 0-79:
          Expected declaration
```

From https://github.com/ocaml/opam-repository/pull/26174