### PR TITLE
Add: uuidm.0.9.9

### DIFF
--- a/packages/uuidm/uuidm.0.9.9/opam
+++ b/packages/uuidm/uuidm.0.9.9/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Universally unique identifiers (UUIDs) for OCaml"
+description: """\
+Uuidm is an OCaml library implementing 128 bits universally unique
+identifiers version 3, 5 (named based with MD5, SHA-1 hashing), 4
+(random based), 7 (time and random based) and 8 (custom) according to
+[RFC 9562].
+
+Uuidm has no dependency. It is distributed under the ISC license.
+
+[RFC 9562]: https://www.rfc-editor.org/rfc/rfc9562
+
+Homepage: <https://erratique.ch/software/uuidm>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uuidm programmers"
+license: "ISC"
+tags: ["uuid" "codec" "org:erratique"]
+homepage: "https://erratique.ch/software/uuidm"
+doc: "https://erratique.ch/software/uuidm/doc/"
+bug-reports: "https://github.com/dbuenzli/uuidm/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+]
+depopts: ["cmdliner"]
+conflicts: [
+  "cmdliner" {< "1.3.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/uuidm.git"
+url {
+  src: "https://erratique.ch/software/uuidm/releases/uuidm-0.9.9.tbz"
+  checksum:
+    "sha512=284218681f28150b23bc6c9a5f6fea66d05b934d1f76d962e4770b04e21d41a60cdb1fefcdf1628ed46fbcd4d8615a7bfa62174e9109342df299be9df7779916"
+}


### PR DESCRIPTION
* Add: `uuidm.0.9.9` [home](https://erratique.ch/software/uuidm), [doc](https://erratique.ch/software/uuidm/doc/), [issues](https://github.com/dbuenzli/uuidm/issues)  
  *Universally unique identifiers (UUIDs) for OCaml*


---

#### `uuidm` v0.9.9 2024-09-26 Zagreb

- Add `Uuidm.{v7,v7_ns}` to create time and random based V7 UUIDs. 
  Thanks to Robin Newton for the patch ([#14](https://github.com/dbuenzli/uuidm/issues/14)) and Christian Linding
  and Pau Ruiz Safont for the help.
- Add `Uuidm.v7_[non_]monotonic_gen` V7 UUID generators.
- Add `Uuidm.v8` to create V8 custom UUIDs.
- Add `Uuidm.max` the RFC 9569 Max UUID.
- Add `Uuidm.{variant,version,time_ms}` UUID property accessors.
- Change `Uuidm.v4_gen` generation strategy.
- Call `Random.State.make_self_init` lazily rather than during module
  initialisation.
- Documentation: clarified that `Random` based UUID generators are not stable 
  accross OCaml and UUID versions.
- Deprecate `Uuidm.v`, use individual version constructors instead.
- Deprecate type `Uuidm.version`.
- Deprecate `Uuidm.pp_string` to `Uuidm.pp'`.
- Deprecate `Uuidm.{to,of}_[mixed_endian_]bytes` to 
  `Uuidm.{to,of}_[mixed_endian_]binary_string` (follow `Stdlib` terminology).
- Require OCaml 4.14.
- `uuidtrip` set standard output to binary when outputing binary uuids.
- `uuidtrip` add options `--v3`, `--v4`, `--v5`, `--v7`.
- `uuidtrip` add support for v7 time and random based v7 UUIDs generation.

---

Use `b0 -- .opam publish uuidm.0.9.9` to update the pull request.