### PR TITLE
[new release] dream-html (2 packages) (3.6.1)

### DIFF
--- a/packages/dream-html/dream-html.3.6.1/opam
+++ b/packages/dream-html/dream-html.3.6.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.6.1/dream-html-3.6.1.tbz"
+  checksum: [
+    "sha256=ef59191bb5de12596923fe5c304aed202986a940cf2a081ccdacf7a4800d89a7"
+    "sha512=a5ffee0e41fad02ddcbf026c6a0a0ecea61a6068379c2d66e78bbb73b5b13a8694abf99ebad4aedc21381aa3fc6ef26a85f6d5ea83b951ed0f80be5fe65cf8a6"
+  ]
+}
+x-commit-hash: "733adbbe867e422b88eaba4bfa8fe5431f531fe7"

--- a/packages/pure-html/pure-html.3.6.1/opam
+++ b/packages/pure-html/pure-html.3.6.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.6.1/dream-html-3.6.1.tbz"
+  checksum: [
+    "sha256=ef59191bb5de12596923fe5c304aed202986a940cf2a081ccdacf7a4800d89a7"
+    "sha512=a5ffee0e41fad02ddcbf026c6a0a0ecea61a6068379c2d66e78bbb73b5b13a8694abf99ebad4aedc21381aa3fc6ef26a85f6d5ea83b951ed0f80be5fe65cf8a6"
+  ]
+}
+x-commit-hash: "733adbbe867e422b88eaba4bfa8fe5431f531fe7"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
