### PR TITLE
Windows CI tweaks

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,6 +18,11 @@ jobs:
       - name: Checkout tree
         uses: actions/checkout@v4
 
+      - name: Download install.ps1
+        run: |
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          (New-Object System.Net.WebClient).DownloadFile("https://raw.githubusercontent.com/kit-ty-kate/opam/windows-installer.debug/shell/install.ps1", ".\install.ps1")
+
       - name: Restore opam cache
         id: cache-opam
         uses: actions/cache/restore@v4
@@ -25,12 +30,12 @@ jobs:
           path: |
             D:\opam\bin
             D:\opamroot
-          key: ${{ runner.os }}-opam
+          key: ${{ runner.os }}-opam-${{ hashFiles('install.ps1') }}
 
       - name: Install opam
         if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
-          Invoke-Expression "& { $(Invoke-RestMethod https://raw.githubusercontent.com/kit-ty-kate/opam/windows-installer.debug/shell/install.ps1) } -OpamBinDir 'D:\opam\bin' -NoSetPath -NoAdmin"
+          Invoke-Expression "& ./install.ps1 -OpamBinDir 'D:\opam\bin'"
 
       - name: Add opam to PATH
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Download install.ps1
         run: |
           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-          (New-Object System.Net.WebClient).DownloadFile("https://raw.githubusercontent.com/kit-ty-kate/opam/windows-installer.debug/shell/install.ps1", ".\install.ps1")
+          (New-Object System.Net.WebClient).DownloadFile("https://raw.githubusercontent.com/ocaml/opam/master/shell/install.ps1", ".\install.ps1")
 
       - name: Restore opam cache
         id: cache-opam

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Add opam to PATH
         run: |
+          D:\opam\bin\opam --version
           "D:\opam\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Init opam

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,6 +40,11 @@ jobs:
         if: steps.cache-opam.outputs.cache-hit != 'true'
         run: opam init --yes --no-setup .
 
+      - name: Restrict testing to available compilers
+        if: steps.cache-opam.outputs.cache-hit != 'true'
+        # TODO Amend this lowerbound as older compiler packages are updated
+        run: opam switch set-invariant --formula "`"ocaml`" {>= `"4.13`"}"
+
       - name: Save opam cache
         if: steps.cache-opam.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4


### PR DESCRIPTION
Four tweaks to the GitHub Actions workflow being used for Windows testing:
- While reviewing #26233, there were failures on old packages because the workflow attempted to downgrade OCaml to a version before 4.13.0. 4.12 and earlier have not (yet) been updated with Windows support. I've added a switch invariant to the workflow so that these don't fail but instead correctly report that they can't be installed.
- I also noticed that the compiler was rebuilding, which made me realise that CI is still running an opam 2.2.0 beta, so I added a display of the version number in the step where opam is added to the cache
- At the moment, the workflow will never update opam - always download install.ps1 and use the hash of that to compute the cache key
- Finally, install.ps1 is switched from a debugging script to download from opam master instead (which updates it from 2.2.0~beta3 to the 2.2.0 release)