### PR TITLE
bounds for cohttp 6*, websocket, current_web

### DIFF
--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha0/opam
@@ -33,8 +33,8 @@ depends: [
   "cohttp-lwt" {= version}
   "cmdliner" {>= "1.1.0"}
   "lwt" {>= "3.0.0"}
-  "conduit-lwt" {>= "5.0.0"}
-  "conduit-lwt-unix" {>= "5.0.0"}
+  "conduit-lwt" {>= "5.0.0" & < "7.0.0"}
+  "conduit-lwt-unix" {>= "5.0.0" & < "7.0.0"}
   "fmt" {>= "0.8.2"}
   "base-unix"
   "ppx_sexp_conv" {>= "v0.13.0"}

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha1/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha1/opam
@@ -33,8 +33,8 @@ depends: [
   "cohttp-lwt" {= version}
   "cmdliner" {>= "1.1.0"}
   "lwt" {>= "3.0.0"}
-  "conduit-lwt" {>= "5.0.0"}
-  "conduit-lwt-unix" {>= "5.0.0"}
+  "conduit-lwt" {>= "5.0.0" & < "7.0.0"}
+  "conduit-lwt-unix" {>= "5.0.0" & < "7.0.0"}
   "fmt" {>= "0.8.2"}
   "base-unix"
   "ppx_sexp_conv" {>= "v0.13.0"}

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha2/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha2/opam
@@ -33,8 +33,8 @@ depends: [
   "cohttp-lwt" {= version}
   "cmdliner" {>= "1.1.0"}
   "lwt" {>= "3.0.0"}
-  "conduit-lwt" {>= "5.0.0"}
-  "conduit-lwt-unix" {>= "5.0.0"}
+  "conduit-lwt" {>= "5.0.0" & < "7.0.0"}
+  "conduit-lwt-unix" {>= "5.0.0" & < "7.0.0"}
   "fmt" {>= "0.8.2"}
   "base-unix"
   "ppx_sexp_conv" {>= "v0.13.0"}

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~beta2/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~beta2/opam
@@ -33,8 +33,8 @@ depends: [
   "cohttp-lwt" {= version}
   "cmdliner" {>= "1.1.0"}
   "lwt" {>= "3.0.0"}
-  "conduit-lwt" {>= "5.0.0"}
-  "conduit-lwt-unix" {>= "5.0.0"}
+  "conduit-lwt" {>= "5.0.0" & < "7.0.0"}
+  "conduit-lwt-unix" {>= "5.0.0" & < "7.0.0"}
   "fmt" {>= "0.8.2"}
   "base-unix"
   "ppx_sexp_conv" {>= "v0.13.0"}

--- a/packages/current_web/current_web.0.1/opam
+++ b/packages/current_web/current_web.0.1/opam
@@ -27,6 +27,7 @@ depends: [
   "cohttp-lwt-unix" {>= "2.2.0"}
   "tyxml"
   "dune" {>= "1.9"}
+  "conduit" {< "7.0.0"}
 ]
 url {
   src:

--- a/packages/current_web/current_web.0.2/opam
+++ b/packages/current_web/current_web.0.2/opam
@@ -28,6 +28,7 @@ depends: [
   "tyxml"
   "routes" {>= "0.7.0" & < "0.8.0"}
   "dune" {>= "1.9"}
+  "conduit" {< "7.0.0"}
 ]
 url {
   src:

--- a/packages/current_web/current_web.0.3/opam
+++ b/packages/current_web/current_web.0.3/opam
@@ -33,6 +33,7 @@ depends: [
   "tyxml"
   "routes" {>= "0.8.0" & < "2.0.0"}
   "dune" {>= "2.0"}
+  "conduit" {< "7.0.0"}
 ]
 url {
   src:

--- a/packages/websocket/websocket.2.15/opam
+++ b/packages/websocket/websocket.2.15/opam
@@ -25,7 +25,7 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.06.0"}
   "base64" {>= "3.3.0"}
-  "conduit" {>= "5.1.0"}
+  "conduit" {>= "5.1.0" & < "7.0.0"}
   "cohttp" {>= "5.0.0"}
   "ocplib-endian" {>= "1.0"}
   "astring" {>= "0.8.3"}

--- a/packages/websocket/websocket.2.16/opam
+++ b/packages/websocket/websocket.2.16/opam
@@ -25,7 +25,7 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.06.0"}
   "base64" {>= "3.3.0"}
-  "conduit" {>= "5.1.0"}
+  "conduit" {>= "5.1.0" & < "7.0.0"}
   "cohttp" {>= "5.0.0"}
   "ocplib-endian" {>= "1.0"}
   "astring" {>= "0.8.3"}


### PR DESCRIPTION
```
File "cohttp-lwt-unix/test/test_parser.ml", line 224, characters 42-68:
224 |           Transfer.sexp_of_chunk chunk |> Sexplib.Sexp.to_string_hum)
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound module Sexplib
```

//cc @avsm 


current_web:

```
File "lib_web/current_web.ml", line 180, characters 2-21:
180 |   Sexplib.Sexp.pp_hum f (Conduit_lwt_unix.sexp_of_server mode)
        ^^^^^^^^^^^^^^^^^^^
Error: Unbound module Sexplib
```

```
File "lib_web/dune", line 33, characters 3-10:
33 |    sexplib
        ^^^^^^^
Error: Library "sexplib" not found.
```

//cc @talex5 


websocket (where websocket-lwt-unix fails):
```
File "lwt/wscat.ml", line 83, characters 49-75:
83 |   let endp_str = endp |> Conduit.sexp_of_endp |> Sexplib.Sexp.to_string_hum in
                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound module Sexplib
```

//cc @vbmithr 

The change in conduit is https://github.com/mirage/ocaml-conduit/pull/427 (cc @emillon @MisterDA). Happy to be of service to the community. Observed in https://github.com/ocaml/opam-repository/pull/26454