### PR TITLE
[new release] slipshow (0.0.33)

### DIFF
--- a/packages/slipshow/slipshow.0.0.33/opam
+++ b/packages/slipshow/slipshow.0.0.33/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "A compiler from markdown to slipshow"
+description: "Slipshow is an engine to write slips, a concept evolved from slides."
+maintainer: ["Paul-Elliot"]
+authors: ["Paul-Elliot"]
+license: "MIT"
+tags: ["slipshow" "presentation" "slideshow" "beamer"]
+homepage: "https://github.com/panglesd/slipshow"
+doc: "https://slipshow.readthedocs.io"
+bug-reports: "https://github.com/panglesd/slipshow/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.6"}
+  "crunch" {with-dev-setup}
+  "cmdliner"
+  "base64"
+  "bos"
+  "lwt"
+  "irmin-watcher"
+  "js_of_ocaml-compiler"
+  "js_of_ocaml-lwt"
+  "magic-mime"
+  "dream" {>= "1.0.0~alpha5"}
+  "fpath"
+  "brr" {>= "0.0.6"}
+  "ppx_blob" {>= "0.7.2"}
+  "odoc" {with-doc}
+  "ocamlformat" {with-dev-setup & = "0.26.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os = "linux"}
+    "@doc" {with-doc}
+  ]
+]
+conflicts: [ "ocaml-option-bytecode-only" ]
+dev-repo: "git+https://github.com/panglesd/slipshow.git"
+url {
+  src:
+    "https://github.com/panglesd/slipshow/releases/download/v0.0.33/slipshow-0.0.33.tbz"
+  checksum: [
+    "sha256=b0775d83069bafbb28041daf4d3fd997d41d32f61186b7dc22510139853b034f"
+    "sha512=c6124f7ba1007fa7497bfade6cdaae5be761b64c15283f7d3f2f018fe1699a1e5357f5d5cc612bfac63539cf08fe74cd31eae326fa93c68d8cae926fb257532d"
+  ]
+}
+x-commit-hash: "12c6ffdb4bc959224f1f9f75b479f3ce634e2bf2"

--- a/packages/slipshow/slipshow.0.0.33/opam
+++ b/packages/slipshow/slipshow.0.0.33/opam
@@ -23,7 +23,7 @@ depends: [
   "dream" {>= "1.0.0~alpha5"}
   "fpath"
   "brr" {>= "0.0.6"}
-  "ppx_blob" {>= "0.7.2"}
+  "ppx_blob" {>= "0.8.0"}
   "odoc" {with-doc}
   "ocamlformat" {with-dev-setup & = "0.26.2"}
 ]


### PR DESCRIPTION
A compiler from markdown to slipshow

- Project page: <a href="https://github.com/panglesd/slipshow">https://github.com/panglesd/slipshow</a>
- Documentation: <a href="https://slipshow.readthedocs.io">https://slipshow.readthedocs.io</a>

##### CHANGES:

### Fixed

- Fixed `--serve` sometimes not working by using long-polling instead of
  websockets.
- Fixed `--serve` not working on MacOS, by using irmin-watcher instead of
  inotify (panglesd/slipshow#65, @patricoferris).