### PR TITLE
[new release] ocamlregextkit (1.0.2)

### DIFF
--- a/packages/ocamlregextkit/ocamlregextkit.1.0.2/opam
+++ b/packages/ocamlregextkit/ocamlregextkit.1.0.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "A regular expression toolkit for OCaml"
+description:
+  "Provides data structures and algorithms for Regular Expressions, Deterministic Finite Automata, and Non-Deterministic Finite Automata"
+maintainer: ["Dominic Too"]
+authors: ["Dominic Too"]
+license: "GPL-3.0-or-later"
+tags: [
+  "automata"
+  "regular expressions"
+  "regular languages"
+  "regex"
+  "library"
+  "DFA"
+  "NFA"
+  "RE"
+]
+homepage: "https://github.com/toodom02/ocamlregextkit"
+doc: "https://toodom02.github.io/ocamlregextkit/"
+bug-reports: "https://github.com/toodom02/ocamlregextkit/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/toodom02/ocamlregextkit.git"
+url {
+  src:
+    "https://github.com/toodom02/ocamlregextkit/releases/download/v1.0.2/ocamlregextkit-1.0.2.tbz"
+  checksum: [
+    "sha256=801dd74f3ac269a33015d0c56b4a400fbfec15a68637775caacde1f377d802f2"
+    "sha512=7ac6ba274f2420f5066b722ee1d3d6e1ba8f967c91fdbc5b8d92c54b5753f6166b398b687de47328a30f4c822eff8167fef11e8f3b26d04d96f07f7f32238f97"
+  ]
+}
+x-commit-hash: "1a5a58cc06b04d84b7f66c313ed8dfbf6662f1b4"


### PR DESCRIPTION
A regular expression toolkit for OCaml

- Project page: <a href="https://github.com/toodom02/ocamlregextkit">https://github.com/toodom02/ocamlregextkit</a>
- Documentation: <a href="https://toodom02.github.io/ocamlregextkit/">https://toodom02.github.io/ocamlregextkit/</a>

##### CHANGES:

### Fix

 - `get_reachable_states` missing epsilon transitions (toodom02/ocamlregextkit#8).
