### PR TITLE
[new release] tar (4 packages) (3.1.2)

### DIFF
--- a/packages/tar-eio/tar-eio.3.1.2/opam
+++ b/packages/tar-eio/tar-eio.3.1.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files using Eio"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library uses Eio to provide a portable tar library.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.00.0"}
+  "eio" {>= "1.1" & < "1.2"}
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.1.2/tar-3.1.2.tbz"
+  checksum: [
+    "sha256=85c79308a41d3d594b98cfe42eaee46b875855748eb0f0e48a9785042bed16a3"
+    "sha512=fa1871d66f3588a08952a9de347af8be94535476be0ed31808996eb79eb13c2e31f8be543e3123e99178a927212e08eca13c4294cd6dcd596513856907cf2218"
+  ]
+}
+x-commit-hash: "6e524cd9567eb4d24b636d1bc7bde0659f5c8719"

--- a/packages/tar-mirage/tar-mirage.3.1.2/opam
+++ b/packages/tar-mirage/tar-mirage.3.1.2/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis: "Read and write tar format files via MirageOS interfaces"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library is functorised over external OS dependencies
+to facilitate embedding within MirageOS.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "5.6.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "mirage-kv" {>= "6.0.0"}
+  "optint"
+  "ptime"
+  "tar" {= version}
+  "mirage-block-unix" {with-test & >= "2.13.0"}
+  "mirage-clock-unix" {with-test & >= "4.0.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "alcotest-lwt" {>= "1.7.0" & with-test}
+  "tar-unix" {with-test & = version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.1.2/tar-3.1.2.tbz"
+  checksum: [
+    "sha256=85c79308a41d3d594b98cfe42eaee46b875855748eb0f0e48a9785042bed16a3"
+    "sha512=fa1871d66f3588a08952a9de347af8be94535476be0ed31808996eb79eb13c2e31f8be543e3123e99178a927212e08eca13c4294cd6dcd596513856907cf2218"
+  ]
+}
+x-commit-hash: "6e524cd9567eb4d24b636d1bc7bde0659f5c8719"

--- a/packages/tar-unix/tar-unix.3.1.2/opam
+++ b/packages/tar-unix/tar-unix.3.1.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files from Unix"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library provides a Unix or Windows compatible interface.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.7.0"}
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.1.2/tar-3.1.2.tbz"
+  checksum: [
+    "sha256=85c79308a41d3d594b98cfe42eaee46b875855748eb0f0e48a9785042bed16a3"
+    "sha512=fa1871d66f3588a08952a9de347af8be94535476be0ed31808996eb79eb13c2e31f8be543e3123e99178a927212e08eca13c4294cd6dcd596513856907cf2218"
+  ]
+}
+x-commit-hash: "6e524cd9567eb4d24b636d1bc7bde0659f5c8719"

--- a/packages/tar/tar.3.1.2/opam
+++ b/packages/tar/tar.3.1.2/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files in pure OCaml"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "decompress" {>= "1.5.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.1.2/tar-3.1.2.tbz"
+  checksum: [
+    "sha256=85c79308a41d3d594b98cfe42eaee46b875855748eb0f0e48a9785042bed16a3"
+    "sha512=fa1871d66f3588a08952a9de347af8be94535476be0ed31808996eb79eb13c2e31f8be543e3123e99178a927212e08eca13c4294cd6dcd596513856907cf2218"
+  ]
+}
+x-commit-hash: "6e524cd9567eb4d24b636d1bc7bde0659f5c8719"


### PR DESCRIPTION
Decode and encode tar format files in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-tar">https://github.com/mirage/ocaml-tar</a>
- Documentation: <a href="https://mirage.github.io/ocaml-tar/">https://mirage.github.io/ocaml-tar/</a>

##### CHANGES:

- Fix a wrong assumption in `Tar_lwt_unix.run` for `Tar.Really_read _` that one
  tar block was always read. This meant that using `Tar.Really_read` with a
  size different from 512 would fail. (Reported by @jonahbeckford, review by @hannesm, @reynir, mirage/ocaml-tar#153)
- Document better the actual behavior of `Tar_unix.extract` and
  `Tar_lwt_unix.extract` (@reynir, mirage/ocaml-tar#155)
