### PR TITLE
[new release] mirage-qubes (2 packages) (0.11.0)

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.11.0/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.11.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "mirage-qubes" {= version}
+  "tcpip" { >= "8.1.0" }
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "ipaddr" { >= "3.0.0" }
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "lwt" { >= "5.7.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.11.0/mirage-qubes-0.11.0.tbz"
+  checksum: [
+    "sha256=dca01eefe34acd02bb0df843f6e015e312526432f2babcde099c63759fef9208"
+    "sha512=99fcf0fe178cbc2b8017cad688aba3600240bbddde2e06ccb2e622ff2ca5367b2587206045ae14103d9092c9f38662c18e837832ec9a0edee98b32c3c773b4c4"
+  ]
+}
+x-commit-hash: "f0292079b83767a3cdb2f430220983ce531086ef"

--- a/packages/mirage-qubes/mirage-qubes.0.11.0/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.11.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "cstruct" { >= "6.0.0" }
+  "vchan-xen" { >= "6.0.0" }
+  "mirage-xen" { >= "8.0.0" }
+  "lwt" { >= "5.7.0" }
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.08.0" }
+  "ohex" { >= "0.2.0" }
+  "fmt" {>= "0.8.5"}
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+description: """
+Implementations of various Qubes protocols:
+
+- Qubes.RExec: provide services to other VMs
+- Qubes.GUI: just enough of the GUI protocol so that Qubes accepts the AppVM
+- Qubes.DB: read and write the VM's QubesDB database"""
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.11.0/mirage-qubes-0.11.0.tbz"
+  checksum: [
+    "sha256=dca01eefe34acd02bb0df843f6e015e312526432f2babcde099c63759fef9208"
+    "sha512=99fcf0fe178cbc2b8017cad688aba3600240bbddde2e06ccb2e622ff2ca5367b2587206045ae14103d9092c9f38662c18e837832ec9a0edee98b32c3c773b4c4"
+  ]
+}
+x-commit-hash: "f0292079b83767a3cdb2f430220983ce531086ef"


### PR DESCRIPTION
Implementations of various Qubes protocols for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-qubes">https://github.com/mirage/mirage-qubes</a>
- Documentation: <a href="https://mirage.github.io/mirage-qubes">https://mirage.github.io/mirage-qubes</a>

##### CHANGES:

- Add `check_memory` that triggers a collection if free memory is low, and `shutdown` that waits for a shutdown request from Qubes (mirage/mirage-qubes#71, @palainp @hannesm)
