### PR TITLE
[new release] corosync (0.0.1)

### DIFF
--- a/packages/conf-libcorosync/conf-libcorosync.3/opam
+++ b/packages/conf-libcorosync/conf-libcorosync.3/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "corosync"
+authors: ["Jan Friesse"]
+homepage: "https://corosync.github.io/corosync/"
+license: "BSD-3-Clause"
+build: ["pkg-config" "--print-errors" "--exists" "libcmap" "libcpg" "libcfg" "libquorum" "libvotequorum"]
+depexts: [
+  ["corosynclib-devel"] {os-distribution = "centos"}
+  ["libcfg-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["libcmap-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["libcpg-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["libquorum-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["libvotequorum-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["corosynclib-devel"] {os-distribution = "fedora"}
+  ["lib64corosync-devel"] {os-distribution = "mageia"}
+  ["libcorosync-devel"] {os-family = "suse"}
+  ["corosync-libs"] {os-family = "opensuse"}
+]
+available: os = "linux" & arch != "arm32"
+synopsis: "Virtual package relying on libcorosync system installation"
+description: "This package can only install if libcorosync is installed on the system."
+depends: ["conf-pkg-config" {build}]
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/corosync/corosync.0.0.1/opam
+++ b/packages/corosync/corosync.0.0.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "OCaml Corosync binding"
+description: "An OCaml language binding to libcorosync"
+maintainer: ["Shuntian Liu"]
+authors: ["Shuntian Liu"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+tags: ["corosync" "binding"]
+homepage: "https://github.com/Vincent-lau/ocaml-corosync"
+doc: "https://Vincent-lau.github.io/ocaml-corosync/doc"
+bug-reports: "https://github.com/Vincent-lau/ocaml-corosync/issues"
+depends: [
+  "astring" {>= "0.8.5"}
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.16"}
+  "stdint"
+  "ctypes" {>= "0.22.0"}
+  "ctypes-foreign" {>= "0.22.0"}
+  "ipaddr"
+  "alcotest" {>= "1.7.0"}
+  "odoc" {with-doc}
+  "conf-libcorosync"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Vincent-lau/ocaml-corosync.git"
+url {
+  src:
+    "https://github.com/Vincent-lau/ocaml-corosync/releases/download/v0.0.1/corosync-0.0.1.tbz"
+  checksum: [
+    "sha256=c1cf8ae96757c0b9f91b7619dc0f6417782e0734404965667796098c0710fafd"
+    "sha512=b936be73cf049c5499e6eafef22caa459cf52553d0412f777213c810bae38bc77b55843edf671652115751279da66e834d4d9b7391e1d85aca4975ab4fd9626f"
+  ]
+}
+x-commit-hash: "56babd87e897b6c86ab7d0ab0614029b04c465d8"


### PR DESCRIPTION
OCaml Corosync binding

- Project page: <a href="https://github.com/Vincent-lau/ocaml-corosync">https://github.com/Vincent-lau/ocaml-corosync</a>
- Documentation: <a href="https://Vincent-lau.github.io/ocaml-corosync/doc">https://Vincent-lau.github.io/ocaml-corosync/doc</a>

##### CHANGES:

- Initial public release of ocaml corosync binding
- Contains bindings to
  - libcfg
  - libcmap
  - libquorum
  - libvotequorum
  - and various helper functions to mimic the corosync tool binaries
- Added test cases for
  - when corosync is running
  - and when it is not (the default)
- Written using ctypes!
