### PR TITLE
Fix upper bounds in neural_nets_lib to prepare for arrayjit.0.4.1

### DIFF
--- a/packages/neural_nets_lib/neural_nets_lib.0.3.3/opam
+++ b/packages/neural_nets_lib/neural_nets_lib.0.3.3/opam
@@ -4,7 +4,7 @@ synopsis:
   "A from-scratch Deep Learning framework with an optimizing compiler, shape inference, concise syntax"
 description:
   "OCaml Compiles Algorithms for Neural Networks Learning is a compiled Deep Learning framework that puts emphasis on low-level backends (like TinyGrad), shape inference, concise notation (ab)using PPX."
-maintainer: ["Lukasz Stafiniak"]
+maintainer: ["Lukasz Stafiniak <lukstafi@gmail.com>"]
 authors: ["Lukasz Stafiniak"]
 license: "BSD-2-Clause"
 tags: ["deeplearning" "tensor" "backprop" "jit" "gccjit" "CUDA"]

--- a/packages/neural_nets_lib/neural_nets_lib.0.3.3/opam
+++ b/packages/neural_nets_lib/neural_nets_lib.0.3.3/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "3.11"}
   "base"
   "core"
-  "arrayjit"
+  "arrayjit" {= "0.3.3"}
   "printbox"
   "printbox-text"
   "ocannl_npy"

--- a/packages/neural_nets_lib/neural_nets_lib.0.4.0/opam
+++ b/packages/neural_nets_lib/neural_nets_lib.0.4.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "3.11"}
   "base"
   "core"
-  "arrayjit"
+  "arrayjit" {= "0.4.0"}
   "printbox"
   "printbox-text"
   "ocannl_npy"

--- a/packages/neural_nets_lib/neural_nets_lib.0.4.0/opam
+++ b/packages/neural_nets_lib/neural_nets_lib.0.4.0/opam
@@ -4,7 +4,7 @@ synopsis:
   "A from-scratch Deep Learning framework with an optimizing compiler, shape inference, concise syntax"
 description:
   "OCaml Compiles Algorithms for Neural Networks Learning is a compiled Deep Learning framework that puts emphasis on low-level backends (like tinygrad), shape inference, concise notation (ab)using PPX."
-maintainer: ["Lukasz Stafiniak"]
+maintainer: ["Lukasz Stafiniak <lukstafi@gmail.com>"]
 authors: ["Lukasz Stafiniak"]
 license: "BSD-2-Clause"
 tags: ["deeplearning" "tensor" "backprop" "jit" "gccjit" "CUDA"]


### PR DESCRIPTION
Internal dependency propagation of OCANNL (packages arrayjit, neural_nets_lib).