### PR TITLE
scrypt-kdf and salsa20 need an upper bound on salsa20-core

### DIFF
--- a/packages/salsa20/salsa20.1.1.0/opam
+++ b/packages/salsa20/salsa20.1.1.0/opam
@@ -29,7 +29,7 @@ depends: [
   "dune" {>= "1.8"}
   "cstruct" {>= "3.2.0" & < "6.1.0"}
   "mirage-crypto" {< "1.0.0"}
-  "salsa20-core" {>= "0.1.0"}
+  "salsa20-core" {>= "0.1.0" & < "2.0.0"}
   "alcotest" {with-test}
 ]
 build: [

--- a/packages/salsa20/salsa20.1.2.0/opam
+++ b/packages/salsa20/salsa20.1.2.0/opam
@@ -29,7 +29,7 @@ depends: [
   "dune" {>= "1.8.0"}
   "cstruct" {>= "6.0.0"}
   "mirage-crypto" {< "1.0.0"}
-  "salsa20-core" {>= "0.1.0"}
+  "salsa20-core" {>= "0.1.0" & < "2.0.0"}
   "alcotest" {with-test}
 ]
 build: [

--- a/packages/scrypt-kdf/scrypt-kdf.0.4.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.0.4.0/opam
@@ -20,7 +20,7 @@ depends: [
   "cstruct" {>= "1.7.0" & < "6.0.1"}
   "nocrypto" {>= "0.5.3"}
   "pbkdf" {>= "0.1.0"}
-  "salsa20-core" {>= "0.1.0"}
+  "salsa20-core" {>= "0.1.0" & < "2.0.0"}
   "alcotest" {with-test}
 ]
 synopsis: "Scrypt Password-Based Key Derivation Function"

--- a/packages/scrypt-kdf/scrypt-kdf.1.0.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.1.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "cstruct" {>= "1.7.0"}
   "nocrypto" {>= "0.5.3"}
   "pbkdf" {>= "0.1.0"}
-  "salsa20-core" {>= "0.1.0"}
+  "salsa20-core" {>= "0.1.0" & < "2.0.0"}
   "alcotest" {with-test}
 ]
 build: [

--- a/packages/scrypt-kdf/scrypt-kdf.1.1.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.1.1.0/opam
@@ -18,7 +18,7 @@ depends: [
   "cstruct" {>= "3.2.0" & < "6.1.0"}
   "mirage-crypto" {< "1.0.0"}
   "pbkdf" {>= "0.1.0"}
-  "salsa20-core" {>= "0.1.0"}
+  "salsa20-core" {>= "0.1.0" & < "2.0.0"}
   "alcotest" {with-test}
 ]
 build: [

--- a/packages/scrypt-kdf/scrypt-kdf.1.2.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.1.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "mirage-crypto" {< "1.0.0"}
   "pbkdf" {>= "0.1.0"}
-  "salsa20-core" {>= "0.1.0"}
+  "salsa20-core" {>= "0.1.0" & < "2.0.0"}
   "alcotest" {with-test}
 ]
 build: [


### PR DESCRIPTION
The API has changed. Failure:
```
         x := Salsa20_core.salsa20_8_core b_i;
                                          ^^^
 Error: This expression has type Cstruct.t
        but an expression was expected of type string
```

Seen on https://github.com/ocaml/opam-repository/pull/26240