### PR TITLE
ocurl: add constraint on ocaml

### DIFF
--- a/packages/ocurl/ocurl.0.7.7/opam
+++ b/packages/ocurl/ocurl.0.7.7/opam
@@ -17,7 +17,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "curl"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "base-unix"
   "conf-libcurl"


### PR DESCRIPTION
It seems ocurl.0.7.7 is not compatible with OCaml 5.

See commit with fix in 0.7.8: https://github.com/ygrek/ocurl/commit/5af7e1217f764864deae606431737cd63008bad6

Related failing build in https://github.com/ocaml/opam-repository/pull/26234/: https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/b117b531e36020f6cccc101562b352550d98dc76/variant/compilers,5.0,passage.0.1.1,lower-bounds

<details><summary>Copy of logs here for posterity</summary>

    ```
    [ERROR] The compilation of passage.0.1.1 failed at "dune build -p passage -j 255 @install".
    #=== ERROR while compiling passage.0.1.1 ======================================#
    # context              2.3.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | pinned(https://github.com/ahrefs/passage/releases/download/0.1.1/passage-0.1.1.tbz)
    # path                 ~/.opam/5.0/.opam-switch/build/passage.0.1.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p passage -j 255 @install
    # exit-code            1
    # env-file             ~/.opam/log/passage-8-985acf.env
    # output-file          ~/.opam/log/passage-8-985acf.out
    ### output ###
    # File "bin/dune", line 2, characters 7-11:
    # 2 |  (name main)
    #            ^^^^
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -open Stdlib -strict-formats -strict-sequence -short-paths -w +a-4@8-40..42-44-45-48-58-66-68-70-102 -g -o bin/main.exe /home/opam/.opam/5.0/lib/cmdliner/cmdliner.cmxa /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.0/lib/ocaml/threads/threads.cmxa /home/opam/.opam/5.0/lib/curl/curl.cmxa -I /home/opam/.opam/5.0/lib/curl /home/opam/.opam/5.0/lib/lwt/lwt.cmxa /home/opam/.opam/5.0/lib/ocplib-endian/ocplib_endian.cmxa /home/opam/.opam/5.0/lib/ocplib-endian/bigstring/ocplib_endian_bigstring.cmxa /home/opam/.opam/5.0/lib/lwt/unix/lwt_unix.cmxa -I /home/opam/.opam/5.0/lib/lwt/unix /home/opam/.opam/5.0/lib/curl/curl_lwt.cmx -I /home/opam/.opam/5.0/lib/curl /home/opam/.opam/5.0/lib/extlib/extlib.cmxa /home/opam/.opam/5.0/lib/extunix/ExtUnix.cmxa -I /home/opam/.opam/5.0/lib/extunix /home/opam/.opam/5.0/lib/libevent/liboevent.cmxa -I /home/opam/.opam/5.0/lib/libevent /home/opam/.opam/5.0/lib/pcre/pcre.cmxa -I /home/opam/.opam/5.0/lib/pcre /home/opam/.opam/5.0/lib/ocaml/str/str.cmxa /home/opam/.opam/5.0/lib/devkit/ocamlnet_lite/ocamlnet_lite.cmxa /home/opam/.opam/5.0/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/5.0/lib/trace/core/trace_core.cmxa /home/opam/.opam/5.0/lib/easy-format/easy_format.cmxa /home/opam/.opam/5.0/lib/camlp-streams/camlp_streams.cmxa /home/opam/.opam/5.0/lib/biniou/biniou.cmxa /home/opam/.opam/5.0/lib/yojson/yojson.cmxa /home/opam/.opam/5.0/lib/zip/zip.cmxa -I /home/opam/.opam/5.0/lib/zip /home/opam/.opam/5.0/lib/devkit/core/devkit_core.cmxa /home/opam/.opam/5.0/lib/devkit/devkit.cmxa /home/opam/.opam/5.0/lib/seq/seq.cmxa /home/opam/.opam/5.0/lib/fileutils/fileutils.cmxa /home/opam/.opam/5.0/lib/astring/astring.cmxa /home/opam/.opam/5.0/lib/fpath/fpath.cmxa /home/opam/.opam/5.0/lib/menhirLib/menhirLib.cmxa /home/opam/.opam/5.0/lib/base/base_internalhash_types/base_internalhash_types.cmxa -I /home/opam/.opam/5.0/lib/base/base_internalhash_types /home/opam/.opam/5.0/lib/base/caml/caml.cmxa /home/opam/.opam/5.0/lib/sexplib0/sexplib0.cmxa /home/opam/.opam/5.0/lib/base/shadow_stdlib/shadow_stdlib.cmxa /home/opam/.opam/5.0/lib/base/base.cmxa -I /home/opam/.opam/5.0/lib/base /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib/ppx_sexp_conv_lib.cmxa /home/opam/.opam/5.0/lib/ppx_compare/runtime-lib/ppx_compare_lib.cmxa /home/opam/.opam/5.0/lib/ppx_enumerate/runtime-lib/ppx_enumerate_lib.cmxa /home/opam/.opam/5.0/lib/ppx_hash/runtime-lib/ppx_hash_lib.cmxa /home/opam/.opam/5.0/lib/ppx_here/runtime-lib/ppx_here_lib.cmxa /home/opam/.opam/5.0/lib/ppx_assert/runtime-lib/ppx_assert_lib.cmxa /home/opam/.opam/5.0/lib/ppx_bench/runtime-lib/ppx_bench_lib.cmxa /home/opam/.opam/5.0/lib/base/md5/md5_lib.cmxa /home/opam/.opam/5.0/lib/fieldslib/fieldslib.cmxa /home/opam/.opam/5.0/lib/variantslib/variantslib.cmxa /home/opam/.opam/5.0/lib/bin_prot/shape/bin_shape_lib.cmxa /home/opam/.opam/5.0/lib/bin_prot/bin_prot.cmxa -I /home/opam/.opam/5.0/lib/bin_prot /home/opam/.opam/5.0/lib/ppx_inline_test/config/inline_test_config.cmxa /home/opam/.opam/5.0/lib/jane-street-headers/jane_street_headers.cmxa /home/opam/.opam/5.0/lib/time_now/time_now.cmxa -I /home/opam/.opam/5.0/lib/time_now /home/opam/.opam/5.0/lib/ppx_inline_test/runtime-lib/ppx_inline_test_lib.cmxa /home/opam/.opam/5.0/lib/stdio/stdio.cmxa /home/opam/.opam/5.0/lib/ppx_module_timer/runtime/ppx_module_timer_runtime.cmxa /home/opam/.opam/5.0/lib/typerep/typerep_lib.cmxa /home/opam/.opam/5.0/lib/ppx_expect/common/expect_test_common.cmxa /home/opam/.opam/5.0/lib/ppx_expect/config_types/expect_test_config_types.cmxa /home/opam/.opam/5.0/lib/ppx_expect/collector/expect_test_collector.cmxa -I /home/opam/.opam/5.0/lib/ppx_expect/collector /home/opam/.opam/5.0/lib/ppx_expect/config/expect_test_config.cmxa /home/opam/.opam/5.0/lib/parsexp/parsexp.cmxa /home/opam/.opam/5.0/lib/sexplib/sexplib.cmxa /home/opam/.opam/5.0/lib/ppx_log/types/ppx_log_types.cmxa /home/opam/.opam/5.0/lib/splittable_random/splittable_random.cmxa /home/opam/.opam/5.0/lib/base_quickcheck/base_quickcheck.cmxa /home/opam/.opam/5.0/lib/base_quickcheck/ppx_quickcheck/runtime/ppx_quickcheck_runtime.cmxa /home/opam/.opam/5.0/lib/int_repr/int_repr.cmxa /home/opam/.opam/5.0/lib/base_bigstring/base_bigstring.cmxa -I /home/opam/.opam/5.0/lib/base_bigstring /home/opam/.opam/5.0/lib/core/base_for_tests/base_for_tests.cmxa /home/opam/.opam/5.0/lib/core/validate/validate.cmxa /home/opam/.opam/5.0/lib/core/core.cmxa -I /home/opam/.opam/5.0/lib/core /home/opam/.opam/5.0/lib/re2/c/re2_c.cmxa -I /home/opam/.opam/5.0/lib/re2/c /home/opam/.opam/5.0/lib/core_kernel/rope/rope.cmxa /home/opam/.opam/5.0/lib/re2/re2.cmxa -I /home/opam/.opam/5.0/lib/re2 /home/opam/.opam/5.0/lib/gen/gen.cmxa /home/opam/.opam/5.0/lib/sedlex/sedlex.cmxa lib/passage.cmxa /home/opam/.opam/5.0/lib/qrc/qrc.cmxa bin/.main.eobjs/native/dune__exe__Main.cmx)
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/libevent/libmloevent.a(event_stubs.o): in function `event_cb':
    # event_stubs.c:(.text+0xd1): undefined reference to `callback3'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/libevent/libmloevent.a(event_stubs.o): in function `oc_event_base_init':
    # event_stubs.c:(.text+0x9b0): undefined reference to `invalid_argument'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `removeConnection':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:805: undefined reference to `enter_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:807: undefined reference to `leave_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:822: undefined reference to `remove_global_root'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `allocConnection':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:699: undefined reference to `register_global_root'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `raiseError':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:680: undefined reference to `raise_with_arg'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `handle_PROXYTYPE':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:2600: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `handle_FTP_SSL_CCC':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:2529: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `handle_SSH_AUTH_TYPES':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:2476: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `handle_FTP_FILEMETHOD':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:2402: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:2402: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o):/home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:2343: more undefined references to `failwith' follow
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_SEEKFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1230: undefined reference to `leave_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_SEEKFUNCTION_nolock':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1194: undefined reference to `copy_int64'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1205: undefined reference to `callback2_exn'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1219: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_SEEKFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1232: undefined reference to `enter_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_SEEKFUNCTION_nolock':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1203: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_HEADERFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1041: undefined reference to `leave_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_HEADERFUNCTION_nolock':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1031: undefined reference to `alloc_string'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1036: undefined reference to `callback_exn'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_HEADERFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1041: undefined reference to `enter_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_WRITEFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:987: undefined reference to `leave_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_WRITEFUNCTION_nolock':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:977: undefined reference to `alloc_string'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:982: undefined reference to `callback_exn'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_WRITEFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:987: undefined reference to `enter_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_PROGRESSFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1074: undefined reference to `leave_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_PROGRESSFUNCTION_nolock':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1056: undefined reference to `copy_double'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1057: undefined reference to `copy_double'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1058: undefined reference to `copy_double'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1059: undefined reference to `copy_double'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1061: undefined reference to `callbackN_exn'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_PROGRESSFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1076: undefined reference to `enter_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_READFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1020: undefined reference to `leave_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_READFUNCTION_nolock':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:998: undefined reference to `callback_exn'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1006: undefined reference to `string_length'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_READFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1020: undefined reference to `enter_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_OPENSOCKETFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1270: undefined reference to `leave_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_OPENSOCKETFUNCTION_nolock':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1254: undefined reference to `callback_exn'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_OPENSOCKETFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1272: undefined reference to `enter_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_DEBUGFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1116: undefined reference to `leave_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_DEBUGFUNCTION_nolock':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1096: undefined reference to `alloc_string'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1101: undefined reference to `callback3_exn'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_DEBUGFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1118: undefined reference to `enter_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `handle_HTTPPOST':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1734: undefined reference to `string_length'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1824: undefined reference to `string_length'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1824: undefined reference to `string_length'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1775: undefined reference to `string_length'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1691: undefined reference to `string_length'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o):/home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1691: more undefined references to `string_length' follow
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `handle_HTTPPOST':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1842: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1707: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1748: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1789: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1675: undefined reference to `string_length'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1675: undefined reference to `string_length'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1761: undefined reference to `string_length'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1804: undefined reference to `string_length'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1804: undefined reference to `string_length'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o):/home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1720: more undefined references to `string_length' follow
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `handle_HTTPPOST':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1714: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1755: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1796: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1669: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_IOCTLFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1179: undefined reference to `leave_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_IOCTLFUNCTION_nolock':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1143: undefined reference to `callback2_exn'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_IOCTLFUNCTION':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1181: undefined reference to `enter_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `cb_IOCTLFUNCTION_nolock':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1139: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `helper_curl_global_init':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:1305: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `helper_curl_easy_perform':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:3190: undefined reference to `enter_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:3192: undefined reference to `leave_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `convertStringList':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:3253: undefined reference to `alloc_tuple'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `helper_curl_easy_getinfo':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:3679: undefined reference to `alloc'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:3674: undefined reference to `alloc'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:3689: undefined reference to `alloc'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:3684: undefined reference to `alloc'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:3685: undefined reference to `copy_double'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:3664: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `helper_curl_escape':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:3707: undefined reference to `string_length'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `helper_curl_unescape':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:3724: undefined reference to `string_length'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `helper_curl_getdate':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:3744: undefined reference to `copy_double'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `caml_curl_multi_init':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:3917: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `caml_curl_multi_cleanup':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:3941: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `findConnection':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:910: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `caml_curl_multi_add_handle':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:4064: undefined reference to `failwith'
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/curl/libcurl-helper.a(curl-helper.o): in function `caml_curl_multi_remove_handle':
    # /home/opam/.opam/5.0/.opam-switch/build/ocurl.0.7.7/curl-helper.c:4082: undefined reference to `failwith'
    # collect2: error: ld returned 1 exit status
    # File "caml_startup", line 1:
    # Error: Error during linking (exit code 1)
    
    
    
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build passage 0.1.1
    +- 
    +- The following changes have been performed
    | - remove    conf-bash                   1
    | - remove    jane_rope                   v0.16.0
    | - remove    passage                     0.1.1
    | - remove    ppx_globalize               v0.16.0
    | - remove    ppx_stable_witness          v0.16.0
    | - remove    ppx_tydi                    v0.16.0
    | - remove    regex_parser_intf           v0.16.0
    | - downgrade base                        v0.16.3 to v0.15.1
    | - downgrade base_bigstring              v0.16.0 to v0.15.0
    | - downgrade base_quickcheck             v0.16.0 to v0.15.0
    | - downgrade bin_prot                    v0.16.0 to v0.15.0
    | - downgrade camlzip                     1.12 to 1.11
    | - downgrade cmdliner                    1.3.0 to 1.1.0
    | - downgrade conf-libcurl                2 to 1
    | - downgrade conf-pkg-config             3 to 1.0
    | - downgrade core                        v0.16.2 to v0.15.1
    | - downgrade cppo                        1.6.9 to 1.6.6
    | - downgrade csexp                       1.5.2 to 1.3.1
    | - downgrade dune                        3.16.0 to 3.9.0
    | - downgrade dune-configurator           3.16.0 to 2.9.0
    | - downgrade fieldslib                   v0.16.0 to v0.15.0
    | - downgrade gen                         1.1 to 0.5.3
    | - downgrade int_repr                    v0.16.0 to v0.15.0
    | - downgrade jane-street-headers         v0.16.0 to v0.15.0
    | - downgrade jst-config                  v0.16.0 to v0.15.0
    | - downgrade libevent                    0.9.0 to 0.8.0
    | - downgrade lwt                         5.7.0 to 5.6.0
    | - downgrade lwt_ppx                     2.1.0 to 2.0.2
    | - downgrade num                         1.5 to 1.0
    | - downgrade ocaml-compiler-libs         v0.12.4 to v0.12.0
    | - downgrade ocamlbuild                  0.15.0 to 0.14.1
    | - downgrade ocamlfind                   1.9.6 to 1.9.5
    | - downgrade ocplib-endian               1.2 to 1.1
    | - downgrade ocurl                       0.9.2 to 0.7.7
    | - downgrade ounit2                      2.2.7 to 2.2.6
    | - downgrade parsexp                     v0.16.0 to v0.15.0
    | - downgrade pcre                        7.5.0 to 7.3.5
    | - downgrade ppx_assert                  v0.16.0 to v0.15.0
    | - downgrade ppx_base                    v0.16.0 to v0.15.0
    | - downgrade ppx_bench                   v0.16.0 to v0.15.0
    | - downgrade ppx_bin_prot                v0.16.0 to v0.15.0
    | - downgrade ppx_cold                    v0.16.0 to v0.15.0
    | - downgrade ppx_compare                 v0.16.0 to v0.15.0
    | - downgrade ppx_custom_printf           v0.16.0 to v0.15.0
    | - downgrade ppx_disable_unused_warnings v0.16.0 to v0.15.0
    | - downgrade ppx_enumerate               v0.16.0 to v0.15.0
    | - downgrade ppx_expect                  v0.16.0 to v0.15.1
    | - downgrade ppx_fields_conv             v0.16.0 to v0.15.0
    | - downgrade ppx_fixed_literal           v0.16.0 to v0.15.0
    | - downgrade ppx_hash                    v0.16.0 to v0.15.0
    | - downgrade ppx_here                    v0.16.0 to v0.15.0
    | - downgrade ppx_ignore_instrumentation  v0.16.0 to v0.15.0
    | - downgrade ppx_inline_test             v0.16.1 to v0.15.0
    | - downgrade ppx_jane                    v0.16.0 to v0.15.0
    | - downgrade ppx_let                     v0.16.0 to v0.15.0
    | - downgrade ppx_log                     v0.16.0 to v0.15.0
    | - downgrade ppx_module_timer            v0.16.0 to v0.15.0
    | - downgrade ppx_optcomp                 v0.16.0 to v0.15.0
    | - downgrade ppx_optional                v0.16.0 to v0.15.0
    | - downgrade ppx_pipebang                v0.16.0 to v0.15.0
    | - downgrade ppx_sexp_conv               v0.16.0 to v0.15.1
    | - downgrade ppx_sexp_message            v0.16.0 to v0.15.0
    | - downgrade ppx_sexp_value              v0.16.0 to v0.15.0
    | - downgrade ppx_stable                  v0.16.0 to v0.15.0
    | - downgrade ppx_string                  v0.16.0 to v0.15.0
    | - downgrade ppx_typerep_conv            v0.16.0 to v0.15.0
    | - downgrade ppx_variants_conv           v0.16.0 to v0.15.0
    | - downgrade ppxlib                      0.32.1 to 0.27.0
    | - downgrade re                          1.11.0 to 1.9.0
    | - downgrade re2                         v0.16.0 to v0.15.0
    | - downgrade sedlex                      3.2 to 3.0
    | - downgrade seq                         base to 0.2.2
    | - downgrade sexplib                     v0.16.0 to v0.15.1
    | - downgrade sexplib0                    v0.16.0 to v0.15.1
    | - downgrade splittable_random           v0.16.0 to v0.15.0
    | - downgrade stdio                       v0.16.0 to v0.15.0
    | - downgrade stdlib-shims                0.3.0 to 0.1.0
    | - downgrade time_now                    v0.16.0 to v0.15.0
    | - downgrade topkg                       1.0.7 to 1.0.6
    | - downgrade trace                       0.7 to 0.4
    | - downgrade typerep                     v0.16.0 to v0.15.0
    | - downgrade variantslib                 v0.16.0 to v0.15.0
    | - downgrade yojson                      2.2.2 to 1.6.0
    | - recompile base-bytes                  base
    | - recompile devkit                      1.20240429
    | - recompile extlib                      1.7.9
    | - recompile extunix                     0.4.1
    | - recompile fileutils                   0.6.4
    | - recompile menhir                      20231231
    | - recompile menhirCST                   20231231
    | - recompile menhirLib                   20231231
    | - recompile menhirSdk                   20231231
    | - recompile ppx_derivers                1.2.1
    | - recompile qrc                         0.1.0
    | - install   biniou                      1.2.2
    | - install   camlp-streams               5.0
    | - install   core_kernel                 v0.15.0
    | - install   easy-format                 1.3.3
    | - install   result                      1.5
    | - install   uchar                       0.0.2
    ```
</details>




Thanks to @kit-ty-kate for help, cc @thatportugueseguy.