### PR TITLE
core v0.14* & core_unix v0.17.0: restrict to FreeBSD < 14

### DIFF
--- a/packages/core/core.v0.14.0/opam
+++ b/packages/core/core.v0.14.0/opam
@@ -35,3 +35,4 @@ url {
     "md5=571dc65fff922c86951068d66e4a05ca"
   ]
 }
+available: [ !(os = "freebsd" & os-version >= "14") ]

--- a/packages/core/core.v0.14.1/opam
+++ b/packages/core/core.v0.14.1/opam
@@ -34,3 +34,4 @@ url {
     "md5=b11f58205953d84cedb0003efcdab231"
   ]
 }
+available: [ !(os = "freebsd" & os-version >= "14") ]

--- a/packages/core_unix/core_unix.v0.17.0/opam
+++ b/packages/core_unix/core_unix.v0.17.0/opam
@@ -25,7 +25,7 @@ depends: [
   "dune"                     {>= "3.11.0"}
   "spawn"                    {>= "v0.15"}
 ]
-available: arch = "x86_64" | arch = "arm64"
+available: [ (arch = "x86_64" | arch = "arm64") & !(os = "freebsd" & os-version >= "14") ]
 synopsis: "Unix-specific portions of Core"
 description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].


### PR DESCRIPTION
upstream issue: https://github.com/janestreet/core_unix/issues/11

Failure:
```
File "tests/dune", line 35, characters 7-36:
35 |  (name test_entropy_collection_async)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(cd _build/default && /home/opam/.opam/4.14.2/bin/ocamlopt.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -o tests/test_entropy_collection_async.exe /home/opam/.opam/4.14.2/lib/base/base_internalhash_types/base_internalhash_types.cmxa -I /home/opam/.opam/4.14.2/lib/base/base_internalhash_types /home/opam/.opam/4.14.2/lib/base/caml/caml.cmxa /home/opam/.opam/4.14.2/lib/sexplib0/sexplib0.cmxa /home/opam/.opam/4.14.2/lib/base/shadow_stdlib/shadow_stdlib.cmxa /home/opam/.opam/4.14.2/lib/base/base.cmxa -I /home/opam/.opam/4.14.2/lib/base /home/opam/.opam/4.14.2/lib/ppx_sexp_conv/runtime-lib/ppx_sexp_conv_lib.cmxa /home/opam/.opam/4.14.2/lib/ppx_compare/runtime-lib/ppx_compare_lib.cmxa /home/opam/.opam/4.14.2/lib/ppx_enumerate/runtime-lib/ppx_enumerate_lib.cmxa /home/opam/.opam/4.14.2/lib/ppx_hash/runtime-lib/ppx_hash_lib.cmxa /home/opam/.opam/4.14.2/lib/ppx_here/runtime-lib/ppx_here_lib.cmxa /home/opam/.opam/4.14.2/lib/ppx_assert/runtime-lib/ppx_assert_lib.cmxa /home/opam/.opam/4.14.2/lib/ppx_bench/runtime-lib/ppx_bench_lib.cmxa /home/opam/.opam/4.14.2/lib/base/md5/md5_lib.cmxa /home/opam/.opam/4.14.2/lib/fieldslib/fieldslib.cmxa /home/opam/.opam/4.14.2/lib/variantslib/variantslib.cmxa /home/opam/.opam/4.14.2/lib/bin_prot/shape/bin_shape_lib.cmxa /home/opam/.opam/4.14.2/lib/bin_prot/bin_prot.cmxa -I /home/opam/.opam/4.14.2/lib/bin_prot /home/opam/.opam/4.14.2/lib/ppx_inline_test/config/inline_test_config.cmxa /home/opam/.opam/4.14.2/lib/jane-street-headers/jane_street_headers.cmxa /home/opam/.opam/4.14.2/lib/time_now/time_now.cmxa -I /home/opam/.opam/4.14.2/lib/time_now /home/opam/.opam/4.14.2/lib/ppx_inline_test/runtime-lib/ppx_inline_test_lib.cmxa /home/opam/.opam/4.14.2/lib/stdio/stdio.cmxa /home/opam/.opam/4.14.2/lib/ppx_module_timer/runtime/ppx_module_timer_runtime.cmxa /home/opam/.opam/4.14.2/lib/typerep/typerep_lib.cmxa /home/opam/.opam/4.14.2/lib/ppx_expect/common/expect_test_common.cmxa /home/opam/.opam/4.14.2/lib/ppx_expect/config_types/expect_test_config_types.cmxa /home/opam/.opam/4.14.2/lib/ppx_expect/collector/expect_test_collector.cmxa -I /home/opam/.opam/4.14.2/lib/ppx_expect/collector /home/opam/.opam/4.14.2/lib/ppx_expect/config/expect_test_config.cmxa /home/opam/.opam/4.14.2/lib/splittable_random/splittable_random.cmxa /home/opam/.opam/4.14.2/lib/base_quickcheck/base_quickcheck.cmxa /home/opam/.opam/4.14.2/lib/base_bigstring/base_bigstring.cmxa -I /home/opam/.opam/4.14.2/lib/base_bigstring /home/opam/.opam/4.14.2/lib/core_kernel/base_for_tests/base_for_tests.cmxa /home/opam/.opam/4.14.2/lib/ocaml/unix.cmxa -I /home/opam/.opam/4.14.2/lib/ocaml /home/opam/.opam/4.14.2/lib/ocaml/bigarray.cmxa -I /home/opam/.opam/4.14.2/lib/ocaml /home/opam/.opam/4.14.2/lib/parsexp/parsexp.cmxa /home/opam/.opam/4.14.2/lib/sexplib/sexplib.cmxa /home/opam/.opam/4.14.2/lib/core_kernel/core_kernel.cmxa -I /home/opam/.opam/4.14.2/lib/core_kernel /home/opam/.opam/4.14.2/lib/core_kernel/moption/moption.cmxa /home/opam/.opam/4.14.2/lib/core_kernel/tuple_pool/tuple_pool.cmxa /home/opam/.opam/4.14.2/lib/core_kernel/pairing_heap/pairing_heap.cmxa /home/opam/.opam/4.14.2/lib/core_kernel/sexp_hidden_in_test/sexp_hidden_in_test.cmxa /home/opam/.opam/4.14.2/lib/core_kernel/thread_pool_cpu_affinity/thread_pool_cpu_affinity.cmxa /home/opam/.opam/4.14.2/lib/core_kernel/uopt/uopt.cmxa /home/opam/.opam/4.14.2/lib/core_kernel/thread_safe_queue/thread_safe_queue.cmxa /home/opam/.opam/4.14.2/lib/core_kernel/timing_wheel/timing_wheel.cmxa /home/opam/.opam/4.14.2/lib/async_kernel/async_kernel.cmxa /home/opam/.opam/4.14.2/lib/ocaml/threads/threads.cmxa -I /home/opam/.opam/4.14.2/lib/ocaml /home/opam/.opam/4.14.2/lib/core/error_checking_mutex/error_checking_mutex.cmxa -I /home/opam/.opam/4.14.2/lib/core/error_checking_mutex /home/opam/.opam/4.14.2/lib/core_kernel/caml_unix/caml_unix.cmxa /home/opam/.opam/4.14.2/lib/core_kernel/flags/flags.cmxa /home/opam/.opam/4.14.2/lib/core_kernel/version_util/version_util.cmxa -I /home/opam/.opam/4.14.2/lib/core_kernel/version_util /home/opam/.opam/4.14.2/lib/sexplib/unix/sexplib_unix.cmxa /home/opam/.opam/4.14.2/lib/spawn/spawn.cmxa -I /home/opam/.opam/4.14.2/lib/spawn /home/opam/.opam/4.14.2/lib/timezone/timezone.cmxa /home/opam/.opam/4.14.2/lib/core/core.cmxa -I /home/opam/.opam/4.14.2/lib/core /home/opam/.opam/4.14.2/lib/core/bigstring_unix/bigstring_unix.cmxa -I /home/opam/.opam/4.14.2/lib/core/bigstring_unix /home/opam/.opam/4.14.2/lib/core_kernel/bounded_int_table/bounded_int_table.cmxa /home/opam/.opam/4.14.2/lib/core_kernel/iobuf/iobuf.cmxa /home/opam/.opam/4.14.2/lib/core/iobuf_unix/iobuf_unix.cmxa -I /home/opam/.opam/4.14.2/lib/core/iobuf_unix /home/opam/.opam/4.14.2/lib/core/nano_mutex/nano_mutex.cmxa /home/opam/.opam/4.14.2/lib/core/squeue/squeue.cmxa /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.cmxa -I /home/opam/.opam/4.14.2/lib/core/linux_ext /home/opam/.opam/4.14.2/lib/async_unix/thread_safe_ivar/thread_safe_ivar.cmxa /home/opam/.opam/4.14.2/lib/async_unix/thread_pool/thread_pool.cmxa /home/opam/.opam/4.14.2/lib/core/time_stamp_counter/time_stamp_counter.cmxa -I /home/opam/.opam/4.14.2/lib/core/time_stamp_counter /home/opam/.opam/4.14.2/lib/core_kernel/uuid/uuid.cmxa /home/opam/.opam/4.14.2/lib/core/uuid/uuid_unix.cmxa /home/opam/.opam/4.14.2/lib/async_unix/async_unix.cmxa -I /home/opam/.opam/4.14.2/lib/async_unix /home/opam/.opam/4.14.2/lib/async/async_command/async_command.cmxa /home/opam/.opam/4.14.2/lib/async/async_quickcheck/async_quickcheck.cmxa /home/opam/.opam/4.14.2/lib/async_kernel/persistent_connection_kernel/persistent_connection_kernel.cmxa /home/opam/.opam/4.14.2/lib/protocol_version_header/protocol_version_header.cmxa /home/opam/.opam/4.14.2/lib/async_rpc_kernel/async_rpc_kernel.cmxa /home/opam/.opam/4.14.2/lib/async/async_rpc/async_rpc.cmxa -I /home/opam/.opam/4.14.2/lib/async/async_rpc /home/opam/.opam/4.14.2/lib/async/async.cmxa /home/opam/.opam/4.14.2/lib/eqaf/eqaf.cmxa src/mirage_crypto.cmxa -I src /home/opam/.opam/4.14.2/lib/digestif/c/digestif_c.cmxa -I /home/opam/.opam/4.14.2/lib/digestif/c rng/mirage_crypto_rng.cmxa /home/opam/.opam/4.14.2/lib/logs/logs.cmxa rng/unix/mirage_crypto_rng_unix.cmxa -I rng/unix rng/async/mirage_crypto_rng_async.cmxa /home/opam/.opam/4.14.2/lib/ohex/ohex.cmxa tests/.test_entropy_collection_async.eobjs/native/dune__exe__Test_entropy_collection_async.cmx)
ld: error: undefined symbol: core_linux_timerfd_create
>>> referenced by linux_ext.o:(.text+0x3AED) in archive /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x26D0) in archive /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_settime
>>> referenced by linux_ext.o:(.text+0x3D51) in archive /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.text+0x3F91) in archive /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x26C8) in archive /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_gettime
>>> referenced by linux_ext.o:(.text+0x3EEA) in archive /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x26C0) in archive /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_CLOCK_REALTIME
>>> referenced by linux_ext.o:(.text+0x6D81) in archive /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x26F0) in archive /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_CLOCK_MONOTONIC
>>> referenced by linux_ext.o:(.text+0x6D9B) in archive /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x26E8) in archive /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_TFD_NONBLOCK
>>> referenced by linux_ext.o:(.text+0x6E4D) in archive /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x26E0) in archive /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.a

ld: error: undefined symbol: core_linux_timerfd_TFD_CLOEXEC
>>> referenced by linux_ext.o:(.text+0x6E66) in archive /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.a
>>> referenced by linux_ext.o:(.data+0x26D8) in archive /home/opam/.opam/4.14.2/lib/core/linux_ext/linux_ext.a
cc: error: linker command failed with exit code 1 (use -v to see invocation)
File "caml_startup", line 1:
Error: Error during linking (exit code 1)
```