### PR TITLE
Package vscoq-language-server.2.1.7

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.1.7/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.1.7/opam
@@ -30,6 +30,7 @@ depends: [
   "sel" {>= "0.4.0"}
 ]
 synopsis: "VSCoq language server"
+available: arch != "arm32" & arch != "x86_32"
 description: """
 LSP based language server for Coq and its VSCoq user interface
 """

--- a/packages/vscoq-language-server/vscoq-language-server.2.1.7/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.1.7/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/coq-community/vscoq"
+bug-reports: "https://github.com/coq-community/vscoq/issues"
+dev-repo: "git+https://github.com/coq-community/vscoq"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { >= "4.14" }
+  "dune" { >= "3.5" }
+  "coq-core" { ((>= "8.18" < "8.21") | (= "dev")) }
+  "coq-stdlib" { ((>= "8.18" < "8.21") | (= "dev")) }
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "ppx_optcomp"
+  "result" { >= "1.5" }
+  "lsp" { >= "1.15" < "1.19"}
+  "sel" {>= "0.4.0"}
+]
+synopsis: "VSCoq language server"
+description: """
+LSP based language server for Coq and its VSCoq user interface
+"""
+url {
+  src:
+    "https://github.com/coq-community/vscoq/releases/download/v2.1.7/vscoq-language-server-2.1.7.tar.gz"
+  checksum: [
+    "md5=81c195fcbe9b23c26db9704a0b8e37f8"
+    "sha512=9b175796b231e3663b1cdd546fde898c1d19a6a4eb16671970797045e0e29acc008630634f0d15fa34a94ccc14a0c16d3851efbf0b74f3e1ac6ada1f1461f7e1"
+  ]
+}


### PR DESCRIPTION
### `vscoq-language-server.2.1.7`
VSCoq language server
LSP based language server for Coq and its VSCoq user interface



---
* Homepage: https://github.com/coq-community/vscoq
* Source repo: git+https://github.com/coq-community/vscoq
* Bug tracker: https://github.com/coq-community/vscoq/issues

---
:camel: Pull-request generated by opam-publish v2.0.3