### PR TITLE
extlib is not compatible with OCaml 5.3

### DIFF
--- a/packages/extlib/extlib.1.7.9/opam
+++ b/packages/extlib/extlib.1.7.9/opam
@@ -30,7 +30,7 @@ doc: "https://ygrek.org/p/extlib/doc/"
 bug-reports: "https://github.com/ygrek/ocaml-extlib/issues"
 depends: [
   "dune" {>= "1.0"}
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.3"}
   "cppo" {build}
 ]
 build: [


### PR DESCRIPTION
```
#=== ERROR while compiling extlib.1.7.9 =======================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/extlib.1.7.9
# command              ~/.opam/5.3/bin/dune build -p extlib -j 1
# exit-code            1
# env-file             ~/.opam/log/extlib-20-35b0de.env
# output-file          ~/.opam/log/extlib-20-35b0de.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlc.opt -w -40 -w -3-6-9-27-32-33-35-39-50 -g -bin-annot -I src/.extlib.objs/byte -intf-suffix .ml -no-alias-deps -o src/.extlib.objs/byte/extArray.cmo -c -impl src/extArray.pp.ml)
# File "src/extArray.pp.ml", line 1:
# Error: The implementation "src/extArray.pp.ml"
#        does not match the interface "src/extArray.pp.ml":  ... In module "Array":
#        Values do not match:
#          external create_float : int -> float array
#            = "caml_array_create_float"
#        is not included in
#          external create_float : int -> float array = "caml_make_float_vect"
#        The names of the primitives are not the same
#        File "src/extArray.mli", line 116, characters 2-69:
#          Expected declaration
#        File "array.mli", line 66, characters 0-69: Actual declaration
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlopt.opt -w -40 -w -3-6-9-27-32-33-35-39-50 -g -I src/.extlib.objs/byte -I src/.extlib.objs/native -intf-suffix .ml -no-alias-deps -o src/.extlib.objs/native/extArray.cmx -c -impl src/extArray.pp.ml)
# File "src/extArray.pp.ml", line 1:
# Error: The implementation "src/extArray.pp.ml"
#        does not match the interface "src/extArray.pp.ml":  ... In module "Array":
#        Values do not match:
#          external create_float : int -> float array
#            = "caml_array_create_float"
#        is not included in
#          external create_float : int -> float array = "caml_make_float_vect"
#        The names of the primitives are not the same
#        File "src/extArray.mli", line 116, characters 2-69:
#          Expected declaration
#        File "array.mli", line 66, characters 0-69: Actual declaration
```
See https://github.com/ygrek/ocaml-extlib/pull/73