### PR TITLE
Make spotify_ml.push unavailable, the version should have been 0.0.1

### DIFF
--- a/packages/spotify_ml/spotify_ml.push/opam
+++ b/packages/spotify_ml/spotify_ml.push/opam
@@ -32,6 +32,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: false
 dev-repo: "git+https://github.com/maxrn/spotify_ml.git"
 url {
   src:


### PR DESCRIPTION
@raphael-proust I think we should revert the original PR or remove the package altogether.

in the meantime merging this as a fix