### PR TITLE
[new release] albatross (2.2.0)

### DIFF
--- a/packages/albatross/albatross.2.2.0/opam
+++ b/packages/albatross/albatross.2.2.0/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/robur-coop/albatross"
+dev-repo: "git+https://github.com/robur-coop/albatross.git"
+bug-reports: "https://github.com/robur-coop/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "5.3.0"}
+  "logs"
+  "bos" {>= "0.2.0"}
+  "ptime"
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "1.0.0"}
+  "tls" {>= "1.0.2"}
+  "tls-lwt" {>= "1.0.2"}
+  "asn1-combinators" {>= "0.3.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "ohex" {>= "0.2.0"}
+  "http-lwt-client" {>= "0.3.0"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.3"}
+  "fpath" {>= "0.7.3"}
+  "logs-syslog" {>= "0.4.1"}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+url {
+  src:
+    "https://github.com/robur-coop/albatross/releases/download/v2.2.0/albatross-2.2.0.tbz"
+  checksum: [
+    "sha256=ca0caf5e74844529cfc21e6328352cf480d9f02bea418251a70aad20390a21e5"
+    "sha512=2c331e12f3d18d51b5784281057416c42d1c711930491220f8daaf874d9d131adf394a76c7eb160b95cf966d9ebe939c4549d95dce2b717d1d47dc2caf7f7415"
+  ]
+}
+x-commit-hash: "834ea533204d5dd13618e88040598d0fe5701e36"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/robur-coop/albatross">https://github.com/robur-coop/albatross</a>

##### CHANGES:

* Store the policies on disk, next to the unikernels (robur-coop/albatross#189 @hannesm)
* Adapt to TLS 1.0.0, mirage-crypto 1.0.0, x509 1.0.0 and asn1-combinators 0.3.0
  API changes (robur-coop/albatross#187 robur-coop/albatross#188 @hannesm)
