### PR TITLE
5 packages from zoggy.frama.io/activitypub/releases/ocaml-activitypub-0.1.0.tar.bz2

### DIFF
--- a/packages/activitypub/activitypub.0.1.0/opam
+++ b/packages/activitypub/activitypub.0.1.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "ActivityPub in OCaml"
+description: "Library and tools to communicate with the ActivityPub protocol"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/activitypub/"
+doc: "https://zoggy.frama.io/activitypub/"
+bug-reports: "https://framagit.org/zoggy/activitypub/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "cohttp-lwt" {>= "5.3.0"}
+  "cryptokit" {>= "1.19"}
+  "fmt" {>= "0.8.9"}
+  "iri" {>= "1.0.0"}
+  "logs" {>= "0.7.0"}
+  "ldp" {>= "0.3.0"}
+  "ldp_tls" {>= "0.3.0"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.3"}
+  "ocaml" {>= "4.14.0"}
+  "ocf" {>= "0.8.0"}
+  "ocf_ppx" {>= "0.8.0"}
+  "ptime" {>= "1.1.0"}
+  "ppx_blob" {>= "0.7.2"}
+  "rdf" {>= "1.0.0"}
+  "rdf_json_ld" {>= "1.0.0"}
+  "rdf_ppx" {>= "1.0.0"}
+  "x509" {>= "1.0.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/activitypub.git"
+url {
+  src:
+    "https://zoggy.frama.io/activitypub/releases/ocaml-activitypub-0.1.0.tar.bz2"
+  checksum: [
+    "md5=332e6cab89ed63fda379aba37e00c40b"
+    "sha512=b6e5fe4948fdbe1d63227adc834c783821b609691c8db24438a8f76c5f6a2c60d1ecbd385baf1029901225abe2031d9aa994a0ed0321ea8082b3281e35552bb0"
+  ]
+}

--- a/packages/activitypub_client/activitypub_client.0.1.0/opam
+++ b/packages/activitypub_client/activitypub_client.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "ActivityPub client in OCaml"
+description:
+  "Activity pub client library, to interact with an activity pub server"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/activitypub/"
+doc: "https://zoggy.frama.io/activitypub/"
+bug-reports: "https://framagit.org/zoggy/activitypub/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "activitypub" {= version}
+  "lru_cache" {>= "0.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/activitypub.git"
+url {
+  src:
+    "https://zoggy.frama.io/activitypub/releases/ocaml-activitypub-0.1.0.tar.bz2"
+  checksum: [
+    "md5=332e6cab89ed63fda379aba37e00c40b"
+    "sha512=b6e5fe4948fdbe1d63227adc834c783821b609691c8db24438a8f76c5f6a2c60d1ecbd385baf1029901225abe2031d9aa994a0ed0321ea8082b3281e35552bb0"
+  ]
+}

--- a/packages/activitypub_gui/activitypub_gui.0.1.0/opam
+++ b/packages/activitypub_gui/activitypub_gui.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Simple ActivityPub client gui in OCaml"
+description:
+  "Activity pub client GUi, to interact with an activity pub server"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/activitypub/"
+doc: "https://zoggy.frama.io/activitypub/"
+bug-reports: "https://framagit.org/zoggy/activitypub/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "activitypub_client" {= version}
+  "omd" {>= "2.0.0~alpha4"}
+  "stk" {>= "0.3.0"}
+  "stk_iconv" {>= "0.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/activitypub.git"
+url {
+  src:
+    "https://zoggy.frama.io/activitypub/releases/ocaml-activitypub-0.1.0.tar.bz2"
+  checksum: [
+    "md5=332e6cab89ed63fda379aba37e00c40b"
+    "sha512=b6e5fe4948fdbe1d63227adc834c783821b609691c8db24438a8f76c5f6a2c60d1ecbd385baf1029901225abe2031d9aa994a0ed0321ea8082b3281e35552bb0"
+  ]
+}

--- a/packages/activitypub_server/activitypub_server.0.1.0/opam
+++ b/packages/activitypub_server/activitypub_server.0.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "ActivityPub server in OCaml"
+description:
+  "Activity pub server, handling client to server and server to server protocols"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/activitypub/"
+doc: "https://zoggy.frama.io/activitypub/"
+bug-reports: "https://framagit.org/zoggy/activitypub/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "5.2.0"}
+  "activitypub" {= version}
+  "lru_cache" {>= "0.4.0"}
+  "webmachine" {>= "0.7.0"}
+  "xtmpl" {>= "0.19.0"}
+  "xtmpl_ppx" {>= "0.19.0"}
+  "odoc" {with-doc}
+]
+available: os != "macos"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/activitypub.git"
+url {
+  src:
+    "https://zoggy.frama.io/activitypub/releases/ocaml-activitypub-0.1.0.tar.bz2"
+  checksum: [
+    "md5=332e6cab89ed63fda379aba37e00c40b"
+    "sha512=b6e5fe4948fdbe1d63227adc834c783821b609691c8db24438a8f76c5f6a2c60d1ecbd385baf1029901225abe2031d9aa994a0ed0321ea8082b3281e35552bb0"
+  ]
+}

--- a/packages/activitypub_server_gui/activitypub_server_gui.0.1.0/opam
+++ b/packages/activitypub_server_gui/activitypub_server_gui.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "ActivityPub server in OCaml, admin GUI"
+description: "Activity pub server admin Gui"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/activitypub/"
+doc: "https://zoggy.frama.io/activitypub/"
+bug-reports: "https://framagit.org/zoggy/activitypub/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "activitypub_server" {= version}
+  "activitypub_gui" {= version}
+  "stk" {>= "0.3.0"}
+  "stk_iconv" {>= "0.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/activitypub.git"
+url {
+  src:
+    "https://zoggy.frama.io/activitypub/releases/ocaml-activitypub-0.1.0.tar.bz2"
+  checksum: [
+    "md5=332e6cab89ed63fda379aba37e00c40b"
+    "sha512=b6e5fe4948fdbe1d63227adc834c783821b609691c8db24438a8f76c5f6a2c60d1ecbd385baf1029901225abe2031d9aa994a0ed0321ea8082b3281e35552bb0"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `activitypub.0.1.0`: ActivityPub in OCaml
- `activitypub_client.0.1.0`: ActivityPub client in OCaml
- `activitypub_gui.0.1.0`: Simple ActivityPub client gui in OCaml
- `activitypub_server.0.1.0`: ActivityPub server in OCaml
- `activitypub_server_gui.0.1.0`: ActivityPub server in OCaml, admin GUI



---
* Homepage: https://zoggy.frama.io/activitypub/
* Source repo: git+https://framagit.org/zoggy/activitypub.git
* Bug tracker: https://framagit.org/zoggy/activitypub/issues

---
:camel: Pull-request generated by opam-publish v2.4.0