### PR TITLE
scrypt-kdf < 1 needs upper bound on new pbkdf

### DIFF
--- a/packages/scrypt-kdf/scrypt-kdf.0.1.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.0.1.0/opam
@@ -31,7 +31,7 @@ depends: [
   "cstruct" {>= "1.7.0" & < "6.0.1"}
   "cstruct" {with-test & < "3.2.0"}
   "nocrypto" {>= "0.5.0"}
-  "pbkdf" {>= "0.1.0"}
+  "pbkdf" {>= "0.1.0" & < "2.0.0"}
   "alcotest" {with-test}
   "ocamlbuild" {build}
 ]

--- a/packages/scrypt-kdf/scrypt-kdf.0.2.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.0.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "topkg" {build}
   "cstruct" {>= "1.7.0" & < "6.0.1"}
   "nocrypto" {>= "0.5.3"}
-  "pbkdf" {>= "0.1.0"}
+  "pbkdf" {>= "0.1.0" & < "2.0.0"}
   "alcotest" {with-test}
 ]
 synopsis: "The scrypt Password-Based Key Derivation Function in pure OCaml"

--- a/packages/scrypt-kdf/scrypt-kdf.0.3.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.0.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "topkg" {build}
   "cstruct" {>= "1.7.0" & < "6.0.1"}
   "nocrypto" {>= "0.5.3"}
-  "pbkdf" {>= "0.1.0"}
+  "pbkdf" {>= "0.1.0" & < "2.0.0"}
   "alcotest" {with-test}
 ]
 synopsis: "The scrypt Password-Based Key Derivation Function in pure OCaml"

--- a/packages/scrypt-kdf/scrypt-kdf.0.4.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.0.4.0/opam
@@ -19,7 +19,7 @@ depends: [
   "topkg" {build}
   "cstruct" {>= "1.7.0" & < "6.0.1"}
   "nocrypto" {>= "0.5.3"}
-  "pbkdf" {>= "0.1.0"}
+  "pbkdf" {>= "0.1.0" & < "2.0.0"}
   "salsa20-core" {>= "0.1.0" & < "2.0.0"}
   "alcotest" {with-test}
 ]

--- a/packages/scrypt-kdf/scrypt-kdf.1.0.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.1.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.8"}
   "cstruct" {>= "1.7.0"}
   "nocrypto" {>= "0.5.3"}
-  "pbkdf" {>= "0.1.0"}
+  "pbkdf" {>= "0.1.0" & < "2.0.0"}
   "salsa20-core" {>= "0.1.0" & < "2.0.0"}
   "alcotest" {with-test}
 ]


### PR DESCRIPTION
Failure:
```
 File "scrypt_kdf.ml", line 49, characters 20-22:
 49 |   let b = partition dk [] p in
                          ^^
 Error: This expression has type "string" but an expression was expected of type
          "Cstruct.t"
```

Seen on https://github.com/ocaml/opam-repository/pull/26246