### PR TITLE
[new release] paf (2 packages) (0.7.0)

### DIFF
--- a/packages/paf-cohttp/paf-cohttp.0.7.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.7.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "cohttp-lwt" {< "6.0.0"}
+  "domain-name"
+  "httpaf"
+  "ipaddr"
+  "alcotest-lwt"      {with-test & >= "1.1.0"}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "mirage-time-unix"  {with-test}
+  "tcpip"             {with-test & >= "6.0.0"}
+  "uri"               {with-test}
+  "lwt"               {with-test}
+  "astring"           {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {os != "macos"}
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.7.0/paf-0.7.0.tbz"
+  checksum: [
+    "sha256=c36946b3e0d8634f0150aba6585c4f1532d02af7513eeec7d457503888c34321"
+    "sha512=b72e79ca5c32f7d7b5134417c685f02215e22375c324d7de1d1534e02d75f60a7efdd31c4189176a65f02ead0dcc4eec33ea83e9690c7b0a31ea26aaf12b98e4"
+  ]
+}
+x-commit-hash: "1d2a656d89b8b4daf33e23d6bde4556dd976c65a"

--- a/packages/paf-cohttp/paf-cohttp.0.7.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.7.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
   "paf" {= version}
-  "cohttp-lwt" {< "6.0.0"}
+  "cohttp-lwt" {< "6.0.0~"}
   "domain-name"
   "httpaf"
   "ipaddr"

--- a/packages/paf/paf.0.7.0/opam
+++ b/packages/paf/paf.0.7.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "tcpip" {>= "8.0.1"}
+  "mirage-time" {>= "2.0.0"}
+  "tls-mirage" {>= "0.17.4"}
+  "mimic" {>= "0.0.7"}
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "x509" {with-test & > "1.0.0"}
+  "bigstringaf" {>= "0.7.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.10.0"}
+  "faraday" {>= "0.7.2"}
+  "tls" {>= "1.0.0"}
+  "cstruct" {>= "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {os != "macos"}
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.7.0/paf-0.7.0.tbz"
+  checksum: [
+    "sha256=c36946b3e0d8634f0150aba6585c4f1532d02af7513eeec7d457503888c34321"
+    "sha512=b72e79ca5c32f7d7b5134417c685f02215e22375c324d7de1d1534e02d75f60a7efdd31c4189176a65f02ead0dcc4eec33ea83e9690c7b0a31ea26aaf12b98e4"
+  ]
+}
+x-commit-hash: "1d2a656d89b8b4daf33e23d6bde4556dd976c65a"


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Upgrade to tls.1.0.0 and x509.1.0.0 (@hannesm, dinosaure/paf-le-chien#96)
