### PR TITLE
[new release] http-mirage-client (0.0.7)

### DIFF
--- a/packages/http-mirage-client/http-mirage-client.0.0.7/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.7/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "HTTP client for MirageOS"
+maintainer: ["team@robur.coop"]
+authors: [
+  "Robur Team <team@robur.coop>"
+]
+license: "MIT"
+homepage: "https://github.com/robur-coop/http-mirage-client"
+bug-reports: "https://github.com/robur-coop/http-mirage-client/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.11.0"}
+  "paf" {>= "0.2.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "mirage-time" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "lwt" {>= "5.5.0"}
+  "mimic-happy-eyeballs" {>= "0.0.9"}
+  "httpaf"
+  "alcotest-lwt" {with-test & >= "1.0.0"}
+  "mirage-clock-unix" {with-test & >= "4.0.0"}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix" {with-test & >= "3.0.0"}
+  "h2" {>= "0.10.0"}
+  "tls" {>= "1.0.0"}
+  "x509" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"} # macOS is disabled due to restrictions in sandbox-exec
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/robur-coop/http-mirage-client.git"
+url {
+  src:
+    "https://github.com/robur-coop/http-mirage-client/releases/download/v0.0.7/http-mirage-client-0.0.7.tbz"
+  checksum: [
+    "sha256=18a3c9295b4711bb7c2fddb6cbf1b5a1ec2a19504ee1fdf5dd769dcc898cb453"
+    "sha512=74e402d110b516c73039660575974f6b3664358eec82fdc1a40ba4995980d82fe2f6a5e422964953132c2c8470e92c400a49b94b51ff2586d7887cd6605f8e1d"
+  ]
+}
+x-commit-hash: "492f77d5ccc1e83e04ce6e1dff7f5ffc12886db8"


### PR DESCRIPTION
HTTP client for MirageOS

- Project page: <a href="https://github.com/robur-coop/http-mirage-client">https://github.com/robur-coop/http-mirage-client</a>

##### CHANGES:

- Adapt to TLS 1.0.0 API changes (robur-coop/http-mirage-client#1, @hannesm)
