### PR TITLE
[new release] multicore-magic (2 packages) (2.3.0)

### DIFF
--- a/packages/multicore-magic-dscheck/multicore-magic-dscheck.2.3.0/opam
+++ b/packages/multicore-magic-dscheck/multicore-magic-dscheck.2.3.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "An implementation of multicore-magic API using the atomic module of DScheck to make DScheck tests possible in libraries using multicore-magic"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-magic"
+bug-reports: "https://github.com/ocaml-multicore/multicore-magic/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "4.12.0"}
+  "dscheck" {>= "0.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-magic.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-magic/releases/download/2.3.0/multicore-magic-2.3.0.tbz"
+  checksum: [
+    "sha256=af9d14a8b39dd83a13cf40845c7a493075f47edcbe98688029376dca4827ceee"
+    "sha512=2c49e30484d2117fbbad5e3255aa82d7d0b0b457cde73a6be1e109afa8cfd012446b2c9f21279350607b0311357e06fbcb36871c4ebf232eec53d46985b885b4"
+  ]
+}
+x-commit-hash: "360c2e829c9addeca9ccaee1c71f4ad36bb14a79"

--- a/packages/multicore-magic/multicore-magic.2.3.0/opam
+++ b/packages/multicore-magic/multicore-magic.2.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Low-level multicore utilities for OCaml"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-magic"
+bug-reports: "https://github.com/ocaml-multicore/multicore-magic/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "4.12.0"}
+  "domain_shims" {>= "0.1.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-magic.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-magic/releases/download/2.3.0/multicore-magic-2.3.0.tbz"
+  checksum: [
+    "sha256=af9d14a8b39dd83a13cf40845c7a493075f47edcbe98688029376dca4827ceee"
+    "sha512=2c49e30484d2117fbbad5e3255aa82d7d0b0b457cde73a6be1e109afa8cfd012446b2c9f21279350607b0311357e06fbcb36871c4ebf232eec53d46985b885b4"
+  ]
+}
+x-commit-hash: "360c2e829c9addeca9ccaee1c71f4ad36bb14a79"


### PR DESCRIPTION
Low-level multicore utilities for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/multicore-magic">https://github.com/ocaml-multicore/multicore-magic</a>

##### CHANGES:

- Add `copy_as ~padded` for convenient optional padding (@polytypic)
- Add `multicore-magic-dscheck` package and library to help testing with DScheck
  (@lyrm, review @polytypic)
