### PR TITLE
Update provider

### DIFF
--- a/packages/provider/provider.0.0.4/opam
+++ b/packages/provider/provider.0.0.4/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis:
   "Parametrize your OCaml library with values that behave like objects but aren't"
-maintainer: ["Mathieu Barbin"]
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
 authors: ["Mathieu Barbin"]
 license: "ISC"
 homepage: "https://github.com/mbarbin/provider"
@@ -33,6 +33,8 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+flags: [ deprecated ]
+messages: [ "Version 0.0.4 has a known bug in the binding lookup logic - please upgrade" ]
 dev-repo: "git+https://github.com/mbarbin/provider.git"
 url {
   src:

--- a/packages/provider/provider.0.0.9/opam
+++ b/packages/provider/provider.0.0.9/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Dynamic Dispatch with Traits"
-maintainer: ["Mathieu Barbin"]
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
 authors: ["Mathieu Barbin"]
 license: "ISC"
 homepage: "https://github.com/mbarbin/provider"


### PR DESCRIPTION
- Add maintainer email to existing provider packages

- Flagged older `provider.0.0.4` as deprecated.

This version has a bug in the binding lookup I'd be happy to forget. `opam.ocaml.org` says this package is not used ~~so I propose to simply delete this release. Is that technically acceptable?~~