### PR TITLE
[new release] spoke (0.0.3)

### DIFF
--- a/packages/spoke/spoke.0.0.3/opam
+++ b/packages/spoke/spoke.0.0.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/spoke"
+bug-reports:  "https://github.com/dinosaure/spoke/issues"
+dev-repo:     "git+https://github.com/dinosaure/spoke.git"
+doc:          "https://dinosaure.github.io/spoke/"
+license:      "MIT"
+synopsis:     "SPAKE+EE implementation in OCaml"
+description: """A Password-authenticated key agreement protocol in OCaml"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ] {os != "macos"}
+
+depends: [
+  "ocaml"         {>= "4.08.0"}
+  "dune"          {>= "2.9.0"}
+  "fmt"
+  "hxd"
+  "logs"
+  "base64"        {>= "3.0.0"}
+  "digestif"      {>= "0.8.1"}
+  "bigstringaf"   {>= "0.9.0"}
+  "encore"        {>= "0.8"}
+  "ke"
+  "mirage-crypto" {>= "0.11.0" & < "1.0.0"}
+  "mirage-flow"   {>= "4.0.0"}
+  "lwt"           {>= "5.6.1"}
+  "result"        {>= "1.5"}
+  "mimic"         {with-test}
+  "rresult"       {with-test}
+  "tcpip"         {with-test}
+]
+url {
+  src:
+    "https://github.com/dinosaure/spoke/releases/download/v0.0.3/spoke-0.0.3.tbz"
+  checksum: [
+    "sha256=42adac21fca4d718902f55032b965b87ed906a20c9cf975e6d579f91888f2f8d"
+    "sha512=64387721c0f56343f46bfca4651e990adb38fd41d15dfc12bad1fa0ae4f63271e1a7c02bde222535843171f12a7775801e2d1b299d016fe51fe38801ce091e78"
+  ]
+}
+x-commit-hash: "6a0e2906d5dc5a122a115672987fff0986e1cca5"


### PR DESCRIPTION
SPAKE+EE implementation in OCaml

- Project page: <a href="https://github.com/dinosaure/spoke">https://github.com/dinosaure/spoke</a>
- Documentation: <a href="https://dinosaure.github.io/spoke/">https://dinosaure.github.io/spoke/</a>

##### CHANGES:

- Fix deprecation (@dinosaure, dinosaure/spoke#5)
- Update to `mirage-flow.4.0.0` and introduce `shutdown` (@dinosaure, dinosaure/spoke#7)
- Restrict `spoke` to not use `mirage-crypto.1.0.0` (@dinosaure, dinosaure/spoke#8)
