### PR TITLE
Package flow_parser.0.246.0

### DIFF
--- a/packages/flow_parser/flow_parser.0.246.0/opam
+++ b/packages/flow_parser/flow_parser.0.246.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "flow@fb.com"
+authors: ["Flow Team <flow@fb.com>"]
+homepage: "https://github.com/facebook/flow/tree/master/src/parser"
+bug-reports: "https://github.com/facebook/flow/issues"
+license: "MIT"
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "5.2.0"}
+  "dune" {>= "3.2"}
+  "base" {>= "v0.16.3"}
+  "ppxlib" {>= "0.32.1"}
+  "ppx_deriving" {build}
+  "ppx_gen_rec" {build}
+  "wtf8"
+]
+dev-repo: "git+https://github.com/facebook/flow.git"
+synopsis: "The Flow parser is a JavaScript parser written in OCaml"
+description: """
+It produces an AST that conforms to ESTree. The Flow Parser can be compiled to native code or can be compiled to JavaScript using js_of_ocaml.
+
+To find out more about Flow, check out <https://flow.org>."""
+url {
+  src: "https://github.com/facebook/flow/archive/refs/tags/v0.246.0.tar.gz"
+  checksum: [
+    "md5=5c57d271f28352f52dff2dadd7cfff02"
+    "sha512=01c10524a82fc31f66a882cb250ea840c40d07e57bf9eec4c9e0ae2aacf750c1de3ed69d5fcc74eb69ed55b8b1987d674970784622b3232a23a7129789c159c9"
+  ]
+}


### PR DESCRIPTION
### `flow_parser.0.246.0`
The Flow parser is a JavaScript parser written in OCaml
It produces an AST that conforms to ESTree. The Flow Parser can be compiled to native code or can be compiled to JavaScript using js_of_ocaml.

To find out more about Flow, check out <https://flow.org>.



---
* Homepage: https://github.com/facebook/flow/tree/master/src/parser
* Source repo: git+https://github.com/facebook/flow.git
* Bug tracker: https://github.com/facebook/flow/issues

---
:camel: Pull-request generated by opam-publish v2.4.0