### PR TITLE
Cryptokit 1.20

### DIFF
--- a/packages/cryptokit/cryptokit.1.20/opam
+++ b/packages/cryptokit/cryptokit.1.20/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A library of cryptographic primitives"
+description:
+  "Cryptokit includes authenticated encryption (AES-GCM, Chacha20-Poly1305), block ciphers (AES, DES, 3DES), stream ciphers (Chacha20, ARCfour), public-key cryptography (RSA, DH), hashes (SHA-256, SHA-512, SHA-3, Blake2, Blake3), MACs, compression, random number generation -- all presented with a compositional, extensible interface."
+maintainer: ["Xavier Leroy <xavier.leroy@college-de-france.fr>"]
+authors: ["Xavier Leroy"]
+license: "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xavierleroy/cryptokit"
+bug-reports: "https://github.com/xavierleroy/cryptokit/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.5"}
+  "dune-configurator"
+  "zarith" {>= "1.4"}
+  "conf-zlib"
+  "conf-gmp-powm-sec"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xavierleroy/cryptokit.git"
+url {
+  src: "https://github.com/xavierleroy/cryptokit/archive/release120.tar.gz"
+  checksum: [
+    "sha256=3a4205703c6819a2c338ffebb2c025af3ef3d24ad716cc9138b5099c5b346873"
+    "sha512=e31b064d63f582c46224a3158f0b48531ce5ad011f697fb86eb43dd654712151a881328d388cf0e634b7f24021c11e4e0ecba301a1e878bb67b6163c1e19f219"
+  ]
+}


### PR DESCRIPTION
- Name space depollution: make C implementations of ciphers local to the OCaml/C stub code, so that they do not conflict with other C libraries implementing crypto functions with the same names