### PR TITLE
Package ldap.2.5.0

### DIFF
--- a/packages/ldap/ldap.2.5.0/opam
+++ b/packages/ldap/ldap.2.5.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Implementation of the Light Weight Directory Access Protocol"
+maintainer: "Kate <kit-ty-kate@outlook.com>"
+authors: "Eric Stokes <letaris@me.com>"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+tags: "ldap"
+homepage: "https://github.com/kit-ty-kate/ocamldap"
+doc: "https://kit-ty-kate.github.io/ocamldap"
+bug-reports: "https://github.com/kit-ty-kate/ocamldap/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.03.0"}
+  "ocamlnet" {>= "3.6.0"}
+  "re" {>= "1.3.0"}
+  "camlp-streams" {>= "5.0.1"}
+  "ssl" {>= "0.5.3"}
+]
+conflicts: [
+  "ocamldap" {!= "transition"}
+]
+build: [
+  "dune"
+  "build"
+  "-p"
+  name
+  "-j"
+  jobs
+  "@install"
+  "@runtest" {with-test}
+]
+dev-repo: "git+https://github.com/kit-ty-kate/ocamldap.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/ocamldap/archive/refs/tags/2.5.0.tar.gz"
+  checksum: [
+    "md5=2dade90cd31811bd502f1af9b49d4e71"
+    "sha512=d82728589ad786e8589578861c519c24c1af467e233ff0c5bfe37471753feb2c0c927ab3cd2fff5821ab01679c910288806928b4ec1fb8aea9fade8e5d7d0c2a"
+  ]
+}


### PR DESCRIPTION
### `ldap.2.5.0`
Implementation of the Light Weight Directory Access Protocol



---
* Homepage: https://github.com/kit-ty-kate/ocamldap
* Source repo: git+https://github.com/kit-ty-kate/ocamldap.git
* Bug tracker: https://github.com/kit-ty-kate/ocamldap/issues

---
:camel: Pull-request generated by opam-publish v2.3.1