### PR TITLE
[new release] ca-certs (1.0.0)

### DIFF
--- a/packages/ca-certs/ca-certs.1.0.0/opam
+++ b/packages/ca-certs/ca-certs.1.0.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "Detect root CA certificates from the operating system"
+description: """
+TLS requires a set of root anchors (Certificate Authorities) to
+authenticate servers. This library exposes this list so that it can be
+registered with ocaml-tls.
+"""
+maintainer: ["Etienne Millon <me@emillon.org>"]
+authors: [
+  "Etienne Millon <me@emillon.org>, Hannes Mehnert <hannes@mehnert.org>"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ca-certs"
+doc: "https://mirage.github.io/ca-certs/doc"
+bug-reports: "https://github.com/mirage/ca-certs/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "bos"
+  "fpath"
+  "ptime"
+  "logs"
+  "digestif" {>= "1.2.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "x509" {>= "1.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "ohex" {>= "0.2.0"}
+  "alcotest" {with-test}
+  "fmt" {with-test & >= "0.8.7"}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+dev-repo: "git+https://github.com/mirage/ca-certs.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"} # the opam sandbox on macos leads to test failures (ocaml/opam#4389)
+    "@doc" {with-doc}
+  ]
+]
+tags: ["org:mirage"]
+depexts: [
+  ["ca_root_nss"] {os = "freebsd"}
+]
+url {
+  src:
+    "https://github.com/mirage/ca-certs/releases/download/v1.0.0/ca-certs-1.0.0.tbz"
+  checksum: [
+    "sha256=8690f2312346724799f2d8a1b684ec16b627b027d4164803a0e2b7e2462c0a72"
+    "sha512=c710059766c0062f767d481f7fd97a693b34d3c83e6a53081dee2074b6b40dccbf9d13fcedf253f16ff2381f36da91f84f40749c68537c47abf619322d95d509"
+  ]
+}
+x-commit-hash: "2c5c0bcc2a336f77ec4bb843265334217996c559"


### PR DESCRIPTION
Detect root CA certificates from the operating system

- Project page: <a href="https://github.com/mirage/ca-certs">https://github.com/mirage/ca-certs</a>
- Documentation: <a href="https://mirage.github.io/ca-certs/doc">https://mirage.github.io/ca-certs/doc</a>

##### CHANGES:

* Use X509.Certificate.fold_decode_pem, available in x509 1.0.0 (mirage/ca-certs#34 mirage/ca-certs#35 @art-w
  @hannesm)
* Remove usage of cstruct, update to x509 1.0.0 and mirage-crypto 1.0.0 API
  (mirage/ca-certs#32 @dinosaure @hannesm)
* Remove astring dependency (mirage/ca-certs#26 @hannesm)
