### PR TITLE
[new release] ezjsonm-encoding (2.1.0)

### DIFF
--- a/packages/ezjsonm-encoding/ezjsonm-encoding.2.1.0/opam
+++ b/packages/ezjsonm-encoding/ezjsonm-encoding.2.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Encoding combinators a la Data_encoding for Ezjsonm"
+maintainer: ["Thomas Letan <lthms@soap.coffee>"]
+authors: ["Thomas Letan <lthms@soap.coffee>"]
+license: "mpl-2.0"
+homepage: "https://github.com/lthms/ezjsonm-encoding"
+bug-reports: "https://github.com/lthms/ezjsonm-encoding/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.8.0"}
+  "ezjsonm" {>= "1.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lthms/ezjsonm-encoding.git"
+url {
+  src:
+    "https://github.com/lthms/ezjsonm-encoding/releases/download/2.1.0/ezjsonm-encoding-2.1.0.tbz"
+  checksum: [
+    "sha256=a91f0d9f7a4bd4adf7a9304b90495aaac4e32e3b9db48f0831ed0610ad3ca96e"
+    "sha512=68252b15b8b00a1a97edf0d51b97fd5b3e61a640ce68602ba93473c46576af037453148c16ec3fa3b0af83f2358a863928ce0ec761a9193669632cb76a4d1a0d"
+  ]
+}
+x-commit-hash: "0822008c68dcbb8949808f4ed686576944e9bc5f"


### PR DESCRIPTION
Encoding combinators a la Data_encoding for Ezjsonm

- Project page: <a href="https://github.com/lthms/ezjsonm-encoding">https://github.com/lthms/ezjsonm-encoding</a>

##### CHANGES:

- Add the `constant` combinator, typically used to tag objects.
- Add the `null` combinator.
- Add `obj0` (matches any object) and `empty` (matches the empty object)
  combinators.
- Add the `union` combinator.
- Add the `dft` field combinator.
- Add the `json` combinator.
- Add the `enum` combinator.
- Add the `satisfies` combinator.
- Add the `tupN` combinators family (`tup1` to `tup10`).
