### PR TITLE
[new release] multicore-bench (0.1.5)

### DIFF
--- a/packages/multicore-bench/multicore-bench.0.1.5/opam
+++ b/packages/multicore-bench/multicore-bench.0.1.5/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Framework for writing multicore benchmark executables to run on current-bench"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-bench"
+bug-reports: "https://github.com/ocaml-multicore/multicore-bench/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "domain-local-await" {>= "1.0.1"}
+  "multicore-magic" {>= "2.1.0"}
+  "mtime" {>= "2.0.0"}
+  "yojson" {>= "2.1.0"}
+  "domain_shims" {>= "0.1.0"}
+  "backoff" {>= "0.1.0"}
+  "mdx" {>= "2.4.0" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
+  "ocaml" {>= "4.13.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-bench.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-bench/releases/download/0.1.5/multicore-bench-0.1.5.tbz"
+  checksum: [
+    "sha256=331fdb6b7bfe0b20c393ab5f66e30bee52d5b2fe33057baa0b4bde7bc5d862f1"
+    "sha512=c4187fa25562582211af150b71c3f875499a356d3fe86c3bd00e3338facba1078018edf7b41c0cd43c4723f420edac8d943a2794e152de409093eaafba93c1db"
+  ]
+}
+x-commit-hash: "26883fbbbe532d764feb6ffe71bb41c5a719d1cc"


### PR DESCRIPTION
Framework for writing multicore benchmark executables to run on current-bench

- Project page: <a href="https://github.com/ocaml-multicore/multicore-bench">https://github.com/ocaml-multicore/multicore-bench</a>

##### CHANGES:

- Improved error handling (@polytypic)
