### PR TITLE
[new release] dream-html (2 packages) (3.6.2)

### DIFF
--- a/packages/dream-html/dream-html.3.6.2/opam
+++ b/packages/dream-html/dream-html.3.6.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.6.2/dream-html-3.6.2.tbz"
+  checksum: [
+    "sha256=0657805451965e0b968af0d8c25be37e0b3dc62497c36fc5e2e1f45d680f702d"
+    "sha512=0a8a2695ade2684e52d539b589f63592d4b8588dc2a2a5ac3eed8aa1bb5abb6533e2572007d78d7aa60b487e7fcf8bec279398857449580d202e662f1d0fc08a"
+  ]
+}
+x-commit-hash: "fd1918c04e0d70bf784c4176595e36c9c26e05b2"

--- a/packages/pure-html/pure-html.3.6.2/opam
+++ b/packages/pure-html/pure-html.3.6.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.6.2/dream-html-3.6.2.tbz"
+  checksum: [
+    "sha256=0657805451965e0b968af0d8c25be37e0b3dc62497c36fc5e2e1f45d680f702d"
+    "sha512=0a8a2695ade2684e52d539b589f63592d4b8588dc2a2a5ac3eed8aa1bb5abb6533e2572007d78d7aa60b487e7fcf8bec279398857449580d202e662f1d0fc08a"
+  ]
+}
+x-commit-hash: "fd1918c04e0d70bf784c4176595e36c9c26e05b2"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
