### PR TITLE
[new release] trace (4 packages) (0.8)

### DIFF
--- a/packages/ppx_trace/ppx_trace.0.8/opam
+++ b/packages/ppx_trace/ppx_trace.0.8/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A ppx-based preprocessor for trace"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "ppx"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "ppxlib" {>= "0.28"}
+  "trace" {= version}
+  "trace-tef" {= version & with-test}
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "mtime" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.8/trace-0.8.tbz"
+  checksum: [
+    "sha256=34cfa5662b611c1e246f0fb8131ee605eeb90b359c105e882f51adc7e70878c3"
+    "sha512=ea47974a77a0ab26c58fe6d1bc898d4f3e6a5f865e4c1acb4188b9acd7ba8e7527d0ea7f2ae66574ceccc14f11127ee203aedba2be334d17b36c83dabff61261"
+  ]
+}
+x-commit-hash: "9a7b4710a3b9838130faada09bd1ef7982c65633"

--- a/packages/trace-fuchsia/trace-fuchsia.0.8/opam
+++ b/packages/trace-fuchsia/trace-fuchsia.0.8/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "A high-performance backend for trace, emitting a Fuchsia trace into a file"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "tracing" "fuchsia"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "trace" {= version}
+  "mtime" {>= "2.0"}
+  "thread-local-storage" {>= "0.2"}
+  "base-bigarray"
+  "base-unix"
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+available: arch != "s390x"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.8/trace-0.8.tbz"
+  checksum: [
+    "sha256=34cfa5662b611c1e246f0fb8131ee605eeb90b359c105e882f51adc7e70878c3"
+    "sha512=ea47974a77a0ab26c58fe6d1bc898d4f3e6a5f865e4c1acb4188b9acd7ba8e7527d0ea7f2ae66574ceccc14f11127ee203aedba2be334d17b36c83dabff61261"
+  ]
+}
+x-commit-hash: "9a7b4710a3b9838130faada09bd1ef7982c65633"

--- a/packages/trace-tef/trace-tef.0.8/opam
+++ b/packages/trace-tef/trace-tef.0.8/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "A simple backend for trace, emitting Catapult/TEF JSON into a file"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "tracing" "catapult" "TEF" "chrome-format"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "trace" {= version}
+  "mtime" {>= "2.0"}
+  "base-unix"
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.8/trace-0.8.tbz"
+  checksum: [
+    "sha256=34cfa5662b611c1e246f0fb8131ee605eeb90b359c105e882f51adc7e70878c3"
+    "sha512=ea47974a77a0ab26c58fe6d1bc898d4f3e6a5f865e4c1acb4188b9acd7ba8e7527d0ea7f2ae66574ceccc14f11127ee203aedba2be334d17b36c83dabff61261"
+  ]
+}
+x-commit-hash: "9a7b4710a3b9838130faada09bd1ef7982c65633"

--- a/packages/trace/trace.0.8/opam
+++ b/packages/trace/trace.0.8/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "A stub for tracing/observability, agnostic in how data is collected"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "tracing" "observability" "profiling"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "hmap"
+  "mtime" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.8/trace-0.8.tbz"
+  checksum: [
+    "sha256=34cfa5662b611c1e246f0fb8131ee605eeb90b359c105e882f51adc7e70878c3"
+    "sha512=ea47974a77a0ab26c58fe6d1bc898d4f3e6a5f865e4c1acb4188b9acd7ba8e7527d0ea7f2ae66574ceccc14f11127ee203aedba2be334d17b36c83dabff61261"
+  ]
+}
+x-commit-hash: "9a7b4710a3b9838130faada09bd1ef7982c65633"


### PR DESCRIPTION
A stub for tracing/observability, agnostic in how data is collected

- Project page: <a href="https://github.com/c-cube/ocaml-trace">https://github.com/c-cube/ocaml-trace</a>

##### CHANGES:

- add `trace.subscriber` instead of a separate library
- add `trace-tef.tldrs`, to trace multiple processes easily (with external rust daemon)

- breaking: `trace-tef`: use `mtime.now`, not a counter, for multiproc
- `trace-fuchsia`: require thread-local-storage 0.2
