### PR TITLE
utop is not compatible with OCaml 5.3 (uses compiler-libs)

### DIFF
--- a/packages/utop/utop.2.14.0/opam
+++ b/packages/utop/utop.2.14.0/opam
@@ -10,7 +10,7 @@ doc: "https://ocaml-community.github.io/utop/"
 bug-reports: "https://github.com/ocaml-community/utop/issues"
 depends: [
   "dune" {>= "2.0"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.11.0" & < "5.3"}
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}


### PR DESCRIPTION
Upstream PR in https://github.com/ocaml-community/utop/pull/489
```
#=== ERROR while compiling utop.2.14.0 ========================================#
# context              2.3.0~alpha~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/utop.2.14.0
# command              ~/.opam/5.3/bin/dune build -p utop -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/utop-20-3fdb02.env
# output-file          ~/.opam/log/utop-20-3fdb02.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/lib/.uTop.objs/byte -I /home/opam/.opam/5.3/lib/bytes -I /home/opam/.opam/5.3/lib/findlib -I /home/opam/.opam/5.3/lib/lambda-term -I /home/opam/.opam/5.3/lib/logs -I /home/opam/.opam/5.3/lib/lwt -I /home/opam/.opam/5.3/lib/lwt/unix -I /home/opam/.opam/5.3/lib/lwt_react -I /home/opam/.opam/5.3/lib/mew -I /home/opam/.opam/5.3/lib/mew_vi -I /home/opam/.opam/5.3/lib/ocaml/compiler-libs -I /home/opam/.opam/5.3/lib/ocaml/threads -I /home/opam/.opam/5.3/lib/ocaml/unix -I /home/opam/.opam/5.3/lib/ocplib-endian -I /home/opam/.opam/5.3/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.3/lib/react -I /home/opam/.opam/5.3/lib/result -I /home/opam/.opam/5.3/lib/trie -I /home/opam/.opam/5.3/lib/uchar -I /home/opam/.opam/5.3/lib/uucp -I /home/opam/.opam/5.3/lib/uuseg -I /home/opam/.opam/5.3/lib/uutf -I /home/opam/.opam/5.3/lib/xdg -I /home/opam/.opam/5.3/lib/zed -no-alias-deps -o src/lib/.uTop.objs/byte/uTop_compat.cmo -c -impl src/lib/uTop_compat.pp.ml)
# File "src/lib/uTop_compat.ml", line 81, characters 8-30:
# Error: The value "Misc.Style.inline_code" has type
#          "string Format_doc.printer" = "Format_doc.formatter -> string -> unit"
#        but an expression was expected of type "Format.formatter -> 'a -> unit"
#        Type "Format_doc.formatter" is not compatible with type "Format.formatter"
```