### PR TITLE
[new release] hardcaml-lua (alpha+19)

### DIFF
--- a/packages/hardcaml-lua/hardcaml-lua.alpha+19/opam
+++ b/packages/hardcaml-lua/hardcaml-lua.alpha+19/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "A lua client for interfacing hardcaml to verilator, UHDM, Verible and RTLIL front-ends"
+description:
+  "Verilator, Surelog and Verible do not generate synthesised Verilog code directly. This software bridges the gap and verifies the results using build-in minisat solver, z3 or external eqy script"
+maintainer: ["Jonathan Kimmitt"]
+authors: ["Jonathan Kimmitt"]
+license: "MIT"
+tags: ["Verilator" "Surelog" "UHDM" "Verible" "Yosys" "RTLIL"]
+available: [ os != "win32" ]
+homepage: "https://github.com/jrrk2/hardcaml-lua"
+bug-reports: "https://github.com/jrrk2/hardcaml-lua/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml-compiler-libs" {>= "v0.17.0"}
+  "xml-light"
+  "msat"
+  "menhir" {>= "20240715"}
+  "hardcaml"
+  "hardcaml_circuits" {>= "v0.17.0"}
+  "lua-ml"
+  "ppx_deriving_yojson"
+  "z3"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jrrk2/hardcaml-lua.git"
+url {
+  src:
+    "https://github.com/jrrk2/hardcaml-lua/releases/download/alpha%2B19/hardcaml-lua-alpha.19.tbz"
+  checksum: [
+    "sha256=5df2b1c3286a7a180b108f333e274c737dd7b5b088649e7a2436a4d20511b1c3"
+    "sha512=e42bd1b5c42e56ece6acec3cf8e10e95e2a42559432e0eff621b7424a1646fe6765f3c276ffbb827d61f803c6333605a966c9ce480043474ca24c014922201cd"
+  ]
+}
+x-commit-hash: "743e2cecde21a765a3a5d6d79bcedd54e1eff821"


### PR DESCRIPTION
A lua client for interfacing hardcaml to verilator, UHDM, Verible and RTLIL front-ends

- Project page: <a href="https://github.com/jrrk2/hardcaml-lua">https://github.com/jrrk2/hardcaml-lua</a>

##### CHANGES:

* Tweak packaging syntax
