### PR TITLE
[new release] server-reason-react (0.3.1)

### DIFF
--- a/packages/server-reason-react/server-reason-react.0.3.1/opam
+++ b/packages/server-reason-react/server-reason-react.0.3.1/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Rendering React components on the server natively"
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/server-reason-react"
+bug-reports: "https://github.com/ml-in-barcelona/server-reason-react/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "5.0.0"}
+  "reason" {>= "3.10.0"}
+  "melange" {>= "3.0.0"}
+  "ppxlib" {> "0.23.0"}
+  "quickjs" {>= "0.1.2"}
+  "promise" {>= "1.1.2"}
+  "lwt" {>= "5.6.0"}
+  "lwt_ppx" {>= "2.1.0"}
+  "uri" {>= "4.2.0"}
+  "integers"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "fmt" {with-test}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {= "0.26.1" & with-test}
+  "ocaml-lsp-server" {with-test}
+  "tiny_httpd" {with-test}
+  "melange-webapi" {with-test}
+  "reason-react" {with-test}
+  "melange-webapi" {with-test}
+  "reason-react-ppx" {with-test}
+]
+dev-repo: "git+https://github.com/ml-in-barcelona/server-reason-react.git"
+# build command is custom to add "@new-doc"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@new-doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ml-in-barcelona/server-reason-react/releases/download/0.3.1/server-reason-react-0.3.1.tbz"
+  checksum: [
+    "sha256=b97fbe6a7c3e5e1a7775e0f6498f257acaaa7e272177a9a3e0e50b7a49408d7c"
+    "sha512=b27a94618c367c80efef83a41c2a59c9cc7848fd753049ed40fa1f2cface1ef34cf3a995835bf08e2eb59c3186911f429b4706ed07dcb9724df6af5eb012a31d"
+  ]
+}
+x-commit-hash: "ee0f34b7046c50d77b1464be390eb2895ab367fe"


### PR DESCRIPTION
Rendering React components on the server natively

- Project page: <a href="https://github.com/ml-in-barcelona/server-reason-react">https://github.com/ml-in-barcelona/server-reason-react</a>

##### CHANGES:

## 0.3.1
* Update quickjs dependency to 0.1.2 by @davesnx
