### PR TITLE
Package MlFront_Cli.0.4.0~prerel7

### DIFF
--- a/packages/MlFront_Cli/MlFront_Cli.0.4.0~prerel7/opam
+++ b/packages/MlFront_Cli/MlFront_Cli.0.4.0~prerel7/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Command line interfaces for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14.0"}
+  "bos" {>= "0.2.1"}
+  "cmdliner" {>= "1.2.0"}
+  "crunch" {>= "3.3.1"}
+  "fmt" {>= "0.9.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "stringext" {>= "1.6.0"}
+  "diskuvbox" {with-test & >= "0.2.0"}
+  "ezjsonm" {>= "1.3.0"}
+  "menhir" {>= "20180523"}
+  "digestif" {>= "1.1.4"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "sh"
+    "ci/build-test.sh"
+    "-t" {with-test}
+    "-d" {with-doc}
+    "-a"
+    "windows_unknown" {os = "win32"}
+    "unix_unknown" {!(os = "win32")}
+  ]
+  ["install" "MlFront_Cli.install.win32" "MlFront_Cli.install"]
+    {os = "win32"}
+  ["install" "MlFront_Cli.install.unix" "MlFront_Cli.install"]
+    {!(os = "win32")}
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/0.4.0-7/MlFront.tar.gz"
+  checksum: [
+    "md5=eaaecad4dfce5ad6849444bfa1e0cc44"
+    "sha512=9cf976ec567c41101249a4cc1f57dedac14597f664d44ab8d25d1507812357ab038a6d47fe7e4450d25114e7f9edcedbcf78c1e24267858d8b7b0c12fb15c22b"
+  ]
+}


### PR DESCRIPTION
### `MlFront_Cli.0.4.0~prerel7`
Command line interfaces for MlFront



---
* Homepage: https://diskuv.com/mlfront/overview-1/
* Source repo: git+https://gitlab.com/dkml/build-tools/MlFront.git
* Bug tracker: https://gitlab.com/dkml/build-tools/MlFront/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0