### PR TITLE
mdx: doesnt compile under ocaml 5.3.0-dev

### DIFF
--- a/packages/mdx/mdx.2.4.0/opam
+++ b/packages/mdx/mdx.2.4.0/opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/realworldocaml/mdx"
 bug-reports: "https://github.com/realworldocaml/mdx/issues"
 depends: [
   "dune" {>= "3.5"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3~~"}
   "ocamlfind"
   "fmt" {>= "0.8.7"}
   "cppo" {build & >= "1.1.0"}

--- a/packages/mdx/mdx.2.4.1/opam
+++ b/packages/mdx/mdx.2.4.1/opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/realworldocaml/mdx"
 bug-reports: "https://github.com/realworldocaml/mdx/issues"
 depends: [
   "dune" {>= "3.5"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3~~"}
   "ocamlfind"
   "fmt" {>= "0.8.7"}
   "cppo" {build & >= "1.1.0"}


### PR DESCRIPTION
fails with:
Error: This constant has type "string" but an expression was expected of type "Unit_info.t option"