### PR TITLE
Add dependency on an OCaml package for `semaphore-compat`

### DIFF
--- a/packages/semaphore-compat/semaphore-compat.1.0.0/opam
+++ b/packages/semaphore-compat/semaphore-compat.1.0.0/opam
@@ -12,6 +12,7 @@ homepage: "https://github.com/mirage/semaphore-compat"
 doc: "https://mirage.github.io/semaphore-compat"
 bug-reports: "https://github.com/mirage/semaphore-compat/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.0"}
 ]
 build: [

--- a/packages/semaphore-compat/semaphore-compat.1.0.1/opam
+++ b/packages/semaphore-compat/semaphore-compat.1.0.1/opam
@@ -12,6 +12,7 @@ homepage: "https://github.com/mirage/semaphore-compat"
 doc: "https://mirage.github.io/semaphore-compat"
 bug-reports: "https://github.com/mirage/semaphore-compat/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.0"}
 ]
 build: [


### PR DESCRIPTION
Dune's package management is more strict about dependencies so package that don't depend on `ocaml` don't have an OCaml compiler available.

This PR adds the dependency.