### PR TITLE
coq-core < 8.19.2 is not compatible with the effect syntax

### DIFF
--- a/packages/coq-core/coq-core.8.17.0/opam
+++ b/packages/coq-core/coq-core.8.17.0/opam
@@ -34,6 +34,7 @@ depends: [
 conflicts: [
   "coq"   { < "8.17" }
   "ocaml-option-bytecode-only"
+  "base-effects"
 ]
 build: [
   [ "./configure"

--- a/packages/coq-core/coq-core.8.17.1/opam
+++ b/packages/coq-core/coq-core.8.17.1/opam
@@ -33,6 +33,7 @@ depends: [
 ]
 conflicts: [
   "coq"   { < "8.17" }
+  "base-effects"
 ]
 build: [
   [ "./configure"

--- a/packages/coq-core/coq-core.8.18.0/opam
+++ b/packages/coq-core/coq-core.8.18.0/opam
@@ -34,6 +34,7 @@ depends: [
 ]
 conflicts: [
   "coq"   { < "8.17" }
+  "base-effects"
 ]
 build: [
   # Requires dune 2.8 due to https://github.com/ocaml/dune/issues/3219

--- a/packages/coq-core/coq-core.8.19.0/opam
+++ b/packages/coq-core/coq-core.8.19.0/opam
@@ -34,6 +34,7 @@ depends: [
 ]
 conflicts: [
   "coq"   { < "8.17" }
+  "base-effects"
 ]
 depopts: ["coq-native"]
 dev-repo: "git+https://github.com/coq/coq.git"

--- a/packages/coq-core/coq-core.8.19.1/opam
+++ b/packages/coq-core/coq-core.8.19.1/opam
@@ -34,6 +34,7 @@ depends: [
 ]
 conflicts: [
   "coq"   { < "8.17" }
+  "base-effects"
 ]
 depopts: ["coq-native"]
 dev-repo: "git+https://github.com/coq/coq.git"


### PR DESCRIPTION
Fixed in 8.19.2 by https://github.com/coq/coq/pull/18863
Requires #26543 to be merged first
```
#=== ERROR while compiling coq-core.8.19.1 ====================================#
# context              2.3.0~alpha~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/coq-core.8.19.1
# command              ~/.opam/5.3/bin/dune build -p coq-core -j 1 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/coq-core-19-6b9012.env
# output-file          ~/.opam/log/coq-core-19-6b9012.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl pretyping/reductionops.ml) > _build/default/pretyping/.pretyping.objs/reductionops.impl.d
# File "pretyping/reductionops.ml", line 47, characters 8-14:
# 47 |     let effect = String.Map.find funkey !effect_table in
#              ^^^^^^
# Error: Syntax error
```