### PR TITLE
5.3 compat (ppx_deriving, dream-httpaf)

### DIFF
--- a/packages/dream-httpaf/dream-httpaf.1.0.0~alpha3/opam
+++ b/packages/dream-httpaf/dream-httpaf.1.0.0~alpha3/opam
@@ -18,7 +18,7 @@ depends: [
   "lwt"
   "lwt_ppx" {>= "1.2.2"}
   "lwt_ssl"
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
 
   # Currently vendored.

--- a/packages/ppx_deriving/ppx_deriving.6.0.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.6.0.2/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.3"}
   "dune" {>= "1.6.3"}
   "cppo" {>= "1.1.0" & build}
   "ocamlfind"


### PR DESCRIPTION
observed in https://ocaml.ci.dev/github/robur-coop/webauthn/commit/7c402937deab88459a767dc8e879b83406da7a5f/variant/debian-12-5.3~alpha1_opam-2.2