### PR TITLE
fix: coq.8.5.3 didn't build anymore

### DIFF
--- a/packages/coq/coq.8.5.3/opam
+++ b/packages/coq/coq.8.5.3/opam
@@ -20,6 +20,8 @@ build: [
     "-debug"
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
+  # Applying this upstream fix: https://github.com/coq/coq/pull/17459
+  ["sed" "-e" "s/CAMLP4DEPS=.*$/CAMLP4DEPS=$\\{shell LC_ALL=C sed -n -e 's@^(\\\\*.*camlp4deps: \"\\\\(.*\\\\)\".*@\\\\1@p' $\\{1}}/" "-i.bak" "Makefile.build"]
   [make "-j%{jobs}%"]
 ]
 remove: ["rm" "-R" "%{lib}%/coq"]


### PR DESCRIPTION
because of the following line:
```
CAMLP4DEPS=$(shell LC_ALL=C sed -n -e 's@^(\*.*camlp4deps: "\(.*\)".*@\1@p' $(1) \#))
```
This patch just applies the upstream fix (https://github.com/coq/coq/pull/17459):
```
CAMLP4DEPS=${shell LC_ALL=C sed -n -e 's@^(\*.*camlp4deps: "\(.*\)".*@\1@p' ${1}}
```
in a portable way (with `sed -e "s/…/…/" "-i.bak" Makefile.build` in this order).

I tested it successfully using Debian stable, locally.