### PR TITLE
tophide is not compatible with OCaml 5.3 (uses compiler-libs)

### DIFF
--- a/packages/tophide/tophide.1.0.4/opam
+++ b/packages/tophide/tophide.1.0.4/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/mjambon/tophide/issues"
 build: make
 remove: [["ocamlfind" "remove" "tophide"]]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.3"}
   "ocamlfind"
 ]
 dev-repo: "git+https://github.com/mjambon/tophide"


### PR DESCRIPTION
```
#=== ERROR while compiling tophide.1.0.4 ======================================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/tophide.1.0.4
# command              /usr/bin/make
# exit-code            2
# env-file             ~/.opam/log/tophide-19-5a4c6d.env
# output-file          ~/.opam/log/tophide-19-5a4c6d.out
### output ###
# cat META.in > META
# echo 'version = "1.0.4"' >> META
# ocamlc -I +compiler-libs -c tophide.ml
# File "tophide.ml", line 29, characters 25-46:
# 29 |   print_out_class_type = !print_out_class_type;
#                               ^^^^^^^^^^^^^^^^^^^^^
# Error: This expression has type
#          "Outcometree.out_class_type Format_doc.printer" =
#            "Format_doc.formatter -> Outcometree.out_class_type -> unit"
#        but an expression was expected of type
#          "Format.formatter -> Outcometree.out_class_type -> unit"
#        Type "Format_doc.formatter" is not compatible with type "Format.formatter"
# make: *** [Makefile:11: tophide.cmo] Error 2
```
Upstream issue: https://github.com/mjambon/tophide/issues/4