### PR TITLE
Package ppxlib_jane.v0.17.1

### DIFF
--- a/packages/ppxlib_jane/ppxlib_jane.v0.17.1/opam
+++ b/packages/ppxlib_jane/ppxlib_jane.v0.17.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppxlib_jane"
+bug-reports: "https://github.com/janestreet/ppxlib_jane/issues"
+dev-repo: "git+https://github.com/janestreet/ppxlib_jane.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppxlib_jane/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"  {>= "5.3.0"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.33.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Utilities for working with Jane Street AST constructs"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppxlib_jane/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=4a9361efc1ee6d099bf6857bbe96e2fb"
+    "sha512=3aacf2b8c01ca45ac3c1e51119fe0cc222739cad4c4def3fbc682aa2f30c35f3e5a91c5e7c859e41cdcce4c52f2f3c2711e6163e0f893cc398e07ce51c2c6265"
+  ]
+}


### PR DESCRIPTION
### `ppxlib_jane.v0.17.1`
Utilities for working with Jane Street AST constructs
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppxlib_jane
* Source repo: git+https://github.com/janestreet/ppxlib_jane.git
* Bug tracker: https://github.com/janestreet/ppxlib_jane/issues

---
:camel: Pull-request generated by opam-publish v2.3.0