### PR TITLE
Add ocaml as a dependency of either

### DIFF
--- a/packages/either/either.1.0.0/opam
+++ b/packages/either/either.1.0.0/opam
@@ -13,6 +13,7 @@ doc: "https://mirage.github.io/either"
 bug-reports: "https://github.com/mirage/either/issues"
 depends: [
   "dune" {>= "2.0"}
+  "ocaml"
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
The package `either` builds with dune, and the dune executable doesn't assume that an ocaml compiler is installed when building a project. Packages that build with dune and need an ocaml compiler must depend on the `ocaml` package.

CC @craigfe 