### PR TITLE
Camlzip 1.12

### DIFF
--- a/packages/camlzip/camlzip.1.12/opam
+++ b/packages/camlzip/camlzip.1.12/opam
@@ -14,7 +14,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.13.0"}
   "ocamlfind" {build}
   "conf-zlib"
 ]

--- a/packages/camlzip/camlzip.1.12/opam
+++ b/packages/camlzip/camlzip.1.12/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis:
+  "Accessing compressed files in ZIP, GZIP and JAR format"
+description:
+  "The Camlzip library provides easy access to compressed files in ZIP and GZIP format, as well as to Java JAR files.  It provides functions for reading from and writing to compressed files in these formats."
+maintainer: ["Xavier Leroy <xavier.leroy@college-de-france.fr>"]
+authors: ["Xavier Leroy"]
+homepage: "https://github.com/xavierleroy/camlzip"
+bug-reports: "https://github.com/xavierleroy/camlzip/issues"
+dev-repo: "git+https://github.com/xavierleroy/camlzip.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+build: [
+  [make "all"]
+]
+install: [make "install"]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "ocamlfind" {build}
+  "conf-zlib"
+]
+url {
+  src: "https://github.com/xavierleroy/camlzip/archive/rel112.tar.gz"
+  checksum: [
+    "sha256=639d3796a506e762f41bc5e513f3ea0ab56b79bd512446fd68cff1f4201d3821"
+    "sha512=467c82a253440caf3d8485c949c4717b77dfdeb38ee474278be8e011ed3cd563fdcf436bc262e2c88fd27b44306f70d48808f0d001b3f62ab4c87010af61f76f"
+  ]
+}


### PR DESCRIPTION
- Add full support for ZIP64 archives
- Fix memory leak when a `Zlib.stream` is finalized and `Zlib.deflate_end` / `Zlib.inflate_end` was not called before