### PR TITLE
Remove parallelism warning from 4.14+

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
@@ -79,15 +79,6 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.14.0.tar.gz"
   checksum: "sha256=39f44260382f28d1054c5f9d8bf4753cb7ad64027da792f7938344544da155e8"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1/opam
@@ -79,15 +79,6 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.14.1.tar.gz"
   checksum: "sha256=776006e6f0b9bcfb6d9d74381c588e587432ca85562fde93bb80472a5145b028"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.2/opam
@@ -79,15 +79,6 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.14.2.tar.gz"
   checksum: "sha256=c2d706432f93ba85bd3383fa451d74543c32a4e84a1afaf3e8ace18f7f097b43"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0/opam
@@ -78,15 +78,6 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/5.0.0.tar.gz"
   checksum: "sha256=72fa3d0ba19b82fcb9e6c62e0090b9d22e5905c4be0f94faf56904a9377a9e5b"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0/opam
@@ -78,15 +78,6 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/5.1.0.tar.gz"
   checksum: "sha256=43a3ac7aab7f8880f2bb6221317be55319b356e517622fdc28359fe943e6a450"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1/opam
@@ -78,15 +78,6 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/5.1.1.tar.gz"
   checksum: "sha256=57f7b382b3d71198413ede405d95ef3506f1cdc480cda1dca1e26b37cb090e17"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0/opam
@@ -78,15 +78,6 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/5.2.0.tar.gz"
   checksum: "sha256=48554abfd530fcdaa08f23f801b699e4f74c320ddf7d0bd56b0e8c24e55fc911"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
@@ -100,15 +100,6 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.13.tar.gz"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
-]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
@@ -99,15 +99,6 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.14.0.tar.gz"
   checksum: "sha256=39f44260382f28d1054c5f9d8bf4753cb7ad64027da792f7938344544da155e8"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+BER/opam
@@ -64,15 +64,6 @@ url {
     "md5=ebdc0ce3b02aacd0567f4136b1b16074"
   ]
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+options/opam
@@ -99,15 +99,6 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.14.1.tar.gz"
   checksum: "sha256=776006e6f0b9bcfb6d9d74381c588e587432ca85562fde93bb80472a5145b028"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.4.14.2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.2+options/opam
@@ -99,15 +99,6 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/4.14.2.tar.gz"
   checksum: "sha256=c2d706432f93ba85bd3383fa451d74543c32a4e84a1afaf3e8ace18f7f097b43"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.4.14.3+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.3+trunk/opam
@@ -5,7 +5,14 @@ maintainer: [
   "David Allsopp <david@tarides.com>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
-authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.14"
@@ -101,15 +108,6 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/4.14.tar.gz"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
@@ -112,15 +112,6 @@ url {
   src: "https://github.com/ocaml/ocaml/archive/5.0.0.tar.gz"
   checksum: "sha256=72fa3d0ba19b82fcb9e6c62e0090b9d22e5905c4be0f94faf56904a9377a9e5b"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
 conflicts: [
   "ocaml-option-fp"
   "system-msvc"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+tsan/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+tsan/opam
@@ -49,15 +49,6 @@ url {
   src:
     "https://github.com/ocaml-multicore/ocaml-tsan/archive/5.0.0+tsan.tar.gz"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
 conflicts: [
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"

--- a/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
@@ -68,6 +68,7 @@ x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build-env: [
+  [MSYS2_ARG_CONV_EXCL = "*"]
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
@@ -112,15 +112,6 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/5.0.tar.gz"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
-]
 conflicts: [
   "ocaml-option-fp"
   "system-msvc"

--- a/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
@@ -68,6 +68,7 @@ x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build-env: [
+  [MSYS2_ARG_CONV_EXCL = "*"]
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
 ]

--- a/packages/ocaml-variants/ocaml-variants.5.2.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.1+trunk/opam
@@ -68,6 +68,7 @@ x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build-env: [
+  [MSYS2_ARG_CONV_EXCL = "*"]
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
 ]


### PR DESCRIPTION
While clearing the decks for something more important, these diffs were irritating.

The parallelism warning has been mostly removed (note that several of the +options packages from recent releases do _not_ include it). It's highly unlikely to be the root cause, and the suggestion just causes the poor user to waste time and energy on a sequential build.

While here, there are three trivial updates to `+trunk` packages when building on MSYS2.

Changes to `post-messages` should not trigger rebuilds 🤞