### PR TITLE
conan: restrict re to < 1.12.0

### DIFF
--- a/packages/conan/conan.0.0.5/opam
+++ b/packages/conan/conan.0.0.5/opam
@@ -11,7 +11,7 @@ doc: "https://mirage.github.io/conan/"
 bug-reports: "https://github.com/mirage/conan/issues"
 depends: [
   "ocaml"               {>= "4.08.0"}
-  "re"                  {>= "1.11.0"}
+  "re"                  {>= "1.11.0" & < "1.12.0"}
   "dune"                {>= "2.9.0"}
   "uutf"
   "ptime"


### PR DESCRIPTION
observed in https://github.com/ocaml/opam-repository/pull/26497 //cc @dinosaure @rgrinberg https://github.com/ocaml/opam-repository/pull/26439

```
== ERROR while compiling conan.0.0.5 ========================================#
context              2.3.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
path                 ~/.opam/4.14/.opam-switch/build/conan.0.0.5
command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p conan -j 39
exit-code            1
env-file             ~/.opam/log/conan-8-2d12a7.env
output-file          ~/.opam/log/conan-8-2d12a7.out
 # output ###
(cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.conan.objs/byte -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/re/pcre -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/uutf -intf-suffix .ml -no-alias-deps -open Conan__ -o src/.conan.objs/byte/conan__Serialize.cmo -c -impl src/serialize.ml)
File "src/serialize.ml", line 82, characters 6-10:
82 |       !lst;
           ^^^^
Error: This expression has type Re__Cset.c list
       but an expression was expected of type int list
       Type Re__Cset.c is not compatible with type int
```