### PR TITLE
Package ocsigenserver.6.0.0

### DIFF
--- a/packages/ocsigenserver/ocsigenserver.6.0.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.6.0.0/opam
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "A full-featured and extensible Web server"
+description: "Ocsigen Server is a Web Server that can be used either as a library for OCaml or as an executable (taking its configuration from a file). It has a very powerful extension mechanism that makes it very easy to plug your own OCaml modules for generating pages. Many extensions are already implemented, like a reverse proxy, content compression, access control, authentication, etc."
+authors: "dev@ocsigen.org"
+homepage: "http://ocsigen.org/ocsigenserver/"
+bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
+build: [
+  [
+    "sh"
+    "configure"
+    "--prefix"
+    "%{prefix}%"
+    "--ocsigen-user"
+    "%{user}%"
+    "--ocsigen-group"
+    "%{group}%"
+    "--commandpipe"
+    "%{lib}%/ocsigenserver/var/run/ocsigenserver_command"
+    "--logdir"
+    "%{lib}%/ocsigenserver/var/log/ocsigenserver"
+    "--mandir"
+    "%{man}%/man1"
+    "--docdir"
+    "%{lib}%/ocsigenserver/share/doc/ocsigenserver"
+    "--commandpipe"
+    "%{lib}%/ocsigenserver/var/run/ocsigenserver_command"
+    "--staticpagesdir"
+    "%{lib}%/ocsigenserver/var/www"
+    "--datadir"
+    "%{lib}%/ocsigenserver/var/lib/ocsigenserver"
+    "--temproot"
+    ""
+    "--sysconfdir"
+    "%{lib}%/ocsigenserver/etc/ocsigenserver"
+  ]
+  [make "-C" "src" "confs"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+install:[make "install.files"]
+depends: [
+  "ocaml" {>= "4.08.1"}
+  "dune" {>= "2.7"}
+  "ocamlfind"
+  "base-unix"
+  "base-threads"
+  "react"
+  "ssl" {>= "0.5.8"}
+  "lwt" {>= "3.0.0"}
+  "lwt_ssl"
+  "lwt_react"
+  "lwt_log"
+  "re" {>= "1.11.0"}
+  "cryptokit"
+  "ipaddr" {>= "2.1"}
+  "cohttp-lwt-unix" {>= "5.0.0" & < "6.0.0~"}
+  "conduit-lwt-unix" {>= "2.0.0"}
+  "xml-light"
+  "camlzip"
+]
+conflicts: [
+  "camlzip" {< "1.04"}
+  "pgocaml" {< "2.2"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsigenserver/archive/refs/tags/6.0.0.tar.gz"
+  checksum: [
+    "md5=001e22ec2da3ab08840f934a8f005859"
+    "sha512=59f36fdf0a640117aa562d1d9ef96b7146843d9b72d71d01366640521405550074e03267fb388c5e685542781fc4bce763818a36cf05c0e033fae5e51c2f1496"
+  ]
+}


### PR DESCRIPTION
### `ocsigenserver.6.0.0`
A full-featured and extensible Web server
Ocsigen Server is a Web Server that can be used either as a library for OCaml or as an executable (taking its configuration from a file). It has a very powerful extension mechanism that makes it very easy to plug your own OCaml modules for generating pages. Many extensions are already implemented, like a reverse proxy, content compression, access control, authentication, etc.



---
* Homepage: http://ocsigen.org/ocsigenserver/
* Source repo: git+https://github.com/ocsigen/ocsigenserver.git
* Bug tracker: https://github.com/ocsigen/ocsigenserver/issues/

---
:camel: Pull-request generated by opam-publish v2.3.0