### PR TITLE
mopsa is not compatible with compilers that have the effect keyword

### DIFF
--- a/packages/mopsa/mopsa.1.0/opam
+++ b/packages/mopsa/mopsa.1.0/opam
@@ -37,6 +37,9 @@ depends: [
   "odoc" {with-doc}
 ]
 depopts: ["elina"]
+conflicts: [
+  "base-effects"
+]
 available:
   !(arch = "x86_32") & !(os-family = "windows") & opam-version >= "2.1.0"
 build: [


### PR DESCRIPTION
```
#=== ERROR while compiling mopsa.1.0 ==========================================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/mopsa.1.0
# command              /usr/bin/make
# exit-code            2
# env-file             ~/.opam/log/mopsa-20-668c43.env
# output-file          ~/.opam/log/mopsa-20-668c43.out
### output ###
# opam exec -- dune build --profile release -p mopsa
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl analyzer/framework/core/effect.ml) > _build/default/analyzer/framework/core/.core.objs/core__Effect.impl.d
# File "analyzer/framework/core/effect.ml", line 30, characters 5-11:
# 30 | type effect =
#           ^^^^^^
# Error: Syntax error
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl analyzer/framework/sig/abstraction/domain.ml) > _build/default/analyzer/framework/sig/abstraction/.abstraction.objs/abstraction__Domain.impl.d
# File "analyzer/framework/sig/abstraction/domain.ml", line 74, characters 22-28:
# 74 |   val merge: t -> t * effect -> t * effect -> t
#                            ^^^^^^
# Error: Syntax error
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl analyzer/framework/sig/abstraction/simplified.ml) > _build/default/analyzer/framework/sig/abstraction/.abstraction.objs/abstraction__Simplified.impl.d
# File "analyzer/framework/sig/abstraction/simplified.ml", line 94, characters 23-29:
# 94 |   val merge : t -> t * effect -> t * effect -> t
#                             ^^^^^^
# Error: Syntax error
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl analyzer/framework/sig/abstraction/stacked.ml) > _build/default/analyzer/framework/sig/abstraction/.abstraction.objs/abstraction__Stacked.impl.d
# File "analyzer/framework/sig/abstraction/stacked.ml", line 72, characters 23-29:
# 72 |   val merge : t -> t * effect -> t * effect -> t
#                             ^^^^^^
# Error: Syntax error
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -intf analyzer/framework/core/effect.mli) > _build/default/analyzer/framework/core/.core.objs/core__Effect.intf.d
# File "analyzer/framework/core/effect.mli", line 36, characters 5-11:
# 36 | type effect =
#           ^^^^^^
# Error: Syntax error
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -intf analyzer/framework/sig/abstraction/domain.mli) > _build/default/analyzer/framework/sig/abstraction/.abstraction.objs/abstraction__Domain.intf.d
# File "analyzer/framework/sig/abstraction/domain.mli", line 84, characters 22-28:
# 84 |   val merge: t -> t * effect -> t * effect -> t
#                            ^^^^^^
# Error: Syntax error
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -intf analyzer/framework/sig/abstraction/simplified.mli) > _build/default/analyzer/framework/sig/abstraction/.abstraction.objs/abstraction__Simplified.intf.d
# File "analyzer/framework/sig/abstraction/simplified.mli", line 104, characters 23-29:
# 104 |   val merge : t -> t * effect -> t * effect -> t
#                              ^^^^^^
# Error: Syntax error
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -intf analyzer/framework/sig/abstraction/stacked.mli) > _build/default/analyzer/framework/sig/abstraction/.abstraction.objs/abstraction__Stacked.intf.d
# File "analyzer/framework/sig/abstraction/stacked.mli", line 81, characters 23-29:
# 81 |   val merge : t -> t * effect -> t * effect -> t
#                             ^^^^^^
# Error: Syntax error
# (cd _build/.sandbox/73b0aaf6ae883f22945ad9384e2bae62/default && /home/opam/.opam/5.3/bin/menhir parsers/universal/U_parser.mly --base parsers/universal/U_parser --infer-read-reply parsers/universal/U_parser__mock.mli.inferred)
# Warning: one state has shift/reduce conflicts.
# Warning: 14 shift/reduce conflicts were arbitrarily resolved.
# make: *** [Makefile:26: all] Error 1
```
Upstream report: https://gitlab.com/mopsa/mopsa-analyzer/-/issues/199