### PR TITLE
[new release] multicore-bench (0.1.6)

### DIFF
--- a/packages/multicore-bench/multicore-bench.0.1.6/opam
+++ b/packages/multicore-bench/multicore-bench.0.1.6/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Framework for writing multicore benchmark executables to run on current-bench"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-bench"
+bug-reports: "https://github.com/ocaml-multicore/multicore-bench/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "domain-local-await" {>= "1.0.1"}
+  "multicore-magic" {>= "2.1.0"}
+  "mtime" {>= "2.0.0"}
+  "yojson" {>= "2.1.0"}
+  "domain_shims" {>= "0.1.0"}
+  "backoff" {>= "0.1.0"}
+  "mdx" {>= "2.4.0" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
+  "ocaml" {>= "4.13.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-bench.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-bench/releases/download/0.1.6/multicore-bench-0.1.6.tbz"
+  checksum: [
+    "sha256=76f0aec5cf353440a929b85069548db21f80b7a42d24d833e06e376f5da4a5f9"
+    "sha512=93ff1d73c02c940b9febbfc055e84c186eb43040d2647a93256a0a8298ee833317de640d67dfc0971f97e3d04c70533ab7a8031d42e6e92802b15c78a89e50b1"
+  ]
+}
+x-commit-hash: "80066beff096be95b548c7b3b8f8d61bc5bede6a"


### PR DESCRIPTION
Framework for writing multicore benchmark executables to run on current-bench

- Project page: <a href="https://github.com/ocaml-multicore/multicore-bench">https://github.com/ocaml-multicore/multicore-bench</a>

##### CHANGES:

- Fail when benchmark results have duplicates (@polytypic)
