### PR TITLE
Package pbkdf.2.0.0

### DIFF
--- a/packages/pbkdf/pbkdf.2.0.0/opam
+++ b/packages/pbkdf/pbkdf.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Password based key derivation functions (PBKDF) from PKCS#5"
+description: """
+An implementation of PBKDF 1 and 2 as defined by [PKCS#5](https://tools.ietf.org/html/rfc2898) using
+ [mirage-crypto](https://github.com/mirage/mirage-crypto)
+"""
+maintainer: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>"]
+authors: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>" "Sonia Meruelo <smeruelo@gmail.com>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/abeaumont/ocaml-pbkdf"
+bug-reports: "https://github.com/abeaumont/ocaml-pbkdf/issues"
+dev-repo: "git+https://github.com/abeaumont/ocaml-pbkdf.git"
+doc: "https://abeaumont.github.io/ocaml-pbkdf/"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.8.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "digestif"
+  "alcotest" {with-test & >= "0.8.1"}
+  "ohex" {with-test}
+]
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-j" jobs "-p" name "@install" ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+url {
+  src:
+    "https://github.com/abeaumont/ocaml-pbkdf/archive/refs/tags/2.0.0.tar.gz"
+  checksum: [
+    "md5=44fe12700b5f5e3dd9ea7457188b3674"
+    "sha512=7520375abe90627aa7aa653083c1914ac79a4c7a44099a1fd77efbce213a64910f2110c42a25883c48b355073060b0afb70222b8666bc33fcca2c913a247c782"
+  ]
+}

--- a/packages/pbkdf/pbkdf.2.0.0/opam
+++ b/packages/pbkdf/pbkdf.2.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.8.0"}
   "mirage-crypto" {>= "1.0.0"}
-  "digestif"
+  "digestif" {>= "1.2"}
   "alcotest" {with-test & >= "0.8.1"}
   "ohex" {with-test}
 ]


### PR DESCRIPTION
### `pbkdf.2.0.0`
Password based key derivation functions (PBKDF) from PKCS#5
An implementation of PBKDF 1 and 2 as defined by [PKCS#5](https://tools.ietf.org/html/rfc2898) using
 [mirage-crypto](https://github.com/mirage/mirage-crypto)



---
* Homepage: https://github.com/abeaumont/ocaml-pbkdf
* Source repo: git+https://github.com/abeaumont/ocaml-pbkdf.git
* Bug tracker: https://github.com/abeaumont/ocaml-pbkdf/issues

---
:camel: Pull-request generated by opam-publish v2.3.1