### PR TITLE
[new release] quickjs (0.1.2)

### DIFF
--- a/packages/quickjs/quickjs.0.1.2/opam
+++ b/packages/quickjs/quickjs.0.1.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "Bindings for QuickJS (a Javascript Engine to be embedded https://bellard.org/quickjs)"
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/quickjs.ml"
+bug-reports: "https://github.com/ml-in-barcelona/quickjs.ml/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "5.0.0"}
+  "integers"
+  "ctypes"
+  "alcotest" {with-test}
+  "fmt" {with-test}
+  "odoc" {with-doc}
+  "ocaml-lsp-server" {with-test}
+  "ocamlformat" {= "0.26.1" & with-test}
+]
+dev-repo: "git+https://github.com/ml-in-barcelona/quickjs.ml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@new-doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ml-in-barcelona/quickjs.ml/releases/download/0.1.2/quickjs-0.1.2.tbz"
+  checksum: [
+    "sha256=27f6c8c9a3a7afa3ab7506d1154f22cf41249e2b789c0c6c634982809d17ad57"
+    "sha512=860ca84b9409a54b2fedc6b9777009872b9508bcee0f8ca3555822618640d763820e1be11c47603a4638885ab3df7eb705523cef330479147340404a7f2faa35"
+  ]
+}
+x-commit-hash: "d58993c2299462690b4fbb94b5912fd12d91c976"

--- a/packages/quickjs/quickjs.0.1.2/opam
+++ b/packages/quickjs/quickjs.0.1.2/opam
@@ -32,6 +32,7 @@ build: [
     "@new-doc" {with-doc}
   ]
 ]
+conflicts: [ "ocaml-option-bytecode-only" ]
 url {
   src:
     "https://github.com/ml-in-barcelona/quickjs.ml/releases/download/0.1.2/quickjs-0.1.2.tbz"

--- a/packages/server-reason-react/server-reason-react.0.2.0/opam
+++ b/packages/server-reason-react/server-reason-react.0.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "reason" {>= "3.10.0"}
   "melange" {>= "3.0.0"}
   "ppxlib" {> "0.23.0"}
-  "quickjs" {>= "0.1.1"}
+  "quickjs" {= "0.1.1"}
   "promise" {>= "1.1.2"}
   "lwt" {>= "5.6.0"}
   "lwt_ppx" {>= "2.1.0"}


### PR DESCRIPTION
Bindings for QuickJS (a Javascript Engine to be embedded https://bellard.org/quickjs)

- Project page: <a href="https://github.com/ml-in-barcelona/quickjs.ml">https://github.com/ml-in-barcelona/quickjs.ml</a>

##### CHANGES:

## 0.1.2

- Support for named groups
- Change RegExp.exec to return a real result