### PR TITLE
OCaml 5.3 and 5.4 development packages

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.4.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.4.0+trunk/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
-synopsis: "Latest 5.3 development"
+synopsis: "Current trunk"
 maintainer: [
   "David Allsopp <david@tarides.com>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
@@ -15,10 +15,10 @@ authors: [
 ]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml.git#5.3"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
 depends: [
-  # This is OCaml 5.3.0
-  "ocaml" {= "5.3.0" & post}
+  # This is OCaml 5.4.0
+  "ocaml" {= "5.4.0" & post}
 
   # General base- packages
   "base-unix" {post}
@@ -113,7 +113,7 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/5.3.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 }
 depopts: [
   "ocaml-option-32bit"

--- a/packages/ocaml/ocaml.5.4.0/opam
+++ b/packages/ocaml/ocaml.5.4.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "David Allsopp <david@tarides.com>"
+depends: [
+  "ocaml-config" {>= "3"}
+  "ocaml-base-compiler" {= "5.4.0"} |
+  "ocaml-variants" {>= "5.4.0~" & < "5.4.1~"} |
+  "ocaml-system" {>= "5.4.0~" & < "5.4.1~"} |
+  "dkml-base-compiler" {>= "5.4.0~" & < "5.4.1~"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build-env: [
+  [CAML_LD_LIBRARY_PATH = ""]
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+flags: conf


### PR DESCRIPTION
With OCaml 5.3 in feature freeze/bug fixing mode, the development package for compiler developers need to switch to version 5.4. Thus this PR creates two packages:

    ocaml.5.4.0 (the metapackage for OCaml 5.4)
    ocaml-variants.5.4.0+trunk (the new latest development package)

and updates the package

    ocaml-variants.5.3.0+trunk

to point towards the new 5.3 branch.
