### PR TITLE
Package vscoq-language-server.2.2.0

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.2.0/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/coq-community/vscoq"
+bug-reports: "https://github.com/coq-community/vscoq/issues"
+dev-repo: "git+https://github.com/coq-community/vscoq"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { >= "4.14" }
+  "dune" { >= "3.5" }
+  "coq-core" { ((>= "8.18" < "8.21") | (= "dev")) }
+  "coq-stdlib" { ((>= "8.18" < "8.21") | (= "dev")) }
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "ppx_optcomp"
+  "result" { >= "1.5" }
+  "lsp" { >= "1.15" < "1.19"}
+  "sel" {>= "0.4.0"}
+]
+synopsis: "VSCoq language server"
+description: """
+LSP based language server for Coq and its VSCoq user interface
+"""
+url {
+  src:
+    "https://github.com/coq-community/vscoq/releases/download/v2.2.0/vscoq-language-server-2.2.0.tar.gz"
+  checksum: [
+    "md5=1a5e8a51bc5c10d50055364c2d58ef24"
+    "sha512=f044284a187a11161740ea93be2d4ffe6a52db3e9e84fbd45b561dc1edd760ecf76a3792609f8e339aba637e1e6a417d47ecaee6a1d9a54d8352a38e9363ec8c"
+  ]
+}

--- a/packages/vscoq-language-server/vscoq-language-server.2.2.0/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.2.0/opam
@@ -30,6 +30,7 @@ depends: [
   "sel" {>= "0.4.0"}
 ]
 synopsis: "VSCoq language server"
+available: arch != "arm32" & arch != "x86_32"
 description: """
 LSP based language server for Coq and its VSCoq user interface
 """


### PR DESCRIPTION
### `vscoq-language-server.2.2.0`
VSCoq language server
LSP based language server for Coq and its VSCoq user interface



---
* Homepage: https://github.com/coq-community/vscoq
* Source repo: git+https://github.com/coq-community/vscoq
* Bug tracker: https://github.com/coq-community/vscoq/issues

---
:camel: Pull-request generated by opam-publish v2.0.3