### PR TITLE
[new release] eio-trace (0.4)

### DIFF
--- a/packages/eio-trace/eio-trace.0.4/opam
+++ b/packages/eio-trace/eio-trace.0.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Trace visualisation for Eio programs"
+maintainer: ["Thomas Leonard"]
+authors: ["Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio-trace"
+bug-reports: "https://github.com/ocaml-multicore/eio-trace/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "5.1.0"}
+  "processor"
+  "eio_main" {>= "0.14"}
+  "cmdliner" {>= "1.2.0"}
+  "lablgtk3" {>= "3.1.4"}
+  "crowbar" {>= "0.2.1" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio-trace.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio-trace/releases/download/v0.4/eio-trace-0.4.tbz"
+  checksum: [
+    "sha256=e5f590734c92d52f607a7af4ad9d54be9af79f3c38040ca92eff47c0d24e3eaf"
+    "sha512=e50e7a2bae8472e80d881f837e32d4da5d0d2872e1fb8b80052d65012e75a4db0a9ca2576246e80d8e450965a13a72396c8da6346b6ea4bfaedf78c7293d53bc"
+  ]
+}
+x-commit-hash: "84921ea0436f5b5e75386948e2f00c4824217a9c"


### PR DESCRIPTION
Trace visualisation for Eio programs

- Project page: <a href="https://github.com/ocaml-multicore/eio-trace">https://github.com/ocaml-multicore/eio-trace</a>

##### CHANGES:

- Add `--cpu` option (@talex5 ocaml-multicore/eio-trace#41).
  Useful to avoid running eio-trace on the same CPU as the program being traced.

- Fix ring height calculation (again) (@talex5 ocaml-multicore/eio-trace#42).

- Link to performance problems blog post (@talex5 ocaml-multicore/eio-trace#40).
  Gives examples showing uses of eio-trace and other tools.

- Add `gc-stats` sub-command (@talex5 ocaml-multicore/eio-trace#39).
  Report about time spent in GC for a recorded trace.
