### PR TITLE
Package ppx_expect.v0.17.2

### DIFF
--- a/packages/ppx_expect/ppx_expect.v0.17.2/opam
+++ b/packages/ppx_expect/ppx_expect.v0.17.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_expect"
+bug-reports: "https://github.com/janestreet/ppx_expect/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_expect.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_expect/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"           {>= "5.1.0"}
+  "base"            {>= "v0.17" & < "v0.18"}
+  "ppx_here"        {>= "v0.17" & < "v0.18"}
+  "ppx_inline_test" {>= "v0.17" & < "v0.18"}
+  "stdio"           {>= "v0.17" & < "v0.18"}
+  "dune"            {>= "3.11.0"}
+  "ppxlib"          {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+conflicts: [
+  "js_of_ocaml-compiler" {< "5.8"}
+]
+
+synopsis: "Cram like framework for OCaml"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_expect/archive/refs/tags/v0.17.2.tar.gz"
+  checksum: [
+    "md5=fcd20075f62461578e4526d0990e7405"
+    "sha512=27da65f8bceae552dedb997384d4c7de34a9700826245f507a625777aa4b392fcde00b0d7f1cd14506b6f474482f7a0d5b9465169399ecfdd5ff6237407237ee"
+  ]
+}


### PR DESCRIPTION
### `ppx_expect.v0.17.2`
Cram like framework for OCaml
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_expect
* Source repo: git+https://github.com/janestreet/ppx_expect.git
* Bug tracker: https://github.com/janestreet/ppx_expect/issues

---
:camel: Pull-request generated by opam-publish v2.3.0