### PR TITLE
octez-internal-libs is not compatible with compilers that have the effect keyword

### DIFF
--- a/packages/octez-internal-libs/octez-internal-libs.20.1/opam
+++ b/packages/octez-internal-libs/octez-internal-libs.20.1/opam
@@ -35,6 +35,9 @@ depends: [
   "rusage"
   "octez-alcotezt" { = version }
 ]
+conflicts: [
+  "base-effects"
+]
 build: [
   ["rm" "-r" "vendors" "contrib"]
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
```
#=== ERROR while compiling octez-internal-libs.20.1 ===========================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/octez-internal-libs.20.1
# command              ~/.opam/5.3/bin/dune build -p octez-internal-libs -j 1
# exit-code            1
# env-file             ~/.opam/log/octez-internal-libs-20-c4eb52.env
# output-file          ~/.opam/log/octez-internal-libs-20-c4eb52.out
### output ###
# (cd _build/.sandbox/65f60270e80076734078d8d5d5049a38/default && .ppx/bbce84780f048f7e50d7efd3db38c872/ppx.exe --lib Type --cookie 'library-name="irmin"' -o irmin/lib_irmin/node_intf.pp.ml --impl irmin/lib_irmin/node_intf.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "irmin/lib_irmin/node_intf.ml", line 127, characters 7-13:
# 127 |   type effect := expected_depth:int -> node_key -> t option
#              ^^^^^^
# Error: Syntax error
```