### PR TITLE
MlFront_Cli is not compatible with compilers that have the effect keyword

### DIFF
--- a/packages/MlFront_Cli/MlFront_Cli.0.4.0~prerel7/opam
+++ b/packages/MlFront_Cli/MlFront_Cli.0.4.0~prerel7/opam
@@ -23,6 +23,9 @@ depends: [
   "tezt" {with-test & >= "4.1.0"}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "base-effects"
+]
 build: [
   [
     "sh"


### PR DESCRIPTION
```
#=== ERROR while compiling MlFront_Cli.0.4.0~prerel7 ==========================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/MlFront_Cli.0.4.0~prerel7
# command              /usr/bin/sh ci/build-test.sh -a unix_unknown
# exit-code            1
# env-file             ~/.opam/log/MlFront_Cli-20-f17b1f.env
# output-file          ~/.opam/log/MlFront_Cli-20-f17b1f.out
### output ###
# File "ast_converter.mlp", lines 406-468, characters 2-60:
# Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
# Here is an example of a case that is not matched:
# Ppat_effect (_, _)
# File "codept/bundled/bundle.ml", line 165, characters 4-10:
# 165 | let effect = chain "Effect" ["Deep"; "Shallow"]
#           ^^^^^^
# Error: Syntax error
# Generating MoonpoolSnips.ml
# Skipping generation of .mli
```
Upstream report: https://gitlab.com/dkml/build-tools/MlFront/-/issues/1