### PR TITLE
[new release] merlin, merlin-lib, dot-merlin-reader (5.2.1-502, 4.17.1-501/414) 

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.17.1-414/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.17.1-414/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "2.9.0"}
-  "merlin-lib" {>= "4.17"}
+  "merlin-lib" {= version}
   "ocamlfind" {>= "1.6.0"}
 ]
 description:
@@ -24,7 +24,7 @@ url {
     "https://github.com/ocaml/merlin/releases/download/v4.17.1-414/merlin-4.17.1-414.tbz"
   checksum: [
     "sha256=bf3f806ef48632053861d54b73bdef9539ba4218af021d8b0acad8e37e645fc6"
-    "sha512=1346170208fa984dfdb45dcce0b44aa8a25a8f8d5ae6da9fbdf521f6abeacf5cc7ac7a567061c2a08c157465f3fb5d59a1c238b634bc74b678816b48bdf05109"
+    "sha512^=1346170208fa984dfdb45dcce0b44aa8a25a8f8d5ae6da9fbdf521f6abeacf5cc7ac7a567061c2a08c157465f3fb5d59a1c238b634bc74b678816b48bdf05109"
   ]
 }
 x-commit-hash: "44c112461cab98b9279798271d003fccda2badba"

--- a/packages/dot-merlin-reader/dot-merlin-reader.4.17.1-501/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.17.1-501/opam
@@ -11,9 +11,9 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "5.2" }
+  "ocaml" {>= "4.14"}
   "dune" {>= "2.9.0"}
-  "merlin-lib" {>= "5.2"}
+  "merlin-lib" {= version}
   "ocamlfind" {>= "1.6.0"}
 ]
 description:
@@ -21,10 +21,10 @@ description:
   stdout."
 url {
   src:
-    "https://github.com/ocaml/merlin/releases/download/v5.2.1-502/merlin-5.2.1-502.tbz"
+    "https://github.com/ocaml/merlin/releases/download/v4.17.1-501/merlin-4.17.1-501.tbz"
   checksum: [
-    "sha256=5c02dc71b2d31b619851c14a965b91c650a4dbcd49bf56004eee61e0c58d584c"
-    "sha512=abf82c906759c8547437664ab5db67b839bbad185fa2541b28e4e07137fdf3824736dae859f0d35bd9a3950633c81a69fd0a1a0e2393ead43822afc66d1aaf3d"
+    "sha256=376707aa871f09e9639456d3fbe4b89a21c9ad75c774e94cbbbe67f842b0a500"
+    "sha512=a11ea4b8e3520b3ee41ae8198cda34b2816b8dfcdcb99350ef29689a7d62bb66d17ffa075c551aa56d521120b55e6db14a106a31f7b3970ed2aa07e1db3c9b88"
   ]
 }
-x-commit-hash: "0eaccc1b8520d605b1e00685e1c3f8acb5da534c"
+x-commit-hash: "650a7865bc37a646250f7c52fa6644d9d4a5218b"

--- a/packages/dot-merlin-reader/dot-merlin-reader.4.17/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.17/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {>= "4.17"}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.17.1-414/merlin-4.17.1-414.tbz"
+  checksum: [
+    "sha256=bf3f806ef48632053861d54b73bdef9539ba4218af021d8b0acad8e37e645fc6"
+    "sha512=1346170208fa984dfdb45dcce0b44aa8a25a8f8d5ae6da9fbdf521f6abeacf5cc7ac7a567061c2a08c157465f3fb5d59a1c238b634bc74b678816b48bdf05109"
+  ]
+}
+x-commit-hash: "44c112461cab98b9279798271d003fccda2badba"

--- a/packages/dot-merlin-reader/dot-merlin-reader.5.2.1-502/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.2.1-502/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" }
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.2.1-502/merlin-5.2.1-502.tbz"
+  checksum: [
+    "sha256=5c02dc71b2d31b619851c14a965b91c650a4dbcd49bf56004eee61e0c58d584c"
+    "sha512=abf82c906759c8547437664ab5db67b839bbad185fa2541b28e4e07137fdf3824736dae859f0d35bd9a3950633c81a69fd0a1a0e2393ead43822afc66d1aaf3d"
+  ]
+}
+x-commit-hash: "0eaccc1b8520d605b1e00685e1c3f8acb5da534c"

--- a/packages/dot-merlin-reader/dot-merlin-reader.5.2/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" }
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {>= "5.2"}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.2.1-502/merlin-5.2.1-502.tbz"
+  checksum: [
+    "sha256=5c02dc71b2d31b619851c14a965b91c650a4dbcd49bf56004eee61e0c58d584c"
+    "sha512=abf82c906759c8547437664ab5db67b839bbad185fa2541b28e4e07137fdf3824736dae859f0d35bd9a3950633c81a69fd0a1a0e2393ead43822afc66d1aaf3d"
+  ]
+}
+x-commit-hash: "0eaccc1b8520d605b1e00685e1c3f8acb5da534c"

--- a/packages/merlin-lib/merlin-lib.4.17.1-414/opam
+++ b/packages/merlin-lib/merlin-lib.4.17.1-414/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.17.1-414/merlin-4.17.1-414.tbz"
+  checksum: [
+    "sha256=bf3f806ef48632053861d54b73bdef9539ba4218af021d8b0acad8e37e645fc6"
+    "sha512=1346170208fa984dfdb45dcce0b44aa8a25a8f8d5ae6da9fbdf521f6abeacf5cc7ac7a567061c2a08c157465f3fb5d59a1c238b634bc74b678816b48bdf05109"
+  ]
+}
+x-commit-hash: "44c112461cab98b9279798271d003fccda2badba"

--- a/packages/merlin-lib/merlin-lib.4.17.1-501/opam
+++ b/packages/merlin-lib/merlin-lib.4.17.1-501/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.1.1" & < "5.2"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.17.1-501/merlin-4.17.1-501.tbz"
+  checksum: [
+    "sha256=376707aa871f09e9639456d3fbe4b89a21c9ad75c774e94cbbbe67f842b0a500"
+    "sha512=a11ea4b8e3520b3ee41ae8198cda34b2816b8dfcdcb99350ef29689a7d62bb66d17ffa075c551aa56d521120b55e6db14a106a31f7b3970ed2aa07e1db3c9b88"
+  ]
+}
+x-commit-hash: "650a7865bc37a646250f7c52fa6644d9d4a5218b"

--- a/packages/merlin-lib/merlin-lib.5.2.1-502/opam
+++ b/packages/merlin-lib/merlin-lib.5.2.1-502/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" & < "5.3"}
+  "dune" {>= "3.0.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.2.1-502/merlin-5.2.1-502.tbz"
+  checksum: [
+    "sha256=5c02dc71b2d31b619851c14a965b91c650a4dbcd49bf56004eee61e0c58d584c"
+    "sha512=abf82c906759c8547437664ab5db67b839bbad185fa2541b28e4e07137fdf3824736dae859f0d35bd9a3950633c81a69fd0a1a0e2393ead43822afc66d1aaf3d"
+  ]
+}
+x-commit-hash: "0eaccc1b8520d605b1e00685e1c3f8acb5da534c"

--- a/packages/merlin/merlin.4.17.1-414/opam
+++ b/packages/merlin/merlin.4.17.1-414/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.14" & < "4.15"}
   "dune" {>= "2.9.0"}
   "merlin-lib" {= version}
-  "dot-merlin-reader" {>= "4.17"}
+  "dot-merlin-reader" {= version}
   "yojson" {>= "2.0.0"}
   "conf-jq" {with-test}
   "ppxlib" {with-test}

--- a/packages/merlin/merlin.4.17.1-414/opam
+++ b/packages/merlin/merlin.4.17.1-414/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.17"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.17.1-414/merlin-4.17.1-414.tbz"
+  checksum: [
+    "sha256=bf3f806ef48632053861d54b73bdef9539ba4218af021d8b0acad8e37e645fc6"
+    "sha512=1346170208fa984dfdb45dcce0b44aa8a25a8f8d5ae6da9fbdf521f6abeacf5cc7ac7a567061c2a08c157465f3fb5d59a1c238b634bc74b678816b48bdf05109"
+  ]
+}
+x-commit-hash: "44c112461cab98b9279798271d003fccda2badba"

--- a/packages/merlin/merlin.4.17.1-501/opam
+++ b/packages/merlin/merlin.4.17.1-501/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "5.1" & < "5.2"}
   "dune" {>= "2.9.0"}
   "merlin-lib" {= version}
-  "dot-merlin-reader" {>= "4.17"}
+  "dot-merlin-reader" {= version}
   "yojson" {>= "2.0.0"}
   "conf-jq" {with-test}
   "ppxlib" {with-test}

--- a/packages/merlin/merlin.4.17.1-501/opam
+++ b/packages/merlin/merlin.4.17.1-501/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.1" & < "5.2"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.17"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.17.1-501/merlin-4.17.1-501.tbz"
+  checksum: [
+    "sha256=376707aa871f09e9639456d3fbe4b89a21c9ad75c774e94cbbbe67f842b0a500"
+    "sha512=a11ea4b8e3520b3ee41ae8198cda34b2816b8dfcdcb99350ef29689a7d62bb66d17ffa075c551aa56d521120b55e6db14a106a31f7b3970ed2aa07e1db3c9b88"
+  ]
+}
+x-commit-hash: "650a7865bc37a646250f7c52fa6644d9d4a5218b"

--- a/packages/merlin/merlin.5.2.1-502/opam
+++ b/packages/merlin/merlin.5.2.1-502/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "5.2" & < "5.3"}
   "dune" {>= "3.0.0"}
   "merlin-lib" {= version}
-  "dot-merlin-reader" {>= "5.2"}
+  "dot-merlin-reader" {= version}
   "ocaml-index" {>= "1.0" & post}
   "yojson" {>= "2.0.0"}
   "conf-jq" {with-test}

--- a/packages/merlin/merlin.5.2.1-502/opam
+++ b/packages/merlin/merlin.5.2.1-502/opam
@@ -1,0 +1,82 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.2" & < "5.3"}
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "5.2"}
+  "ocaml-index" {>= "1.0" & post}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.2.1-502/merlin-5.2.1-502.tbz"
+  checksum: [
+    "sha256=5c02dc71b2d31b619851c14a965b91c650a4dbcd49bf56004eee61e0c58d584c"
+    "sha512=abf82c906759c8547437664ab5db67b839bbad185fa2541b28e4e07137fdf3824736dae859f0d35bd9a3950633c81a69fd0a1a0e2393ead43822afc66d1aaf3d"
+  ]
+}
+x-commit-hash: "0eaccc1b8520d605b1e00685e1c3f8acb5da534c"

--- a/packages/ocaml-index/ocaml-index.1.1/opam
+++ b/packages/ocaml-index/ocaml-index.1.1/opam
@@ -5,12 +5,12 @@ description:
 maintainer: ["ulysse@tarides.com"]
 authors: ["ulysse@tarides.com"]
 license: "MIT"
-homepage: "https://github.com/voodoos/ocaml-index"
-bug-reports: "https://github.com/voodoos/ocaml-index/issues"
+homepage: "https://github.com/ocaml/merlin"
+bug-reports: "https://github.com/ocaml/merlin/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "5.2"}
-  "merlin-lib" {>= "5.1-502" & < "5.2"}
+  "merlin-lib" {>= "5.2.1-502"}
   "odoc" {with-doc}
 ]
 build: [
@@ -29,13 +29,13 @@ build: [
   ]
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
-dev-repo: "git+https://github.com/voodoos/ocaml-index.git"
+dev-repo: "git+https://github.com/ocaml/merlin.git"
 url {
   src:
-    "https://github.com/voodoos/ocaml-index/releases/download/v1.0/ocaml-index-1.0.tbz"
+    "https://github.com/ocaml/merlin/releases/download/v5.2.1-502/merlin-5.2.1-502.tbz"
   checksum: [
-    "sha256=01e39ca310d561f7012f5dad47905173747466c5c9f7dfe14833db5c72871e1c"
-    "sha512=3fa40158d20a9da66d6e10d4ff566457f9279f6e6b5012275ad30c11678a4516922f940817d4d70c9eec68dc2458848d09e75b5bd7f3f08aee01e82a063f0c1f"
+    "sha256=5c02dc71b2d31b619851c14a965b91c650a4dbcd49bf56004eee61e0c58d584c"
+    "sha512=abf82c906759c8547437664ab5db67b839bbad185fa2541b28e4e07137fdf3824736dae859f0d35bd9a3950633c81a69fd0a1a0e2393ead43822afc66d1aaf3d"
   ]
 }
-x-commit-hash: "0f9ffbbc9d1b4def495d3d2c7aa135a486bbcc9d"
+x-commit-hash: "0eaccc1b8520d605b1e00685e1c3f8acb5da534c"


### PR DESCRIPTION
Editor helper, provides completion, typing and source browsing in Vim and Emacs

- Project page: <a href="https://github.com/ocaml/merlin">https://github.com/ocaml/merlin</a>

##### CHANGES:

Fri Sep 27 12:02:42 CEST 2024

  + merlin binary
    - A new `WRAPPING_PREFIX` configuration directive that can be used to tell Merlin
      what to append to the current unit name in the presence of wrapping (ocaml/merlin#1788)
    - Add `-unboxed-types` and `-no-unboxed-types` as ocaml ignored flags (ocaml/merlin#1795, fixes ocaml/merlin#1794)
    - destruct: Refinement in the presence of optional arguments (ocaml/merlin#1800 ocaml/merlin#1807, fixes ocaml/merlin#1770)
    - Implement new expand-node command for expanding PPX annotations (ocaml/merlin#1745)
    - Implement new inlay-hints command for adding hints on a sourcetree (ocaml/merlin#1812)
    - Implement new search-by-type command for searching values by types (ocaml/merlin#1828)
    - Canonicalize paths in occurrences. This helps deduplicate the results and
      show more user-friendly paths. (ocaml/merlin#1840)
    - Fix dot-merlin-reader ignoring `SOURCE_ROOT` and `STDLIB` directives
      (ocaml/merlin#1839, ocaml/merlin#1803)
  + editor modes
    - vim: fix python-3.12 syntax warnings in merlin.py (ocaml/merlin#1798)
    - vim: Dead code / doc removal for previously deleted MerlinPhrase command (ocaml/merlin#1804)
    - emacs: Improve the way that result of polarity search is displayed (ocaml/merlin#1814)
    - emacs: Add `merlin-search-by-type`, `merlin-search-by-polarity` and change the
	  behaviour of `merlin-search` to switch between `by-type` or `by-polarity`
	  depending on the query (ocaml/merlin#1828)
