### PR TITLE
[new release] awa (2 packages) (0.4.0)

### DIFF
--- a/packages/awa-mirage/awa-mirage.0.4.0/opam
+++ b/packages/awa-mirage/awa-mirage.0.4.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime" {>= "1.0.0"}
+  "lwt" {>= "5.3.0"}
+  "mirage-time" {>= "2.0.0"}
+  "duration" {>= "0.2.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "logs"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.4.0/awa-0.4.0.tbz"
+  checksum: [
+    "sha256=b804ca1abf89d7c8c1c79bc4ac1f7743df81091edece2d50fae7901a8969c9b4"
+    "sha512=afc56aab411a7649f4a10759bf036d6ae8436ec34bba8e211483a77ad569609395e69a7f1617096418e2ec092625831bc703a15d93ecc2b0bc505ad7f0655843"
+  ]
+}
+x-commit-hash: "9543077a0720094ad4d2b40dd595c847d8421b82"

--- a/packages/awa/awa.0.4.0/opam
+++ b/packages/awa/awa.0.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.7"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "1.0.0"}
+  "x509" {>= "1.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-unix"
+  "mtime" {>= "1.0.0"}
+  "logs"
+  "fmt"
+  "cmdliner" {>= "1.1.0"}
+  "base64" {>= "3.0.0"}
+  "zarith"
+  "eqaf" {>= "0.8"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.4.0/awa-0.4.0.tbz"
+  checksum: [
+    "sha256=b804ca1abf89d7c8c1c79bc4ac1f7743df81091edece2d50fae7901a8969c9b4"
+    "sha512=afc56aab411a7649f4a10759bf036d6ae8436ec34bba8e211483a77ad569609395e69a7f1617096418e2ec092625831bc703a15d93ecc2b0bc505ad7f0655843"
+  ]
+}
+x-commit-hash: "9543077a0720094ad4d2b40dd595c847d8421b82"


### PR DESCRIPTION
SSH implementation in OCaml

- Project page: <a href="https://github.com/mirage/awa-ssh">https://github.com/mirage/awa-ssh</a>
- Documentation: <a href="https://mirage.github.io/awa-ssh/api">https://mirage.github.io/awa-ssh/api</a>

##### CHANGES:

* Update to mirage-crypto 1.0.0 API (mirage/awa-ssh#73 @hannesm)
