### PR TITLE
[new release] kdf (1.0.0)

### DIFF
--- a/packages/kdf/kdf.1.0.0/opam
+++ b/packages/kdf/kdf.1.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>" "Hannes Mehnert <hannes@mehnert.org>"]
+authors: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>" "Sonia Meruelo <smeruelo@gmail.com>" "Hannes Mehnert <hannes@mehnert.org>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/robur-coop/kdf"
+doc: "https://robur-coop.github.io/kdf/doc"
+bug-reports: "https://github.com/robur-coop/kdf/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.8.0"}
+  "digestif" {>= "1.2.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/kdf.git"
+synopsis: "Key Derivation Functions: HKDF RFC 5869, PBKDF RFC 2898, SCRYPT RFC 7914"
+description: """
+A pure OCaml implementation of [scrypt](https://tools.ietf.org/html/rfc7914),
+[PBKDF 1 and 2 as defined by PKCS#5](https://tools.ietf.org/html/rfc2898),
+and [HKDF](https://tools.ietf.org/html/rfc5869).
+"""
+url {
+  src:
+    "https://github.com/robur-coop/kdf/releases/download/v1.0.0/kdf-1.0.0.tbz"
+  checksum: [
+    "sha256=d161582b0efe66d958dd6b8c9c21068e9f6454ce218377d6cf87823dec62e0ce"
+    "sha512=8c518494a7c2e030c079a22fc0d27e4dccd1b2d6edb8fcd2ee7121cdd3d56ff416a37876b6bb13b8be015922c3487536038373bfa0934a165055c1cb5dd3c2e1"
+  ]
+}
+x-commit-hash: "a6da77f39fd1b3acc6865a9a20dca567a5e1fe89"


### PR DESCRIPTION
Key Derivation Functions: HKDF RFC 5869, PBKDF RFC 2898, SCRYPT RFC 7914

- Project page: <a href="https://github.com/robur-coop/kdf">https://github.com/robur-coop/kdf</a>
- Documentation: <a href="https://robur-coop.github.io/kdf/doc">https://robur-coop.github.io/kdf/doc</a>

##### CHANGES:

* Migrate scrypt from Cstruct.t to string
* Merge ocaml-pbkdf (from https://github.com/abeaumont/ocaml-pbkdf),
  hkdf (from https://github.com/hannesm/ocaml-hkdf), and scrypt (from
  https://github.com/abeaumont/ocaml-scrypt-kdf) into a single repository
  and opam package (with three subpackages, kdf.pbkdf. kdf.hkdf, and
  kdf.scrypt).
* Disable a failing testcase for architectures with integers no longer than 31
  bits (thanks to @kit-ty-kate)
