### PR TITLE
[new release] coq-serapi (8.20.0+0.20.0)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.20.0+0.20.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.20.0+0.20.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "LGPL-2.1-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "dune"                { >= "2.9.1"                     }
+  "ocaml"               { >= "4.12.0"                    }
+  "coq"                 { >= "8.20" & < "8.21" | = "dev" }
+  "cmdliner"            { >= "1.1.0"                     }
+  "ocamlfind"           { >= "1.8.0"                     }
+  "sexplib"             { >= "v0.13.0"                   }
+  "dune"                { >= "2.0.1"                     }
+  "cmdliner"            { >= "1.1.0"               }
+  "ocamlfind"           { >= "1.8.0"               }
+  "ppx_import"          { >= "1.11.0" & < "2.0"    }
+  "ppx_deriving"        { >= "4.2.1"               }
+  "ppx_deriving_yojson" { >= "3.4" }
+  "sexplib"             { >= "v0.13.0" & < "v0.18" }
+  "ppx_sexp_conv"       { >= "v0.13.0" & < "v0.18" }
+  "ppx_compare"         { >= "v0.13.0" & < "v0.18" }
+  "ppx_hash"            { >= "v0.13.0" & < "v0.18" }
+]
+
+conflicts: [
+  "result" {< "1.5"}
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ [ "dune" "runtest" "-p" name "-j" jobs ] ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.20.0%2B0.20.0/coq-serapi-8.20.0.0.20.0.tbz"
+  checksum: [
+    "sha256=ead9382f111ea385008fe9037513ff1f738dd90d8e989b8d1a0c9290963d9afe"
+    "sha512=b29103c2d1eb3cf8a33fa9ddf26b5a6c89e7277cd31256589bcae8a89c37a3de7a3c3e7fe5d376358e874d44dc6c60ab96736cbd1037511ab36705e9f40f0ade"
+  ]
+}
+x-commit-hash: "e052cadeaace39e00f9dcef9e768fc0fa4ac1d3b"


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

 - [serapi] (!) support for Coq 8.20, thanks to all the developers
            that contributed compatibility patches.
 - [serlib] Support `micromega_core` plugin (@ejgallego)
 - [serlib] Compat with ppx_deriving 6 (@ejgallego)
 - [serlib] Move `serlib` sources to `coq-lsp` (@ejgallego, ejgallego/coq-serapi#409)
 - [general] Drop support for OCaml 4.09-4.11 (@ejgallego, ejgallego/coq-serapi#409)
 - [serlib] Embed `serlib` from `coq-lsp` as to help 8.20 release (@ejgallego)
 - [meta] Add license info for sertop.el (@ejgallego, @SnarkBoojum, fixes ejgallego/coq-serapi#411)
