### PR TITLE
merlin-extend is not compatible with OCaml 5.3 (uses compiler-libs)

### DIFF
--- a/packages/merlin-extend/merlin-extend.0.6.1/opam
+++ b/packages/merlin-extend/merlin-extend.0.6.1/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "dune" {>= "1.0"}
   "cppo" {build & >= "1.1.0"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.3"}
 ]
 synopsis: "A protocol to provide custom frontend to Merlin"
 description: """

--- a/packages/merlin-extend/merlin-extend.0.6/opam
+++ b/packages/merlin-extend/merlin-extend.0.6/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "dune" {>= "1.0"}
   "cppo" {build & >= "1.1.0"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.3"}
 ]
 synopsis: "A protocol to provide custom frontend to Merlin"
 description: """


### PR DESCRIPTION
```
#=== ERROR while compiling merlin-extend.0.6.1 ================================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/merlin-extend.0.6.1
# command              ~/.opam/5.3/bin/dune build -p merlin-extend -j 1
# exit-code            1
# env-file             ~/.opam/log/merlin-extend-20-6fad97.env
# output-file          ~/.opam/log/merlin-extend-20-6fad97.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlc.opt -w -40 -w -50 -g -bin-annot -bin-annot-occurrences -I .merlin_extend.objs/byte -I /home/opam/.opam/5.3/lib/ocaml/compiler-libs -I /home/opam/.opam/5.3/lib/ocaml/unix -intf-suffix .ml -no-alias-deps -o .merlin_extend.objs/byte/extend_helper.cmo -c -impl extend_helper.ml)
# File "extend_helper.cppo.ml", line 14, characters 52-55:
# Error: The value "ppf" has type "Format.formatter"
#        but an expression was expected of type "Format_doc.formatter"
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlopt.opt -w -40 -w -50 -g -I .merlin_extend.objs/byte -I .merlin_extend.objs/native -I /home/opam/.opam/5.3/lib/ocaml/compiler-libs -I /home/opam/.opam/5.3/lib/ocaml/unix -intf-suffix .ml -no-alias-deps -o .merlin_extend.objs/native/extend_helper.cmx -c -impl extend_helper.ml)
# File "extend_helper.cppo.ml", line 14, characters 52-55:
# Error: The value "ppf" has type "Format.formatter"
#        but an expression was expected of type "Format_doc.formatter"
```
Upstream PR: https://github.com/let-def/merlin-extend/pull/15