### PR TITLE
[new release] semaphore-compat (1.0.2)

### DIFF
--- a/packages/semaphore-compat/semaphore-compat.1.0.2/opam
+++ b/packages/semaphore-compat/semaphore-compat.1.0.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Compatibility Semaphore module"
+description: """
+Projects that want to use the Semaphore module defined in OCaml 4.12.0 while
+staying compatible with older versions of OCaml should use this library
+instead.
+"""
+maintainer: ["Craig Ferguson <me@craigfe.io>"]
+authors: ["Xavier Leroy"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/mirage/semaphore-compat"
+doc: "https://mirage.github.io/semaphore-compat"
+bug-reports: "https://github.com/mirage/semaphore-compat/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/semaphore-compat.git"
+url {
+  src:
+    "https://github.com/mirage/semaphore-compat/releases/download/1.0.2/semaphore-compat-1.0.2.tbz"
+  checksum: [
+    "sha256=e029d9daf5f5ec83e99e503b08d7aec5910a7c0e47168790bf01f4b4228d4676"
+    "sha512=1f37e88c95cf69119c3a7a77ff3a3196a861c28658896ca9981138d6a3faf3fb557d0085dcffc080beb60c1f1ac997df78e069772d5a699b3ea8b08214210e17"
+  ]
+}
+x-commit-hash: "b3608286ec6425c9c1c9b783d5cc230081acf219"

--- a/packages/semaphore-compat/semaphore-compat.1.0.2/opam
+++ b/packages/semaphore-compat/semaphore-compat.1.0.2/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
Compatibility Semaphore module

- Project page: <a href="https://github.com/mirage/semaphore-compat">https://github.com/mirage/semaphore-compat</a>
- Documentation: <a href="https://mirage.github.io/semaphore-compat">https://mirage.github.io/semaphore-compat</a>

##### CHANGES:

- Depend explicitely on `ocaml` as the library depends on the
  standard library (mirage/semaphore-compat#3, @Leonidas-from-XIV)
