### PR TITLE
Release x509 v1.0.2

### DIFF
--- a/packages/x509/x509.1.0.0/opam
+++ b/packages/x509/x509.1.0.0/opam
@@ -55,3 +55,4 @@ url {
     "sha512=fb692e54c75243b28ea1596b987156d0d6c07d82eee0a7fbeb4e2a90a4f7d4d39100c0f17477683a08f4ed4d2dac7a018ca1d8d306ecdee8ba2a39d4dd008531"
   ]
 }
+available: false # RSA public key and private key decoding and encoding is broken

--- a/packages/x509/x509.1.0.1/opam
+++ b/packages/x509/x509.1.0.1/opam
@@ -57,3 +57,4 @@ url {
   ]
 }
 x-commit-hash: "61fbd38a1ec59662816843b2a868f388bf03e281"
+available: false # RSA public key and private key decoding and encoding is broken

--- a/packages/x509/x509.1.0.2/opam
+++ b/packages/x509/x509.1.0.2/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "David Kaloper <dk505@cam.ac.uk>"
+]
+license: "BSD-2-Clause"
+tags: "org:mirage"
+homepage: "https://github.com/mirleft/ocaml-x509"
+doc: "https://mirleft.github.io/ocaml-x509/doc"
+bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.2"}
+  "asn1-combinators" {>= "0.3.1"}
+  "ptime"
+  "base64" {>= "3.3.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.7"}
+  "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+  "gmap" {>= "0.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "logs"
+  "pbkdf" {>= "2.0.0"}
+  "ohex" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
+synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
+description: """
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority. Authorities must be exchanged over a second channel to establish the
+trust relationship. This library implements most parts of RFC5280 and RFC6125.
+The Public Key Cryptography Standards (PKCS) defines encoding and decoding
+(in ASN.1 DER and PEM format), which is also implemented by this library -
+namely PKCS 1, PKCS 5, PKCS 7, PKCS 8, PKCS 9, PKCS 10, and PKCS 12.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-x509/releases/download/v1.0.2/x509-1.0.2.tbz"
+  checksum: [
+    "sha256=2eb5186cb2c94cd096bc466d45752fe4b1dd1326b6a0d4ed01badf9bb104d818"
+    "sha512=8b4e7248dcb1ffe9576860ce2b6c4c28b917102d72ae8b9254ffada7b73adbf15271ff3eb3a9f7073fc864c8def067711944ce8ecba5faee25f397b5aa0e08af"
+  ]
+}
+x-commit-hash: "2e4b1a969aa0d34107bebf1be6e85779c2bb75db"


### PR DESCRIPTION
CHANGES:
    
* Fix RSA public and private key encoding and decoding (@hannesm mirleft/ocaml-x509#172, reported by @anmonteiro mirleft/ocaml-x509#171)
