### PR TITLE
[package update] Strenghten dependencies constraints in Ortac packages

### DIFF
--- a/packages/ortac-core/ortac-core.0.1.0/opam
+++ b/packages/ortac-core/ortac-core.0.1.0/opam
@@ -30,7 +30,7 @@ depends: [
   "ppxlib" {>= "0.26.0"}
   "gospel" {>= "0.2.0"}
   "alcotest" {with-test & >= "0.8.1"}
-  "ortac-runtime" {with-test}
+  "ortac-runtime" {with-test & = version}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/ortac-core/ortac-core.0.1.0/opam
+++ b/packages/ortac-core/ortac-core.0.1.0/opam
@@ -28,7 +28,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "fmt"
   "ppxlib" {>= "0.26.0"}
-  "gospel" {>= "0.2.0"}
+  "gospel" {= "0.2.0"}
   "alcotest" {with-test & >= "0.8.1"}
   "ortac-runtime" {with-test & = version}
 ]

--- a/packages/ortac-core/ortac-core.0.2.0/opam
+++ b/packages/ortac-core/ortac-core.0.2.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ppxlib" {>= "0.26.0"}
   "gospel" {>= "0.3.0"}
   "alcotest" {with-test & >= "0.8.1"}
-  "ortac-runtime" {with-test}
+  "ortac-runtime" {with-test & = version}
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/packages/ortac-core/ortac-core.0.2.0/opam
+++ b/packages/ortac-core/ortac-core.0.2.0/opam
@@ -29,7 +29,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "fmt"
   "ppxlib" {>= "0.26.0"}
-  "gospel" {>= "0.3.0"}
+  "gospel" {= "0.3.0"}
   "alcotest" {with-test & >= "0.8.1"}
   "ortac-runtime" {with-test & = version}
   "odoc" {with-doc}

--- a/packages/ortac-core/ortac-core.0.3.0/opam
+++ b/packages/ortac-core/ortac-core.0.3.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ppxlib" {>= "0.26.0"}
   "gospel" {= "0.3.0"}
   "alcotest" {with-test & >= "0.8.1"}
-  "ortac-runtime" {with-test}
+  "ortac-runtime" {with-test & = version}
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/packages/ortac-dune/ortac-dune.0.3.0/opam
+++ b/packages/ortac-dune/ortac-dune.0.3.0/opam
@@ -12,7 +12,7 @@ depends: [
   "fmt"
   "cmdliner" {>= "1.1.0"}
   "ortac-core" {= version}
-  "ortac-qcheck-stm" {with-test}
+  "ortac-qcheck-stm" {with-test & = version}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ortac-qcheck-stm/ortac-qcheck-stm.0.1.0/opam
+++ b/packages/ortac-qcheck-stm/ortac-qcheck-stm.0.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "fmt"
   "ppxlib" {>= "0.26.0"}
   "mdx" {with-test}
-  "gospel" {>= "0.2.0"}
+  "gospel" {= "0.2.0"}
   "qcheck-core" {with-test}
   "qcheck-stm" {with-test}
   "qcheck-multicoretests-util" {with-test}

--- a/packages/ortac-qcheck-stm/ortac-qcheck-stm.0.1.0/opam
+++ b/packages/ortac-qcheck-stm/ortac-qcheck-stm.0.1.0/opam
@@ -29,8 +29,8 @@ depends: [
   "qcheck-core" {with-test}
   "qcheck-stm" {with-test}
   "qcheck-multicoretests-util" {with-test}
-  "ortac-core"
-  "ortac-runtime" {with-test}
+  "ortac-core" {= version}
+  "ortac-runtime" {with-test & = version}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/ortac-qcheck-stm/ortac-qcheck-stm.0.2.0/opam
+++ b/packages/ortac-qcheck-stm/ortac-qcheck-stm.0.2.0/opam
@@ -30,9 +30,9 @@ depends: [
   "qcheck-core" {with-test}
   "qcheck-stm" {with-test}
   "qcheck-multicoretests-util" {with-test}
-  "ortac-core" {>= "0.2.0"}
-  "ortac-runtime" {with-test}
-  "ortac-runtime-qcheck-stm" {with-test}
+  "ortac-core" {= version}
+  "ortac-runtime" {with-test & = version}
+  "ortac-runtime-qcheck-stm" {with-test & = version}
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/packages/ortac-runtime-qcheck-stm/ortac-runtime-qcheck-stm.0.2.0/opam
+++ b/packages/ortac-runtime-qcheck-stm/ortac-runtime-qcheck-stm.0.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "3.8"}
   "ocaml" {>= "4.12.0"}
   "qcheck-stm"
-  "ortac-runtime" {>= "0.2.0"}
+  "ortac-runtime" {= version}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
This PR updates some dependencies constraints for some Ortac packages.

When an Ortac package depends on another Ortac package, make the constraints ask for the exact same version.
The reason why is that version 0.4.0 brings some breaking changes (see #26691) and we can't guarantee that it will be an isolate case.

Constraints on the Gospel package are also added, as the next release is expected to bring breaking changes.
