### PR TITLE
[ocamlfind] Fix critical windows bug in `norm_dir`

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.9.5/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.5/opam
@@ -34,7 +34,7 @@ install: [
   [make "install"]
   ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
 ]
-patches: ["0001-Fix-bug-when-installing-with-a-system-compiler.patch"]
+patches: ["0001-Fix-bug-when-installing-with-a-system-compiler.patch" "0002-Fix-from-https-github.com-ocaml-ocamlfind-pull-64.patch"]
 dev-repo: "git+https://github.com/ocaml/ocamlfind.git"
 url {
   src: "http://download.camlcity.org/download/findlib-1.9.5.tar.gz"
@@ -49,6 +49,14 @@ extra-source "0001-Fix-bug-when-installing-with-a-system-compiler.patch" {
   checksum: [
     "sha256=66776698f5ea1e686f5b81014119a5f0d48278604a721036c7def0346a4749a3"
     "md5=130d3d6fe399948ed7991b7756f50dc3"
+  ]
+}
+extra-source "0002-Fix-from-https-github.com-ocaml-ocamlfind-pull-64.patch" {
+  src:
+    "https://gist.githubusercontent.com/ejgallego/c39fc0509cc34629c54ea7f3cc7cf1a1/raw/4889981b1ef70bede3c5cfa6adb53bff1256eab5/0002-Fix-from-https-github.com-ocaml-ocamlfind-pull-64.patch"
+  checksum: [
+    "sha256=01669773070b7bf098d89b233924fe43de785add8e7da24c1e6740d86d884797"
+    "md5=c366bb2beb071c7216ad64dae8ac4b4c"
   ]
 }
 


### PR DESCRIPTION
This is making a few packages (for example `coq-core`, but others too) fail in the Windows native CI.

Workarounds https://github.com/ocaml/opam/issues/6129