### PR TITLE
Package chamo.4.1.0

### DIFF
--- a/packages/chamo/chamo.4.1.0/opam
+++ b/packages/chamo/chamo.4.1.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "A kind of emacs-like editor, using OCaml instead of lisp"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/chamo/"
+doc: "https://zoggy.frama.io/chamo/doc.html"
+bug-reports: "https://framagit.org/zoggy/chamo/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.2.0"}
+  "fmt" {>= "0.9.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.2"}
+  "ocf" {>= "0.8.0"}
+  "ocf_ppx" {>= "0.8.0"}
+  "ppx_blob" {>= "0.7.2"}
+  "re" {>= "1.10.4"}
+  "pcre" {>= "7.5.0"}
+  "sedlex" {>= "2.3"}
+  "stk" {>= "0.2.0"}
+  "stk_iconv" {>= "0.2.0"}
+  "stk_ocf" {>= "0.2.0"}
+  "tsdl" {>= "1.1.0"}
+  "tsdl-image" {>= "0.5"}
+  "tsdl-ttf" {>= "0.5"}
+  "uutf" {>= "1.0.0"}
+  "xmlm" {>= "1.4"}
+  "xtmpl" {>= "0.19.0"}
+  "xtmpl_ppx" {>= "0.19.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/chamo.git"
+url {
+  src: "https://framagit.org/zoggy/chamo/-/archive/4.1.0/chamo-4.1.0.tar.bz2"
+  checksum: [
+    "md5=97dddda8d30ff74318f3079716a83103"
+    "sha512=988a0d3f0b1440ac99286b087a6d8629dd79a2bf1941fc99a68567063ff1d74130402927670458ba934f3c5423d83cca5af42a81b0205c97a984659893f6c091"
+  ]
+}


### PR DESCRIPTION
### `chamo.4.1.0`
A kind of emacs-like editor, using OCaml instead of lisp



---
* Homepage: https://zoggy.frama.io/chamo/
* Source repo: git+https://framagit.org/zoggy/chamo.git
* Bug tracker: https://framagit.org/zoggy/chamo/issues

---
:camel: Pull-request generated by opam-publish v2.4.0