### PR TITLE
[new release] mirage (2 packages) (4.8.0)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.4.8.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.4.8.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+available: opam-version >= "2.1.0"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.9.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "4.0.0"}
+  "ipaddr" {>= "5.5.0"}
+  "cmdliner" {>= "1.2.0"}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "ppxlib" {= "0.29.0"} #0.29.0 provides a vendored ppx_sexp_conv
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.8.0/mirage-4.8.0.tbz"
+  checksum: [
+    "sha256=4f728c08cfb08d24f276f899f2d931aefb698ec558781f2429dc1f5cb9f11fd8"
+    "sha512=5015fe33d9ab7edfdb56bf148b1d867dd5f0f3cf9e47d9e3edd4560e21e178a44a841b095405d3fc3c33edbced161f5969dbe370ac49cd2ffabc5f1dafe0293b"
+  ]
+}
+x-commit-hash: "39a93aab355f440199857db641659cb5c5dbcd9a"

--- a/packages/mirage/mirage.4.8.0/opam
+++ b/packages/mirage/mirage.4.8.0/opam
@@ -19,6 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.13.0"}
+  "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
   "cmdliner" {>= "1.2.0"}

--- a/packages/mirage/mirage.4.8.0/opam
+++ b/packages/mirage/mirage.4.8.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+available: opam-version >= "2.1.0"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.9.0"}
+  "astring"
+  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {with-test & >= "1.3.0"}
+  "emile" {>= "1.1"}
+  "fmt" {>= "0.8.7"}
+  "ipaddr" {>= "5.0.0"}
+  "bos"
+  "fpath"
+  "rresult" {>= "0.7.0"}
+  "uri" {>= "4.2.0"}
+  "logs" {>= "0.7.0"}
+  "opam-monorepo" {>= "0.4.0"}
+  "alcotest" {with-test}
+  "mirage-runtime" {with-test & = version}
+]
+
+conflicts: [ "jbuilder" {with-test} ]
+
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.8.0/mirage-4.8.0.tbz"
+  checksum: [
+    "sha256=4f728c08cfb08d24f276f899f2d931aefb698ec558781f2429dc1f5cb9f11fd8"
+    "sha512=5015fe33d9ab7edfdb56bf148b1d867dd5f0f3cf9e47d9e3edd4560e21e178a44a841b095405d3fc3c33edbced161f5969dbe370ac49cd2ffabc5f1dafe0293b"
+  ]
+}
+x-commit-hash: "39a93aab355f440199857db641659cb5c5dbcd9a"


### PR DESCRIPTION
The MirageOS library operating system

- Project page: <a href="https://github.com/mirage/mirage">https://github.com/mirage/mirage</a>
- Documentation: <a href="https://mirage.github.io/mirage/">https://mirage.github.io/mirage/</a>

##### CHANGES:

- BREAKING avoid optional runtime arguments in devices (ip, git, happy-eyeballs,
  dns) (mirage/mirage#1552 mirage/mirage#1577 by @hannesm)
- update documentation (fixes mirage/mirage#1560, mirage/mirage#1571 mirage/mirage#1576 by @hannesm)
- code cleanups, removed unused code (mirage/mirage#1575 by @reynir)
- provide Mirage_runtime,register_arg, deprecate Mirage_runtime.register
  (mirage/mirage#1574 by @hannesm)
- improve Mirage_runtime argument error message (mirage/mirage#1573 by @hannesm)
- config.ml: make deprecation warnings non-errors (mirage/mirage#1568 by @reynir)
- Use copy# for config.ml (mirage/mirage#1570 by @reynir)
- generated opam file: avoid double slash (reported in mirage/mirage#1563 by @reynir, fixed
  in mirage/mirage#1564 by @reynir)
- BUGFIX: version check: log a warning if version is not parseable
  (reported in mirage/mirage#1565 by @reynir, fixed in mirage/mirage#1566 by @hannesm)
