### PR TITLE
sqlite3, openssl and libffi on msys2

### DIFF
--- a/packages/conf-mingw-w64-libffi-i686/conf-mingw-w64-libffi-i686.1/opam
+++ b/packages/conf-mingw-w64-libffi-i686/conf-mingw-w64-libffi-i686.1/opam
@@ -7,7 +7,7 @@ license: "MIT"
 homepage: "https://sourceware.org/libffi"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
-available: os = "win32" & os-distribution = "cygwin"
+available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" "libffi"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-mingw-w64-libffi-x86_64/conf-mingw-w64-libffi-x86_64.1/opam
+++ b/packages/conf-mingw-w64-libffi-x86_64/conf-mingw-w64-libffi-x86_64.1/opam
@@ -7,7 +7,7 @@ license: "MIT"
 homepage: "https://sourceware.org/libffi"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
-available: os = "win32" & os-distribution = "cygwin"
+available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" "libffi"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-mingw-w64-openssl-i686/conf-mingw-w64-openssl-i686.1/opam
+++ b/packages/conf-mingw-w64-openssl-i686/conf-mingw-w64-openssl-i686.1/opam
@@ -7,7 +7,7 @@ license: "Apache-1.0"
 homepage: "https://www.openssl.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
-available: os = "win32" & os-distribution = "cygwin"
+available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" "openssl"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-mingw-w64-openssl-x86_64/conf-mingw-w64-openssl-x86_64.1/opam
+++ b/packages/conf-mingw-w64-openssl-x86_64/conf-mingw-w64-openssl-x86_64.1/opam
@@ -7,7 +7,7 @@ license: "Apache-1.0"
 homepage: "https://www.openssl.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
-available: os = "win32" & os-distribution = "cygwin"
+available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" "openssl"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-mingw-w64-sqlite3-i686/conf-mingw-w64-sqlite3-i686.1/opam
+++ b/packages/conf-mingw-w64-sqlite3-i686/conf-mingw-w64-sqlite3-i686.1/opam
@@ -11,7 +11,7 @@ license: "blessing"
 homepage: "http://www.sqlite3.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
-available: os = "win32" & os-distribution = "cygwin"
+available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" "sqlite3"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-mingw-w64-sqlite3-x86_64/conf-mingw-w64-sqlite3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sqlite3-x86_64/conf-mingw-w64-sqlite3-x86_64.1/opam
@@ -11,7 +11,7 @@ license: "blessing"
 homepage: "http://www.sqlite3.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
-available: os = "win32" & os-distribution = "cygwin"
+available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" "sqlite3"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-sqlite3/conf-sqlite3.1/opam
+++ b/packages/conf-sqlite3/conf-sqlite3.1/opam
@@ -9,9 +9,9 @@ homepage: "http://www.sqlite3.org"
 dev-repo: "git+https://github.com/mmottl/sqlite3-ocaml.git"
 license: "blessing"
 build: [
-  ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
-   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
-   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
+  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
    "pkg-config" {os != "win32" | os-distribution != "cygwin"}
   "sqlite3"]
 ]


### PR DESCRIPTION
* `libffi`, `openssl` and `sqlite3` include `depexts` for both `cygwin` and `msys2` but `msys2` is excluded as an `available` platform.
* `conf-sqlite3` configuration options don't allow for an installation on `msys2` but the underlying packages `conf-mingw-w64-sqlite3-x86_64`, `conf-mingw-w64-sqlite3-i686` do.