### PR TITLE
[new release] reason (2 packages) (3.12.0)

### DIFF
--- a/packages/reason/reason.3.12.0/opam
+++ b/packages/reason/reason.3.12.0/opam
@@ -36,7 +36,6 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/reason/reason.3.12.0/opam
+++ b/packages/reason/reason.3.12.0/opam
@@ -14,7 +14,7 @@ homepage: "https://reasonml.github.io/"
 bug-reports: "https://github.com/reasonml/reason/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.03" & < "5.3"}
+  "ocaml" {>= "4.06" & < "5.3"}
   "ocamlfind" {build}
   "dune-build-info" {>= "2.9.3"}
   "menhir" {>= "20180523"}

--- a/packages/reason/reason.3.12.0/opam
+++ b/packages/reason/reason.3.12.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Reason: Syntax & Toolchain for OCaml"
+description: """
+Reason gives OCaml a new syntax that is remniscient of languages like
+JavaScript. It's also the umbrella project for a set of tools for the OCaml &
+JavaScript ecosystem."""
+maintainer: [
+  "Jordan Walke <jordojw@gmail.com>"
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+]
+authors: ["Jordan Walke <jordojw@gmail.com>"]
+license: "MIT"
+homepage: "https://reasonml.github.io/"
+bug-reports: "https://github.com/reasonml/reason/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.03" & < "5.3"}
+  "ocamlfind" {build}
+  "dune-build-info" {>= "2.9.3"}
+  "menhir" {>= "20180523"}
+  "merlin-extend" {>= "0.6"}
+  "fix"
+  "ppx_derivers"
+  "cppo"
+  "ppxlib" {>= "0.28.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/reasonml/reason.git"
+url {
+  src:
+    "https://github.com/reasonml/reason/releases/download/3.12.0/reason-3.12.0.tbz"
+  checksum: [
+    "sha256=63d950affbe203701a3d4c076a2750b56211bae7017cd8f59da508efb09a1afe"
+    "sha512=3ed24f4567dcf2ef2c05cec45fae18da2b9a78dab098a8e97e6430aaed4c8e3f659c7a5ccab88bce498c4b3d3cd54b01e72b2be4fefdf9f3bfcc2c8eb7fd86d4"
+  ]
+}
+x-commit-hash: "66d220960cb0fedc3674a1e80aa13b599e9a633e"

--- a/packages/rtop/rtop.3.12.0/opam
+++ b/packages/rtop/rtop.3.12.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Reason toplevel"
+description:
+  "rtop is the toplevel (or REPL) for Reason, based on utop (https://github.com/ocaml-community/utop)."
+maintainer: [
+  "Jordan Walke <jordojw@gmail.com>"
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+]
+authors: ["Jordan Walke <jordojw@gmail.com>"]
+license: "MIT"
+homepage: "https://reasonml.github.io/"
+bug-reports: "https://github.com/reasonml/reason/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.03" & < "5.3"}
+  "reason" {= version}
+  "utop" {>= "2.0"}
+  "cppo"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/reasonml/reason.git"
+url {
+  src:
+    "https://github.com/reasonml/reason/releases/download/3.12.0/reason-3.12.0.tbz"
+  checksum: [
+    "sha256=63d950affbe203701a3d4c076a2750b56211bae7017cd8f59da508efb09a1afe"
+    "sha512=3ed24f4567dcf2ef2c05cec45fae18da2b9a78dab098a8e97e6430aaed4c8e3f659c7a5ccab88bce498c4b3d3cd54b01e72b2be4fefdf9f3bfcc2c8eb7fd86d4"
+  ]
+}
+x-commit-hash: "66d220960cb0fedc3674a1e80aa13b599e9a633e"


### PR DESCRIPTION
Reason: Syntax & Toolchain for OCaml

- Project page: <a href="https://reasonml.github.io/">https://reasonml.github.io/</a>

##### CHANGES:

- Add `\u{hex-escape}` syntax (@anmonteiro,
  [reasonml/reason#2738](https://github.com/reasonml/reason/pull/2738))
- Support local open and let bindings (@SanderSpies) [reasonml/reason#2716](https://github.com/reasonml/reason/pull/2716)
- outcome printer: change the printing of `@bs.*` to `@mel.*` (@anmonteiro, [reasonml/reason#2755](https://github.com/reasonml/reason/pull/2755))
- Fix outcome printing of optional arguments on OCaml 5.2 (@anmonteiro, [reasonml/reason#2753](https://github.com/reasonml/reason/pull/2753))
- support parsing and printing of `external%extension` (@anmonteiro, [reasonml/reason#2750](https://github.com/reasonml/reason/pull/2750), [reasonml/reason#2766](https://github.com/reasonml/reason/pull/2766), [reasonml/reason#2767](https://github.com/reasonml/reason/pull/2767))
- install `refmt` manpage (@anmonteiro, [reasonml/reason#2760](https://github.com/reasonml/reason/pull/2760))
- add support for parsing / printing of refutation clause in `switch` (@anmonteiro, [reasonml/reason#2765](https://github.com/reasonml/reason/pull/2765))
- support `let%ppx` in signatures (@anmonteiro, [reasonml/reason#2770](https://github.com/reasonml/reason/pull/2770))
