### PR TITLE
prbnmcn-dagger >= 0.0.2 is not compatible with compilers that have the effect keyword

### DIFF
--- a/packages/prbnmcn-dagger/prbnmcn-dagger.0.0.2/opam
+++ b/packages/prbnmcn-dagger/prbnmcn-dagger.0.0.2/opam
@@ -14,6 +14,9 @@ depends: [
   "prbnmcn-cgrph" {= "0.0.2"}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "base-effects"
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/prbnmcn-dagger/prbnmcn-dagger.0.0.3/opam
+++ b/packages/prbnmcn-dagger/prbnmcn-dagger.0.0.3/opam
@@ -17,6 +17,9 @@ depends: [
   "prbnmcn-cgrph" {= "0.0.2"}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "base-effects"
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/prbnmcn-dagger/prbnmcn-dagger.0.0.4/opam
+++ b/packages/prbnmcn-dagger/prbnmcn-dagger.0.0.4/opam
@@ -18,6 +18,9 @@ depends: [
   "prbnmcn-cgrph" {= "0.0.2"}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "base-effects"
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/prbnmcn-dagger/prbnmcn-dagger.0.0.5/opam
+++ b/packages/prbnmcn-dagger/prbnmcn-dagger.0.0.5/opam
@@ -18,6 +18,9 @@ depends: [
   "prbnmcn-cgrph" {= "0.0.2"}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "base-effects"
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
```
#=== ERROR while compiling prbnmcn-dagger.0.0.5 ===============================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/prbnmcn-dagger.0.0.5
# command              ~/.opam/5.3/bin/dune build -p prbnmcn-dagger -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/prbnmcn-dagger-20-a2ca7a.env
# output-file          ~/.opam/log/prbnmcn-dagger-20-a2ca7a.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl src/cps_monad.ml) > _build/default/src/.dagger.objs/dagger__Cps_monad.impl.d
# File "src/cps_monad.ml", line 1, characters 8-14:
# 1 | type 'a effect = ..
#             ^^^^^^
# Error: Syntax error
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl src/lmh_generic.ml) > _build/default/src/.dagger.objs/dagger__Lmh_generic.impl.d
# File "src/lmh_generic.ml", line 7, characters 20-26:
# 7 |   type 'a Cps_monad.effect +=
#                         ^^^^^^
# Error: Syntax error
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl src/lmh_incremental_inference.ml) > _build/default/src/.dagger.objs/dagger__Lmh_incremental_inference.impl.d
# File "src/lmh_incremental_inference.ml", line 211, characters 42-48:
# 211 |         (fun (type a) (dist : a Cps_monad.effect) k () ->
#                                                 ^^^^^^
# Error: Syntax error
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl src/lmh_inference.ml) > _build/default/src/.dagger.objs/dagger__Lmh_inference.impl.d
# File "src/lmh_inference.ml", line 79, characters 44-50:
# 79 |           (fun (type a) (dist : a Cps_monad.effect) k () trace ->
#                                                  ^^^^^^
# Error: Syntax error
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl src/smc_inference.ml) > _build/default/src/.dagger.objs/dagger__Smc_inference.impl.d
# File "src/smc_inference.ml", line 594, characters 22-28:
# 594 |     type 'a Cps_monad.effect +=
#                             ^^^^^^
# Error: Syntax error
```
Upstream issue: https://github.com/igarnier/prbnmcn-dagger/issues/21