### PR TITLE
[new release] moonpool (3 packages) (0.7)

### DIFF
--- a/packages/moonpool-io/moonpool-io.0.7/opam
+++ b/packages/moonpool-io/moonpool-io.0.7/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Async IO for moonpool, relying on picos (experimental)"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+homepage: "https://github.com/c-cube/moonpool"
+bug-reports: "https://github.com/c-cube/moonpool/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "moonpool" {= version}
+  "picos_io" {>= "0.5" & < "0.6"}
+  "ocaml" {>= "5.0"}
+  "trace" {with-test}
+  "trace-tef" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/moonpool.git"
+url {
+  src:
+    "https://github.com/c-cube/moonpool/releases/download/v0.7/moonpool-0.7.tbz"
+  checksum: [
+    "sha256=c4a1f974200530ab7f6014de3a369fdbb260ff454183640f32e51ba3fec51b15"
+    "sha512=865daabb96e3d60f88ecee9fc9030dad8b257fff4121b404e882d8a8d6687b737beb6e22366f52eb14e770dfab28b326853a1d3d883fa19bbd791d8450b40f8b"
+  ]
+}
+x-commit-hash: "0d8767f45f9cf8730724acb67e74aa57db7217b9"

--- a/packages/moonpool-lwt/moonpool-lwt.0.7/opam
+++ b/packages/moonpool-lwt/moonpool-lwt.0.7/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Event loop for moonpool based on Lwt-engine (experimental)"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+homepage: "https://github.com/c-cube/moonpool"
+bug-reports: "https://github.com/c-cube/moonpool/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "moonpool" {= version}
+  "ocaml" {>= "5.0"}
+  "lwt"
+  "base-unix"
+  "trace" {with-test}
+  "trace-tef" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/moonpool.git"
+url {
+  src:
+    "https://github.com/c-cube/moonpool/releases/download/v0.7/moonpool-0.7.tbz"
+  checksum: [
+    "sha256=c4a1f974200530ab7f6014de3a369fdbb260ff454183640f32e51ba3fec51b15"
+    "sha512=865daabb96e3d60f88ecee9fc9030dad8b257fff4121b404e882d8a8d6687b737beb6e22366f52eb14e770dfab28b326853a1d3d883fa19bbd791d8450b40f8b"
+  ]
+}
+x-commit-hash: "0d8767f45f9cf8730724acb67e74aa57db7217b9"

--- a/packages/moonpool/moonpool.0.7/opam
+++ b/packages/moonpool/moonpool.0.7/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Pools of threads supported by a pool of domains"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["thread" "pool" "domain" "futures" "fork-join"]
+homepage: "https://github.com/c-cube/moonpool"
+bug-reports: "https://github.com/c-cube/moonpool/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0"}
+  "either" {>= "1.0"}
+  "trace" {with-test}
+  "trace-tef" {with-test}
+  "qcheck-core" {with-test & >= "0.19"}
+  "thread-local-storage" {>= "0.2" & < "0.3"}
+  "odoc" {with-doc}
+  "hmap" {with-test}
+  "picos" {>= "0.5" & < "0.6"}
+  "picos_std" {>= "0.5" & < "0.6"}
+  "mdx" {>= "1.9.0" & with-test}
+]
+depopts: [
+  "hmap"
+  "trace" {>= "0.6"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/moonpool.git"
+url {
+  src:
+    "https://github.com/c-cube/moonpool/releases/download/v0.7/moonpool-0.7.tbz"
+  checksum: [
+    "sha256=c4a1f974200530ab7f6014de3a369fdbb260ff454183640f32e51ba3fec51b15"
+    "sha512=865daabb96e3d60f88ecee9fc9030dad8b257fff4121b404e882d8a8d6687b737beb6e22366f52eb14e770dfab28b326853a1d3d883fa19bbd791d8450b40f8b"
+  ]
+}
+x-commit-hash: "0d8767f45f9cf8730724acb67e74aa57db7217b9"


### PR DESCRIPTION
Pools of threads supported by a pool of domains

- Project page: <a href="https://github.com/c-cube/moonpool">https://github.com/c-cube/moonpool</a>

##### CHANGES:

- add `Moonpool_fiber.spawn_top_ignore`
- add `moonpool-io`, based on `picos_io` (still very experimental)
- move to picos as the foundation layer for concurrency primitives (c-cube/moonpool#30)
- move to `thread-local-storage` 0.2 with get/set API
