### PR TITLE
[new release] asn1-combinators (0.3.2)

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.3.2/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.3.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+authors: "David Kaloper Meršinjak"
+maintainer: "David Kaloper Meršinjak <dk505@cam.ac.uk>"
+homepage: "https://github.com/mirleft/ocaml-asn1-combinators"
+doc: "https://mirleft.github.io/ocaml-asn1-combinators/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/mirleft/ocaml-asn1-combinators.git"
+bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
+synopsis: "Embed typed ASN.1 grammars in OCaml"
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+depends: [
+  "ocaml" {>="4.13.0"}
+  "dune" {>= "1.2.0"}
+  "ptime" {>= "0.8.6"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+description: """
+asn1-combinators is a library for expressing ASN.1 in OCaml. Skip the notation
+part of ASN.1, and embed the abstract syntax directly in the language. These
+abstract syntax representations can be used for parsing, serialization, or
+random testing.
+
+The only ASN.1 encodings currently supported are BER and DER.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.3.2/asn1-combinators-0.3.2.tbz"
+  checksum: [
+    "sha256=2b26985f6e2722073dcd9f84355bd6757e12643b5a48e30b3c07ff7cfb0d8a7f"
+    "sha512=8ca5a9dfa080cd2e6c3ef05a232e90916df921b09e8445728c6b46438d39056ccb8cd61325f3858490f032a17620a0de17f9d910fd8f0cabe961b02bc76a2eca"
+  ]
+}
+x-commit-hash: "2f80f3495ccfa88a506d83b811d74f0a2bd63114"


### PR DESCRIPTION
Embed typed ASN.1 grammars in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-asn1-combinators">https://github.com/mirleft/ocaml-asn1-combinators</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-asn1-combinators/doc">https://mirleft.github.io/ocaml-asn1-combinators/doc</a>

##### CHANGES:

* Drop OCaml < 4.13 support (mirleft/ocaml-asn1-combinators#45 @hannesm)
