### PR TITLE
release pa_ppx_q_ast 0.12 w/ ocaml 5.2.0 support

### DIFF
--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.12/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.12/opam
@@ -1,0 +1,47 @@
+
+synopsis: "A PPX Rewriter for automating generation of data-conversion code for use with Camlp5's Q_ast"
+description:
+"""
+This is a PPX Rewriter for generating data-conversion code that is otherwise
+hand-written, when using Camlp5's Q_ast.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_q_ast"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_q_ast/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_q_ast.git"
+doc: "https://github.com/camlp5/pa_ppx_q_ast/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" }
+  "conf-diffutils" { >= "1.2" & with-test }
+  "conf-perl"
+  "cppo" { >= "1.6.9" }
+  "camlp5-buildscripts" { >= "0.01" }
+  "camlp5"      { >= "8.00.04" }
+  "pa_ppx"      { >= "0.08" }
+  "pa_ppx_migrate"      { with-test & >= "0.08" }
+  "pa_ppx_hashcons"      { >= "0.08" }
+  "pa_ppx_unique"      { >= "0.08" }
+  "pa_ppx_regexp"
+  "not-ocamlfind" { >= "0.01" }
+  "pcre2"
+  "ounit" { >= "2.2.7" & with-test}
+  "bos" { >= "0.2.0" }
+  "menhir" { >= "20220210" }
+  "mdx" { >= "2.3.0" & with-test}
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_q_ast/archive/refs/tags/0.12.tar.gz"
+  checksum: [
+    "sha512=594eb9343e1deed31ff6dc2fb005eb8a81c72530ad1fa57a25b290a30abf91c69dbfe1075ae1e2face00302a4580cd5ee238a8b35e8d84fe90628a1841939eb5"
+  ]
+}

--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.12/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.12/opam
@@ -37,6 +37,7 @@ depends: [
 conflicts: [
    "pa_ppx_parsetree" { <= "0.02" }
 ]
+x-ci-accept-failures: [ "opensuse-tumbleweed" ]
 build: [
   [make "sys"]
   [make "test"] {with-test}

--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.12/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.12/opam
@@ -21,8 +21,8 @@ depends: [
   "conf-perl"
   "cppo" { >= "1.6.9" }
   "camlp5-buildscripts" { >= "0.01" }
-  "camlp5"      { >= "8.00.04" }
-  "pa_ppx"      { >= "0.08" }
+  "camlp5"      { >= "8.03.00" }
+  "pa_ppx"      { >= "0.15" }
   "pa_ppx_migrate"      { with-test & >= "0.08" }
   "pa_ppx_hashcons"      { >= "0.08" }
   "pa_ppx_unique"      { >= "0.08" }
@@ -33,6 +33,9 @@ depends: [
   "bos" { >= "0.2.0" }
   "menhir" { >= "20220210" }
   "mdx" { >= "2.3.0" & with-test}
+]
+conflicts: [
+   "pa_ppx_parsetree" { <= "0.02" }
 ]
 build: [
   [make "sys"]


### PR DESCRIPTION
release pa_ppx_q_ast 0.12 w/ ocaml 5.2.0 support

and many bugfixes for the quotation_test PPX rewriter