### PR TITLE
disable melange 4.0.0-52

### DIFF
--- a/packages/melange/melange.4.0.0-52/opam
+++ b/packages/melange/melange.4.0.0-52/opam
@@ -32,7 +32,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-available: arch != "x86_32" & arch != "arm32"
+available: false
 dev-repo: "git+https://github.com/melange-re/melange.git"
 url {
   src:


### PR DESCRIPTION
didn't have support for `-bin-annot-occurrences`