### PR TITLE
Dream 1.0.0~alpha7: tidy Web framework

### DIFF
--- a/packages/dream/dream.1.0.0~alpha7/opam
+++ b/packages/dream/dream.1.0.0~alpha7/opam
@@ -1,0 +1,106 @@
+opam-version: "2.0"
+
+synopsis: "Tidy, feature-complete Web framework"
+tags: ["http" "web" "framework" "websocket" "graphql" "server" "http2" "tls"]
+
+description: """
+Dream is a feature-complete Web framework with a simple programming
+model and no boilerplate. It provides only two data types, request and
+response.
+
+Almost everything else is either a built-in OCaml type, or an
+abbreviation for a bare function. For example, a Web app, known in
+Dream as a handler, is just an ordinary function from requests to
+responses. And a middleware is then just a function from handlers to
+handlers.
+
+Within this model, Dream adds:
+
+- Session management with pluggable back ends.
+- A fully composable router.
+- Support for HTTP/1.1, HTTP/2, and HTTPS.
+- WebSockets.
+- GraphQL, including subscriptions and a built-in GraphiQL editor.
+- SQL connection pool helpers.
+- Server-side HTML templates.
+- Automatic secure handling of cookies and forms.
+- Unified, internationalization-friendly error handling.
+- A neat log, and OCaml runtime configuration.
+- Helpers for Web formats, such as Base64url, and a modern cipher.
+
+Because of the simple programming model, everything is optional and
+composable. It is trivailly possible to strip Dream down to just a
+bare driver of the various HTTP protocols.
+
+Dream is presented as a single module, whose API is documented on one
+page. In addition, Dream comes with a large number of examples.
+Security topics are introduced throughout, wherever they are
+applicable."""
+
+license: "MIT"
+homepage: "https://github.com/aantron/dream"
+doc: "https://aantron.github.io/dream"
+bug-reports: "https://github.com/aantron/dream/issues"
+dev-repo: "git+https://github.com/aantron/dream.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "base-unix"
+  "bigarray-compat"
+  "camlp-streams"
+  "caqti" {>= "2.0.0"}
+  "caqti-lwt" {>= "2.0.0"}
+  ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
+  "cstruct" {>= "6.0.0"}
+  "digestif" {>= "0.7"}  # to_raw_string.
+  "dream-httpaf" {>= "1.0.0~alpha3"}
+  "dream-pure" {>= "1.0.0~alpha2"}
+  "dune" {>= "2.7.0"}  # --instrument-with.
+  "fmt" {>= "0.8.7"}  # `Italic.
+  "graphql_parser"
+  "graphql-lwt"
+  "lambdasoup" {>= "0.6.1"}
+  "lwt"
+  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ssl"
+  "logs" {>= "0.5.0"}
+  "magic-mime"
+  "markup" {>= "1.0.2"}
+  "mirage-clock" {>= "3.0.0"}  # now_d_ps : unit -> int * int64.
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "mirage-crypto-rng-lwt"
+  "multipart_form" {>= "0.4.0"}
+  "multipart_form-lwt"
+  "ocaml" {>= "4.08.0"}
+  "ptime" {>= "0.8.1"}  # Ptime.v.
+  "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
+  "uri" {>= "4.2.0"}
+  "yojson"  # ...
+
+  # Testing, development.
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}  # --instrument-with.
+  "caqti-driver-postgresql" {with-test}
+  "caqti-driver-sqlite3" {with-test}
+  "crunch" {with-test}
+  "html_of_jsx" {with-test}
+  "js_of_ocaml" {with-test}
+  "js_of_ocaml-ppx" {with-test}
+  "ppx_expect" {with-test & >= "v0.15.0"}  # Formatting changes.
+  "ppx_yojson_conv" {with-test}
+  "reason" {with-test}
+  "tyxml" {with-test & >= "4.5.0"}
+  "tyxml-jsx" {with-test}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/dream/releases/download/1.0.0-alpha7/dream-1.0.0-alpha7.tar.gz"
+  checksum: "sha256=b715cecf7e2b249335c8d1cd22c3e87017e40c0556774d209f338f9d78388c86"
+}


### PR DESCRIPTION
This release is mainly to unblock @hannesm adapting more packages to mirage-crypto 1.0.0.

From the [changelog](https://github.com/aantron/dream/releases/tag/1.0.0-alpha7):

> - Add JSX [example](https://github.com/aantron/dream/tree/05a04f56c21a6c9c59a45285c513a310ad14ae8a/example/r-html_of_jsx) (aantron/dream#326, David Sancho).
> - Adapt to mirage-crypto 1.0.0 (aantron/dream#334).
> - Warn upon re-entrant calls to `Dream.sql` (aantron/dream#332, reported Adrien Guatto).
> - Disable Dream's `~adjust_terminal` behavior, so that it does not clip log lines (aantron/dream#336, Max Große).