### PR TITLE
[new release] lsp (3 packages) (1.19.0)

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.19.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.19.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.19.0/lsp-1.19.0.tbz"
+  checksum: [
+    "sha256=e783d9f1a7f89ce1bf4c9148aa34a228368bd149bbcca43de80b459221dee5ec"
+    "sha512=85c233a7a14d38e76b3d28694054b04fb818290d2c4c009e7ce189040e2aab570ee0caaf1a826b064fb1595f29b696932daea9f6812d3dfa9b6f0387e02e254b"
+  ]
+}
+x-commit-hash: "45f5ddac12bb580b4ecaec2d93ee7fac2c903aff"

--- a/packages/lsp/lsp.1.19.0/opam
+++ b/packages/lsp/lsp.1.19.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "jsonrpc" {= version}
+  "yojson"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "cinaps" {with-test}
+  "ppx_expect" {>= "v0.15.0" & < "0.17.0" & with-test}
+  "uutf" {>= "1.0.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.14"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.19.0/lsp-1.19.0.tbz"
+  checksum: [
+    "sha256=e783d9f1a7f89ce1bf4c9148aa34a228368bd149bbcca43de80b459221dee5ec"
+    "sha512=85c233a7a14d38e76b3d28694054b04fb818290d2c4c009e7ce189040e2aab570ee0caaf1a826b064fb1595f29b696932daea9f6812d3dfa9b6f0387e02e254b"
+  ]
+}
+x-commit-hash: "45f5ddac12bb580b4ecaec2d93ee7fac2c903aff"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson"
+  "base"
+  "lsp" {= version}
+  "jsonrpc" {= version}
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc" {>= "3.4.0"}
+  "chrome-trace" {>= "3.3.0"}
+  "dyn"
+  "stdune"
+  "fiber" {>= "3.1.1" & < "4.0.0"}
+  "ocaml" {>= "5.2.0"}
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "astring"
+  "camlp-streams"
+  "ppx_expect" {>= "v0.15.0" & < "0.17.0" & with-test}
+  "ocamlformat" {with-test & = "0.26.2"}
+  "ocamlc-loc" {>= "3.7.0"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "merlin-lib" {>= "5.0" & < "6.0"}
+  "ocaml-index" {>= "1.0" & post}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.19.0/lsp-1.19.0.tbz"
+  checksum: [
+    "sha256=e783d9f1a7f89ce1bf4c9148aa34a228368bd149bbcca43de80b459221dee5ec"
+    "sha512=85c233a7a14d38e76b3d28694054b04fb818290d2c4c009e7ce189040e2aab570ee0caaf1a826b064fb1595f29b696932daea9f6812d3dfa9b6f0387e02e254b"
+  ]
+}
+x-commit-hash: "45f5ddac12bb580b4ecaec2d93ee7fac2c903aff"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
   "dune" {>= "3.0"}
   "yojson"
-  "base"
+  "base" {>= "v0.16.0"}
   "lsp" {= version}
   "jsonrpc" {= version}
   "re" {>= "1.5.0"}

--- a/packages/vscoq-language-server/vscoq-language-server.2.0.1+coq8.18/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.0.1+coq8.18/opam
@@ -26,7 +26,7 @@ depends: [
   "ppx_yojson_conv"
   "ppx_import"
   "result" { >= "1.5" }
-  "lsp" { >= "1.15"}
+  "lsp" { >= "1.15" & < "1.19.0" }
   "sel" {>= "0.4.0"}
 ]
 synopsis: "VSCoq language server"

--- a/packages/vscoq-language-server/vscoq-language-server.2.0.2+coq8.18/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.0.2+coq8.18/opam
@@ -26,7 +26,7 @@ depends: [
   "ppx_yojson_conv"
   "ppx_import"
   "result" { >= "1.5" }
-  "lsp" { >= "1.15"}
+  "lsp" { >= "1.15" & < "1.19.0" }
   "sel" {>= "0.4.0"}
 ]
 synopsis: "VSCoq language server"

--- a/packages/vscoq-language-server/vscoq-language-server.2.0.3+coq8.18/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.0.3+coq8.18/opam
@@ -26,7 +26,7 @@ depends: [
   "ppx_yojson_conv"
   "ppx_import"
   "result" { >= "1.5" }
-  "lsp" { >= "1.15"}
+  "lsp" { >= "1.15" & < "1.19.0" }
   "sel" {>= "0.4.0"}
 ]
 synopsis: "VSCoq language server"

--- a/packages/vscoq-language-server/vscoq-language-server.2.1.0+coq8.19/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.1.0+coq8.19/opam
@@ -27,7 +27,7 @@ depends: [
   "ppx_import"
   "ppx_optcomp"
   "result" { >= "1.5" }
-  "lsp" { >= "1.15"}
+  "lsp" { >= "1.15" & < "1.19.0" }
   "sel" {>= "0.4.0"}
 ]
 synopsis: "VSCoq language server"

--- a/packages/vscoq-language-server/vscoq-language-server.2.1.2/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.1.2/opam
@@ -27,7 +27,7 @@ depends: [
   "ppx_import"
   "ppx_optcomp"
   "result" { >= "1.5" }
-  "lsp" { >= "1.15"}
+  "lsp" { >= "1.15" & < "1.19.0" }
   "sel" {>= "0.4.0"}
 ]
 synopsis: "VSCoq language server"

--- a/packages/vscoq-language-server/vscoq-language-server.2.1.3/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.1.3/opam
@@ -27,7 +27,7 @@ depends: [
   "ppx_import"
   "ppx_optcomp"
   "result" { >= "1.5" }
-  "lsp" { >= "1.15"}
+  "lsp" { >= "1.15" & < "1.19.0" }
   "sel" {>= "0.4.0"}
 ]
 synopsis: "VSCoq language server"

--- a/packages/vscoq-language-server/vscoq-language-server.2.1.4/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.1.4/opam
@@ -27,7 +27,7 @@ depends: [
   "ppx_import"
   "ppx_optcomp"
   "result" { >= "1.5" }
-  "lsp" { >= "1.15"}
+  "lsp" { >= "1.15" & < "1.19.0" }
   "sel" {>= "0.4.0"}
 ]
 synopsis: "VSCoq language server"


### PR DESCRIPTION
LSP protocol implementation in OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-lsp">https://github.com/ocaml/ocaml-lsp</a>

##### CHANGES:

## Features

- Add custom [`ocamllsp/getDocumentation`](/ocaml-lsp-server/docs/ocamllsp/getDocumentation-spec.md) request (ocaml/ocaml-lsp#1336)
- Add support for OCaml 5.2 (ocaml/ocaml-lsp#1233)

## Fixes

- Kill unnecessary ocamlformat processes with sigterm rather than sigint or
  sigkill (ocaml/ocaml-lsp#1343)
