### PR TITLE
[new release] albatross (2.1.0)

### DIFF
--- a/packages/albatross/albatross.2.1.0/opam
+++ b/packages/albatross/albatross.2.1.0/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/robur-coop/albatross"
+dev-repo: "git+https://github.com/robur-coop/albatross.git"
+bug-reports: "https://github.com/robur-coop/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "2.7.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "5.3.0"}
+  "cstruct" {>= "6.0.0"}
+  "logs"
+  "bos" {>= "0.2.0"}
+  "ptime"
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "0.13.0"}
+  "tls" {>= "0.16.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "mirage-crypto"
+  "mirage-crypto-rng" {>= "0.11.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "checkseum"
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "ohex" {>= "0.2.0"}
+  "http-lwt-client" {>= "0.2.0"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.3"}
+  "owee" {>= "0.4"}
+  "fpath" {>= "0.7.3"}
+  "logs-syslog" {>= "0.4.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+url {
+  src:
+    "https://github.com/robur-coop/albatross/releases/download/v2.1.0/albatross-2.1.0.tbz"
+  checksum: [
+    "sha256=3abbb859e885571d70fdd0c7e0c00be06c21280341b9303e85a2a0bdc5c3846d"
+    "sha512=a5d247573bed9013e8debe7d9608104ee53307347b7acacbb75f0ae31444c83f07f4b9d24dba054cae2dc878d498360125e0da7c11d8880f6d8a32ab021743ac"
+  ]
+}
+x-commit-hash: "eb6a6ff598cc00a35ee0e1a6f8ee5c586dc99ff0"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/robur-coop/albatross">https://github.com/robur-coop/albatross</a>

##### CHANGES:

* BUGFIX install tls_endpoint as systemd service (not only as example), fix typo
  (robur-coop/albatross#183 @PizieDust)
* BUGFIX albatross-influx: use "cow_faults" (fixed typo in robur-coop/albatross#182) as unsigned
  integer (b9695dd9c267f5e59f18154a632adba0481f9d72, @hannesm)
* BUGFIX albatross-influx: avoid empty measurement (robur-coop/albatross#182 @hannesm)
* BUGFIX tls-endpoint: don't fail if a bad client connects (robur-coop/albatross#180 @hannesm)
* FEATURE tls-endpoint: add syslog support (esp. useful for inetd) (robur-coop/albatross#185 @hannesm)
* FEATURE Update to FreeBSD 14 (robur-coop/albatross#172, @hannesm)
* BUGFIX update command: make usable with local client (robur-coop/albatross#184, @reynir)
* BUGFIX update command: handle HTTP not found explicitly
  (fixes robur-coop/albatross#147, robur-coop/albatross#171 @hannesm)
* FEATURE Albatross: record start timestamp via info (fixes robur-coop/albatross#168, robur-coop/albatross#169 @hannesm)
* BUGFIX Albatross: store timestamp as generalized time instead of utc time
  (robur-coop/albatross#167 @hannesm @reynir, adjusted by robur-coop/albatross#181 for backwards compatibility
   @PizieDust)
* BUGFIX FreeBSD: restart services when they terminate
  (@hannesm, 64f28fbd88504ec33d6bfde5211684e0ba1bc193)
* BUGFIX packaging: install albatross-client as albatross-client
  (@hannesm, 23acb8b3edbe0153e1bd24a1736b80e73a27e33f)
* update nix inputs (robur-coop/albatross#175, robur-coop/albatross#179 @Julow)
* use ohex instead of hex (robur-coop/albatross#174 @hannesm)
* fix README (robur-coop/albatross#177 @PizieDust, 2a1c3d898b586946ce7c4f3171ea5eb856f4ade8,
  107c235eb94e83d6a077c42ee8b527c207af4ba7)
