### PR TITLE
Remove duplicate available field

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.1.0+tsan/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+tsan/opam
@@ -84,7 +84,6 @@ extra-source "ocaml-variants.install" {
     "md5=3e969b841df1f51ca448e6e6295cb451"
   ]
 }
-available: os != "win32"
 # Back-ported ocaml/ocaml#13100 (5.2.0) - fixes the misdetection of zstd with
 # ocaml-option-musl
 patches: ["zstd-detection.patch"]

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+tsan/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+tsan/opam
@@ -84,7 +84,6 @@ extra-source "ocaml-variants.install" {
     "md5=3e969b841df1f51ca448e6e6295cb451"
   ]
 }
-available: os != "win32"
 # Back-ported ocaml/ocaml#13100 (5.2.0) - fixes the misdetection of zstd with
 # ocaml-option-musl
 patches: ["zstd-detection.patch"]

--- a/packages/tezos-sapling/tezos-sapling.11.0/opam
+++ b/packages/tezos-sapling/tezos-sapling.11.0/opam
@@ -2,7 +2,6 @@ opam-version: "2.0"
 authors: [ "Nomadic Labs <contact@nomadic-labs.com>" ]
 maintainer: "Nomadic Labs <contact@nomadic-labs.com>"
 synopsis: "OCaml library for the Sapling protocol, using librustzcash"
-available: false
 homepage: "https://gitlab.com/nomadic-labs/tezos"
 bug-reports: "https://gitlab.com/tezos/nomadic-labs/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/tezos.git"

--- a/packages/tezos-sapling/tezos-sapling.11.1/opam
+++ b/packages/tezos-sapling/tezos-sapling.11.1/opam
@@ -2,7 +2,6 @@ opam-version: "2.0"
 authors: [ "Nomadic Labs <contact@nomadic-labs.com>" ]
 maintainer: "Nomadic Labs <contact@nomadic-labs.com>"
 synopsis: "OCaml library for the Sapling protocol, using librustzcash"
-available: false
 homepage: "https://gitlab.com/nomadic-labs/tezos"
 bug-reports: "https://gitlab.com/tezos/nomadic-labs/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/tezos.git"

--- a/packages/tezos-sapling/tezos-sapling.12.0/opam
+++ b/packages/tezos-sapling/tezos-sapling.12.0/opam
@@ -2,7 +2,6 @@ opam-version: "2.0"
 authors: [ "Nomadic Labs <contact@nomadic-labs.com>" ]
 maintainer: "Nomadic Labs <contact@nomadic-labs.com>"
 synopsis: "OCaml library for the Sapling protocol, using librustzcash"
-available: false
 homepage: "https://gitlab.com/nomadic-labs/tezos"
 bug-reports: "https://gitlab.com/tezos/nomadic-labs/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/tezos.git"

--- a/packages/tezos-sapling/tezos-sapling.8.0/opam
+++ b/packages/tezos-sapling/tezos-sapling.8.0/opam
@@ -2,7 +2,6 @@ opam-version: "2.0"
 authors: [ "Nomadic Labs <contact@nomadic-labs.com>" ]
 maintainer: "Nomadic Labs <contact@nomadic-labs.com>"
 synopsis: "OCaml library for the Sapling protocol, using librustzcash"
-available: false
 homepage: "https://gitlab.com/nomadic-labs/tezos"
 bug-reports: "https://gitlab.com/tezos/nomadic-labs/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/tezos.git"

--- a/packages/tezos-sapling/tezos-sapling.8.1/opam
+++ b/packages/tezos-sapling/tezos-sapling.8.1/opam
@@ -2,7 +2,6 @@ opam-version: "2.0"
 authors: [ "Nomadic Labs <contact@nomadic-labs.com>" ]
 maintainer: "Nomadic Labs <contact@nomadic-labs.com>"
 synopsis: "OCaml library for the Sapling protocol, using librustzcash"
-available: false
 homepage: "https://gitlab.com/nomadic-labs/tezos"
 bug-reports: "https://gitlab.com/tezos/nomadic-labs/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/tezos.git"

--- a/packages/tezos-sapling/tezos-sapling.8.2/opam
+++ b/packages/tezos-sapling/tezos-sapling.8.2/opam
@@ -2,7 +2,6 @@ opam-version: "2.0"
 authors: [ "Nomadic Labs <contact@nomadic-labs.com>" ]
 maintainer: "Nomadic Labs <contact@nomadic-labs.com>"
 synopsis: "OCaml library for the Sapling protocol, using librustzcash"
-available: false
 homepage: "https://gitlab.com/nomadic-labs/tezos"
 bug-reports: "https://gitlab.com/tezos/nomadic-labs/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/tezos.git"

--- a/packages/tezos-sapling/tezos-sapling.8.3/opam
+++ b/packages/tezos-sapling/tezos-sapling.8.3/opam
@@ -2,7 +2,6 @@ opam-version: "2.0"
 authors: [ "Nomadic Labs <contact@nomadic-labs.com>" ]
 maintainer: "Nomadic Labs <contact@nomadic-labs.com>"
 synopsis: "OCaml library for the Sapling protocol, using librustzcash"
-available: false
 homepage: "https://gitlab.com/nomadic-labs/tezos"
 bug-reports: "https://gitlab.com/tezos/nomadic-labs/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/tezos.git"

--- a/packages/tezos-sapling/tezos-sapling.9.0/opam
+++ b/packages/tezos-sapling/tezos-sapling.9.0/opam
@@ -20,7 +20,6 @@ build: [
 #  requires the "zcash-params" files
 ]
 synopsis: "OCaml library for the Sapling protocol, using librustzcash"
-available: false
 
 url {
   src: "https://github.com/ocaml/opam-source-archives/raw/main/tezos-v9.0.tar.bz2"

--- a/packages/tezos-sapling/tezos-sapling.9.1/opam
+++ b/packages/tezos-sapling/tezos-sapling.9.1/opam
@@ -20,7 +20,6 @@ build: [
 #  requires the "zcash-params" files
 ]
 synopsis: "OCaml library for the Sapling protocol, using librustzcash"
-available: false
 
 url {
   src: "https://github.com/ocaml/opam-source-archives/raw/main/tezos-v9.1.tar.bz2"

--- a/packages/tezos-sapling/tezos-sapling.9.2/opam
+++ b/packages/tezos-sapling/tezos-sapling.9.2/opam
@@ -20,7 +20,6 @@ build: [
 #  requires the "zcash-params" files
 ]
 synopsis: "OCaml library for the Sapling protocol, using librustzcash"
-available: false
 
 url {
   src: "https://github.com/ocaml/opam-source-archives/raw/main/tezos-v9.2.tar.bz2"

--- a/packages/tezos-sapling/tezos-sapling.9.3/opam
+++ b/packages/tezos-sapling/tezos-sapling.9.3/opam
@@ -20,7 +20,6 @@ build: [
 #  requires the "zcash-params" files
 ]
 synopsis: "OCaml library for the Sapling protocol, using librustzcash"
-available: false
 
 url {
   src: "https://github.com/ocaml/opam-source-archives/raw/main/tezos-v9.3.tar.bz2"

--- a/packages/tezos-sapling/tezos-sapling.9.4/opam
+++ b/packages/tezos-sapling/tezos-sapling.9.4/opam
@@ -20,7 +20,6 @@ build: [
 #  requires the "zcash-params" files
 ]
 synopsis: "OCaml library for the Sapling protocol, using librustzcash"
-available: false
 
 url {
   src: "https://gitlab.com/tezos/tezos/-/archive/v9.4/tezos-v9.4.tar.bz2"


### PR DESCRIPTION
Should fix #26371. I got the list of changes with

```
$ rg '^\s*available:\s' | uniq -d | sort
packages/tezos-sapling/tezos-sapling.11.0/opam:available: false
packages/tezos-sapling/tezos-sapling.11.1/opam:available: false
packages/tezos-sapling/tezos-sapling.12.0/opam:available: false
packages/tezos-sapling/tezos-sapling.8.0/opam:available: false
packages/tezos-sapling/tezos-sapling.8.1/opam:available: false
packages/tezos-sapling/tezos-sapling.8.2/opam:available: false
packages/tezos-sapling/tezos-sapling.8.3/opam:available: false
packages/tezos-sapling/tezos-sapling.9.0/opam:available: false
packages/tezos-sapling/tezos-sapling.9.1/opam:available: false
packages/tezos-sapling/tezos-sapling.9.2/opam:available: false
packages/tezos-sapling/tezos-sapling.9.3/opam:available: false
packages/tezos-sapling/tezos-sapling.9.4/opam:available: false
```
I am not sure why it did not pick up the compiler packages, added separately.