### PR TITLE
Package ocaml-version.3.6.9

### DIFF
--- a/packages/ocaml-version/ocaml-version.3.6.9/opam
+++ b/packages/ocaml-version/ocaml-version.3.6.9/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """\
+This library provides facilities to parse version numbers of the OCaml compiler, and enumerates the various official OCaml releases and configuration variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the `patch` and `extra` fields are optional.  This library offers the following functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under the Ecosystem category.
+- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: "org:ocamllabs"
+homepage: "https://github.com/ocurrent/ocaml-version"
+doc: "https://ocurrent.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-version/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.07.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-version/releases/download/v3.6.9/ocaml-version-3.6.9.tbz"
+  checksum: [
+    "md5=af259c3ff397832324976e35b3f023ff"
+    "sha512=71d22d1b9e6783e899f24a996d97bd838ce3b97a4dabd1cc7238ba705d890ab407f8b8d848f22e0f89ce1f580078ea2b80ddd7a84c44e42ac77ff1b2626689c5"
+  ]
+}


### PR DESCRIPTION
### `ocaml-version.3.6.9`
Manipulate, parse and generate OCaml compiler version strings
This library provides facilities to parse version numbers of the OCaml compiler, and enumerates the various official OCaml releases and configuration variants.

OCaml version numbers are of the form `major.minor.patch+extra`, where the `patch` and `extra` fields are optional.  This library offers the following functionality:

- Functions to parse and serialise OCaml compiler version numbers.
- Enumeration of official OCaml compiler version releases.
- Test compiler versions for a particular feature (e.g. the `bytes` type)
- [opam](https://opam.ocaml.org) compiler switch enumeration.

### Further information

- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under the Ecosystem category.
- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
- **Docs:** <http://docs.mirage.io/ocaml-version>



---
* Homepage: https://github.com/ocurrent/ocaml-version
* Source repo: git+https://github.com/ocurrent/ocaml-version.git
* Bug tracker: https://github.com/ocurrent/ocaml-version/issues

---
:camel: Pull-request generated by opam-publish v2.4.0