### PR TITLE
[new release] gluten (6 packages) (0.5.2)

### DIFF
--- a/packages/gluten-async/gluten-async.0.5.2/opam
+++ b/packages/gluten-async/gluten-async.0.5.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Async support for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "gluten" {= version}
+  "faraday-async" {>= "0.7.3"}
+  "async" {>= "v0.15.0"}
+  "core" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "async_ssl"
+  "tls-async" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.2/gluten-0.5.2.tbz"
+  checksum: [
+    "sha256=b1eed89f9f6080bb4bd289cc8d252c6bcf01f03d395726e66fa6067207e7015f"
+    "sha512=105e549d5ff83c43be6ab5e71ec1c19b27140a279002f04e02792e778f9e75deaecf4251324e6273e43039e38572b45ea236626b3afa7ef5c3c72baa3002c129"
+  ]
+}
+x-commit-hash: "6a438739280b855474d5eb7906e4daa2b129ffa8"

--- a/packages/gluten-eio/gluten-eio.0.5.2/opam
+++ b/packages/gluten-eio/gluten-eio.0.5.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "EIO runtime for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "gluten" {= version}
+  "eio" {>= "0.12"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.2/gluten-0.5.2.tbz"
+  checksum: [
+    "sha256=b1eed89f9f6080bb4bd289cc8d252c6bcf01f03d395726e66fa6067207e7015f"
+    "sha512=105e549d5ff83c43be6ab5e71ec1c19b27140a279002f04e02792e778f9e75deaecf4251324e6273e43039e38572b45ea236626b3afa7ef5c3c72baa3002c129"
+  ]
+}
+x-commit-hash: "6a438739280b855474d5eb7906e4daa2b129ffa8"

--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.2/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Lwt + Unix support for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "gluten-lwt" {= version}
+  "faraday-lwt-unix" {>= "0.7.3"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "lwt_ssl" {>= "1.2.0"}
+  "tls-lwt" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.2/gluten-0.5.2.tbz"
+  checksum: [
+    "sha256=b1eed89f9f6080bb4bd289cc8d252c6bcf01f03d395726e66fa6067207e7015f"
+    "sha512=105e549d5ff83c43be6ab5e71ec1c19b27140a279002f04e02792e778f9e75deaecf4251324e6273e43039e38572b45ea236626b3afa7ef5c3c72baa3002c129"
+  ]
+}
+x-commit-hash: "6a438739280b855474d5eb7906e4daa2b129ffa8"

--- a/packages/gluten-lwt/gluten-lwt.0.5.2/opam
+++ b/packages/gluten-lwt/gluten-lwt.0.5.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Lwt-specific runtime for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "gluten" {= version}
+  "lwt" {>= "5.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.2/gluten-0.5.2.tbz"
+  checksum: [
+    "sha256=b1eed89f9f6080bb4bd289cc8d252c6bcf01f03d395726e66fa6067207e7015f"
+    "sha512=105e549d5ff83c43be6ab5e71ec1c19b27140a279002f04e02792e778f9e75deaecf4251324e6273e43039e38572b45ea236626b3afa7ef5c3c72baa3002c129"
+  ]
+}
+x-commit-hash: "6a438739280b855474d5eb7906e4daa2b129ffa8"

--- a/packages/gluten-mirage/gluten-mirage.0.5.2/opam
+++ b/packages/gluten-mirage/gluten-mirage.0.5.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Mirage support for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "gluten-lwt" {= version}
+  "faraday-lwt" {>= "0.7.3"}
+  "conduit-mirage" {>= "2.0.2"}
+  "mirage-flow" {>= "2.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.2/gluten-0.5.2.tbz"
+  checksum: [
+    "sha256=b1eed89f9f6080bb4bd289cc8d252c6bcf01f03d395726e66fa6067207e7015f"
+    "sha512=105e549d5ff83c43be6ab5e71ec1c19b27140a279002f04e02792e778f9e75deaecf4251324e6273e43039e38572b45ea236626b3afa7ef5c3c72baa3002c129"
+  ]
+}
+x-commit-hash: "6a438739280b855474d5eb7906e4daa2b129ffa8"

--- a/packages/gluten-mirage/gluten-mirage.0.5.2/opam
+++ b/packages/gluten-mirage/gluten-mirage.0.5.2/opam
@@ -11,7 +11,7 @@ depends: [
   "gluten-lwt" {= version}
   "faraday-lwt" {>= "0.7.3"}
   "conduit-mirage" {>= "2.0.2"}
-  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow" {>= "3.0.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/gluten/gluten.0.5.2/opam
+++ b/packages/gluten/gluten.0.5.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A reusable runtime library for network protocols"
+description:
+  "gluten implements platform specific runtime code for driving network libraries based on state machines, such as http/af, h2 and websocketaf."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "bigstringaf" {>= "0.4.0"}
+  "faraday" {>= "0.7.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.5.2/gluten-0.5.2.tbz"
+  checksum: [
+    "sha256=b1eed89f9f6080bb4bd289cc8d252c6bcf01f03d395726e66fa6067207e7015f"
+    "sha512=105e549d5ff83c43be6ab5e71ec1c19b27140a279002f04e02792e778f9e75deaecf4251324e6273e43039e38572b45ea236626b3afa7ef5c3c72baa3002c129"
+  ]
+}
+x-commit-hash: "6a438739280b855474d5eb7906e4daa2b129ffa8"


### PR DESCRIPTION
A reusable runtime library for network protocols

- Project page: <a href="https://github.com/anmonteiro/gluten">https://github.com/anmonteiro/gluten</a>

##### CHANGES:

- gluten-async: Silence async deprecation warnings
  ([anmonteiro/gluten#78)(https://github.com/anmonteiro/gluten/pull/78))
- migrate to tls 1.0.0 without cstruct
  ([anmonteiro/gluten#80](https://github.com/anmonteiro/gluten/pull/80))
