### PR TITLE
Fix smtml.0.2.3 and Package smtml.0.2.4

### DIFF
--- a/packages/smtml/smtml.0.2.4/opam
+++ b/packages/smtml/smtml.0.2.4/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/formalsec/smtml/issues"
 depends: [
   "dune" {>= "3.10"}
   "ocaml" {>= "4.14.0"}
-  "prelude" {>= "0.2" & < "0.3"}
+  "prelude" {>= "0.3"}
   "ocaml_intrinsics"
   "fmt" {>= "0.8.7"}
   "cmdliner" {>= "1.2.0"}
@@ -50,9 +50,9 @@ build: [
 dev-repo: "git+https://github.com/formalsec/smtml.git"
 available: arch != "arm32" & arch != "x86_32"
 url {
-  src: "https://github.com/formalsec/smtml/archive/refs/tags/v0.2.3.tar.gz"
+  src: "https://github.com/formalsec/smtml/archive/refs/tags/v0.2.4.tar.gz"
   checksum: [
-    "md5=b984b48856b792a4bc2d88c43d2c631f"
-    "sha512=c8b89cc96c258bfca39bba17c99269f5b85f8cedc44ea6c83316b61f0cc6c22b6e4879bd71ffe141df51788b47d8211ec5780dcd05a61b1376f2796e4aedfee7"
+    "md5=5a7e7474e1953a96e7bc159ef6f4659b"
+    "sha512=7426252d9e8086011817c786a84f26fce4b7f63d4fcf9d9f42c7d11174eac5a263d3ac663b0b75fd687a5e43f242781c04efd683662f42a6152dda1aa9dca2b1"
   ]
 }


### PR DESCRIPTION
This fixes problems with reverse dependencies in https://github.com/ocaml/opam-repository/pull/26291 and publishes release 0.2.4 (which depends on https://github.com/ocaml/opam-repository/pull/26291, so I'll leave this as a draft until that is merged).