### PR TITLE
Package ppx_expect.v0.17.1

### DIFF
--- a/packages/ppx_expect/ppx_expect.v0.17.1/opam
+++ b/packages/ppx_expect/ppx_expect.v0.17.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_expect"
+bug-reports: "https://github.com/janestreet/ppx_expect/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_expect.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_expect/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"           {>= "5.1.0"}
+  "base"            {>= "v0.17" & < "v0.18"}
+  "ppx_here"        {>= "v0.17" & < "v0.18"}
+  "ppx_inline_test" {>= "v0.17" & < "v0.18"}
+  "stdio"           {>= "v0.17" & < "v0.18"}
+  "dune"            {>= "3.11.0"}
+  "ppxlib"          {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+conflicts: [
+  "js_of_ocaml-compiler" {< "5.8"}
+]
+
+synopsis: "Cram like framework for OCaml"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_expect/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=bc426d44bd413aa231e484c7c3378185"
+    "sha512=036b039cf069b2a283135bdb1d7643719bec2eaca59debd0b20d7b87742d4404c0db2259ef46ad7ecc77520f3272b02e2af5f83a740fdb0fc0d0479dfe3af9bb"
+  ]
+}


### PR DESCRIPTION
### `ppx_expect.v0.17.1`
Cram like framework for OCaml
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_expect
* Source repo: git+https://github.com/janestreet/ppx_expect.git
* Bug tracker: https://github.com/janestreet/ppx_expect/issues

---
:camel: Pull-request generated by opam-publish v2.3.0