### PR TITLE
[new release] printbox (5 packages) (0.12)

### DIFF
--- a/packages/printbox-ext-plot/printbox-ext-plot.0.12/opam
+++ b/packages/printbox-ext-plot/printbox-ext-plot.0.12/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Printbox extension for plotting"
+description: """
+
+Extends Printbox with the ability to print scatter plots, line plots, decision boundaries.
+Printbox allows to print nested boxes, lists, arrays, tables in several formats"""
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "printbox" {= version}
+  "printbox-text" {= version}
+  "printbox-html" {= version}
+  "printbox-md" {= version}
+  "tyxml" {>= "4.3"}
+  "odoc" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.12/printbox-0.12.tbz"
+  checksum: [
+    "sha256=c783dfbbc21ed9bdab04980b58efa901b149f38f9992f2cdc624abd681d8dedb"
+    "sha512=43968271141a44ab4655586bf35bb8540d1ca6312e0a93b14311ae82e6edd700be92d598677fda3bdc6fd8537890ea42cd0224fe9447a6cf8471ba915299ee36"
+  ]
+}
+x-commit-hash: "9e36427450c1d2fbefe446f074797acb35db58c2"

--- a/packages/printbox-html/printbox-html.0.12/opam
+++ b/packages/printbox-html/printbox-html.0.12/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Printbox unicode handling"
+description: """
+
+Adds html output handling to the printbox package.
+Printbox allows to print nested boxes, lists, arrays, tables in several formats"""
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "printbox" {= version}
+  "printbox-text" {with-test & = version}
+  "odoc" {with-test}
+  "tyxml" {>= "4.3"}
+  "mdx" {>= "1.4" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.12/printbox-0.12.tbz"
+  checksum: [
+    "sha256=c783dfbbc21ed9bdab04980b58efa901b149f38f9992f2cdc624abd681d8dedb"
+    "sha512=43968271141a44ab4655586bf35bb8540d1ca6312e0a93b14311ae82e6edd700be92d598677fda3bdc6fd8537890ea42cd0224fe9447a6cf8471ba915299ee36"
+  ]
+}
+x-commit-hash: "9e36427450c1d2fbefe446f074797acb35db58c2"

--- a/packages/printbox-md/printbox-md.0.12/opam
+++ b/packages/printbox-md/printbox-md.0.12/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Printbox Markdown rendering"
+description: """
+
+Adds Markdown output handling to the printbox package, with fallback to text and simplified HTML.
+Printbox allows to print nested boxes, lists, arrays, tables in several formats"""
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "printbox" {= version}
+  "printbox-text" {= version}
+  "odoc" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.12/printbox-0.12.tbz"
+  checksum: [
+    "sha256=c783dfbbc21ed9bdab04980b58efa901b149f38f9992f2cdc624abd681d8dedb"
+    "sha512=43968271141a44ab4655586bf35bb8540d1ca6312e0a93b14311ae82e6edd700be92d598677fda3bdc6fd8537890ea42cd0224fe9447a6cf8471ba915299ee36"
+  ]
+}
+x-commit-hash: "9e36427450c1d2fbefe446f074797acb35db58c2"

--- a/packages/printbox-text/printbox-text.0.12/opam
+++ b/packages/printbox-text/printbox-text.0.12/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Text renderer for printbox, using unicode edges"
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "printbox" {= version}
+  "uutf" {>= "1.0"}
+  "uucp" {>= "2.0"}
+  "odoc" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.12/printbox-0.12.tbz"
+  checksum: [
+    "sha256=c783dfbbc21ed9bdab04980b58efa901b149f38f9992f2cdc624abd681d8dedb"
+    "sha512=43968271141a44ab4655586bf35bb8540d1ca6312e0a93b14311ae82e6edd700be92d598677fda3bdc6fd8537890ea42cd0224fe9447a6cf8471ba915299ee36"
+  ]
+}
+x-commit-hash: "9e36427450c1d2fbefe446f074797acb35db58c2"

--- a/packages/printbox/printbox.0.12/opam
+++ b/packages/printbox/printbox.0.12/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Allows to print nested boxes, lists, arrays, tables in several formats"
+maintainer: ["c-cube" "lukstafi"]
+authors: ["Simon Cruanes" "Guillaume Bury" "lukstafi"]
+license: "BSD-2-Clause"
+tags: ["print" "box" "table" "tree"]
+homepage: "https://github.com/c-cube/printbox"
+bug-reports: "https://github.com/c-cube/printbox/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+url {
+  src:
+    "https://github.com/c-cube/printbox/releases/download/v0.12/printbox-0.12.tbz"
+  checksum: [
+    "sha256=c783dfbbc21ed9bdab04980b58efa901b149f38f9992f2cdc624abd681d8dedb"
+    "sha512=43968271141a44ab4655586bf35bb8540d1ca6312e0a93b14311ae82e6edd700be92d598677fda3bdc6fd8537890ea42cd0224fe9447a6cf8471ba915299ee36"
+  ]
+}
+x-commit-hash: "9e36427450c1d2fbefe446f074797acb35db58c2"


### PR DESCRIPTION
Allows to print nested boxes, lists, arrays, tables in several formats

- Project page: <a href="https://github.com/c-cube/printbox">https://github.com/c-cube/printbox</a>

##### CHANGES:

- Remove fallback to and dependency on `printbox-html` from `printbox-md` (@lukstafi)
- introduce notion of extensions (@lukstafi)
- add `printbox-ext-plot` extension for text and HTML plots (@lukstafi)
- feat: add `?stretch` param to `frame`

- fix c-cube/printbox#45, problem with nested frames
