### PR TITLE
Add: qrc.0.2.0

### DIFF
--- a/packages/qrc/qrc.0.2.0/opam
+++ b/packages/qrc/qrc.0.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "QR code encoder for OCaml"
+description: """\
+Qrc encodes your data into QR codes. It has built-in QR matrix
+renderers for SVG, ANSI terminal and text.
+
+Qrc is distributed under the ISC license. It has no dependencies.
+
+Homepage: https://erratique.ch/software/qrc"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The qrc programmers"
+license: "ISC"
+tags: ["qr-code" "codec" "org:erratique"]
+homepage: "https://erratique.ch/software/qrc"
+doc: "https://erratique.ch/software/qrc/doc"
+bug-reports: "https://github.com/dbuenzli/qrc/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "b0" {dev & with-test}
+]
+depopts: ["cmdliner"]
+conflicts: [
+  "cmdliner" {< "1.3.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/qrc.git"
+url {
+  src: "https://erratique.ch/software/qrc/releases/qrc-0.2.0.tbz"
+  checksum:
+    "sha512=5a65088dfc6994b2d4aee096a3082386099dbcf4b0682e8fb16f21a9b5d3f218ecf109f7f7d3c60c6ccc378d83a3be2aa412ec0196cc75d671677931ad58d668"
+}


### PR DESCRIPTION
* Add: `qrc.0.2.0` [home](https://erratique.ch/software/qrc), [doc](https://erratique.ch/software/qrc/doc), [issues](https://github.com/dbuenzli/qrc/issues)  
  *QR code encoder for OCaml*


---

#### `qrc` v0.2.0 2024-09-10 Zagreb

- `Qrc.Matrix.to_svg`, change matrix rendering strategy. The result doesn't
  use xlink (no risk of identifier clashes when embedding), renders faster in
  browsers and is more compact ([#1](https://github.com/dbuenzli/qrc/issues/1)). Thanks to Alain Frisch for the patch.

- `qrtrip` tool. Fix `stdin` reading bug, newlines were being dropped
  and arbitrary binary input was impossible ([#5](https://github.com/dbuenzli/qrc/issues/5)).

- `qrtrip` tool. Incompatible change to fix the footgun UI. Before,
  the optional positional argument was the message to QR encode, but
  it feels natural to specify a file to QR encode. In which case you
  would silently QR encode a file path… The optional argument is now a
  file to read by default. Use option `-m/--message` to treat the
  argument as the message and make the tool operate as it used to.

- Require OCaml 4.14.0.

---

Use `b0 -- .opam publish qrc.0.2.0` to update the pull request.