### PR TITLE
[new release] styled-ppx (0.59.0)

### DIFF
--- a/packages/styled-ppx/styled-ppx.0.59.0/opam
+++ b/packages/styled-ppx/styled-ppx.0.59.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Type-safe styled components for ReScript and Melange"
+description:
+  "styled-ppx is the ppx that brings styled components to ReScript and Melange, allowing you to create React Components with type-safe style definitions using CSS."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://styled-ppx.vercel.app"
+bug-reports: "https://github.com/davesnx/styled-ppx/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "5.1.0"}
+  "reason" {>= "3.11.0"}
+  "menhir" {>= "20220210"}
+  "ppx_deriving" {>= "5.0"}
+  "ppx_deriving_yojson" {>= "3.7.0"}
+  "ppxlib" {>= "0.27.0"}
+  "sedlex" {>= "3.2"}
+  "melange" {>= "3.0.0"}
+  "server-reason-react"
+  "reason-react" {>= "0.14.0"}
+  "alcotest" {with-test}
+  "conf-npm" {with-test}
+  "reason-react-ppx" {with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+  "utop" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/styled-ppx.git"
+depexts: [
+  ["@emotion/css"] {npm-version = ">=11.0.0"}
+]
+url {
+  src:
+    "https://github.com/davesnx/styled-ppx/releases/download/0.59.0/styled-ppx-0.59.0.tbz"
+  checksum: [
+    "sha256=c10d7a48a52bde0d4b78151ccefc57bc5d0dc9b5ad8a22a16ad19fa30e8c3401"
+    "sha512=049f3280d3c4d56da37626fcb72fbf8309a983d222282eb1e6e54331d0a155bb86f5e3857fd1ca0cc43bc47678294ba9facbaa5aea2feb1a3e235d7139a19ef9"
+  ]
+}
+x-commit-hash: "2fd57cd270505eb7adabcd2d9afd47e2d29560b0"


### PR DESCRIPTION
Type-safe styled components for ReScript and Melange

- Project page: <a href="https://styled-ppx.vercel.app">https://styled-ppx.vercel.app</a>

##### CHANGES:

## 0.59.0
- [BREAKING] Change entry point module `CSS` (from `CssJs`) on `styled-ppx.melange`, `styled-ppx.native` and `styled-ppx.rescript` (davesnx/styled-ppx#490) (@davesnx)
- [FEATURE] Add support and interpolation for `zoom`, `will-change` and `user-select` properties (davesnx/styled-ppx#489) (@davesnx)
- [FEATURE] Support content with interpolation davesnx/styled-ppx#494 (@davesnx)
- [FEATURE] Support define CSS variables in global and use CSS variables in properties davesnx/styled-ppx#492 (@davesnx)
- [FEATURE] Support overflow with 2 values
- [FEATURE] Make animation-name abstract (@davesnx)
- [FIX] Add 100 unsupported properties, which will render properly (davesnx/styled-ppx#489) (@davesnx)
- [FIX] Inline all CSS.Var and CSS.Cascading in properties (davesnx/styled-ppx#495) (@davesnx)
- [FIX] Color with support for rgba/hsla and others with calc/min and max (davesnx/styled-ppx#495) (@davesnx)
- [FIX] Warning of kebab-case on emotion client side (davesnx/styled-ppx#493) (@davesnx)

## 0.58.1
- [BREAKING] FontFamilyName.t is now a string (@davesnx)
- [FIX] Make unsafe calls from "Cascading" be camelCase to avoid emotion's warning davesnx/styled-ppx#488 (@davesnx)
- [FIX] Keep classname when ampersand is at the end of the selector (@davesnx)
- [FIX] Fix fontFace in both melange and native (@davesnx)

## 0.58.0
- [FEATURE] Initial @container support davesnx/styled-ppx#476 (@zakybilfagih)
- [FIX] Make selector nested maintain other selectors davesnx/styled-ppx#486 (@davesnx)
- [BREAKING] Remove `Css` module, `styled_label` and friends davesnx/styled-ppx#487 (@davesnx)
- [BREAKING] Merge styled-ppx.css and styled-ppx.emotion into styled-ppx.melange davesnx/styled-ppx#487 (@davesnx)
- [BREAKING] Merge styled-ppx.css-native and styled-ppx.emotion-native into styled-ppx.native davesnx/styled-ppx#487 (@davesnx)
- [BREAKING] Merge styled-ppx.css-native and styled-ppx.emotion-native into styled-ppx.native davesnx/styled-ppx#487 (@davesnx)
- [BREAKING] Remove PseudoClass and PseudoClassParam davesnx/styled-ppx#487 (@davesnx)
- Remove functor from Css_Js_Core davesnx/styled-ppx#487 (@davesnx)
- Remove melange.js and melange.belt from styled-ppx.melange davesnx/styled-ppx#487 (@davesnx)
- Remove server-reason-react.js and server-reason-react.belt from styled-ppx.native davesnx/styled-ppx#487 (@davesnx)

