### PR TITLE
Add: brr.0.0.7

### DIFF
--- a/packages/brr/brr.0.0.7/opam
+++ b/packages/brr/brr.0.0.7/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Browser programming toolkit for OCaml"
+description: """\
+Brr is a toolkit for programming browsers in OCaml with the
+[`js_of_ocaml`][jsoo] compiler. It provides:
+
+* Interfaces to a selection of browser APIs.
+* An OCaml console developer tool for live interaction 
+  with programs running in web pages.
+* A JavaScript FFI for idiomatic OCaml programming.
+
+Brr is distributed under the ISC license. It depends on the
+`js_of_ocaml` compiler and runtime – but not on its libraries or
+syntax extension.
+
+[jsoo]: https://ocsigen.org/js_of_ocaml
+
+Homepage: <https://erratique.ch/software/brr>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The brr programmers"
+license: ["ISC" "BSD-3-Clause"]
+tags: ["reactive" "declarative" "frp" "front-end" "browser" "org:erratique"]
+homepage: "https://erratique.ch/software/brr"
+doc: "https://erratique.ch/software/brr/doc/"
+bug-reports: "https://github.com/dbuenzli/brr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "js_of_ocaml-compiler" {>= "5.5.0"}
+  "js_of_ocaml-toplevel" {>= "5.5.0"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/brr.git"
+url {
+  src: "https://erratique.ch/software/brr/releases/brr-0.0.7.tbz"
+  checksum:
+    "sha512=4b3d42eb6a32c1d6f1c5ef003f5311b5029156b31f6e51af098b695c769699e0304b66afd2dd574ecf1084e095bbbc4eac552daab083766cd81ed2f1d9897d51"
+}


### PR DESCRIPTION
* Add: `brr.0.0.7` [home](https://erratique.ch/software/brr), [doc](https://erratique.ch/software/brr/doc/), [issues](https://github.com/dbuenzli/brr/issues)  
  *Browser programming toolkit for OCaml*


---

#### `brr` v0.0.7 2024-09-09 Zagreb

- Add support for `wasm_of_ocaml`. Thanks to Jérôme Vouillon
  for the patchset ([#51](https://github.com/dbuenzli/brr/issues/51)).
- Deprecate `Tarray.{get,set}`. These function become less efficient
  in order to support wasm_of_ocaml. Use `Tarray.to_bigarray1` to
  convert to a bigarray and operate on that instead ([#51](https://github.com/dbuenzli/brr/issues/51)).
- Fix `Jstr.pad_{start,end}` specifying the [pad] optional argument
  was being ignored. Thanks to Valentin Gatien-Baron for noticing.
- Add `Jv.is_array` a binding to `Array.isArray` which is the
  recommended way to test a value for an array. Thanks to
  Valentin Gatien-Baron for the patch ([#59](https://github.com/dbuenzli/brr/issues/59)).
- Fix `Brr_webaudio.Audio.Node.Media_element_source.create` the
  `MediaElementAudioSourceNode` property was mispelled. Thanks
  to Emile Trotignon for the report and the patch ([#57](https://github.com/dbuenzli/brr/issues/57)).
- Fix `Fut.tick` in the presence of effects compilation.
- Add `At.download` attribute constructor.
- Fix `At.draggable`. It is enumerated not a boolean attribute. Thanks
  to Ulysse for the patch ([#55](https://github.com/dbuenzli/brr/issues/55)).
- `At.class'` attribute values. Allow to specify multiple classes in a
  single `At.t` value. This was not possible before which is
  surprising. Thanks to Basile Clément for noticing and patching
  ([#53](https://github.com/dbuenzli/brr/issues/53)).

---

Use `b0 -- .opam publish brr.0.0.7` to update the pull request.