### PR TITLE
[new release] provider (0.0.6)

### DIFF
--- a/packages/provider/provider.0.0.6/opam
+++ b/packages/provider/provider.0.0.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Parametrize your OCaml library with values that behave like objects but aren't"
+maintainer: ["Mathieu Barbin"]
+authors: ["Mathieu Barbin"]
+license: "ISC"
+homepage: "https://github.com/mbarbin/provider"
+doc: "https://mbarbin.github.io/provider/"
+bug-reports: "https://github.com/mbarbin/provider/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.2"}
+  "bisect_ppx" {dev & >= "2.8.3"}
+  "ppx_js_style" {dev & >= "v0.16"}
+  "sexplib0" {>= "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/provider.git"
+url {
+  src:
+    "https://github.com/mbarbin/provider/releases/download/0.0.6/provider-0.0.6.tbz"
+  checksum: [
+    "sha256=c1153161721668aaf572cc1c4e24eb716b2cdaa41628e843a9aba079e17ecf4d"
+    "sha512=026b85294464760432c81c7fa662858db6bd4fab17446c8c553a52dac113e4682099086e9f90452e0d51a9c1866392e48ad5b68e13264ff184f213cc59449dc6"
+  ]
+}
+x-commit-hash: "3a54141c3e579a293e8d26899dfb441c7bd3cddf"


### PR DESCRIPTION
### `provider.0.0.6`
Parametrize your OCaml library with values that behave like objects but aren't



---
* Homepage: https://github.com/mbarbin/provider
* Source repo: git+https://github.com/mbarbin/provider.git
* Bug tracker: https://github.com/mbarbin/provider/issues

---
## 0.0.6 (2024-08-02)

### Changed

- Reduce `provider` package dependencies - reduce from `base` to `sexplib0`.

### Fixed

- Make sure to select the right most implementation in case of overrides, as per specification.

### Removed

- Removed `Trait.Uid.Comparable.S` as this requires `Base`. Make it compatible with `Comparable.Make (Trait.Uid)` and add tests for this use case.
