### PR TITLE
[new release] tls-miou-unix (1.0.1)

### DIFF
--- a/packages/tls-miou-unix/tls-miou-unix.1.0.1/opam
+++ b/packages/tls-miou-unix/tls-miou-unix.1.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/"
+maintainer:   ["Romain Calascibetta <romain.calascibetta@gmail.com>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.0"}
+  "tls" {= "1.0.0"}
+  "mirage-crypto-rng-miou-unix" {>= "1.0.0" & with-test}
+  "x509" {>= "1.0.0"}
+  "miou" {>= "0.3.0"}
+  "crowbar" {with-test}
+  "rresult" {with-test}
+  "ohex" {with-test}
+  "ptime" {with-test}
+  "hxd" {with-test}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, Miou+Unix layer"
+description: """
+Tls-miou provides an effectful Tls_miou module to be used with Miou and Unix.
+"""
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v1.0.1/tls-1.0.1.tbz"
+  checksum: [
+    "sha256=dae4b5ffc803e882e984804258ff8aaca7b837d8556de68400195da5c70a8d83"
+    "sha512=2e470bfb6ea8be00e2810c284421c164abde282afe951c3c24d4cf3021d80cc4b2dbc7fe7d8cfa934f40564d1f99b6e7a9ad99720e4698a01b2c6d6826d45593"
+  ]
+}
+x-commit-hash: "0a6bc919f34d17f3132b1c6cfcf24d1609c789a4"


### PR DESCRIPTION
CHANGES:

* tls-miou-unix: fix file descriptor leak (mirleft/ocaml-tls#508 @dinosaure)
* tls-miou-unix: fix fuzz test (mirleft/ocaml-tls#507 @dinosaure)