### PR TITLE
ctypes prior to 0.4.0 doesn't support Windows

### DIFF
--- a/packages/ctypes/ctypes.0.1.1/opam
+++ b/packages/ctypes/ctypes.0.1.1/opam
@@ -5,6 +5,7 @@ bug-reports: "http://github.com/yallop/ocaml-ctypes/issues"
 license: "MIT"
 build: make
 remove: [["ocamlfind" "remove" "ctypes"]]
+available: os != "win32"
 depends: [
   "ocaml" {>= "4.00.0" & < "4.03.0"}
   "ocamlfind"

--- a/packages/ctypes/ctypes.0.2.3/opam
+++ b/packages/ctypes/ctypes.0.2.3/opam
@@ -7,6 +7,7 @@ build: make
 remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
+available: os != "win32"
 depends: [
   "ocaml" {>= "4.00.0" & < "4.03.0"}
   "ocamlfind"

--- a/packages/ctypes/ctypes.0.3.4/opam
+++ b/packages/ctypes/ctypes.0.3.4/opam
@@ -7,6 +7,7 @@ build: make
 remove: [
   ["ocamlfind" "remove" "ctypes"]
 ]
+available: os != "win32"
 depends: [
   "ocaml" {>= "4.00.0" & < "4.03.0"}
   "base-bytes"


### PR DESCRIPTION
Windows support was added in https://github.com/yallop/ocaml-ctypes/pull/190 in 0.4.0.

Putting this in a separate PR rather than in suggesting in https://github.com/ocaml/opam-repository/pull/26233 in order to limit the revdeps.