### PR TITLE
yocaml is not compatible with the effect syntax

### DIFF
--- a/packages/yocaml/yocaml.1.0.0/opam
+++ b/packages/yocaml/yocaml.1.0.0/opam
@@ -23,6 +23,9 @@ depends: [
   "alcotest" {with-test}
   "preface" { >= "1.0.0"}
 ]
+conflicts: [
+  "base-effects"
+]
 url {
   src:
     "https://github.com/xhtmlboi/yocaml/releases/download/v1.0.0/yocaml-1.0.0.tbz"


### PR DESCRIPTION
Reported upstream in https://github.com/xhtmlboi/yocaml/issues/52
```
#=== ERROR while compiling yocaml.1.0.0 =======================================#
# context              2.3.0~alpha~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/yocaml.1.0.0
# command              ~/.opam/5.3/bin/dune build -p yocaml -j 1
# exit-code            1
# env-file             ~/.opam/log/yocaml-20-6964b3.env
# output-file          ~/.opam/log/yocaml-20-6964b3.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl lib/yocaml/build.ml) > _build/default/lib/yocaml/.yocaml.objs/yocaml__Build.impl.d
# File "lib/yocaml/build.ml", line 192, characters 15-21:
# 192 | let collection effect arrow process =
#                      ^^^^^^
# Error: Syntax error
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl lib/yocaml/effect.ml) > _build/default/lib/yocaml/.yocaml.objs/yocaml__Effect.impl.d
# File "lib/yocaml/effect.ml", line 106, characters 34-40:
# 106 | let process_files paths predicate effect =
#                                         ^^^^^^
# Error: Syntax error
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl lib/yocaml/runtime.ml) > _build/default/lib/yocaml/.yocaml.objs/yocaml__Runtime.impl.d
# File "lib/yocaml/runtime.ml", line 93, characters 16-22:
# 93 |      fun resume effect -> resume $ perform effect
#                      ^^^^^^
# Error: Syntax error
```