### PR TITLE
[new release] colombe, sendmail and sendmail-lwt (0.9.0)

### DIFF
--- a/packages/colombe/colombe.0.9.0/opam
+++ b/packages/colombe/colombe.0.9.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat <gwenaelle@osau.re>" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat <gwenaelle@osau.re>" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+synopsis:     "SMTP protocol in OCaml"
+doc:          "https://mirage.github.io/colombe/"
+description: """SMTP protocol according RFC5321 without extension."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "3.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "ocaml-syntax-shims"
+  "alcotest" {with-test}
+  "crowbar" {>= "0.2" & with-test}
+]
+depopts: [ "emile" ]
+conflicts: [ "emile" {< "0.8"} ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.9.0/colombe-0.9.0.tbz"
+  checksum: [
+    "sha256=65606fad7368988c45254aabe24f02b0f6fe128df84c5b085700184caf33723e"
+    "sha512=aa5e0ca28d3eba81f721e1c0785390d5cdccdffc74f3371d96885d8d2049790345113d59606907b1cb275d97164a06ef2f216043174530bffd12a914fecf63c7"
+  ]
+}
+x-commit-hash: "d0624ad01f330b04efddf7423d4141e344982132"

--- a/packages/sendmail-lwt/sendmail-lwt.0.9.0/opam
+++ b/packages/sendmail-lwt/sendmail-lwt.0.9.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat <gwenaelle@osau.re>" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat <gwenaelle@osau.re>" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT and TLS."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "sendmail" {= version}
+  "domain-name"
+  "lwt"
+  "tls" {>= "0.13.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "x509" {>= "0.12.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.9.0/colombe-0.9.0.tbz"
+  checksum: [
+    "sha256=65606fad7368988c45254aabe24f02b0f6fe128df84c5b085700184caf33723e"
+    "sha512=aa5e0ca28d3eba81f721e1c0785390d5cdccdffc74f3371d96885d8d2049790345113d59606907b1cb275d97164a06ef2f216043174530bffd12a914fecf63c7"
+  ]
+}
+x-commit-hash: "d0624ad01f330b04efddf7423d4141e344982132"

--- a/packages/sendmail/sendmail.0.9.0/opam
+++ b/packages/sendmail/sendmail.0.9.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat <gwenaelle@osau.re>" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat <gwenaelle@osau.re>" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command"
+description: """A library to be able to send an email."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "colombe" {= version}
+  "tls" {>= "1.0.2"}
+  "base64" {>= "3.0.0"}
+  "ke" {>= "0.4"}
+  "logs"
+  "rresult"
+  "bigstringaf" {>= "0.2.0"}
+  "emile" {>= "0.8" & with-test}
+  "mrmime" {>= "0.3.2" & with-test}
+  "cstruct" {>= "6.0.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.9.0/colombe-0.9.0.tbz"
+  checksum: [
+    "sha256=65606fad7368988c45254aabe24f02b0f6fe128df84c5b085700184caf33723e"
+    "sha512=aa5e0ca28d3eba81f721e1c0785390d5cdccdffc74f3371d96885d8d2049790345113d59606907b1cb275d97164a06ef2f216043174530bffd12a914fecf63c7"
+  ]
+}
+x-commit-hash: "d0624ad01f330b04efddf7423d4141e344982132"


### PR DESCRIPTION
SMTP protocol in OCaml

- Project page: <a href="https://github.com/mirage/colombe">https://github.com/mirage/colombe</a>
- Documentation: <a href="https://mirage.github.io/colombe/">https://mirage.github.io/colombe/</a>

##### CHANGES:

- Upgrade to `tls.1.0.0` (mirage/colombe#74, @dinosaure, @hannesm)
