### PR TITLE
Package ocsigen-toolkit.4.0.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.4.0.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.4.0.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "js_of_ocaml" {>= "4.1.0"}
+  "eliom" {>= "11.0.0"}
+  "calendar" {>= "2.0.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsigen-toolkit/archive/refs/tags/4.0.0.tar.gz"
+  checksum: [
+    "md5=ae5d3894c74a88db3723ad5d0c0e28a4"
+    "sha512=6997ef4c341b0276fb21c9bc40b20ecb5a74af0373565a3842985f92c71bb5cbe0514b5f1447dc5cc8ca1750a74c74274d308490a4e20be36a2ff7ecdd57d0c0"
+  ]
+}

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.4.0.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.4.0.0/opam
@@ -9,6 +9,7 @@ dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
+available: arch != "x86_32" & arch != "arm32"
 depends: [
   "ocaml" {>= "4.08.0"}
   "js_of_ocaml" {>= "4.1.0"}


### PR DESCRIPTION
### `ocsigen-toolkit.4.0.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.3.0