### PR TITLE
[new release] docteur (3 packages) (0.0.7)

### DIFF
--- a/packages/docteur-solo5/docteur-solo5.0.0.7/opam
+++ b/packages/docteur-solo5/docteur-solo5.0.0.7/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "A simple read-only Key/Value from Git to MirageOS"
+description: "An opiniated file-system for MirageOS"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/docteur"
+doc: "https://dinosaure.github.io/docteur/"
+bug-reports: "https://github.com/dinosaure/docteur/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.8.0"}
+  "docteur" {= version}
+  "mirage-solo5" {>= "0.7.0"}
+  "mirage-block-solo5"
+  "art" {>= "0.1.1"}
+  "bigstringaf" {>= "0.7.0"}
+  "carton" {>= "0.4.1"}
+  "digestif" {>= "1.0.0"}
+  "git" {>= "3.7.0"}
+  "hxd" {>= "0.3.1"}
+  "lwt" {>= "5.4.0"}
+  "mirage-kv" {>= "6.1.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/docteur.git"
+url {
+  src:
+    "https://github.com/dinosaure/docteur/releases/download/v0.0.7/docteur-0.0.7.tbz"
+  checksum: [
+    "sha256=8bfdbcbb49e668f115634cb5923e72e0faeb21efcf76e996d8c59719f3c50458"
+    "sha512=d3a1c1cae65db8ab0e9e986bef0bf1720a30f60af5ee4cbb7808483f9a8a9deffbb30271c12dbcfcd76655273efeb570a1aea9da7a8846fa52a0f335493a8652"
+  ]
+}
+x-commit-hash: "c36cb75eaaea9de03caff3734600db00d874e389"

--- a/packages/docteur-unix/docteur-unix.0.0.7/opam
+++ b/packages/docteur-unix/docteur-unix.0.0.7/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A simple read-only Key/Value from Git to MirageOS"
+description: "An opiniated file-system for MirageOS"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/docteur"
+doc: "https://dinosaure.github.io/docteur/"
+bug-reports: "https://github.com/dinosaure/docteur/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.8.0"}
+  "docteur" {= version}
+  "mirage-unix" {>= "5.0.0"}
+  "art" {>= "0.1.1"}
+  "bigstringaf" {>= "0.7.0"}
+  "carton" {>= "0.4.1"}
+  "digestif" {>= "1.0.0"}
+  "git" {>= "3.7.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "mirage-kv" {>= "6.1.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/docteur.git"
+url {
+  src:
+    "https://github.com/dinosaure/docteur/releases/download/v0.0.7/docteur-0.0.7.tbz"
+  checksum: [
+    "sha256=8bfdbcbb49e668f115634cb5923e72e0faeb21efcf76e996d8c59719f3c50458"
+    "sha512=d3a1c1cae65db8ab0e9e986bef0bf1720a30f60af5ee4cbb7808483f9a8a9deffbb30271c12dbcfcd76655273efeb570a1aea9da7a8846fa52a0f335493a8652"
+  ]
+}
+x-commit-hash: "c36cb75eaaea9de03caff3734600db00d874e389"

--- a/packages/docteur/docteur.0.0.7/opam
+++ b/packages/docteur/docteur.0.0.7/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A simple read-only Key/Value from Git to MirageOS"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/docteur"
+doc: "https://dinosaure.github.io/docteur/"
+bug-reports: "https://github.com/dinosaure/docteur/issues"
+description: """An opiniated file-system for MirageOS"""
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.8.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.0"}
+  "digestif" {>= "1.0.0"}
+  "fmt" {>= "0.8.9"}
+  "fpath" {>= "0.7.0"}
+  "git" {>= "3.7.0"}
+  "git-unix" {>= "3.7.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "mtime" {>= "2.0.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "carton" {>= "0.4.0"}
+  "art" {>= "0.1.1"}
+  "mmap"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/docteur.git"
+url {
+  src:
+    "https://github.com/dinosaure/docteur/releases/download/v0.0.7/docteur-0.0.7.tbz"
+  checksum: [
+    "sha256=8bfdbcbb49e668f115634cb5923e72e0faeb21efcf76e996d8c59719f3c50458"
+    "sha512=d3a1c1cae65db8ab0e9e986bef0bf1720a30f60af5ee4cbb7808483f9a8a9deffbb30271c12dbcfcd76655273efeb570a1aea9da7a8846fa52a0f335493a8652"
+  ]
+}
+x-commit-hash: "c36cb75eaaea9de03caff3734600db00d874e389"


### PR DESCRIPTION
A simple read-only Key/Value from Git to MirageOS

- Project page: <a href="https://github.com/dinosaure/docteur">https://github.com/dinosaure/docteur</a>
- Documentation: <a href="https://dinosaure.github.io/docteur/">https://dinosaure.github.io/docteur/</a>

##### CHANGES:

- Upgrade with `mirage-flow.4.0.0` (@dinosaure, dinosaure/docteur#31, dinosaure/docteur#33)
