### PR TITLE
Package tablecloth-base.0.0.10

### DIFF
--- a/packages/tablecloth-base/tablecloth-base.0.0.10/opam
+++ b/packages/tablecloth-base/tablecloth-base.0.0.10/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml and Rescript"
+description: """
+Tablecloth is an ergonomic, cross-platform, standard library for use with OCaml and Rescript. It provides an easy-to-use, comprehensive and performant standard library, that has the same API on in OCaml and Rescript.
+"""
+maintainer: "Paul Biggar <paul@darklang.com>"
+authors: [
+  "Paul Biggar <paul@darklang.com>"
+  "Dean Merchant <deanmerchant@gmail.com>"
+  "Pomin Wu <pomin.wu@proton.me>"
+]
+license: "MIT"
+homepage: "https://github.com/darklang/tablecloth-ocaml-base"
+bug-reports: "https://github.com/darklang/tablecloth-ocaml-base/issues"
+dev-repo: "git://github.com/darklang/tablecloth-ocaml-base"
+depends: [ "ocaml" {>= "4.10" } "dune" {>= "2.4" } "base" { >= "v0.15.0" } ]
+build: ["dune" "build" "-p" name "-j" jobs]
+conflicts: [ "tablecloth-native" {!= "transition"} ]
+url {
+  src:
+    "https://github.com/darklang/tablecloth-ocaml-base/archive/refs/tags/0.0.10.tar.gz"
+  checksum: [
+    "md5=c46b1ab3dc31cac3d17aab14e4d2246a"
+    "sha512=b65eee22b8059e13baeb10d2de7c294878c7839cf582c8f49e3954f22245d4ee8977d8fd22154e82a1b253a8d3afa7005b125b8c0f79f1e9a0f5a96da4ef8463"
+  ]
+}


### PR DESCRIPTION
### `tablecloth-base.0.0.10`
Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml and Rescript
Tablecloth is an ergonomic, cross-platform, standard library for use with OCaml and Rescript. It provides an easy-to-use, comprehensive and performant standard library, that has the same API on in OCaml and Rescript.



---
* Homepage: https://github.com/darklang/tablecloth-ocaml-base
* Source repo: git://github.com/darklang/tablecloth-ocaml-base
* Bug tracker: https://github.com/darklang/tablecloth-ocaml-base/issues

---
:camel: Pull-request generated by opam-publish v2.3.1