### PR TITLE
OCaml 5.2.0 manual package

### DIFF
--- a/packages/ocaml-manual/ocaml-manual.5.2.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.5.2.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "Xavier Leroy"
+           "Damien Doligez"
+           "Alain Frisch"
+           "Jacques Garrigue"
+           "Didier Rémy"
+           "Jérôme Vouillon" ]
+homepage: "http://ocaml.org/"
+doc: "https://ocaml.org/manual/"
+license: "CC-BY-SA-4.0"
+dev-repo: "git+https://github.com/ocaml/ocaml.git"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+install:
+[
+ [ "cp" "-R" "." _:doc ] {os != "win32"}
+ [ "robocopy" "/E" "." _:doc ] {os = "win32"}
+]
+synopsis: "The OCaml system manual"
+depends: [
+  "ocaml" {>= "5.2.0" & < "5.2.1"}
+]
+url {
+  src: "http://caml.inria.fr/distrib/ocaml-5.2/ocaml-5.2-refman-html.tar.gz"
+  checksum: "sha256=361b7096d0092b11b96f0beee217af2b8c6fe3981145a2c4b4d43d656e4dcaf5"
+}


### PR DESCRIPTION
This PR adds the 5.2.0 package for the ocaml manual (that I had forgotten to update until now).