### PR TITLE
[new release] miou (0.3.0)

### DIFF
--- a/packages/miou/miou.0.3.0/opam
+++ b/packages/miou/miou.0.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://git.robur.coop/robur/miou"
+bug-reports:  "https://git.robur.coop/robur/miou/issues"
+dev-repo:     "git+https://github.com/robur-coop/miou.git"
+doc:          "https://docs.osau.re/miou/"
+license:      "MIT"
+synopsis:     "Composable concurrency primitives for OCaml"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"             {>= "5.0.0"}
+  "dune"              {>= "2.8.0"}
+  "dscheck"           {with-test & >= "0.4.0"}
+  "digestif"          {with-test}
+  "happy-eyeballs"    {with-test & >= "0.6.0"}
+  "dns-client"        {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test}
+  "ipaddr"            {with-test}
+  "logs"              {with-test & >= "0.7.0"}
+  "dns"               {with-test}
+  "dns-client"        {with-test}
+  "mtime"             {with-test & >= "2.0.0"}
+]
+url {
+  src:
+    "https://github.com/robur-coop/miou/releases/download/v0.3.0/miou-0.3.0.tbz"
+  checksum: [
+    "sha256=9231806e6d60945e36ee060e5ca4a881bf87a60510a8ae5fa8bf45d3a16d0b84"
+    "sha512=cfac5caaa2fdcc3b572c6a541270ffbe9540e2fc35aa4ef7d84390a4d87f81214f69828642d1b84698c1798de8553f7d7cc5fe88d5dd68a12b694b7ba565b3b2"
+  ]
+}
+x-commit-hash: "71ff559afff880ec4f280fc6b78e7c46e7801995"


### PR DESCRIPTION
Composable concurrency primitives for OCaml

- Project page: <a href="https://git.robur.coop/robur/miou">https://git.robur.coop/robur/miou</a>
- Documentation: <a href="https://docs.osau.re/miou/">https://docs.osau.re/miou/</a>

##### CHANGES:

- Set the internal pipe used to interrupt a domain to a non-blocking mode and
  remove the usage of an atomic which protect how we fill the pipe
  (@haesbaert, @dinosaure, robur-coop/miou#28)
- Expose option to reuse addr/port when we `Miou_unix.bind_and_listen`
  (@ada2k, @dinosaure, robur-coop/miou#27)
- Protect an illegal access to the orphan from a possibly parallel task which
  does not own the orphan value
  (@poytypic, @dinosaure, robur-coop/miou#31, robur-coop/miou#32)
- Be able to pin a specific domain when we want to launch a parallel task
  (@dinosaure, robur-coop/miou#34)
- Expose the `Miou.Backoff` module which can be useful for users
  (@dinosaure, robur-coop/miou#35)
- Fix or improve (from the maintainance point-of-view) the `Miou.Queue` module
  and some internal parts of Miou about the usage of atomics
  (@dinosaure, @polytypic, robur-coop/miou#36, robur-coop/miou#33)
- Prefer to require a `finaliser` function for the `events` value and actually
  close the internal `Unix.pipe` used to interrupt domain than to use
  `Gc.finaliser` and possibly leak file-descriptors
  (spotted by @hannesm, @dinosaure, robur-coop/miou#37)
