### PR TITLE
[new release] thread-local-storage (0.2)

### DIFF
--- a/packages/thread-local-storage/thread-local-storage.0.2/opam
+++ b/packages/thread-local-storage/thread-local-storage.0.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Efficient thread local storage for OCaml"
+maintainer: ["Simon Cruanes"]
+authors: ["Vesa Karvonen"]
+license: "MIT"
+tags: ["topics" "threads" "tls"]
+homepage: "https://github.com/c-cube/thread-local-storage"
+doc: "https://c-cube.github.io/thread-local-storage"
+bug-reports: "https://github.com/c-cube/thread-local-storage/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/thread-local-storage.git"
+url {
+  src:
+    "https://github.com/c-cube/thread-local-storage/releases/download/v0.2/thread-local-storage-0.2.tbz"
+  checksum: [
+    "sha256=938a51c9ca4415efd37e23792b5123a84f0f1c429494a5f27c3af804496af69a"
+    "sha512=00a108f657796b640081b0dba029d89c97b4227f20d30e469e9c978ff60a747e700b3042c8b6ae41d004bd7638abcafbe3cb980d3e97259c864adbe41e1e8131"
+  ]
+}
+x-commit-hash: "d0fd27a3e15caedcc7e4fe8c1af5747af3151574"


### PR DESCRIPTION
Efficient thread local storage for OCaml

- Project page: <a href="https://github.com/c-cube/thread-local-storage">https://github.com/c-cube/thread-local-storage</a>
- Documentation: <a href="https://c-cube.github.io/thread-local-storage">https://c-cube.github.io/thread-local-storage</a>

##### CHANGES:

- Incompatible API change, making things simpler.
- It is now safe to read TLS from asynchronous callbacks (e.g. memprof
  callbacks).
