### PR TITLE
Make the 5.3+ compiler packages depend on base-effects (effect syntax)

### DIFF
--- a/packages/base-effects/base-effects.base/opam
+++ b/packages/base-effects/base-effects.base/opam
@@ -4,10 +4,5 @@ description: """
 Effects-based variant distributed with the Multicore OCaml compiler"
 """
 depends: [
- "ocaml" {>= "4.12.0"}
- "ocaml-variants" {
-    = "4.12.0+domains+effects"
-   | = "5.1.1+effect-syntax"
- }
- "base-domains"
+ "ocaml-variants" {= "4.12.0+domains+effects" | = "5.1.1+effect-syntax"} | "ocaml" {>= "5.3.0"}
 ]

--- a/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
@@ -26,6 +26,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+  "base-effects" {post}
 
   "ocaml-beta" {opam-version < "2.1.0"}
 

--- a/packages/ocaml-variants/ocaml-variants.5.4.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.4.0+trunk/opam
@@ -26,6 +26,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+  "base-effects" {post}
 
   "ocaml-beta" {opam-version < "2.1.0"}
 


### PR DESCRIPTION
While fixing https://github.com/ocaml-omake/omake/pull/159 in opam-repository, i realised that package already conflicts with `base-effects` (the meta package supposed to show the presence of the `effect` syntax)
But that package is not linked with OCaml >= 5.3 which now has the `effect` keyword and syntax, so this PR makes OCaml >= 5.3 compilers depend on that meta package