### PR TITLE
[new release] sail (12 packages) (0.18)

### DIFF
--- a/packages/libsail/libsail.0.18/opam
+++ b/packages/libsail/libsail.0.18/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis:
+  "Sail is a language for describing the instruction semantics of processors"
+description: """
+Sail is a language for describing the instruction-set
+architecture (ISA) semantics of processors. Sail aims to provide a
+engineer-friendly, vendor-pseudocode-like language for describing
+instruction semantics. It is essentially a first-order imperative
+language, but with lightweight dependent typing for numeric types and
+bitvector lengths, which are automatically checked using Z3. It has
+been used for several papers, available from
+http://www.cl.cam.ac.uk/~pes20/sail/.
+"""
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "dune-site" {>= "3.0.2"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "menhir" {>= "20240715" & build}
+  "ott" {>= "0.28" & build}
+  "lem" {>= "2018-12-14"}
+  "linksem" {>= "0.3"}
+  "conf-gmp"
+  "conf-zlib"
+  "yojson" {>= "1.6.0"}
+  "pprint" {>= "20220103"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.18/sail-0.18.tbz"
+  checksum: [
+    "sha256=fcdbda14f1ed59fa30e23da34abe02547416e3c2a83fbeee5606e100a5edcf35"
+    "sha512=0bbd72706cb4c1ddf13ea1c42004ec498aa9db8a301020f0dd3d8ac582d1bed8a48c7a825b8e3e6f629279f1f900384f6966608e1cd59e7b1217776413c7fa27"
+  ]
+}
+x-commit-hash: "5d35b1a34d5c8baa70c87a3f485a9e36f7a36746"

--- a/packages/sail/sail.0.18/opam
+++ b/packages/sail/sail.0.18/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+synopsis:
+  "Sail is a language for describing the instruction semantics of processors"
+description: """
+Sail is a language for describing the instruction-set
+architecture (ISA) semantics of processors. Sail aims to provide a
+engineer-friendly, vendor-pseudocode-like language for describing
+instruction semantics. It is essentially a first-order imperative
+language, but with lightweight dependent typing for numeric types and
+bitvector lengths, which are automatically checked using Z3. It has
+been used for several papers, available from
+http://www.cl.cam.ac.uk/~pes20/sail/.
+"""
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "sail_manifest" {= version & build}
+  "sail_ocaml_backend" {= version & post}
+  "sail_c_backend" {= version & post}
+  "sail_smt_backend" {= version & post}
+  "sail_sv_backend" {= version & post}
+  "sail_lem_backend" {= version & post}
+  "sail_coq_backend" {= version & post}
+  "sail_latex_backend" {= version & post}
+  "sail_doc_backend" {= version & post}
+  "sail_output" {= version & post}
+  "linenoise" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+substs: [ "src/bin/manifest.ml" ]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.18/sail-0.18.tbz"
+  checksum: [
+    "sha256=fcdbda14f1ed59fa30e23da34abe02547416e3c2a83fbeee5606e100a5edcf35"
+    "sha512=0bbd72706cb4c1ddf13ea1c42004ec498aa9db8a301020f0dd3d8ac582d1bed8a48c7a825b8e3e6f629279f1f900384f6966608e1cd59e7b1217776413c7fa27"
+  ]
+}
+x-commit-hash: "5d35b1a34d5c8baa70c87a3f485a9e36f7a36746"

--- a/packages/sail_c_backend/sail_c_backend.0.18/opam
+++ b/packages/sail_c_backend/sail_c_backend.0.18/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to C translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.18/sail-0.18.tbz"
+  checksum: [
+    "sha256=fcdbda14f1ed59fa30e23da34abe02547416e3c2a83fbeee5606e100a5edcf35"
+    "sha512=0bbd72706cb4c1ddf13ea1c42004ec498aa9db8a301020f0dd3d8ac582d1bed8a48c7a825b8e3e6f629279f1f900384f6966608e1cd59e7b1217776413c7fa27"
+  ]
+}
+x-commit-hash: "5d35b1a34d5c8baa70c87a3f485a9e36f7a36746"

--- a/packages/sail_coq_backend/sail_coq_backend.0.18/opam
+++ b/packages/sail_coq_backend/sail_coq_backend.0.18/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Coq translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.18/sail-0.18.tbz"
+  checksum: [
+    "sha256=fcdbda14f1ed59fa30e23da34abe02547416e3c2a83fbeee5606e100a5edcf35"
+    "sha512=0bbd72706cb4c1ddf13ea1c42004ec498aa9db8a301020f0dd3d8ac582d1bed8a48c7a825b8e3e6f629279f1f900384f6966608e1cd59e7b1217776413c7fa27"
+  ]
+}
+x-commit-hash: "5d35b1a34d5c8baa70c87a3f485a9e36f7a36746"

--- a/packages/sail_doc_backend/sail_doc_backend.0.18/opam
+++ b/packages/sail_doc_backend/sail_doc_backend.0.18/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Sail documentation generator"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "base64" {>= "3.1.0"}
+  "omd" {>= "1.3.1" & < "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.18/sail-0.18.tbz"
+  checksum: [
+    "sha256=fcdbda14f1ed59fa30e23da34abe02547416e3c2a83fbeee5606e100a5edcf35"
+    "sha512=0bbd72706cb4c1ddf13ea1c42004ec498aa9db8a301020f0dd3d8ac582d1bed8a48c7a825b8e3e6f629279f1f900384f6966608e1cd59e7b1217776413c7fa27"
+  ]
+}
+x-commit-hash: "5d35b1a34d5c8baa70c87a3f485a9e36f7a36746"

--- a/packages/sail_latex_backend/sail_latex_backend.0.18/opam
+++ b/packages/sail_latex_backend/sail_latex_backend.0.18/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to LaTeX formatting"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "omd" {>= "1.3.1" & < "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.18/sail-0.18.tbz"
+  checksum: [
+    "sha256=fcdbda14f1ed59fa30e23da34abe02547416e3c2a83fbeee5606e100a5edcf35"
+    "sha512=0bbd72706cb4c1ddf13ea1c42004ec498aa9db8a301020f0dd3d8ac582d1bed8a48c7a825b8e3e6f629279f1f900384f6966608e1cd59e7b1217776413c7fa27"
+  ]
+}
+x-commit-hash: "5d35b1a34d5c8baa70c87a3f485a9e36f7a36746"

--- a/packages/sail_lem_backend/sail_lem_backend.0.18/opam
+++ b/packages/sail_lem_backend/sail_lem_backend.0.18/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Lem translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.18/sail-0.18.tbz"
+  checksum: [
+    "sha256=fcdbda14f1ed59fa30e23da34abe02547416e3c2a83fbeee5606e100a5edcf35"
+    "sha512=0bbd72706cb4c1ddf13ea1c42004ec498aa9db8a301020f0dd3d8ac582d1bed8a48c7a825b8e3e6f629279f1f900384f6966608e1cd59e7b1217776413c7fa27"
+  ]
+}
+x-commit-hash: "5d35b1a34d5c8baa70c87a3f485a9e36f7a36746"

--- a/packages/sail_manifest/sail_manifest.0.18/opam
+++ b/packages/sail_manifest/sail_manifest.0.18/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Helper tool for compiling Sail"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.18/sail-0.18.tbz"
+  checksum: [
+    "sha256=fcdbda14f1ed59fa30e23da34abe02547416e3c2a83fbeee5606e100a5edcf35"
+    "sha512=0bbd72706cb4c1ddf13ea1c42004ec498aa9db8a301020f0dd3d8ac582d1bed8a48c7a825b8e3e6f629279f1f900384f6966608e1cd59e7b1217776413c7fa27"
+  ]
+}
+x-commit-hash: "5d35b1a34d5c8baa70c87a3f485a9e36f7a36746"

--- a/packages/sail_ocaml_backend/sail_ocaml_backend.0.18/opam
+++ b/packages/sail_ocaml_backend/sail_ocaml_backend.0.18/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to OCaml translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "base64" {>= "3.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.18/sail-0.18.tbz"
+  checksum: [
+    "sha256=fcdbda14f1ed59fa30e23da34abe02547416e3c2a83fbeee5606e100a5edcf35"
+    "sha512=0bbd72706cb4c1ddf13ea1c42004ec498aa9db8a301020f0dd3d8ac582d1bed8a48c7a825b8e3e6f629279f1f900384f6966608e1cd59e7b1217776413c7fa27"
+  ]
+}
+x-commit-hash: "5d35b1a34d5c8baa70c87a3f485a9e36f7a36746"

--- a/packages/sail_output/sail_output.0.18/opam
+++ b/packages/sail_output/sail_output.0.18/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Example Sail output plugin"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.18/sail-0.18.tbz"
+  checksum: [
+    "sha256=fcdbda14f1ed59fa30e23da34abe02547416e3c2a83fbeee5606e100a5edcf35"
+    "sha512=0bbd72706cb4c1ddf13ea1c42004ec498aa9db8a301020f0dd3d8ac582d1bed8a48c7a825b8e3e6f629279f1f900384f6966608e1cd59e7b1217776413c7fa27"
+  ]
+}
+x-commit-hash: "5d35b1a34d5c8baa70c87a3f485a9e36f7a36746"

--- a/packages/sail_smt_backend/sail_smt_backend.0.18/opam
+++ b/packages/sail_smt_backend/sail_smt_backend.0.18/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to C translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.18/sail-0.18.tbz"
+  checksum: [
+    "sha256=fcdbda14f1ed59fa30e23da34abe02547416e3c2a83fbeee5606e100a5edcf35"
+    "sha512=0bbd72706cb4c1ddf13ea1c42004ec498aa9db8a301020f0dd3d8ac582d1bed8a48c7a825b8e3e6f629279f1f900384f6966608e1cd59e7b1217776413c7fa27"
+  ]
+}
+x-commit-hash: "5d35b1a34d5c8baa70c87a3f485a9e36f7a36746"

--- a/packages/sail_sv_backend/sail_sv_backend.0.18/opam
+++ b/packages/sail_sv_backend/sail_sv_backend.0.18/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Systemverilog translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.18/sail-0.18.tbz"
+  checksum: [
+    "sha256=fcdbda14f1ed59fa30e23da34abe02547416e3c2a83fbeee5606e100a5edcf35"
+    "sha512=0bbd72706cb4c1ddf13ea1c42004ec498aa9db8a301020f0dd3d8ac582d1bed8a48c7a825b8e3e6f629279f1f900384f6966608e1cd59e7b1217776413c7fa27"
+  ]
+}
+x-commit-hash: "5d35b1a34d5c8baa70c87a3f485a9e36f7a36746"


### PR DESCRIPTION
Sail is a language for describing the instruction semantics of processors

- Project page: <a href="https://github.com/rems-project/sail">https://github.com/rems-project/sail</a>

##### CHANGES:

This release mostly incorporates many small improvements and fixes
to Sail 0.17.1.

##### Module System

This release introduces a simple module system. See the section of
the manual for details.

##### Type level if-then-else

If expressions are now permitted in types, so one can write types such
as
```
bits(if XLEN == 32 then 15 else 57)
```
this doesn't add any additional expressiveness, as one could
previously introduce additional type variables and constrain them in
such a way to guarantee the same thing, but being able to use
if-then-else directly is usually more clear.

##### Improved kind inference

Previously, type synonyms would require annotation with *kinds* (types
of types), for example:
```
union option('a : Type) = { Some : 'a, None : unit }

type xlen : Int = 64
```
Now, type variable kinds are inferred in most places, so the above
could be written as:
```
union option('a) = { Some : 'a, None : unit }

type xlen = 64
```
There are still some places where explicit kinds are necessary, such
as for scattered type definitions or abstract types.

##### Documentation backend

The Sail documentation backend can now produce hyperlinked and syntax
highlighted source code output with the `--html` option. The
Asciidoctor plugin can now hyperlink between definitions included in
the documentation, and otherwise link into a hyperlinked version of
the source.
