### PR TITLE
5 packages from zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.2.0.tar.bz2

### DIFF
--- a/packages/stk/stk.0.2.0/opam
+++ b/packages/stk/stk.0.2.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "SDL-based GUI toolkit"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.2.0"}
+  "css" {>= "0.2.0"}
+  "fmt" {>= "0.9.0"}
+  "higlo" {>= "0.9"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.2"}
+  "pcre" {>= "7.5.0"}
+  "ocf" {>= "0.8.0"}
+  "ocf_ppx" {>= "0.8.0"}
+  "ppx_blob" {>= "0.7.2"}
+  "ptime" {>= "1.1.0"}
+  "sedlex" {>= "1.2"}
+  "stk_ppx" {= version}
+  "tsdl" {>= "1.1.0"}
+  "tsdl-image" {>= "0.3.2"}
+  "tsdl-ttf" {>= "0.3.2"}
+  "uunf" {>= "15.0.0"}
+  "uutf" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.2.0.tar.bz2"
+  checksum: [
+    "md5=84927cce2b859a484df176163a68a21c"
+    "sha512=7d79d0b18c1550d59932ec27e5162f5ec5cfeb6560de32224cc7915f392e11d2c2fd94c44128b4b828b6ed700c2f079d120b2423874d71544e71bbab9253e870"
+  ]
+}

--- a/packages/stk_iconv/stk_iconv.0.2.0/opam
+++ b/packages/stk_iconv/stk_iconv.0.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Bindings to GNU libiconv"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ctypes" {>= "0.20.1"}
+  "ctypes-foreign" {>= "0.18.0"}
+  "logs" {>= "0.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.2.0.tar.bz2"
+  checksum: [
+    "md5=84927cce2b859a484df176163a68a21c"
+    "sha512=7d79d0b18c1550d59932ec27e5162f5ec5cfeb6560de32224cc7915f392e11d2c2fd94c44128b4b828b6ed700c2f079d120b2423874d71544e71bbab9253e870"
+  ]
+}

--- a/packages/stk_ocf/stk_ocf.0.2.0/opam
+++ b/packages/stk_ocf/stk_ocf.0.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Utils to build GUI above Ocf"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocf" {>= "0.8.0"}
+  "stk" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.2.0.tar.bz2"
+  checksum: [
+    "md5=84927cce2b859a484df176163a68a21c"
+    "sha512=7d79d0b18c1550d59932ec27e5162f5ec5cfeb6560de32224cc7915f392e11d2c2fd94c44128b4b828b6ed700c2f079d120b2423874d71544e71bbab9253e870"
+  ]
+}

--- a/packages/stk_ppx/stk_ppx.0.2.0/opam
+++ b/packages/stk_ppx/stk_ppx.0.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "PPX used for debug logging in Stk"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.2.0"}
+  "ppxlib"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.2.0.tar.bz2"
+  checksum: [
+    "md5=84927cce2b859a484df176163a68a21c"
+    "sha512=7d79d0b18c1550d59932ec27e5162f5ec5cfeb6560de32224cc7915f392e11d2c2fd94c44128b4b828b6ed700c2f079d120b2423874d71544e71bbab9253e870"
+  ]
+}

--- a/packages/stk_rdf/stk_rdf.0.2.0/opam
+++ b/packages/stk_rdf/stk_rdf.0.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Utilities to display and edit RDF data"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "rdf" {>= "1.0.0"}
+  "stk" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.2.0.tar.bz2"
+  checksum: [
+    "md5=84927cce2b859a484df176163a68a21c"
+    "sha512=7d79d0b18c1550d59932ec27e5162f5ec5cfeb6560de32224cc7915f392e11d2c2fd94c44128b4b828b6ed700c2f079d120b2423874d71544e71bbab9253e870"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `stk.0.2.0`: SDL-based GUI toolkit
- `stk_iconv.0.2.0`: Bindings to GNU libiconv
- `stk_ocf.0.2.0`: Utils to build GUI above Ocf
- `stk_ppx.0.2.0`: PPX used for debug logging in Stk
- `stk_rdf.0.2.0`: Utilities to display and edit RDF data



---
* Homepage: https://zoggy.frama.io/ocaml-stk/
* Source repo: git+https://framagit.org/zoggy/ocaml-stk.git
* Bug tracker: https://framagit.org/zoggy/ocaml-stk/issues

---
:camel: Pull-request generated by opam-publish v2.4.0