### PR TITLE
4 packages from diskuv/dkml-install-api at 0.5.3

### DIFF
--- a/packages/dkml-install-installer/dkml-install-installer.0.5.3/opam
+++ b/packages/dkml-install-installer/dkml-install-installer.0.5.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Build tools for DkML installers"
+description:
+  "Build-time executables that can generate Dune include files which will compile essential end-user executables."
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "re" {>= "1.3.0"}
+  "crunch" {>= "3.3.1"}
+  "odoc" {with-doc}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.5.3/src.tar.gz"
+  checksum: [
+    "md5=e61b1ab5693a4749caae1959aea6fd70"
+    "sha512=8321e92d8c204eb26da69c8b522fbcca0c38fbc61a26d1d367aad28e6c8c3d4ee8933596b9a63f8c6d6c3bbd36582292d5bfd4680906e4a2e4bef45e3f6f17aa"
+  ]
+}

--- a/packages/dkml-install-runner/dkml-install-runner.0.5.3/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.5.3/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Runner executable for DkML installation"
+description:
+  "The runner executable is responsible for loading and running all DkML installation components."
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "dkml-install" {= version}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.1"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "diskuvbox" {>= "0.1.1"}
+  "odoc" {with-doc}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.5.3/src.tar.gz"
+  checksum: [
+    "md5=e61b1ab5693a4749caae1959aea6fd70"
+    "sha512=8321e92d8c204eb26da69c8b522fbcca0c38fbc61a26d1d367aad28e6c8c3d4ee8933596b9a63f8c6d6c3bbd36582292d5bfd4680906e4a2e4bef45e3f6f17aa"
+  ]
+}

--- a/packages/dkml-install/dkml-install.0.5.3/opam
+++ b/packages/dkml-install/dkml-install.0.5.3/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "API and registry for DkML installation components"
+description:
+  "All DkML installation components implement the interfaces exposed in this API."
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "ppx_deriving" {>= "5.2.1"}
+  "result" {>= "1.5"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.1"}
+  "fmt" {>= "0.8.9"}
+  "tsort" {>= "2.1.0"}
+  "diskuvbox" {>= "0.1.1" & with-test}
+  "odoc" {with-doc}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.5.3/src.tar.gz"
+  checksum: [
+    "md5=e61b1ab5693a4749caae1959aea6fd70"
+    "sha512=8321e92d8c204eb26da69c8b522fbcca0c38fbc61a26d1d367aad28e6c8c3d4ee8933596b9a63f8c6d6c3bbd36582292d5bfd4680906e4a2e4bef45e3f6f17aa"
+  ]
+}

--- a/packages/dkml-package-console/dkml-package-console.0.5.3/opam
+++ b/packages/dkml-package-console/dkml-package-console.0.5.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Console setup and uninstall executables for DkML installation"
+description:
+  "The setup and uninstall executables are responsible for launching the DkML runners."
+maintainer: "opensource+dkml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "diskuvbox" {>= "0.1.1"}
+  "crunch" {>= "3.3.1"}
+  "dkml-component-xx-console" {>= "0.1.1"}
+  "odoc" {with-doc}
+]
+available: os = "win32" | os = "linux" | os = "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.5.3/src.tar.gz"
+  checksum: [
+    "md5=e61b1ab5693a4749caae1959aea6fd70"
+    "sha512=8321e92d8c204eb26da69c8b522fbcca0c38fbc61a26d1d367aad28e6c8c3d4ee8933596b9a63f8c6d6c3bbd36582292d5bfd4680906e4a2e4bef45e3f6f17aa"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`dkml-install.0.5.3`: API and registry for DkML installation components
-`dkml-install-installer.0.5.3`: Build tools for DkML installers
-`dkml-install-runner.0.5.3`: Runner executable for DkML installation
-`dkml-package-console.0.5.3`: Console setup and uninstall executables for DkML installation



---
* Homepage: https://github.com/diskuv/dkml-install-api
* Source repo: git+https://github.com/diskuv/dkml-install-api.git
* Bug tracker: https://github.com/diskuv/dkml-install-api/issues

---
:camel: Pull-request generated by opam-publish v2.1.0