### PR TITLE
[new release] dockerfile, dockerfile-opam, dockerfile-cmd (8.2.2)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.8.2.2/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.2.2/opam
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- generation support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically.
+"""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile-cmd/"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "bos" {>= "0.2"}
+  "cmdliner"
+  "dockerfile-opam" {= version}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.2.2/dockerfile-8.2.2.tbz"
+  checksum: [
+    "sha256=c862934be41936d65fbf7ca89d8699adc3deb22d0fb4e0e0e8505342a107c5ab"
+    "sha512=a5300fd66567c02b3987801f1905a3d15f1f7217d3c83ff70a1190520c3a000ef256541d3b471df26be52e245c187b4f12e20c5bb6e6f033a1a185cd5c96428b"
+  ]
+}
+x-commit-hash: "2f7379b072897cb42fa62f70ca7f49a5598f50f6"

--- a/packages/dockerfile-opam/dockerfile-opam.8.2.2/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.8.2.2/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution support
+for generating dockerfiles.
+"""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile-opam/"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "astring"
+  "dockerfile" {= version}
+  "fmt" {>= "0.8.7"}
+  "ocaml-version" {>= "3.5.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.2.2/dockerfile-8.2.2.tbz"
+  checksum: [
+    "sha256=c862934be41936d65fbf7ca89d8699adc3deb22d0fb4e0e0e8505342a107c5ab"
+    "sha512=a5300fd66567c02b3987801f1905a3d15f1f7217d3c83ff70a1190520c3a000ef256541d3b471df26be52e245c187b4f12e20c5bb6e6f033a1a185cd5c96428b"
+  ]
+}
+x-commit-hash: "2f7379b072897cb42fa62f70ca7f49a5598f50f6"

--- a/packages/dockerfile/dockerfile.8.2.2/opam
+++ b/packages/dockerfile/dockerfile.8.2.2/opam
@@ -36,6 +36,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
+  "alcotest" {>= "1.7.0" & with-test}
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/packages/dockerfile/dockerfile.8.2.2/opam
+++ b/packages/dockerfile/dockerfile.8.2.2/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+"""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile/"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "fmt" {>= "0.8.7"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.2.2/dockerfile-8.2.2.tbz"
+  checksum: [
+    "sha256=c862934be41936d65fbf7ca89d8699adc3deb22d0fb4e0e0e8505342a107c5ab"
+    "sha512=a5300fd66567c02b3987801f1905a3d15f1f7217d3c83ff70a1190520c3a000ef256541d3b471df26be52e245c187b4f12e20c5bb6e6f033a1a185cd5c96428b"
+  ]
+}
+x-commit-hash: "2f7379b072897cb42fa62f70ca7f49a5598f50f6"


### PR DESCRIPTION
Dockerfile eDSL in OCaml

- Project page: https://github.com/ocurrent/ocaml-dockerfile
- Documentation: https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile/

Changes:

- Added Opam 2.2 (@mtelvers, ocurrent/ocaml-dockerfile#215)
- Deprecate Ubuntu 23.10. (@mtelvers, ocurrent/ocaml-dockerfile#214)
- Deprecate Ubuntu 23.04. (@punchagan, ocurrent/ocaml-dockerfile#213)
- Deprecate Fedora 38. (@mtelvers, ocurrent/ocaml-dockerfile#211)
- Deprecate Debian 10. (@shonfeder, ocurrent/ocaml-dockerfile#210)
- Add Ubuntu 24.04. (@mtelvers, ocurrent/ocaml-dockerfile#205)
- Add Fedora 40, deprecate Fedora 37. (@mtelvers, ocurrent/ocaml-dockerfile#203)
- Refactored Windows builds (@mtelvers, ocurrent/ocaml-dockerfile#201)
- Add Fedora 39. (@MisterDA ocurrent/ocaml-dockerfile#200)
- Add Alpine 3.20, deprecate Alpine 3.18, 3.19. (@MisterDA ocurrent/ocaml-dockerfile#167, ocurrent/ocaml-dockerfile#197, ocurrent/ocaml-dockerfile#199, ocurrent/ocaml-dockerfile#207)
- Support formatting RUN heredocs. (@MisterDA ocurrent/ocaml-dockerfile#193 ocurrent/ocaml-dockerfile#195, reported by @kit-ty-kate)
- Turned off address space layout randomization on Windows 1809. (@mtelvers ocurrent/ocaml-dockerfile#196)
- Add Ubuntu 23.10. (@MisterDA ocurrent/ocaml-dockerfile#189)
- Deprecate Ubuntu 22.10 it is now EOL. (@tmcgilchrist ocurrent/ocaml-dockerfile#184).
- Support `--start-interval` in `HEALTCHECK` Dockerfile instruction.
  (@MisterDA ocurrent/ocaml-dockerfile#183)
- Support `--keep-git-dir` in `ADD` Dockerfile instruction. (@MisterDA ocurrent/ocaml-dockerfile#182)
- Add Debian 12 as main distribution. (@MisterDA ocurrent/ocaml-dockerfile#172)
- Deprecate Ubuntu 18.04 it is now EOL (@avsm).
- Deprecate Alpine 3.16 and 3.17, OracleLinux 7  and OpenSUSE 15.2 (@avsm)
- Add ARM64 builds to OpenSUSE (@mtelvers ocurrent/ocaml-dockerfile#178)
- Support `--checksum` argument in `ADD` Dockerfile instruction.
  (@MisterDA #175)
- Support `--chmod` argument in `COPY` and `ADD` Dockerfile
  instructions. (@MisterDA ocurrent/ocaml-dockerfile#174)
- Add OpenSUSE Leap 15.6 to Tier 2, deprecate 15.5 and 15.4. (@MisterDA ocurrent/ocaml-dockerfile#171, ocurrent/ocaml-dockerfile#208)
- Add OpenSUSE Tumbleweed to Tier 2. (@MisterDA ocurrent/ocaml-dockerfile#168 ocurrent/ocaml-dockerfile#169)
- Deprecate Fedora 36. (@MisterDA ocurrent/ocaml-dockerfile#170)
- Support opam new `--with-vendored-deps` configure option. (@MisterDA ocurrent/ocaml-dockerfile#165)
- Rework Windows images and update their dependencies. (@MisterDA ocurrent/ocaml-dockerfile#162)
  + Fix the origin of `Install.cmd` (avsm -> ocurrent);
  + Rename `Windows.Cygwin.install_from_release` to `install_cygwin`;
  + Rework Cygwin package list needed for opam and OCaml for Windows;
  + Remove msvs-tools from the mingw images;
  + Build opam with MSVS in the MSVS images. Explicitly set MSVS
    environment vars with msvs-detect.
  + Update to VC Redist 17 and MSVC 2022;
  + Track msvs-tools master;
  + Split MSVC build into multiple build steps;
  + Internal refactors.
- Add Ubuntu 23.04 and Fedora 38. (@mtelvers #164)
- Add newlines in some cases for better formatting.
  (@MisterDA #161, review by @benmandrew)
- Various LCU Updates. (@mtelvers ocurrent/ocaml-dockerfile#160 ocurrent/ocaml-dockerfile#166 ocurrent/ocaml-dockerfile#173 ocurrent/ocaml-dockerfile#179 ocurrent/ocaml-dockerfile#180 ocurrent/ocaml-dockerfile#185 ocurrent/ocaml-dockerfile#188)