### PR TITLE
[new release] provider (0.0.6)

### DIFF
--- a/packages/provider/provider.0.0.6/opam
+++ b/packages/provider/provider.0.0.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Parametrize your OCaml library with values that behave like objects but aren't"
+maintainer: ["Mathieu Barbin"]
+authors: ["Mathieu Barbin"]
+license: "ISC"
+homepage: "https://github.com/mbarbin/provider"
+doc: "https://mbarbin.github.io/provider/"
+bug-reports: "https://github.com/mbarbin/provider/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1"}
+  "bisect_ppx" {dev & >= "2.8.3"}
+  "ppx_js_style" {dev & >= "v0.16"}
+  "sexplib0" {>= "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/provider.git"
+url {
+  src:
+    "https://github.com/mbarbin/provider/releases/download/0.0.6/provider-0.0.6.tbz"
+  checksum: [
+    "sha256=b8c23c6cccf421e620d40798ab1876e0124f0925b11894ec80a97e6efca7d9d3"
+    "sha512=b7b2b9cb7c4dc33be49af579ee5ecb5801371920982d725f3e329f5f1433dd36b1461e744f051c1fe22ddb3c744060555f764d9127e5c4fefff4c41bd4db4d59"
+  ]
+}
+x-commit-hash: "fd412c1be40001da0ad1e68a7534b262f54ec64f"


### PR DESCRIPTION
### `provider.0.0.6`
Parametrize your OCaml library with values that behave like objects but aren't



---
* Homepage: https://github.com/mbarbin/provider
* Source repo: git+https://github.com/mbarbin/provider.git
* Bug tracker: https://github.com/mbarbin/provider/issues

---
## 0.0.6 (2024-08-02)

### Changed

- Reduce `provider` package dependencies - reduce from `base` to `sexplib0`.

### Fixed

- Make sure to select the right most implementation in case of overrides, as per specification.

### Removed

- Removed `Trait.Uid.Comparable.S` as this requires `Base`. Make it compatible with `Comparable.Make (Trait.Uid)` and add tests for this use case.
