### PR TITLE
[new release] pyre-ast (0.1.11)

### DIFF
--- a/packages/pyre-ast/pyre-ast.0.1.11/opam
+++ b/packages/pyre-ast/pyre-ast.0.1.11/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Full-fidelity Python parser in OCaml"
+description:
+  "pyre-ast is an OCaml library to parse Python source files into abstract syntax trees. Under the hood, it relies on the CPython parser to do the parsing work and therefore the result is always 100% compatible with the official CPython implementation."
+maintainer: ["grievejia@gmail.com"]
+authors: ["Jia Chen"]
+license: "MIT"
+homepage: "https://github.com/grievejia/pyre-ast"
+doc: "https://grievejia.github.io/pyre-ast/doc"
+bug-reports: "https://github.com/grievejia/pyre-ast/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "base" {>= "v0.14.1"}
+  "ppx_sexp_conv" {>= "v0.14.0"}
+  "ppx_compare" {>= "v0.14.0"}
+  "ppx_hash" {>= "v0.14.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "ppx_make" {>= "0.2.1"}
+  "stdio" {with-test & >= "v0.14.0"}
+  "sexplib" {with-test & >= "v0.14.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/grievejia/pyre-ast.git"
+available: [ os-family != "windows" ]
+url {
+  src:
+    "https://github.com/grievejia/pyre-ast/releases/download/0.1.11/pyre-ast-0.1.11.tbz"
+  checksum: [
+    "sha256=c344def5b0360185b404f99cacdb250b7061e38ed547cb871b7f9398c94c4900"
+    "sha512=4579de8085f42757224744f5980034ca589b2bd6eb77f7966a277c63011201fb2a260f730691aecd4e8c21cf2d1ae98b741277649ec965b256c4e333722e055f"
+  ]
+}
+x-commit-hash: "07998e061535e1e7baee6ac7b9d4ded3679a7825"


### PR DESCRIPTION
Full-fidelity Python parser in OCaml

- Project page: <a href="https://github.com/grievejia/pyre-ast">https://github.com/grievejia/pyre-ast</a>
- Documentation: <a href="https://grievejia.github.io/pyre-ast/doc">https://grievejia.github.io/pyre-ast/doc</a>

##### CHANGES:

- Fixed a major bug in 0.1.10 where the parser cannot differentiate `async def` and `def`.
