### PR TITLE
[new release] x509 (1.0.4)

### DIFF
--- a/packages/x509/x509.1.0.4/opam
+++ b/packages/x509/x509.1.0.4/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "David Kaloper <dk505@cam.ac.uk>"
+]
+license: "BSD-2-Clause"
+tags: "org:mirage"
+homepage: "https://github.com/mirleft/ocaml-x509"
+doc: "https://mirleft.github.io/ocaml-x509/doc"
+bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "asn1-combinators" {>= "0.3.1"}
+  "ptime"
+  "base64" {>= "3.3.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.7"}
+  "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+  "gmap" {>= "0.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "logs"
+  "kdf" {>= "1.0.0"}
+  "ohex" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
+synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
+description: """
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority. Authorities must be exchanged over a second channel to establish the
+trust relationship. This library implements most parts of RFC5280 and RFC6125.
+The Public Key Cryptography Standards (PKCS) defines encoding and decoding
+(in ASN.1 DER and PEM format), which is also implemented by this library -
+namely PKCS 1, PKCS 5, PKCS 7, PKCS 8, PKCS 9, PKCS 10, and PKCS 12.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-x509/releases/download/v1.0.4/x509-1.0.4.tbz"
+  checksum: [
+    "sha256=3e09d3983e53119d40cb0bfa9b07d595db7d0c5c9df06f5f2ac82a6258f5e702"
+    "sha512=0d45b3ee148c0bd06be1294437b8aee9c779721313b832ade98b81e5067c11a431e3bc480d7884bc4e92126962748bb958e23c9286d93f7234255d2fb975f772"
+  ]
+}
+x-commit-hash: "0f178a162e5f5a3b809b4e6874ca1cf5673e4de3"


### PR DESCRIPTION
Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-x509">https://github.com/mirleft/ocaml-x509</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-x509/doc">https://mirleft.github.io/ocaml-x509/doc</a>

##### CHANGES:

* **breaking change** Allow decoding of negative serial numbers (mirleft/ocaml-x509#177 @hannesm)
  Now, `serial` returns the entire (integer) value as a string - previously the
  potentially leading 0 byte was removed. So:
  -serial d795 49bd 1a67 1751
  +serial 00d7 9549 bd1a 6717  51
* Add alternate SHA1RSA OID 1.3.14.3.2.29 (mirleft/ocaml-x509#176 @mefyl)
* Allow custom pretty printers for unknown X509 extensions (mirleft/ocaml-x509#175 @reynir)
* Minor code cleanups: remove unused algorithms, remove `def` and `def'`
  (mirleft/ocaml-x509#177 @hannesm)
