### PR TITLE
[new release] ca-certs-nss (3.101-1)

### DIFF
--- a/packages/ca-certs-nss/ca-certs-nss.3.101-1/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.101-1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "X.509 trust anchors extracted from Mozilla's NSS"
+description: """
+Trust anchors extracted from Mozilla's NSS certdata.txt package,
+to be used in MirageOS unikernels.
+"""
+maintainer: ["Hannes Mehnert <hannes@mehnert.org>"]
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+license: "ISC"
+homepage: "https://github.com/mirage/ca-certs-nss"
+doc: "https://mirage.github.io/ca-certs-nss/doc"
+bug-reports: "https://github.com/mirage/ca-certs-nss/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "mirage-crypto"
+  "mirage-clock" {>= "3.0.0"}
+  "x509" {>= "1.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "logs" {build}
+  "fmt" {build & >= "0.8.7"}
+  "bos" {build}
+  "cmdliner" {build & >= "1.1.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ca-certs-nss.git"
+tags: ["org:mirage"]
+url {
+  src:
+    "https://github.com/mirage/ca-certs-nss/releases/download/v3.101-1/ca-certs-nss-3.101-1.tbz"
+  checksum: [
+    "sha256=4cbfe7cd5b8cdbb9f2be968a5d5a162f9758de4ec9406e002fdfe99bd0ad7516"
+    "sha512=27aa27953cd1a0dd7ae44b640a1e5dd5753071cd253a6760526f6a47368f6fb5d3a6dab35e8b1ce63183dc63018bfadef7493b3b24acd52fcf891bead273b954"
+  ]
+}
+x-commit-hash: "c02166c248de0a8b8901a52643fc370f1804e3d4"


### PR DESCRIPTION
X.509 trust anchors extracted from Mozilla's NSS

- Project page: <a href="https://github.com/mirage/ca-certs-nss">https://github.com/mirage/ca-certs-nss</a>
- Documentation: <a href="https://mirage.github.io/ca-certs-nss/doc">https://mirage.github.io/ca-certs-nss/doc</a>

##### CHANGES:

* Delete `cstruct` and replace it by `string` (@dinosaure, mirage/ca-certs-nss#9)
