### PR TITLE
malfunction is not compatible with OCaml 5.3 (uses compiler-libs)

### DIFF
--- a/packages/malfunction/malfunction.0.6/opam
+++ b/packages/malfunction/malfunction.0.6/opam
@@ -11,7 +11,7 @@ build: [
 ]
 conflicts: [ "ocaml-option-bytecode-only" ]
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.3"}
   "ocamlfind"
   "dune" {>= "2.9.1"}
   "cppo" {build}


### PR DESCRIPTION
Reported upstream in https://github.com/stedolan/malfunction/issues/44
```
#=== ERROR while compiling malfunction.0.6 ====================================#
# context              2.3.0~alpha~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/malfunction.0.6
# command              ~/.opam/5.3/bin/dune build -p malfunction -j 1
# exit-code            1
# env-file             ~/.opam/log/malfunction-20-c96ea6.env
# output-file          ~/.opam/log/malfunction-20-c96ea6.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/.malfunction.objs/byte -I /home/opam/.opam/5.3/lib/findlib -I /home/opam/.opam/5.3/lib/ocaml/compiler-libs -I /home/opam/.opam/5.3/lib/ocaml/dynlink -I /home/opam/.opam/5.3/lib/ocaml/str -I /home/opam/.opam/5.3/lib/ocaml/unix -I /home/opam/.opam/5.3/lib/zarith -intf-suffix .ml -no-alias-deps -o src/.malfunction.objs/byte/malfunction_compiler.cmo -c -impl src/malfunction_compiler.ml)
# File "src/malfunction_compiler.ml", line 774, characters 4-21:
# 774 |     Env.set_unit_name module_name;
#           ^^^^^^^^^^^^^^^^^
# Error: Unbound value "Env.set_unit_name"
```