### PR TITLE
[new release] ppx_heml (0.1.0)

### DIFF
--- a/packages/ppx_heml/ppx_heml.0.1.0/opam
+++ b/packages/ppx_heml/ppx_heml.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "PPX for deriving HTML templates"
+description: "PPX for deriving HTML templates. Includes %heml"
+maintainer: ["Petri-Johan Last"]
+authors: ["Petri-Johan Last"]
+license: "MIT"
+tags: ["topics" "to describe" "your" "project"]
+homepage: "https://github.com/pjlast/heml"
+bug-reports: "https://github.com/pjlast/heml/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.16"}
+  "ppxlib"
+  "base"
+  "ppx_string"
+  "menhir" {build}
+  "ppx_inline_test" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/pjlast/heml.git"
+url {
+  src:
+    "https://github.com/pjlast/heml/releases/download/v0.1.0/ppx_heml-0.1.0.tbz"
+  checksum: [
+    "sha256=c7d369e204477bf80a690d71a4a47c1baab2c0a0a2e16f8da4fb9a89b3000a5a"
+    "sha512=c11f2cdc73d285a71b4c9c84bc63c644996965d5649cc0a50c72b6c19790cbe7c97f9426422c3b7341804ac946284e7ce9a58b880474588f25ffa95e540c3698"
+  ]
+}
+x-commit-hash: "69c0346bf48f8639ef92f2efa214e0b25e8bf608"


### PR DESCRIPTION
PPX for deriving HTML templates

- Project page: <a href="https://github.com/pjlast/heml">https://github.com/pjlast/heml</a>

##### CHANGES:

* Initial release
