### PR TITLE
Fix quickjs dep constraint in server-reason-react

### DIFF
--- a/packages/server-reason-react/server-reason-react.0.3.0/opam
+++ b/packages/server-reason-react/server-reason-react.0.3.0/opam
@@ -11,7 +11,7 @@ depends: [
   "reason" {>= "3.10.0"}
   "melange" {>= "3.0.0"}
   "ppxlib" {> "0.23.0"}
-  "quickjs" {>= "0.1.1"}
+  "quickjs" {>= "0.1.2"}
   "promise" {>= "1.1.2"}
   "lwt" {>= "5.6.0"}
   "lwt_ppx" {>= "2.1.0"}


### PR DESCRIPTION
There is a failure in the CI of https://github.com/ocaml/opam-repository/pull/26271 which seem to be related to server-reason-react.

When checking the revdeps `server-reason-react.0.3.0`, the following type mismatch happens.

```
# File "packages/melange.js/Js.ml", line 496, characters 44-73:
# 496 |   let fromString : string -> t = fun str -> Quickjs.RegExp.compile str ""
#                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: This expression has type
#          "(Quickjs.RegExp.t,
#           [ `Invalid_escape_sequence
#           | `Malformed_unicode_char
#           | `Nothing_to_repeat
#           | `Unexpected_end
#           | `Unknown of string ] * string)
#          Stdlib.result"
#        but an expression was expected of type "t" = "Quickjs.RegExp.t"
```

ping @davesnx