### PR TITLE
odoc is not compatible with OCaml 5.3 (uses compiler-libs)

### DIFF
--- a/packages/odoc/odoc.2.4.3/opam
+++ b/packages/odoc/odoc.2.4.3/opam
@@ -43,7 +43,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.7.0"}
   "fpath"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.3"}
   "result"
   "tyxml" {>= "4.4.0"}
   "fmt"


### PR DESCRIPTION
Already done in https://github.com/ocaml/opam-repository/pull/26537 but a new version popped-up since