### PR TITLE
libevent < 0.9.0 is not compatible with ocaml 5

### DIFF
--- a/packages/libevent/libevent.0.7.0/opam
+++ b/packages/libevent/libevent.0.7.0/opam
@@ -17,7 +17,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "conf-libevent" {build}
 ]

--- a/packages/libevent/libevent.0.8.0/opam
+++ b/packages/libevent/libevent.0.8.0/opam
@@ -17,7 +17,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "base-unix"
   "conf-libevent" {build}


### PR DESCRIPTION
Followup to https://github.com/ocaml/opam-repository/pull/26241