### PR TITLE
Add: mtime.2.1.0, ptime.1.2.0

### DIFF
--- a/packages/mtime/mtime.2.1.0/opam
+++ b/packages/mtime/mtime.2.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Monotonic wall-clock time for OCaml"
+description: """\
+Mtime has platform independent support for monotonic wall-clock time
+in pure OCaml. This time increases monotonically and is not subject to
+operating system calendar time adjustments. The library has types to
+represent nanosecond precision timestamps and time spans.
+
+The additional Mtime_clock library provide access to a system
+monotonic clock.
+
+Mtime has a no dependency. Mtime_clock depends on your system library
+or JavaScript runtime system. Mtime and its libraries are distributed
+under the ISC license.
+
+Home page: <http://erratique.ch/software/mtime>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The mtime programmers"
+license: "ISC"
+tags: ["time" "monotonic" "system" "org:erratique"]
+homepage: "https://erratique.ch/software/mtime"
+doc: "https://erratique.ch/software/mtime/doc/"
+bug-reports: "https://github.com/dbuenzli/mtime/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build & != "0.9.0"}
+  "topkg" {build & >= "1.0.3"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/mtime.git"
+url {
+  src: "https://erratique.ch/software/mtime/releases/mtime-2.1.0.tbz"
+  checksum:
+    "sha512=a6619f1a3f1a5b32b7a9a067b939f94e6c66244eb90762d41f2cb1c9af852dd7d270fedb20e2b9b61875d52ba46e24af6ebf5950d1284b0b75b2fd2c380d9af3"
+}

--- a/packages/ptime/ptime.1.2.0/opam
+++ b/packages/ptime/ptime.1.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "POSIX time for OCaml"
+description: """\
+Ptime has platform independent POSIX time support in pure OCaml. It
+provides a type to represent a well-defined range of POSIX timestamps
+with picosecond precision, conversion with date-time values,
+conversion with [RFC 3339 timestamps][rfc3339] and pretty printing to
+a human-readable, locale-independent representation.
+
+The additional Ptime_clock library provides access to a system POSIX
+clock and to the system's current time zone offset.
+
+Ptime is not a calendar library.
+
+Ptime has no dependency. Ptime_clock depends on your system library or
+JavaScript runtime system. Ptime and its libraries are distributed
+under the ISC license.
+
+[rfc3339]: http://tools.ietf.org/html/rfc3339
+
+Home page: <http://erratique.ch/software/ptime>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The ptime programmers"
+license: "ISC"
+tags: ["time" "posix" "system" "org:erratique"]
+homepage: "https://erratique.ch/software/ptime"
+doc: "https://erratique.ch/software/ptime/doc/"
+bug-reports: "https://github.com/dbuenzli/ptime/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build & != "0.9.0"}
+  "topkg" {build & >= "1.0.3"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/ptime.git"
+url {
+  src: "https://erratique.ch/software/ptime/releases/ptime-1.2.0.tbz"
+  checksum:
+    "sha512=b0c3240dd9e777a5e60b5269eb2e312fc644d29ef55e257d2f2538c03bf62274173ed36e13858c44d2dbee8fe375c9c483e705706e4aa5b3b5c4609ca6324a5c"
+}


### PR DESCRIPTION
* Add: `mtime.2.1.0` [home](https://erratique.ch/software/mtime), [doc](https://erratique.ch/software/mtime/doc/), [issues](https://github.com/dbuenzli/mtime/issues)  
  *Monotonic wall-clock time for OCaml*
* Add: `ptime.1.2.0` [home](https://erratique.ch/software/ptime), [doc](https://erratique.ch/software/ptime/doc/), [issues](https://github.com/dbuenzli/ptime/issues)  
  *POSIX time for OCaml*


---

Use `b0 -- .opam publish mtime.2.1.0 ptime.1.2.0` to update the pull request.