### PR TITLE
irmin >= 2.10 is not compatible with compilers that have the effect keyword

### DIFF
--- a/packages/irmin/irmin.2.10.0/opam
+++ b/packages/irmin/irmin.2.10.0/opam
@@ -34,6 +34,7 @@ depends: [
 ]
 conflicts: [
     "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+    "base-effects"
  ]
 synopsis: """
 Irmin, a distributed database that follows the same design principles as Git

--- a/packages/irmin/irmin.2.10.1/opam
+++ b/packages/irmin/irmin.2.10.1/opam
@@ -34,6 +34,7 @@ depends: [
 ]
 conflicts: [
     "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+    "base-effects"
  ]
 synopsis: """
 Irmin, a distributed database that follows the same design principles as Git

--- a/packages/irmin/irmin.2.10.2/opam
+++ b/packages/irmin/irmin.2.10.2/opam
@@ -34,6 +34,7 @@ depends: [
 ]
 conflicts: [
     "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+    "base-effects"
  ]
 synopsis: """
 Irmin, a distributed database that follows the same design principles as Git

--- a/packages/irmin/irmin.3.0.0/opam
+++ b/packages/irmin/irmin.3.0.0/opam
@@ -39,6 +39,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.1.0/opam
+++ b/packages/irmin/irmin.3.1.0/opam
@@ -39,6 +39,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.2.0/opam
+++ b/packages/irmin/irmin.3.2.0/opam
@@ -40,6 +40,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.2.1/opam
+++ b/packages/irmin/irmin.3.2.1/opam
@@ -40,6 +40,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.2.2/opam
+++ b/packages/irmin/irmin.3.2.2/opam
@@ -40,6 +40,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.3.0/opam
+++ b/packages/irmin/irmin.3.3.0/opam
@@ -40,6 +40,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.3.1/opam
+++ b/packages/irmin/irmin.3.3.1/opam
@@ -40,6 +40,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.3.2/opam
+++ b/packages/irmin/irmin.3.3.2/opam
@@ -40,6 +40,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.4.0/opam
+++ b/packages/irmin/irmin.3.4.0/opam
@@ -42,6 +42,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.4.1/opam
+++ b/packages/irmin/irmin.3.4.1/opam
@@ -41,6 +41,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.4.2/opam
+++ b/packages/irmin/irmin.3.4.2/opam
@@ -41,6 +41,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.4.3/opam
+++ b/packages/irmin/irmin.3.4.3/opam
@@ -41,6 +41,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.5.0/opam
+++ b/packages/irmin/irmin.3.5.0/opam
@@ -41,6 +41,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.5.1/opam
+++ b/packages/irmin/irmin.3.5.1/opam
@@ -41,6 +41,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.5.2/opam
+++ b/packages/irmin/irmin.3.5.2/opam
@@ -41,6 +41,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.6.0/opam
+++ b/packages/irmin/irmin.3.6.0/opam
@@ -41,6 +41,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.6.1/opam
+++ b/packages/irmin/irmin.3.6.1/opam
@@ -41,6 +41,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.7.0/opam
+++ b/packages/irmin/irmin.3.7.0/opam
@@ -41,6 +41,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.7.1/opam
+++ b/packages/irmin/irmin.3.7.1/opam
@@ -41,6 +41,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.7.2/opam
+++ b/packages/irmin/irmin.3.7.2/opam
@@ -41,6 +41,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.8.0/opam
+++ b/packages/irmin/irmin.3.8.0/opam
@@ -41,6 +41,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """

--- a/packages/irmin/irmin.3.9.0/opam
+++ b/packages/irmin/irmin.3.9.0/opam
@@ -41,6 +41,7 @@ depends: [
 
 conflicts: [
   "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+  "base-effects"
 ]
 
 synopsis: """


### PR DESCRIPTION
```
#=== ERROR while compiling irmin.3.9.0 ========================================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/irmin.3.9.0
# command              ~/.opam/5.3/bin/dune build -p irmin -j 1
# exit-code            1
# env-file             ~/.opam/log/irmin-20-bc7cf4.env
# output-file          ~/.opam/log/irmin-20-bc7cf4.out
### output ###
# (cd _build/default && .ppx/851ddbf37b8928057d14b915d5ceebb6/ppx.exe --lib Type --cookie 'library-name="irmin"' -o src/irmin/node_intf.pp.ml --impl src/irmin/node_intf.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "src/irmin/node_intf.ml", line 127, characters 7-13:
# 127 |   type effect := expected_depth:int -> node_key -> t option
#              ^^^^^^
# Error: Syntax error
```
Reported upstream in https://github.com/mirage/irmin/issues/2346