### PR TITLE
[new release] provider 0.0.8

### DIFF
--- a/packages/provider/provider.0.0.8/opam
+++ b/packages/provider/provider.0.0.8/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Dynamic Dispatch with Traits"
+maintainer: ["Mathieu Barbin"]
+authors: ["Mathieu Barbin"]
+license: "ISC"
+homepage: "https://github.com/mbarbin/provider"
+doc: "https://mbarbin.github.io/provider/"
+bug-reports: "https://github.com/mbarbin/provider/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.2"}
+  "bisect_ppx" {dev & >= "2.8.3"}
+  "ppx_js_style" {dev & >= "v0.17" & < "v0.18"}
+  "sexplib0" {>= "v0.17" & < "v0.18"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/provider.git"
+url {
+  src:
+    "https://github.com/mbarbin/provider/releases/download/0.0.8/provider-0.0.8.tbz"
+  checksum: [
+    "sha256=433b981763a0734e107890d04368315969422440e6a845c01bfc0bf7c24d680d"
+    "sha512=da903fb935b9ae6eff6b75168eddeb6d67f66be13221d6c705d532723d7bc8fd8ff54324a28bf070ce38aae42c322f07ee7232f3a822bff3ed67186139171b9e"
+  ]
+}
+x-commit-hash: "b3164ad630b2dbf5ee20965e4f6653afeb5392d1"

--- a/packages/provider/provider.0.0.8/opam
+++ b/packages/provider/provider.0.0.8/opam
@@ -10,8 +10,8 @@ depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.2"}
   "bisect_ppx" {dev & >= "2.8.3"}
-  "ppx_js_style" {dev & >= "v0.17" & < "v0.18"}
-  "sexplib0" {>= "v0.17" & < "v0.18"}
+  "ppx_js_style" {dev & >= "v0.17"}
+  "sexplib0" {>= "v0.17"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Going directly from `0.0.4` to `0.08` - skipping internal releases published in my custom opam-repository.

I added a commit to allow `>= sexplib.0.17` in the hope things will be compatible going forward - this may be adjusted later.

Detailed changelog below: 

## 0.0.8 (2024-08-19)

### Fixed

- Follow-up fixes to binding renaming.

## 0.0.7 (2024-08-05)

### Added

- Added dedicated tests for internal functions.

### Changed

- More renamings. `Implementation => Binding`, `Interface => Handler`. This brings the lib closer to the original namings from Eio.

## 0.0.6 (2024-08-02)

### Changed

- Rename `Provider.Trait.Implementation` as `Provider.Implementation` to expose the concepts in a more flat way.
- Reduce `provider` package dependencies - reduce from `base` to `sexplib0`.

### Fixed

- Make sure to select the right most implementation in case of overrides, as per specification.

### Removed

- Removed `Trait.Uid.Comparable.S` as this requires `Base`. Make it compatible with `Comparable.Make (Trait.Uid)` and add tests for this use case.

## 0.0.5 (2024-07-26)

### Added

- Added dependabot config for automatically upgrading action files.

### Changed

- Upgrade `ppxlib` to `0.33` - activate unused items warnings.
- Upgrade `ocaml` to `5.2`.
- Upgrade `dune` to `3.16`.
- Upgrade `eio` to `1.0` (no change required).
- Upgrade base & co to `0.17`.