### PR TITLE
[new release] parsite (0.11-4-g420e9bd)

### DIFF
--- a/packages/parsite/parsite.0.11-4-g420e9bd/opam
+++ b/packages/parsite/parsite.0.11-4-g420e9bd/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A micro library for simple parsing combinators"
+description: "A micro library for simple parsing combinators"
+maintainer: ["faber-1"]
+authors: ["faber-1"]
+license: "MIT"
+tags: [
+  "string"
+  "ocaml"
+  "functional-programming"
+  "parsing-combinators"
+  "parsing-library"
+]
+homepage: "https://github.com/faber-1/parsite"
+doc: "https://faber-1.github.io/parsite/"
+bug-reports: "https://github.com/faber-1/parsite/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.13"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/faber-1/parsite.git"
+url {
+  src:
+    "https://github.com/faber-1/parsite/releases/download/0.11-4-g420e9bd/parsite-0.11-4-g420e9bd.tbz"
+  checksum: [
+    "sha256=cb5fdf15797b69f81bd4681a25a411d65624dda325f89230f8c0e5dd3031a1a3"
+    "sha512=aae6705a5997e422f29280a30f95e4fb8b669f41c117f1ff1b1443e1ec6f5788a1798befa55ecea36c9fbf5211d7dfb7046f4cf30a5cf0471d2e55b91ec1dd86"
+  ]
+}
+x-commit-hash: "420e9bd87d43286f410205beb419dd80f6e90bfa"


### PR DESCRIPTION
A micro library for simple parsing combinators

- Project page: <a href="https://github.com/faber-1/parsite">https://github.com/faber-1/parsite</a>
- Documentation: <a href="https://faber-1.github.io/parsite/">https://faber-1.github.io/parsite/</a>

##### CHANGES:

- Changed name of `result` to `p_result` and `ResultM` to `PResultM` to avoid conflict with OCaml result type (also keeps naming convention of library and functions consistent)
- Fixed dune issues
- Working on docs
