### PR TITLE
odoc is not compatible with OCaml 5.3 (compiler-libs change)

### DIFF
--- a/packages/odoc/odoc.2.4.2/opam
+++ b/packages/odoc/odoc.2.4.2/opam
@@ -43,7 +43,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.7.0"}
   "fpath"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.3"}
   "result"
   "tyxml" {>= "4.4.0"}
   "fmt"


### PR DESCRIPTION
```
#=== ERROR while compiling odoc.2.4.2 =========================================#
# context              2.3.0~alpha~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/odoc.2.4.2
# command              ~/.opam/5.3/bin/dune build -p odoc -j 1 @install
# exit-code            1           
# env-file             ~/.opam/log/odoc-20-7bf2bf.env 
# output-file          ~/.opam/log/odoc-20-7bf2bf.out 
### output ###                    
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlopt.opt -w -40 -g -w -18-53 -g -I src/syntax_highlighter/.syntax_highlighter.objs/byte -I src/syntax_highlighter/.syntax_highlighter.objs/native -I /home/opam/.o
pam/5.3/lib/ocaml/compiler-libs -intf-suffix .ml -no-alias-deps -o src/syntax_highlighter/.syntax_highlighter.objs/native/syntax_highlighter.cmx -c -impl src/syntax_highlighter/syntax_highlighter.pp.ml)
# File "src/syntax_highlighter/syntax_highlighter.ml", lines 4-146, characters 2-22:
# Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
# Here is an example of a case that is not matched:
# (METAOCAML_ESCAPE|METAOCAML_BRACKET_OPEN|METAOCAML_BRACKET_CLOSE|EFFECT)
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlc.opt -w -40 -g -w -18-53 -g -bin-annot -bin-annot-occurrences -I src/loader/.odoc_loader.objs/byte -I /home/opam/.opam/5.3/lib/astring -I /home/opam/.opam/5.3/l
ib/camlp-streams -I /home/opam/.opam/5.3/lib/fpath -I /home/opam/.opam/5.3/lib/ocaml/compiler-libs -I /home/opam/.opam/5.3/lib/odoc-parser -I /home/opam/.opam/5.3/lib/result -I src/document/.odoc_document.objs/byte 
-I src/model/.odoc_model.objs/byte -I src/syntax_highlighter/.syntax_highlighter.objs/byte -intf-suffix .ml -no-alias-deps -open Odoc_loader__ -o src/loader/.odoc_loader.objs/byte/odoc_loader__Doc_attr.cmo -c -impl 
src/loader/doc_attr.pp.ml)       
# File "src/loader/doc_attr.ml", line 43, characters 19-47:
# Error: This pattern should not be a constructor, the expected type is
#        "Parsetree.constant"     
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlc.opt -w -40 -g -w -18-53 -g -bin-annot -bin-annot-occurrences -I src/syntax_highlighter/.syntax_highlighter.objs/byte -I /home/opam/.opam/5.3/lib/ocaml/compiler
-libs -intf-suffix .ml -no-alias-deps -o src/syntax_highlighter/.syntax_highlighter.objs/byte/syntax_highlighter.cmo -c -impl src/syntax_highlighter/syntax_highlighter.pp.ml)
# File "src/syntax_highlighter/syntax_highlighter.ml", lines 4-146, characters 2-22:
# Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
# Here is an example of a case that is not matched:
# (METAOCAML_ESCAPE|METAOCAML_BRACKET_OPEN|METAOCAML_BRACKET_CLOSE|EFFECT)
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlc.opt -w -40 -g -w -18-53 -g -bin-annot -bin-annot-occurrences -I test/xref2/lib/.odoc_xref_test.objs/byte -I /home/opam/.opam/5.3/lib/astring -I /home/opam/.opa
m/5.3/lib/camlp-streams -I /home/opam/.opam/5.3/lib/fmt -I /home/opam/.opam/5.3/lib/fpath -I /home/opam/.opam/5.3/lib/ocaml/compiler-libs -I /home/opam/.opam/5.3/lib/ocaml/unix -I /home/opam/.opam/5.3/lib/odoc-parse
r -I /home/opam/.opam/5.3/lib/re -I /home/opam/.opam/5.3/lib/result -I /home/opam/.opam/5.3/lib/seq -I /home/opam/.opam/5.3/lib/tyxml -I /home/opam/.opam/5.3/lib/tyxml/functor -I /home/opam/.opam/5.3/lib/uutf -I src
/document/.odoc_document.objs/byte -I src/html/.odoc_html.objs/byte -I src/html_support_files/.odoc_html_support_files.objs/byte -I src/latex/.odoc_latex.objs/byte -I src/loader/.odoc_loader.objs/byte -I src/manpage
/.odoc_manpage.objs/byte -I src/model/.odoc_model.objs/byte -I src/odoc/.odoc_odoc.objs/byte -I src/search/.odoc_html_frontend.objs/byte -I src/search/.odoc_search.objs/byte -I src/search/json_index/.odoc_json_index
.objs/byte -I src/syntax_highlighter/.syntax_highlighter.objs/byte -I src/xref2/.odoc_xref2.objs/byte -no-alias-deps -open Odoc_xref_test -o test/xref2/lib/.odoc_xref_test.objs/byte/odoc_xref_test__Common.cmo -c -im
pl test/xref2/lib/common.ml)
# File "test/xref2/lib/common.cppo.ml", line 38, characters 64-66:
# Error: This constant has type "string" but an expression was expected of type
#          "Unit_info.intf_or_impl"
```