### PR TITLE
[new release] file-rewriter (2 packages) (0.0.3)

### DIFF
--- a/packages/file-rewriter/file-rewriter.0.0.3/opam
+++ b/packages/file-rewriter/file-rewriter.0.0.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Apply small rewrites to tweak or refactor your files"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "Apache-2.0"
+homepage: "https://github.com/mbarbin/file-rewriter"
+doc: "https://mbarbin.github.io/file-rewriter/"
+bug-reports: "https://github.com/mbarbin/file-rewriter/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.2"}
+  "fpath" {>= "0.7.3"}
+  "loc" {>= "0.2.0"}
+  "sexplib0" {>= "v0.17" & < "v0.18"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/file-rewriter.git"
+url {
+  src:
+    "https://github.com/mbarbin/file-rewriter/releases/download/0.0.3/file-rewriter-0.0.3.tbz"
+  checksum: [
+    "sha256=bcc2177b21daf06d379806045cab266ef9017968645dd8fb445594222e0f1d07"
+    "sha512=e7c546d98d1b0da412d63366cce777cc50a24f89c60ce9af67bb6698e6c12a620480daaefb5e186d6d5daf6143ac2b65a6f26a8daea0588055cfcfef90c13401"
+  ]
+}
+x-commit-hash: "6698f5814716014225e04d39d493adc6ee200b06"

--- a/packages/sexps-rewriter/sexps-rewriter.0.0.3/opam
+++ b/packages/sexps-rewriter/sexps-rewriter.0.0.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A specialized file-rewriter for applying rewrites to sexp files"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "Apache-2.0"
+homepage: "https://github.com/mbarbin/file-rewriter"
+doc: "https://mbarbin.github.io/file-rewriter/"
+bug-reports: "https://github.com/mbarbin/file-rewriter/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.2"}
+  "file-rewriter" {= version}
+  "fpath" {>= "0.7.3"}
+  "loc" {>= "0.2.0"}
+  "parsexp" {>= "v0.17" & < "v0.18"}
+  "sexplib0" {>= "v0.17" & < "v0.18"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/file-rewriter.git"
+url {
+  src:
+    "https://github.com/mbarbin/file-rewriter/releases/download/0.0.3/file-rewriter-0.0.3.tbz"
+  checksum: [
+    "sha256=bcc2177b21daf06d379806045cab266ef9017968645dd8fb445594222e0f1d07"
+    "sha512=e7c546d98d1b0da412d63366cce777cc50a24f89c60ce9af67bb6698e6c12a620480daaefb5e186d6d5daf6143ac2b65a6f26a8daea0588055cfcfef90c13401"
+  ]
+}
+x-commit-hash: "6698f5814716014225e04d39d493adc6ee200b06"


### PR DESCRIPTION
This is the initial release for 2 packages for applying small rewrites to tweak or refactor your files. Short synopsis below, more info at https://github.com/mbarbin/file-rewriter.

## Synopsis

### file-rewriter

`File_rewriter` is an OCaml library for applying small rewrites to tweak or refactor your files. It provides a convenient interface to apply surgical textual substitutions on the fly, while navigating the contents of a file through an abstract representation containing code locations.

### sexps-rewriter

`Sexps_rewriter` is a specialized version of the main library dedicated to rewriting sexp files.

## Motivation

We created these libraries as part of an ongoing work to create linting and refactoring tools for the many `dune` files found in big monorepos (see [dunolint](https://github.com/mbarbin/dunolint)).