### PR TITLE
[new release] api-watch (0.1.1)

### DIFF
--- a/packages/api-watch/api-watch.0.1.1/opam
+++ b/packages/api-watch/api-watch.0.1.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Libraries and tools to keep watch on your OCaml lib's API changes"
+maintainer: ["Nathan Rebours <nathan.p.rebours@gmail.com>"]
+authors: ["Nathan Rebours <nathan.p.rebours@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/NathanReb/ocaml-api-watch"
+bug-reports: "https://github.com/NathanReb/ocaml-api-watch/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "5.2.0" & < "5.3.0"}
+  "ppx_expect" {with-test}
+  "ppx_deriving"
+  "logs"
+  "containers"
+  "fmt"
+  "cmdliner" {>= "1.1.0"}
+  "ocamlformat" {with-dev-setup & = "0.26.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/NathanReb/ocaml-api-watch.git"
+url {
+  src:
+    "https://github.com/NathanReb/ocaml-api-watch/releases/download/0.1.1/api-watch-0.1.1.tbz"
+  checksum: [
+    "sha256=71413c20a6871a240ff419bc64b5cfed884076ccdc62f8b7133cae3b2ed4b4f2"
+    "sha512=7ebb71ef07a99df86f6f38ecd8eaccce2d58bf192309c2c5dda17a7b35d6f5e6a5c3780ed969515f2ae19780d8db58d8c83db7f96ba97bb254e834714febddfc"
+  ]
+}
+x-commit-hash: "39b1cde698cd34873b578b76304ef90a5bc1b014"


### PR DESCRIPTION
Libraries and tools to keep watch on your OCaml lib's API changes

- Project page: <a href="https://github.com/NathanReb/ocaml-api-watch">https://github.com/NathanReb/ocaml-api-watch</a>

##### CHANGES:

### Fixed

- Remove dependency on unreleased `diffutils` package
  (NathanReb/ocaml-api-watch#88, NathanReb/ocaml-api-watch#95, @azzsal)
