### PR TITLE
hpack < 0.13 is not compatible with OCaml 5.3 (compiler-libs change)

### DIFF
--- a/packages/hpack/hpack.0.1.0/opam
+++ b/packages/hpack/hpack.0.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
 dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
 doc: "https://anmonteiro.github.io/ocaml-h2/"
 depends: [
-  "ocaml" {>= "4.04"}
+  "ocaml" {>= "4.04" & < "5.3"}
   "dune" {>= "1.7"}
   "yojson" {with-test}
   "hex" {with-test}

--- a/packages/hpack/hpack.0.10.0/opam
+++ b/packages/hpack/hpack.0.10.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/anmonteiro/ocaml-h2"
 bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "angstrom"
   "faraday" {>= "0.7.3"}
   "yojson" {with-test}

--- a/packages/hpack/hpack.0.11.0/opam
+++ b/packages/hpack/hpack.0.11.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/anmonteiro/ocaml-h2"
 bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "angstrom"
   "faraday" {>= "0.7.3"}
   "yojson" {with-test}

--- a/packages/hpack/hpack.0.12.0/opam
+++ b/packages/hpack/hpack.0.12.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/anmonteiro/ocaml-h2"
 bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "angstrom"
   "faraday" {>= "0.7.3"}
   "yojson" {with-test}

--- a/packages/hpack/hpack.0.2.0/opam
+++ b/packages/hpack/hpack.0.2.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
 dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
 doc: "https://anmonteiro.github.io/ocaml-h2/"
 depends: [
-  "ocaml" {>= "4.04"}
+  "ocaml" {>= "4.04" & < "5.3"}
   "dune" {>= "1.7"}
   "yojson" {with-test}
   "hex" {with-test}

--- a/packages/hpack/hpack.0.9.0/opam
+++ b/packages/hpack/hpack.0.9.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
 dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
 doc: "https://anmonteiro.github.io/ocaml-h2/"
 depends: [
-  "ocaml" {>= "4.04"}
+  "ocaml" {>= "4.04" & < "5.3"}
   "dune" {>= "1.7"}
   "yojson" {with-test}
   "hex" {with-test}


### PR DESCRIPTION
```
#=== ERROR while compiling hpack.0.12.0 =======================================#
# context              2.3.0~alpha~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/hpack.0.12.0
# command              ~/.opam/5.3/bin/dune build -p hpack -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/hpack-20-a43dd2.env
# output-file          ~/.opam/log/hpack-20-a43dd2.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I hpack/util/.gen_huffman.eobjs/byte -I /home/opam/.opam/5.3/lib/ocaml/compiler-libs -no-alias-deps -o hpack/util/.gen_huffman.eobjs/byte/dune__exe__Gen_huffman.cmo -c -impl hpack/util/gen_huffman.ml)
# File "hpack/util/gen_huffman.ml", line 113, characters 28-71:
# 113 |              [ Exp.constant (Pconst_integer (string_of_int code, None))
#                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: This expression should not be a constructor, the expected type is
#        "Parsetree.constant"
```
This was temporary fixed in 0.13.0 by https://github.com/anmonteiro/ocaml-h2/pull/251