### PR TITLE
Package cpdf.2.7.1

### DIFF
--- a/packages/cpdf/cpdf.2.7.1/opam
+++ b/packages/cpdf/cpdf.2.7.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "contact@coherentgraphics.co.uk"
+license: "AGPL-3.0-or-later"
+build: [[make]]
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "ocamlfind" {build}
+  "camlpdf" {= version}
+]
+homepage: "http://github.com/johnwhitington/cpdf-source"
+authors: ["John Whitington"]
+bug-reports: "http://github.com/johnwhitington/cpdf-source/issues"
+dev-repo: "git+https://github.com/johnwhitington/cpdf-source"
+install: [[make "install"]]
+synopsis: "PDF command line tools"
+url {
+  src:
+    "https://github.com/johnwhitington/cpdf-source/archive/refs/tags/v2.7.1.tar.gz"
+  checksum: [
+    "md5=9dc2502c6e97a786cdd1af5e1db5a2e1"
+    "sha512=b23c1c151f095d11b6c3c56766cdc05aa6b12a0e1224880a050f69f67c4d40053f2415ac3f9e54233bf8314ca8bdfccc2c65dd44b0c6d60ae8d7c08b1c411a04"
+  ]
+}


### PR DESCRIPTION
### `cpdf.2.7.1`
PDF command line tools



---
* Homepage: http://github.com/johnwhitington/cpdf-source
* Source repo: git+https://github.com/johnwhitington/cpdf-source
* Bug tracker: http://github.com/johnwhitington/cpdf-source/issues

---
:camel: Pull-request generated by opam-publish v2.3.1