### PR TITLE
[new release] dns-client-miou-unix (9.0.1)

### DIFF
--- a/packages/dns-client-miou-unix/dns-client-miou-unix.9.0.1/opam
+++ b/packages/dns-client-miou-unix/dns-client-miou-unix.9.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.0.0"}
+  "ocaml" {>= "5.0.0"}
+  "dns-client" {= version}
+  "domain-name" {>= "0.4.0"}
+  "ipaddr" {>= "5.3.0"}
+  "miou" {>= "0.1.0"}
+  "tls-miou-unix"
+  "happy-eyeballs" {>= "0.6.0"}
+  "happy-eyeballs-miou-unix"
+]
+synopsis: "DNS client API for Miou"
+description: """
+A client implementation using uDNS using Miou.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v9.0.1/dns-9.0.1.tbz"
+  checksum: [
+    "sha256=99776e46aa317650f77f47a09efdf594b5a37db5f802d32134d0dddda5f94a03"
+    "sha512=b8d74278e69d3aea5a7cef1e36b3ad2bdd68354210ba1e7137e9743854430c657dc464d22f760a7f55b447d017730342c18b989c4b87297da54cfd7b09ff77f7"
+  ]
+}
+x-commit-hash: "43dfd9454a4140900f4acf08dc07338eebcd06da"

--- a/packages/dns-client-miou-unix/dns-client-miou-unix.9.0.1/opam
+++ b/packages/dns-client-miou-unix/dns-client-miou-unix.9.0.1/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune" {>="2.0.0"}
   "ocaml" {>= "5.0.0"}
-  "dns-client" {= version}
+  "dns-client" {= "9.0.0"}
   "domain-name" {>= "0.4.0"}
   "ipaddr" {>= "5.3.0"}
   "miou" {>= "0.1.0"}


### PR DESCRIPTION
DNS client API for Miou

- Project page: <a href="https://github.com/mirage/ocaml-dns">https://github.com/mirage/ocaml-dns</a>

##### CHANGES:

* dns-client-miou: use String.get_uint16_be instead of String.get_int16_be
  (mirage/ocaml-dns#354 @dinosaure)
