### PR TITLE
Add: tsdl.1.1.0

### DIFF
--- a/packages/tsdl/tsdl.1.1.0/opam
+++ b/packages/tsdl/tsdl.1.1.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Thin bindings to SDL for OCaml"
+description: """\
+Tsdl is an OCaml library providing thin bindings to the cross-platform
+[SDL library].
+
+Tsdl depends on the [SDL 2.0.10][sdl] C library (or later),
+[ocaml-ctypes][ctypes] and the `result` compatibility package.
+Tsdl is distributed under the ISC license.
+
+[SDL library]: https://www.libsdl.org/
+[ctypes]: https://github.com/ocamllabs/ocaml-ctypes
+
+Home page: <http://erratique.ch/software/tsdl>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The tsdl programmers"
+license: "ISC"
+tags: [
+  "audio"
+  "bindings"
+  "graphics"
+  "media"
+  "opengl"
+  "input"
+  "hci"
+  "org:erratique"
+]
+homepage: "https://erratique.ch/software/tsdl"
+doc: "https://erratique.ch/software/tsdl/doc/"
+bug-reports: "https://github.com/dbuenzli/tsdl/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "conf-sdl2"
+  "ctypes" {>= "0.21.1"}
+  "ctypes-foreign" {>= "0.21.1"}
+]
+available: os-distribution != "opensuse-leap" | os-version >= "16"
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/tsdl.git"
+url {
+  src: "https://erratique.ch/software/tsdl/releases/tsdl-1.1.0.tbz"
+  checksum:
+    "sha512=f6d429ac5f7d1ea2411fb65f08e454fc5f515879c92e9031afb978dd0c8865739931a83a277fc3bf556e743a710ec8b530717f9e30e353660e1f0219c8293413"
+}


### PR DESCRIPTION
* Add: `tsdl.1.1.0` [home](https://erratique.ch/software/tsdl), [doc](https://erratique.ch/software/tsdl/doc/), [issues](https://github.com/dbuenzli/tsdl/issues)  
  *Thin bindings to SDL for OCaml*


---

#### `tsdl` v1.1.0 2024-09-12 Zagreb

- Require SDL >= 2.0.18.
- Add binding to `SDL_Vertex`, `SDL_RenderGeometry[Raw]`.
  Thanks to Frank Standaert for the patches ([#101](https://github.com/dbuenzli/tsdl/issues/101)).
- Add binding to `SDL_GetTicks64`.
- Fix segmentation fault on macOS arm64 when using varargs functions
  through ctypes ([#99](https://github.com/dbuenzli/tsdl/issues/99)). Thanks to Jonah Beckford for the report and
  the help.
- Fix `Sdl.rw_from_const_mem` to pass the ocaml string rather than a copy.
  Thanks to Maxence Guesdon for the patch ([#102](https://github.com/dbuenzli/tsdl/issues/102)).
- Add binding to `SDL_RWFromMem`. Thanks to Maxence Guesdon for the 
  patch ([#102](https://github.com/dbuenzli/tsdl/issues/102)).
- Use package `ctypes-foreign` instead of `ctypes.foreign`.
- Improve documentation linking into SDL documentation.

---

Use `b0 -- .opam publish tsdl.1.1.0` to update the pull request.