### PR TITLE
[new release] cmdliner-stdlib (1.0.1)

### DIFF
--- a/packages/cmdliner-stdlib/cmdliner-stdlib.1.0.1/opam
+++ b/packages/cmdliner-stdlib/cmdliner-stdlib.1.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   ["thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire"  "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/cmdliner-stdlib"
+bug-reports:  "https://github.com/mirage/cmdliner-stdlib/issues/"
+dev-repo:     "git+https://github.com/mirage/cmdliner-stdlib.git"
+license:      "ISC"
+tags:         ["org:mirage"]
+doc:          "https://mirage.github.io/cmdliner-stdlib/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.9.0"}
+  "cmdliner" {>= "1.0.0"}
+]
+synopsis: "A collection of cmdliner terms to control OCaml runtime parameters"
+description: """
+Cmdliner-stdlib is a package that provides a collection of cmdliner terms
+to control the OCaml runtime parameters. This is typically done with environment
+variables, but there are situations where such an environment is not accessible,
+like in MirageOS. This package enables the configuration and manipulation of
+runtime parameters in these contexts, improving the flexibility of applications
+built on these platforms.
+"""
+url {
+  src:
+    "https://github.com/mirage/cmdliner-stdlib/releases/download/1.0.1/cmdliner-stdlib-1.0.1.tbz"
+  checksum: [
+    "sha256=19b5b963c21b6fe98d2f62e404e53611c3bcc7baf538efd01f598ef928257aae"
+    "sha512=bfb47467967e662e22163de0714642eb3a4cec05c85e0d76b0a5eebe75e2d3b1a3273432b58e1e4ab078026597182dd9d517832405bf00ef02d7751d0b3c9ece"
+  ]
+}
+x-commit-hash: "4b815099967f3a5184a08ff7d6ea511fd83e8c57"


### PR DESCRIPTION
A collection of cmdliner terms to control OCaml runtime parameters

- Project page: <a href="https://github.com/mirage/cmdliner-stdlib">https://github.com/mirage/cmdliner-stdlib</a>
- Documentation: <a href="https://mirage.github.io/cmdliner-stdlib/">https://mirage.github.io/cmdliner-stdlib/</a>

##### CHANGES:

- use "OCAML RUNTIME OPTIONS" as section header (not "OCAML RUNTIME PARAMETERS")
  mirage/cmdliner-stdlib#2 @hannesm
