### PR TITLE
[new release] ppx_deriving_jsonschema (0.0.2)

### DIFF
--- a/packages/ppx_deriving_jsonschema/ppx_deriving_jsonschema.0.0.2/opam
+++ b/packages/ppx_deriving_jsonschema/ppx_deriving_jsonschema.0.0.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Jsonschema generator for ppx_deriving"
+description:
+  "ppx_deriving_jsonschema is a ppx rewriter that generates jsonschema from ocaml types"
+maintainer: [
+  "Louis Roché <louis.roche@ahrefs.com>" "Ahrefs <github@ahrefs.com>"
+]
+authors: [
+  "Louis Roché <louis.roche@ahrefs.com>" "Ahrefs <github@ahrefs.com>"
+]
+license: "MIT"
+tags: ["jsonschema" "org:ahrefs" "syntax"]
+homepage: "https://github.com/ahrefs/ppx_deriving_jsonschema"
+doc: "https://ahrefs.github.io/ppx_deriving_jsonschema/"
+bug-reports: "https://github.com/ahrefs/ppx_deriving_jsonschema/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.16"}
+  "ppxlib" {>= "0.24.0"}
+  "yojson" {with-test}
+  "ppx_expect" {with-test}
+  "ocamlformat" {with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ppx_deriving_jsonschema.git"
+url {
+  src:
+    "https://github.com/ahrefs/ppx_deriving_jsonschema/releases/download/0.0.2/ppx_deriving_jsonschema-0.0.2.tbz"
+  checksum: [
+    "sha256=fc8a8ff5d75e3b9d296324dafd6b823cc5869486ef9b7e5dcbf7df6304ac3d04"
+    "sha512=71663dfb7fb02c2d96bb5b55d5293eb3ca745aa949e53356a78708d09468b80e02e5d2847f309cb92f55db8e429fcc97f53a6e9f18bf2c8d11896ee026e1c65a"
+  ]
+}
+x-commit-hash: "d188a1021b64163e6f0aa270f9ab4a55e0e372b5"


### PR DESCRIPTION
Jsonschema generator for ppx_deriving

- Project page: <a href="https://github.com/ahrefs/ppx_deriving_jsonschema">https://github.com/ahrefs/ppx_deriving_jsonschema</a>
- Documentation: <a href="https://ahrefs.github.io/ppx_deriving_jsonschema/">https://ahrefs.github.io/ppx_deriving_jsonschema/</a>

##### CHANGES:

- add support for nativeint, bytes, ref, unit
- add ~variant_as_array for compatibility with ppx_deriving_yojson
- support variant payloads
- support polymorphic variants inheritance
- fix encoding of tuples
- change encoding of variants from enum to anyOf
