### PR TITLE
Fix base32 and cborl 404s

### DIFF
--- a/packages/base32/base32.1.0.0/opam
+++ b/packages/base32/base32.1.0.0/opam
@@ -34,7 +34,7 @@ build: [
 ]
 dev-repo: "git+https://inqlab.net/git/ocaml-base32.git"
 url {
-  src: "https://inqlab.net/projects/ocaml-base32/release/ocaml-base32-v1.0.0.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/base32-1.0.0.tar.gz"
   checksum: [
     "md5=04f0113150261bae2075381c18c6e60c"
     "sha512=4c07480b52d84619befe6d898ba6d771f633383c57a636f13f525e74f9f4fe90442fb7de0d1581626576925010bd3bf227bbf81ee75a85288b04c5eee827014b"

--- a/packages/cborl/cborl.0.1.0/opam
+++ b/packages/cborl/cborl.0.1.0/opam
@@ -38,7 +38,7 @@ build: [
 ]
 dev-repo: "git+https://inqlab.net/git/ocaml-cborl.git"
 url {
-  src: "https://inqlab.net/projects/ocaml-cborl/release/ocaml-cborl-v0.1.0.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/cborl-0.1.0.tar.gz"
   checksum: [
     "md5=855106fd1a3bed94af232eb168a51fd0"
     "sha256=b065f4fb7961b8f7fbcffe0ee1cd8c7cfdd447b200a81e908fee00e73096a1e5"


### PR DESCRIPTION
Fixes #24886

I'm seeing these triggered again on #26196:
```
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[ERROR] Failed to get sources of base32.1.0.0: curl error code 404
```
and
```
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[ERROR] Failed to get sources of cborl.0.1.0: curl error code 404
```

I was surprised to see these already available from `opam-source-archives` for 7 months! :smiley: 
(I've also downloaded and checked the checksums locally)