### PR TITLE
[new release] tls-miou-unix (1.0.3)

### DIFF
--- a/packages/tls-miou-unix/tls-miou-unix.1.0.3/opam
+++ b/packages/tls-miou-unix/tls-miou-unix.1.0.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/"
+maintainer:   ["Romain Calascibetta <romain.calascibetta@gmail.com>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "mirage-crypto-rng-miou-unix" {>= "1.0.0" & with-test}
+  "x509" {>= "1.0.0"}
+  "miou" {>= "0.3.0"}
+  "crowbar" {with-test}
+  "rresult" {with-test}
+  "ohex" {with-test}
+  "ptime" {with-test}
+  "hxd" {with-test}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, Miou+Unix layer"
+description: """
+Tls-miou provides an effectful Tls_miou module to be used with Miou and Unix.
+"""
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v1.0.3/tls-1.0.3.tbz"
+  checksum: [
+    "sha256=b27f0d5cfc1aea26e9a45070fcc57c6c6d02c91e58ac026166552fc23e3f6150"
+    "sha512=ec26bebdb8ab9459d8be643b4a2ad51997aab900f1eac6e5856d54af5babfae25dc4318bdc10136e6c0c1d1f5460c24d0d54fd113a3750ebbc18126929d8ae63"
+  ]
+}
+x-commit-hash: "bb01986d3e87c4c7ab098812594ad943e60bb082"

--- a/packages/tls-miou-unix/tls-miou-unix.1.0.3/opam
+++ b/packages/tls-miou-unix/tls-miou-unix.1.0.3/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "5.0.0"}
   "dune" {>= "3.0"}
-  "tls" {= version}
+  "tls" {= "1.0.2"}
   "mirage-crypto-rng-miou-unix" {>= "1.0.0" & with-test}
   "x509" {>= "1.0.0"}
   "miou" {>= "0.3.0"}


### PR DESCRIPTION
Transport Layer Security purely in OCaml, Miou+Unix layer

- Project page: <a href="https://github.com/mirleft/ocaml-tls">https://github.com/mirleft/ocaml-tls</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-tls/">https://mirleft.github.io/ocaml-tls/</a>

##### CHANGES:

* tls-miou-unix: fix recursive call in read_in (mirleft/ocaml-tls#511 @dinosaure)
