### PR TITLE
[new release] opam-0install (0.4.4)

### DIFF
--- a/packages/opam-0install/opam-0install.0.4.4/opam
+++ b/packages/opam-0install/opam-0install.0.4.4/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Opam solver using 0install backend"
+description: """
+Opam's default solver is designed to maintain a set of packages
+over time, minimising disruption when installing new programs and
+finding a compromise solution across all packages.
+
+In many situations (e.g. CI, local roots or duniverse builds) this
+is not necessary, and we can get a solution much faster by using
+a different algorithm.
+
+This package uses 0install's solver algorithm with opam packages.
+"""
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "ISC"
+homepage: "https://github.com/ocaml-opam/opam-0install-solver"
+doc: "https://ocaml-opam.github.io/opam-0install-solver/"
+bug-reports: "https://github.com/ocaml-opam/opam-0install-solver/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "fmt" {>= "0.8.7"}
+  "cmdliner" {>= "1.1.0"}
+  "opam-state" {>= "2.1.0~rc"}
+  "ocaml" {>= "4.10.0"}
+  "0install-solver"
+  "opam-file-format" {>= "2.1.1"}
+  "opam-client" {with-test & < "2.2.0~alpha"}
+  "opam-solver" {with-test}
+  "astring" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-opam/opam-0install-solver.git"
+url {
+  src:
+    "https://github.com/ocaml-opam/opam-0install-solver/releases/download/v0.4.4/opam-0install-0.4.4.tbz"
+  checksum: [
+    "sha256=3e114c3e27bd0aa004eeffd91ff337d2f67a4cce23342244e6e8bd2ea3605723"
+    "sha512=6c14c9ba8a6385ead5652243b54507775ed383b28308de6288ed2bc3cb8e6aa0a3c82f299badeda89e6dcf07adb293ddf6479462e87772df5f36cf8b1e765194"
+  ]
+}
+x-commit-hash: "11198d9e3062bb9d17cf3828d51a9724f4670a96"


### PR DESCRIPTION
Opam solver using 0install backend

- Project page: <a href="https://github.com/ocaml-opam/opam-0install-solver">https://github.com/ocaml-opam/opam-0install-solver</a>
- Documentation: <a href="https://ocaml-opam.github.io/opam-0install-solver/">https://ocaml-opam.github.io/opam-0install-solver/</a>

##### CHANGES:

- Remove opam-0install-cudf (split off to its own repository) (@kit-ty-kate ocaml-opam/opam-0install-solver#55).

- Avoid non-domain-safe global counter (@talex5 ocaml-opam/opam-0install-solver#53).

- Add `--dot` option to output a dependency graph (@talex5 ocaml-opam/opam-0install-solver#48).
