### PR TITLE
[new release] hardcaml-lua (alpha+29)

### DIFF
--- a/packages/hardcaml-lua/hardcaml-lua.alpha+29/opam
+++ b/packages/hardcaml-lua/hardcaml-lua.alpha+29/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis:
+  "A lua client for interfacing hardcaml to verilator, UHDM, Verible and RTLIL front-ends"
+description:
+  "Verilator, Surelog and Verible do not generate synthesised Verilog code directly. This software bridges the gap and verifies the results using build-in minisat solver, z3 or external eqy script"
+maintainer: ["Jonathan Kimmitt"]
+authors: ["Jonathan Kimmitt"]
+license: "MIT"
+tags: ["Verilator" "Surelog" "UHDM" "Verible" "Yosys" "RTLIL"]
+# This option excludes RISCV because there are insufficient regression stations
+# to complete in a timely manner and win32 because Z3 apparently does not work
+# and flambda because it hangs (or takes a very long time) on my code for the present time.
+available: [ os != "win32" & os != "riscv64" ]
+homepage: "https://github.com/jrrk2/hardcaml-lua"
+bug-reports: "https://github.com/jrrk2/hardcaml-lua/issues"
+depends: [
+  "ocaml" { != "ocaml-5.2-flambda" }
+  "dune" {>= "3.7"}
+  "xml-light"
+  "msat"
+  "menhir" {>= "20240715"}
+  "hardcaml"
+  "hardcaml_circuits" {>= "v0.17.0"}
+  "lua-ml"
+  "ppx_deriving_yojson"
+  "z3"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jrrk2/hardcaml-lua.git"
+url {
+  src:
+    "https://github.com/jrrk2/hardcaml-lua/releases/download/alpha%2B29/hardcaml-lua-alpha.29.tbz"
+  checksum: [
+    "sha256=c64366f386c2e807157bf569f6ee541fd89754988fbba3c52b55341bb545d14b"
+    "sha512=3c15c11d8eb3e46b11fc719d562bcd248dc6c6119a7c44d4eab79e6142165f25cf09cc836e018b73299a640ba9200e77149b6300f889afb5a7e967284042bca7"
+  ]
+}
+x-commit-hash: "0ac843f624215c4aaa4186b9a02e4c34ece3070e"


### PR DESCRIPTION
A lua client for interfacing hardcaml to verilator, UHDM, Verible and RTLIL front-ends

- Project page: <a href="https://github.com/jrrk2/hardcaml-lua">https://github.com/jrrk2/hardcaml-lua</a>

##### CHANGES:

* Tweak packaging syntax
