### PR TITLE
[conf-gmp] [depext] 32bit dev package for Debian

### DIFF
--- a/packages/conf-gmp/conf-gmp.4/opam
+++ b/packages/conf-gmp/conf-gmp.4/opam
@@ -28,6 +28,8 @@ depends: [
 depexts: [
   ["libgmp-dev"] {os-family = "debian"}
   ["libgmp-dev"] {os-family = "ubuntu"}
+  ["libgmp-dev:i386"] {os-family = "debian" & arch = "x86_32"}
+  ["libgmp-dev:i386"] {os-family = "ubuntu" & arch = "x86_32"}
   ["gmp"] {os = "macos" & os-distribution = "homebrew"}
   ["gmp"] {os-distribution = "macports" & os = "macos"}
   ["gmp" "gmp-devel"] {os-distribution = "centos"}


### PR DESCRIPTION
I think this should be fine, and makes the `zarith` opam package build with a 32bit OCaml on Ubuntu / Debian.

In the case of a very old distro, this should be OK as `libgmp-dev:i386` is rewritten to `libgmp-dev`.