### PR TITLE
[new release] ocaml-protoc (4 packages) (3.1)

### DIFF
--- a/packages/ocaml-protoc/ocaml-protoc.3.1/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.3.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.08"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/ocaml-protoc/ocaml-protoc.3.1/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.3.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Pure OCaml compiler for .proto files"
+maintainer: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+authors: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+license: "MIT"
+tags: ["protoc" "protobuf" "codegen"]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports: "https://github.com/mransan/ocaml-protoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "odoc" {with-doc}
+  "pbrt" {= version}
+  "pbrt_yojson" {= version & with-test}
+  "pbrt_services" {= version & with-test}
+  "ocaml" {>= "4.08"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
+url {
+  src:
+    "https://github.com/mransan/ocaml-protoc/releases/download/v3.1/ocaml-protoc-3.1.tbz"
+  checksum: [
+    "sha256=4bd16bb119f5c55a9d5e906173d8611cb7664a0c926f108077eb05f1ceb7de03"
+    "sha512=01266efcc926dd7042e9eddc874b0c41c65688b36ec3e30756a69e09d6cc57eaa8d4a043015b668a2e61cc45cac7efa51cdbad06757a98a55ff53416af98c44d"
+  ]
+}
+x-commit-hash: "955cce3335833c1e0c2327bb99696da57941096c"

--- a/packages/pbrt/pbrt.3.1/opam
+++ b/packages/pbrt/pbrt.3.1/opam
@@ -15,7 +15,7 @@ depends: [
 dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
 available: arch != "arm32" & arch != "x86_32" & arch != "ppc32" & arch != "ppc64"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pbrt/pbrt.3.1/opam
+++ b/packages/pbrt/pbrt.3.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Runtime library for Protobuf tooling"
+maintainer: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+authors: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+license: "MIT"
+tags: ["protobuf" "encode" "decode"]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports: "https://github.com/mransan/ocaml-protoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "stdlib-shims"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08"}
+]
+dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
+available: arch != "arm32" & arch != "x86_32" & arch != "ppc32" & arch != "ppc64"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@src/tests/unit-tests/pbrt/runtest" {with-test}  # custom path
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mransan/ocaml-protoc/releases/download/v3.1/ocaml-protoc-3.1.tbz"
+  checksum: [
+    "sha256=4bd16bb119f5c55a9d5e906173d8611cb7664a0c926f108077eb05f1ceb7de03"
+    "sha512=01266efcc926dd7042e9eddc874b0c41c65688b36ec3e30756a69e09d6cc57eaa8d4a043015b668a2e61cc45cac7efa51cdbad06757a98a55ff53416af98c44d"
+  ]
+}
+x-commit-hash: "955cce3335833c1e0c2327bb99696da57941096c"

--- a/packages/pbrt_services/pbrt_services.3.1/opam
+++ b/packages/pbrt_services/pbrt_services.3.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Runtime library for ocaml-protoc to support RPC services"
+maintainer: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+authors: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+license: "MIT"
+tags: ["protobuf" "encode" "decode" "services" "rpc"]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports: "https://github.com/mransan/ocaml-protoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "pbrt" {= version}
+  "pbrt_yojson" {= version}
+]
+dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    # "@runtest" {with-test} # no tests
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mransan/ocaml-protoc/releases/download/v3.1/ocaml-protoc-3.1.tbz"
+  checksum: [
+    "sha256=4bd16bb119f5c55a9d5e906173d8611cb7664a0c926f108077eb05f1ceb7de03"
+    "sha512=01266efcc926dd7042e9eddc874b0c41c65688b36ec3e30756a69e09d6cc57eaa8d4a043015b668a2e61cc45cac7efa51cdbad06757a98a55ff53416af98c44d"
+  ]
+}
+x-commit-hash: "955cce3335833c1e0c2327bb99696da57941096c"

--- a/packages/pbrt_services/pbrt_services.3.1/opam
+++ b/packages/pbrt_services/pbrt_services.3.1/opam
@@ -14,7 +14,7 @@ depends: [
 ]
 dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pbrt_yojson/pbrt_yojson.3.1/opam
+++ b/packages/pbrt_yojson/pbrt_yojson.3.1/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pbrt_yojson/pbrt_yojson.3.1/opam
+++ b/packages/pbrt_yojson/pbrt_yojson.3.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "Runtime library for ocaml-protoc to support JSON encoding/decoding"
+maintainer: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+authors: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+license: "MIT"
+tags: ["protobuf" "encode" "decode"]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports: "https://github.com/mransan/ocaml-protoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+  "yojson" {>= "1.6"}
+  "base64" {>= "3.0"}
+]
+dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@src/tests/yojson/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mransan/ocaml-protoc/releases/download/v3.1/ocaml-protoc-3.1.tbz"
+  checksum: [
+    "sha256=4bd16bb119f5c55a9d5e906173d8611cb7664a0c926f108077eb05f1ceb7de03"
+    "sha512=01266efcc926dd7042e9eddc874b0c41c65688b36ec3e30756a69e09d6cc57eaa8d4a043015b668a2e61cc45cac7efa51cdbad06757a98a55ff53416af98c44d"
+  ]
+}
+x-commit-hash: "955cce3335833c1e0c2327bb99696da57941096c"


### PR DESCRIPTION
Pure OCaml compiler for .proto files

- Project page: <a href="https://github.com/mransan/ocaml-protoc">https://github.com/mransan/ocaml-protoc</a>

##### CHANGES:

- Expose one-of per-constructor options
- Support options for enum values
- expose server stubs for advanced users

- fix: only generate services from the current file
- silence warning 44 in generated code
- Use generated encoders/decoders for empty messages in rpc

breaking:

- remove bs runtime, we don't support it going forward
