### PR TITLE
[new release] httpun (7 packages) (0.2.0)

### DIFF
--- a/packages/httpun-async/httpun-async.0.2.0/opam
+++ b/packages/httpun-async/httpun-async.0.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [
+  "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/httpun"
+bug-reports: "https://github.com/anmonteiro/httpun/issues"
+dev-repo: "git+https://github.com/anmonteiro/httpun.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.0.0"}
+  "async" {>= "v0.16.0"}
+  "httpun" {= version}
+  "gluten-async" {>= "0.5.0"}
+]
+depopts: ["async_ssl"]
+synopsis: "Async support for httpun"
+url {
+  src:
+    "https://github.com/anmonteiro/httpun/releases/download/0.2.0/httpun-0.2.0.tbz"
+  checksum: [
+    "sha256=a2ce27ef4c85ae8e1c1008d1e3d5e893d6b211b934586a1dd2942f7db687bd2c"
+    "sha512=53ae8409321533b4092df166c69cd219a4e2071bb3b9fa3361072205eda6d62df25fe964c62d2b49c14530fd34746b8d8c8f010293ebe099bed0237d0f55a66b"
+  ]
+}
+x-commit-hash: "80755658e548fce295ee3df118d6c1b8f5fa6956"

--- a/packages/httpun-eio/httpun-eio.0.2.0/opam
+++ b/packages/httpun-eio/httpun-eio.0.2.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/httpun"
+bug-reports: "https://github.com/anmonteiro/httpun/issues"
+dev-repo: "git+https://github.com/anmonteiro/httpun.git"
+build: [
+  ["dune" "build" "-p" name]
+]
+depends: [
+  "ocaml" {>= "5.0"}
+  "dune" {>= "3.0.0"}
+  "httpun" {= version}
+  "gluten-eio" {>= "0.5.1"}
+]
+synopsis: "EIO support for httpun"
+url {
+  src:
+    "https://github.com/anmonteiro/httpun/releases/download/0.2.0/httpun-0.2.0.tbz"
+  checksum: [
+    "sha256=a2ce27ef4c85ae8e1c1008d1e3d5e893d6b211b934586a1dd2942f7db687bd2c"
+    "sha512=53ae8409321533b4092df166c69cd219a4e2071bb3b9fa3361072205eda6d62df25fe964c62d2b49c14530fd34746b8d8c8f010293ebe099bed0237d0f55a66b"
+  ]
+}
+x-commit-hash: "80755658e548fce295ee3df118d6c1b8f5fa6956"

--- a/packages/httpun-lwt-unix/httpun-lwt-unix.0.2.0/opam
+++ b/packages/httpun-lwt-unix/httpun-lwt-unix.0.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/httpun"
+bug-reports: "https://github.com/anmonteiro/httpun/issues"
+dev-repo: "git+https://github.com/anmonteiro/httpun.git"
+build: [
+  ["dune" "build" "-p" name]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "httpun" {= version}
+  "httpun-lwt" {= version}
+  "dune" {>= "3.0.0"}
+  "gluten-lwt-unix" {>= "0.5.0"}
+]
+synopsis: "Lwt + Unix support for httpun"
+url {
+  src:
+    "https://github.com/anmonteiro/httpun/releases/download/0.2.0/httpun-0.2.0.tbz"
+  checksum: [
+    "sha256=a2ce27ef4c85ae8e1c1008d1e3d5e893d6b211b934586a1dd2942f7db687bd2c"
+    "sha512=53ae8409321533b4092df166c69cd219a4e2071bb3b9fa3361072205eda6d62df25fe964c62d2b49c14530fd34746b8d8c8f010293ebe099bed0237d0f55a66b"
+  ]
+}
+x-commit-hash: "80755658e548fce295ee3df118d6c1b8f5fa6956"

--- a/packages/httpun-lwt/httpun-lwt.0.2.0/opam
+++ b/packages/httpun-lwt/httpun-lwt.0.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/httpun"
+bug-reports: "https://github.com/anmonteiro/httpun/issues"
+dev-repo: "git+https://github.com/anmonteiro/httpun.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.0.0"}
+  "httpun" {= version}
+  "lwt"
+  "gluten-lwt" {>= "0.5.0"}
+]
+synopsis: "Lwt support for httpun"
+url {
+  src:
+    "https://github.com/anmonteiro/httpun/releases/download/0.2.0/httpun-0.2.0.tbz"
+  checksum: [
+    "sha256=a2ce27ef4c85ae8e1c1008d1e3d5e893d6b211b934586a1dd2942f7db687bd2c"
+    "sha512=53ae8409321533b4092df166c69cd219a4e2071bb3b9fa3361072205eda6d62df25fe964c62d2b49c14530fd34746b8d8c8f010293ebe099bed0237d0f55a66b"
+  ]
+}
+x-commit-hash: "80755658e548fce295ee3df118d6c1b8f5fa6956"

--- a/packages/httpun-mirage/httpun-mirage.0.2.0/opam
+++ b/packages/httpun-mirage/httpun-mirage.0.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/httpun"
+bug-reports: "https://github.com/anmonteiro/httpun/issues"
+dev-repo: "git+https://github.com/anmonteiro/httpun.git"
+build: [
+  ["dune" "build" "-p" name]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.0.0"}
+  "httpun-lwt" {= version}
+  "gluten-mirage" {>= "0.5.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "cstruct"
+  "lwt"
+]
+synopsis: "Mirage support for httpun"
+url {
+  src:
+    "https://github.com/anmonteiro/httpun/releases/download/0.2.0/httpun-0.2.0.tbz"
+  checksum: [
+    "sha256=a2ce27ef4c85ae8e1c1008d1e3d5e893d6b211b934586a1dd2942f7db687bd2c"
+    "sha512=53ae8409321533b4092df166c69cd219a4e2071bb3b9fa3361072205eda6d62df25fe964c62d2b49c14530fd34746b8d8c8f010293ebe099bed0237d0f55a66b"
+  ]
+}
+x-commit-hash: "80755658e548fce295ee3df118d6c1b8f5fa6956"

--- a/packages/httpun-types/httpun-types.0.2.0/opam
+++ b/packages/httpun-types/httpun-types.0.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [
+  "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/httpun"
+bug-reports: "https://github.com/anmonteiro/httpun/issues"
+dev-repo: "git+https://github.com/anmonteiro/httpun.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.0.0"}
+  "faraday"  {>= "0.8.0"}
+]
+synopsis:
+  "Common HTTP/1.x types"
+url {
+  src:
+    "https://github.com/anmonteiro/httpun/releases/download/0.2.0/httpun-0.2.0.tbz"
+  checksum: [
+    "sha256=a2ce27ef4c85ae8e1c1008d1e3d5e893d6b211b934586a1dd2942f7db687bd2c"
+    "sha512=53ae8409321533b4092df166c69cd219a4e2071bb3b9fa3361072205eda6d62df25fe964c62d2b49c14530fd34746b8d8c8f010293ebe099bed0237d0f55a66b"
+  ]
+}
+x-commit-hash: "80755658e548fce295ee3df118d6c1b8f5fa6956"

--- a/packages/httpun/httpun.0.2.0/opam
+++ b/packages/httpun/httpun.0.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+authors: [
+  "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/httpun"
+bug-reports: "https://github.com/anmonteiro/httpun/issues"
+dev-repo: "git+https://github.com/anmonteiro/httpun.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.0.0"}
+  "alcotest" {with-test}
+  "httpun-types" {= version}
+  "bigstringaf" {>= "0.9.0"}
+  "angstrom" {>= "0.15.0"}
+  "faraday"  {>= "0.8.0"}
+]
+synopsis:
+  "A high-performance, memory-efficient, and scalable HTTP library for OCaml"
+url {
+  src:
+    "https://github.com/anmonteiro/httpun/releases/download/0.2.0/httpun-0.2.0.tbz"
+  checksum: [
+    "sha256=a2ce27ef4c85ae8e1c1008d1e3d5e893d6b211b934586a1dd2942f7db687bd2c"
+    "sha512=53ae8409321533b4092df166c69cd219a4e2071bb3b9fa3361072205eda6d62df25fe964c62d2b49c14530fd34746b8d8c8f010293ebe099bed0237d0f55a66b"
+  ]
+}
+x-commit-hash: "80755658e548fce295ee3df118d6c1b8f5fa6956"


### PR DESCRIPTION
A high-performance, memory-efficient, and scalable HTTP library for OCaml

- Project page: <a href="https://github.com/anmonteiro/httpun">https://github.com/anmonteiro/httpun</a>

##### CHANGES:

- client: report exceptions before closing the response body
  ([anmonteiro/httpun#135](https://github.com/anmonteiro/httpun/pull/135))
- server: process requests after EOF
  ([anmonteiro/httpun#136](https://github.com/anmonteiro/httpun/pull/136))
- surface (body) write errors through `flush`
  ([anmonteiro/httpun#138](https://github.com/anmonteiro/httpun/pull/138))
    - `Body.Writer.flush` now takes a callback of the type
       ``([ `Written | ` Closed] -> unit)``, informing the caller whether the
       previous writes have been written or whether the output channel was
       closed.
