### PR TITLE
Packages for OCaml 5.3.0~alpha1

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.3.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.3.0~alpha1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First alpha release of OCaml 5.3.0"
+maintainer: [
+  "David Allsopp <david@tarides.com>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.3"
+depends: [
+  "ocaml-compiler" {= "5.3.0~alpha1"}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
+  "ocaml-options-vanilla" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]

--- a/packages/ocaml-compiler/ocaml-compiler.5.3.0~alpha1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3.0~alpha1/opam
@@ -1,0 +1,142 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First alpha release of OCaml 5.3.0"
+maintainer: [
+  "David Allsopp <david@tarides.com>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.3"
+depends: [
+  # This is OCaml 5.3.0
+  "ocaml" {= "5.3.0" & post}
+
+  # General base- packages
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "base-effects" {post}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
+  # i686 mingw-w64 / MSVC
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
+]
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
+build-env: [
+  [MSYS2_ARG_CONV_EXCL = "*"]
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
+    "--with-winpthreads-msvc=%{winpthreads:share}%" {system-msvc:installed}
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--without-zstd" {ocaml-option-no-compression:installed}
+    "--enable-tsan" {ocaml-option-tsan:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
+    "CFLAGS=-Os -mno-outline-atomics" {ocaml-option-musl:installed & arch = "arm64"}
+    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.3.0-alpha1.tar.gz"
+  checksum: "sha256=6c0fc1a4d88f1cf8cd403c8375ecb52324ac29c1ac00c37fe1a59462d13ba661"
+}
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-no-compression"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+  "ocaml-option-tsan"
+]
+extra-source "ocaml-compiler.install" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/ocaml/899b8f3bece45f55161dad72eaa223c2bb7202e8/ocaml-variants.install"
+  checksum: [
+    "sha256=7af3dc34e6f9f3be2ffd8d32cd64fa650d6a036c86c4821a7033d24a90fba11c"
+    "md5=781ea69255fd0cb643a9617ff56fd6ba"
+  ]
+}

--- a/packages/ocaml-compiler/ocaml-compiler.5.3/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3/opam
@@ -1,0 +1,133 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "Latest 5.3 development"
+maintainer: [
+  "David Allsopp <david@tarides.com>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.3"
+depends: [
+  # This is OCaml 5.3.0
+  "ocaml" {= "5.3.0" & post}
+
+  # General base- packages
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "base-effects" {post}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
+  # i686 mingw-w64 / MSVC
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
+]
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
+build-env: [
+  [MSYS2_ARG_CONV_EXCL = "*"]
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
+    "--with-winpthreads-msvc=%{winpthreads:share}%" {system-msvc:installed}
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--without-zstd" {ocaml-option-no-compression:installed}
+    "--enable-tsan" {ocaml-option-tsan:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
+    "CFLAGS=-Os -mno-outline-atomics" {ocaml-option-musl:installed & arch = "arm64"}
+    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.3.tar.gz"
+}
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-no-compression"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+  "ocaml-option-tsan"
+]

--- a/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam
@@ -11,122 +11,16 @@ authors: [
   "Alain Frisch"
   "Jacques Garrigue"
   "Didier Rémy"
+  "KC Sivaramakrishnan"
   "Jérôme Vouillon"
 ]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.3"
 depends: [
-  # This is OCaml 5.3.0
-  "ocaml" {= "5.3.0" & post}
-
-  # General base- packages
-  "base-unix" {post}
-  "base-bigarray" {post}
-  "base-threads" {post}
-  "base-domains" {post}
-  "base-nnp" {post}
-  "base-effects" {post}
+  "ocaml-compiler" {= "5.3"}
 
   "ocaml-beta" {opam-version < "2.1.0"}
-
-  # Architecture (non-Windows)
-  # opam-repository at present requires that ocaml-base-compiler is installed
-  # using an architecture which matches the machine's, since arch is used in
-  # available fields. Cross-compilation at this stage is an unstable accident.
-  "host-arch-arm32" {arch = "arm32" & post}
-  "host-arch-arm64" {arch = "arm64" & post}
-  "host-arch-ppc64" {arch = "ppc64" & post}
-  "host-arch-riscv64" {arch = "riscv64" & post}
-  "host-arch-s390x" {arch = "s390x" & post}
-  # The Windows ports explicitly select the architecture (see below) this
-  # facility is not yet available for other platforms.
-  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
-   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
-  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
-
-  # Port selection (Windows)
-  # amd64 mingw-w64 / MSVC
-  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
-      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
-  # i686 mingw-w64 / MSVC
-   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
-      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
-  # Non-Windows systems
-   "host-system-other" {os != "win32" & post})
-
-  # All the 32-bit architectures are bytecode-only
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
-
-  # Support Packages
-  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
-setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
-x-env-path-rewrite: [
-  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
-]
-build-env: [
-  [MSYS2_ARG_CONV_EXCL = "*"]
-  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
-  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
-]
-build: [
-  [
-    "./configure"
-    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
-    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
-    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
-    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
-    "--prefix=%{prefix}%"
-    "--docdir=%{doc}%/ocaml"
-    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
-    "--with-winpthreads-msvc=%{winpthreads:share}%" {system-msvc:installed}
-    "-C"
-    "--with-afl" {ocaml-option-afl:installed}
-    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
-    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
-    "--enable-flambda" {ocaml-option-flambda:installed}
-    "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--without-zstd" {ocaml-option-no-compression:installed}
-    "--enable-tsan" {ocaml-option-tsan:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
-    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
-    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
-    "CFLAGS=-Os" {ocaml-option-musl:installed}
-    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
-    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
-    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
-    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
-    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
-    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
-    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
-    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
-    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
-    "LIBS=-static" {ocaml-option-static:installed}
-    "--disable-warn-error"
-  ]
-  [make "-j%{jobs}%"]
-]
-install: [make "install"]
-url {
-  src: "https://github.com/ocaml/ocaml/archive/5.3.tar.gz"
-}
-depopts: [
-  "ocaml-option-32bit"
-  "ocaml-option-afl"
-  "ocaml-option-bytecode-only"
-  "ocaml-option-no-flat-float-array"
-  "ocaml-option-flambda"
-  "ocaml-option-fp"
-  "ocaml-option-no-compression"
-  "ocaml-option-musl"
-  "ocaml-option-leak-sanitizer"
-  "ocaml-option-address-sanitizer"
-  "ocaml-option-static"
-  "ocaml-option-tsan"
-]

--- a/packages/ocaml-variants/ocaml-variants.5.3.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0~alpha1+options/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First alpha release of OCaml 5.3.0"
+maintainer: [
+  "David Allsopp <david@tarides.com>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.3"
+depends: [
+  "ocaml-compiler" {= "5.3.0~alpha1"}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]

--- a/packages/ocaml/ocaml.5.3.0/opam
+++ b/packages/ocaml/ocaml.5.3.0/opam
@@ -25,12 +25,15 @@ depends: [
 ]
 flags: conf
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build-env: [
   [CAML_LD_LIBRARY_PATH = ""]

--- a/packages/ocaml/ocaml.5.3.0/opam
+++ b/packages/ocaml/ocaml.5.3.0/opam
@@ -18,7 +18,7 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 depends: [
   "ocaml-config" {>= "3"}
-  "ocaml-base-compiler" {= "5.3.0"} |
+  "ocaml-base-compiler" {>= "5.3.0~" & < "5.3.1~"} |
   "ocaml-variants" {>= "5.3.0~" & < "5.3.1~"} |
   "ocaml-system" {>= "5.3.0~" & < "5.3.1~"} |
   "dkml-base-compiler" {>= "5.3.0~" & < "5.3.1~"}

--- a/packages/ocaml/ocaml.5.3.0/opam
+++ b/packages/ocaml/ocaml.5.3.0/opam
@@ -5,6 +5,17 @@ description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
 maintainer: "David Allsopp <david@tarides.com>"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 depends: [
   "ocaml-config" {>= "3"}
   "ocaml-base-compiler" {= "5.3.0"} |
@@ -12,6 +23,7 @@ depends: [
   "ocaml-system" {>= "5.3.0~" & < "5.3.1~"} |
   "dkml-base-compiler" {>= "5.3.0~" & < "5.3.1~"}
 ]
+flags: conf
 setenv: [
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
@@ -20,20 +32,9 @@ setenv: [
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
-build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [
   [CAML_LD_LIBRARY_PATH = ""]
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
 ]
-homepage: "https://ocaml.org"
-bug-reports: "https://github.com/ocaml/opam-repository/issues"
-authors: [
-  "Xavier Leroy"
-  "Damien Doligez"
-  "Alain Frisch"
-  "Jacques Garrigue"
-  "Didier Rémy"
-  "Jérôme Vouillon"
-]
-flags: conf
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]


### PR DESCRIPTION
This PR adds ocaml-base-compiler.5.3.0\~alpha1 and ocaml-variants.5.3.0\~alpha1+options.

As a trial for this release cycle, in a similar vein to #17541, there is a small tweak to the compiler's packaging, intended to reduce the maintenance burden in future. The change should be almost completely transparent to users - please either install `ocaml.5.3.0`, `ocaml-base-compiler.5.3.0~alpha1`, or `ocaml-variants.5.3.0~alpha1+options` as you would have done before.

The restructuring introduces a new package ocaml-compiler.5.3.0~alpha1. The intention of this package is similar to ocaml-config, in that it carries the source tarball, dependencies and build instructions for the compiler. This package becomes a single source of truth for a given release of the compiler and means that when changes such as #16722, #19855 and #26177 come along in future only _one_ package per release has to be updated. It also reduces the number of packages to which configuration improvements need to be added such as in #26323.

In terms of review, if one compares the _current_ packages/ocaml-variants/ocaml-variants.5.3.0+trunk/opam with packages/ocaml-compiler/ocaml-compiler.5.3.0\~alpha1/opam, the only pertinent difference is that the new ocaml-compiler packages do _not_ have the `conflict-class` field. The new ocaml-base-compiler.5.3.0\~alpha1 and ocaml-variants.5.3.0\~alpha1 packages then just have to depend on ocaml-compiler.5.3.0\~alpha1 and retain the `conflict-class` field. Note that ocaml-base-compiler.5.3.0\~alpha1 still depends on ocaml-options-vanilla.  That package conflicts all the ocaml-option-\* packages, and so all the `:installed` tests being false reduces the myriad options passed to `configure` to be equivalent to those passed in ocaml-base-compiler.5.2.0 with one exception. `ASPP=cc -c` is no longer passed to `configure` for OpenBSD and macOS, however the default in OCaml's `configure` has already catered for this since OCaml 4.08 (so there is no semantic difference).

The ocaml-variants.5.3.0+trunk package is updated to use ocaml-compiler.5.3. This version ("5.3") of ocaml-compiler is "cunningly" picked as it is _older_ than release versions, which avoids any temptation of opam to try to upgrade to it. It's necessary to use the structure for ocaml-variants.5.3.0+trunk now as, uniquely, during a release cycle we have avoid-version set on the alpha releases which otherwise makes ocaml-variants.5.3.0+trunk more tempting to the solver, because it involves one package installation fewer.

I have tested this packaging locally on Linux and Windows (mingw-w64 and msvc64) with `opam switch create ocaml-5.3 --formula '"ocaml" {>= "5.3" & < "5.4"}'` and verified that in each case ocaml-base-compiler.5.3.0~alpha1 is the default selected package.

Finally, there is a minor tweak to ocaml.5.3.0 to allow the use of pre-release ocaml-base-compiler packages and in the environment commands the beginnings of a fix for #25819 (on which more soon).