### PR TITLE
[new release] sqlite3 (5.2.0)

### DIFF
--- a/packages/sqlite3/sqlite3.5.2.0/opam
+++ b/packages/sqlite3/sqlite3.5.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "SQLite3 bindings for OCaml"
+description: """
+sqlite3-ocaml is an OCaml library with bindings to the SQLite3 client API.
+Sqlite3 is a self-contained, serverless, zero-configuration, transactional SQL
+database engine with outstanding performance for many use cases."""
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christian Szegedy <csdontspam@metamatix.com>"
+]
+license: "MIT"
+tags: ["clib:sqlite3" "clib:pthread"]
+homepage: "https://mmottl.github.io/sqlite3-ocaml"
+doc: "https://mmottl.github.io/sqlite3-ocaml/api"
+bug-reports: "https://github.com/mmottl/sqlite3-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "dune-configurator"
+  "conf-sqlite3" {build}
+  "ppx_inline_test" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/sqlite3-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/sqlite3-ocaml/releases/download/5.2.0/sqlite3-5.2.0.tbz"
+  checksum: [
+    "sha256=942283a454f4b21f7517f2e8be3d3a30594779c78a6b0478f4b70b8ca7c98cbb"
+    "sha512=59ed9dfe340339228513c77f04abaf2a4b42428c0d41f4c9ced17ce24378635d4d0a71329794164ea324365e6021d954ea0ddad76a6992d71c9585f390516ad8"
+  ]
+}
+x-commit-hash: "85d8758bfb5e844192b0b4ae3fab7130deac9fe1"


### PR DESCRIPTION
SQLite3 bindings for OCaml

- Project page: <a href="https://mmottl.github.io/sqlite3-ocaml">https://mmottl.github.io/sqlite3-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/sqlite3-ocaml/api">https://mmottl.github.io/sqlite3-ocaml/api</a>

##### CHANGES:

- Support MSVC compiler (Jonah Beckford)

- Add `extended_errcode_int` function (Petter A. Urkedal)

- Fix memory alloc in `caml_sqlite3_backup_init()`
  (Mark Elvers, Pierre Boutillier, and Benjamin Canou)

- Add Github CI (Yilin Wei)

- Detect pkgconf on Windows/mingw (Mark Elvers, reviewed by Shon Feder)

- Fixed shadowing of `agg_ctx` when using `sizeof`.

- Formatted sources using `ocamlformat` and `clang-format`.

- Fixed switch syntax error flagged by cppcheck.

- Added `.editorconfig`.

- Removed superfluous macro conditions.

- Improved API documentation formatting.

- Improved README, license file, copyright notices, and changelog format.
