### PR TITLE
Add `ocaml` dependency to `rusage`

### DIFF
--- a/packages/rusage/rusage.1.0.0/opam
+++ b/packages/rusage/rusage.1.0.0/opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/CraigFe/ocaml-rusage"
 doc: "https://CraigFe.github.io/ocaml-rusage/"
 bug-reports: "https://github.com/CraigFe/ocaml-rusage/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.0"}
 ]
 build: [

--- a/packages/rusage/rusage.1.0.0/opam
+++ b/packages/rusage/rusage.1.0.0/opam
@@ -10,6 +10,7 @@ depends: [
   "ocaml"
   "dune" {>= "2.0"}
 ]
+license: "MIT"
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
Compiling rusage requires an OCaml compiler, thus this PR adds that dependency.

The reasoning is the same as for #26610.

Upstream PR here: https://github.com/craigfe/ocaml-rusage/pull/3