### PR TITLE
[new release] ppx_blob (0.9.0)

### DIFF
--- a/packages/ppx_blob/ppx_blob.0.9.0/opam
+++ b/packages/ppx_blob/ppx_blob.0.9.0/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.08"}
   "dune" {>= "1.11"}
   "ppxlib" {>= "0.9.0"}
   "alcotest" {with-test}

--- a/packages/ppx_blob/ppx_blob.0.9.0/opam
+++ b/packages/ppx_blob/ppx_blob.0.9.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+authors: "John Whitington"
+maintainer: "contact@coherentgraphics.co.uk"
+homepage: "https://github.com/johnwhitington/ppx_blob"
+dev-repo: "git+https://github.com/johnwhitington/ppx_blob.git"
+bug-reports: "https://github.com/johnwhitington/ppx_blob/issues/"
+doc: "https://johnwhitington.github.io/ppx_blob/"
+license: "Unlicense"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "ppxlib" {>= "0.9.0"}
+  "alcotest" {with-test}
+]
+synopsis: "Include a file as a string at compile time"
+description:
+  "ppx_blob allows you to include a binary blob from a file as a string. Writing `[%blob \"filename\"]` will replace the string with the contents of the file at compile time. This allows the inclusion of arbitary, possibly compressed, data, without the need to respect OCaml's lexical conventions."
+url {
+  src:
+    "https://github.com/johnwhitington/ppx_blob/releases/download/0.9.0/ppx_blob-0.9.0.tbz"
+  checksum: [
+    "sha256=f115e90a5f1075cedc9d930ab91271f8670ece4dee10dc1147ab39b8afb570e4"
+    "sha512=bad11f8ffbec82a04bb5f90e7548a7ad9ac4bf7e9b733815f6c956d7e0002fb258c52783ded847ab09fe3cd60e5eac2901fccaefd4fd4f885f20942d0ef66fea"
+  ]
+}
+x-commit-hash: "38c7693141bd629b70cd8a17306f5ce359ea9c59"


### PR DESCRIPTION
Include a file as a string at compile time

- Project page: <a href="https://github.com/johnwhitington/ppx_blob">https://github.com/johnwhitington/ppx_blob</a>
- Documentation: <a href="https://johnwhitington.github.io/ppx_blob/">https://johnwhitington.github.io/ppx_blob/</a>

##### CHANGES:

- Absolute paths are no longer concatenated with the source directory to
  form a blob candidate path: they are only treated as absolute paths.
- Minor robustness improvements (reminder: this happens at build time):
  - Reading is done in one pass (instead of checking for existence first).
  - Only the first good path is queried (instead of both).
  - Better I/O error handling.
