### PR TITLE
Package opam-0install-cudf.0.5.0

### DIFF
--- a/packages/opam-0install-cudf/opam-0install-cudf.0.5.0/opam
+++ b/packages/opam-0install-cudf/opam-0install-cudf.0.5.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Opam solver using 0install backend using the CUDF interface"
+description: """\
+Opam's default solver is designed to maintain a set of packages
+over time, minimising disruption when installing new programs and
+finding a compromise solution across all packages.
+
+In many situations (e.g. CI, local roots or duniverse builds) this
+is not necessary, and we can get a solution much faster by using
+a different algorithm.
+
+This package provides a generic solver library which uses 0install's
+solver library. The library uses the CUDF library in order to interface
+with opam as it is the format common used to talk to all the supported solvers."""
+maintainer: "Kate <kit-ty-kate@outlook.com>"
+authors: "Kate <kit-ty-kate@outlook.com>"
+license: "ISC"
+homepage: "https://github.com/ocaml-opam/opam-0install-cudf"
+doc: "https://ocaml-opam.github.io/opam-0install-cudf/"
+bug-reports: "https://github.com/ocaml-opam/opam-0install-cudf/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "cudf" {>= "0.10"}
+  "ocaml" {>= "4.08.0"}
+  "0install-solver" {>= "2.18"}
+  "alcotest" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "test" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml-opam/opam-0install-cudf.git"
+url {
+  src:
+    "https://github.com/ocaml-opam/opam-0install-cudf/releases/download/v0.5.0/opam-0install-cudf-0.5.0.tar.gz"
+  checksum: [
+    "md5=75419722aa839f518a25cae1b3c6efd4"
+    "sha512=83c0372168d612ef80548ab7fb021a92cdc39e13a77d87c5af5fd21eb515389b624d09c24d500e9ac33b3fc10d17c9869f160f8771f9c8f545b0453b9a0fd4df"
+  ]
+}


### PR DESCRIPTION
### `opam-0install-cudf.0.5.0`
Opam solver using 0install backend using the CUDF interface
Opam's default solver is designed to maintain a set of packages
over time, minimising disruption when installing new programs and
finding a compromise solution across all packages.

In many situations (e.g. CI, local roots or duniverse builds) this
is not necessary, and we can get a solution much faster by using
a different algorithm.

This package provides a generic solver library which uses 0install's
solver library. The library uses the CUDF library in order to interface
with opam as it is the format common used to talk to all the supported solvers.



---
* Homepage: https://github.com/ocaml-opam/opam-0install-cudf
* Source repo: git+https://github.com/ocaml-opam/opam-0install-cudf.git
* Bug tracker: https://github.com/ocaml-opam/opam-0install-cudf/issues

---
:camel: Pull-request generated by opam-publish v2.3.1