### PR TITLE
[new release] mirage (2 packages) (4.7.0)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.4.7.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.4.7.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.9.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "4.0.0"}
+  "ipaddr" {>= "5.5.0"}
+  "cmdliner" {>= "1.2.0"}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "ppxlib" {= "0.29.0"} #0.29.0 provides a vendored ppx_sexp_conv
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.7.0/mirage-4.7.0.tbz"
+  checksum: [
+    "sha256=ade8c410b2de3997c4a513f53f6c990dac6af508161e20df01b64fa7975ca5be"
+    "sha512=42fddf09be84c4251417145b88d4f63b41db1b29c9622b2b4e4508e31146f227a16875e670da96251208745f79a42f0b7d2bd8b44b883a705381b4c97a4255b8"
+  ]
+}
+x-commit-hash: "438b8d8f23cdca43ad0298f020d3068680c07d8a"

--- a/packages/mirage/mirage.4.7.0/opam
+++ b/packages/mirage/mirage.4.7.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+available: opam-version >= "2.1.0"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.9.0"}
+  "astring"
+  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {with-test & >= "1.3.0"}
+  "emile" {>= "1.1"}
+  "fmt" {>= "0.8.7"}
+  "ipaddr" {>= "5.0.0"}
+  "bos"
+  "fpath"
+  "rresult" {>= "0.7.0"}
+  "uri" {>= "4.2.0"}
+  "logs" {>= "0.7.0"}
+  "opam-monorepo" {>= "0.4.0"}
+  "alcotest" {with-test}
+  "mirage-runtime" {with-test & = version}
+]
+
+conflicts: [ "jbuilder" {with-test} ]
+
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.7.0/mirage-4.7.0.tbz"
+  checksum: [
+    "sha256=ade8c410b2de3997c4a513f53f6c990dac6af508161e20df01b64fa7975ca5be"
+    "sha512=42fddf09be84c4251417145b88d4f63b41db1b29c9622b2b4e4508e31146f227a16875e670da96251208745f79a42f0b7d2bd8b44b883a705381b4c97a4255b8"
+  ]
+}
+x-commit-hash: "438b8d8f23cdca43ad0298f020d3068680c07d8a"

--- a/packages/mirage/mirage.4.7.0/opam
+++ b/packages/mirage/mirage.4.7.0/opam
@@ -19,6 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
+  "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
   "cmdliner" {>= "1.2.0"}


### PR DESCRIPTION
The MirageOS library operating system

- Project page: <a href="https://github.com/mirage/mirage">https://github.com/mirage/mirage</a>
- Documentation: <a href="https://mirage.github.io/mirage/">https://mirage.github.io/mirage/</a>

##### CHANGES:

- Adapt bounds for mirage-crypto-rng-mirage {>= "1.0.0"}, tls {>= "1.0.0"},
  conduit {>= "7.0.0"}, dns {>= "9.0.0"}, happy-eyeballs {>= "1.2.0"},
  tcpip {>= "8.2.0"}, mirage-qubes {>= "1.0.0"}, git {>= "3.17"}.
  The changes are in mirage-crypto to use string instead of cstruct.t
  (mirage/mirage#1559 @hannesm)
