### PR TITLE
camllib.1.3.3: update availability range

### DIFF
--- a/packages/camllib/camllib.1.3.3/opam
+++ b/packages/camllib/camllib.1.3.3/opam
@@ -19,6 +19,7 @@ depends: [
   "ocamlbuild" {build}
   "stdlib-shims"
 ]
+available: [ os != "win32" & os != "cygwin" ]
 synopsis: "Utility Library (including various datatypes)"
 url {
   src: "https://nberth.space/pool/camllib/camllib-1.3.3.tar.gz"

--- a/packages/camllib/camllib.1.3.3/opam
+++ b/packages/camllib/camllib.1.3.3/opam
@@ -6,14 +6,15 @@ bug-reports: "https://framagit.org/nberth/camllib/-/issues"
 dev-repo: "git+https://framagit.org/nberth/camllib.git"
 license: "LGPL-2.1-only"
 build: [
-  ["sh" "./configure"]
+  ["sh" "./configure"
+        "--disable-profiling" {ocaml >= "4.08"}]
   [make]
 ]
 install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.02.0" & <= "4.12"}
+  "ocaml" {>= "4.02.0" & < "5"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "stdlib-shims"

--- a/packages/camllib/camllib.1.3.3/opam
+++ b/packages/camllib/camllib.1.3.3/opam
@@ -2,9 +2,8 @@ opam-version: "2.0"
 maintainer: "Nicolas Berthier <m@nberth.space>"
 authors: ["Bertrand Jeannet"]
 homepage: "https://www.inrialpes.fr/pop-art/people/bjeannet/bjeannet-forge/camllib/index.html"
-bug-reports: "https://gforge.inria.fr/projects/bjeannet/"
-# SVN repositories not supported (yet).
-# dev-repo: "svn://scm.gforge.inria.fr/svnroot/bjeannet/pkg/camllib/branches/opam-packaging"
+bug-reports: "https://framagit.org/nberth/camllib/-/issues"
+dev-repo: "git+https://framagit.org/nberth/camllib.git"
 license: "LGPL-2.1-only"
 build: [
   ["sh" "./configure"]

--- a/packages/camllib/camllib.1.3.3/opam
+++ b/packages/camllib/camllib.1.3.3/opam
@@ -14,14 +14,14 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.02.0" & < "4.08"}
+  "ocaml" {>= "4.02.0" & <= "4.12"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "stdlib-shims"
 ]
 synopsis: "Utility Library (including various datatypes)"
 url {
-  src: "http://nberth.space/pool/camllib/camllib-1.3.3.tar.gz"
+  src: "https://nberth.space/pool/camllib/camllib-1.3.3.tar.gz"
   checksum: [
     "sha256=ca9a1ee7bad44d7e5a7578f0eabdafc41161bd301fb5e0008d2edeaaccda9a64"
     "md5=59424473c5a79c4a38da034de36b0293"


### PR DESCRIPTION
For a reason I don't really grasp (maybe an unintended change of the archive that I host on my own website), I am unable to find an archive that corresponds to `camllib.1.3.3` with the previous checksums. I am not sure what is the policy regarding such a case (there's no real reason to make a new version that would be identical to the previous one).

Note that package is quite old and seems very rarely used anyways.