### PR TITLE
[new release] mirage-crypto (9 packages) (1.0.1)

### DIFF
--- a/packages/mirage-crypto-ec/mirage-crypto-ec.1.0.1/opam
+++ b/packages/mirage-crypto-ec/mirage-crypto-ec.1.0.1/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Elliptic Curve Cryptography with primitives taken from Fiat"
+description: """
+An implementation of key exchange (ECDH) and digital signature (ECDSA/EdDSA)
+algorithms using code from Fiat (<https://github.com/mit-plv/fiat-crypto>).
+
+The curves P256 (SECP256R1), P384 (SECP384R1),
+P521 (SECP521R1), and 25519 (X25519, Ed25519) are implemented by this package.
+"""
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "Nathan Rebours <nathan.p.rebours@gmail.com>"
+  "Clément Pascutto <clement@tarides.com>"
+  "Etienne Millon <me@emillon.org>"
+  "Virgile Robles <virgile.robles@protonmail.ch>"
+# and from the fiat-crypto AUTHORS file
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+  "Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mirage/mirage-crypto"
+doc: "https://mirage.github.io/mirage-crypto/doc"
+bug-reports: "https://github.com/mirage/mirage-crypto/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.13.0"}
+  "dune-configurator"
+  "eqaf" {>= "0.7"}
+  "mirage-crypto-rng" {=version}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "ppx_deriving_yojson" {with-test}
+  "ppx_deriving" {with-test}
+  "yojson" {with-test & >= "1.6.0"}
+  "asn1-combinators" {with-test & >= "0.3.1"}
+  "ohex" {with-test & >= "0.2.0"}
+  "ounit2" {with-test}
+]
+conflicts: [
+  "ocaml-freestanding"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
+tags: ["org:mirage"]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.1/mirage-crypto-1.0.1.tbz"
+  checksum: [
+    "sha256=7cb3876265f257c2ebec9d32c2c88c6e9a74f1c54d615550c60738989f3f04bc"
+    "sha512=14f32b48582d80eecae6c30fecfda4f930ac63c4324c2bddfd01990eb83805cd2ec43844e6ba11186fc70486f25bb33ec0dbb487df153bab38629e12694d5fe0"
+  ]
+}
+x-commit-hash: "56906c0b19d663330b030bcb3fc318ce6e7be525"

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.1.0.1/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.1.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "ounit2" {with-test}
+  "randomconv" {with-test & >= "0.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "digestif" {>= "1.2.0"}
+  "zarith" {>= "1.13"}
+  "eqaf" {>= "0.8"}
+]
+conflicts: [
+  "ocaml-freestanding"
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.1/mirage-crypto-1.0.1.tbz"
+  checksum: [
+    "sha256=7cb3876265f257c2ebec9d32c2c88c6e9a74f1c54d615550c60738989f3f04bc"
+    "sha512=14f32b48582d80eecae6c30fecfda4f930ac63c4324c2bddfd01990eb83805cd2ec43844e6ba11186fc70486f25bb33ec0dbb487df153bab38629e12694d5fe0"
+  ]
+}
+x-commit-hash: "56906c0b19d663330b030bcb3fc318ce6e7be525"

--- a/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.1.0.1/opam
+++ b/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.1.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an Async-friendly way"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "async" {>= "v0.14"}
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "ohex" {with-test & >= "0.2.0"}
+]
+available: os != "win32"
+description: """
+
+Mirage-crypto-rng-async feeds the entropy source for Mirage_crypto_rng-based
+random number generator implementations, in an Async-friendly way.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.1/mirage-crypto-1.0.1.tbz"
+  checksum: [
+    "sha256=7cb3876265f257c2ebec9d32c2c88c6e9a74f1c54d615550c60738989f3f04bc"
+    "sha512=14f32b48582d80eecae6c30fecfda4f930ac63c4324c2bddfd01990eb83805cd2ec43844e6ba11186fc70486f25bb33ec0dbb487df153bab38629e12694d5fe0"
+  ]
+}
+x-commit-hash: "56906c0b19d663330b030bcb3fc318ce6e7be525"
+

--- a/packages/mirage-crypto-rng-eio/mirage-crypto-rng-eio.1.0.1/opam
+++ b/packages/mirage-crypto-rng-eio/mirage-crypto-rng-eio.1.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["Bikal Gurung <gbikal@gmail.com>" ]
+maintainer:   "Bikal Gurung <gbikal@gmail.com>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an eio-friendly way"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7"}
+  "eio" {>= "0.12"}
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "mtime"
+  "eio_main" {with-test}
+  "ohex" {with-test & >= "0.2.0"}
+]
+description: """
+Mirage-crypto-rng-eio feeds the entropy source for Mirage_crypto_rng-based
+random number generator implementations, in an eio-friendly way.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.1/mirage-crypto-1.0.1.tbz"
+  checksum: [
+    "sha256=7cb3876265f257c2ebec9d32c2c88c6e9a74f1c54d615550c60738989f3f04bc"
+    "sha512=14f32b48582d80eecae6c30fecfda4f930ac63c4324c2bddfd01990eb83805cd2ec43844e6ba11186fc70486f25bb33ec0dbb487df153bab38629e12694d5fe0"
+  ]
+}
+x-commit-hash: "56906c0b19d663330b030bcb3fc318ce6e7be525"

--- a/packages/mirage-crypto-rng-lwt/mirage-crypto-rng-lwt.1.0.1/opam
+++ b/packages/mirage-crypto-rng-lwt/mirage-crypto-rng-lwt.1.0.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "duration"
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "mtime" {>= "1.0.0"}
+  "lwt" {>= "4.0.0"}
+]
+description: """
+Mirage-crypto-rng-lwt provides entropy collection code for the RNG using Lwt.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.1/mirage-crypto-1.0.1.tbz"
+  checksum: [
+    "sha256=7cb3876265f257c2ebec9d32c2c88c6e9a74f1c54d615550c60738989f3f04bc"
+    "sha512=14f32b48582d80eecae6c30fecfda4f930ac63c4324c2bddfd01990eb83805cd2ec43844e6ba11186fc70486f25bb33ec0dbb487df153bab38629e12694d5fe0"
+  ]
+}
+x-commit-hash: "56906c0b19d663330b030bcb3fc318ce6e7be525"

--- a/packages/mirage-crypto-rng-miou-unix/mirage-crypto-rng-miou-unix.1.0.1/opam
+++ b/packages/mirage-crypto-rng-miou-unix/mirage-crypto-rng-miou-unix.1.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an miou.unix-friendly way"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7"}
+  "miou" {>= "0.2.0"}
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "mtime" {>= "1.0.0"}
+  "digestif" {>= "1.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+description: """
+Mirage-crypto-rng-miou-unix feeds the entropy source for Mirage_crypto_rng-based
+random number generator implementations, in an miou.unix-friendly way.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.1/mirage-crypto-1.0.1.tbz"
+  checksum: [
+    "sha256=7cb3876265f257c2ebec9d32c2c88c6e9a74f1c54d615550c60738989f3f04bc"
+    "sha512=14f32b48582d80eecae6c30fecfda4f930ac63c4324c2bddfd01990eb83805cd2ec43844e6ba11186fc70486f25bb33ec0dbb487df153bab38629e12694d5fe0"
+  ]
+}
+x-commit-hash: "56906c0b19d663330b030bcb3fc318ce6e7be525"

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.1.0.1/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "BSD-2-Clause"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "logs"
+  "lwt" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.8.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-unix" {with-test & >= "5.0.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.1/mirage-crypto-1.0.1.tbz"
+  checksum: [
+    "sha256=7cb3876265f257c2ebec9d32c2c88c6e9a74f1c54d615550c60738989f3f04bc"
+    "sha512=14f32b48582d80eecae6c30fecfda4f930ac63c4324c2bddfd01990eb83805cd2ec43844e6ba11186fc70486f25bb33ec0dbb487df153bab38629e12694d5fe0"
+  ]
+}
+x-commit-hash: "56906c0b19d663330b030bcb3fc318ce6e7be525"

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.1.0.1/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "duration"
+  "logs"
+  "mirage-crypto" {=version}
+  "digestif" {>= "1.1.4"}
+  "ounit2" {with-test}
+  "randomconv" {with-test & >= "0.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.1/mirage-crypto-1.0.1.tbz"
+  checksum: [
+    "sha256=7cb3876265f257c2ebec9d32c2c88c6e9a74f1c54d615550c60738989f3f04bc"
+    "sha512=14f32b48582d80eecae6c30fecfda4f930ac63c4324c2bddfd01990eb83805cd2ec43844e6ba11186fc70486f25bb33ec0dbb487df153bab38629e12694d5fe0"
+  ]
+}
+x-commit-hash: "56906c0b19d663330b030bcb3fc318ce6e7be525"

--- a/packages/mirage-crypto/mirage-crypto.1.0.0/opam
+++ b/packages/mirage-crypto/mirage-crypto.1.0.0/opam
@@ -36,3 +36,4 @@ url {
   ]
 }
 x-commit-hash: "28e9cc96492b43a994652c25ab8db4f265f51165"
+available: false # there's a bug in Mirage_crypto.AES.CCM16, 1.0.1 has a fix

--- a/packages/mirage-crypto/mirage-crypto.1.0.1/opam
+++ b/packages/mirage-crypto/mirage-crypto.1.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit2" {with-test}
+  "ohex" {with-test & >= "0.2.0"}
+  "eqaf" {>= "0.8"}
+]
+conflicts: [
+  "ocaml-freestanding"
+  "result" {< "1.5"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.0.1/mirage-crypto-1.0.1.tbz"
+  checksum: [
+    "sha256=7cb3876265f257c2ebec9d32c2c88c6e9a74f1c54d615550c60738989f3f04bc"
+    "sha512=14f32b48582d80eecae6c30fecfda4f930ac63c4324c2bddfd01990eb83805cd2ec43844e6ba11186fc70486f25bb33ec0dbb487df153bab38629e12694d5fe0"
+  ]
+}
+x-commit-hash: "56906c0b19d663330b030bcb3fc318ce6e7be525"


### PR DESCRIPTION
Simple symmetric cryptography for the modern age

- Project page: <a href="https://github.com/mirage/mirage-crypto">https://github.com/mirage/mirage-crypto</a>
- Documentation: <a href="https://mirage.github.io/mirage-crypto/doc">https://mirage.github.io/mirage-crypto/doc</a>

##### CHANGES:

* mirage-crypto: fix CCM implementation, discovered while porting TLS to
  mirage-crypto 1.0.0 (@hannesm @dinosaure @reynir mirage/mirage-crypto#242)
