### PR TITLE
[new release] corosync (0.1.0)

### DIFF
--- a/packages/conf-libcorosync/conf-libcorosync.3/opam
+++ b/packages/conf-libcorosync/conf-libcorosync.3/opam
@@ -14,7 +14,7 @@ depexts: [
   ["corosynclib-devel"] {os-distribution = "fedora"}
   ["lib64corosync-devel"] {os-distribution = "mageia"}
   ["libcorosync-devel"] {os-family = "suse"}
-  ["corosync-libs"] {os-family = "opensuse"}
+  ["corosync-devel"] {os-family = "opensuse"}
 ]
 available: os = "linux" & arch != "arm32"
 synopsis: "Virtual package relying on libcorosync system installation"

--- a/packages/corosync/corosync.0.1.0/opam
+++ b/packages/corosync/corosync.0.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "OCaml Corosync binding"
+description: "An OCaml language binding to libcorosync"
+maintainer: ["Shuntian Liu <shuntian.liu@outlook.com>"]
+authors: ["Shuntian Liu"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+tags: ["corosync" "binding"]
+homepage: "https://github.com/Vincent-lau/ocaml-corosync"
+doc: "https://Vincent-lau.github.io/ocaml-corosync/doc"
+bug-reports: "https://github.com/Vincent-lau/ocaml-corosync/issues"
+depends: [
+  "astring" {>= "0.8.5"}
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.11" & >= "3.16"}
+  "stdint"
+  "ctypes" {>= "0.22.0"}
+  "ctypes-foreign" {>= "0.22.0"}
+  "ipaddr"
+  "alcotest" {>= "1.7.0"}
+  "conf-libcorosync"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Vincent-lau/ocaml-corosync.git"
+url {
+  src:
+    "https://github.com/Vincent-lau/ocaml-corosync/releases/download/v0.1.0/corosync-0.1.0.tbz"
+  checksum: [
+    "sha256=50dfd86c7142e6fcd1a9aac3f17733e4ce4036823d3447852afa753152a88821"
+    "sha512=d43d33f1073bea24dfe3443859673dceeb7c26bae8198d7fef0477dc9779e51ffb5771e1a2964c0ae9ff73625c48e3e74d6d221dbcc3c803e8481331e443c7a3"
+  ]
+}
+x-commit-hash: "82b3ca04a5dd861e5cf815bd6457948c14a4a627"


### PR DESCRIPTION
OCaml Corosync binding

- Project page: <a href="https://github.com/Vincent-lau/ocaml-corosync">https://github.com/Vincent-lau/ocaml-corosync</a>
- Documentation: <a href="https://Vincent-lau.github.io/ocaml-corosync/doc">https://Vincent-lau.github.io/ocaml-corosync/doc</a>

##### CHANGES:

- Use GADT for one of the get functions in cmap to make the return type more precise
- Add initial bindings to libcpg
- Use after free bug fixes
- More docs
