### PR TITLE
Package red-black-tree.1.0.5

### DIFF
--- a/packages/red-black-tree/red-black-tree.1.0.5/opam
+++ b/packages/red-black-tree/red-black-tree.1.0.5/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Functional Red-Black Tree"
+description: "Functional Red-Black Tree in Ocaml"
+maintainer: "Andrew Baine <andrew.baine@gmail.com>"
+authors: "Andrew Baine"
+license: "MIT"
+homepage: "https://github.com/andrewbaine/rbtree"
+bug-reports: "https://github.com/andrewbaine/rbtree/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14.0"}
+  "melange" {>= "4.0.0"}
+  "alcotest" {with-test}
+  "core" {with-test}
+  "melange-jest" {with-test}
+  "merlin" {with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/andrewbaine/rbtree.git"
+url {
+  src:
+    "https://github.com/andrewbaine/rbtree/archive/refs/tags/v1.0.5.tar.gz"
+  checksum: [
+    "md5=9bf8cd113df9cf7e0011c93b3f2a98ca"
+    "sha512=8b12a93c409a47f5418406e17a615d52d559e1be7c6ac6afbeecdf8d1d0f033b94ef5247a84a86514cad4ad71b45e104ba5863a7b602893c7f1fc78a2cffe751"
+  ]
+}

--- a/packages/red-black-tree/red-black-tree.1.0.5/opam
+++ b/packages/red-black-tree/red-black-tree.1.0.5/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Functional Red-Black Tree"
-description: "Functional Red-Black Tree in Ocaml"
+description: "Functional Red-Black Tree in OCaml"
 maintainer: "Andrew Baine <andrew.baine@gmail.com>"
 authors: "Andrew Baine"
 license: "MIT"


### PR DESCRIPTION
### `red-black-tree.1.0.5`
Functional Red-Black Tree
Functional Red-Black Tree in Ocaml



---
* Homepage: https://github.com/andrewbaine/rbtree
* Source repo: git+https://github.com/andrewbaine/rbtree.git
* Bug tracker: https://github.com/andrewbaine/rbtree/issues

---
:camel: Pull-request generated by opam-publish v2.4.0