### PR TITLE
[new release] iostream (2 packages) (0.3)

### DIFF
--- a/packages/iostream-camlzip/iostream-camlzip.0.3/opam
+++ b/packages/iostream-camlzip/iostream-camlzip.0.3/opam
@@ -15,7 +15,7 @@ depends: [
   "ounit2" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/iostream-camlzip/iostream-camlzip.0.3/opam
+++ b/packages/iostream-camlzip/iostream-camlzip.0.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Stream (de)compression using deflate"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["topics" "io" "channels" "streams" "zip" "deflate"]
+homepage: "https://github.com/c-cube/ocaml-iostream"
+doc: "https://c-cube.github.io/ocaml-iostream"
+bug-reports: "https://github.com/c-cube/ocaml-iostream/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "iostream" {= version}
+  "camlzip"
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-iostream.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-iostream/releases/download/v0.3/iostream-0.3.tbz"
+  checksum: [
+    "sha256=0bf255c06593a3cd72a44eaf3fb4568fc42c8771afe5bcee8d63ea662ee7f009"
+    "sha512=68ff56d48b2fcbd34ef2c15f6a8969543caa5c5e6b14177a0fde1e2b12d2fe52448d233e02cd1ab2529f74f48b31954ae8ec9e22601cfda6d3c38ce667c1b851"
+  ]
+}
+x-commit-hash: "2fd7de85902988beab568c2abab03b499d25191b"

--- a/packages/iostream/iostream.0.3/opam
+++ b/packages/iostream/iostream.0.3/opam
@@ -14,7 +14,7 @@ depends: [
 ]
 depopts: ["base-unix"]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/iostream/iostream.0.3/opam
+++ b/packages/iostream/iostream.0.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Generic, composable IO input and output streams"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["topics" "io" "channels" "streams"]
+homepage: "https://github.com/c-cube/ocaml-iostream"
+doc: "https://c-cube.github.io/ocaml-iostream"
+bug-reports: "https://github.com/c-cube/ocaml-iostream/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "ounit2" {with-test}
+]
+depopts: ["base-unix"]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-iostream.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-iostream/releases/download/v0.3/iostream-0.3.tbz"
+  checksum: [
+    "sha256=0bf255c06593a3cd72a44eaf3fb4568fc42c8771afe5bcee8d63ea662ee7f009"
+    "sha512=68ff56d48b2fcbd34ef2c15f6a8969543caa5c5e6b14177a0fde1e2b12d2fe52448d233e02cd1ab2529f74f48b31954ae8ec9e22601cfda6d3c38ce667c1b851"
+  ]
+}
+x-commit-hash: "2fd7de85902988beab568c2abab03b499d25191b"


### PR DESCRIPTION
Generic, composable IO input and output streams

- Project page: <a href="https://github.com/c-cube/ocaml-iostream">https://github.com/c-cube/ocaml-iostream</a>
- Documentation: <a href="https://c-cube.github.io/ocaml-iostream">https://c-cube.github.io/ocaml-iostream</a>

##### CHANGES:

- refactor: extract type definitions to `iostream.types`
- perf slice: improve `Slice.find_index_from`
