### PR TITLE
Add: uucd.16.0.0, uucp.16.0.0, uunf.16.0.0, uuseg.16.0.0

### DIFF
--- a/packages/uucd/uucd.16.0.0/opam
+++ b/packages/uucd/uucd.16.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Unicode character database decoder for OCaml"
+description: """\
+Uucd is an OCaml module to decode the data of the [Unicode character 
+database][1] from its XML [representation][2]. It provides high-level 
+(but not necessarily efficient) access to the data so that efficient 
+representations can be extracted.
+
+Uucd is made of a single module, depends on [Xmlm][xmlm] and is distributed
+under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr44/
+[2]: http://www.unicode.org/reports/tr42/
+[xmlm]: http://erratique.ch/software/xmlm 
+
+Home page: <http://erratique.ch/software/uucd>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uucd programmers"
+license: "ISC"
+tags: ["unicode" "database" "decoder" "org:erratique"]
+homepage: "https://erratique.ch/software/uucd"
+doc: "https://erratique.ch/software/uucd/doc/Uucd"
+bug-reports: "https://github.com/dbuenzli/uucd/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "xmlm"
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/uucd.git"
+url {
+  src: "https://erratique.ch/software/uucd/releases/uucd-16.0.0.tbz"
+  checksum:
+    "sha512=8f9961d7f68414e08fdc2cb7fec0726be75b210cc2a10bc6e3dcc8e07e146f47bd8675671d0143428088e1e20d3e3c134233bfb86d2b9a76e772e515de929eae"
+}

--- a/packages/uucp/uucp.16.0.0/opam
+++ b/packages/uucp/uucp.16.0.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Unicode character properties for OCaml"
+description: """\
+Uucp is an OCaml library providing efficient access to a selection of
+character properties of the [Unicode character database].
+
+Uucp is distributed under the ISC license. It has no dependency.
+
+Home page: <http://erratique.ch/software/uucp>
+
+[Unicode character database]: http://www.unicode.org/reports/tr44/"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uucp programmers"
+license: "ISC"
+tags: ["unicode" "text" "character" "org:erratique"]
+homepage: "https://erratique.ch/software/uucp"
+doc: "https://erratique.ch/software/uucp/doc/"
+bug-reports: "https://github.com/dbuenzli/uucp/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "uucd" {with-test & dev & >= "16.0.0" & < "17.0.0"}
+  "uunf" {with-test}
+]
+depopts: ["uunf" "cmdliner"]
+conflicts: [
+  "uunf" {< "16.0.0" | >= "17.0.0"}
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-uunf"
+  "%{uunf:installed}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+post-messages:
+  "If the build fails with \"ocamlopt.opt got signal and exited\", issue 'ulimit -s unlimited' and retry."
+    {failure & (arch = "ppc64" | arch = "arm64")}
+dev-repo: "git+https://erratique.ch/repos/uucp.git"
+url {
+  src: "https://erratique.ch/software/uucp/releases/uucp-16.0.0.tbz"
+  checksum:
+    "sha512=5c06d8cadb2b011b1e4ac52e14732044f6ab8e9c11e1184950ff8629b26bd173f1264247623a635b8aa4033e287bfe42d709994f19a3d79f7cbfd20158aa4992"
+}

--- a/packages/uunf/uunf.16.0.0/opam
+++ b/packages/uunf/uunf.16.0.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Unicode text normalization for OCaml"
+description: """\
+Uunf is an OCaml library for normalizing Unicode text. It supports all
+Unicode [normalization forms]. The library is independent from any IO
+mechanism or Unicode text data structure and it can process text
+without a complete in-memory representation.
+
+Uunf is distributed under the ISC license. It has no dependency.
+
+[normalization forms]: http://www.unicode.org/reports/tr15/
+
+Homepage: <http://erratique.ch/software/uunf>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uunf programmers"
+license: "ISC"
+tags: ["unicode" "text" "normalization" "org:erratique"]
+homepage: "https://erratique.ch/software/uunf"
+doc: "https://erratique.ch/software/uunf/doc/Uunf"
+bug-reports: "https://github.com/dbuenzli/uunf/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "uucd" {dev & >= "16.0.0" & < "17.0.0"}
+]
+depopts: ["uutf" "cmdliner"]
+conflicts: [
+  "uutf" {< "1.0.0"}
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-uutf"
+  "%{uutf:installed}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+post-messages:
+  "If the build fails with \"ocamlopt.opt got signal and exited\", issue 'ulimit -s unlimited' and retry."
+    {failure & (arch = "ppc64" | arch = "arm64")}
+dev-repo: "git+https://erratique.ch/repos/uunf.git"
+url {
+  src: "https://erratique.ch/software/uunf/releases/uunf-16.0.0.tbz"
+  checksum:
+    "sha512=55e6aa2c0190667467744991839ae1024aa539fc94d9b8dcbaf8fdefed4f77a274acd22f79354b48b4a7582f308dbaadf14991ffee0c2aaf6e16f8efd538b756"
+}

--- a/packages/uuseg/uuseg.16.0.0/opam
+++ b/packages/uuseg/uuseg.16.0.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Unicode text segmentation for OCaml"
+description: """\
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the [Unicode
+line breaking algorithm][2] to detect line break opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg is distributed under the ISC license. It depends on [Uucp].
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/
+[Uucp]: http://erratique.ch/software/uucp
+
+Homepage: <http://erratique.ch/software/uuseg>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uuseg programmers"
+license: "ISC"
+tags: ["unicode" "text" "segmentation" "org:erratique"]
+homepage: "https://erratique.ch/software/uuseg"
+doc: "https://erratique.ch/software/uuseg/doc/"
+bug-reports: "https://github.com/dbuenzli/uuseg/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "uucp" {>= "16.0.0" & < "17.0.0"}
+]
+depopts: ["uutf" "cmdliner"]
+conflicts: [
+  "uutf" {< "1.0.0"}
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-uutf"
+  "%{uutf:installed}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/uuseg.git"
+url {
+  src: "https://erratique.ch/software/uuseg/releases/uuseg-16.0.0.tbz"
+  checksum:
+    "sha512=355139aee2a72baddf3d811e522948456147546ee946b6eca20f57711865770d4b8d32ea01a7338b8e6cdedb4423ee65cee387704bb9c0c057bcbd65012679b8"
+}


### PR DESCRIPTION
* Add: `uucd.16.0.0` [home](https://erratique.ch/software/uucd), [doc](https://erratique.ch/software/uucd/doc/Uucd), [issues](https://github.com/dbuenzli/uucd/issues)  
  *Unicode character database decoder for OCaml*
* Add: `uucp.16.0.0` [home](https://erratique.ch/software/uucp), [doc](https://erratique.ch/software/uucp/doc/), [issues](https://github.com/dbuenzli/uucp/issues)  
  *Unicode character properties for OCaml*
* Add: `uunf.16.0.0` [home](https://erratique.ch/software/uunf), [doc](https://erratique.ch/software/uunf/doc/Uunf), [issues](https://github.com/dbuenzli/uunf/issues)  
  *Unicode text normalization for OCaml*
* Add: `uuseg.16.0.0` [home](https://erratique.ch/software/uuseg), [doc](https://erratique.ch/software/uuseg/doc/), [issues](https://github.com/dbuenzli/uuseg/issues)  
  *Unicode text segmentation for OCaml*


---

#### `uucd` v16.0.0 2024-09-11 Zagreb

- Support for Unicode 16.0.0

---

#### `uucp` v16.0.0 2024-09-11 Zagreb

- Unicode 16.0.0 support.
- Fix larger than needed size constant in implementation of boolean
  trie maps. Thanks to John Tristan for the report ([#26](https://github.com/dbuenzli/uucp/issues/26)).

---

#### `uunf` v16.0.0 2024-09-10 Zagreb

- Unicode 16.0.0 support.

---

#### `uuseg` v16.0.0 2024-09-11 Zagreb

- Unicode 16.0.0 support.

---

Use `b0 -- .opam publish uucd.16.0.0 uucp.16.0.0 uunf.16.0.0 uuseg.16.0.0` to update the pull request.