### PR TITLE
[new release] tar (4 packages) (3.0.0)

### DIFF
--- a/packages/tar-eio/tar-eio.3.0.0/opam
+++ b/packages/tar-eio/tar-eio.3.0.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files using Eio"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library uses Eio to provide a portable tar library.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.00.0"}
+  "eio" {>= "1.1" & < "1.2"}
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.0.0/tar-3.0.0.tbz"
+  checksum: [
+    "sha256=0451f858db837ae47b8e792a999d5b9a688782c981377fd5b2dcf58cfb86b2f3"
+    "sha512=609f9b40b28b6a3045a628107a0879fad05d5dece469772175881cd7858c2de7fb4858db9727f1740603f0cc19d6295b37bb0df1a3f7afdc05867b622551f6f4"
+  ]
+}
+x-commit-hash: "d8c7eae2cdadcf3354e70f06ca350a2f3b1c9c1b"

--- a/packages/tar-mirage/tar-mirage.3.0.0/opam
+++ b/packages/tar-mirage/tar-mirage.3.0.0/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis: "Read and write tar format files via MirageOS interfaces"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library is functorised over external OS dependencies
+to facilitate embedding within MirageOS.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "5.6.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "mirage-kv" {>= "6.0.0"}
+  "optint"
+  "ptime"
+  "tar" {= version}
+  "mirage-block-unix" {with-test & >= "2.13.0"}
+  "mirage-clock-unix" {with-test & >= "4.0.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "alcotest-lwt" {>= "1.7.0" & with-test}
+  "tar-unix" {with-test & = version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.0.0/tar-3.0.0.tbz"
+  checksum: [
+    "sha256=0451f858db837ae47b8e792a999d5b9a688782c981377fd5b2dcf58cfb86b2f3"
+    "sha512=609f9b40b28b6a3045a628107a0879fad05d5dece469772175881cd7858c2de7fb4858db9727f1740603f0cc19d6295b37bb0df1a3f7afdc05867b622551f6f4"
+  ]
+}
+x-commit-hash: "d8c7eae2cdadcf3354e70f06ca350a2f3b1c9c1b"

--- a/packages/tar-unix/tar-unix.3.0.0/opam
+++ b/packages/tar-unix/tar-unix.3.0.0/opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.08.0"}
-  "lwt"
+  "lwt" {>= "5.7.0"}
   "tar" {= version}
   "odoc" {with-doc}
 ]

--- a/packages/tar-unix/tar-unix.3.0.0/opam
+++ b/packages/tar-unix/tar-unix.3.0.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files from Unix"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library provides a Unix or Windows compatible interface.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "lwt"
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.0.0/tar-3.0.0.tbz"
+  checksum: [
+    "sha256=0451f858db837ae47b8e792a999d5b9a688782c981377fd5b2dcf58cfb86b2f3"
+    "sha512=609f9b40b28b6a3045a628107a0879fad05d5dece469772175881cd7858c2de7fb4858db9727f1740603f0cc19d6295b37bb0df1a3f7afdc05867b622551f6f4"
+  ]
+}
+x-commit-hash: "d8c7eae2cdadcf3354e70f06ca350a2f3b1c9c1b"

--- a/packages/tar/tar.3.0.0/opam
+++ b/packages/tar/tar.3.0.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files in pure OCaml"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "decompress" {>= "1.5.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.0.0/tar-3.0.0.tbz"
+  checksum: [
+    "sha256=0451f858db837ae47b8e792a999d5b9a688782c981377fd5b2dcf58cfb86b2f3"
+    "sha512=609f9b40b28b6a3045a628107a0879fad05d5dece469772175881cd7858c2de7fb4858db9727f1740603f0cc19d6295b37bb0df1a3f7afdc05867b622551f6f4"
+  ]
+}
+x-commit-hash: "d8c7eae2cdadcf3354e70f06ca350a2f3b1c9c1b"


### PR DESCRIPTION
Decode and encode tar format files in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-tar">https://github.com/mirage/ocaml-tar</a>
- Documentation: <a href="https://mirage.github.io/ocaml-tar/">https://mirage.github.io/ocaml-tar/</a>

##### CHANGES:

- Fix `Header.marshal` and the checksum and the length (@reynir, mirage/ocaml-tar#145)
- Delete a mutable field about the level into the header (@hannesm, mirage/ocaml-tar#141)
- **BREAKING**: de-functorize the package (@hannesm, @reynir, @dinosaure, mirage/ocaml-tar#140, mirage/ocaml-tar#143, mirage/ocaml-tar#146)

  These PRs attempt to de-functorize `Tar` so that users can implement I/O
  themselves, using `Tar`'s own element serialization/deserialization functions
  to take advantage of read/write methods. This avoids imposing on the user the
  implementation of a module that is too rigid in his/her case (which could have
  performance implications).

  `Tar` offers functions for serializing/deserializing tar-specific elements
  from `string`. It is then up to the user to know how to obtain or write these
  `strings`.

  To this, these PRs add "logics" (see `'a Tar.t`) requiring read and/or write
  implementations and describing how to extract all entries from a tar file or
  how to write a tar file according to a "dispenser" (like `Seq.to_dispenser`)
  of entries.

  These logics do not depend on a particular "scheduler", and these PRs propose
  a derivation of these logics with `tar-unix`, `tar-eio` and `tar-mirage`.
  These latter derivations mean that the API for these packages has only been
  extended, and there are no breaking changes as such.

  These logics also make it easy to offer a compression/decompression layer with
  `decompress`, so you can easily manipulate and/or create a .tar.gz file.
