### PR TITLE
[new release] reason-react (2 packages) (0.15.0)

### DIFF
--- a/packages/reason-react-ppx/reason-react-ppx.0.15.0/opam
+++ b/packages/reason-react-ppx/reason-react-ppx.0.15.0/opam
@@ -31,7 +31,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/reason-react-ppx/reason-react-ppx.0.15.0/opam
+++ b/packages/reason-react-ppx/reason-react-ppx.0.15.0/opam
@@ -14,7 +14,7 @@ doc: "https://reasonml.github.io/reason-react"
 bug-reports: "https://github.com/reasonml/reason-react/issues"
 depends: [
   "dune" {>= "3.9"}
-  "ocaml"
+  "ocaml" {>= "4.14"}
   "reason" {>= "3.12.0"}
   "ppxlib" {>= "0.33.0"}
   "merlin" {with-test}

--- a/packages/reason-react-ppx/reason-react-ppx.0.15.0/opam
+++ b/packages/reason-react-ppx/reason-react-ppx.0.15.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "React.js JSX PPX"
+description: "ReasonReact JSX PPX"
+maintainer: [
+  "David Sancho <dsnxmoreno@gmail.com>"
+  "Antonio Monteiro <anmonteiro@gmail.com>"
+]
+authors: [
+  "Cheng Lou <chenglou92@gmail.com>" "Ricky Vetter <rickywvetter@gmail.com>"
+]
+license: "MIT"
+homepage: "https://reasonml.github.io/reason-react"
+doc: "https://reasonml.github.io/reason-react"
+bug-reports: "https://github.com/reasonml/reason-react/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml"
+  "reason" {>= "3.12.0"}
+  "ppxlib" {>= "0.33.0"}
+  "merlin" {with-test}
+  "ocamlformat" {= "0.24.0" & with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reasonml/reason-react.git"
+url {
+  src:
+    "https://github.com/reasonml/reason-react/releases/download/0.15.0/reason-react-0.15.0.tbz"
+  checksum: [
+    "sha256=fa93c9a3f6f9d2fa78a400bfca02352c70793b4a43275c6971064e7453fc43cd"
+    "sha512=7408f3b9a86a78b8062d45b131f4fb166c75a783be7a33bf63b3841b32b9022230b45e69323ef7ed6b717921b4ddb375ead0f0ce534174552f032f4de23de2ad"
+  ]
+}
+x-commit-hash: "c575d278daa73618a7883290fffe7397447c10a9"

--- a/packages/reason-react/reason-react.0.15.0/opam
+++ b/packages/reason-react/reason-react.0.15.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Reason bindings for React.js"
+description: """
+ReasonReact helps you use Reason to build React components with deeply integrated, strong, static type safety.
+
+It is designed and built by people using Reason and React in large, mission critical production React codebases."""
+maintainer: [
+  "David Sancho <dsnxmoreno@gmail.com>"
+  "Antonio Monteiro <anmonteiro@gmail.com>"
+]
+authors: [
+  "Cheng Lou <chenglou92@gmail.com>" "Ricky Vetter <rickywvetter@gmail.com>"
+]
+license: "MIT"
+homepage: "https://reasonml.github.io/reason-react"
+doc: "https://reasonml.github.io/reason-react"
+bug-reports: "https://github.com/reasonml/reason-react/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml"
+  "melange" {>= "3.0.0"}
+  "reason-react-ppx" {= version}
+  "reason" {>= "3.12.0"}
+  "ocaml-lsp-server" {with-dev-setup}
+  "opam-check-npm-deps" {= "1.0.0" & with-dev-setup}
+  "ocamlformat" {= "0.24.0" & with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reasonml/reason-react.git"
+depexts: [
+  ["react"] {npm-version = "^18.0.0"}
+  ["react-dom"] {npm-version = "^18.0.0"}
+]
+url {
+  src:
+    "https://github.com/reasonml/reason-react/releases/download/0.15.0/reason-react-0.15.0.tbz"
+  checksum: [
+    "sha256=fa93c9a3f6f9d2fa78a400bfca02352c70793b4a43275c6971064e7453fc43cd"
+    "sha512=7408f3b9a86a78b8062d45b131f4fb166c75a783be7a33bf63b3841b32b9022230b45e69323ef7ed6b717921b4ddb375ead0f0ce534174552f032f4de23de2ad"
+  ]
+}
+x-commit-hash: "c575d278daa73618a7883290fffe7397447c10a9"


### PR DESCRIPTION
Reason bindings for React.js

- Project page: <a href="https://reasonml.github.io/reason-react">https://reasonml.github.io/reason-react</a>
- Documentation: <a href="https://reasonml.github.io/reason-react">https://reasonml.github.io/reason-react</a>

##### CHANGES:

* Add `isValidElement` (@r17x in
  https://github.com/reasonml/reason-react/pull/837)
* Add `startTransition` (@r17x in
  https://github.com/reasonml/reason-react/pull/838)
* Convert `ReasonReactErrorBoundary` to Reason instead of `%raw` JS. This has
  the benefit of skipping a hardcoded `require('react')` call (@anmonteiro in
  [reasonml/reason-react#839](https://github.com/reasonml/reason-react/pull/839))
* Add CSS Box Alignment Module Level 3 (@davesnx in
  https://github.com/reasonml/reason-react/pull/847)
* Fix: Remove "unique `key` prop" warnings from multi-child fragment elements
  (@jchavarri in https://github.com/reasonml/reason-react/pull/852)
