### PR TITLE
107 packages (bls12-381.20.2-rc2-mavryk, gitlab_ci.20.2-rc2-mavryk, etc.)

### DIFF
--- a/packages/bls12-381/bls12-381.20.2-rc2-mavryk/opam
+++ b/packages/bls12-381/bls12-381.20.2-rc2-mavryk/opam
@@ -1,0 +1,28 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "integers"
+  "integers_stubs_js"
+  "zarith" { >= "1.13" & < "1.14" }
+  "zarith_stubs_js" { >= "0.16.1" }
+  "hex" { >= "1.3.0" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-alcotezt" { with-test & = version }
+  "qcheck-alcotest" { with-test & >= "0.20" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+available: arch != "arm32" & arch != "x86_32" & arch != "ppc32" & arch != "ppc64" & arch != "s390x"
+synopsis: "Implementation of the BLS12-381 curve (wrapper for the Blst library)"

--- a/packages/gitlab_ci/gitlab_ci.20.2-rc2-mavryk/opam
+++ b/packages/gitlab_ci/gitlab_ci.20.2-rc2-mavryk/opam
@@ -1,0 +1,21 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "ppx_expect"
+  "yaml" { >= "3.1.0" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "OCaml library for generating GitLab CI YAML configuration files"

--- a/packages/internal-devtools/internal-devtools.20.2-rc2-mavryk/opam
+++ b/packages/internal-devtools/internal-devtools.20.2-rc2-mavryk/opam
@@ -1,0 +1,27 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-protocol-compiler" { = version }
+  "mavkit-libs" { = version }
+]
+depopts: [
+  "utop"
+]
+conflicts: [
+  "utop" { < "2.8" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Internal dev tools"

--- a/packages/internal-devtools_proto-context-du/internal-devtools_proto-context-du.20.2-rc2-mavryk/opam
+++ b/packages/internal-devtools_proto-context-du/internal-devtools_proto-context-du.20.2-rc2-mavryk/opam
@@ -1,0 +1,24 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-node-config" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavryk-protocol-alpha" { = version }
+  "mavkit-protocol-alpha-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "A script to print protocol context disk usage"

--- a/packages/kaitai-of-data-encoding/kaitai-of-data-encoding.20.2-rc2-mavryk/opam
+++ b/packages/kaitai-of-data-encoding/kaitai-of-data-encoding.20.2-rc2-mavryk/opam
@@ -1,0 +1,23 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "yaml" { >= "3.1.0" }
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+  "kaitai" { = version }
+  "ppx_expect"
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Kaitai spec generator for data-encoding library"

--- a/packages/kaitai/kaitai.20.2-rc2-mavryk/opam
+++ b/packages/kaitai/kaitai.20.2-rc2-mavryk/opam
@@ -1,0 +1,23 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "ppx_sexp_conv"
+  "yaml" { >= "3.1.0" }
+  "sexplib"
+  "ppx_expect"
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "OCaml library for reading Kaitai spec files"

--- a/packages/mavkit-accuser-PtAtLas/mavkit-accuser-PtAtLas.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-accuser-PtAtLas/mavkit-accuser-PtAtLas.20.2-rc2-mavryk/opam
@@ -1,0 +1,23 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-protocol-001-PtAtLas" { = version }
+  "mavkit-protocol-001-PtAtLas-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: accuser binary"

--- a/packages/mavkit-accuser-PtBoreas/mavkit-accuser-PtBoreas.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-accuser-PtBoreas/mavkit-accuser-PtBoreas.20.2-rc2-mavryk/opam
@@ -1,0 +1,23 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-protocol-002-PtBoreas" { = version }
+  "mavkit-protocol-002-PtBoreas-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: accuser binary"

--- a/packages/mavkit-accuser-alpha/mavkit-accuser-alpha.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-accuser-alpha/mavkit-accuser-alpha.20.2-rc2-mavryk/opam
@@ -1,0 +1,23 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-protocol-alpha" { = version }
+  "mavkit-protocol-alpha-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: accuser binary"

--- a/packages/mavkit-alcotezt/mavkit-alcotezt.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-alcotezt/mavkit-alcotezt.20.2-rc2-mavryk/opam
@@ -1,0 +1,20 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { >= "4.0.0" & < "5.0.0" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Provide the interface of Alcotest for Mavkit, but with Tezt as backend"

--- a/packages/mavkit-baker-PtAtLas/mavkit-baker-PtAtLas.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-baker-PtAtLas/mavkit-baker-PtAtLas.20.2-rc2-mavryk/opam
@@ -1,0 +1,23 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-protocol-001-PtAtLas" { = version }
+  "mavkit-protocol-001-PtAtLas-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: baker binary"

--- a/packages/mavkit-baker-PtBoreas/mavkit-baker-PtBoreas.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-baker-PtBoreas/mavkit-baker-PtBoreas.20.2-rc2-mavryk/opam
@@ -1,0 +1,23 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-protocol-002-PtBoreas" { = version }
+  "mavkit-protocol-002-PtBoreas-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: baker binary"

--- a/packages/mavkit-baker-alpha/mavkit-baker-alpha.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-baker-alpha/mavkit-baker-alpha.20.2-rc2-mavryk/opam
@@ -1,0 +1,23 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-protocol-alpha" { = version }
+  "mavkit-protocol-alpha-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: baker binary"

--- a/packages/mavkit-client/mavkit-client.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-client/mavkit-client.20.2-rc2-mavryk/opam
@@ -1,0 +1,36 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "uri" { >= "3.1.0" }
+  "mavkit-protocol-001-PtAtLas-libs" { = version }
+  "mavkit-protocol-002-PtBoreas-libs" { = version }
+]
+depopts: [
+  "mavryk-client-genesis"
+  "mavryk-client-demo-counter"
+  "mavkit-protocol-000-Ps9mPmXa-libs"
+  "mavkit-protocol-alpha-libs"
+]
+conflicts: [
+  "mavryk-client-genesis" { != version }
+  "mavryk-client-demo-counter" { != version }
+  "mavkit-protocol-000-Ps9mPmXa-libs" { != version }
+  "mavkit-protocol-alpha-libs" { != version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: `mavkit-client` binary"

--- a/packages/mavkit-codec-kaitai/mavkit-codec-kaitai.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-codec-kaitai/mavkit-codec-kaitai.20.2-rc2-mavryk/opam
@@ -1,0 +1,30 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+  "kaitai-of-data-encoding" { = version }
+  "kaitai" { = version }
+  "mavkit-libs"
+  "mavkit-shell-libs"
+  "mavkit-version"
+]
+depopts: [
+  "mavkit-protocol-001-PtAtLas-libs"
+  "mavkit-protocol-002-PtBoreas-libs"
+  "mavkit-protocol-alpha-libs"
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: `mavkit-codec-kaitai` binary to generate kaitai descriptions"

--- a/packages/mavkit-codec/mavkit-codec.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-codec/mavkit-codec.20.2-rc2-mavryk/opam
@@ -1,0 +1,34 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavkit-node-config" { = version }
+  "mavkit-version" { = version }
+]
+depopts: [
+  "mavkit-protocol-001-PtAtLas-libs"
+  "mavkit-protocol-002-PtBoreas-libs"
+  "mavkit-protocol-alpha-libs"
+]
+conflicts: [
+  "mavkit-protocol-001-PtAtLas-libs" { != version }
+  "mavkit-protocol-002-PtBoreas-libs" { != version }
+  "mavkit-protocol-alpha-libs" { != version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: `mavkit-codec` binary to encode and decode values"

--- a/packages/mavkit-crawler/mavkit-crawler.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-crawler/mavkit-crawler.20.2-rc2-mavryk/opam
@@ -1,0 +1,21 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit: library to crawl blocks of the L1 chain"

--- a/packages/mavkit-dac-client/mavkit-dac-client.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-dac-client/mavkit-dac-client.20.2-rc2-mavryk/opam
@@ -1,0 +1,31 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavryk-dac-lib" { = version }
+  "mavryk-dac-client-lib" { = version }
+  "mavkit-protocol-001-PtAtLas-libs" { = version }
+  "mavkit-protocol-002-PtBoreas-libs" { = version }
+]
+depopts: [
+  "mavkit-protocol-alpha-libs"
+]
+conflicts: [
+  "mavkit-protocol-alpha-libs" { != version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: `mavkit-dac-client` binary"

--- a/packages/mavkit-dac-node/mavkit-dac-node.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-dac-node/mavkit-dac-node.20.2-rc2-mavryk/opam
@@ -1,0 +1,34 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavryk-dac-lib" { = version }
+  "mavryk-dac-node-lib" { = version }
+  "mavkit-l2-libs" { = version }
+  "mavkit-internal-libs" { = version }
+  "mavkit-protocol-001-PtAtLas-libs" { = version }
+  "mavkit-protocol-002-PtBoreas-libs" { = version }
+]
+depopts: [
+  "mavkit-protocol-alpha-libs"
+]
+conflicts: [
+  "checkseum" { = "0.5.0" }
+  "mavkit-protocol-alpha-libs" { != version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: `mavkit-dac-node` binary"

--- a/packages/mavkit-dal-node/mavkit-dal-node.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-dal-node/mavkit-dal-node.20.2-rc2-mavryk/opam
@@ -1,0 +1,37 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "cmdliner" { >= "1.1.0" }
+  "mavkit-shell-libs" { = version }
+  "mavryk-dal-node-lib" { = version }
+  "mavryk-dal-node-services" { = version }
+  "mavkit-l2-libs" { = version }
+  "mavkit-internal-libs" { = version }
+  "prometheus-app" { >= "1.2" }
+  "prometheus" { >= "1.2" }
+  "mavkit-protocol-001-PtAtLas-libs" { = version }
+  "mavkit-protocol-002-PtBoreas-libs" { = version }
+]
+depopts: [
+  "mavkit-protocol-alpha-libs"
+]
+conflicts: [
+  "checkseum" { = "0.5.0" }
+  "mavkit-protocol-alpha-libs" { != version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: `mavkit-dal-node` binary"

--- a/packages/mavkit-distributed-internal/mavkit-distributed-internal.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-distributed-internal/mavkit-distributed-internal.20.2-rc2-mavryk/opam
@@ -1,0 +1,20 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "base-unix"
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Fork of distributed. Use for Mavkit only"

--- a/packages/mavkit-distributed-lwt-internal/mavkit-distributed-lwt-internal.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-distributed-lwt-internal/mavkit-distributed-lwt-internal.20.2-rc2-mavryk/opam
@@ -1,0 +1,23 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "base-unix"
+  "mavkit-distributed-internal" { = version }
+  "lwt" { >= "5.7.0" }
+  "logs"
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Fork of distributed-lwt. Use for Mavkit only"

--- a/packages/mavkit-evm-node-libs/mavkit-evm-node-libs.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-evm-node-libs/mavkit-evm-node-libs.20.2-rc2-mavryk/opam
@@ -1,0 +1,33 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs"
+  "mavkit-smart-rollup-wasm-debugger-plugin"
+  "ocaml-protoc-plugin" { >= "4.5.0" }
+  "caqti-lwt" { >= "2.0.1" }
+  "crunch" { >= "3.3.0" }
+  "re" { >= "1.10.0" }
+  "mavkit-version"
+  "lwt-watcher" { = "0.2" }
+  "lwt-exit"
+  "caqti"
+  "caqti-driver-sqlite3" { >= "2.0.1" }
+  "mavkit-shell-libs"
+  "mavkit-l2-libs"
+  "mavkit-smart-rollup-wasm-debugger-lib"
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit EVM node libraries"

--- a/packages/mavkit-evm-node-tests/mavkit-evm-node-tests.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-evm-node-tests/mavkit-evm-node-tests.20.2-rc2-mavryk/opam
@@ -1,0 +1,24 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-libs" {with-test}
+  "qcheck-alcotest" { with-test & >= "0.20" }
+  "mavkit-alcotezt" {with-test}
+  "mavkit-evm-node-libs" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tests for the EVM Node"

--- a/packages/mavkit-evm-node/mavkit-evm-node.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-evm-node/mavkit-evm-node.20.2-rc2-mavryk/opam
@@ -1,0 +1,23 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs"
+  "mavkit-version"
+  "mavkit-shell-libs"
+  "mavkit-evm-node-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "An implementation of a subset of Ethereum JSON-RPC API for the EVM rollup"

--- a/packages/mavkit-injector-server/mavkit-injector-server.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-injector-server/mavkit-injector-server.20.2-rc2-mavryk/opam
@@ -1,0 +1,33 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-injector" { = version }
+  "mavkit-shell-libs" { = version }
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+]
+depopts: [
+  "mavryk-injector-001-PtAtLas"
+  "mavryk-injector-002-PtBoreas"
+  "mavryk-injector-alpha"
+]
+conflicts: [
+  "mavryk-injector-001-PtAtLas" { != version }
+  "mavryk-injector-002-PtBoreas" { != version }
+  "mavryk-injector-alpha" { != version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit injector"

--- a/packages/mavkit-injector/mavkit-injector.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-injector/mavkit-injector.20.2-rc2-mavryk/opam
@@ -1,0 +1,23 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "logs"
+  "mavkit-shell-libs" { = version }
+  "mavkit-crawler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit: library for building injectors"

--- a/packages/mavkit-internal-libs/mavkit-internal-libs.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-internal-libs/mavkit-internal-libs.20.2-rc2-mavryk/opam
@@ -1,0 +1,46 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: [
+  "Mavryk Dynamics"
+  "Tezos devteam"
+  "Thomas Gazagnaire"
+  "Thomas Leonard"
+  "Craig Ferguson"
+]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "ISC"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "ppx_repr" { >= "0.6.0" }
+  "logs"
+  "ppxlib"
+  "bigstringaf" { >= "0.5.0" }
+  "fmt" { >= "0.8.7" }
+  "astring"
+  "bheap"
+  "digestif"
+  "jsonm"
+  "lwt" { >= "5.7.0" }
+  "mtime" { >= "2.0.0" }
+  "ocamlgraph"
+  "uri" { >= "3.1.0" }
+  "uutf"
+  "repr"
+  "optint"
+  "index" { >= "1.6.0" & < "1.7.0" }
+  "cmdliner" { >= "1.1.0" }
+  "checkseum" { != "0.5.0" }
+  "rusage"
+  "mavkit-alcotezt" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "A package that contains some libraries used by the Mavkit suite"

--- a/packages/mavkit-l2-libs/mavkit-l2-libs.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-l2-libs/mavkit-l2-libs.20.2-rc2-mavryk/opam
@@ -1,0 +1,41 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam" "WebAssembly Authors"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "Apache-2.0"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "ppx_deriving"
+  "mavkit-libs" { = version }
+  "zarith" { >= "1.13" & < "1.14" }
+  "lwt" { >= "5.7.0" }
+  "ctypes" { >= "0.18.0" }
+  "ctypes-foreign" { >= "0.18.0" }
+  "tezos-rust-libs" { = "1.6" }
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+  "index" { >= "1.6.0" & < "1.7.0" }
+  "mavkit-internal-libs" { = version }
+  "aches-lwt" { >= "1.0.0" }
+  "yaml" { >= "3.1.0" }
+  "ppx_import"
+  "qcheck-alcotest" { >= "0.20" }
+  "mavkit-alcotezt" { = version }
+  "tezt" { >= "4.0.0" & < "5.0.0" }
+]
+x-opam-monorepo-opam-provided: [
+  "tezos-rust-libs"
+]
+conflicts: [
+  "checkseum" { = "0.5.0" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit layer2 libraries"

--- a/packages/mavkit-libs/mavkit-libs.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-libs/mavkit-libs.20.2-rc2-mavryk/opam
@@ -1,0 +1,86 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "Apache-2.0"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14.1" & < "4.15" }
+  "tezt" { >= "4.0.0" & < "5.0.0" }
+  "uri" { >= "3.1.0" }
+  "fmt" { >= "0.8.7" }
+  "qcheck-alcotest" { >= "0.20" }
+  "lwt" { >= "5.7.0" }
+  "pure-splitmix" { = "0.3" }
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+  "ppx_expect"
+  "hex" { >= "1.3.0" }
+  "zarith" { >= "1.13" & < "1.14" }
+  "zarith_stubs_js" { >= "0.16.1" }
+  "aches" { >= "1.0.0" }
+  "seqes" { >= "0.2" }
+  "lwt-canceler" { >= "0.3" & < "0.4" }
+  "hacl-star" { >= "0.7.1" & < "0.8" }
+  "hacl-star-raw"
+  "ctypes_stubs_js"
+  "ctypes" { >= "0.18.0" }
+  "ezjsonm" { >= "1.3.0" }
+  "resto" { >= "1.2" }
+  "resto-directory" { >= "1.2" }
+  "bls12-381" { = version }
+  "re" { >= "1.10.0" }
+  "secp256k1-internal" { >= "0.4.0" }
+  "alcotest" { >= "1.5.0" }
+  "bigarray-compat"
+  "eqaf"
+  "ppx_repr" { >= "0.6.0" }
+  "bigstringaf" { >= "0.5.0" }
+  "cmdliner" { >= "1.1.0" }
+  "base-unix"
+  "ppx_deriving"
+  "repr"
+  "stdint"
+  "logs"
+  "mavkit-distributed-lwt-internal" { = version }
+  "mavkit-alcotezt" { = version }
+  "aches-lwt" { >= "1.0.0" }
+  "ipaddr" { >= "5.3.0" & < "6.0.0" }
+  "ptime" { >= "1.1.0" }
+  "mtime" { >= "2.0.0" }
+  "conf-libev"
+  "uutf"
+  "ringo" { >= "1.0.0" }
+  "qcheck-core" {with-test}
+  "mavkit-internal-libs" { = version }
+  "conf-rust"
+  "integers"
+  "integers_stubs_js"
+  "tezos-rust-libs" { = "1.6" }
+  "tezos-sapling-parameters" { >= "1.1.0" }
+  "lwt-watcher" { = "0.2" }
+  "resto-cohttp" { >= "1.2" }
+  "resto-cohttp-client" { >= "1.2" }
+  "cohttp-lwt-unix" { >= "5.2.0" }
+  "resto-cohttp-server" { >= "1.2" }
+  "resto-acl" { >= "1.2" }
+  "bigstring" {with-test}
+]
+x-opam-monorepo-opam-provided: [
+  "tezos-rust-libs"
+  "tezos-sapling-parameters"
+]
+conflicts: [
+  "checkseum" { = "0.5.0" }
+  "hacl_x25519"
+  "result" { < "1.5" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "A package that contains multiple base libraries used by the Mavkit suite"

--- a/packages/mavkit-node-config/mavkit-node-config.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-node-config/mavkit-node-config.20.2-rc2-mavryk/opam
@@ -1,0 +1,21 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit: `mavkit-node-config` library"

--- a/packages/mavkit-node/mavkit-node.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-node/mavkit-node.20.2-rc2-mavryk/opam
@@ -1,0 +1,49 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-version" { = version }
+  "mavkit-node-config" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavkit-rpc-process" { = version }
+  "cmdliner" { >= "1.1.0" }
+  "fmt" { >= "0.8.7" }
+  "tls-lwt" { >= "0.16.0" }
+  "prometheus-app" { >= "1.2" }
+  "lwt-exit"
+  "uri" { >= "3.1.0" }
+  "mavryk-protocol-000-Ps9mPmXa" { = version }
+  "mavryk-protocol-001-PtAtLas" { = version }
+  "mavkit-protocol-001-PtAtLas-libs" { = version }
+  "mavryk-protocol-002-PtBoreas" { = version }
+  "mavkit-protocol-002-PtBoreas-libs" { = version }
+]
+depopts: [
+  "mavryk-protocol-genesis"
+  "mavryk-protocol-demo-noops"
+  "mavryk-protocol-demo-counter"
+  "mavryk-protocol-alpha"
+  "mavkit-protocol-alpha-libs"
+]
+conflicts: [
+  "mavryk-protocol-genesis" { != version }
+  "mavryk-protocol-demo-noops" { != version }
+  "mavryk-protocol-demo-counter" { != version }
+  "mavryk-protocol-alpha" { != version }
+  "mavkit-protocol-alpha-libs" { != version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: `mavkit-node` binary"

--- a/packages/mavkit-proto-libs/mavkit-proto-libs.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-proto-libs/mavkit-proto-libs.20.2-rc2-mavryk/opam
@@ -1,0 +1,32 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-l2-libs" { = version }
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+  "bls12-381" { = version }
+  "zarith" { >= "1.13" & < "1.14" }
+  "zarith_stubs_js" { >= "0.16.1" }
+  "class_group_vdf" { >= "0.0.4" }
+  "aches" { >= "1.0.0" }
+  "aches-lwt" { >= "1.0.0" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-alcotezt" { with-test & = version }
+  "qcheck-alcotest" { with-test & >= "0.20" }
+  "lwt" { with-test & >= "5.7.0" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit protocol libraries"

--- a/packages/mavkit-protocol-000-Ps9mPmXa-libs/mavkit-protocol-000-Ps9mPmXa-libs.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-protocol-000-Ps9mPmXa-libs/mavkit-protocol-000-Ps9mPmXa-libs.20.2-rc2-mavryk/opam
@@ -1,0 +1,22 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavryk-protocol-000-Ps9mPmXa" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit protocol 000-Ps9mPmXa libraries"

--- a/packages/mavkit-protocol-001-PtAtLas-libs/mavkit-protocol-001-PtAtLas-libs.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-protocol-001-PtAtLas-libs/mavkit-protocol-001-PtAtLas-libs.20.2-rc2-mavryk/opam
@@ -1,0 +1,40 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "ppx_expect"
+  "mavkit-libs" { = version }
+  "mavryk-protocol-001-PtAtLas" { = version }
+  "mavkit-shell-libs" { = version }
+  "uri" { >= "3.1.0" }
+  "qcheck-alcotest" { >= "0.20" }
+  "mavkit-proto-libs" { = version }
+  "mavkit-version" { = version }
+  "mavryk-dal-node-services" { = version }
+  "lwt-canceler" { >= "0.3" & < "0.4" }
+  "lwt-exit"
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+  "tezt" { >= "4.0.0" & < "5.0.0" }
+  "mavkit-protocol-compiler" { = version }
+  "mavryk-dal-node-lib" { = version }
+  "mavryk-dac-lib" { = version }
+  "mavryk-dac-client-lib" { = version }
+  "mavkit-injector" { = version }
+  "mavkit-l2-libs" { = version }
+  "mavkit-alcotezt" { with-test & = version }
+  "mavryk-dac-node-lib" { with-test & = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit protocol 001-PtAtLas libraries"

--- a/packages/mavkit-protocol-002-PtBoreas-libs/mavkit-protocol-002-PtBoreas-libs.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-protocol-002-PtBoreas-libs/mavkit-protocol-002-PtBoreas-libs.20.2-rc2-mavryk/opam
@@ -1,0 +1,40 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "ppx_expect"
+  "mavkit-libs" { = version }
+  "mavryk-protocol-002-PtBoreas" { = version }
+  "mavkit-shell-libs" { = version }
+  "uri" { >= "3.1.0" }
+  "tezt" { >= "4.0.0" & < "5.0.0" }
+  "qcheck-alcotest" { >= "0.20" }
+  "mavkit-proto-libs" { = version }
+  "mavkit-version" { = version }
+  "mavryk-dal-node-services" { = version }
+  "lwt-canceler" { >= "0.3" & < "0.4" }
+  "lwt-exit"
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+  "mavkit-protocol-compiler" { = version }
+  "mavryk-dal-node-lib" { = version }
+  "mavryk-dac-lib" { = version }
+  "mavryk-dac-client-lib" { = version }
+  "mavkit-injector" { = version }
+  "mavkit-l2-libs" { = version }
+  "mavkit-alcotezt" { with-test & = version }
+  "mavryk-dac-node-lib" { with-test & = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit protocol 002-PtBoreas libraries"

--- a/packages/mavkit-protocol-alpha-libs/mavkit-protocol-alpha-libs.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-protocol-alpha-libs/mavkit-protocol-alpha-libs.20.2-rc2-mavryk/opam
@@ -1,0 +1,41 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "ppx_expect"
+  "mavkit-libs" { = version }
+  "mavryk-protocol-alpha" { = version }
+  "mavkit-shell-libs" { = version }
+  "uri" { >= "3.1.0" }
+  "tezt" { >= "4.0.0" & < "5.0.0" }
+  "tezt-mavryk" { = version }
+  "qcheck-alcotest" { >= "0.20" }
+  "mavkit-proto-libs" { = version }
+  "mavkit-version" { = version }
+  "mavryk-dal-node-services" { = version }
+  "lwt-canceler" { >= "0.3" & < "0.4" }
+  "lwt-exit"
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+  "mavkit-protocol-compiler" { = version }
+  "mavryk-dal-node-lib" { = version }
+  "mavryk-dac-lib" { = version }
+  "mavryk-dac-client-lib" { = version }
+  "mavkit-injector" { = version }
+  "mavkit-l2-libs" { = version }
+  "mavkit-alcotezt" { with-test & = version }
+  "mavryk-dac-node-lib" { with-test & = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit protocol alpha libraries"

--- a/packages/mavkit-protocol-compiler/mavkit-protocol-compiler.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-protocol-compiler/mavkit-protocol-compiler.20.2-rc2-mavryk/opam
@@ -1,0 +1,25 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-proto-libs" { = version }
+  "lwt" { >= "5.7.0" }
+  "ocp-ocamlres" { >= "0.4" }
+  "base-unix"
+  "mavkit-version" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: economic-protocol compiler"

--- a/packages/mavkit-proxy-server/mavkit-proxy-server.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-proxy-server/mavkit-proxy-server.20.2-rc2-mavryk/opam
@@ -1,0 +1,43 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "cmdliner" { >= "1.1.0" }
+  "lwt-exit"
+  "lwt" { >= "5.7.0" }
+  "mavkit-shell-libs" { = version }
+  "mavryk-proxy-server-config" { = version }
+  "mavkit-version" { = version }
+  "uri" { >= "3.1.0" }
+]
+depopts: [
+  "mavryk-client-genesis"
+  "mavryk-client-demo-counter"
+  "mavkit-protocol-000-Ps9mPmXa-libs"
+  "mavkit-protocol-001-PtAtLas-libs"
+  "mavkit-protocol-002-PtBoreas-libs"
+  "mavkit-protocol-alpha-libs"
+]
+conflicts: [
+  "mavryk-client-genesis" { != version }
+  "mavryk-client-demo-counter" { != version }
+  "mavkit-protocol-000-Ps9mPmXa-libs" { != version }
+  "mavkit-protocol-001-PtAtLas-libs" { != version }
+  "mavkit-protocol-002-PtBoreas-libs" { != version }
+  "mavkit-protocol-alpha-libs" { != version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit: `mavkit-proxy-server` binary"

--- a/packages/mavkit-risc-v-pvm-test/mavkit-risc-v-pvm-test.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-risc-v-pvm-test/mavkit-risc-v-pvm-test.20.2-rc2-mavryk/opam
@@ -1,0 +1,22 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-alcotezt" {with-test}
+  "mavkit-risc-v-pvm" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tests for RISC-V interpreter bindings"

--- a/packages/mavkit-risc-v-pvm/mavkit-risc-v-pvm.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-risc-v-pvm/mavkit-risc-v-pvm.20.2-rc2-mavryk/opam
@@ -1,0 +1,21 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "ctypes" { >= "0.18.0" }
+  "ctypes-foreign" { >= "0.18.0" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Bindings for RISC-V interpreter"

--- a/packages/mavkit-rpc-process/mavkit-rpc-process.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-rpc-process/mavkit-rpc-process.20.2-rc2-mavryk/opam
@@ -1,0 +1,25 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavkit-node-config" { = version }
+  "lwt" { >= "5.7.0" }
+  "lwt-exit"
+  "prometheus-app" { >= "1.2" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: RPC process"

--- a/packages/mavkit-shell-libs/mavkit-shell-libs.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-shell-libs/mavkit-shell-libs.20.2-rc2-mavryk/opam
@@ -1,0 +1,56 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "lwt-watcher" { = "0.2" }
+  "lwt-canceler" { >= "0.3" & < "0.4" }
+  "ringo" { >= "1.0.0" }
+  "aches" { >= "1.0.0" }
+  "prometheus" { >= "1.2" }
+  "tezt" { >= "4.0.0" & < "5.0.0" }
+  "tezt-mavryk" { with-test & = version }
+  "mavkit-alcotezt" { with-test & = version }
+  "astring" {with-test}
+  "mavkit-proto-libs" { = version }
+  "mavkit-protocol-compiler" { = version }
+  "lwt-exit"
+  "mavkit-version" { = version }
+  "aches-lwt" { >= "1.0.0" }
+  "index" { >= "1.6.0" & < "1.7.0" }
+  "mavkit-internal-libs" { = version }
+  "camlzip" { >= "1.11" & < "1.12" }
+  "tar"
+  "tar-unix" { >= "2.0.1" & < "3.0.0" }
+  "ppx_expect"
+  "uri" { >= "3.1.0" }
+  "ocplib-endian"
+  "fmt" { >= "0.8.7" }
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+  "resto-cohttp-self-serving-client" { >= "1.2" }
+  "mavryk-benchmark" { = version }
+  "qcheck-alcotest" { with-test & >= "0.20" }
+  "qcheck-core" {with-test}
+  "lwt" { with-test & >= "5.7.0" }
+]
+depopts: [
+  "ledgerwallet-tezos"
+]
+conflicts: [
+  "checkseum" { = "0.5.0" }
+  "ledgerwallet-tezos" { < "0.4.0" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit shell libraries"

--- a/packages/mavkit-shell-tests/mavkit-shell-tests.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-shell-tests/mavkit-shell-tests.20.2-rc2-mavryk/opam
@@ -1,0 +1,26 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-libs" {with-test}
+  "mavkit-shell-libs" {with-test}
+  "mavryk-protocol-demo-noops" {with-test}
+  "mavkit-alcotezt" {with-test}
+  "mavkit-version" {with-test}
+  "qcheck-alcotest" { with-test & >= "0.20" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Shell tests"

--- a/packages/mavkit-signer/mavkit-signer.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-signer/mavkit-signer.20.2-rc2-mavryk/opam
@@ -1,0 +1,21 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: `mavkit-signer` binary"

--- a/packages/mavkit-smart-rollup-node-PtAtLas/mavkit-smart-rollup-node-PtAtLas.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-smart-rollup-node-PtAtLas/mavkit-smart-rollup-node-PtAtLas.20.2-rc2-mavryk/opam
@@ -1,0 +1,39 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavkit-protocol-001-PtAtLas-libs" { = version }
+  "mavryk-protocol-001-PtAtLas" { = version }
+  "mavryk-dal-node-services" { = version }
+  "mavryk-dal-node-lib" { = version }
+  "mavryk-dac-lib" { = version }
+  "mavryk-dac-client-lib" { = version }
+  "mavkit-l2-libs" { = version }
+  "mavkit-crawler" { = version }
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+  "mavkit-internal-libs" { = version }
+  "aches" { >= "1.0.0" }
+  "aches-lwt" { >= "1.0.0" }
+  "mavkit-injector" { = version }
+  "mavkit-smart-rollup-node-lib" { = version }
+  "mavkit-version" { = version }
+]
+conflicts: [
+  "checkseum" { = "0.5.0" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Protocol specific (for 001-PtAtLas) library for smart rollup node"

--- a/packages/mavkit-smart-rollup-node-PtBoreas/mavkit-smart-rollup-node-PtBoreas.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-smart-rollup-node-PtBoreas/mavkit-smart-rollup-node-PtBoreas.20.2-rc2-mavryk/opam
@@ -1,0 +1,39 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavkit-protocol-002-PtBoreas-libs" { = version }
+  "mavryk-protocol-002-PtBoreas" { = version }
+  "mavryk-dal-node-services" { = version }
+  "mavryk-dal-node-lib" { = version }
+  "mavryk-dac-lib" { = version }
+  "mavryk-dac-client-lib" { = version }
+  "mavkit-l2-libs" { = version }
+  "mavkit-crawler" { = version }
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+  "mavkit-internal-libs" { = version }
+  "aches" { >= "1.0.0" }
+  "aches-lwt" { >= "1.0.0" }
+  "mavkit-injector" { = version }
+  "mavkit-smart-rollup-node-lib" { = version }
+  "mavkit-version" { = version }
+]
+conflicts: [
+  "checkseum" { = "0.5.0" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Protocol specific (for 002-PtBoreas) library for smart rollup node"

--- a/packages/mavkit-smart-rollup-node-alpha/mavkit-smart-rollup-node-alpha.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-smart-rollup-node-alpha/mavkit-smart-rollup-node-alpha.20.2-rc2-mavryk/opam
@@ -1,0 +1,39 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavkit-protocol-alpha-libs" { = version }
+  "mavryk-protocol-alpha" { = version }
+  "mavryk-dal-node-services" { = version }
+  "mavryk-dal-node-lib" { = version }
+  "mavryk-dac-lib" { = version }
+  "mavryk-dac-client-lib" { = version }
+  "mavkit-l2-libs" { = version }
+  "mavkit-crawler" { = version }
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+  "mavkit-internal-libs" { = version }
+  "aches" { >= "1.0.0" }
+  "aches-lwt" { >= "1.0.0" }
+  "mavkit-injector" { = version }
+  "mavkit-smart-rollup-node-lib" { = version }
+  "mavkit-version" { = version }
+]
+conflicts: [
+  "checkseum" { = "0.5.0" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Protocol specific (for alpha) library for smart rollup node"

--- a/packages/mavkit-smart-rollup-node-lib/mavkit-smart-rollup-node-lib.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-smart-rollup-node-lib/mavkit-smart-rollup-node-lib.20.2-rc2-mavryk/opam
@@ -1,0 +1,35 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "cohttp-lwt-unix" { >= "5.2.0" }
+  "mavryk-openapi" { = version }
+  "mavkit-node-config" { = version }
+  "prometheus-app" { >= "1.2" }
+  "camlzip" { >= "1.11" & < "1.12" }
+  "tar"
+  "tar-unix" { >= "2.0.1" & < "3.0.0" }
+  "mavryk-dal-node-lib" { = version }
+  "mavryk-dac-lib" { = version }
+  "mavryk-dac-client-lib" { = version }
+  "mavkit-injector" { = version }
+  "mavkit-version" { = version }
+  "mavkit-l2-libs" { = version }
+  "mavkit-crawler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit: library for Smart Rollup node"

--- a/packages/mavkit-smart-rollup-node/mavkit-smart-rollup-node.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-smart-rollup-node/mavkit-smart-rollup-node.20.2-rc2-mavryk/opam
@@ -1,0 +1,31 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavkit-l2-libs" { = version }
+  "mavkit-smart-rollup-node-lib" { = version }
+  "mavkit-smart-rollup-node-PtAtLas" { = version }
+  "mavkit-smart-rollup-node-PtBoreas" { = version }
+]
+depopts: [
+  "mavkit-smart-rollup-node-alpha"
+]
+conflicts: [
+  "mavkit-smart-rollup-node-alpha" { != version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit: Smart rollup node"

--- a/packages/mavkit-smart-rollup-wasm-debugger-lib/mavkit-smart-rollup-wasm-debugger-lib.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-smart-rollup-wasm-debugger-lib/mavkit-smart-rollup-wasm-debugger-lib.20.2-rc2-mavryk/opam
@@ -1,0 +1,26 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-protocol-alpha-libs" { = version }
+  "cohttp-lwt-unix" { >= "5.2.0" }
+  "mavkit-l2-libs" { = version }
+  "mavkit-version" { = version }
+  "mavkit-smart-rollup-wasm-debugger-plugin" { = version }
+  "lambda-term" { >= "3.3.1" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: Library used for the Smart Rollups' WASM debugger"

--- a/packages/mavkit-smart-rollup-wasm-debugger-plugin/mavkit-smart-rollup-wasm-debugger-plugin.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-smart-rollup-wasm-debugger-plugin/mavkit-smart-rollup-wasm-debugger-plugin.20.2-rc2-mavryk/opam
@@ -1,0 +1,19 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Plugin interface for the Mavkit Smart Rollup WASM Debugger"

--- a/packages/mavkit-smart-rollup-wasm-debugger/mavkit-smart-rollup-wasm-debugger.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-smart-rollup-wasm-debugger/mavkit-smart-rollup-wasm-debugger.20.2-rc2-mavryk/opam
@@ -1,0 +1,20 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-smart-rollup-wasm-debugger-lib" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: Debugger for the smart rollups’ WASM kernels"

--- a/packages/mavkit-snoop/mavkit-snoop.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-snoop/mavkit-snoop.20.2-rc2-mavryk/opam
@@ -1,0 +1,27 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-benchmark" { = version }
+  "mavryk-benchmark-examples" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavryk-benchmarks-proto-alpha" { = version }
+  "pyml" { >= "20220905" }
+  "prbnmcn-stats" { = "0.0.6" }
+  "mavkit-version" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: `mavkit-snoop` binary"

--- a/packages/mavkit-store-tests/mavkit-store-tests.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-store-tests/mavkit-store-tests.20.2-rc2-mavryk/opam
@@ -1,0 +1,27 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-libs" {with-test}
+  "mavkit-shell-libs" {with-test}
+  "mavryk-protocol-demo-noops" {with-test}
+  "mavryk-protocol-genesis" {with-test}
+  "mavryk-protocol-alpha" {with-test}
+  "mavkit-protocol-alpha-libs" {with-test}
+  "mavkit-alcotezt" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Store tests"

--- a/packages/mavkit-testnet-scenarios/mavkit-testnet-scenarios.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-testnet-scenarios/mavkit-testnet-scenarios.20.2-rc2-mavryk/opam
@@ -1,0 +1,22 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs"
+  "tezt-mavryk"
+  "tezt-etherlink" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Run scenarios on testnets"

--- a/packages/mavkit-version/mavkit-version.20.2-rc2-mavryk/opam
+++ b/packages/mavkit-version/mavkit-version.20.2-rc2-mavryk/opam
@@ -1,0 +1,21 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "dune-configurator"
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: version value generated from Git"

--- a/packages/mavryk-benchmark-001-PtAtLas/mavryk-benchmark-001-PtAtLas.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-benchmark-001-PtAtLas/mavryk-benchmark-001-PtAtLas.20.2-rc2-mavryk/opam
@@ -1,0 +1,27 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-micheline-rewriting" { = version }
+  "mavryk-benchmark" { = version }
+  "mavryk-benchmark-type-inference-001-PtAtLas" { = version }
+  "mavryk-protocol-001-PtAtLas" { = version }
+  "hashcons"
+  "mavkit-protocol-001-PtAtLas-libs" { = version }
+  "prbnmcn-stats" { = "0.0.6" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: library for writing benchmarks (protocol-specific part)"

--- a/packages/mavryk-benchmark-002-PtBoreas/mavryk-benchmark-002-PtBoreas.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-benchmark-002-PtBoreas/mavryk-benchmark-002-PtBoreas.20.2-rc2-mavryk/opam
@@ -1,0 +1,27 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-micheline-rewriting" { = version }
+  "mavryk-benchmark" { = version }
+  "mavryk-benchmark-type-inference-002-PtBoreas" { = version }
+  "mavryk-protocol-002-PtBoreas" { = version }
+  "hashcons"
+  "mavkit-protocol-002-PtBoreas-libs" { = version }
+  "prbnmcn-stats" { = "0.0.6" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: library for writing benchmarks (protocol-specific part)"

--- a/packages/mavryk-benchmark-alpha/mavryk-benchmark-alpha.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-benchmark-alpha/mavryk-benchmark-alpha.20.2-rc2-mavryk/opam
@@ -1,0 +1,27 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-micheline-rewriting" { = version }
+  "mavryk-benchmark" { = version }
+  "mavryk-benchmark-type-inference-alpha" { = version }
+  "mavryk-protocol-alpha" { = version }
+  "hashcons"
+  "mavkit-protocol-alpha-libs" { = version }
+  "prbnmcn-stats" { = "0.0.6" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: library for writing benchmarks (protocol-specific part)"

--- a/packages/mavryk-benchmark-examples/mavryk-benchmark-examples.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-benchmark-examples/mavryk-benchmark-examples.20.2-rc2-mavryk/opam
@@ -1,0 +1,21 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-benchmark" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: examples for lib-benchmarks"

--- a/packages/mavryk-benchmark-tests/mavryk-benchmark-tests.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-benchmark-tests/mavryk-benchmark-tests.20.2-rc2-mavryk/opam
@@ -1,0 +1,24 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-alcotezt" {with-test}
+  "mavkit-libs" {with-test}
+  "mavryk-benchmark" {with-test}
+  "mavryk-benchmark-examples" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: tests for lib-benchmarks"

--- a/packages/mavryk-benchmark-type-inference-001-PtAtLas/mavryk-benchmark-type-inference-001-PtAtLas.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-benchmark-type-inference-001-PtAtLas/mavryk-benchmark-type-inference-001-PtAtLas.20.2-rc2-mavryk/opam
@@ -1,0 +1,24 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-micheline-rewriting" { = version }
+  "mavryk-protocol-001-PtAtLas" { = version }
+  "hashcons"
+  "mavkit-protocol-001-PtAtLas-libs" { with-test & = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: type inference for partial Michelson expressions"

--- a/packages/mavryk-benchmark-type-inference-002-PtBoreas/mavryk-benchmark-type-inference-002-PtBoreas.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-benchmark-type-inference-002-PtBoreas/mavryk-benchmark-type-inference-002-PtBoreas.20.2-rc2-mavryk/opam
@@ -1,0 +1,24 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-micheline-rewriting" { = version }
+  "mavryk-protocol-002-PtBoreas" { = version }
+  "hashcons"
+  "mavkit-protocol-002-PtBoreas-libs" { with-test & = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: type inference for partial Michelson expressions"

--- a/packages/mavryk-benchmark-type-inference-alpha/mavryk-benchmark-type-inference-alpha.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-benchmark-type-inference-alpha/mavryk-benchmark-type-inference-alpha.20.2-rc2-mavryk/opam
@@ -1,0 +1,24 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-micheline-rewriting" { = version }
+  "mavryk-protocol-alpha" { = version }
+  "hashcons"
+  "mavkit-protocol-alpha-libs" { with-test & = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: type inference for partial Michelson expressions"

--- a/packages/mavryk-benchmark/mavryk-benchmark.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-benchmark/mavryk-benchmark.20.2-rc2-mavryk/opam
@@ -1,0 +1,25 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "ppx_expect"
+  "mavkit-libs" { = version }
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+  "prbnmcn-linalg" { = "0.0.1" }
+  "prbnmcn-stats" { = "0.0.6" }
+  "pringo" { >= "1.3" & < "1.4" }
+  "pyml" { >= "20220905" }
+  "ocamlgraph"
+  "ocaml-migrate-parsetree"
+  "hashcons"
+]
+build: [["rm" "-r" "vendors" "contrib"] ["dune" "build" "-p" name "-j" jobs]]
+synopsis: "Mavryk: library for writing benchmarks and performing simple parameter inference"

--- a/packages/mavryk-benchmarks-proto-001-PtAtLas/mavryk-benchmarks-proto-001-PtAtLas.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-benchmarks-proto-001-PtAtLas/mavryk-benchmarks-proto-001-PtAtLas.20.2-rc2-mavryk/opam
@@ -1,0 +1,27 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-protocol-001-PtAtLas" { = version }
+  "mavryk-benchmark" { = version }
+  "mavryk-benchmark-001-PtAtLas" { = version }
+  "mavryk-benchmark-type-inference-001-PtAtLas" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavkit-protocol-001-PtAtLas-libs" { = version }
+  "mavkit-proto-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: protocol benchmarks"

--- a/packages/mavryk-benchmarks-proto-002-PtBoreas/mavryk-benchmarks-proto-002-PtBoreas.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-benchmarks-proto-002-PtBoreas/mavryk-benchmarks-proto-002-PtBoreas.20.2-rc2-mavryk/opam
@@ -1,0 +1,27 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-protocol-002-PtBoreas" { = version }
+  "mavryk-benchmark" { = version }
+  "mavryk-benchmark-002-PtBoreas" { = version }
+  "mavryk-benchmark-type-inference-002-PtBoreas" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavkit-protocol-002-PtBoreas-libs" { = version }
+  "mavkit-proto-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: protocol benchmarks"

--- a/packages/mavryk-benchmarks-proto-alpha/mavryk-benchmarks-proto-alpha.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-benchmarks-proto-alpha/mavryk-benchmarks-proto-alpha.20.2-rc2-mavryk/opam
@@ -1,0 +1,27 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-protocol-alpha" { = version }
+  "mavryk-benchmark" { = version }
+  "mavryk-benchmark-alpha" { = version }
+  "mavryk-benchmark-type-inference-alpha" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavkit-protocol-alpha-libs" { = version }
+  "mavkit-proto-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: protocol benchmarks"

--- a/packages/mavryk-client-demo-counter/mavryk-client-demo-counter.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-client-demo-counter/mavryk-client-demo-counter.20.2-rc2-mavryk/opam
@@ -1,0 +1,22 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavryk-protocol-demo-counter" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: protocol specific library for `mavkit-client`"

--- a/packages/mavryk-client-genesis/mavryk-client-genesis.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-client-genesis/mavryk-client-genesis.20.2-rc2-mavryk/opam
@@ -1,0 +1,23 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavkit-proto-libs" { = version }
+  "mavryk-protocol-genesis" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: protocol specific library for `mavkit-client`"

--- a/packages/mavryk-dac-client-lib/mavryk-dac-client-lib.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-dac-client-lib/mavryk-dac-client-lib.20.2-rc2-mavryk/opam
@@ -1,0 +1,22 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavryk-dac-lib" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: `mavryk-dac-client` library"

--- a/packages/mavryk-dac-lib-test/mavryk-dac-lib-test.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-dac-lib-test/mavryk-dac-lib-test.20.2-rc2-mavryk/opam
@@ -1,0 +1,23 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-libs" {with-test}
+  "mavryk-dac-lib" {with-test}
+  "mavkit-alcotezt" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Test for dac lib"

--- a/packages/mavryk-dac-lib/mavryk-dac-lib.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-dac-lib/mavryk-dac-lib.20.2-rc2-mavryk/opam
@@ -1,0 +1,21 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: `mavryk-dac` library"

--- a/packages/mavryk-dac-node-lib-test/mavryk-dac-node-lib-test.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-dac-node-lib-test/mavryk-dac-node-lib-test.20.2-rc2-mavryk/opam
@@ -1,0 +1,23 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-libs" {with-test}
+  "mavryk-dac-node-lib" {with-test}
+  "mavkit-alcotezt" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Test for dac node lib"

--- a/packages/mavryk-dac-node-lib/mavryk-dac-node-lib.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-dac-node-lib/mavryk-dac-node-lib.20.2-rc2-mavryk/opam
@@ -1,0 +1,24 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavkit-l2-libs" { = version }
+  "mavryk-dac-lib" { = version }
+  "mavryk-dac-client-lib" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: `mavryk-dac-node` library"

--- a/packages/mavryk-dal-node-lib/mavryk-dal-node-lib.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-dal-node-lib/mavryk-dal-node-lib.20.2-rc2-mavryk/opam
@@ -1,0 +1,22 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-dal-node-services" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: `mavryk-dal-node` library"

--- a/packages/mavryk-dal-node-services/mavryk-dal-node-services.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-dal-node-services/mavryk-dal-node-services.20.2-rc2-mavryk/opam
@@ -1,0 +1,20 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: `mavryk-dal-node` RPC services"

--- a/packages/mavryk-injector-001-PtAtLas/mavryk-injector-001-PtAtLas.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-injector-001-PtAtLas/mavryk-injector-001-PtAtLas.20.2-rc2-mavryk/opam
@@ -1,0 +1,24 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-protocol-001-PtAtLas" { = version }
+  "mavkit-injector" { = version }
+  "mavkit-protocol-001-PtAtLas-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: protocol-specific library for the injector binary"

--- a/packages/mavryk-injector-002-PtBoreas/mavryk-injector-002-PtBoreas.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-injector-002-PtBoreas/mavryk-injector-002-PtBoreas.20.2-rc2-mavryk/opam
@@ -1,0 +1,24 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-protocol-002-PtBoreas" { = version }
+  "mavkit-injector" { = version }
+  "mavkit-protocol-002-PtBoreas-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: protocol-specific library for the injector binary"

--- a/packages/mavryk-injector-alpha/mavryk-injector-alpha.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-injector-alpha/mavryk-injector-alpha.20.2-rc2-mavryk/opam
@@ -1,0 +1,24 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "mavryk-protocol-alpha" { = version }
+  "mavkit-injector" { = version }
+  "mavkit-protocol-alpha-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: protocol-specific library for the injector binary"

--- a/packages/mavryk-lazy-containers-tests/mavryk-lazy-containers-tests.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-lazy-containers-tests/mavryk-lazy-containers-tests.20.2-rc2-mavryk/opam
@@ -1,0 +1,25 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-libs" {with-test}
+  "qcheck-core" {with-test}
+  "qcheck-alcotest" { with-test & >= "0.20" }
+  "lwt" { with-test & >= "5.7.0" }
+  "mavkit-alcotezt" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Various tests for the lazy containers library"

--- a/packages/mavryk-micheline-rewriting/mavryk-micheline-rewriting.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-micheline-rewriting/mavryk-micheline-rewriting.20.2-rc2-mavryk/opam
@@ -1,0 +1,25 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "zarith" { >= "1.13" & < "1.14" }
+  "zarith_stubs_js" { >= "0.16.1" }
+  "mavkit-libs" { = version }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavryk-protocol-alpha" { with-test & = version }
+  "mavkit-protocol-alpha-libs" { with-test & = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: library for rewriting Micheline expressions"

--- a/packages/mavryk-openapi/mavryk-openapi.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-openapi/mavryk-openapi.20.2-rc2-mavryk/opam
@@ -1,0 +1,22 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "ezjsonm" { >= "1.3.0" }
+  "json-data-encoding" { >= "1.0.1" & < "1.1" }
+  "tezt" { >= "4.0.0" & < "5.0.0" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: a library for querying RPCs and converting into the OpenAPI format"

--- a/packages/mavryk-protocol-000-Ps9mPmXa/mavryk-protocol-000-Ps9mPmXa.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-protocol-000-Ps9mPmXa/mavryk-protocol-000-Ps9mPmXa.20.2-rc2-mavryk/opam
@@ -1,0 +1,21 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-proto-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk protocol 000-Ps9mPmXa package"

--- a/packages/mavryk-protocol-001-PtAtLas-tests/mavryk-protocol-001-PtAtLas-tests.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-protocol-001-PtAtLas-tests/mavryk-protocol-001-PtAtLas-tests.20.2-rc2-mavryk/opam
@@ -1,0 +1,32 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-libs" {with-test}
+  "mavkit-alcotezt" {with-test}
+  "mavkit-protocol-001-PtAtLas-libs" {with-test}
+  "mavryk-protocol-001-PtAtLas" {with-test}
+  "mavryk-benchmark" {with-test}
+  "mavryk-benchmark-001-PtAtLas" {with-test}
+  "mavryk-benchmark-type-inference-001-PtAtLas" {with-test}
+  "qcheck-alcotest" { with-test & >= "0.20" }
+  "tezt-mavryk" {with-test}
+  "mavkit-shell-libs" {with-test}
+  "mavkit-proto-libs" {with-test}
+  "mavkit-l2-libs" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: tests for economic-protocol definition"

--- a/packages/mavryk-protocol-001-PtAtLas/mavryk-protocol-001-PtAtLas.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-protocol-001-PtAtLas/mavryk-protocol-001-PtAtLas.20.2-rc2-mavryk/opam
@@ -1,0 +1,22 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-proto-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavkit-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk protocol 001-PtAtLas package"

--- a/packages/mavryk-protocol-002-PtBoreas-tests/mavryk-protocol-002-PtBoreas-tests.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-protocol-002-PtBoreas-tests/mavryk-protocol-002-PtBoreas-tests.20.2-rc2-mavryk/opam
@@ -1,0 +1,32 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-libs" {with-test}
+  "mavkit-alcotezt" {with-test}
+  "mavkit-protocol-002-PtBoreas-libs" {with-test}
+  "mavryk-protocol-002-PtBoreas" {with-test}
+  "mavryk-benchmark" {with-test}
+  "mavryk-benchmark-002-PtBoreas" {with-test}
+  "mavryk-benchmark-type-inference-002-PtBoreas" {with-test}
+  "qcheck-alcotest" { with-test & >= "0.20" }
+  "tezt-mavryk" {with-test}
+  "mavkit-shell-libs" {with-test}
+  "mavkit-proto-libs" {with-test}
+  "mavkit-l2-libs" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: tests for economic-protocol definition"

--- a/packages/mavryk-protocol-002-PtBoreas/mavryk-protocol-002-PtBoreas.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-protocol-002-PtBoreas/mavryk-protocol-002-PtBoreas.20.2-rc2-mavryk/opam
@@ -1,0 +1,22 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-proto-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavkit-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk protocol 002-PtBoreas package"

--- a/packages/mavryk-protocol-alpha-tests/mavryk-protocol-alpha-tests.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-protocol-alpha-tests/mavryk-protocol-alpha-tests.20.2-rc2-mavryk/opam
@@ -1,0 +1,32 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-libs" {with-test}
+  "mavkit-alcotezt" {with-test}
+  "mavkit-protocol-alpha-libs" {with-test}
+  "mavryk-protocol-alpha" {with-test}
+  "mavryk-benchmark" {with-test}
+  "mavryk-benchmark-alpha" {with-test}
+  "mavryk-benchmark-type-inference-alpha" {with-test}
+  "qcheck-alcotest" { with-test & >= "0.20" }
+  "tezt-mavryk" {with-test}
+  "mavkit-shell-libs" {with-test}
+  "mavkit-proto-libs" {with-test}
+  "mavkit-l2-libs" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk/Protocol: tests for economic-protocol definition"

--- a/packages/mavryk-protocol-alpha/mavryk-protocol-alpha.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-protocol-alpha/mavryk-protocol-alpha.20.2-rc2-mavryk/opam
@@ -1,0 +1,22 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-proto-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavkit-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk protocol alpha package"

--- a/packages/mavryk-protocol-demo-counter/mavryk-protocol-demo-counter.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-protocol-demo-counter/mavryk-protocol-demo-counter.20.2-rc2-mavryk/opam
@@ -1,0 +1,21 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-proto-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk protocol demo-counter package"

--- a/packages/mavryk-protocol-demo-noops/mavryk-protocol-demo-noops.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-protocol-demo-noops/mavryk-protocol-demo-noops.20.2-rc2-mavryk/opam
@@ -1,0 +1,21 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-proto-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk protocol demo-noops package"

--- a/packages/mavryk-protocol-genesis/mavryk-protocol-genesis.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-protocol-genesis/mavryk-protocol-genesis.20.2-rc2-mavryk/opam
@@ -1,0 +1,21 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-proto-libs" { = version }
+  "mavkit-shell-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk protocol genesis package"

--- a/packages/mavryk-proxy-server-config/mavryk-proxy-server-config.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-proxy-server-config/mavryk-proxy-server-config.20.2-rc2-mavryk/opam
@@ -1,0 +1,24 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "uri" { >= "3.1.0" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "qcheck-alcotest" { with-test & >= "0.20" }
+  "mavkit-alcotezt" { with-test & = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: proxy server configuration"

--- a/packages/mavryk-sc-rollup-node-test/mavryk-sc-rollup-node-test.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-sc-rollup-node-test/mavryk-sc-rollup-node-test.20.2-rc2-mavryk/opam
@@ -1,0 +1,31 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-libs" {with-test}
+  "mavryk-protocol-001-PtAtLas" {with-test}
+  "mavkit-protocol-001-PtAtLas-libs" {with-test}
+  "mavkit-smart-rollup-node-PtAtLas" {with-test}
+  "mavkit-alcotezt" {with-test}
+  "mavryk-protocol-002-PtBoreas" {with-test}
+  "mavkit-protocol-002-PtBoreas-libs" {with-test}
+  "mavkit-smart-rollup-node-PtBoreas" {with-test}
+  "mavryk-protocol-alpha" {with-test}
+  "mavkit-protocol-alpha-libs" {with-test}
+  "mavkit-smart-rollup-node-alpha" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tests for the smart rollup node library"

--- a/packages/mavryk-scoru-wasm-regressions/mavryk-scoru-wasm-regressions.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-scoru-wasm-regressions/mavryk-scoru-wasm-regressions.20.2-rc2-mavryk/opam
@@ -1,0 +1,26 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "ppx_import" {with-test}
+  "ppx_deriving" {with-test}
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-libs" {with-test}
+  "mavkit-l2-libs" {with-test}
+  "mavryk-protocol-alpha" {with-test}
+  "mavkit-protocol-alpha-libs" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "WASM PVM regressions"

--- a/packages/mavryk-smart-rollup-node-lib-test/mavryk-smart-rollup-node-lib-test.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-smart-rollup-node-lib-test/mavryk-smart-rollup-node-lib-test.20.2-rc2-mavryk/opam
@@ -1,0 +1,33 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-libs" {with-test}
+  "mavkit-l2-libs" {with-test}
+  "mavkit-smart-rollup-node-lib" {with-test}
+  "qcheck-alcotest" { with-test & >= "0.20" }
+  "qcheck-core" {with-test}
+  "logs" {with-test}
+  "mavkit-alcotezt" {with-test}
+  "mavkit-shell-libs" {with-test}
+  "mavkit-smart-rollup-node-PtAtLas" {with-test}
+  "mavkit-smart-rollup-node-PtBoreas" {with-test}
+]
+depopts: [
+  "mavkit-smart-rollup-node-alpha" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tests for the smart rollup node library"

--- a/packages/mavryk-tooling/mavryk-tooling.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-tooling/mavryk-tooling.20.2-rc2-mavryk/opam
@@ -1,0 +1,24 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "bisect_ppx" { >= "2.7.0" }
+  "ocamlformat" { = "0.24.1" }
+  "base-unix"
+  "num"
+  "re" { >= "1.10.0" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk: tooling for the project"

--- a/packages/mavryk-tps-evaluation/mavryk-tps-evaluation.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-tps-evaluation/mavryk-tps-evaluation.20.2-rc2-mavryk/opam
@@ -1,0 +1,31 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "caqti"
+  "caqti-dynload"
+  "caqti-lwt" { >= "2.0.1" }
+  "data-encoding" { >= "1.0.1" & < "1.1" }
+  "lwt" { >= "5.7.0" }
+  "mavkit-protocol-alpha-libs" { = version }
+  "mavkit-shell-libs" { = version }
+  "mavryk-protocol-alpha" { = version }
+  "tezt" { >= "4.0.0" & < "5.0.0" }
+  "tezt-mavryk" { = version }
+  "uri" { >= "3.1.0" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk TPS evaluation tool"

--- a/packages/mavryk-tree-encoding-test/mavryk-tree-encoding-test.20.2-rc2-mavryk/opam
+++ b/packages/mavryk-tree-encoding-test/mavryk-tree-encoding-test.20.2-rc2-mavryk/opam
@@ -1,0 +1,24 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-libs" {with-test}
+  "mavkit-l2-libs" {with-test}
+  "qcheck-alcotest" { with-test & >= "0.20" }
+  "mavkit-alcotezt" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tests for the tree encoding library"

--- a/packages/mavryk_internal_irmin_tests/mavryk_internal_irmin_tests.20.2-rc2-mavryk/opam
+++ b/packages/mavryk_internal_irmin_tests/mavryk_internal_irmin_tests.20.2-rc2-mavryk/opam
@@ -1,0 +1,22 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavkit-libs" {with-test}
+  "mavkit-internal-libs" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavryk internal irmin tests"

--- a/packages/octogram/octogram.20.2-rc2-mavryk/opam
+++ b/packages/octogram/octogram.20.2-rc2-mavryk/opam
@@ -1,0 +1,26 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-shell-libs" { = version }
+  "mavkit-libs" { = version }
+  "tezt" { >= "4.0.0" & < "5.0.0" }
+  "tezt-mavryk" { = version }
+  "jingoo"
+  "dmap"
+  "yaml" { >= "3.1.0" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "An Ansible-inspired environment to run scenarios and experiments"

--- a/packages/tezt-etherlink/tezt-etherlink.20.2-rc2-mavryk/opam
+++ b/packages/tezt-etherlink/tezt-etherlink.20.2-rc2-mavryk/opam
@@ -1,0 +1,25 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs"
+  "tezt-mavryk"
+  "ppx_import" {with-test}
+  "ppx_deriving" {with-test}
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+  "mavryk-protocol-alpha" {with-test}
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezt integration tests for Etherlink"

--- a/packages/tezt-mavryk/tezt-mavryk.20.2-rc2-mavryk/opam
+++ b/packages/tezt-mavryk/tezt-mavryk.20.2-rc2-mavryk/opam
@@ -1,0 +1,24 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "uri" { >= "3.1.0" }
+  "cohttp-lwt-unix" { >= "5.2.0" }
+  "hex" { >= "1.3.0" }
+  "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Mavkit test framework based on Tezt"

--- a/packages/tezt-risc-v-sandbox/tezt-risc-v-sandbox.20.2-rc2-mavryk/opam
+++ b/packages/tezt-risc-v-sandbox/tezt-risc-v-sandbox.20.2-rc2-mavryk/opam
@@ -1,0 +1,21 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "mavkit-libs" { = version }
+  "tezt-mavryk" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Test framework for RISC-V sandbox"

--- a/packages/tezt-tx-kernel/tezt-tx-kernel.20.2-rc2-mavryk/opam
+++ b/packages/tezt-tx-kernel/tezt-tx-kernel.20.2-rc2-mavryk/opam
@@ -1,0 +1,23 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "info@mavryk.io"
+authors: ["Mavryk Dynamics" "Tezos devteam"]
+homepage: "https://mavrykdynamics.com/"
+bug-reports: "https://gitlab.com/mavryk-network/mavryk-protocol/issues"
+dev-repo: "git+https://gitlab.com/mavryk-network/mavryk-protocol.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.11.1" }
+  "ocaml" { >= "4.14" }
+  "tezt" { >= "4.0.0" & < "5.0.0" }
+  "tezt-mavryk" { = version }
+  "mavryk-protocol-alpha" { = version }
+  "mavkit-libs" { = version }
+]
+build: [
+  ["rm" "-r" "vendors" "contrib"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tx kernel test framework based on Tezt"


### PR DESCRIPTION
This pull-request concerns:
- `bls12-381.20.2-rc2-mavryk`: Implementation of the BLS12-381 curve (wrapper for the Blst library)
- `gitlab_ci.20.2-rc2-mavryk`: OCaml library for generating GitLab CI YAML configuration files
- `internal-devtools.20.2-rc2-mavryk`: Internal dev tools
- `internal-devtools_proto-context-du.20.2-rc2-mavryk`: A script to print protocol context disk usage
- `kaitai.20.2-rc2-mavryk`: OCaml library for reading Kaitai spec files
- `kaitai-of-data-encoding.20.2-rc2-mavryk`: Kaitai spec generator for data-encoding library
- `mavkit-accuser-alpha.20.2-rc2-mavryk`: Mavryk/Protocol: accuser binary
- `mavkit-accuser-PtAtLas.20.2-rc2-mavryk`: Mavryk/Protocol: accuser binary
- `mavkit-accuser-PtBoreas.20.2-rc2-mavryk`: Mavryk/Protocol: accuser binary
- `mavkit-alcotezt.20.2-rc2-mavryk`: Provide the interface of Alcotest for Mavkit, but with Tezt as backend
- `mavkit-baker-alpha.20.2-rc2-mavryk`: Mavryk/Protocol: baker binary
- `mavkit-baker-PtAtLas.20.2-rc2-mavryk`: Mavryk/Protocol: baker binary
- `mavkit-baker-PtBoreas.20.2-rc2-mavryk`: Mavryk/Protocol: baker binary
- `mavkit-client.20.2-rc2-mavryk`: Mavryk: `mavkit-client` binary
- `mavkit-codec.20.2-rc2-mavryk`: Mavryk: `mavkit-codec` binary to encode and decode values
- `mavkit-codec-kaitai.20.2-rc2-mavryk`: Mavryk: `mavkit-codec-kaitai` binary to generate kaitai descriptions
- `mavkit-crawler.20.2-rc2-mavryk`: Mavkit: library to crawl blocks of the L1 chain
- `mavkit-dac-client.20.2-rc2-mavryk`: Mavryk: `mavkit-dac-client` binary
- `mavkit-dac-node.20.2-rc2-mavryk`: Mavryk: `mavkit-dac-node` binary
- `mavkit-dal-node.20.2-rc2-mavryk`: Mavryk: `mavkit-dal-node` binary
- `mavkit-distributed-internal.20.2-rc2-mavryk`: Fork of distributed. Use for Mavkit only
- `mavkit-distributed-lwt-internal.20.2-rc2-mavryk`: Fork of distributed-lwt. Use for Mavkit only
- `mavkit-evm-node.20.2-rc2-mavryk`: An implementation of a subset of Ethereum JSON-RPC API for the EVM rollup
- `mavkit-evm-node-libs.20.2-rc2-mavryk`: Mavkit EVM node libraries
- `mavkit-evm-node-tests.20.2-rc2-mavryk`: Tests for the EVM Node
- `mavkit-injector.20.2-rc2-mavryk`: Mavkit: library for building injectors
- `mavkit-injector-server.20.2-rc2-mavryk`: Mavkit injector
- `mavkit-internal-libs.20.2-rc2-mavryk`: A package that contains some libraries used by the Mavkit suite
- `mavkit-l2-libs.20.2-rc2-mavryk`: Mavkit layer2 libraries
- `mavkit-libs.20.2-rc2-mavryk`: A package that contains multiple base libraries used by the Mavkit suite
- `mavkit-node.20.2-rc2-mavryk`: Mavryk: `mavkit-node` binary
- `mavkit-node-config.20.2-rc2-mavryk`: Mavkit: `mavkit-node-config` library
- `mavkit-proto-libs.20.2-rc2-mavryk`: Mavkit protocol libraries
- `mavkit-protocol-000-Ps9mPmXa-libs.20.2-rc2-mavryk`: Mavkit protocol 000-Ps9mPmXa libraries
- `mavkit-protocol-001-PtAtLas-libs.20.2-rc2-mavryk`: Mavkit protocol 001-PtAtLas libraries
- `mavkit-protocol-002-PtBoreas-libs.20.2-rc2-mavryk`: Mavkit protocol 002-PtBoreas libraries
- `mavkit-protocol-alpha-libs.20.2-rc2-mavryk`: Mavkit protocol alpha libraries
- `mavkit-protocol-compiler.20.2-rc2-mavryk`: Mavryk: economic-protocol compiler
- `mavkit-proxy-server.20.2-rc2-mavryk`: Mavkit: `mavkit-proxy-server` binary
- `mavkit-risc-v-pvm.20.2-rc2-mavryk`: Bindings for RISC-V interpreter
- `mavkit-risc-v-pvm-test.20.2-rc2-mavryk`: Tests for RISC-V interpreter bindings
- `mavkit-rpc-process.20.2-rc2-mavryk`: Mavryk: RPC process
- `mavkit-shell-libs.20.2-rc2-mavryk`: Mavkit shell libraries
- `mavkit-shell-tests.20.2-rc2-mavryk`: Shell tests
- `mavkit-signer.20.2-rc2-mavryk`: Mavryk: `mavkit-signer` binary
- `mavkit-smart-rollup-node.20.2-rc2-mavryk`: Mavkit: Smart rollup node
- `mavkit-smart-rollup-node-alpha.20.2-rc2-mavryk`: Protocol specific (for alpha) library for smart rollup node
- `mavkit-smart-rollup-node-lib.20.2-rc2-mavryk`: Mavkit: library for Smart Rollup node
- `mavkit-smart-rollup-node-PtAtLas.20.2-rc2-mavryk`: Protocol specific (for 001-PtAtLas) library for smart rollup node
- `mavkit-smart-rollup-node-PtBoreas.20.2-rc2-mavryk`: Protocol specific (for 002-PtBoreas) library for smart rollup node
- `mavkit-smart-rollup-wasm-debugger.20.2-rc2-mavryk`: Mavryk: Debugger for the smart rollups’ WASM kernels
- `mavkit-smart-rollup-wasm-debugger-lib.20.2-rc2-mavryk`: Mavryk: Library used for the Smart Rollups' WASM debugger
- `mavkit-smart-rollup-wasm-debugger-plugin.20.2-rc2-mavryk`: Plugin interface for the Mavkit Smart Rollup WASM Debugger
- `mavkit-snoop.20.2-rc2-mavryk`: Mavryk: `mavkit-snoop` binary
- `mavkit-store-tests.20.2-rc2-mavryk`: Store tests
- `mavkit-testnet-scenarios.20.2-rc2-mavryk`: Run scenarios on testnets
- `mavkit-version.20.2-rc2-mavryk`: Mavryk: version value generated from Git
- `mavryk-benchmark.20.2-rc2-mavryk`: Mavryk: library for writing benchmarks and performing simple parameter inference
- `mavryk-benchmark-001-PtAtLas.20.2-rc2-mavryk`: Mavryk/Protocol: library for writing benchmarks (protocol-specific part)
- `mavryk-benchmark-002-PtBoreas.20.2-rc2-mavryk`: Mavryk/Protocol: library for writing benchmarks (protocol-specific part)
- `mavryk-benchmark-alpha.20.2-rc2-mavryk`: Mavryk/Protocol: library for writing benchmarks (protocol-specific part)
- `mavryk-benchmark-examples.20.2-rc2-mavryk`: Mavryk: examples for lib-benchmarks
- `mavryk-benchmark-tests.20.2-rc2-mavryk`: Mavryk: tests for lib-benchmarks
- `mavryk-benchmark-type-inference-001-PtAtLas.20.2-rc2-mavryk`: Mavryk: type inference for partial Michelson expressions
- `mavryk-benchmark-type-inference-002-PtBoreas.20.2-rc2-mavryk`: Mavryk: type inference for partial Michelson expressions
- `mavryk-benchmark-type-inference-alpha.20.2-rc2-mavryk`: Mavryk: type inference for partial Michelson expressions
- `mavryk-benchmarks-proto-001-PtAtLas.20.2-rc2-mavryk`: Mavryk/Protocol: protocol benchmarks
- `mavryk-benchmarks-proto-002-PtBoreas.20.2-rc2-mavryk`: Mavryk/Protocol: protocol benchmarks
- `mavryk-benchmarks-proto-alpha.20.2-rc2-mavryk`: Mavryk/Protocol: protocol benchmarks
- `mavryk-client-demo-counter.20.2-rc2-mavryk`: Mavryk/Protocol: protocol specific library for `mavkit-client`
- `mavryk-client-genesis.20.2-rc2-mavryk`: Mavryk/Protocol: protocol specific library for `mavkit-client`
- `mavryk-dac-client-lib.20.2-rc2-mavryk`: Mavryk: `mavryk-dac-client` library
- `mavryk-dac-lib.20.2-rc2-mavryk`: Mavryk: `mavryk-dac` library
- `mavryk-dac-lib-test.20.2-rc2-mavryk`: Test for dac lib
- `mavryk-dac-node-lib.20.2-rc2-mavryk`: Mavryk: `mavryk-dac-node` library
- `mavryk-dac-node-lib-test.20.2-rc2-mavryk`: Test for dac node lib
- `mavryk-dal-node-lib.20.2-rc2-mavryk`: Mavryk: `mavryk-dal-node` library
- `mavryk-dal-node-services.20.2-rc2-mavryk`: Mavryk: `mavryk-dal-node` RPC services
- `mavryk-injector-001-PtAtLas.20.2-rc2-mavryk`: Mavryk/Protocol: protocol-specific library for the injector binary
- `mavryk-injector-002-PtBoreas.20.2-rc2-mavryk`: Mavryk/Protocol: protocol-specific library for the injector binary
- `mavryk-injector-alpha.20.2-rc2-mavryk`: Mavryk/Protocol: protocol-specific library for the injector binary
- `mavryk-lazy-containers-tests.20.2-rc2-mavryk`: Various tests for the lazy containers library
- `mavryk-micheline-rewriting.20.2-rc2-mavryk`: Mavryk: library for rewriting Micheline expressions
- `mavryk-openapi.20.2-rc2-mavryk`: Mavryk: a library for querying RPCs and converting into the OpenAPI format
- `mavryk-protocol-000-Ps9mPmXa.20.2-rc2-mavryk`: Mavryk protocol 000-Ps9mPmXa package
- `mavryk-protocol-001-PtAtLas.20.2-rc2-mavryk`: Mavryk protocol 001-PtAtLas package
- `mavryk-protocol-001-PtAtLas-tests.20.2-rc2-mavryk`: Mavryk/Protocol: tests for economic-protocol definition
- `mavryk-protocol-002-PtBoreas.20.2-rc2-mavryk`: Mavryk protocol 002-PtBoreas package
- `mavryk-protocol-002-PtBoreas-tests.20.2-rc2-mavryk`: Mavryk/Protocol: tests for economic-protocol definition
- `mavryk-protocol-alpha.20.2-rc2-mavryk`: Mavryk protocol alpha package
- `mavryk-protocol-alpha-tests.20.2-rc2-mavryk`: Mavryk/Protocol: tests for economic-protocol definition
- `mavryk-protocol-demo-counter.20.2-rc2-mavryk`: Mavryk protocol demo-counter package
- `mavryk-protocol-demo-noops.20.2-rc2-mavryk`: Mavryk protocol demo-noops package
- `mavryk-protocol-genesis.20.2-rc2-mavryk`: Mavryk protocol genesis package
- `mavryk-proxy-server-config.20.2-rc2-mavryk`: Mavryk: proxy server configuration
- `mavryk-sc-rollup-node-test.20.2-rc2-mavryk`: Tests for the smart rollup node library
- `mavryk-scoru-wasm-regressions.20.2-rc2-mavryk`: WASM PVM regressions
- `mavryk-smart-rollup-node-lib-test.20.2-rc2-mavryk`: Tests for the smart rollup node library
- `mavryk-tooling.20.2-rc2-mavryk`: Mavryk: tooling for the project
- `mavryk-tps-evaluation.20.2-rc2-mavryk`: Mavryk TPS evaluation tool
- `mavryk-tree-encoding-test.20.2-rc2-mavryk`: Tests for the tree encoding library
- `mavryk_internal_irmin_tests.20.2-rc2-mavryk`: Mavryk internal irmin tests
- `octogram.20.2-rc2-mavryk`: An Ansible-inspired environment to run scenarios and experiments
- `tezt-etherlink.20.2-rc2-mavryk`: Tezt integration tests for Etherlink
- `tezt-mavryk.20.2-rc2-mavryk`: Mavkit test framework based on Tezt
- `tezt-risc-v-sandbox.20.2-rc2-mavryk`: Test framework for RISC-V sandbox
- `tezt-tx-kernel.20.2-rc2-mavryk`: Tx kernel test framework based on Tezt



---
* Homepage: https://mavrykdynamics.com/
* Source repo: git+https://gitlab.com/mavryk-network/mavryk-protocol.git
* Bug tracker: https://gitlab.com/mavryk-network/mavryk-protocol/issues

---
:camel: Pull-request generated by opam-publish v2.3.0