### PR TITLE
[new release] lambdapi (2.5.1)

### DIFF
--- a/packages/lambdapi/lambdapi.2.5.1/opam
+++ b/packages/lambdapi/lambdapi.2.5.1/opam
@@ -1,44 +1,17 @@
 opam-version: "2.0"
 synopsis: "Proof assistant for the λΠ-calculus modulo rewriting"
 description: """
-This package provides:
-- A lambdapi command for checking .lp or .dk files,
-translating .dk files to .lp files and vice versa,
-or launching an LSP server for editing .lp files.
-- A library of logic definitions and basic definitions and proofs
-on natural numbers and polymorphic lists.
-- A rich Emacs mode based on LSP (available on MELPA too).
-- A basic mode for Vim.
-- OCaml libraries.
-A VSCode extension is also available on the VSCode Marketplace.
-
-Find Lambdapi user manual on https://lambdapi.readthedocs.io/.
-
-Lambdapi provides a rich type system with dependent types.
-In Lambdapi, one can define both type and function symbols
-by using rewriting rules (oriented equations).
-A symbol can be declared associative and commutative.
-Lambdapi supports unicode symbols and infix operators.
-The declaration of symbols and rewriting rules is separated
-so that one can easily define inductive-recursive types.
-
-Lambdapi checks that rules are locally confluent (by checking
-the joinability of critical pairs) and preserve typing.
-Rewrite rules can also be exported to the TRS and XTC formats
-for checking confluence and termination with external tools.
-
-Lambdapi does not come with a pre-defined logic. It is a
-powerful logical framework in which one can easily define
-its own logic and build and check proofs in this logic.
-There exist .lp files defining first or higher-order logic
-and complex type systems like in Coq or Agda.
-
-Lambdapi provides a basic module and package system,
-interactive modes for proving both unification goals
-and typing goals, and tactics for solving them step by step.
-In particular, a rewrite tactic like in SSReflect, and
-a why3 tactic for calling external automated provers through
-the Why3 platform."""
+Lambdapi is an interactive proof assistant for the λΠ-calculus modulo
+rewriting. It can call external automated theorem provers via Why3.
+The user manual is on https://lambdapi.readthedocs.io/.
+A standard library and other developments are available on
+https://github.com/Deducteam/opam-lambdapi-repository/. An extension
+for Emacs is available on MELPA. An extension for VSCode is available
+on the VSCode Marketplace. Lambdapi can read Dedukti files. It
+includes checkers for local confluence and subject reduction. It also
+provides commands to export Lambdapi files to other formats or
+systems: Dedukti, Coq, HRS, CPF.
+"""
 maintainer: ["dedukti-dev@inria.fr"]
 authors: ["Deducteam"]
 license: "CECILL-2.1"

--- a/packages/lambdapi/lambdapi.2.5.1/opam
+++ b/packages/lambdapi/lambdapi.2.5.1/opam
@@ -78,7 +78,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-available: arch != "ppc64"
+conflicts: [ "ocaml-option-bytecode-only" ]
 url {
   src:
     "https://github.com/Deducteam/lambdapi/releases/download/2.5.1/lambdapi-2.5.1.tbz"

--- a/packages/lambdapi/lambdapi.2.5.1/opam
+++ b/packages/lambdapi/lambdapi.2.5.1/opam
@@ -1,0 +1,90 @@
+opam-version: "2.0"
+synopsis: "Proof assistant for the λΠ-calculus modulo rewriting"
+description: """
+This package provides:
+- A lambdapi command for checking .lp or .dk files,
+translating .dk files to .lp files and vice versa,
+or launching an LSP server for editing .lp files.
+- A library of logic definitions and basic definitions and proofs
+on natural numbers and polymorphic lists.
+- A rich Emacs mode based on LSP (available on MELPA too).
+- A basic mode for Vim.
+- OCaml libraries.
+A VSCode extension is also available on the VSCode Marketplace.
+
+Find Lambdapi user manual on https://lambdapi.readthedocs.io/.
+
+Lambdapi provides a rich type system with dependent types.
+In Lambdapi, one can define both type and function symbols
+by using rewriting rules (oriented equations).
+A symbol can be declared associative and commutative.
+Lambdapi supports unicode symbols and infix operators.
+The declaration of symbols and rewriting rules is separated
+so that one can easily define inductive-recursive types.
+
+Lambdapi checks that rules are locally confluent (by checking
+the joinability of critical pairs) and preserve typing.
+Rewrite rules can also be exported to the TRS and XTC formats
+for checking confluence and termination with external tools.
+
+Lambdapi does not come with a pre-defined logic. It is a
+powerful logical framework in which one can easily define
+its own logic and build and check proofs in this logic.
+There exist .lp files defining first or higher-order logic
+and complex type systems like in Coq or Agda.
+
+Lambdapi provides a basic module and package system,
+interactive modes for proving both unification goals
+and typing goals, and tactics for solving them step by step.
+In particular, a rewrite tactic like in SSReflect, and
+a why3 tactic for calling external automated provers through
+the Why3 platform."""
+maintainer: ["dedukti-dev@inria.fr"]
+authors: ["Deducteam"]
+license: "CECILL-2.1"
+homepage: "https://github.com/Deducteam/lambdapi"
+bug-reports: "https://github.com/Deducteam/lambdapi/issues"
+dev-repo: "git+https://github.com/Deducteam/lambdapi.git"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08.0"}
+  "menhir" {>= "20200624"}
+  "sedlex" {>= "3.2"}
+  "alcotest" {with-test}
+  "dedukti" {with-test & >= "2.7"}
+  "bindlib" {>= "6.0.0"}
+  "timed" {>= "1.0"}
+  "pratter" {>= "3.0.0" & < "4"}
+  "camlp-streams" {>= "5.0"}
+  "why3" {>= "1.6.0" & < "1.8~"}
+  "yojson" {>= "1.6.0"}
+  "cmdliner" {>= "1.1.0"}
+  "stdlib-shims" {>= "0.1.0"}
+  "odoc" {with-doc}
+  "lwt_ppx" {>= "1.0.0"}
+  "dream" {>= "1.0.0~alpha3"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "ppc64"
+url {
+  src:
+    "https://github.com/Deducteam/lambdapi/releases/download/2.5.1/lambdapi-2.5.1.tbz"
+  checksum: [
+    "sha256=2c251021b6fac40c05282ca183902da5b1008e69d9179d7a9543905c2c21a28a"
+    "sha512=69535f92766e6fedc2675fc214f0fb699bde2a06aa91d338c93c99756235a293cf16776f6328973dda07cf2ad402e58fe3104a08f1a896990c1778b42f7f9fcf"
+  ]
+}
+x-commit-hash: "e119c8cee3647e1d17fa6fdaf1bb6129f42927bc"


### PR DESCRIPTION
Proof assistant for the λΠ-calculus modulo rewriting

- Project page: <a href="https://github.com/Deducteam/lambdapi">https://github.com/Deducteam/lambdapi</a>

##### CHANGES:

### Added

- Add export format `raw_dk`.
- Fix of the color of the text in command line when console.out is used.
- Use black text instead of red when diplaying query answers.
- Allow negative numbers in notation priorities.
- New release 0.2.2 of the VSCode plugin.
