### PR TITLE
Package ppx_expect.v0.17.2

### DIFF
--- a/packages/ppx_expect/ppx_expect.v0.17.2/opam
+++ b/packages/ppx_expect/ppx_expect.v0.17.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_expect"
+bug-reports: "https://github.com/janestreet/ppx_expect/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_expect.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_expect/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"           {>= "5.1.0"}
+  "base"            {>= "v0.17" & < "v0.18"}
+  "ppx_here"        {>= "v0.17" & < "v0.18"}
+  "ppx_inline_test" {>= "v0.17" & < "v0.18"}
+  "stdio"           {>= "v0.17" & < "v0.18"}
+  "dune"            {>= "3.11.0"}
+  "ppxlib"          {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+conflicts: [
+  "js_of_ocaml-compiler" {< "5.8"}
+]
+
+synopsis: "Cram like framework for OCaml"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_expect/archive/refs/tags/v0.17.2.tar.gz"
+  checksum: [
+    "md5=055c8c86665d158e0b03494a3e188f1c"
+    "sha512=c6394522da7f1e03df5d2f62766aa8534c09a12efff7908cc1215b06959e6eeaa2cb85514cd5def1582db66455ed922024387f28b84b4412aed4879ea905c38a"
+  ]
+}


### PR DESCRIPTION
### `ppx_expect.v0.17.2`
Cram like framework for OCaml
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_expect
* Source repo: git+https://github.com/janestreet/ppx_expect.git
* Bug tracker: https://github.com/janestreet/ppx_expect/issues

---
:camel: Pull-request generated by opam-publish v2.3.0