### PR TITLE
[new release] builder-web (0.2.0)

### DIFF
--- a/packages/builder-web/builder-web.0.2.0/opam
+++ b/packages/builder-web/builder-web.0.2.0/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+maintainer: "Reynir Björnsson <reynir@reynir.dk>"
+authors: ["Reynir Björnsson <reynir@reynir.dk>"]
+homepage: "https://github.com/robur-coop/builder-web"
+dev-repo: "git+https://github.com/robur-coop/builder-web.git"
+bug-reports: "https://github.com/robur-coop/builder-web/issues"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian"}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7.0"}
+  "builder" {>= "0.4.0"}
+  "dream" {>= "1.0.0~alpha7"}
+  "bos"
+  "ohex" {>= "0.2.0"}
+  "lwt" {>= "5.7.0"}
+  "caqti" {>= "2.1.2"}
+  "caqti-lwt"
+  "caqti-driver-sqlite3"
+  "mirage-crypto-rng" {>= "0.11.0"}
+  "kdf"
+  "opam-core"
+  "opam-format" {>= "2.1.0"}
+  "metrics" {>= "0.3.0"}
+  "metrics-lwt" {>= "0.3.0"}
+  "metrics-influx" {>= "0.3.0"}
+  "metrics-rusage" {>= "0.3.0"}
+  "ipaddr"
+  "tyxml" {>= "4.3.0"}
+  "ptime"
+  "duration"
+  "asn1-combinators" {>= "0.3.0"}
+  "logs"
+  "cmdliner" {>= "1.1.0"}
+  "uri"
+  "fmt" {>= "0.8.7"}
+  "cmarkit" {>= "0.3.0"}
+  "tar" {>= "3.0.0"}
+  "tar-unix" {>= "3.0.0"}
+  "owee"
+  "solo5-elftool" {>= "0.3.0"}
+  "decompress" {>= "1.5.0"}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {>= "1.2.0" & with-test}
+  "ppx_deriving" {with-test}
+  "ppx_deriving_yojson" {with-test}
+  "yojson" {with-test}
+]
+
+synopsis: "Web interface for builder"
+description: """
+Builder-web takes in submissions of builds, typically from [builder](https://github.com/robur-coop/builder/), and displays the produced artifacts in a way that makes it easy to compare checksums and build status.
+Produced binaries can be downloaded and executed.
+[builds.robur.coop](https://builds.robur.coop/) itself runs builder-web.
+"""
+url {
+  src:
+    "https://github.com/robur-coop/builder-web/releases/download/v0.2.0/builder-web-0.2.0.tbz"
+  checksum: [
+    "sha256=5f4f388368a6be57ca59a4463f00f0e52262fd45b85d8e8d757f1a0cf84b9df2"
+    "sha512=ce3572c962dc46b68237b62a48da6d8b431a3ac3ff4b786efa482142332f641bcc8793626b6c97b43912a5da1103c6246e97ecd608df75a32bc7c54c47acbe76"
+  ]
+}
+x-commit-hash: "402894405dea558e6ad9bc3466932d78e87d4f71"


### PR DESCRIPTION
Web interface for builder

- Project page: <a href="https://github.com/robur-coop/builder-web">https://github.com/robur-coop/builder-web</a>

##### CHANGES:

A whole slew of changes. Internally, we made a lot of incremental changes and improvements without doing a release. Thus this release is rather big. There is a lot of database migrations to apply, and unfortunately they have to be applied one at a time.

* Add a /failed-builds/ endpoint that lists the most recent failed builds.
* By default don't display failed builds on the front page.
* Times are printed with the 'Z' time zone offset indicator.
* Link to comparisons of builds take into account whether the "input", among others the list of dependencies, is different.
* New subcommand `builder-db extract-build` takes a build UUID and extracts the builder "full" file.
* Add /job/<job>/build/<build>/all.tar.gz endpoint with a gzip compressed tar archive of all build artifacts.
* Visual overhaul.
* Add (optional) visualizations displaying package dependencies ("opam-graph") and for unikernels a "modulectomy" view of how much each OCaml module is contributing to the final binary size. The visualizations are read from a cache on disk and can be generated from a script.
* A script hook is added on file upload. It may be used to generate visualizations or publish system packages to a repository.
* The 404 file not found page tries to be more informative.
* The build page for a unikernel build displays the solo5 device manifest, e.g. `with block devices "storage", and net devices "service"`.
* URLs with trailing slash redirect to without the trailing slash.
* Builder-web will try to be more helpful if its database doesn't exist or the database version is wrong.
* The opam diff works for mirage 4 unikernels taking into account the opam-monorepo/duniverse packages.
* Markdown rendering is now done using cmarkit instead of omd.
* Builder-web doesn't display jobs older than 30 days (customizable with `--expired-jobs` command line argument) on the front page.
* Build artifacts are stored by their content, and artifacts are automatically deduplicated. This makes builder-web much more space efficient on deployments that don't use deduplication on the filesystem level.
* New subcommands `builder-db vacuum *` to remove older builds. Can be called from a cron job to keep disk usage bounded.
* Lots of other improvements and bug fixes.
