### PR TITLE
Package cdb.1.0.1

### DIFF
--- a/packages/cdb/cdb.1.0.1/opam
+++ b/packages/cdb/cdb.1.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "CDB implementation in OCaml"
+description: """
+CDB (Constant Database) is a fast, reliable, simple package for creating
+and reading constant databases.
+"""
+maintainer: "jesse <jesse@createthis.com>"
+authors: "Dustin Sallings <dustin@spy.net>"
+license: "MIT"
+homepage: "https://github.com/createthis/ocaml-cdb"
+bug-reports: "https://github.com/createthis/ocaml-cdb/issues"
+depends: [
+  "ocaml" {>= "5.00.0"}
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name]
+]
+install: [
+  ["dune" "install" "-p" name]
+]
+url {
+  src:
+    "https://github.com/createthis/ocaml-cdb/archive/refs/tags/1.0.1.tar.gz"
+  checksum: [
+    "md5=deb487b574cf1a925424b410627a9e05"
+    "sha512=fedf279196fa894e7a7fdc47ccc05ad7b32e6e98a2ad51281aab78a3715de42a46efbc2c34861d0df8f5f0280ca5ff3520516bc648dfbc32e3db0c2161507dc7"
+  ]
+}


### PR DESCRIPTION
### `cdb.1.0.1`
CDB implementation in OCaml
CDB (Constant Database) is a fast, reliable, simple package for creating
and reading constant databases.



---
* Homepage: https://github.com/createthis/ocaml-cdb
* Bug tracker: https://github.com/createthis/ocaml-cdb/issues

---
:camel: Pull-request generated by opam-publish v2.3.1