### PR TITLE
Revert "Improve INFO and WARNING for the opam version"

### DIFF
--- a/repo
+++ b/repo
@@ -3,10 +3,10 @@ browse: "https://opam.ocaml.org/pkg/"
 upstream: "https://github.com/ocaml/opam-repository/tree/master/"
 announce: [
 """
-[WARNING] opam %{opam-version}% is out-of-date. Please consider updating it (https://opam.ocaml.org/doc/Install.html)
+[WARNING] opam is out-of-date. Please consider updating it (https://opam.ocaml.org/doc/Install.html)
 """ {(opam-version >= "2.1.0~~" & opam-version < "2.1.6") | opam-version < "2.0.10" | (opam-version >= "2.2.0~~" & opam-version < "2.2.1")}
 """
-[INFO] opam 2.1 and 2.2 include many performance and security improvements over %{opam-version}%; please consider upgrading (https://opam.ocaml.org/doc/Install.html)
+[INFO] opam 2.1 and 2.2 include many performance and security improvements over 2.0; please consider upgrading (https://opam.ocaml.org/doc/Install.html)
 """ {opam-version >= "2.0.10" & opam-version < "2.1.0~~"}
 """
 [WARNING] please ensure to have GNU patch installed as `patch`. Otherwise update may fail silently (since it can't remove files).


### PR DESCRIPTION
This reverts commit d9168d4702a8dbd2b7ca702583740992a4cf367d.

Interpolation of the %{opam-version}% variable seems to not work on the announce strings.