### PR TITLE
2 packages from ocaml-community/cppo at 1.7.0

### DIFF
--- a/packages/cppo/cppo.1.7.0/opam
+++ b/packages/cppo/cppo.1.7.0/opam
@@ -24,7 +24,7 @@ depends: [
   "base-unix"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/cppo/cppo.1.7.0/opam
+++ b/packages/cppo/cppo.1.7.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Code preprocessor like cpp for OCaml"
+description: """\
+Cppo is an equivalent of the C preprocessor for OCaml programs.
+It allows the definition of simple macros and file inclusion.
+
+Cppo is:
+
+* more OCaml-friendly than cpp
+* easy to learn without consulting a manual
+* reasonably fast
+* simple to install and to maintain"""
+maintainer: [
+  "Martin Jambon <martin@mjambon.com>" "Yishuai Li <yishuai@upenn.edu>"
+]
+authors: "Martin Jambon"
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/cppo"
+doc: "https://ocaml-community.github.io/cppo"
+bug-reports: "https://github.com/ocaml-community/cppo/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "2.0"}
+  "base-unix"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-community/cppo.git"
+url {
+  src:
+    "https://github.com/ocaml-community/cppo/archive/refs/tags/v1.7.0.tar.gz"
+  checksum: [
+    "md5=90f66810f73b115cc55e581a34bf7db9"
+    "sha512=cafa2f7add42912b413f39e1d9fb7a2a42a9be134128c179dfe353f35a6c32840720d2166a77d985941300cb945b9c424b38401d20027d814b25f3bac534506d"
+  ]
+}

--- a/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.7.0/opam
+++ b/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.7.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Plugin to use cppo with ocamlbuild"
+description: """\
+This ocamlbuild plugin lets you use cppo in ocamlbuild projects.
+
+To use it, you can call ocamlbuild with the argument `-plugin-tag
+package(cppo_ocamlbuild)` (only since ocaml 4.01 and cppo >= 0.9.4)."""
+maintainer: [
+  "Martin Jambon <martin@mjambon.com>" "Yishuai Li <yishuai@upenn.edu>"
+]
+authors: "Martin Jambon"
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/cppo"
+doc: "https://ocaml-community.github.io/cppo"
+bug-reports: "https://github.com/ocaml-community/cppo/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "2.0"}
+  "ocamlbuild"
+  "ocamlfind"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-community/cppo.git"
+url {
+  src:
+    "https://github.com/ocaml-community/cppo/archive/refs/tags/v1.7.0.tar.gz"
+  checksum: [
+    "md5=90f66810f73b115cc55e581a34bf7db9"
+    "sha512=cafa2f7add42912b413f39e1d9fb7a2a42a9be134128c179dfe353f35a6c32840720d2166a77d985941300cb945b9c424b38401d20027d814b25f3bac534506d"
+  ]
+}

--- a/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.7.0/opam
+++ b/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.7.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
This pull-request concerns:
- `cppo.1.7.0`: Code preprocessor like cpp for OCaml
- `cppo_ocamlbuild.1.7.0`: Plugin to use cppo with ocamlbuild



---
* Homepage: https://github.com/ocaml-community/cppo
* Source repo: git+https://github.com/ocaml-community/cppo.git
* Bug tracker: https://github.com/ocaml-community/cppo/issues

---
:camel: Pull-request generated by opam-publish v2.3.0