### PR TITLE
[ci] Add cygwin bin directories to PATH

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,6 +41,8 @@ jobs:
         run: |
           D:\opam\bin\opam --version
           "D:\opam\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "D:\opamroot\.cygwin\root\usr\x86_64-w64-mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "D:\opamroot\.cygwin\root\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Init opam
         if: steps.cache-opam.outputs.cache-hit != 'true'


### PR DESCRIPTION
Without these PATH entries, cygwin's binaries never get used. This means that `make` and `bash` and other executables are not used from cygwin, but from other preinstalled packages in the github actions runner (e.g. git bash and the preinstalled mingw).

This causes build issues with certain packages, see:
https://github.com/ocaml/opam-repository/pull/26501
https://github.com/aantron/luv/issues/162