### PR TITLE
mlx is not compatible with OCaml 5.3 (uses compiler-libs)

### DIFF
--- a/packages/mlx/mlx.0.9/opam
+++ b/packages/mlx/mlx.0.9/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/ocaml-mlx/mlx"
 doc: "https://url/to/documentation"
 bug-reports: "https://github.com/ocaml-mlx/mlx/issues"
 depends: [
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "4.14.0" & < "5.3"}
   "ppxlib" {>= "0.32.1"}
   "dune" {>= "3.15"}
   "menhir" {= "20210419" & with-dev-setup}


### PR DESCRIPTION
```
#=== ERROR while compiling mlx.0.9 ============================================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/mlx.0.9
# command              ~/.opam/5.3/bin/dune build -p mlx -j 1 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/mlx-20-99adef.env
# output-file          ~/.opam/log/mlx-20-99adef.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlopt.opt -w -40 -w -9-67 -open Astlib.Ast_501 -g -I mlx/.pp.eobjs/byte -I mlx/.pp.eobjs/native -I /home/opam/.opam/5.3/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.3/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.3/lib/ocaml/compiler-libs -I /home/opam/.opam/5.3/lib/ppx_derivers -I /home/opam/.opam/5.3/lib/ppxlib -I /home/opam/.opam/5.3/lib/ppxlib/ast -I /home/opam/.opam/5.3/lib/ppxlib/astlib -I /home/opam/.opam/5.3/lib/ppxlib/print_diff -I /home/opam/.opam/5.3/lib/ppxlib/stdppx -I /home/opam/.opam/5.3/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.3/lib/sexplib0 -I /home/opam/.opam/5.3/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -open Dune__exe -o mlx/.pp.eobjs/native/dune__exe__Lexer.cmx -c -impl mlx/lexer.ml)
# File "mlx/lexer.mll", line 287, characters 34-37:
# Error: The value "ppf" has type "Format_doc.formatter"
#        but an expression was expected of type
#          "Format.formatter" = "Stdlib__Format.formatter"
```
Upstream report: https://github.com/ocaml-mlx/mlx/issues/8