### PR TITLE
[new release] mirage-qubes (2 packages) (1.0.0)

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.1.0.0/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.1.0.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "mirage-qubes" {= version}
-  "tcpip" { >= "8.1.0" }
+  "tcpip" { >= "8.2.0" }
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "ipaddr" { >= "3.0.0" }

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.1.0.0/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.1.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "mirage-qubes" {= version}
+  "tcpip" { >= "8.1.0" }
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "ipaddr" { >= "3.0.0" }
+  "mirage-crypto-rng-mirage" {>= "1.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "lwt" { >= "5.7.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v1.0.0/mirage-qubes-1.0.0.tbz"
+  checksum: [
+    "sha256=b20340a52a3a2d01bbab1cc01ce03ed11793738caa0f73f954fe331813acf991"
+    "sha512=01fed03f00d166e2378fae8e19cd6bb057ed1ce8d24ed89aa0469b8bc38ba7cb8a050a2d268c2a7c7c53f3683ba51f2373bd21907975248c940339ef90440d4b"
+  ]
+}
+x-commit-hash: "2773d32762153fcc695ed30efce0f9dd8516d350"

--- a/packages/mirage-qubes/mirage-qubes.1.0.0/opam
+++ b/packages/mirage-qubes/mirage-qubes.1.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "cstruct" { >= "6.0.0" }
+  "vchan-xen" { >= "6.0.0" }
+  "mirage-xen" { >= "8.0.0" }
+  "lwt" { >= "5.7.0" }
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.08.0" }
+  "ohex" { >= "0.2.0" }
+  "fmt" {>= "0.8.5"}
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+description: """
+Implementations of various Qubes protocols:
+
+- Qubes.RExec: provide services to other VMs
+- Qubes.GUI: just enough of the GUI protocol so that Qubes accepts the AppVM
+- Qubes.DB: read and write the VM's QubesDB database"""
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v1.0.0/mirage-qubes-1.0.0.tbz"
+  checksum: [
+    "sha256=b20340a52a3a2d01bbab1cc01ce03ed11793738caa0f73f954fe331813acf991"
+    "sha512=01fed03f00d166e2378fae8e19cd6bb057ed1ce8d24ed89aa0469b8bc38ba7cb8a050a2d268c2a7c7c53f3683ba51f2373bd21907975248c940339ef90440d4b"
+  ]
+}
+x-commit-hash: "2773d32762153fcc695ed30efce0f9dd8516d350"


### PR DESCRIPTION
Implementations of various Qubes protocols for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-qubes">https://github.com/mirage/mirage-qubes</a>
- Documentation: <a href="https://mirage.github.io/mirage-qubes">https://mirage.github.io/mirage-qubes</a>

##### CHANGES:

- Update to mirage-crypto 1.0.0 series (mirage/mirage-qubes#73, @hannesm)
