### PR TITLE
mock is not compatible with compilers that have the effect keyword

### DIFF
--- a/packages/mock/mock.0.1.0/opam
+++ b/packages/mock/mock.0.1.0/opam
@@ -14,6 +14,9 @@ depends: [
   "ocaml" {< "5.0"}
   "jbuilder" {>= "1.0+beta10"}
 ]
+conflicts: [
+  "base-effects"
+]
 synopsis: "Configurable functions to test impure code"
 description: """
 This package provides "mocks", fake functions that can be configured to return

--- a/packages/mock/mock.0.1.1/opam
+++ b/packages/mock/mock.0.1.1/opam
@@ -13,6 +13,9 @@ depends: [
   "dune"
   "ocaml" {>= "4.04.0" & < "5.0"}
 ]
+conflicts: [
+  "base-effects"
+]
 synopsis: "Configurable functions to test impure code"
 description: """
 This package provides "mocks", fake functions that can be configured to return

--- a/packages/mock/mock.1.0.0/opam
+++ b/packages/mock/mock.1.0.0/opam
@@ -13,6 +13,9 @@ depends: [
   "dune"
   "ocaml" {>= "4.07.0"}
 ]
+conflicts: [
+  "base-effects"
+]
 synopsis: "Configurable functions to test impure code"
 description: """
 This package provides "mocks", fake functions that can be configured to return


### PR DESCRIPTION
```
#=== ERROR while compiling mock.1.0.0 =========================================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/mock.1.0.0
# command              ~/.opam/5.3/bin/dune build -p mock -j 1
# exit-code            1
# env-file             ~/.opam/log/mock-20-0e115c.env
# output-file          ~/.opam/log/mock-20-0e115c.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlopt.opt -w -40 -g -I src/.mock.objs/byte -I src/.mock.objs/native -intf-suffix .ml -no-alias-deps -o src/.mock.objs/native/mock.cmx -c -impl src/mock.ml)
# File "src/mock.ml", line 44, characters 4-6:
# 44 |     ->
#          ^^
# Error: Syntax error
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/.mock.objs/byte -intf-suffix .ml -no-alias-deps -o src/.mock.objs/byte/mock.cmo -c -impl src/mock.ml)
# File "src/mock.ml", line 44, characters 4-6:
# 44 |     ->
#          ^^
# Error: Syntax error
```
Reported upstream in https://github.com/cryptosense/ocaml-mock/issues/9