### PR TITLE
[new release] alcotest (5 packages) (1.8.0)

### DIFF
--- a/packages/alcotest-async/alcotest-async.1.8.0/opam
+++ b/packages/alcotest-async/alcotest-async.1.8.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Async-based helpers for Alcotest"
+description: "Async-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "re" {with-test}
+  "fmt" {with-test}
+  "cmdliner" {with-test & >= "1.2.0"}
+  "core" {>= "v0.16.0"}
+  "core_unix" {>= "v0.16.0"}
+  "base"
+  "async_kernel"
+  "ocaml" {>= "4.14.0"}
+  "alcotest" {= version}
+  "async" {>= "v0.16.0"}
+  "async_unix" {>= "v0.16.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.8.0/alcotest-1.8.0.tbz"
+  checksum: [
+    "sha256=cba1bd01707c8c55b4764bb0df8c9c732be321e1f1c1a96a406e56d8dbca1d0e"
+    "sha512=eebb034c990abd253f526e848a99881686d7bd3c7d1b1d373953d568d062e3d5aaa79b6b4807455aaa9a98710eca4ada30e816a0134717a380619a597575564d"
+  ]
+}
+x-commit-hash: "6313c95008cc5d87888cdd86ae1c25e50627f466"

--- a/packages/alcotest-js/alcotest-js.1.8.0/opam
+++ b/packages/alcotest-js/alcotest-js.1.8.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Virtual package containing optional JavaScript dependencies for Alcotest"
+description:
+  "Virtual package containing optional JavaScript dependencies for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "alcotest" {= version}
+  "js_of_ocaml-compiler" {>= "3.11.0"}
+  "fmt" {with-test & >= "0.8.7"}
+  "cmdliner" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@runtest-js" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.8.0/alcotest-1.8.0.tbz"
+  checksum: [
+    "sha256=cba1bd01707c8c55b4764bb0df8c9c732be321e1f1c1a96a406e56d8dbca1d0e"
+    "sha512=eebb034c990abd253f526e848a99881686d7bd3c7d1b1d373953d568d062e3d5aaa79b6b4807455aaa9a98710eca4ada30e816a0134717a380619a597575564d"
+  ]
+}
+x-commit-hash: "6313c95008cc5d87888cdd86ae1c25e50627f466"

--- a/packages/alcotest-lwt/alcotest-lwt.1.8.0/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.1.8.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Lwt-based helpers for Alcotest"
+description: "Lwt-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "re" {with-test}
+  "cmdliner" {with-test & >= "1.2.0"}
+  "fmt"
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {= version}
+  "lwt"
+  "logs"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.8.0/alcotest-1.8.0.tbz"
+  checksum: [
+    "sha256=cba1bd01707c8c55b4764bb0df8c9c732be321e1f1c1a96a406e56d8dbca1d0e"
+    "sha512=eebb034c990abd253f526e848a99881686d7bd3c7d1b1d373953d568d062e3d5aaa79b6b4807455aaa9a98710eca4ada30e816a0134717a380619a597575564d"
+  ]
+}
+x-commit-hash: "6313c95008cc5d87888cdd86ae1c25e50627f466"

--- a/packages/alcotest-mirage/alcotest-mirage.1.8.0/opam
+++ b/packages/alcotest-mirage/alcotest-mirage.1.8.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Mirage implementation for Alcotest"
+description: "Mirage implementation for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "re" {with-test}
+  "cmdliner" {with-test & >= "1.2.0"}
+  "fmt"
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {= version}
+  "mirage-clock" {>= "2.0.0"}
+  "duration"
+  "lwt"
+  "logs"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.8.0/alcotest-1.8.0.tbz"
+  checksum: [
+    "sha256=cba1bd01707c8c55b4764bb0df8c9c732be321e1f1c1a96a406e56d8dbca1d0e"
+    "sha512=eebb034c990abd253f526e848a99881686d7bd3c7d1b1d373953d568d062e3d5aaa79b6b4807455aaa9a98710eca4ada30e816a0134717a380619a597575564d"
+  ]
+}
+x-commit-hash: "6313c95008cc5d87888cdd86ae1c25e50627f466"

--- a/packages/alcotest/alcotest.1.8.0/opam
+++ b/packages/alcotest/alcotest.1.8.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Alcotest is a lightweight and colourful test framework"
+description: """
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "cmdliner" {>= "1.2.0"}
+  "re" {>= "1.7.2"}
+  "stdlib-shims"
+  "uutf" {>= "1.0.1"}
+  "ocaml-syntax-shims"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "js_of_ocaml-compiler" {< "5.8"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.8.0/alcotest-1.8.0.tbz"
+  checksum: [
+    "sha256=cba1bd01707c8c55b4764bb0df8c9c732be321e1f1c1a96a406e56d8dbca1d0e"
+    "sha512=eebb034c990abd253f526e848a99881686d7bd3c7d1b1d373953d568d062e3d5aaa79b6b4807455aaa9a98710eca4ada30e816a0134717a380619a597575564d"
+  ]
+}
+x-commit-hash: "6313c95008cc5d87888cdd86ae1c25e50627f466"


### PR DESCRIPTION
Alcotest is a lightweight and colourful test framework

- Project page: <a href="https://github.com/mirage/alcotest">https://github.com/mirage/alcotest</a>
- Documentation: <a href="https://mirage.github.io/alcotest">https://mirage.github.io/alcotest</a>

##### CHANGES:

- Add `match_raises`, a generalized version of `check_raises`
  (mirage/alcotest#88, mirage/alcotest#386, @JoanThibault)

- Update JaneStreet core and async to v0.16 (mirage/alcotest#390 @tmcgilchrist)

- Fix division by zero when size of the terminal is incorrectly
  reported as zero. (fix mirage/alcotest#356, mirage/alcotest#381, @MisterDA)

- Enable terminal size reporting on macOS and Windows. Also report the
  terminal size even when the test is run buffered by Dune.
  (mirage/alcotest#381, mirage/alcotest#396, @MisterDA)

- Allow overriding the number of columns with `ALCOTEST_COLUMNS` env
  var. (mirage/alcotest#322, mirage/alcotest#381, @MisterDA)

- Be able to allocate and use user's formatters for stdout/stderr
  (mirage/alcotest#399, @dinosaure)

- Stop detecting ocamlci specifically, since there's nothing specific
  about it. Simply use the `CI` env var to detect CIs. Improve CI
  detection.
  (mirage/alcotest#397, @MisterDA)
