### PR TITLE
[new release] hardcaml-lua (alpha+24)

### DIFF
--- a/packages/hardcaml-lua/hardcaml-lua.alpha+24/opam
+++ b/packages/hardcaml-lua/hardcaml-lua.alpha+24/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "A lua client for interfacing hardcaml to verilator, UHDM, Verible and RTLIL front-ends"
+description:
+  "Verilator, Surelog and Verible do not generate synthesised Verilog code directly. This software bridges the gap and verifies the results using build-in minisat solver, z3 or external eqy script"
+maintainer: ["Jonathan Kimmitt"]
+authors: ["Jonathan Kimmitt"]
+license: "MIT"
+tags: ["Verilator" "Surelog" "UHDM" "Verible" "Yosys" "RTLIL"]
+available: [ os != "win32" ]
+homepage: "https://github.com/jrrk2/hardcaml-lua"
+bug-reports: "https://github.com/jrrk2/hardcaml-lua/issues"
+depends: [
+  "ocaml" {!= "ocaml-5.2-flambda" & != "riscv64-ocaml-5.2"}
+  "dune" {>= "3.7"}
+  "xml-light"
+  "msat"
+  "menhir" {>= "20240715"}
+  "hardcaml"
+  "hardcaml_circuits" {>= "v0.17.0"}
+  "lua-ml"
+  "ppx_deriving_yojson"
+  "z3"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jrrk2/hardcaml-lua.git"
+url {
+  src:
+    "https://github.com/jrrk2/hardcaml-lua/releases/download/alpha%2B24/hardcaml-lua-alpha.24.tbz"
+  checksum: [
+    "sha256=11262747a7d5ac99e451454ff051a13354261dc47952c1da803a11f249308924"
+    "sha512=0c6817da15e0cf0b47f11c233eb282c4d06d0d44b80bc32a5041475ee3c3af1add6e5df2ad73cc3e1f967218b176e47a868113cf2e7cb044e49fbc078c88f6bf"
+  ]
+}
+x-commit-hash: "aafe50b535c064c03a6faa3e639c4874f0248038"


### PR DESCRIPTION
A lua client for interfacing hardcaml to verilator, UHDM, Verible and RTLIL front-ends

- Project page: <a href="https://github.com/jrrk2/hardcaml-lua">https://github.com/jrrk2/hardcaml-lua</a>

##### CHANGES:

* Tweak packaging syntax
