### PR TITLE
[new release] unisim_archisec (0.0.9)

### DIFF
--- a/packages/unisim_archisec/unisim_archisec.0.0.9/opam
+++ b/packages/unisim_archisec/unisim_archisec.0.0.9/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "UNISIM-VP DBA decoder"
+description: """
+
+UNISIM ARCHISEC is a companion project of the binary analysis platform
+BINSEC. It exposes disassembly metadata and DBA (Dynamic Bitvector Automata)
+semantics of several instruction set architectures, including ARM and x86."""
+maintainer: ["BINSEC <binsec@saxifrage.saclay.cea.fr>"]
+authors: ["Yves Lhuillier" "Frédéric Recoules"]
+license: "BSD-3-Clause"
+homepage: "https://binsec.github.io"
+bug-reports: "mailto:binsec@saxifrage.saclay.cea.fr"
+depends: [
+  "dune" {>= "3.0"}
+  "conf-gcc" {build}
+  "conf-g++" {build}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "binsec" {< "0.5.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/binsec/unisim_archisec.git"
+available: [ os = "linux" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) | os = "macos" & os-distribution = "homebrew" ]
+url {
+  src:
+    "https://github.com/binsec/unisim_archisec/releases/download/0.0.9/unisim_archisec-0.0.9.tbz"
+  checksum: [
+    "sha256=26db741815f127acf73f133420a2a1aa5840c77e01955e868f21a587dcbe54f8"
+    "sha512=434559465cd861e899ec6cdb8bcf6954235763cdc9ec0c6bbf68004333c2568a3388a1df94834bfa16e300b1e95db8598bc12b6876b5ae1893d0c168f585b6be"
+  ]
+}
+x-commit-hash: "0b3759820b486924cd97902b8478a0537693df87"

--- a/packages/unisim_archisec/unisim_archisec.0.0.9/opam
+++ b/packages/unisim_archisec/unisim_archisec.0.0.9/opam
@@ -39,8 +39,8 @@ url {
   src:
     "https://github.com/binsec/unisim_archisec/releases/download/0.0.9/unisim_archisec-0.0.9.tbz"
   checksum: [
-    "sha256=26db741815f127acf73f133420a2a1aa5840c77e01955e868f21a587dcbe54f8"
-    "sha512=434559465cd861e899ec6cdb8bcf6954235763cdc9ec0c6bbf68004333c2568a3388a1df94834bfa16e300b1e95db8598bc12b6876b5ae1893d0c168f585b6be"
+    "sha256=2bb9c1410be7b06520cc630b18eef53fd2f53f8df20e89777b5ee0948f32df91"
+    "sha512=4c120b6ef1bbb44bc0fdd1b0f0f299f8d40d1c8405df9f8eebd0376d4480cb2b2c26f47b2dd4b8d149082854fb3ed3ee09f895cb7bb2db1fd7833b38e947f44b"
   ]
 }
-x-commit-hash: "0b3759820b486924cd97902b8478a0537693df87"
+x-commit-hash: "7b4bc4c42d608ae6fc17ea7ed558f41b35b3ec73"


### PR DESCRIPTION
UNISIM-VP DBA decoder

- Project page: <a href="https://binsec.github.io">https://binsec.github.io</a>

##### CHANGES:

- support for NEON instructions in AARCH64
- handling some new VEX encoded instructions (x86)
- more systematic branchless semantics
  (e.g. [binsec/unisim_archisec#37](https://github.com/binsec/binsec/issues/37))
- various bug fixes and code improvements
