### PR TITLE
[new release] hardcaml-lua (alpha+26)

### DIFF
--- a/packages/hardcaml-lua/hardcaml-lua.alpha+26/opam
+++ b/packages/hardcaml-lua/hardcaml-lua.alpha+26/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "A lua client for interfacing hardcaml to verilator, UHDM, Verible and RTLIL front-ends"
+description:
+  "Verilator, Surelog and Verible do not generate synthesised Verilog code directly. This software bridges the gap and verifies the results using build-in minisat solver, z3 or external eqy script"
+maintainer: ["Jonathan Kimmitt"]
+authors: ["Jonathan Kimmitt"]
+license: "MIT"
+tags: ["Verilator" "Surelog" "UHDM" "Verible" "Yosys" "RTLIL"]
+available: [ os != "win32" & os != "riscv64" ]
+homepage: "https://github.com/jrrk2/hardcaml-lua"
+bug-reports: "https://github.com/jrrk2/hardcaml-lua/issues"
+depends: [
+  "ocaml" { != "ocaml-5.2-flambda" }
+  "dune" {>= "3.7"}
+  "xml-light"
+  "msat"
+  "menhir" {>= "20240715"}
+  "hardcaml"
+  "hardcaml_circuits" {>= "v0.17.0"}
+  "lua-ml"
+  "ppx_deriving_yojson"
+  "z3"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jrrk2/hardcaml-lua.git"
+url {
+  src:
+    "https://github.com/jrrk2/hardcaml-lua/releases/download/alpha%2B26/hardcaml-lua-alpha.26.tbz"
+  checksum: [
+    "sha256=20302b07e6ae9c717a9c60e20072d877277d7fc7e03369b29475c63fe1648d48"
+    "sha512=b1d67b11c7f18988f3d4adb49d9f4647653bfe4968ecf70f77b78db565d73c8706ffbe3f032fb296c2d9b9b01ef287d2ed0aa7d5d66ace8fd0b5d6569f813194"
+  ]
+}
+x-commit-hash: "a9df02e17b8cf3c8fe785b3a50c3bc374452d8c4"


### PR DESCRIPTION
A lua client for interfacing hardcaml to verilator, UHDM, Verible and RTLIL front-ends

- Project page: <a href="https://github.com/jrrk2/hardcaml-lua">https://github.com/jrrk2/hardcaml-lua</a>

##### CHANGES:

* Tweak packaging syntax
