### PR TITLE
Ctypes does not compile using msvc

### DIFF
--- a/packages/ctypes/ctypes.0.10.0/opam
+++ b/packages/ctypes/ctypes.0.10.0/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.10.1/opam
+++ b/packages/ctypes/ctypes.0.10.1/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.10.2/opam
+++ b/packages/ctypes/ctypes.0.10.2/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.10.3/opam
+++ b/packages/ctypes/ctypes.0.10.3/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.10.4/opam
+++ b/packages/ctypes/ctypes.0.10.4/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.10.5/opam
+++ b/packages/ctypes/ctypes.0.10.5/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.11.0/opam
+++ b/packages/ctypes/ctypes.0.11.0/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.11.1/opam
+++ b/packages/ctypes/ctypes.0.11.1/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.11.2/opam
+++ b/packages/ctypes/ctypes.0.11.2/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.11.3/opam
+++ b/packages/ctypes/ctypes.0.11.3/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.11.4/opam
+++ b/packages/ctypes/ctypes.0.11.4/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.11.5/opam
+++ b/packages/ctypes/ctypes.0.11.5/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.12.0/opam
+++ b/packages/ctypes/ctypes.0.12.0/opam
@@ -66,4 +66,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.12.1/opam
+++ b/packages/ctypes/ctypes.0.12.1/opam
@@ -66,4 +66,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.13.0/opam
+++ b/packages/ctypes/ctypes.0.13.0/opam
@@ -66,4 +66,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.13.1/opam
+++ b/packages/ctypes/ctypes.0.13.1/opam
@@ -66,4 +66,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.14.0/opam
+++ b/packages/ctypes/ctypes.0.14.0/opam
@@ -66,4 +66,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.15.0/opam
+++ b/packages/ctypes/ctypes.0.15.0/opam
@@ -66,4 +66,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.15.1/opam
+++ b/packages/ctypes/ctypes.0.15.1/opam
@@ -62,4 +62,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.16.0/opam
+++ b/packages/ctypes/ctypes.0.16.0/opam
@@ -62,4 +62,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.17.0/opam
+++ b/packages/ctypes/ctypes.0.17.0/opam
@@ -62,4 +62,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.17.1/opam
+++ b/packages/ctypes/ctypes.0.17.1/opam
@@ -61,4 +61,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.18.0/opam
+++ b/packages/ctypes/ctypes.0.18.0/opam
@@ -61,4 +61,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.19.1/opam
+++ b/packages/ctypes/ctypes.0.19.1/opam
@@ -61,4 +61,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.20.0/opam
+++ b/packages/ctypes/ctypes.0.20.0/opam
@@ -59,4 +59,5 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.20.1/opam
+++ b/packages/ctypes/ctypes.0.20.1/opam
@@ -59,4 +59,5 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.20.2/opam
+++ b/packages/ctypes/ctypes.0.20.2/opam
@@ -59,4 +59,5 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.21.1/opam
+++ b/packages/ctypes/ctypes.0.21.1/opam
@@ -60,3 +60,6 @@ url {
     "md5=8b201d932741c5096854e5eb39139b90"
   ]
 }
+conflicts: [
+  "host-system-msvc"
+]

--- a/packages/ctypes/ctypes.0.22.0/opam
+++ b/packages/ctypes/ctypes.0.22.0/opam
@@ -60,3 +60,6 @@ url {
     "md5=8a301a3e3b79156448a6659859ad506c"
   ]
 }
+conflicts: [
+  "host-system-msvc"
+]

--- a/packages/ctypes/ctypes.0.4.0/opam
+++ b/packages/ctypes/ctypes.0.4.0/opam
@@ -55,4 +55,5 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.4.1/opam
+++ b/packages/ctypes/ctypes.0.4.1/opam
@@ -55,4 +55,5 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.4.2/opam
+++ b/packages/ctypes/ctypes.0.4.2/opam
@@ -56,4 +56,5 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.5.0/opam
+++ b/packages/ctypes/ctypes.0.5.0/opam
@@ -56,4 +56,5 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.5.1/opam
+++ b/packages/ctypes/ctypes.0.5.1/opam
@@ -56,4 +56,5 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.6.0/opam
+++ b/packages/ctypes/ctypes.0.6.0/opam
@@ -57,4 +57,5 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.6.1/opam
+++ b/packages/ctypes/ctypes.0.6.1/opam
@@ -57,4 +57,5 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.6.2/opam
+++ b/packages/ctypes/ctypes.0.6.2/opam
@@ -57,4 +57,5 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.6.3/opam
+++ b/packages/ctypes/ctypes.0.6.3/opam
@@ -57,4 +57,5 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.7.0/opam
+++ b/packages/ctypes/ctypes.0.7.0/opam
@@ -62,4 +62,5 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.7.1/opam
+++ b/packages/ctypes/ctypes.0.7.1/opam
@@ -62,4 +62,5 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.7.2/opam
+++ b/packages/ctypes/ctypes.0.7.2/opam
@@ -62,4 +62,5 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.8.0/opam
+++ b/packages/ctypes/ctypes.0.8.0/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.8.1/opam
+++ b/packages/ctypes/ctypes.0.8.1/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.8.2/opam
+++ b/packages/ctypes/ctypes.0.8.2/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.9.0/opam
+++ b/packages/ctypes/ctypes.0.9.0/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.9.1/opam
+++ b/packages/ctypes/ctypes.0.9.1/opam
@@ -65,4 +65,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.9.2/opam
+++ b/packages/ctypes/ctypes.0.9.2/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.9.3/opam
+++ b/packages/ctypes/ctypes.0.9.3/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.9.4/opam
+++ b/packages/ctypes/ctypes.0.9.4/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]

--- a/packages/ctypes/ctypes.0.9.5/opam
+++ b/packages/ctypes/ctypes.0.9.5/opam
@@ -64,4 +64,5 @@ conflicts: [
   "mirage-xen" {>= "6.0.0"}
   "base-nnp"
   "ocaml-option-nnpchecker"
+  "host-system-msvc"
 ]


### PR DESCRIPTION
See https://github.com/yallop/ocaml-ctypes/pull/685
Work is needed to be able to use ctypes in a swicth that uses msvc compiler on Windows...