### PR TITLE
Package ocaml_intrinsics_kernel.v0.17.1

### DIFF
--- a/packages/ocaml_intrinsics_kernel/ocaml_intrinsics_kernel.v0.17.1/opam
+++ b/packages/ocaml_intrinsics_kernel/ocaml_intrinsics_kernel.v0.17.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ocaml_intrinsics_kernel"
+bug-reports: "https://github.com/janestreet/ocaml_intrinsics_kernel/issues"
+dev-repo: "git+https://github.com/janestreet/ocaml_intrinsics_kernel.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ocaml_intrinsics_kernel/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Intrinsics"
+description: "
+Provides functions to invoke amd64 instructions (such as cmov, min/maxsd, popcnt)
+     when available, or compatible software implementation on other targets.
+     See also ocaml_intrinsics library.
+"
+url {
+  src:
+    "https://github.com/janestreet/ocaml_intrinsics_kernel/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=56ed7d0b0331e5bcfa4e016515c0267d"
+    "sha512=21e596d6407a620866cee7cab47ef1a9446d6a733b4994e809ea5566d5fa956682a5c6a6190ffb0ed48458abd658301944ed10c4389d91ecb8df677a5f87f2ab"
+  ]
+}


### PR DESCRIPTION
### `ocaml_intrinsics_kernel.v0.17.1`
Intrinsics
Provides functions to invoke amd64 instructions (such as cmov, min/maxsd, popcnt)
     when available, or compatible software implementation on other targets.
     See also ocaml_intrinsics library.



---
* Homepage: https://github.com/janestreet/ocaml_intrinsics_kernel
* Source repo: git+https://github.com/janestreet/ocaml_intrinsics_kernel.git
* Bug tracker: https://github.com/janestreet/ocaml_intrinsics_kernel/issues

---
:camel: Pull-request generated by opam-publish v2.3.0