### PR TITLE
[new release] mirage (2 packages) (4.8.1)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.4.8.1/opam
+++ b/packages/mirage-runtime/mirage-runtime.4.8.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+available: opam-version >= "2.1.0"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.9.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "4.0.0"}
+  "ipaddr" {>= "5.5.0"}
+  "cmdliner" {>= "1.2.0"}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "ppxlib" {= "0.29.0"} #0.29.0 provides a vendored ppx_sexp_conv
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.8.1/mirage-4.8.1.tbz"
+  checksum: [
+    "sha256=c024c04ab11c5ad6a25d7a00d44734a3c18ffe5012cc999412d853ff70c89476"
+    "sha512=8b2546975f7f23dcd39796a04818d1978bae593e3179c3d00afd25ec8f3d39525b6bea91ab62987795ced217a602f49abe26742fcfd044914f0a158bbbb8f676"
+  ]
+}
+x-commit-hash: "070af6b65e50948e82d64e4998a8639a57f1178c"

--- a/packages/mirage/mirage.4.8.1/opam
+++ b/packages/mirage/mirage.4.8.1/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+available: opam-version >= "2.1.0"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.9.0"}
+  "astring"
+  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {with-test & >= "1.3.0"}
+  "emile" {>= "1.1"}
+  "fmt" {>= "0.8.7"}
+  "ipaddr" {>= "5.0.0"}
+  "bos"
+  "fpath"
+  "rresult" {>= "0.7.0"}
+  "uri" {>= "4.2.0"}
+  "logs" {>= "0.7.0"}
+  "opam-monorepo" {>= "0.4.0"}
+  "alcotest" {with-test}
+  "mirage-runtime" {with-test & = version}
+]
+
+conflicts: [ "jbuilder" {with-test} ]
+
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.8.1/mirage-4.8.1.tbz"
+  checksum: [
+    "sha256=c024c04ab11c5ad6a25d7a00d44734a3c18ffe5012cc999412d853ff70c89476"
+    "sha512=8b2546975f7f23dcd39796a04818d1978bae593e3179c3d00afd25ec8f3d39525b6bea91ab62987795ced217a602f49abe26742fcfd044914f0a158bbbb8f676"
+  ]
+}
+x-commit-hash: "070af6b65e50948e82d64e4998a8639a57f1178c"

--- a/packages/mirage/mirage.4.8.1/opam
+++ b/packages/mirage/mirage.4.8.1/opam
@@ -19,6 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.13.0"}
+  "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
   "cmdliner" {>= "1.2.0"}


### PR DESCRIPTION
The MirageOS library operating system

- Project page: <a href="https://github.com/mirage/mirage">https://github.com/mirage/mirage</a>
- Documentation: <a href="https://mirage.github.io/mirage/">https://mirage.github.io/mirage/</a>

##### CHANGES:

* Mirage_runtime: add a top-level call to Printexc.record_backtrace
  The runtime argument --backtrace=true/false turns backtraces on and off in
  the running unikernel - but for the time where runtime arguments are not yet
  evaluated, we enable backtraces by default. The reason is that e.g.
  `Mirage_runtime.register_arg <my-cmdliner-term> ()` leads to an exception,
  and without backtrace this is not easy to spot where work needs to be done
  (mirage/mirage#1584 @reynir)
* Document Mirage_runtime.register_arg, add parens around its return value
  (unit -> 'a) (mirage/mirage#1580 mirage/mirage#1585 @hannesm)
* Use OCaml runtime arguments from cmdliner-stdlib opam package
  (mirage/mirage#1580 by @hannesm)
* Allow solo5 0.9 (mirage/mirage#1583 by @hannesm)
* Mirage_runtime.logs: explain the log levels (mirage/mirage#1581 by @reynir)
* Mirage.register: document ?src argument (mirage/mirage#1578 by @reynir)
