### PR TITLE
[new release] h2 (7 packages) (0.13.0)

### DIFF
--- a/packages/h2-async/h2-async.0.13.0/opam
+++ b/packages/h2-async/h2-async.0.13.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Async support for h2"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-async provides an Async runtime implementation for h2."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "h2" {= version}
+  "faraday-async"
+  "gluten-async" {>= "0.4.0"}
+  "odoc" {with-doc}
+]
+depopts: ["async_ssl" "tls-async"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.13.0/h2-0.13.0.tbz"
+  checksum: [
+    "sha256=775a345c852d15cb093a1df2f4490e0fdc8197ea7a78a7fffbdc07c91007b9e1"
+    "sha512=e116e6473ab6c23a44ac95aafea77db774dfdeddcdce172df6054d1f8437e1232e69d5cd3977320997f1924d9dad1708eee3fa1b785fd255c1ef461db6e45150"
+  ]
+}
+x-commit-hash: "10a06bd792c7f5315b0fb83ee3a738b55225ecdf"

--- a/packages/h2-eio/h2-eio.0.13.0/opam
+++ b/packages/h2-eio/h2-eio.0.13.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "EIO support for h2"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-eio provides an EIO runtime implementation for h2."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "h2" {= version}
+  "gluten-eio" {>= "0.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.13.0/h2-0.13.0.tbz"
+  checksum: [
+    "sha256=775a345c852d15cb093a1df2f4490e0fdc8197ea7a78a7fffbdc07c91007b9e1"
+    "sha512=e116e6473ab6c23a44ac95aafea77db774dfdeddcdce172df6054d1f8437e1232e69d5cd3977320997f1924d9dad1708eee3fa1b785fd255c1ef461db6e45150"
+  ]
+}
+x-commit-hash: "10a06bd792c7f5315b0fb83ee3a738b55225ecdf"

--- a/packages/h2-lwt-unix/h2-lwt-unix.0.13.0/opam
+++ b/packages/h2-lwt-unix/h2-lwt-unix.0.13.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Lwt + UNIX support for h2"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-lwt-unix provides an Lwt runtime implementation for h2 that targets UNIX binaries."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "h2-lwt" {= version}
+  "faraday-lwt-unix"
+  "gluten-lwt-unix" {>= "0.2.1"}
+  "odoc" {with-doc}
+]
+depopts: ["tls-lwt" "lwt_ssl"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.13.0/h2-0.13.0.tbz"
+  checksum: [
+    "sha256=775a345c852d15cb093a1df2f4490e0fdc8197ea7a78a7fffbdc07c91007b9e1"
+    "sha512=e116e6473ab6c23a44ac95aafea77db774dfdeddcdce172df6054d1f8437e1232e69d5cd3977320997f1924d9dad1708eee3fa1b785fd255c1ef461db6e45150"
+  ]
+}
+x-commit-hash: "10a06bd792c7f5315b0fb83ee3a738b55225ecdf"

--- a/packages/h2-lwt/h2-lwt.0.13.0/opam
+++ b/packages/h2-lwt/h2-lwt.0.13.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Lwt support for h2"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-lwt provides an Lwt runtime implementation for h2."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "h2" {= version}
+  "lwt" {>= "5.1.1"}
+  "gluten-lwt" {>= "0.2.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.13.0/h2-0.13.0.tbz"
+  checksum: [
+    "sha256=775a345c852d15cb093a1df2f4490e0fdc8197ea7a78a7fffbdc07c91007b9e1"
+    "sha512=e116e6473ab6c23a44ac95aafea77db774dfdeddcdce172df6054d1f8437e1232e69d5cd3977320997f1924d9dad1708eee3fa1b785fd255c1ef461db6e45150"
+  ]
+}
+x-commit-hash: "10a06bd792c7f5315b0fb83ee3a738b55225ecdf"

--- a/packages/h2-mirage/h2-mirage.0.13.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.13.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Lwt support for h2"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. h2-mirage provides an Lwt runtime implementation for h2 that targets MirageOS unikernels."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "h2-lwt" {= version}
+  "faraday-lwt"
+  "lwt"
+  "gluten-mirage" {>= "0.3.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "cstruct"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.13.0/h2-0.13.0.tbz"
+  checksum: [
+    "sha256=775a345c852d15cb093a1df2f4490e0fdc8197ea7a78a7fffbdc07c91007b9e1"
+    "sha512=e116e6473ab6c23a44ac95aafea77db774dfdeddcdce172df6054d1f8437e1232e69d5cd3977320997f1924d9dad1708eee3fa1b785fd255c1ef461db6e45150"
+  ]
+}
+x-commit-hash: "10a06bd792c7f5315b0fb83ee3a738b55225ecdf"

--- a/packages/h2/h2.0.13.0/opam
+++ b/packages/h2/h2.0.13.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "A high-performance, memory-efficient, and scalable HTTP/2 library for OCaml"
+description:
+  "h2 is an implementation of the HTTP/2 specification entirely in OCaml. It is based on the concepts in httpun, and therefore uses the Angstrom and Faraday libraries to implement the parsing and serialization layers of the HTTP/2 standard as a state machine that is agnostic to the underlying I/O specifics. It also preserves the same API as httpun wherever possible."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "base64" {>= "3.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "faraday" {>= "0.7.3"}
+  "bigstringaf" {>= "0.5.0"}
+  "psq"
+  "hpack" {= version}
+  "httpun-types"
+  "alcotest" {with-test}
+  "yojson" {with-test}
+  "hex" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.13.0/h2-0.13.0.tbz"
+  checksum: [
+    "sha256=775a345c852d15cb093a1df2f4490e0fdc8197ea7a78a7fffbdc07c91007b9e1"
+    "sha512=e116e6473ab6c23a44ac95aafea77db774dfdeddcdce172df6054d1f8437e1232e69d5cd3977320997f1924d9dad1708eee3fa1b785fd255c1ef461db6e45150"
+  ]
+}
+x-commit-hash: "10a06bd792c7f5315b0fb83ee3a738b55225ecdf"

--- a/packages/hpack/hpack.0.13.0/opam
+++ b/packages/hpack/hpack.0.13.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "An HPACK (Header Compression for HTTP/2) implementation in OCaml"
+description:
+  "hpack is an implementation of the HPACK: Header Compression for HTTP/2 specification (RFC7541) written in OCaml. It uses Angstrom and Faraday for parsing and serialization, respectively."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "angstrom"
+  "faraday" {>= "0.7.3"}
+  "yojson" {with-test}
+  "hex" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.13.0/h2-0.13.0.tbz"
+  checksum: [
+    "sha256=775a345c852d15cb093a1df2f4490e0fdc8197ea7a78a7fffbdc07c91007b9e1"
+    "sha512=e116e6473ab6c23a44ac95aafea77db774dfdeddcdce172df6054d1f8437e1232e69d5cd3977320997f1924d9dad1708eee3fa1b785fd255c1ef461db6e45150"
+  ]
+}
+x-commit-hash: "10a06bd792c7f5315b0fb83ee3a738b55225ecdf"


### PR DESCRIPTION
A high-performance, memory-efficient, and scalable HTTP/2 library for OCaml

- Project page: <a href="https://github.com/anmonteiro/ocaml-h2">https://github.com/anmonteiro/ocaml-h2</a>

##### CHANGES:

- surface write failures through `Body.Writer.flush`
  ([anmonteiro/ocaml-h2#247](https://github.com/anmonteiro/ocaml-h2/pull/247))
