### PR TITLE
Add missing ppx_deriving upper bounds

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.5.2.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.2.1/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.3"}
   "dune" {>= "1.6.3"}
   "cppo" {build & >= "1.1.0"}
   "ocamlfind"

--- a/packages/ppx_deriving/ppx_deriving.5.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.2/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.3"}
   "dune" {>= "1.6.3"}
   "cppo" {build & >= "1.1.0"}
   "ocamlfind"


### PR DESCRIPTION
#26654 added constraints on ppx_deriving.6.0.2 to record that it is not 5.3-compatible.

The lower-bound search then spotted that 5.2.1 (and 5.2) similarly was missing an upper ocaml bound.
This is showing up as red lights on https://github.com/ocaml/opam-repository/pull/26697 here:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/49691385a284bc26db43c8ebf8bdca24897bfbe4

I've also confirmed that `opam install ppx_deriving.5.2` (and 5.2.1) fails locally on a freshly install `5.3.0~alpha1` switch:
```
$ opam install ppx_deriving.5.2
The following actions will be performed:
=== install 1 package
  ∗ ppx_deriving 5.2

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
⬇ retrieved ppx_deriving.5.2  (https://opam.ocaml.org/cache)
[ERROR] The compilation of ppx_deriving.5.2 failed at "dune build -p ppx_deriving -j 15".

#=== ERROR while compiling ppx_deriving.5.2 ===================================#
# context     2.2.1 | linux/x86_64 | ocaml-base-compiler.5.3.0~alpha1 ocaml-compiler.5.3.0~alpha1 | https://opam.ocaml.org#6b08ef082c296ff6b539e9a8ec4b15ff67f68b61
# path        ~/.opam/5.3.0~alpha1/.opam-switch/build/ppx_deriving.5.2
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ppx_deriving -j 15
# exit-code   1
# env-file    ~/.opam/log/ppx_deriving-32826-fb8b2e.env
# output-file ~/.opam/log/ppx_deriving-32826-fb8b2e.out
### output ###
# Error: The value "sub" has type
# [...]
# (cd _build/default && /home/jmi/.opam/5.3.0~alpha1/bin/ocamlc.opt -w -40 -w -27-9 -g -bin-annot -bin-annot-occurrences -I src/api/.ppx_deriving_api.objs/byte -I /home/jmi/.opam/5.3.0~alpha1/lib/ocaml-compiler-libs/common -I /home/jmi/.opam/5.3.0~alpha1/lib/ocaml-compiler-libs/shadow -I /home/jmi/.opam/5.3.0~alpha1/lib/ocaml/compiler-libs -I /home/jmi/.opam/5.3.0~alpha1/lib/ppx_derivers -I /ho[...]
# File "ppx_deriving.cppo.ml", line 181, characters 30-33:
# Error: The value "sub" has type
#          "(Format.formatter -> unit) Ppxlib.Asttypes.loc list option"
#        but an expression was expected of type "Location.msg list option"
#        Type
#          "(Format.formatter -> unit) Ppxlib.Asttypes.loc" =
#            "(Format.formatter -> unit) Location.loc"
#        is not compatible with type "Location.msg" = "Format_doc.t Location.loc"
#        Type "Format.formatter -> unit" is not compatible with type
#          "Format_doc.t" = "Format_doc.Doc.t"



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
┌─ The following actions failed
│ λ build ppx_deriving 5.2
└─ 
╶─ No changes have been performed

```