### PR TITLE
[new release] ppx_heml (0.1.0)

### DIFF
--- a/packages/ppx_heml/ppx_heml.0.1.0/opam
+++ b/packages/ppx_heml/ppx_heml.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "PPX for deriving HTML templates"
+description: "PPX for deriving HTML templates. Includes %heml"
+maintainer: ["Petri-Johan Last"]
+authors: ["Petri-Johan Last"]
+license: "MIT"
+tags: ["topics" "to describe" "your" "project"]
+homepage: "https://github.com/pjlast/heml"
+bug-reports: "https://github.com/pjlast/heml/issues"
+depends: [
+  "ocaml" {>= "5.0"}
+  "dune" {>= "3.16"}
+  "ppxlib"
+  "base"
+  "ppx_string"
+  "menhir" {build}
+  "ppx_inline_test" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/pjlast/heml.git"
+url {
+  src:
+    "https://github.com/pjlast/heml/releases/download/v0.1.0/ppx_heml-0.1.0.tbz"
+  checksum: [
+    "sha256=f87c0743f9d798a7f31a8f5abdae9374a838497fb2306d0bf6b729a4e65ae170"
+    "sha512=6fedbc58c4c472f90c46f581c199b85620fa911a3cd57dd33290e9dd472b7dd269d0529594a6ac7b973d10a7f293637cd751a0a799b3bcaa0fc1c7a1934d7095"
+  ]
+}
+x-commit-hash: "557bc3e82f6722f5f491f35c62c18468ad41b722"


### PR DESCRIPTION
PPX for deriving HTML templates

- Project page: <a href="https://github.com/pjlast/heml">https://github.com/pjlast/heml</a>

##### CHANGES:

* Initial release
