### PR TITLE
[new release] hardcaml-lua (alpha+20)

### DIFF
--- a/packages/hardcaml-lua/hardcaml-lua.alpha+20/opam
+++ b/packages/hardcaml-lua/hardcaml-lua.alpha+20/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis:
+  "A lua client for interfacing hardcaml to verilator, UHDM, Verible and RTLIL front-ends"
+description:
+  "Verilator, Surelog and Verible do not generate synthesised Verilog code directly. This software bridges the gap and verifies the results using build-in minisat solver, z3 or external eqy script"
+maintainer: ["Jonathan Kimmitt"]
+authors: ["Jonathan Kimmitt"]
+license: "MIT"
+tags: ["Verilator" "Surelog" "UHDM" "Verible" "Yosys" "RTLIL"]
+available: [ os != "win32" ]
+homepage: "https://github.com/jrrk2/hardcaml-lua"
+bug-reports: "https://github.com/jrrk2/hardcaml-lua/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "xml-light"
+  "msat"
+  "menhir" {>= "20240715"}
+  "hardcaml"
+  "hardcaml_circuits" {>= "v0.17.0"}
+  "lua-ml"
+  "ppx_deriving_yojson"
+  "z3"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jrrk2/hardcaml-lua.git"
+url {
+  src:
+    "https://github.com/jrrk2/hardcaml-lua/releases/download/alpha%2B20/hardcaml-lua-alpha.20.tbz"
+  checksum: [
+    "sha256=455503414a02d165f1d2ca421254cbd96e31b2273e28b085911b3e9bd221d00b"
+    "sha512=3b87f2f47e0c24256ce69bfda78c0e220e2af5455e112bffdc0c982737d65b8ba564d6349eaf1ac3e5bc2a2a2785f2522f5d253b56eaba8694c1de346fcfb08f"
+  ]
+}
+x-commit-hash: "6f48a5e03bb39f7379acec7bb338602ca87fc426"


### PR DESCRIPTION
A lua client for interfacing hardcaml to verilator, UHDM, Verible and RTLIL front-ends

- Project page: <a href="https://github.com/jrrk2/hardcaml-lua">https://github.com/jrrk2/hardcaml-lua</a>

##### CHANGES:

* Tweak packaging syntax
