### PR TITLE
httpun-ws-eio: remove erroneous quotes around "version"

### DIFF
--- a/packages/httpun-ws-eio/httpun-ws-eio.0.2.0/opam
+++ b/packages/httpun-ws-eio/httpun-ws-eio.0.2.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/anmonteiro/httpun-ws/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.08"}
-  "httpun-ws" {= "version"}
+  "httpun-ws" {= version}
   "digestif" {>= "1.2.0"}
   "gluten-eio" {>= "0.2.1"}
   "odoc" {with-doc}


### PR DESCRIPTION
cc @anmonteiro

Fixes the following problem:

```
% opam install httpun-ws.0.2.0 httpun-ws-eio.0.2.0
[ERROR] Package conflict!
  * Missing dependency:
    - httpun-ws >= version
    no matching version
```