### PR TITLE
[new release] styled-ppx (0.59.1)

### DIFF
--- a/packages/styled-ppx/styled-ppx.0.56.0/opam
+++ b/packages/styled-ppx/styled-ppx.0.56.0/opam
@@ -4,7 +4,7 @@ description:
   "styled-ppx is the ppx that brings styled components to ReScript and Melange, allowing you to create React Components with type-safe style definitions using CSS."
 maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
 authors: ["David Sancho <dsnxmoreno@gmail.com>"]
-license: "MIT"
+license: "BSD 2 Clause"
 homepage: "https://styled-ppx.vercel.app"
 bug-reports: "https://github.com/davesnx/styled-ppx/issues"
 depends: [

--- a/packages/styled-ppx/styled-ppx.0.56.0/opam
+++ b/packages/styled-ppx/styled-ppx.0.56.0/opam
@@ -4,7 +4,7 @@ description:
   "styled-ppx is the ppx that brings styled components to ReScript and Melange, allowing you to create React Components with type-safe style definitions using CSS."
 maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
 authors: ["David Sancho <dsnxmoreno@gmail.com>"]
-license: "BSD 2 Clause"
+license: "BSD-2-Clause"
 homepage: "https://styled-ppx.vercel.app"
 bug-reports: "https://github.com/davesnx/styled-ppx/issues"
 depends: [

--- a/packages/styled-ppx/styled-ppx.0.59.1/opam
+++ b/packages/styled-ppx/styled-ppx.0.59.1/opam
@@ -9,7 +9,7 @@ homepage: "https://styled-ppx.vercel.app"
 bug-reports: "https://github.com/davesnx/styled-ppx/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "5.1.0"}
+  "ocaml" {>= "5.1.0" & < "5.2.0"}
   "reason" {>= "3.11.0"}
   "menhir" {>= "20220210"}
   "ppx_deriving" {>= "5.0"}

--- a/packages/styled-ppx/styled-ppx.0.59.1/opam
+++ b/packages/styled-ppx/styled-ppx.0.59.1/opam
@@ -4,7 +4,7 @@ description:
   "styled-ppx is the ppx that brings styled components to ReScript and Melange, allowing you to create React Components with type-safe style definitions using CSS."
 maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
 authors: ["David Sancho <dsnxmoreno@gmail.com>"]
-license: "MIT"
+license: "BSD 2 Clause"
 homepage: "https://styled-ppx.vercel.app"
 bug-reports: "https://github.com/davesnx/styled-ppx/issues"
 depends: [

--- a/packages/styled-ppx/styled-ppx.0.59.1/opam
+++ b/packages/styled-ppx/styled-ppx.0.59.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Type-safe styled components for ReScript and Melange"
+description:
+  "styled-ppx is the ppx that brings styled components to ReScript and Melange, allowing you to create React Components with type-safe style definitions using CSS."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://styled-ppx.vercel.app"
+bug-reports: "https://github.com/davesnx/styled-ppx/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "5.1.0"}
+  "reason" {>= "3.11.0"}
+  "menhir" {>= "20220210"}
+  "ppx_deriving" {>= "5.0"}
+  "ppx_deriving_yojson" {>= "3.7.0"}
+  "ppxlib" {>= "0.27.0"}
+  "sedlex" {>= "3.2"}
+  "melange" {>= "3.0.0"}
+  "server-reason-react" {>= "0.3.1"}
+  "reason-react" {>= "0.14.0"}
+  "alcotest" {with-test}
+  "conf-npm" {with-test}
+  "reason-react-ppx" {with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+  "utop" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/styled-ppx.git"
+depexts: [
+  ["@emotion/css"] {npm-version = ">=11.0.0"}
+]
+url {
+  src:
+    "https://github.com/davesnx/styled-ppx/releases/download/0.59.1/styled-ppx-0.59.1.tbz"
+  checksum: [
+    "sha256=8e9aabb5b5f98be5ecf8ba733a0111bcffd5fa2cba85181a58ba791f6d01d454"
+    "sha512=fcd0cd606a2630268e8cf38e36dedfdbb1fb6171160808b486d79200c0170460cf32900741eaa7b881ceea644b31ee1dc2a555ad208ccb9ad845c3d86b83085c"
+  ]
+}
+x-commit-hash: "21b4a4bd7c7aa98eade34a1149ea4ac5a4a4a30e"

--- a/packages/styled-ppx/styled-ppx.0.59.1/opam
+++ b/packages/styled-ppx/styled-ppx.0.59.1/opam
@@ -4,7 +4,7 @@ description:
   "styled-ppx is the ppx that brings styled components to ReScript and Melange, allowing you to create React Components with type-safe style definitions using CSS."
 maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
 authors: ["David Sancho <dsnxmoreno@gmail.com>"]
-license: "BSD 2 Clause"
+license: "BSD-2-Clause"
 homepage: "https://styled-ppx.vercel.app"
 bug-reports: "https://github.com/davesnx/styled-ppx/issues"
 depends: [


### PR DESCRIPTION
Type-safe styled components for ReScript and Melange

- Project page: <a href="https://styled-ppx.vercel.app">https://styled-ppx.vercel.app</a>

##### CHANGES:

## 0.59.0
- [BREAKING] Change entry point module `CSS` (from `CssJs`) on `styled-ppx.melange`, `styled-ppx.native` and `styled-ppx.rescript` (davesnx/styled-ppx#490) (@davesnx)
- [FEATURE] Add support and interpolation for `zoom`, `will-change` and `user-select` properties (davesnx/styled-ppx#489) (@davesnx)
- [FEATURE] Support content with interpolation davesnx/styled-ppx#494 (@davesnx)
- [FEATURE] Support define CSS variables in global and use CSS variables in properties davesnx/styled-ppx#492 (@davesnx)
- [FEATURE] Support overflow with 2 values
- [FEATURE] Make animation-name abstract (@davesnx)
- [FIX] Add 100 unsupported properties, which will render properly (davesnx/styled-ppx#489) (@davesnx)
- [FIX] Inline all CSS.Var and CSS.Cascading in properties (davesnx/styled-ppx#495) (@davesnx)
- [FIX] Color with support for rgba/hsla and others with calc/min and max (davesnx/styled-ppx#495) (@davesnx)
- [FIX] Warning of kebab-case on emotion client side (davesnx/styled-ppx#493) (@davesnx)

## 0.58.1
- [BREAKING] FontFamilyName.t is now a string (@davesnx)
- [FIX] Make unsafe calls from "Cascading" be camelCase to avoid emotion's warning davesnx/styled-ppx#488 (@davesnx)
- [FIX] Keep classname when ampersand is at the end of the selector (@davesnx)
- [FIX] Fix fontFace in both melange and native (@davesnx)

## 0.58.0
- [FEATURE] Initial @container support davesnx/styled-ppx#476 (@zakybilfagih)
- [FIX] Make selector nested maintain other selectors davesnx/styled-ppx#486 (@davesnx)
- [BREAKING] Remove `Css` module, `styled_label` and friends davesnx/styled-ppx#487 (@davesnx)
- [BREAKING] Merge styled-ppx.css and styled-ppx.emotion into styled-ppx.melange davesnx/styled-ppx#487 (@davesnx)
- [BREAKING] Merge styled-ppx.css-native and styled-ppx.emotion-native into styled-ppx.native davesnx/styled-ppx#487 (@davesnx)
- [BREAKING] Merge styled-ppx.css-native and styled-ppx.emotion-native into styled-ppx.native davesnx/styled-ppx#487 (@davesnx)
- [BREAKING] Remove PseudoClass and PseudoClassParam davesnx/styled-ppx#487 (@davesnx)
- Remove functor from Css_Js_Core davesnx/styled-ppx#487 (@davesnx)
- Remove melange.js and melange.belt from styled-ppx.melange davesnx/styled-ppx#487 (@davesnx)
- Remove server-reason-react.js and server-reason-react.belt from styled-ppx.native davesnx/styled-ppx#487 (@davesnx)

## 0.57.1
- Remove public_name from alcotest_extra davesnx/styled-ppx#484 (@davesnx)
- Fix nesting for selectors (and pseudo) in native davesnx/styled-ppx#483 (@davesnx)

## 0.57.0

- Improvement for locations in both code-gen and error reporting by @davesnx in https://github.com/davesnx/styled-ppx/pull/456
- Support css min and max functions by @lubegasimon in https://github.com/davesnx/styled-ppx/pull/411
- Update docs by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/457
- update server-reason-react pin to main branch by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/460
- Native support for styled.{{tag}} by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/461
- Fix linear-gradient and radial-gradient  by @davesnx in https://github.com/davesnx/styled-ppx/pull/464
- Add getting started docs by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/459
- escape curly on remote markdown content by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/466
- Add Melange and native instructions by @davesnx in https://github.com/davesnx/styled-ppx/pull/465
- Global styles for native server on emotion by @pedrobslisboa in https://github.com/davesnx/styled-ppx/pull/468
- Style HTML tag by @pedrobslisboa in https://github.com/davesnx/styled-ppx/pull/467
- [emotion native] Fix nested pseudoelements by @davesnx in https://github.com/davesnx/styled-ppx/pull/470
- Transform with variable handle unsafe interpolation by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/471
- Add depext for @emotion/css >= 11.0.0 by @feihong in https://github.com/davesnx/styled-ppx/pull/473
- Add support for transition by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/472
- Fix animation codegen by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/475
- Fix error line number coming from parser by @zakybilfagih in https://github.com/davesnx/styled-ppx/pull/478
- Polish emotion-native by @davesnx in https://github.com/davesnx/styled-ppx/pull/481
- Rename `render_style_tag` to `get_stylesheet` (@davesnx)
- Docs: Explain show server rendered stylesheets work natively by @ManasJayanth in https://github.com/davesnx/styled-ppx/pull/480

## 0.56.0

- Improvement for locations in both code-gen and error reporting (davesnx/styled-ppx#456) by @davesnx
- Support css min and max functions (davesnx/styled-ppx#411) by @lubegasimon
- Update docs (davesnx/styled-ppx#457) by @zakybilfagih
- Native support for styled.{{tag}} (davesnx/styled-ppx#461) by @zakybilfagih
- background-clip: text support by @davesnx
- Fix linear-gradient and radial-gradient (davesnx/styled-ppx#464) by @davesnx
- Rename emotion-hash into murmur2 and remove public testing cli by @davesnx
- Use server-reason-react from opam by @davesnx
