### PR TITLE
[new release] merlin (3 packages) (4.17.1-501)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.17.1-501/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.17.1-501/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {>= "4.17"}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.17.1-501/merlin-4.17.1-501.tbz"
+  checksum: [
+    "sha256=376707aa871f09e9639456d3fbe4b89a21c9ad75c774e94cbbbe67f842b0a500"
+    "sha512=a11ea4b8e3520b3ee41ae8198cda34b2816b8dfcdcb99350ef29689a7d62bb66d17ffa075c551aa56d521120b55e6db14a106a31f7b3970ed2aa07e1db3c9b88"
+  ]
+}
+x-commit-hash: "650a7865bc37a646250f7c52fa6644d9d4a5218b"

--- a/packages/merlin-lib/merlin-lib.4.17.1-501/opam
+++ b/packages/merlin-lib/merlin-lib.4.17.1-501/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.1.1" & < "5.2"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.17.1-501/merlin-4.17.1-501.tbz"
+  checksum: [
+    "sha256=376707aa871f09e9639456d3fbe4b89a21c9ad75c774e94cbbbe67f842b0a500"
+    "sha512=a11ea4b8e3520b3ee41ae8198cda34b2816b8dfcdcb99350ef29689a7d62bb66d17ffa075c551aa56d521120b55e6db14a106a31f7b3970ed2aa07e1db3c9b88"
+  ]
+}
+x-commit-hash: "650a7865bc37a646250f7c52fa6644d9d4a5218b"

--- a/packages/merlin/merlin.4.17.1-501/opam
+++ b/packages/merlin/merlin.4.17.1-501/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.1" & < "5.2"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.17"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.17.1-501/merlin-4.17.1-501.tbz"
+  checksum: [
+    "sha256=376707aa871f09e9639456d3fbe4b89a21c9ad75c774e94cbbbe67f842b0a500"
+    "sha512=a11ea4b8e3520b3ee41ae8198cda34b2816b8dfcdcb99350ef29689a7d62bb66d17ffa075c551aa56d521120b55e6db14a106a31f7b3970ed2aa07e1db3c9b88"
+  ]
+}
+x-commit-hash: "650a7865bc37a646250f7c52fa6644d9d4a5218b"


### PR DESCRIPTION
Editor helper, provides completion, typing and source browsing in Vim and Emacs

- Project page: <a href="https://github.com/ocaml/merlin">https://github.com/ocaml/merlin</a>

##### CHANGES:

Fri Sep 27 12:02:42 CEST 2024

  + merlin binary
    - A new `WRAPPING_PREFIX` configuration directive that can be used to tell Merlin
      what to append to the current unit name in the presence of wrapping (ocaml/merlin#1788)
    - Add `-unboxed-types` and `-no-unboxed-types` as ocaml ignored flags (ocaml/merlin#1795, fixes ocaml/merlin#1794)
    - destruct: Refinement in the presence of optional arguments (ocaml/merlin#1800 ocaml/merlin#1807, fixes ocaml/merlin#1770)
    - Implement new expand-node command for expanding PPX annotations (ocaml/merlin#1745)
    - Implement new inlay-hints command for adding hints on a sourcetree (ocaml/merlin#1812)
    - Add `signature-help` command (ocaml/merlin#1720)
    - Implement new search-by-type command for searching values by types (ocaml/merlin#1828)
    - Fix dot-merlin-reader ignoring `SOURCE_ROOT` and `STDLIB` directives
      (ocaml/merlin#1839, ocaml/merlin#1803)
  + editor modes
    - vim: fix python-3.12 syntax warnings in merlin.py (ocaml/merlin#1798)
    - vim: Dead code / doc removal for previously deleted MerlinPhrase command (ocaml/merlin#1804)
    - emacs: Improve the way that result of polarity search is displayed (ocaml/merlin#1814)
    - emacs: Add `merlin-search-by-type`, `merlin-search-by-polarity` and change the
	  behaviour of `merlin-search` to switch between `by-type` or `by-polarity`
	  depending on the query (ocaml/merlin#1828)
