### PR TITLE
[new release] merlin 4.17-414, 4.17-501 and 5.2-502

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.17/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.17/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14" }
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {>= "4.17"}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.17-501/merlin-4.17-501.tbz"
+  checksum: [
+    "sha256=b15cd89a139a30826eaeaa01aa178ee60c82e3c7bbe6e3f91b806388f522d126"
+    "sha512=b5dfe17466c10fb51dca75b1717cf491f21b3812616f74731df360513dcd94759fd18cbbd65c3bf03807428ecc22351d587334f55cfe1cffa57693a323341cb2"
+  ]
+}
+x-commit-hash: "754b0ec3e415b2fd9da0804ad1443cc10965b41f"

--- a/packages/dot-merlin-reader/dot-merlin-reader.5.2-502/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.2-502/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" }
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {>= "5.0"}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.2-502/merlin-5.2-502.tbz"
+  checksum: [
+    "sha256=5a9d02a831311f8b26d439ae11931a9faaf943c90fdc807c87fc7e3e0be35a85"
+    "sha512=ffb7c7d1f9cbd444972e9c1b3d87375f103cf0b565680e912ea5c3810f4b91d02210b25580235e8592a847011026f05df657f7c89c15b91692d18e1840572c6f"
+  ]
+}
+x-commit-hash: "c76379cdaeb429459c9ecfc2990936eb8a36980a"

--- a/packages/dot-merlin-reader/dot-merlin-reader.5.2/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.2/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "5.2" }
   "dune" {>= "2.9.0"}
-  "merlin-lib" {>= "5.0"}
+  "merlin-lib" {>= "5.2"}
   "ocamlfind" {>= "1.6.0"}
 ]
 description:

--- a/packages/merlin-lib/merlin-lib.4.17-414/opam
+++ b/packages/merlin-lib/merlin-lib.4.17-414/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.17-414/merlin-4.17-414.tbz"
+  checksum: [
+    "sha256=6a71f91fedf46b82c88b3f51d74f61db63cb23adbbc568f77982dd3022e91157"
+    "sha512=1bf2bedd03592dd166835339906bccb62d77df0d96a7ec17011c81fdd2717abfc49b25c44424a674b7c64803d88f0e8cde05c1bb314c3a555eb6afd680812355"
+  ]
+}
+x-commit-hash: "611e0ec5bc599800b7f2c4be2f8f6cbed08482c2"

--- a/packages/merlin-lib/merlin-lib.4.17-501/opam
+++ b/packages/merlin-lib/merlin-lib.4.17-501/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.1.1" & < "5.2"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.17-501/merlin-4.17-501.tbz"
+  checksum: [
+    "sha256=b15cd89a139a30826eaeaa01aa178ee60c82e3c7bbe6e3f91b806388f522d126"
+    "sha512=b5dfe17466c10fb51dca75b1717cf491f21b3812616f74731df360513dcd94759fd18cbbd65c3bf03807428ecc22351d587334f55cfe1cffa57693a323341cb2"
+  ]
+}
+x-commit-hash: "754b0ec3e415b2fd9da0804ad1443cc10965b41f"

--- a/packages/merlin-lib/merlin-lib.5.2-502/opam
+++ b/packages/merlin-lib/merlin-lib.5.2-502/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" & < "5.3"}
+  "dune" {>= "3.0.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.2-502/merlin-5.2-502.tbz"
+  checksum: [
+    "sha256=5a9d02a831311f8b26d439ae11931a9faaf943c90fdc807c87fc7e3e0be35a85"
+    "sha512=ffb7c7d1f9cbd444972e9c1b3d87375f103cf0b565680e912ea5c3810f4b91d02210b25580235e8592a847011026f05df657f7c89c15b91692d18e1840572c6f"
+  ]
+}
+x-commit-hash: "c76379cdaeb429459c9ecfc2990936eb8a36980a"

--- a/packages/merlin/merlin.4.17-414/opam
+++ b/packages/merlin/merlin.4.17-414/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.17"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.17-414/merlin-4.17-414.tbz"
+  checksum: [
+    "sha256=6a71f91fedf46b82c88b3f51d74f61db63cb23adbbc568f77982dd3022e91157"
+    "sha512=1bf2bedd03592dd166835339906bccb62d77df0d96a7ec17011c81fdd2717abfc49b25c44424a674b7c64803d88f0e8cde05c1bb314c3a555eb6afd680812355"
+  ]
+}
+x-commit-hash: "611e0ec5bc599800b7f2c4be2f8f6cbed08482c2"

--- a/packages/merlin/merlin.4.17-501/opam
+++ b/packages/merlin/merlin.4.17-501/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.1" & < "5.2"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.17"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.17-501/merlin-4.17-501.tbz"
+  checksum: [
+    "sha256=b15cd89a139a30826eaeaa01aa178ee60c82e3c7bbe6e3f91b806388f522d126"
+    "sha512=b5dfe17466c10fb51dca75b1717cf491f21b3812616f74731df360513dcd94759fd18cbbd65c3bf03807428ecc22351d587334f55cfe1cffa57693a323341cb2"
+  ]
+}
+x-commit-hash: "754b0ec3e415b2fd9da0804ad1443cc10965b41f"

--- a/packages/merlin/merlin.5.2-502/opam
+++ b/packages/merlin/merlin.5.2-502/opam
@@ -1,0 +1,82 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.2" & < "5.3"}
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "5.0"}
+  "ocaml-index" {>= "1.0" & post}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.2-502/merlin-5.2-502.tbz"
+  checksum: [
+    "sha256=5a9d02a831311f8b26d439ae11931a9faaf943c90fdc807c87fc7e3e0be35a85"
+    "sha512=ffb7c7d1f9cbd444972e9c1b3d87375f103cf0b565680e912ea5c3810f4b91d02210b25580235e8592a847011026f05df657f7c89c15b91692d18e1840572c6f"
+  ]
+}
+x-commit-hash: "c76379cdaeb429459c9ecfc2990936eb8a36980a"

--- a/packages/merlin/merlin.5.2-502/opam
+++ b/packages/merlin/merlin.5.2-502/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "5.2" & < "5.3"}
   "dune" {>= "3.0.0"}
   "merlin-lib" {= version}
-  "dot-merlin-reader" {>= "5.0"}
+  "dot-merlin-reader" {>= "5.2"}
   "ocaml-index" {>= "1.0" & post}
   "yojson" {>= "2.0.0"}
   "conf-jq" {with-test}

--- a/packages/ocaml-index/ocaml-index.5.2-502/opam
+++ b/packages/ocaml-index/ocaml-index.5.2-502/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A tool that indexes value usages from cmt files"
+description:
+  "ocaml-index should integrate with the build system to index codebase and allow tools such as Merlin to perform project-wide occurrences queries."
+maintainer: ["ulysse@tarides.com"]
+authors: ["ulysse@tarides.com"]
+license: "MIT"
+homepage: "https://github.com/ocaml/merlin/ocaml-index"
+bug-reports: "https://github.com/ocaml/merlin/issues"
+depends: [
+  "dune" {>= "3.0.0"}
+  "ocaml" {>= "5.2"}
+  "merlin-lib" {>= "5.1-502"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.2-502/merlin-5.2-502.tbz"
+  checksum: [
+    "sha256=5a9d02a831311f8b26d439ae11931a9faaf943c90fdc807c87fc7e3e0be35a85"
+    "sha512=ffb7c7d1f9cbd444972e9c1b3d87375f103cf0b565680e912ea5c3810f4b91d02210b25580235e8592a847011026f05df657f7c89c15b91692d18e1840572c6f"
+  ]
+}
+x-commit-hash: "c76379cdaeb429459c9ecfc2990936eb8a36980a"


### PR DESCRIPTION
Editor helper, provides completion, typing and source browsing in Vim and Emacs

- Project page: <a href="https://github.com/ocaml/merlin">https://github.com/ocaml/merlin</a>

##### CHANGES:

Thu Sep 26 18:48:42 CEST 2024

  + merlin binary
    - A new `WRAPPING_PREFIX` configuration directive that can be used to tell Merlin
      what to append to the current unit name in the presence of wrapping (ocaml/merlin#1788)
    - Add `-unboxed-types` and `-no-unboxed-types` as ocaml ignored flags (ocaml/merlin#1795, fixes ocaml/merlin#1794)
    - destruct: Refinement in the presence of optional arguments (ocaml/merlin#1800 ocaml/merlin#1807, fixes ocaml/merlin#1770)
    - Implement new expand-node command for expanding PPX annotations (ocaml/merlin#1745)
    - Implement new inlay-hints command for adding hints on a sourcetree (ocaml/merlin#1812)
    - Implement new search-by-type command for searching values by types (ocaml/merlin#1828)
    - Canonicalize paths in occurrences. This helps deduplicate the results and
      show more user-friendly paths. (ocaml/merlin#1840)
    - Fix dot-merlin-reader ignoring `SOURCE_ROOT` and `STDLIB` directives
      (ocaml/merlin#1839, ocaml/merlin#1803)
  + editor modes
    - vim: fix python-3.12 syntax warnings in merlin.py (ocaml/merlin#1798)
    - vim: Dead code / doc removal for previously deleted MerlinPhrase command (ocaml/merlin#1804)
    - emacs: Improve the way that result of polarity search is displayed (ocaml/merlin#1814)
    - emacs: Add `merlin-search-by-type`, `merlin-search-by-polarity` and change the
	  behaviour of `merlin-search` to switch between `by-type` or `by-polarity`
	  depending on the query (ocaml/merlin#1828)
