### PR TITLE
solid is not compatible with OCaml 5.3 (type-checker fixed corner-cases)

### DIFF
--- a/packages/solid/solid.0.1.0/opam
+++ b/packages/solid/solid.0.1.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
 depends: [
   "dune" {>= "2.9"}
   "ldp" {= version}
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "4.14.0" & < "5.3"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/solid/solid.0.2.0/opam
+++ b/packages/solid/solid.0.2.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
 depends: [
   "dune" {>= "2.9"}
   "ldp" {= version}
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "4.14.0" & < "5.3"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/solid/solid.0.3.0/opam
+++ b/packages/solid/solid.0.3.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
 depends: [
   "dune" {>= "2.9"}
   "ldp" {= version}
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "4.14.0" & < "5.3"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Type-checker change explained in: https://github.com/ocaml/ocaml/issues/13176
```
#=== ERROR while compiling solid.0.3.0 ========================================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/solid.0.3.0
# command              ~/.opam/5.3/bin/dune build -p solid -j 1 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/solid-20-e655d2.env
# output-file          ~/.opam/log/solid-20-e655d2.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlopt.opt -g -w -40 -w -6-7-9-10-27-32-33-34-35-36-50-52 -no-strict-sequence -g -I solid/.solid.objs/byte -I solid/.solid.objs/native -I /home/opam/.opam/5.3/lib/angstrom -I /home/opam/.opam/5.3/lib/base64 -I /home/opam/.opam/5.3/lib/bigstringaf -I /home/opam/.opam/5.3/lib/bytes -I /home/opam/.opam/5.3/lib/cohttp -I /home/opam/.opam/5.3/lib/cohttp-lwt -I /home/opam/.opam/5.3/lib/dune-build-info -I /home/opam/.opam/5.3/lib/fmt -I /home/opam/.opam/5.3/lib/gen -I /home/opam/.opam/5.3/lib/http -I /home/opam/.opam/5.3/lib/http/__private__/http_bytebuffer -I /home/opam/.opam/5.3/lib/iri -I /home/opam/.opam/5.3/lib/ldp -I /home/opam/.opam/5.3/lib/logs -I /home/opam/.opam/5.3/lib/lwt -I /home/opam/.opam/5.3/lib/lwt/unix -I /home/opam/.opam/5.3/lib/menhirLib -I /home/opam/.opam/5.3/lib/ocaml/threads -I /home/opam/.opam/5.3/lib/ocaml/unix -I /home/opam/.opam/5.3/lib/ocf -I /home/opam/.opam/5.3/lib/ocplib-endian -I /home/opam/.opam/5.3/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.3/lib/pcre -I /home/opam/.opam/5.3/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.3/lib/ptime -I /home/opam/.opam/5.3/lib/rdf -I /home/opam/.opam/5.3/lib/re -I /home/opam/.opam/5.3/lib/re/str -I /home/opam/.opam/5.3/lib/sedlex -I /home/opam/.opam/5.3/lib/seq -I /home/opam/.opam/5.3/lib/sexplib0 -I /home/opam/.opam/5.3/lib/stringext -I /home/opam/.opam/5.3/lib/uri -I /home/opam/.opam/5.3/lib/uri-sexp -I /home/opam/.opam/5.3/lib/uucp -I /home/opam/.opam/5.3/lib/uuidm -I /home/opam/.opam/5.3/lib/uunf -I /home/opam/.opam/5.3/lib/uutf -I /home/opam/.opam/5.3/lib/xmlm -I /home/opam/.opam/5.3/lib/yojson -intf-suffix .ml -no-alias-deps -open Solid -o solid/.solid.objs/native/solid__Conf.cmx -c -impl solid/conf.pp.ml)
# File "solid/conf.ml", line 253, characters 16-33:
# 253 |     { wrapper = Obj.magic wrapper ;
#                       ^^^^^^^^^^^^^^^^^
# Error: This field value has type "'b wrapper" which is less general than
#          "'a. 'a wrapper"
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlc.opt -g -w -40 -w -6-7-9-10-27-32-33-34-35-36-50-52 -no-strict-sequence -g -bin-annot -bin-annot-occurrences -I solid/.solid.objs/byte -I /home/opam/.opam/5.3/lib/angstrom -I /home/opam/.opam/5.3/lib/base64 -I /home/opam/.opam/5.3/lib/bigstringaf -I /home/opam/.opam/5.3/lib/bytes -I /home/opam/.opam/5.3/lib/cohttp -I /home/opam/.opam/5.3/lib/cohttp-lwt -I /home/opam/.opam/5.3/lib/dune-build-info -I /home/opam/.opam/5.3/lib/fmt -I /home/opam/.opam/5.3/lib/gen -I /home/opam/.opam/5.3/lib/http -I /home/opam/.opam/5.3/lib/iri -I /home/opam/.opam/5.3/lib/ldp -I /home/opam/.opam/5.3/lib/logs -I /home/opam/.opam/5.3/lib/lwt -I /home/opam/.opam/5.3/lib/lwt/unix -I /home/opam/.opam/5.3/lib/menhirLib -I /home/opam/.opam/5.3/lib/ocaml/threads -I /home/opam/.opam/5.3/lib/ocaml/unix -I /home/opam/.opam/5.3/lib/ocf -I /home/opam/.opam/5.3/lib/ocplib-endian -I /home/opam/.opam/5.3/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.3/lib/pcre -I /home/opam/.opam/5.3/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.3/lib/ptime -I /home/opam/.opam/5.3/lib/rdf -I /home/opam/.opam/5.3/lib/re -I /home/opam/.opam/5.3/lib/re/str -I /home/opam/.opam/5.3/lib/sedlex -I /home/opam/.opam/5.3/lib/seq -I /home/opam/.opam/5.3/lib/sexplib0 -I /home/opam/.opam/5.3/lib/stringext -I /home/opam/.opam/5.3/lib/uri -I /home/opam/.opam/5.3/lib/uri-sexp -I /home/opam/.opam/5.3/lib/uucp -I /home/opam/.opam/5.3/lib/uuidm -I /home/opam/.opam/5.3/lib/uunf -I /home/opam/.opam/5.3/lib/uutf -I /home/opam/.opam/5.3/lib/xmlm -I /home/opam/.opam/5.3/lib/yojson -intf-suffix .ml -no-alias-deps -open Solid -o solid/.solid.objs/byte/solid__Conf.cmo -c -impl solid/conf.pp.ml)
# File "solid/conf.ml", line 253, characters 16-33:
# 253 |     { wrapper = Obj.magic wrapper ;
#                       ^^^^^^^^^^^^^^^^^
# Error: This field value has type "'b wrapper" which is less general than
#          "'a. 'a wrapper"
```
cc @zoggy 