### PR TITLE
Luv 0.5.14: async I/O

### DIFF
--- a/packages/luv/luv.0.5.14/opam
+++ b/packages/luv/luv.0.5.14/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+
+synopsis: "Binding to libuv: cross-platform asynchronous I/O"
+
+license: "MIT"
+homepage: "https://github.com/aantron/luv"
+doc: "https://aantron.github.io/luv"
+bug-reports: "https://github.com/aantron/luv/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/luv.git"
+
+depends: [
+  "base-unix" {build}
+  "ctypes" {>= "0.14.0"}
+  "dune" {>= "2.7.0"}
+  "integers" {>= "0.3.0"}
+  "ocaml" {>= "4.03.0"}
+
+  "alcotest" {with-test & >= "0.8.1"}
+  "base-unix" {with-test}
+  "odoc" {with-doc & = "2.4.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "Luv is a binding to libuv, the cross-platform C library that does
+asynchronous I/O in Node.js and runs its main loop.
+
+Besides asynchronous I/O, libuv also supports multiprocessing and
+multithreading. Multiple event loops can be run in different threads. libuv also
+exposes a lot of other functionality, amounting to a full OS API, and an
+alternative to the standard module Unix."
+
+url {
+  src:
+    "https://github.com/aantron/luv/releases/download/0.5.14/luv-0.5.14.tar.gz"
+  checksum: [
+    "sha256=8e01b4a50c8876cdd98d8e245c0687c4dc4d883aed161ad9c5ace1fb1fdaae99"
+  ]
+}


### PR DESCRIPTION
From the [changelog](https://github.com/aantron/luv/releases/tag/0.5.14):

> Bugs fixed
>
> - `const`-ness wrapper was harmful on GCC 14 and ctypes 0.23.0 (aantron/luv#159, reported Olaf Hering).
> - Need quotes in path expansion during build (aantron/luv#160, @tobil4sk).