### PR TITLE
[new release] yocaml (12 packages) (2.0.0)

### DIFF
--- a/packages/yocaml/yocaml.2.0.0/opam
+++ b/packages/yocaml/yocaml.2.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "odoc" {with-doc}
   "sherlodoc" {with-doc}
   "fmt" {with-test}
-  "alcotest" {with-test}
+  "alcotest" {with-test & >= "1.3.0"}
   "qcheck" {with-test}
   "qcheck-alcotest" {with-test}
   "ppx_expect"

--- a/packages/yocaml/yocaml.2.0.0/opam
+++ b/packages/yocaml/yocaml.2.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Core engine of the YOCaml Static Site Generator"
+description: "YOCaml is a build system dedicated to generate static document"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "ocaml" {>= "5.1.1" & < "5.3"}
+  "dune" {>= "3.14" & >= "3.0.0"}
+  "odoc" {with-doc}
+  "sherlodoc" {with-doc}
+  "fmt" {with-test}
+  "alcotest" {with-test}
+  "qcheck" {with-test}
+  "qcheck-alcotest" {with-test}
+  "ppx_expect"
+  "mdx" {with-test & = "2.4.1"}
+  "ocamlformat" {with-dev-setup}
+  "ocp-indent" {with-dev-setup}
+  "merlin" {with-dev-setup}
+  "utop" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.0.0/yocaml-2.0.0.tbz"
+  checksum: [
+    "sha256=fddf61500e828ac88d86ba982084cc817299302082a6e797b36787ff18235ec2"
+    "sha512=8b71a8cecd3e101df55eef0bba7a24d4dde9d66b5ecedd9f6d55834fcdc8d33fd875092ca73a398e1715664caee06cdc1bdb1b4da85bff0a687faac5c0445023"
+  ]
+}
+x-commit-hash: "ff83a5e53e2a492cf782ee3296feb7119605e151"

--- a/packages/yocaml_cmarkit/yocaml_cmarkit.2.0.0/opam
+++ b/packages/yocaml_cmarkit/yocaml_cmarkit.2.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Yocaml plugin for using Markdown (via Cmarkit package) as a Markup language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "ocaml" {>= "5.1.1"}
+  "dune" {>= "3.14" & >= "3.0.0"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.4.1"}
+  "yocaml" {= version}
+  "cmarkit"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.0.0/yocaml-2.0.0.tbz"
+  checksum: [
+    "sha256=fddf61500e828ac88d86ba982084cc817299302082a6e797b36787ff18235ec2"
+    "sha512=8b71a8cecd3e101df55eef0bba7a24d4dde9d66b5ecedd9f6d55834fcdc8d33fd875092ca73a398e1715664caee06cdc1bdb1b4da85bff0a687faac5c0445023"
+  ]
+}
+x-commit-hash: "ff83a5e53e2a492cf782ee3296feb7119605e151"

--- a/packages/yocaml_eio/yocaml_eio.2.0.0/opam
+++ b/packages/yocaml_eio/yocaml_eio.2.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "The Eio runtime YOCaml"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "ocaml" {>= "5.1.1"}
+  "dune" {>= "3.14" & >= "3.0.0"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.4.1"}
+  "yocaml" {= version}
+  "yocaml_runtime" {= version}
+  "eio" {= "1.1"}
+  "eio_main" {= "1.1"}
+  "cohttp-eio" {= "6.0.0~beta2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.0.0/yocaml-2.0.0.tbz"
+  checksum: [
+    "sha256=fddf61500e828ac88d86ba982084cc817299302082a6e797b36787ff18235ec2"
+    "sha512=8b71a8cecd3e101df55eef0bba7a24d4dde9d66b5ecedd9f6d55834fcdc8d33fd875092ca73a398e1715664caee06cdc1bdb1b4da85bff0a687faac5c0445023"
+  ]
+}
+x-commit-hash: "ff83a5e53e2a492cf782ee3296feb7119605e151"

--- a/packages/yocaml_git/yocaml_git.2.0.0/opam
+++ b/packages/yocaml_git/yocaml_git.2.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "Yocaml plugins for generating Yocaml program into a Git repository"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "ocaml" {>= "5.1.1"}
+  "dune" {>= "3.14" & >= "3.0.0"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.4.1"}
+  "lwt" {>= "5.7.0"}
+  "mimic" {>= "0.0.9"}
+  "cstruct" {>= "6.2.0"}
+  "git-kv" {>= "0.0.5"}
+  "git-unix" {>= "3.16.1"}
+  "mirage-clock" {>= "4.2.0"}
+  "yocaml" {= version}
+  "yocaml_runtime" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.0.0/yocaml-2.0.0.tbz"
+  checksum: [
+    "sha256=fddf61500e828ac88d86ba982084cc817299302082a6e797b36787ff18235ec2"
+    "sha512=8b71a8cecd3e101df55eef0bba7a24d4dde9d66b5ecedd9f6d55834fcdc8d33fd875092ca73a398e1715664caee06cdc1bdb1b4da85bff0a687faac5c0445023"
+  ]
+}
+x-commit-hash: "ff83a5e53e2a492cf782ee3296feb7119605e151"

--- a/packages/yocaml_jingoo/yocaml_jingoo.2.0.0/opam
+++ b/packages/yocaml_jingoo/yocaml_jingoo.2.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for using Jingoo as a template language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "ocaml" {>= "5.1.1"}
+  "dune" {>= "3.14" & >= "3.0.0"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.4.1"}
+  "yocaml" {= version}
+  "jingoo" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.0.0/yocaml-2.0.0.tbz"
+  checksum: [
+    "sha256=fddf61500e828ac88d86ba982084cc817299302082a6e797b36787ff18235ec2"
+    "sha512=8b71a8cecd3e101df55eef0bba7a24d4dde9d66b5ecedd9f6d55834fcdc8d33fd875092ca73a398e1715664caee06cdc1bdb1b4da85bff0a687faac5c0445023"
+  ]
+}
+x-commit-hash: "ff83a5e53e2a492cf782ee3296feb7119605e151"

--- a/packages/yocaml_mustache/yocaml_mustache.2.0.0/opam
+++ b/packages/yocaml_mustache/yocaml_mustache.2.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for using Mustache as a template language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "ocaml" {>= "5.1.1"}
+  "dune" {>= "3.14" & >= "3.0.0"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.4.1"}
+  "yocaml" {= version}
+  "mustache" {= "3.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.0.0/yocaml-2.0.0.tbz"
+  checksum: [
+    "sha256=fddf61500e828ac88d86ba982084cc817299302082a6e797b36787ff18235ec2"
+    "sha512=8b71a8cecd3e101df55eef0bba7a24d4dde9d66b5ecedd9f6d55834fcdc8d33fd875092ca73a398e1715664caee06cdc1bdb1b4da85bff0a687faac5c0445023"
+  ]
+}
+x-commit-hash: "ff83a5e53e2a492cf782ee3296feb7119605e151"

--- a/packages/yocaml_omd/yocaml_omd.2.0.0/opam
+++ b/packages/yocaml_omd/yocaml_omd.2.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Yocaml plugin for using Markdown (via OMD package) as a Markup language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "ocaml" {>= "5.1.1"}
+  "dune" {>= "3.14" & >= "3.0.0"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.4.1"}
+  "yocaml" {= version}
+  "omd" {>= "2.0.0~alpha4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.0.0/yocaml-2.0.0.tbz"
+  checksum: [
+    "sha256=fddf61500e828ac88d86ba982084cc817299302082a6e797b36787ff18235ec2"
+    "sha512=8b71a8cecd3e101df55eef0bba7a24d4dde9d66b5ecedd9f6d55834fcdc8d33fd875092ca73a398e1715664caee06cdc1bdb1b4da85bff0a687faac5c0445023"
+  ]
+}
+x-commit-hash: "ff83a5e53e2a492cf782ee3296feb7119605e151"

--- a/packages/yocaml_otoml/yocaml_otoml.2.0.0/opam
+++ b/packages/yocaml_otoml/yocaml_otoml.2.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for dealing with TOML as metadata provider"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "ocaml" {>= "5.1.1"}
+  "dune" {>= "3.14" & >= "3.0.0"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.4.1"}
+  "yocaml" {= version}
+  "otoml" {>= "1.0.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.0.0/yocaml-2.0.0.tbz"
+  checksum: [
+    "sha256=fddf61500e828ac88d86ba982084cc817299302082a6e797b36787ff18235ec2"
+    "sha512=8b71a8cecd3e101df55eef0bba7a24d4dde9d66b5ecedd9f6d55834fcdc8d33fd875092ca73a398e1715664caee06cdc1bdb1b4da85bff0a687faac5c0445023"
+  ]
+}
+x-commit-hash: "ff83a5e53e2a492cf782ee3296feb7119605e151"

--- a/packages/yocaml_runtime/yocaml_runtime.2.0.0/opam
+++ b/packages/yocaml_runtime/yocaml_runtime.2.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Tool for describing runtimes (using Logs and Digestif)"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "ocaml" {>= "5.1.1"}
+  "dune" {>= "3.14" & >= "3.0.0"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.4.1"}
+  "yocaml" {= version}
+  "cohttp" {>= "5.3.11"}
+  "magic-mime" {>= "1.3.1"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.9.0"}
+  "digestif" {>= "1.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.0.0/yocaml-2.0.0.tbz"
+  checksum: [
+    "sha256=fddf61500e828ac88d86ba982084cc817299302082a6e797b36787ff18235ec2"
+    "sha512=8b71a8cecd3e101df55eef0bba7a24d4dde9d66b5ecedd9f6d55834fcdc8d33fd875092ca73a398e1715664caee06cdc1bdb1b4da85bff0a687faac5c0445023"
+  ]
+}
+x-commit-hash: "ff83a5e53e2a492cf782ee3296feb7119605e151"

--- a/packages/yocaml_syndication/yocaml_syndication.2.0.0/opam
+++ b/packages/yocaml_syndication/yocaml_syndication.2.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for dealing with RSS and Atom feed"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "ocaml" {>= "5.1.1"}
+  "dune" {>= "3.14" & >= "3.0.0"}
+  "yocaml" {= version}
+  "fmt" {with-test}
+  "alcotest" {with-test}
+  "qcheck" {with-test}
+  "qcheck-alcotest" {with-test}
+  "ppx_expect"
+  "mdx" {with-test & = "2.4.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.0.0/yocaml-2.0.0.tbz"
+  checksum: [
+    "sha256=fddf61500e828ac88d86ba982084cc817299302082a6e797b36787ff18235ec2"
+    "sha512=8b71a8cecd3e101df55eef0bba7a24d4dde9d66b5ecedd9f6d55834fcdc8d33fd875092ca73a398e1715664caee06cdc1bdb1b4da85bff0a687faac5c0445023"
+  ]
+}
+x-commit-hash: "ff83a5e53e2a492cf782ee3296feb7119605e151"

--- a/packages/yocaml_unix/yocaml_unix.2.0.0/opam
+++ b/packages/yocaml_unix/yocaml_unix.2.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "The Unix runtime for YOCaml"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "ocaml" {>= "5.1.1"}
+  "dune" {>= "3.14" & >= "3.0.0"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.4.1"}
+  "httpcats" {>= "0.0.1"}
+  "yocaml" {= version}
+  "yocaml_runtime" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.0.0/yocaml-2.0.0.tbz"
+  checksum: [
+    "sha256=fddf61500e828ac88d86ba982084cc817299302082a6e797b36787ff18235ec2"
+    "sha512=8b71a8cecd3e101df55eef0bba7a24d4dde9d66b5ecedd9f6d55834fcdc8d33fd875092ca73a398e1715664caee06cdc1bdb1b4da85bff0a687faac5c0445023"
+  ]
+}
+x-commit-hash: "ff83a5e53e2a492cf782ee3296feb7119605e151"

--- a/packages/yocaml_yaml/yocaml_yaml.2.0.0/opam
+++ b/packages/yocaml_yaml/yocaml_yaml.2.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for dealing with Yaml as metadata provider"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "ocaml" {>= "5.1.1"}
+  "dune" {>= "3.14" & >= "3.0.0"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.4.1"}
+  "yocaml" {= version}
+  "yaml" {>= "3.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.0.0/yocaml-2.0.0.tbz"
+  checksum: [
+    "sha256=fddf61500e828ac88d86ba982084cc817299302082a6e797b36787ff18235ec2"
+    "sha512=8b71a8cecd3e101df55eef0bba7a24d4dde9d66b5ecedd9f6d55834fcdc8d33fd875092ca73a398e1715664caee06cdc1bdb1b4da85bff0a687faac5c0445023"
+  ]
+}
+x-commit-hash: "ff83a5e53e2a492cf782ee3296feb7119605e151"


### PR DESCRIPTION
Core engine of the YOCaml Static Site Generator

- Project page: <a href="https://github.com/xhtmlboi/yocaml">https://github.com/xhtmlboi/yocaml</a>

##### CHANGES:

#### yocaml

- Complete reconstruction of the YOCaml core (by [xhtmlboi](https://github.com/xhtmlboi), [xvw](https://github.com/xvw), [gr-im](https://github.com/gr-im), [mspwn](https://github.com/mspwn), [dinosaure](https://github.com/dinosaure), [maiste](https://github.com/maiste) and [hakimba](https://github.com/Hakimba))

#### yocaml_cmarkit

- Second release (by [maiste](https://github.com/maiste) and [xvw](https://github.com/xvw))

#### yocaml_eio

- First release (by [xvw](https://github.com/xvw), [dinosaure](https://github.com/dinosaure), [hannesm](https://github.com/hannesm), and [xhtmlboi](https://github.com/xhtmlboi))

#### yocaml_git

- First release (by [dinosaure](https://github.com/dinosaure) and [xhtmlboi](https://github.com/xhtmlboi))


#### yocaml_jingoo

- Second release (by [xhtmlboi](https://github.com/xhtmlboi), [mspwn](https://github.com/mspwn) and [xvw](https://github.com/xvw))

#### yocaml_mustache

- Second release (by [xhtmlboi](https://github.com/xhtmlboi), [mspwn](https://github.com/mspwn) and [xvw](https://github.com/xvw))

#### yocaml_omd

- Second release (by [xhtmlboi](https://github.com/xhtmlboi), [mspwn](https://github.com/mspwn) and [xvw](https://github.com/xvw))

#### yocaml_otoml

- First release (by [xvw](https://github.com/xvw))

#### yocaml_syndication

- Second release (by [xvw](https://github.com/xvw), [mspwn](https://github.com/mspwn), [gr-im](https://github.com/gr-im) and [tim-ats-d](https://github.com/Tim-ats-d))

#### yocaml_unix

- Second release (by [xvw](https://github.com/xvw), [dinosaure](https://github.com/dinosaure), [hannesm](https://github.com/hannesm), and [xhtmlboi](https://github.com/xhtmlboi))

#### yocaml_yaml

- Second release (by [xhtmlboi](https://github.com/xhtmlboi), [mspwn](https://github.com/mspwn) and [xvw](https://github.com/xvw))
