### PR TITLE
[new release] loc (0.2.0)

### DIFF
--- a/packages/loc/loc.0.2.0/opam
+++ b/packages/loc/loc.0.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Representing ranges of lexing positions from parsed files"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/loc"
+doc: "https://mbarbin.github.io/loc/"
+bug-reports: "https://github.com/mbarbin/loc/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.2"}
+  "fpath" {>= "0.7.3"}
+  "sexplib0" {>= "v0.17" & < "v0.18"}
+  "stdune" {>= "3.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/loc.git"
+url {
+  src: "https://github.com/mbarbin/loc/releases/download/0.2.0/loc-0.2.0.tbz"
+  checksum: [
+    "sha256=30e0468f1a2876accef1aacf8441faac88fa64feb8653a1496c47dd56a8aff29"
+    "sha512=a8ee464212811bdd71be86cd5a174ffa337e816ec23323dd9268dd87603ae83f0593ac0b2c46d9b9a5c49cc5596670434dd99f8f2dcd54754ec90c70c30db320"
+  ]
+}
+x-commit-hash: "25a3faf3069e13575519dd498f97c9fba3a93bb8"


### PR DESCRIPTION
This is the initial release for `Loc`, an OCaml library to manipulate code locations, which are ranges of lexing positions from a parsed file. More info at https://github.com/mbarbin/loc

See discussion in #26604 about publishing a package named `loc` to opam.

See discussion https://github.com/ocaml/dune/discussions/10948 about more sharing with stdune [^1]

[^1]: Regarding the potential follow up with dune's stdlib, I suppose it should be possible to replace an opam package from a certain new major semver in the future. I think it is fine to start with this `loc` and reconsider at a later point. Feel free to comment on the Dune discussion.

