### PR TITLE
Package ocsigen-start.7.0.0

### DIFF
--- a/packages/ocsigen-start/ocsigen-start.7.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.7.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+authors: "dev@ocsigen.org"
+maintainer: "dev@ocsigen.org"
+synopsis: "Higher-level library for developing Web and mobile applications with users, registration, notifications, etc"
+description: """
+Ocsigen Start is a set of higher-level libraries for building client-server Web and mobile applications with Ocsigen (Js_of_ocaml and Eliom).
+It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users.
+Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management.
+This template is intended to serve as a basis for quickly building the Minimum Viable Product for Web and mobile applications with users.
+The goal is to enable the programmer to concentrate on the core of the app, and not on user management.
+"""
+homepage: "https://ocsigen.org/ocsigen-start/"
+bug-reports: "https://github.com/ocsigen/ocsigen-start/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-start.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.08.1"}
+  "pgocaml" {>= "4.0"}
+  "pgocaml_ppx" {>= "4.0"}
+  "safepass" {>= "3.0"}
+  "ocsigen-i18n" {>= "4.0.0"}
+  "eliom" {>= "11.0.0" & < "12.0.0"}
+  "ocsigen-toolkit" {>= "2.7.0"}
+  "ocsigen-ppx-rpc"
+  "ocsigen-i18n" {>= "3.7.0"}
+  "yojson" {>= "1.6.0"}
+  "resource-pooling" {>= "1.0" & < "2.0"}
+  "cohttp-lwt-unix"
+  "re" {>= "1.7.2"}
+]
+depexts: [
+  ["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}
+  ["postgresql" "md5sha1sum" "sassc"] {os = "macos" & os-distribution = "homebrew"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsigen-start/archive/refs/tags/7.0.0.tar.gz"
+  checksum: [
+    "md5=6d93a472dc41729c7f2b2dc12f66c59d"
+    "sha512=c3877eddd499cebd8b02465d41f38e01f50b64d831d65aa0f9e58d729fc4cdb22c2e0b7d8e398a53cfe70ecb9b9342b7789d6dbd51900310c8afb2d2801e38d4"
+  ]
+}

--- a/packages/ocsigen-start/ocsigen-start.7.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.7.0.0/opam
@@ -15,6 +15,7 @@ dev-repo: "git+https://github.com/ocsigen/ocsigen-start.git"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
+available: arch != "x86_32" & arch != "arm32"
 depends: [
   "ocaml" {>= "4.08.1"}
   "pgocaml" {>= "4.0"}


### PR DESCRIPTION
### `ocsigen-start.7.0.0`
Higher-level library for developing Web and mobile applications with users, registration, notifications, etc
Ocsigen Start is a set of higher-level libraries for building client-server Web and mobile applications with Ocsigen (Js_of_ocaml and Eliom).
It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users.
Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management.
This template is intended to serve as a basis for quickly building the Minimum Viable Product for Web and mobile applications with users.
The goal is to enable the programmer to concentrate on the core of the app, and not on user management.



---
* Homepage: https://ocsigen.org/ocsigen-start/
* Source repo: git+https://github.com/ocsigen/ocsigen-start.git
* Bug tracker: https://github.com/ocsigen/ocsigen-start/issues

---
:camel: Pull-request generated by opam-publish v2.3.0