### PR TITLE
Package salsa20-core.2.0.0

### DIFF
--- a/packages/salsa20-core/salsa20-core.2.0.0/opam
+++ b/packages/salsa20-core/salsa20-core.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+homepage:     "https://github.com/abeaumont/ocaml-salsa20-core"
+dev-repo:     "git+https://github.com/abeaumont/ocaml-salsa20-core.git"
+bug-reports:  "https://github.com/abeaumont/ocaml-salsa20-core/issues"
+doc:          "https://abeaumont.github.io/ocaml-salsa20-core/"
+authors:      "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+maintainer:   "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+depends: [
+  "dune" {>= "1.3.0"}
+  "ocaml" {>= "4.02.0"}
+  "alcotest" {with-test}
+  "ohex" {with-test}
+]
+synopsis: "The Salsa20 core functions, in OCaml"
+description: """
+An OCaml implementation of [Salsa20 Core](http://cr.yp.to/salsa20.html) functions, both Salsa20/20 Core and the reduced Salsa20/8 Core and Salsa20/12 Core functions.
+The hot loop is implemented in C for efficiency reasons.
+"""
+url {
+  src:
+    "https://github.com/abeaumont/ocaml-salsa20-core/archive/refs/tags/2.0.0.tar.gz"
+  checksum: [
+    "md5=ee701612460d97d0dc3ca615af3ef5cb"
+    "sha512=9f413abcd15be97b3ad39efea1557e4a6b80892fbe89796298fcae5207d9f894d824ee602459e43eda07fd2875bdd90ad4c0e2a87c8cfa4ecef83ae31b4a5136"
+  ]
+}


### PR DESCRIPTION
### `salsa20-core.2.0.0`
The Salsa20 core functions, in OCaml
An OCaml implementation of [Salsa20 Core](http://cr.yp.to/salsa20.html) functions, both Salsa20/20 Core and the reduced Salsa20/8 Core and Salsa20/12 Core functions.
The hot loop is implemented in C for efficiency reasons.



---
* Homepage: https://github.com/abeaumont/ocaml-salsa20-core
* Source repo: git+https://github.com/abeaumont/ocaml-salsa20-core.git
* Bug tracker: https://github.com/abeaumont/ocaml-salsa20-core/issues

---
:camel: Pull-request generated by opam-publish v2.3.1