### PR TITLE
ZArith version 1.14

### DIFF
--- a/packages/zarith/zarith.1.14/opam
+++ b/packages/zarith/zarith.1.14/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "zarith"
 maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
 authors: [
   "Antoine Miné"

--- a/packages/zarith/zarith.1.14/opam
+++ b/packages/zarith/zarith.1.14/opam
@@ -38,7 +38,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml"     {>= "4.04.0"}
+  "ocaml"     {>= "4.07.0"}
   "ocamlfind"
   "conf-gmp"
 ]

--- a/packages/zarith/zarith.1.14/opam
+++ b/packages/zarith/zarith.1.14/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+name: "zarith"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+authors: [
+  "Antoine Miné"
+  "Xavier Leroy"
+  "Pascal Cuoq"
+]
+homepage: "https://github.com/ocaml/Zarith"
+bug-reports: "https://github.com/ocaml/Zarith/issues"
+dev-repo: "git+https://github.com/ocaml/Zarith.git"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
+build: [
+  ["./configure"] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "sh"
+    "-exc"
+    "LDFLAGS=\"$LDFLAGS -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/usr/local/include\" ./configure"
+  ] {os = "openbsd" | os = "freebsd"}
+  [
+    "sh"
+    "-exc"
+    "LDFLAGS=\"$LDFLAGS -L/opt/local/lib -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/opt/local/include -I/usr/local/include\" ./configure"
+  ] {os = "macos" & os-distribution != "homebrew"}
+  [
+    "sh"
+    "-exc"
+    "LDFLAGS=\"$LDFLAGS -L/opt/local/lib -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/opt/local/include -I/usr/local/include\" ./configure"
+  ] {os = "macos" & os-distribution = "homebrew" & arch = "x86_64" }
+  [
+    "sh"
+    "-exc"
+    "LDFLAGS=\"$LDFLAGS -L/opt/homebrew/lib\" CFLAGS=\"$CFLAGS -I/opt/homebrew/include\" ./configure"
+  ] {os = "macos" & os-distribution = "homebrew" & arch = "arm64" }
+  [make]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml"     {>= "4.04.0"}
+  "ocamlfind"
+  "conf-gmp"
+]
+synopsis:
+  "Implements arithmetic and logical operations over arbitrary-precision integers"
+description: """
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy."""
+
+url {
+  src: "https://github.com/ocaml/Zarith/archive/release-1.14.tar.gz"
+  checksum: [
+    "sha256=5db9dcbd939153942a08581fabd846d0f3f2b8c67fe68b855127e0472d4d1859"
+    "sha512=8a7f3e82dfa5699c8dda54dd5398c712f3ac4fe04f5208d43d8ba198fb8152de5f91cbb59c15c0a4ba010d4dfcc79f52e405bdd0abbf2798167e9e4216bcb3dd"
+  ]
+}

--- a/packages/zarith/zarith.1.14/opam
+++ b/packages/zarith/zarith.1.14/opam
@@ -10,27 +10,7 @@ bug-reports: "https://github.com/ocaml/Zarith/issues"
 dev-repo: "git+https://github.com/ocaml/Zarith.git"
 license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 build: [
-  ["./configure"] {os != "openbsd" & os != "freebsd" & os != "macos"}
-  [
-    "sh"
-    "-exc"
-    "LDFLAGS=\"$LDFLAGS -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/usr/local/include\" ./configure"
-  ] {os = "openbsd" | os = "freebsd"}
-  [
-    "sh"
-    "-exc"
-    "LDFLAGS=\"$LDFLAGS -L/opt/local/lib -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/opt/local/include -I/usr/local/include\" ./configure"
-  ] {os = "macos" & os-distribution != "homebrew"}
-  [
-    "sh"
-    "-exc"
-    "LDFLAGS=\"$LDFLAGS -L/opt/local/lib -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/opt/local/include -I/usr/local/include\" ./configure"
-  ] {os = "macos" & os-distribution = "homebrew" & arch = "x86_64" }
-  [
-    "sh"
-    "-exc"
-    "LDFLAGS=\"$LDFLAGS -L/opt/homebrew/lib\" CFLAGS=\"$CFLAGS -I/opt/homebrew/include\" ./configure"
-  ] {os = "macos" & os-distribution = "homebrew" & arch = "arm64" }
+  ["./configure"]
   [make]
 ]
 install: [
@@ -39,6 +19,7 @@ install: [
 depends: [
   "ocaml"     {>= "4.07.0"}
   "ocamlfind"
+  "conf-pkg-config"
   "conf-gmp"
 ]
 synopsis:


### PR DESCRIPTION
https://github.com/ocaml/Zarith/issues/148, https://github.com/ocaml/Zarith/pull/149: Fail unmarshaling when it would produce non-canonical big ints
    https://github.com/ocaml/Zarith/pull/145, https://github.com/ocaml/Zarith/pull/150: Use standard hash function for Z.hash and add Z.seeded_hash
    https://github.com/ocaml/Zarith/issues/140, https://github.com/ocaml/Zarith/pull/147: Add fast path for Z.divisible on small arguments