### PR TITLE
Lambda Soup 1.1.0: HTML scraping with CSS

### DIFF
--- a/packages/lambdasoup/lambdasoup.1.1.0/opam
+++ b/packages/lambdasoup/lambdasoup.1.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+
+synopsis: "Easy functional HTML scraping and manipulation with CSS selectors"
+
+license: "MIT"
+homepage: "https://github.com/aantron/lambdasoup"
+doc: "https://aantron.github.io/lambdasoup"
+bug-reports: "https://github.com/aantron/lambdasoup/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/lambdasoup.git"
+
+depends: [
+  "camlp-streams" {>= "5.0.1"}
+  "dune" {>= "2.7.0"}
+  "markup" {>= "1.0.0"}
+  "ocaml" {>= "4.03.0"}
+
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "ounit2" {with-test}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+description: """
+Lambda Soup is an HTML scraping library inspired by Python's Beautiful Soup. It
+provides lazy traversals from HTML nodes to their parents, children, siblings,
+etc., and to nodes matching CSS selectors. The traversals can be manipulated
+using standard functional combinators such as fold, filter, and map.
+
+The DOM tree is mutable. You can use Lambda Soup for automatic HTML rewriting in
+scripts. Lambda Soup rewrites its own ocamldoc page this way.
+
+A major goal of Lambda Soup is to be easy to use, including in interactive
+sessions, and to have a minimal learning curve. It is a very simple library.
+"""
+
+url {
+  src: "https://github.com/aantron/lambdasoup/archive/1.1.0.tar.gz"
+  checksum: "sha256=9135c035f4857591ede227b8628dec8f28f410f65996b7e60075d1395b86773f"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/aantron/lambdasoup/releases/tag/1.1.0):

> - Add `:has()` selector (aantron/lambdasoup#56, aantron/lambdasoup#57, Jayesh Bhoot).
> - Add [`Soup.is_document`](https://github.com/aantron/lambdasoup/blob/6c05f4dcfdf223fcd63bcbb0628bd7f8e6d6a01f/src/soup.mli#L433) and [`Soup.is_text`](https://github.com/aantron/lambdasoup/blob/6c05f4dcfdf223fcd63bcbb0628bd7f8e6d6a01f/src/soup.mli#L439) (aantron/lambdasoup#52, Daniil Baturin).