### PR TITLE
Lem 2022 requires the native ocaml compiler

### DIFF
--- a/packages/lem/lem.2022-12-10/opam
+++ b/packages/lem/lem.2022-12-10/opam
@@ -32,6 +32,7 @@ depends: [
   "zarith" {>= "1.4"}
   "num"
 ]
+conflicts: [ "ocaml-option-bytecode-only" ]
 synopsis: "Lem is a tool for lightweight executable mathematics"
 description: """
 Lem is a tool for lightweight executable mathematics, for writing,


### PR DESCRIPTION
Fails with
```
#=== ERROR while compiling lem.2022-12-10 =====================================#
# context              2.3.0~alpha~dev | linux/arm32 | ocaml-base-compiler.5.2.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/lem.2022-12-10
# command              ~/.opam/opam-init/hooks/sandbox.sh build make INSTALL_DIR=/home/opam/.opam/5.2
# exit-code            2
# env-file             ~/.opam/log/lem-7-84bb26.env
# output-file          ~/.opam/log/lem-7-84bb26.out
### output ###
# echo "(* Generated file -- do not edit. *)" > src/version.ml
# echo 'let v="2022-12-10"' >> src/version.ml
# echo "(* Generated file -- do not edit. *)" > src/share_directory.ml
# echo let d=\"/home/opam/.opam/5.2/share/lem\" >> src/share_directory.ml
# make -C src all
# make[1]: Entering directory '/home/opam/.opam/5.2/.opam-switch/build/lem.2022-12-10/src'
# ocamlbuild -use-ocamlfind -cflags -g main.native
# + ocamlfind ocamldep -package zarith -modules main.ml > main.ml.depends
# + ocamlfind ocamldep -package zarith -modules main.mli > main.mli.depends
# + ocamlfind ocamlc -c -g -annot -package zarith -I ulib -o main.cmi main.mli
# + ocamlfind ocamldep -package zarith -modules ast.ml > ast.ml.depends
# + ocamlfind ocamldep -package zarith -modules ulib/ulib.ml > ulib/ulib.ml.depends
# + ocamlfind ocamldep -package zarith -modules ulib/batText.mli > ulib/batText.mli.depends
# + ocamlfind ocamldep -package zarith -modules ulib/batUChar.mli > ulib/batUChar.mli.depends
# + ocamlfind ocamlc -c -g -annot -package zarith -I ulib -o ulib/batUChar.cmi ulib/batUChar.mli
# + ocamlfind ocamldep -package zarith -modules ulib/batUTF8.mli > ulib/batUTF8.mli.depends
# + ocamlfind ocamlc -c -g -annot -package zarith -I ulib -o ulib/batText.cmi ulib/batText.mli
# + ocamlfind ocamlc -c -g -annot -package zarith -I ulib -o ulib/batUTF8.cmi ulib/batUTF8.mli
# + ocamlfind ocamlc -c -g -annot -package zarith -I ulib -o ulib/ulib.cmo ulib/ulib.ml
# + ocamlfind ocamlc -c -g -annot -package zarith -I ulib -o ast.cmo ast.ml
# + ocamlfind ocamldep -package zarith -modules ulib/batText.ml > ulib/batText.ml.depends
# + ocamlfind ocamldep -package zarith -modules ulib/batReturn.ml > ulib/batReturn.ml.depends
# + ocamlfind ocamldep -package zarith -modules ulib/batReturn.mli > ulib/batReturn.mli.depends
# + ocamlfind ocamlc -c -g -annot -package zarith -I ulib -o ulib/batReturn.cmi ulib/batReturn.mli
# + ocamlfind ocamldep -package zarith -modules ulib/batUChar.ml > ulib/batUChar.ml.depends
# + ocamlfind ocamldep -package zarith -modules ulib/batUTF8.ml > ulib/batUTF8.ml.depends
# + ocamlfind ocamlopt -c -g -annot -package zarith -I ulib -o ulib/batUChar.cmx ulib/batUChar.ml
# + ocamlfind ocamlopt -c -g -annot -package zarith -I ulib -o ulib/batUChar.cmx ulib/batUChar.ml
# ocamlfind: Not supported in your configuration: ocamlopt
# Command exited with code 2.
# make[1]: *** [Makefile:2: all] Error 10
# make[1]: Leaving directory '/home/opam/.opam/5.2/.opam-switch/build/lem.2022-12-10/src'
# make: *** [Makefile:180: build-lem] Error 2
```