### PR TITLE
[new release] server-reason-react (0.3.0)

### DIFF
--- a/packages/server-reason-react/server-reason-react.0.3.0/opam
+++ b/packages/server-reason-react/server-reason-react.0.3.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Rendering React components on the server natively"
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/server-reason-react"
+bug-reports: "https://github.com/ml-in-barcelona/server-reason-react/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "5.0.0"}
+  "reason" {>= "3.10.0"}
+  "melange" {>= "3.0.0"}
+  "ppxlib" {> "0.23.0"}
+  "quickjs" {>= "0.1.1"}
+  "promise" {>= "1.1.2"}
+  "lwt" {>= "5.6.0"}
+  "lwt_ppx" {>= "2.1.0"}
+  "uri" {>= "4.2.0"}
+  "integers"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "fmt" {with-test}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {= "0.26.1" & with-test}
+  "ocaml-lsp-server" {with-test}
+  "tiny_httpd" {with-test}
+  "melange-webapi" {with-test}
+  "reason-react" {with-test}
+  "melange-webapi" {with-test}
+  "reason-react-ppx" {with-test}
+]
+dev-repo: "git+https://github.com/ml-in-barcelona/server-reason-react.git"
+# build command is custom to add "@new-doc"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@new-doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ml-in-barcelona/server-reason-react/releases/download/0.3.0/server-reason-react-0.3.0.tbz"
+  checksum: [
+    "sha256=2a6fc7197d251dc91babcf22cb6987e1d07e91ae631cc62a893df2c6da6b49b5"
+    "sha512=c6ed6eb39b046b698844e561cf9a42a866e4df632a6e495a6473ba629ecd9ee534db0b5b42737776d9a4b15376bea1380b77749228c88a0fc0f6b10ead4b3a01"
+  ]
+}
+x-commit-hash: "702a5cd3c3fcc852b0d007d9f5782a69f844b4f9"


### PR DESCRIPTION
Rendering React components on the server natively

- Project page: <a href="https://github.com/ml-in-barcelona/server-reason-react">https://github.com/ml-in-barcelona/server-reason-react</a>

##### CHANGES:

## 0.2.0

- Remove data-reactroot attr from ReactDOM.renderToString ml-in-barcelona/server-reason-react#129 by @pedrobslisboa
- Make useUrl return the provided serverUrl ml-in-barcelona/server-reason-react#125 by @purefunctor
- Replace Js.Re implemenation from `pcre` to quickjs b1a3e225cdad1298d705fbbd9618e15b0427ef0f by @davesnx
- Remove Belt.Array.push ml-in-barcelona/server-reason-react#122 by @davesnx

## 0.1.0

Initial release of server-reason-react, includes:

- Server-side rendering of ReasonReact components (renderToString, renderToStaticMarkup & renderToLwtStream)
- `server-reason-react.browser_ppx` for skipping code from the server
- `server-reason-react.melange_ppx` for enabling melange bindings and extensions which run on the server
- `server-reason-react.belt` a native Belt implementation
- `server-reason-react.js` a native Js implementation (unsafe and limited)
- `server-reason-react.url` and `server-reason-react.url-native` a universal library with both implementations to work with URLs on the server and the client
- `server-reason-react.promise` and `server-reason-react.promise-native` a universal library with both implementations to work with Promises on the server and the client. Based on https://github.com/aantron/promise
- `server-reason-react.melange-fetch` a fork of melange-fetch which is a melange library to fetch data on the client via the Fetch API. This fork is to be able to compile it on the server (not running).
- `server-reason-react.webapi` a fork of melange-webapi which is a melange library to work with the Web API on the client. This fork is to be able to compile it on the server (not running).
