### PR TITLE
arrayjit, neural_nets_lib: upper bind ppx_minidebug

### DIFF
--- a/packages/arrayjit/arrayjit.0.3.3/opam
+++ b/packages/arrayjit/arrayjit.0.3.3/opam
@@ -27,7 +27,7 @@ depends: [
   "ppxlib"
   "ppx_jane"
   "ppx_expect"
-  "ppx_minidebug" {>= "1.5"}
+  "ppx_minidebug" {>= "1.5" & < "2.0.0"}
   "odoc" {with-doc}
 ]
 depopts: ["cudajit"]

--- a/packages/neural_nets_lib/neural_nets_lib.0.3.3/opam
+++ b/packages/neural_nets_lib/neural_nets_lib.0.3.3/opam
@@ -26,7 +26,7 @@ depends: [
   "ppxlib"
   "ppx_jane"
   "ppx_expect"
-  "ppx_minidebug" {>= "1.5"}
+  "ppx_minidebug" {>= "1.5" & < "2.0.0"}
   "odoc" {with-doc}
   "md2mld" {with-doc}
 ]


### PR DESCRIPTION
in preparation for a non-backward-compatible release: ppx_minidebug 2.0.