### PR TITLE
[new release] parsite (0.1.2)

### DIFF
--- a/packages/parsite/parsite.0.1.2/opam
+++ b/packages/parsite/parsite.0.1.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "A micro library for simple parsing combinators"
+description: "A micro library for simple parsing combinators"
+maintainer: ["faber-1"]
+authors: ["faber-1"]
+license: "MIT"
+tags: [
+  "string"
+  "ocaml"
+  "functional-programming"
+  "parsing-combinators"
+  "parsing-library"
+]
+homepage: "https://github.com/faber-1/parsite"
+doc: "https://faber-1.github.io/parsite/"
+bug-reports: "https://github.com/faber-1/parsite/issues"
+depends: [
+  "ocaml" {>= "4.07"}
+  "dune" {>= "3.13"}
+  "ounit2"
+  "odoc"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/faber-1/parsite.git"
+url {
+  src:
+    "https://github.com/faber-1/parsite/releases/download/v0.1.2/parsite-0.1.2.tbz"
+  checksum: [
+    "sha256=15f763e9d98014be41677913974ade7c1346bc5f8cae927b7fd24984c251879c"
+    "sha512=9fabb389cc6f68fa8b106a9939d41651824693192a1feb67cfda034e9bb18dd6c7702a43da10943ff462f762b5178349894291596fc1e1384c9b4e161de1551d"
+  ]
+}
+x-commit-hash: "cdc542118dae33d9de6ef8e878a9c09f9aded44a"


### PR DESCRIPTION
A micro library for simple parsing combinators

- Project page: <a href="https://github.com/faber-1/parsite">https://github.com/faber-1/parsite</a>
- Documentation: <a href="https://faber-1.github.io/parsite/">https://faber-1.github.io/parsite/</a>

##### CHANGES:

- Added `fail` and `( =<< )` functions to `PResultM` monad.
- Rewrote some functions to use `fail` and `( =<< )` functions.
- Fixed up docs heavily.
- Changed version scheme to match OCaml style
