### PR TITLE
Package catala-lsp.0.0.1

### DIFF
--- a/packages/catala-lsp/catala-lsp.0.0.1/opam
+++ b/packages/catala-lsp/catala-lsp.0.0.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Vincent Botbol"
+authors: [ "Vincent Botbol" ]
+license: "Apache-2.0"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.14.1"}
+  "dune" { >= "3.0" }
+  "catala"    { = "dev" }
+  "logs"
+  "uri"
+  "linol"     { = "dev" }
+  "linol-lwt" { = "dev" }
+]
+pin-depends: [
+  ["catala.dev" "git+https://github.com/CatalaLang/catala#lsp-compat"]
+  # TODO: remove linol's pinning once the required changes are
+  # published in opam
+  ["linol.dev" "git+https://github.com/c-cube/linol#a779942f9592a762d26484d03b1f93110dbaf577"]
+  ["linol-lwt.dev" "git+https://github.com/c-cube/linol#a779942f9592a762d26484d03b1f93110dbaf577"]
+]
+tags: [ "catala" "lsp" ]
+homepage: "https://github.com/CatalaLang/catala-language-server"
+dev-repo: "git+https://github.com/CatalaLang/catala-language-server.git"
+bug-reports: "https://github.com/CatalaLang/catala-language-server/issues"
+synopsis: "Catala Language Server Protocol (LSP)"
+description:"Implementation of a Language Server Protocol (LSP) for Catala."
+url {
+  src:
+    "https://github.com/CatalaLang/catala-language-server/archive/refs/tags/catala-lsp.0.0.1.tar.gz"
+  checksum: [
+    "md5=ab26aac2c9d2512231a8448cd8344435"
+    "sha512=353762b10d46f50d4261f07978b8a7e69be5d3a6fcda9c0c892d75a4f165630f8fbdf95e318b34871865a6d4155f153848a72f3d448a387fe679cf472ce21a98"
+  ]
+}


### PR DESCRIPTION
### `catala-lsp.0.0.1`
Catala Language Server Protocol (LSP)
Implementation of a Language Server Protocol (LSP) for Catala.



---
* Homepage: https://github.com/CatalaLang/catala-language-server
* Source repo: git+https://github.com/CatalaLang/catala-language-server.git
* Bug tracker: https://github.com/CatalaLang/catala-language-server/issues

---
:camel: Pull-request generated by opam-publish v2.3.0