### PR TITLE
[new release] http-lwt-client (0.3.0)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.3.0/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/http-lwt-client"
+dev-repo: "git+https://github.com/robur-coop/http-lwt-client.git"
+bug-reports: "https://github.com/robur-coop/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "lwt"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "1.0.0"}
+  "tls-lwt" {>= "1.0.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.10.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/robur-coop/http-lwt-client/releases/download/v0.3.0/http-lwt-client-0.3.0.tbz"
+  checksum: [
+    "sha256=1a147038ef48592216848b98ff528b6d3deb197884c185e26091e6bb8bc4f3f2"
+    "sha512=3b4a5cd17572b4d983553c393c90656df6c72f55b014f5a0c3f83d62375b2a12395b0c065a9168b11b3d88e7b173d21a1990bc86804b0f036b9e669b3a12b08a"
+  ]
+}
+x-commit-hash: "8f12b318ad20577137e65fd98a51b163deb84a30"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/robur-coop/http-lwt-client">https://github.com/robur-coop/http-lwt-client</a>

##### CHANGES:

* http2: shutdown the connection once finished (robur-coop/http-lwt-client#23, @reynir)
* update to TLS 1.0 API (robur-coop/http-lwt-client#25, @hannesm)
