### PR TITLE
[new release] hardcaml-lua (alpha+35)

### DIFF
--- a/packages/hardcaml-lua/hardcaml-lua.alpha+35/opam
+++ b/packages/hardcaml-lua/hardcaml-lua.alpha+35/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis:
+  "A lua client for interfacing hardcaml to verilator, UHDM, Verible and RTLIL front-ends"
+description:
+  "Verilator, Surelog and Verible do not generate synthesised Verilog code directly. This software bridges the gap and verifies the results using build-in minisat solver, z3 or external eqy script"
+maintainer: ["Jonathan Kimmitt"]
+authors: ["Jonathan Kimmitt"]
+license: "MIT"
+tags: ["Verilator" "Surelog" "UHDM" "Verible" "Yosys" "RTLIL"]
+# This option excludes win32 because Z3 apparently does not work
+# and flambda because it hangs (or takes a very long time) on my code for the present time.
+# uncertain how to detect flambda
+available: [ os != "win32" & arch != "riscv64" & arch != "riscv32" ]
+homepage: "https://github.com/jrrk2/hardcaml-lua"
+bug-reports: "https://github.com/jrrk2/hardcaml-lua/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "xml-light"
+  "msat"
+  "menhir" {>= "20240715"}
+  "hardcaml"
+  "hardcaml_circuits" {>= "v0.17.0"}
+  "lua-ml"
+  "ppx_deriving_yojson"
+  "z3"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-option-flambda"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jrrk2/hardcaml-lua.git"
+url {
+  src:
+    "https://github.com/jrrk2/hardcaml-lua/releases/download/alpha%2B35/hardcaml-lua-alpha.35.tbz"
+  checksum: [
+    "sha256=60bdc11cc72a1ea4195a26a90e7829f28a3ece86bb45675c5c9b014072e553c3"
+    "sha512=5b47adffa8e84d88c36dc932e3f2aab31d14ce34abd3727ccd42d37eca59b685101bbd15dbfae99dde7021460d4417d8c6db74ca16ed8f9284e77e5c38bb06f2"
+  ]
+}
+x-commit-hash: "3faf51a5452159ffe7248370be809c267ac1d7e5"


### PR DESCRIPTION
A lua client for interfacing hardcaml to verilator, UHDM, Verible and RTLIL front-ends

- Project page: <a href="https://github.com/jrrk2/hardcaml-lua">https://github.com/jrrk2/hardcaml-lua</a>

##### CHANGES:

* Tweak packaging syntax
