### PR TITLE
Allow frame pointers on macOS from 5.3 onwards.

### DIFF
--- a/packages/ocaml-option-fp/ocaml-option-fp.1/opam
+++ b/packages/ocaml-option-fp/ocaml-option-fp.1/opam
@@ -8,9 +8,9 @@ homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "CC0-1.0+"
 depends: [
-  "ocaml-variants" {post & >= "4.12.0~"}
+  "ocaml-variants" {post & (os = "linux" & >= "4.12.0~" | os = "macos" & >= "5.3.0~")}
 ]
 conflicts: ["ocaml-option-musl"]
-available: os = "linux" & arch = "x86_64"
+available: (os = "linux" | os = "macos") & arch = "x86_64"
 maintainer: "David Allsopp <david@tarides.com>"
 flags: compiler


### PR DESCRIPTION
OCaml 5.3.0 includes the option for compiling with frame pointers on macOS x86_64 [change log entry](https://github.com/ocaml/ocaml/blob/5.3/Changes#L88-L89).

It can be tested locally using these commands to create a switch:
```
opam repo add tmcgilchrist https://github.com/tmcgilchrist/opam-repository.git\#macos_frame_pointers
opam switch create 5.3.0~alpha1+fp ocaml-variants.5.3.0~alpha1+options ocaml-option-fp
```

Relates to https://github.com/ocaml/opam-repository/issues/26596
