### PR TITLE
[new release] ppxlib.0.33.0

### DIFF
--- a/packages/ppxlib/ppxlib.0.33.0/opam
+++ b/packages/ppxlib/ppxlib.0.33.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Standard infrastructure for ppx rewriters"
+description: """
+Ppxlib is the standard infrastructure for ppx rewriters
+and other programs that manipulate the in-memory representation of
+OCaml programs, a.k.a the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04.1" & < "5.3.0"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0" {>= "v0.12"}
+  "sexplib0" {with-test & >= "v0.15"}
+  "stdlib-shims"
+  "ocamlfind" {with-test}
+  "re" {with-test & >= "1.9.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-migrate-parsetree" {< "2.0.0"}
+  "ocaml-base-compiler" {= "5.1.0~alpha1"}
+  "ocaml-variants" {= "5.1.0~alpha1+options"}
+  "base-effects"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.33.0/ppxlib-0.33.0.tbz"
+  checksum: [
+    "sha256=ffa44ef551f23b75e21dbd698a30310431381aaf140b9fe4b81c2e70a2d2c63a"
+    "sha512=cd865efc78e85d662fab3d05de7675a46252a241db44cbf13a930017c6890da5f161fbf8511b97abd9d61bffca0cb84b3adf580b55a3820afdb4a2337e9a4a63"
+  ]
+}
+x-commit-hash: "563d5651e877c6f7d5561f9d8ca93fca05b07d07"


### PR DESCRIPTION
Release of ppxlib.0.33.0.
 
## Changes
 
- Fix a bug where `Code_path.main_module_name` would not properly remove extensions from the filename and therefore return an invalid module name.
(ocaml-ppx/ppxlib#512, @NathanReb)
    
- Add `-unused-type-warnings` flag to the driver to allow users to disable only the generation of warning 34 silencing structure items when using `[@@deriving ...]` on type declarations.
(ocaml-ppx/ppxlib#511, @mbarbin, @NathanReb)
 
- Make `-unused-code-warnings` flag to the driver also controls the generation of warning 34 silencing structure items when using `[@@deriving ...]` on type declarations.
(ocaml-ppx/ppxlib#510, @mbarbin, @NathanReb)
    
- Driver: Add `-unused-code-warnings=force` command-line flag argument.
(ocaml-ppx/ppxlib#490, @mbarbin)
    
- new functions `Ast_builder.{e,p}list_tail` that take an extra tail expression/pattern argument parameter compared to `Ast_builder.{e,p}list`, so they can build ASTs like `a :: b :: c` instead of only `[ a; b ]`.
(ocaml-ppx/ppxlib#498, ocaml-ppx/ppxlib#502, @v-gb, @NathanReb)
    
- Fix `Longident.parse` so it also handles indexing operators such as `.!()`, `.%(;..)<-`, or `Vec.(.%())`
(ocaml-ppx/ppxlib#494, @octachron)
    
- Add a `special_function'` variant which directly takes a `Longident.t` argument to avoid the issue that `Longident.t` cover distinct syntaxic classes which cannot be easily parsed by a common parser
(ocaml-ppx/ppxlib#496, @octachron).
    
- Keep location ranges consistent when migrating `Pexp_function` nodes from 5.2+ to older versions
(ocaml-ppx/ppxlib#504, @jchavarri)
    
- Fix `-locations-check` behaviour so it is no longer required to pass `-check` as well to enable location checks.
(ocaml-ppx/ppxlib#506, @NathanReb)
