### PR TITLE
Package cvc5.1.2.0

### DIFF
--- a/packages/cvc5/cvc5.1.2.0/opam
+++ b/packages/cvc5/cvc5.1.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for the cvc5 SMT solver"
+description: "OCaml bindings for the cvc5 SMT solver"
+maintainer: "João Pereira <joaomhmpereira@tecnico.ulisboa.pt>"
+authors: "João Pereira <joaomhmpereira@tecnico.ulisboa.pt>"
+license: "GPL-3.0-only"
+homepage: "https://github.com/formalsec/ocaml-cvc5"
+bug-reports: "https://github.com/formalsec/ocaml-cvc5/issues"
+depends: [
+  "dune" {>= "3.10"}
+  "ocaml" {>= "4.12"}
+  "conf-gcc" {build}
+  "conf-g++" {build}
+  "conf-gmp" {build}
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+  "conf-python-3-dev" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/formalsec/ocaml-cvc5.git"
+url {
+  src:
+    "https://github.com/formalsec/ocaml-cvc5/releases/download/v1.2.0/ocaml-cvc5-v1.2.0.tar.gz"
+  checksum: [
+    "md5=7bbd386569ee1350bf0d76282db37ce7"
+    "sha512=f128abf96eb08a888d7996ad8decb8fe4c553e6dee1eef41b7bb4a55e78e0295d82c02155feafb096847217becdf19285c7ee2fef27db3f4799bae01f99d42d5"
+  ]
+}

--- a/packages/cvc5/cvc5.1.2.0/opam
+++ b/packages/cvc5/cvc5.1.2.0/opam
@@ -15,6 +15,8 @@ depends: [
   "conf-cmake" {build}
   "conf-python-3" {build}
   "conf-python-3-dev" {build}
+  "conf-python3-pyparsing" {build}
+  "conf-python3-tomli" {build}
   "odoc" {with-doc}
 ]
 build: [
@@ -36,7 +38,7 @@ url {
   src:
     "https://github.com/formalsec/ocaml-cvc5/releases/download/v1.2.0/ocaml-cvc5-v1.2.0.tar.gz"
   checksum: [
-    "md5=7bbd386569ee1350bf0d76282db37ce7"
-    "sha512=f128abf96eb08a888d7996ad8decb8fe4c553e6dee1eef41b7bb4a55e78e0295d82c02155feafb096847217becdf19285c7ee2fef27db3f4799bae01f99d42d5"
+    "md5=f3bef1351994740ad6a11f55f77b4fbf"
+    "sha512=2b526cf9cd9cb4b240466bd69d8608a2257e57930b07ebc99c57aa2633bde45d40f4e10797794cbcf6d9f7ca78dd91d4c3d54b516ac04f625518159b4189833a"
   ]
 }


### PR DESCRIPTION
### `cvc5.1.2.0`
OCaml bindings for the cvc5 SMT solver
OCaml bindings for the cvc5 SMT solver



---
* Homepage: https://github.com/formalsec/ocaml-cvc5
* Source repo: git+https://github.com/formalsec/ocaml-cvc5.git
* Bug tracker: https://github.com/formalsec/ocaml-cvc5/issues

---
:camel: Pull-request generated by opam-publish v2.3.1