### PR TITLE
[new release] albatross (2.3.0)

### DIFF
--- a/packages/albatross/albatross.2.3.0/opam
+++ b/packages/albatross/albatross.2.3.0/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/robur-coop/albatross"
+dev-repo: "git+https://github.com/robur-coop/albatross.git"
+bug-reports: "https://github.com/robur-coop/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "5.3.0"}
+  "logs"
+  "bos" {>= "0.2.0"}
+  "ptime"
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "1.0.0"}
+  "tls" {>= "1.0.2"}
+  "tls-lwt" {>= "1.0.2"}
+  "asn1-combinators" {>= "0.3.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "ohex" {>= "0.2.0"}
+  "http-lwt-client" {>= "0.3.0"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.3"}
+  "fpath" {>= "0.7.3"}
+  "logs-syslog" {>= "0.4.1"}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+url {
+  src:
+    "https://github.com/robur-coop/albatross/releases/download/v2.3.0/albatross-2.3.0.tbz"
+  checksum: [
+    "sha256=4fc85fc15e3226c8c083047efe424d39daac38e55752c7ae1b412296726f04a2"
+    "sha512=a9e7d9eca3c8e771ffc345e3a4f8a4e376af63683250013d5050e73beb60c0dfe0a66db7a3fd785e4aa52ad27df2807e743d5674d6c137e7a36bfc9c5a8232c2"
+  ]
+}
+x-commit-hash: "eb17bdb12d1811e511154462d1a33046cf4d2031"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/robur-coop/albatross">https://github.com/robur-coop/albatross</a>

##### CHANGES:

* Albatross-daemon: discover and provide root policy with the available system
  resources (robur-coop/albatross#190 @hannesm @reynir @PizieDust)
* Vmm_core.Policy.usable: check that block size, if present, is non-negative
  (robur-coop/albatross#192 @hannesm)
* BREAKING: rename vm to unikernel (robur-coop/albatross#192 @hannesm)
* Document Vmm_trie (robur-coop/albatross#192 @hannesm)
* Parse /proc/pid/status less strict (robur-coop/albatross#193 @Firobe)
