### PR TITLE
[new release] fpath-base (2 packages) (0.2.1)

### DIFF
--- a/packages/fpath-base/fpath-base.0.2.1/opam
+++ b/packages/fpath-base/fpath-base.0.2.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Adds a few functions to Fpath to use alongside Base"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/fpath-base"
+doc: "https://mbarbin.github.io/fpath-base/"
+bug-reports: "https://github.com/mbarbin/fpath-base/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.2"}
+  "base" {>= "v0.17" & < "v0.18"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/fpath-base.git"
+url {
+  src:
+    "https://github.com/mbarbin/fpath-base/releases/download/0.2.1/fpath-base-0.2.1.tbz"
+  checksum: [
+    "sha256=c99182de14f46509fca1635d32ac6d6369f7f962cb3ea547c901821d75aa7150"
+    "sha512=36b23cb9bd57f71bd48c22e4b07735a3639ded3a69bf1b0072ea1c5d3207de8ef936f9a144ae17572ba3175c6d63215de8615e4dd6af5af61056a5c424b845af"
+  ]
+}
+x-commit-hash: "87d0612e1503f4d6c22aac3bf2ae60dd3fe47c99"

--- a/packages/fpath-sexp0/fpath-sexp0.0.2.1/opam
+++ b/packages/fpath-sexp0/fpath-sexp0.0.2.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "Adds Fpath.sexp_of_t and defines 3 new modules: Fpart, Absolute_path and Relative_path"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/fpath-base"
+doc: "https://mbarbin.github.io/fpath-base/"
+bug-reports: "https://github.com/mbarbin/fpath-base/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.2"}
+  "fpath" {>= "0.7.3"}
+  "sexplib0" {>= "v0.17" & < "v0.18"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/fpath-base.git"
+url {
+  src:
+    "https://github.com/mbarbin/fpath-base/releases/download/0.2.1/fpath-base-0.2.1.tbz"
+  checksum: [
+    "sha256=c99182de14f46509fca1635d32ac6d6369f7f962cb3ea547c901821d75aa7150"
+    "sha512=36b23cb9bd57f71bd48c22e4b07735a3639ded3a69bf1b0072ea1c5d3207de8ef936f9a144ae17572ba3175c6d63215de8615e4dd6af5af61056a5c424b845af"
+  ]
+}
+x-commit-hash: "87d0612e1503f4d6c22aac3bf2ae60dd3fe47c99"


### PR DESCRIPTION
This is the initial release for 2 packages `fpath-sexplib0` and `fpath-base`. Short synopsis below, more information at https://github.com/mbarbin/fpath-base

## fpath-sexplib0

This package only depends on `fpath` and `sexplib0`. It defines a single module, `Fpath_sexplib0`, which is designed to be opened to shadow the `Fpath` module to add small helpers and a sexp serializer to it. The package also introduces three new modules to the scope: `Fpart`, `Absolute_path` and `Relative_path` to increase type-safety when manipulating paths that are known to be relative or absolute.

## fpath-base

This package further extends `fpath-sexplib0` and adds a dependency on base. It is designed to be compatible with Base-style containers such as `Map`, `Set`, `Hashtbl`, `Hash_set`.

## Motivation

This is a dependency to my [vcs](https://github.com/mbarbin/vcs) project. Publishing these packages to opam brings me one step closer to publishing `vcs` to opam one day. Thanks for your consideration!