### PR TITLE
[new release] parsite (0.11)

### DIFF
--- a/packages/parsite/parsite.0.11/opam
+++ b/packages/parsite/parsite.0.11/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A micro library for simple parsing combinators"
+description: "A micro library for simple parsing combinators"
+maintainer: ["faber-1"]
+authors: ["faber-1"]
+license: "MIT"
+tags: [
+  "string"
+  "ocaml"
+  "functional-programming"
+  "parsing-combinators"
+  "parsing-library"
+]
+homepage: "https://github.com/faber-1/parsite"
+doc: "https://faber-1.github.io/parsite/"
+bug-reports: "https://github.com/faber-1/parsite/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {>= "3.13"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/faber-1/parsite.git"
+url {
+  src:
+    "https://github.com/faber-1/parsite/releases/download/v0.11/parsite-0.11.tbz"
+  checksum: [
+    "sha256=654c89765c65b459caa3b6838ef10d57f36bc95611a02664d4f7f08e147ce19a"
+    "sha512=bc68346d333975af0c6d0ff7b4ff44c4446a3b9cd962ad29d6fd15fea4325c261606b53b4bc16c7782e59da9085dcbfd6336124249889e45b08acd2e6a4bb11f"
+  ]
+}
+x-commit-hash: "ec2aae41121e251612cff2726549c9a51bdfc0e2"


### PR DESCRIPTION
A micro library for simple parsing combinators

- Project page: <a href="https://github.com/faber-1/parsite">https://github.com/faber-1/parsite</a>
- Documentation: <a href="https://faber-1.github.io/parsite/">https://faber-1.github.io/parsite/</a>

##### CHANGES:

- Changed name of `result` to `p_result` and `ResultM` to `PResultM` to avoid conflict with OCaml result type (also keeps naming convention of library and functions consistent)
- Fixed dune issues
- Working on docs
