### PR TITLE
ocaml-lsp-server: remove avoid-version now ocaml.5.2.0 is out

### DIFF
--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0~5.2preview/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0~5.2preview/opam
@@ -46,8 +46,6 @@ depends: [
   "merlin-lib" {>= "5.1"}
   "ocaml-index" {>= "1.0" & post}
 ]
-flags: avoid-version
-available: opam-version >= "2.1.0"
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Without this, attempting to `opam install ocamlformat ocaml-lsp-server` is resulting in the compiler being downgraded to 5.1.1 rather than install the right LSP server in 5.2.0

Noticed by @yminsky and me as part of the Gitpod template-ocaml install process