### PR TITLE
[new release] piaf (0.2.0)

### DIFF
--- a/packages/lambda-runtime/lambda-runtime.0.1.0/opam
+++ b/packages/lambda-runtime/lambda-runtime.0.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "result"
   "yojson" {>= "1.6.0" & < "2.0.0"}
   "ppx_deriving_yojson"
-  "piaf"
+  "piaf" {< "0.2.0"}
   "uri"
   "logs"
   "lwt"

--- a/packages/otoggl/otoggl.0.3.2/opam
+++ b/packages/otoggl/otoggl.0.3.2/opam
@@ -13,7 +13,7 @@ depends: [
   "atdgen-runtime" {>= "2"}
   "base64" {>= "3"}
   "containers" {>= "3.6"}
-  "piaf" {>= "0.1.0"}
+  "piaf" {>= "0.1.0" & < "0.2.0"}
   "ppx_deriving" {build}
   "ptime" {>= "1.0.0"}
   "alcotest" {with-test}

--- a/packages/piaf/piaf.0.2.0/opam
+++ b/packages/piaf/piaf.0.2.0/opam
@@ -38,7 +38,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/piaf/piaf.0.2.0/opam
+++ b/packages/piaf/piaf.0.2.0/opam
@@ -20,9 +20,9 @@ depends: [
   "gluten-eio"
   "h2-eio" {>= "0.13.0"}
   "httpun-ws" {>= "0.2.0"}
-  "pecu"
+  "pecu"  {>= "0.4"}
   "prettym"
-  "unstrctrd"
+  "unstrctrd" {>= "0.2"}
   "eio_main" {>= "1.0"}
   "dune-site" {with-test}
   "alcotest" {with-test}

--- a/packages/piaf/piaf.0.2.0/opam
+++ b/packages/piaf/piaf.0.2.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "An HTTP library with HTTP/2 support written entirely in OCaml"
+description:
+  "Piaf is an HTTP library and webserver written entirely in OCaml."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/piaf"
+bug-reports: "https://github.com/anmonteiro/piaf/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "5.1"}
+  "logs"
+  "eio-ssl" {>= "0.3.0"}
+  "magic-mime"
+  "ssl"
+  "uri"
+  "ipaddr"
+  "httpun-eio" {>= "0.2.0"}
+  "gluten-eio"
+  "h2-eio" {>= "0.13.0"}
+  "httpun-ws" {>= "0.2.0"}
+  "pecu"
+  "prettym"
+  "unstrctrd"
+  "eio_main" {>= "1.0"}
+  "dune-site" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/piaf.git"
+url {
+  src:
+    "https://github.com/anmonteiro/piaf/releases/download/0.2.0/piaf-0.2.0.tbz"
+  checksum: [
+    "sha256=07fa9009a52faeaae6d86116e75007f5279b185c7bc7c95aab9455f2107370fb"
+    "sha512=dfde4bd0a5c8a3b795a8e3d6f6e1f9f1864a9eb0a1b96763c17515d771566af7623ca64db671a8dce2c7838dad08d8465db98f5e4f8dcf5e1a386ef5b29da56c"
+  ]
+}
+x-commit-hash: "f67d4ccb230248a5f913f0daa2dd41799c48ffa5"

--- a/packages/vercel/vercel.0.1.0/opam
+++ b/packages/vercel/vercel.0.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "yojson"
   "lwt"
   "base64"
-  "piaf"
+  "piaf" {< "0.2.0"}
   "ppx_deriving_yojson"
   "lambda-runtime" {=version}
   "alcotest" {with-test}


### PR DESCRIPTION
An HTTP library with HTTP/2 support written entirely in OCaml

- Project page: <a href="https://github.com/anmonteiro/piaf">https://github.com/anmonteiro/piaf</a>

##### CHANGES:

- Improve certificate checking and authentication
  ([anmonteiro/piaf#93](https://github.com/anmonteiro/piaf/pull/93)) -
  [@Firgeis](https://github.com/Firgeis)
- Check certificate SAN IP address when appropriate
  ([anmonteiro/piaf#96](https://github.com/anmonteiro/piaf/pull/96)) -
  [@Firgeis](https://github.com/Firgeis)
- Close the file descriptor when failing to open a connection
  ([anmonteiro/piaf#97](https://github.com/anmonteiro/piaf/pull/97)) -
  [@EduardoRFS](https://github.com/EduardoRFS)
- Yield to other threads when reading a message body. This improves fairness
  for large message bodies
  ([anmonteiro/piaf#100](https://github.com/anmonteiro/piaf/pull/100))
- Add error handling to `Response.of_file`
  ([anmonteiro/piaf#103](https://github.com/anmonteiro/piaf/pull/103))
- Add `Client.send` which sends a `Request.t`
  ([anmonteiro/piaf#110](https://github.com/anmonteiro/piaf/pull/110))
- openssl: set the client verify callback
  ([anmonteiro/piaf#112](https://github.com/anmonteiro/piaf/pull/112))
- Piaf.Response: add `or_internal_error`
  ([anmonteiro/piaf#120](https://github.com/anmonteiro/piaf/pull/120))
- Piaf.Response: Add `Body.sendfile` and `Response.sendfile`
  ([anmonteiro/piaf#124](https://github.com/anmonteiro/piaf/pull/124))
- Piaf.Config: Add `config.flush_headers_immediately`
  ([anmonteiro/piaf#125](https://github.com/anmonteiro/piaf/pull/125))
- Piaf.Server: Add `config.shutdown_timeout` to wait before shutting down the
  Piaf server ([anmonteiro/piaf#174](https://github.com/anmonteiro/piaf/pull/174))
- Websocket support ([anmonteiro/piaf#139](https://github.com/anmonteiro/piaf/pull/139))
- Multicore support ([anmonteiro/piaf#151](https://github.com/anmonteiro/piaf/pull/151))
- Allow binding to UNIX domain socket
  ([anmonteiro/piaf#161](https://github.com/anmonteiro/piaf/pull/161))
- Don't send invalid HTTP/2 headers
  ([anmonteiro/piaf#197](https://github.com/anmonteiro/piaf/pull/197))
