### PR TITLE
Fix revdeps

### DIFF
--- a/packages/bap-byteweight/bap-byteweight.2.5.0/opam
+++ b/packages/bap-byteweight/bap-byteweight.2.5.0/opam
@@ -28,7 +28,7 @@ depends: [
   "bap-std" {= "2.5.0"}
   "bap-signatures" {= "2.5.0"}
   "regular" {= "2.5.0"}
-  "camlzip"
+  "camlzip" {< "1.12"}
   "uri"
 ]
 synopsis: "BAP facility for indentifying code entry points"

--- a/packages/phylogenetics/phylogenetics.0.2.0/opam
+++ b/packages/phylogenetics/phylogenetics.0.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "angstrom-unix"
   "binning"
   "biotk" {>= "0.2.0"}
-  "core" {>= "v0.15.0" & < "v0.17.0"}
+  "core" {>= "v0.15.0" & < "v0.16"}
   "dune" {>= "3.6"}
   "gsl"
   "lacaml" {>= "10.0.2"}


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/26207, although only one is related to camlzip