### PR TITLE
Package ldap.2.5.1

### DIFF
--- a/packages/ldap/ldap.2.5.1/opam
+++ b/packages/ldap/ldap.2.5.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Implementation of the Light Weight Directory Access Protocol"
+maintainer: "Kate <kit-ty-kate@outlook.com>"
+authors: "Eric Stokes <letaris@me.com>"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+tags: "ldap"
+homepage: "https://github.com/kit-ty-kate/ocamldap"
+doc: "https://kit-ty-kate.github.io/ocamldap"
+bug-reports: "https://github.com/kit-ty-kate/ocamldap/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.03.0"}
+  "ocamlnet" {>= "3.6.0"}
+  "re" {>= "1.3.0"}
+  "camlp-streams" {>= "5.0.1"}
+  "ssl" {>= "0.5.3"}
+]
+conflicts: [
+  "ocamldap" {!= "transition"}
+]
+build: [
+  "dune"
+  "build"
+  "-p"
+  name
+  "-j"
+  jobs
+  "@install"
+  "@runtest" {with-test}
+]
+dev-repo: "git+https://github.com/kit-ty-kate/ocamldap.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/ocamldap/releases/download/2.5.1/ldap-2.5.1.tar.gz"
+  checksum: [
+    "md5=d28ce5956436f129dc2fb4f94f0b277a"
+    "sha512=b28e31a471321b4fcde93d47c9d7d3bf0f317be36a96116ef45a9fbd2b957f843df94cf70121b9e6d60c0a98117deba898366f0e03ec7e08ff2e4aafb6b03d5c"
+  ]
+}


### PR DESCRIPTION
### `ldap.2.5.1`
Implementation of the Light Weight Directory Access Protocol



---
* Homepage: https://github.com/kit-ty-kate/ocamldap
* Source repo: git+https://github.com/kit-ty-kate/ocamldap.git
* Bug tracker: https://github.com/kit-ty-kate/ocamldap/issues

---
:camel: Pull-request generated by opam-publish v2.3.1