### PR TITLE
[new release] letsencrypt (4 packages) (1.0.0)

### DIFF
--- a/packages/letsencrypt-app/letsencrypt-app.1.0.0/opam
+++ b/packages/letsencrypt-app/letsencrypt-app.1.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An ACME client implementation of the ACME protocol (RFC 8555) for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/robur-coop/ocaml-letsencrypt"
+bug-reports: "https://github.com/robur-coop/ocaml-letsencrypt/issues"
+doc: "https://robur-coop.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "letsencrypt-dns" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "logs"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "2.6.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "ptime"
+  "bos"
+  "fpath"
+  "randomconv" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/ocaml-letsencrypt.git"
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-letsencrypt/releases/download/v1.0.0/letsencrypt-1.0.0.tbz"
+  checksum: [
+    "sha256=928346d7d6a82d8dbc1dbec6cae3ee254cab080139f67daf8db1f8cf4ca41af0"
+    "sha512=bcb394200ac4a9d4bc4ed45cc60d6c6af0827d81b68b79d0fcc5e80700a33eb6792cb3fd76ebb2309fe50a61c4ad71def3f8f10a508d7c50c38a4b30dccba906"
+  ]
+}
+x-commit-hash: "baf1fd86199920eeaa8cb8af4ca08ab296070742"

--- a/packages/letsencrypt-dns/letsencrypt-dns.1.0.0/opam
+++ b/packages/letsencrypt-dns/letsencrypt-dns.1.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "DNS solver for ACME implementation in OCaml"
+description: "A DNS solver for the ACME implementation in OCaml."
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/robur-coop/ocaml-letsencrypt"
+bug-reports: "https://github.com/robur-coop/ocaml-letsencrypt/issues"
+doc: "https://robur-coop.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "logs"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "2.6.0"}
+  "dns" {>= "9.0.0"}
+  "dns-tsig" {>= "9.0.0"}
+  "domain-name" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/ocaml-letsencrypt.git"
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-letsencrypt/releases/download/v1.0.0/letsencrypt-1.0.0.tbz"
+  checksum: [
+    "sha256=928346d7d6a82d8dbc1dbec6cae3ee254cab080139f67daf8db1f8cf4ca41af0"
+    "sha512=bcb394200ac4a9d4bc4ed45cc60d6c6af0827d81b68b79d0fcc5e80700a33eb6792cb3fd76ebb2309fe50a61c4ad71def3f8f10a508d7c50c38a4b30dccba906"
+  ]
+}
+x-commit-hash: "baf1fd86199920eeaa8cb8af4ca08ab296070742"

--- a/packages/letsencrypt-mirage/letsencrypt-mirage.1.0.0/opam
+++ b/packages/letsencrypt-mirage/letsencrypt-mirage.1.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml for MirageOS"
+description: "An ACME client implementation of the ACME protocol (RFC 8555) for OCaml & MirageOS"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/robur-coop/ocaml-letsencrypt"
+bug-reports: "https://github.com/robur-coop/ocaml-letsencrypt/issues"
+doc: "https://robur-coop.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "http-mirage-client"
+  "tcpip" {>= "7.0.0"}
+  "mirage-time" {>= "3.0.0"}
+  "duration"
+  "emile" {>= "1.1"}
+  "paf" {>= "0.4.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/ocaml-letsencrypt.git"
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-letsencrypt/releases/download/v1.0.0/letsencrypt-1.0.0.tbz"
+  checksum: [
+    "sha256=928346d7d6a82d8dbc1dbec6cae3ee254cab080139f67daf8db1f8cf4ca41af0"
+    "sha512=bcb394200ac4a9d4bc4ed45cc60d6c6af0827d81b68b79d0fcc5e80700a33eb6792cb3fd76ebb2309fe50a61c4ad71def3f8f10a508d7c50c38a4b30dccba906"
+  ]
+}
+x-commit-hash: "baf1fd86199920eeaa8cb8af4ca08ab296070742"

--- a/packages/letsencrypt/letsencrypt.1.0.0/opam
+++ b/packages/letsencrypt/letsencrypt.1.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An implementation of the ACME protocol (RFC 8555) for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/robur-coop/ocaml-letsencrypt"
+bug-reports: "https://github.com/robur-coop/ocaml-letsencrypt/issues"
+doc: "https://robur-coop.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.2.0"}
+  "base64" {>= "3.3.0"}
+  "logs"
+  "fmt" {>= "0.8.7"}
+  "uri"
+  "lwt" {>= "2.6.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-ec" {>= "1.0.0"}
+  "mirage-crypto-pk" {>= "1.0.0"}
+  "mirage-crypto-rng" {with-test & >= "1.0.0"}
+  "digestif" {>= "1.2.0"}
+  "x509" {>= "1.0.0"}
+  "yojson" {>= "1.6.0"}
+  "ounit2" {with-test}
+  "ptime"
+  "domain-name" {>= "0.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/ocaml-letsencrypt.git"
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-letsencrypt/releases/download/v1.0.0/letsencrypt-1.0.0.tbz"
+  checksum: [
+    "sha256=928346d7d6a82d8dbc1dbec6cae3ee254cab080139f67daf8db1f8cf4ca41af0"
+    "sha512=bcb394200ac4a9d4bc4ed45cc60d6c6af0827d81b68b79d0fcc5e80700a33eb6792cb3fd76ebb2309fe50a61c4ad71def3f8f10a508d7c50c38a4b30dccba906"
+  ]
+}
+x-commit-hash: "baf1fd86199920eeaa8cb8af4ca08ab296070742"


### PR DESCRIPTION
ACME implementation in OCaml

- Project page: <a href="https://github.com/robur-coop/ocaml-letsencrypt">https://github.com/robur-coop/ocaml-letsencrypt</a>
- Documentation: <a href="https://robur-coop.github.io/ocaml-letsencrypt">https://robur-coop.github.io/ocaml-letsencrypt</a>

##### CHANGES:

* update to mirage-crypto 1.0.0 and x509 1.0.0 API (robur-coop/ocaml-letsencrypt#34 @hannesm)
* package moved to the robur-coop organization
