### PR TITLE
Lambda Soup 1.1.1: HTML scraping with CSS

### DIFF
--- a/packages/lambdasoup/lambdasoup.1.1.1/opam
+++ b/packages/lambdasoup/lambdasoup.1.1.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+
+synopsis: "Easy functional HTML scraping and manipulation with CSS selectors"
+
+license: "MIT"
+homepage: "https://github.com/aantron/lambdasoup"
+doc: "https://aantron.github.io/lambdasoup"
+bug-reports: "https://github.com/aantron/lambdasoup/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/lambdasoup.git"
+
+depends: [
+  "camlp-streams" {>= "5.0.1"}
+  "dune" {>= "2.7.0"}
+  "markup" {>= "1.0.0"}
+  "ocaml" {>= "4.03.0"}
+
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "ounit2" {with-test}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+description: """
+Lambda Soup is an HTML scraping library inspired by Python's Beautiful Soup. It
+provides lazy traversals from HTML nodes to their parents, children, siblings,
+etc., and to nodes matching CSS selectors. The traversals can be manipulated
+using standard functional combinators such as fold, filter, and map.
+
+The DOM tree is mutable. You can use Lambda Soup for automatic HTML rewriting in
+scripts. Lambda Soup rewrites its own ocamldoc page this way.
+
+A major goal of Lambda Soup is to be easy to use, including in interactive
+sessions, and to have a minimal learning curve. It is a very simple library.
+"""
+
+url {
+  src: "https://github.com/aantron/lambdasoup/archive/1.1.1.tar.gz"
+  checksum: "sha256=05d97f38e534a431176ed8d3dbe6dfb7bdcf7770109193c5a69dff53e38f10fe"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/aantron/lambdasoup/releases/tag/1.1.1):

> - Don't remove namespace names from attributes (aantron/lambdasoup#61, aantron/lambdasoup#12, Max Große).

Would fix https://github.com/aantron/dream/issues/324 and https://github.com/PataphysicalSociety/soupault/issues/51.