### PR TITLE
[new release] flint (4 packages) (0.4.0)

### DIFF
--- a/packages/antic/antic.0.4.0/opam
+++ b/packages/antic/antic.0.4.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "deprecated use flint"
+maintainer: ["François Bobot"]
+authors: ["François Bobot"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/bobot/ocaml-flint"
+bug-reports: "https://github.com/bobot/ocaml-flint/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "flint" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bobot/ocaml-flint.git"
+url {
+  src:
+    "https://github.com/bobot/ocaml-flint/releases/download/0.4.0/flint-0.4.0.tbz"
+  checksum: [
+    "sha256=65625a5c4ab3922a9b39bca0f42a57b3ee18844786c4672c68da98a7bbc863d8"
+    "sha512=c92b1099cacac6bf7a181db0c52444d36180b02a1b2aa5c8aff943318f7c3440457126fb0c2dcf56bf341c05c0f287a67b8df9d05f19fe0321b992a0e04e4a8e"
+  ]
+}
+x-commit-hash: "4cd9eaee849258fcec12549488ccc501fdc9d4a8"

--- a/packages/arb/arb.0.4.0/opam
+++ b/packages/arb/arb.0.4.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "deprecated use flint"
+maintainer: ["François Bobot"]
+authors: ["François Bobot"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/bobot/ocaml-flint"
+bug-reports: "https://github.com/bobot/ocaml-flint/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "flint" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bobot/ocaml-flint.git"
+url {
+  src:
+    "https://github.com/bobot/ocaml-flint/releases/download/0.4.0/flint-0.4.0.tbz"
+  checksum: [
+    "sha256=65625a5c4ab3922a9b39bca0f42a57b3ee18844786c4672c68da98a7bbc863d8"
+    "sha512=c92b1099cacac6bf7a181db0c52444d36180b02a1b2aa5c8aff943318f7c3440457126fb0c2dcf56bf341c05c0f287a67b8df9d05f19fe0321b992a0e04e4a8e"
+  ]
+}
+x-commit-hash: "4cd9eaee849258fcec12549488ccc501fdc9d4a8"

--- a/packages/calcium/calcium.0.4.0/opam
+++ b/packages/calcium/calcium.0.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "deprecated use flint"
+maintainer: ["François Bobot"]
+authors: ["François Bobot"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/bobot/ocaml-flint"
+bug-reports: "https://github.com/bobot/ocaml-flint/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "flint" {= version}
+  "antic" {= version}
+  "arb" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bobot/ocaml-flint.git"
+url {
+  src:
+    "https://github.com/bobot/ocaml-flint/releases/download/0.4.0/flint-0.4.0.tbz"
+  checksum: [
+    "sha256=65625a5c4ab3922a9b39bca0f42a57b3ee18844786c4672c68da98a7bbc863d8"
+    "sha512=c92b1099cacac6bf7a181db0c52444d36180b02a1b2aa5c8aff943318f7c3440457126fb0c2dcf56bf341c05c0f287a67b8df9d05f19fe0321b992a0e04e4a8e"
+  ]
+}
+x-commit-hash: "4cd9eaee849258fcec12549488ccc501fdc9d4a8"

--- a/packages/flint/flint.0.4.0/opam
+++ b/packages/flint/flint.0.4.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Stub of the C library Flint3"
+maintainer: ["François Bobot"]
+authors: ["François Bobot"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/bobot/ocaml-flint"
+bug-reports: "https://github.com/bobot/ocaml-flint/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "conf-flint" {>= "3.0"}
+  "zarith" {>= "1.12"}
+  "ctypes" {>= "0.20.1"}
+  "conf-mpfr" {>= "3"}
+  "dune-site" {with-test}
+  "ocaml" {>= "4.10"}
+  "conf-pkg-config" {>= "2"}
+  "dune-configurator"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bobot/ocaml-flint.git"
+conflicts: [ "ocaml-option-bytecode-only" ]
+messages: [ "Problem with the installation of the external
+             libraries can be fixed using version 0.3 which
+             compile them locally" { failure } ]
+url {
+  src:
+    "https://github.com/bobot/ocaml-flint/releases/download/0.4.0/flint-0.4.0.tbz"
+  checksum: [
+    "sha256=65625a5c4ab3922a9b39bca0f42a57b3ee18844786c4672c68da98a7bbc863d8"
+    "sha512=c92b1099cacac6bf7a181db0c52444d36180b02a1b2aa5c8aff943318f7c3440457126fb0c2dcf56bf341c05c0f287a67b8df9d05f19fe0321b992a0e04e4a8e"
+  ]
+}
+x-commit-hash: "4cd9eaee849258fcec12549488ccc501fdc9d4a8"


### PR DESCRIPTION
Stub of the C library Flint3

- Project page: <a href="https://github.com/bobot/ocaml-flint">https://github.com/bobot/ocaml-flint</a>

##### CHANGES:

  - As in the C library regroup all package into flint
  - Bump to flint version 3.0.0
