### PR TITLE
[new release] x509 (1.0.3)

### DIFF
--- a/packages/x509/x509.1.0.3/opam
+++ b/packages/x509/x509.1.0.3/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "David Kaloper <dk505@cam.ac.uk>"
+]
+license: "BSD-2-Clause"
+tags: "org:mirage"
+homepage: "https://github.com/mirleft/ocaml-x509"
+doc: "https://mirleft.github.io/ocaml-x509/doc"
+bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.2"}
+  "asn1-combinators" {>= "0.3.1"}
+  "ptime"
+  "base64" {>= "3.3.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.7"}
+  "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+  "gmap" {>= "0.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "logs"
+  "kdf" {>= "1.0.0"}
+  "ohex" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
+synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
+description: """
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority. Authorities must be exchanged over a second channel to establish the
+trust relationship. This library implements most parts of RFC5280 and RFC6125.
+The Public Key Cryptography Standards (PKCS) defines encoding and decoding
+(in ASN.1 DER and PEM format), which is also implemented by this library -
+namely PKCS 1, PKCS 5, PKCS 7, PKCS 8, PKCS 9, PKCS 10, and PKCS 12.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-x509/releases/download/v1.0.3/x509-1.0.3.tbz"
+  checksum: [
+    "sha256=1452c0c95479065a2e5e36d02e879e4e7961800ccf0c0a7c3b2c077e5fb5c8f1"
+    "sha512=933941a1ed67ce963286a15fe481e97ac692579ae9ae81877c25c6be24ccb2bf77a26b2e12f02d2d474b54fa0f14c199d32548a9053e054df2a89245e335d7ea"
+  ]
+}
+x-commit-hash: "38a5ee9330832a7bb9b3e040f53c459e749958f0"


### PR DESCRIPTION
Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-x509">https://github.com/mirleft/ocaml-x509</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-x509/doc">https://mirleft.github.io/ocaml-x509/doc</a>

##### CHANGES:

* Use the opam package kdf instead of pbkdf (@hannesm mirleft/ocaml-x509#174)
