### PR TITLE
[new release] conduit (5 packages) (7.0.0)

### DIFF
--- a/packages/conduit-async/conduit-async.7.0.0/opam
+++ b/packages/conduit-async/conduit-async.7.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "core" {>= "v0.15.0"}
+  "uri" {>= "4.0.0"}
+  "ppx_here" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib0"
+  "conduit" {=version}
+  "async" {>= "v0.15.0"}
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp" {>= "4.0.0"}
+]
+depopts: ["async_ssl"]
+conflicts: [
+  "async_ssl" {< "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Async"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v7.0.0/conduit-7.0.0.tbz"
+  checksum: [
+    "sha256=3e0ec284896a95d178d8d135792e7a46cb24f9cb0af0ea964d05cee1abcb1218"
+    "sha512=d19c7f8df38a18e14abbb67f5af895230b3dc01e284969b017d6e0851bc4baf93c229b19523e24a4d87f344ec3482ae0683925d19c262b196af1b5f62322a541"
+  ]
+}
+x-commit-hash: "1af12b88843b950c7a78cd5e93302682d5a904e7"

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.7.0.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.7.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "base-unix"
+  "logs"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "conduit-lwt" {=version}
+  "lwt" {>= "5.7.0"}
+  "uri" {>= "1.9.4"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+  "ca-certs"
+  "lwt_log" {with-test}
+  "ssl" {with-test}
+  "lwt_ssl" {with-test}
+]
+depopts: ["tls-lwt" "lwt_ssl" "launchd"]
+conflicts: [
+  "tls-lwt" {< "1.0.0"}
+  "ssl" {< "0.5.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Lwt_unix"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v7.0.0/conduit-7.0.0.tbz"
+  checksum: [
+    "sha256=3e0ec284896a95d178d8d135792e7a46cb24f9cb0af0ea964d05cee1abcb1218"
+    "sha512=d19c7f8df38a18e14abbb67f5af895230b3dc01e284969b017d6e0851bc4baf93c229b19523e24a4d87f344ec3482ae0683925d19c262b196af1b5f62322a541"
+  ]
+}
+x-commit-hash: "1af12b88843b950c7a78cd5e93302682d5a904e7"

--- a/packages/conduit-lwt/conduit-lwt.7.0.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.7.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib0"
+  "conduit" {=version}
+  "lwt" {>= "5.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v7.0.0/conduit-7.0.0.tbz"
+  checksum: [
+    "sha256=3e0ec284896a95d178d8d135792e7a46cb24f9cb0af0ea964d05cee1abcb1218"
+    "sha512=d19c7f8df38a18e14abbb67f5af895230b3dc01e284969b017d6e0851bc4baf93c229b19523e24a4d87f344ec3482ae0683925d19c262b196af1b5f62322a541"
+  ]
+}
+x-commit-hash: "1af12b88843b950c7a78cd5e93302682d5a904e7"

--- a/packages/conduit-mirage/conduit-mirage.7.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.7.0.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib0"
+  "uri" {>= "4.0.0"}
+  "cstruct" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "mirage-flow-combinators" {>= "2.0.0"}
+  "mirage-crypto-rng-mirage" {>= "1.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "dns-client-mirage" {>= "8.0.0"}
+  "conduit-lwt" {=version}
+  "vchan" {>= "5.0.0"}
+  "xenstore"
+  "tls" {>= "1.0.0"}
+  "tls-mirage" {>= "1.0.0"}
+  "ca-certs-nss"
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp"
+  "tcpip" {>= "7.0.0"}
+  "fmt" {>= "0.8.7"}
+]
+conflicts: [
+  "mirage-conduit"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v7.0.0/conduit-7.0.0.tbz"
+  checksum: [
+    "sha256=3e0ec284896a95d178d8d135792e7a46cb24f9cb0af0ea964d05cee1abcb1218"
+    "sha512=d19c7f8df38a18e14abbb67f5af895230b3dc01e284969b017d6e0851bc4baf93c229b19523e24a4d87f344ec3482ae0683925d19c262b196af1b5f62322a541"
+  ]
+}
+x-commit-hash: "1af12b88843b950c7a78cd5e93302682d5a904e7"

--- a/packages/conduit/conduit.7.0.0/opam
+++ b/packages/conduit/conduit.7.0.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib0"
+  "astring"
+  "uri"
+  "logs" {>= "0.5.0"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library"
+description: """
+The `conduit` library takes care of establishing and listening for
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The useful opam packages available that extend this library are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `conduit-mirage`: the MirageOS compatible implementation
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v7.0.0/conduit-7.0.0.tbz"
+  checksum: [
+    "sha256=3e0ec284896a95d178d8d135792e7a46cb24f9cb0af0ea964d05cee1abcb1218"
+    "sha512=d19c7f8df38a18e14abbb67f5af895230b3dc01e284969b017d6e0851bc4baf93c229b19523e24a4d87f344ec3482ae0683925d19c262b196af1b5f62322a541"
+  ]
+}
+x-commit-hash: "1af12b88843b950c7a78cd5e93302682d5a904e7"


### PR DESCRIPTION
A network connection establishment library

- Project page: <a href="https://github.com/mirage/ocaml-conduit">https://github.com/mirage/ocaml-conduit</a>
- Documentation: <a href="https://mirage.github.io/ocaml-conduit/">https://mirage.github.io/ocaml-conduit/</a>

##### CHANGES:

* adapt to TLS 1.0.0 API changes, bump OCaml lower bound to 4.13 (mirage/ocaml-conduit#432 @hannesm)
* conduit-lwt-unix: improve the no TLS error message (mirage/ocaml-conduit#431 @filipeom)
* Remove 4.12 CI runners, add 5.2 (mirage/ocaml-conduit#433 @art-w)
* Update GitHub actions (mirage/ocaml-conduit#429 @smorimoto)
* use failwith instead of Lwt.fail_with, use Lwt.reraise (mirage/ocaml-conduit#430 @MisterDA)
* switch to sexplib0 instead of sexplib for lighter dependencies (mirage/ocaml-conduit#427 @emillon)
