### PR TITLE
typerep is not compatible with OCaml 5.3 (value restriction change)

### DIFF
--- a/packages/typerep/typerep.v0.10.0/opam
+++ b/packages/typerep/typerep.v0.10.0/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.3"}
   "base" {>= "v0.10" & < "v0.11"}
   "jbuilder" {>= "1.0+beta12"}
 ]

--- a/packages/typerep/typerep.v0.11.0/opam
+++ b/packages/typerep/typerep.v0.11.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 conflicts: [ "jbuilder" { = "1.0+beta19" } ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.3"}
   "base" {>= "v0.11" & < "v0.12"}
   "jbuilder" {>= "1.0+beta18.1"}
 ]

--- a/packages/typerep/typerep.v0.12.0/opam
+++ b/packages/typerep/typerep.v0.12.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.04.2" & < "5.3"}
   "base"  {>= "v0.12" & < "v0.13"}
   "dune"  {>= "1.5.1"}
 ]

--- a/packages/typerep/typerep.v0.13.0/opam
+++ b/packages/typerep/typerep.v0.13.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.04.2" & < "5.3"}
   "base"  {>= "v0.13" & < "v0.14"}
   "dune"  {>= "1.5.1"}
 ]

--- a/packages/typerep/typerep.v0.14.0/opam
+++ b/packages/typerep/typerep.v0.14.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.04.2" & < "5.3"}
   "base"  {>= "v0.14" & < "v0.15"}
   "dune"  {>= "2.0.0"}
 ]

--- a/packages/typerep/typerep.v0.15.0/opam
+++ b/packages/typerep/typerep.v0.15.0/opam
@@ -10,13 +10,11 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "base"  {>= "v0.15" & < "v0.16"}
   "dune"  {>= "2.0.0"}
 ]
 synopsis: "Typerep is a library for runtime types"
-description: "
-"
 url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.15/files/typerep-v0.15.0.tar.gz"
 checksum: "sha256=26c8d37db41440a417593fcb389aaebafdf2e33e62bd762e1f148875a7a3183e"

--- a/packages/typerep/typerep.v0.16.0/opam
+++ b/packages/typerep/typerep.v0.16.0/opam
@@ -10,13 +10,11 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "4.14.0" & < "5.3"}
   "base"  {>= "v0.16" & < "v0.17"}
   "dune"  {>= "2.0.0"}
 ]
 synopsis: "Typerep is a library for runtime types"
-description: "
-"
 url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/typerep-v0.16.0.tar.gz"
 checksum: "sha256=e5157fef61e0229dacf01a5677bb93416ab59ee86046904c3d691e872ed4f72c"

--- a/packages/typerep/typerep.v0.17.0/opam
+++ b/packages/typerep/typerep.v0.17.0/opam
@@ -10,14 +10,12 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "5.1.0"}
+  "ocaml" {>= "5.1.0" & < "5.3"}
   "base"  {>= "v0.17" & < "v0.18"}
   "dune"  {>= "3.11.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Typerep is a library for runtime types"
-description: "
-"
 url {
 src: "https://github.com/janestreet/typerep/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=ff8268f46f447bbc95dac29a50f465625646b213e3a9638f4d773b9e17b650e8"

--- a/packages/typerep/typerep.v0.9.0/opam
+++ b/packages/typerep/typerep.v0.9.0/opam
@@ -13,7 +13,7 @@ build: [
   ]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.3"}
   "base" {>= "v0.9" & < "v0.10"}
   "jbuilder" {>= "1.0+beta4"}
 ]


### PR DESCRIPTION
This breakage is expected. See https://github.com/ocaml/ocaml/issues/13176
```
#=== ERROR while compiling typerep.v0.17.0 ====================================#
# context              2.3.0~alpha~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/typerep.v0.17.0
# command              ~/.opam/5.3/bin/dune build -p typerep -j 1
# exit-code            1
# env-file             ~/.opam/log/typerep-20-a4e418.env
# output-file          ~/.opam/log/typerep-20-a4e418.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlopt.opt -w -40 -g -I lib/.typerep_lib.objs/byte -I lib/.typerep_lib.objs/native -I /home/opam/.opam/5.3/lib/base -I /home/opam/.opam/5.3/lib/base/base_internalhash_types -I /home/opam/.opam/5.3/lib/base/shadow_stdlib -I /home/opam/.opam/5.3/lib/ocaml_intrinsics_kernel -I /home/opam/.opam/5.3/lib/sexplib0 -intf-suffix .ml -no-alias-deps -open Typerep_lib -o lib/.typerep_lib.objs/native/typerep_lib__Typename.cmx -c -impl lib/typename.ml)
# File "lib/typename.ml", line 214, characters 41-66:
# 214 |     if Uid.equal uid_a uid_b then { eq = Obj.magic Type_equal.refl } else fail uid_a uid_b
#                                                ^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: This field value has type "('b A.t, 'b B.t) Typerep_lib.Type_equal.t"
#        which is less general than
#          "'a. ('a A.t, 'a B.t) Typerep_lib.Type_equal.t"
```