### PR TITLE
restrict http-mirage-client 0.0.6 to paf < 0.7

### DIFF
--- a/packages/http-mirage-client/http-mirage-client.0.0.6/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.6/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/robur-coop/http-mirage-client/issues"
 depends: [
   "dune" {>= "2.3"}
   "ocaml" {>= "4.11.0"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.7.0"}
   "mirage-clock" {>= "4.0.0"}
   "mirage-time" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}


### PR DESCRIPTION
```
File "src/http_mirage_client.ml", line 431, characters 47-57:
431 |     single_request ~ctx ~alpn_protocol ?config tls_config ~meth ~headers ?body
                                                     ^^^^^^^^^^
Error: This expression has type
         "([> `Custom of 'a
           | `Default of (Tls.Config.client, [> `Msg of string ]) result ],
          [ `Msg of string ])
         result lazy_t"
       but an expression was expected of type
         "([< `Custom of Tls.Config.client | `Default of Tls.Config.client ]
          as 'b, 'c)
         result Lazy.t" = "('b, 'c) result lazy_t"
       Type "(Tls.Config.client, [> `Msg of string ]) result"
       is not compatible with type "Tls.Config.client"
       Types for tag "`Default" are incompatible
```

seen in https://github.com/ocaml/opam-repository/pull/26443