### PR TITLE
[new release] hardcaml-lua (alpha+22)

### DIFF
--- a/packages/hardcaml-lua/hardcaml-lua.alpha+22/opam
+++ b/packages/hardcaml-lua/hardcaml-lua.alpha+22/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis:
+  "A lua client for interfacing hardcaml to verilator, UHDM, Verible and RTLIL front-ends"
+description:
+  "Verilator, Surelog and Verible do not generate synthesised Verilog code directly. This software bridges the gap and verifies the results using build-in minisat solver, z3 or external eqy script"
+maintainer: ["Jonathan Kimmitt"]
+authors: ["Jonathan Kimmitt"]
+license: "MIT"
+tags: ["Verilator" "Surelog" "UHDM" "Verible" "Yosys" "RTLIL"]
+available: [ os != "win32" ]
+homepage: "https://github.com/jrrk2/hardcaml-lua"
+bug-reports: "https://github.com/jrrk2/hardcaml-lua/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "xml-light"
+  "msat"
+  "menhir" {>= "20240715"}
+  "hardcaml"
+  "hardcaml_circuits" {>= "v0.17.0"}
+  "lua-ml"
+  "ppx_deriving_yojson"
+  "z3"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jrrk2/hardcaml-lua.git"
+url {
+  src:
+    "https://github.com/jrrk2/hardcaml-lua/releases/download/alpha%2B22/hardcaml-lua-alpha.22.tbz"
+  checksum: [
+    "sha256=5abf14eca0118c1ca6d2ebf27e70fc38003ca8668d4273e468c45e3ee94da9be"
+    "sha512=2e61565560e1a7ab50c984592bf9649735603ec1fa25fbe07c625035f6df86b9df535d0c3f5867b7f1d8870a3a27f801608bd7bcaf68f6875bee3f893846c327"
+  ]
+}
+x-commit-hash: "40be1ffceaa2bff6057ffd5f928f29e24a116918"


### PR DESCRIPTION
A lua client for interfacing hardcaml to verilator, UHDM, Verible and RTLIL front-ends

- Project page: <a href="https://github.com/jrrk2/hardcaml-lua">https://github.com/jrrk2/hardcaml-lua</a>

##### CHANGES:

* Tweak packaging syntax
