### PR TITLE
[new release] colombe, sendmail, sendmail-lwt, sendmail-mirage and sendmail-miou-unix (0.10.0)

### DIFF
--- a/packages/colombe/colombe.0.10.0/opam
+++ b/packages/colombe/colombe.0.10.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+synopsis:     "SMTP protocol in OCaml"
+doc:          "https://mirage.github.io/colombe/"
+description: """SMTP protocol according RFC5321 without extension."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "3.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "ocaml-syntax-shims"
+  "alcotest" {with-test}
+  "crowbar" {>= "0.2" & with-test}
+]
+depopts: [ "emile" ]
+conflicts: [ "emile" {< "0.8"} ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.10.0/colombe-0.10.0.tbz"
+  checksum: [
+    "sha256=065ecfe82e867f4f8b267c5fcb7e9dd8fef424601b10bc731f5f2012fde81bda"
+    "sha512=7ed60b73420ab7a3950f9d0fe7b5d05d18eff48080cce1869adfd601c71a06ee01f818a0010e2c38b30d45305c99765339917123ff300ca0de375263c2ef544a"
+  ]
+}
+x-commit-hash: "8e6c1d430b60f2a2f7fe9c4d5c121ab11dba5ec7"

--- a/packages/sendmail-lwt/sendmail-lwt.0.10.0/opam
+++ b/packages/sendmail-lwt/sendmail-lwt.0.10.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT and TLS."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "sendmail" {= version}
+  "domain-name"
+  "ipaddr"
+  "ca-certs"
+  "lwt"
+  "tls" {>= "0.13.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "x509" {>= "0.12.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.10.0/colombe-0.10.0.tbz"
+  checksum: [
+    "sha256=065ecfe82e867f4f8b267c5fcb7e9dd8fef424601b10bc731f5f2012fde81bda"
+    "sha512=7ed60b73420ab7a3950f9d0fe7b5d05d18eff48080cce1869adfd601c71a06ee01f818a0010e2c38b30d45305c99765339917123ff300ca0de375263c2ef544a"
+  ]
+}
+x-commit-hash: "8e6c1d430b60f2a2f7fe9c4d5c121ab11dba5ec7"

--- a/packages/sendmail-miou-unix/sendmail-miou-unix.0.10.0/opam
+++ b/packages/sendmail-miou-unix/sendmail-miou-unix.0.10.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT and TLS."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "2.0"}
+  "sendmail" {= version}
+  "domain-name"
+  "happy-eyeballs-miou-unix"
+  "tls-miou-unix" {>= "1.0.3"}
+  "x509"
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.10.0/colombe-0.10.0.tbz"
+  checksum: [
+    "sha256=065ecfe82e867f4f8b267c5fcb7e9dd8fef424601b10bc731f5f2012fde81bda"
+    "sha512=7ed60b73420ab7a3950f9d0fe7b5d05d18eff48080cce1869adfd601c71a06ee01f818a0010e2c38b30d45305c99765339917123ff300ca0de375263c2ef544a"
+  ]
+}
+x-commit-hash: "8e6c1d430b60f2a2f7fe9c4d5c121ab11dba5ec7"

--- a/packages/sendmail-miou-unix/sendmail-miou-unix.0.10.0/opam
+++ b/packages/sendmail-miou-unix/sendmail-miou-unix.0.10.0/opam
@@ -20,6 +20,7 @@ depends: [
   "sendmail" {= version}
   "domain-name"
   "happy-eyeballs-miou-unix"
+  "ca-certs"
   "tls-miou-unix" {>= "1.0.3"}
   "x509"
   "alcotest" {with-test}

--- a/packages/sendmail-mirage/sendmail-mirage.0.10.0/opam
+++ b/packages/sendmail-mirage/sendmail-mirage.0.10.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT and TLS."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "sendmail" {= version}
+  "domain-name"
+  "happy-eyeballs-mirage"
+  "mirage-flow"
+  "ca-certs-nss"
+  "lwt"
+  "tls" {>= "0.13.0"}
+  "tls-mirage" {>= "0.16.0"}
+  "x509" {>= "0.12.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.10.0/colombe-0.10.0.tbz"
+  checksum: [
+    "sha256=065ecfe82e867f4f8b267c5fcb7e9dd8fef424601b10bc731f5f2012fde81bda"
+    "sha512=7ed60b73420ab7a3950f9d0fe7b5d05d18eff48080cce1869adfd601c71a06ee01f818a0010e2c38b30d45305c99765339917123ff300ca0de375263c2ef544a"
+  ]
+}
+x-commit-hash: "8e6c1d430b60f2a2f7fe9c4d5c121ab11dba5ec7"

--- a/packages/sendmail/sendmail.0.10.0/opam
+++ b/packages/sendmail/sendmail.0.10.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command"
+description: """A library to be able to send an email."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "colombe" {= version}
+  "tls" {>= "1.0.2"}
+  "base64" {>= "3.0.0"}
+  "ke" {>= "0.4"}
+  "logs"
+  "rresult"
+  "bigstringaf" {>= "0.2.0"}
+  "emile" {>= "0.8" & with-test}
+  "mrmime" {>= "0.3.2" & with-test}
+  "cstruct" {>= "6.0.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.10.0/colombe-0.10.0.tbz"
+  checksum: [
+    "sha256=065ecfe82e867f4f8b267c5fcb7e9dd8fef424601b10bc731f5f2012fde81bda"
+    "sha512=7ed60b73420ab7a3950f9d0fe7b5d05d18eff48080cce1869adfd601c71a06ee01f818a0010e2c38b30d45305c99765339917123ff300ca0de375263c2ef544a"
+  ]
+}
+x-commit-hash: "8e6c1d430b60f2a2f7fe9c4d5c121ab11dba5ec7"


### PR DESCRIPTION
SMTP protocol in OCaml

- Project page: <a href="https://github.com/mirage/colombe">https://github.com/mirage/colombe</a>
- Documentation: <a href="https://mirage.github.io/colombe/">https://mirage.github.io/colombe/</a>

##### CHANGES:

- Be able to compose errors from sendmail packages (@dinosaure, mirage/colombe#76)
- Add the new package `sendmail-mirage` (@dinosaure, mirage/colombe#77)
- **breaking-change** Improve the `sendmail` library.

  The sendmail library is able to send an email with or without STARTTLS. If
  the user gives an authentication method (with a password), we require STARTTLS
  in anyway. Otherwise, we return the `Encryption_required` error. By this way,
  the `sendmail` package does not leak such information.

  We also separate two kind of use about `sendmail`:
  - the submission of an email to an authority
  - how send an email to its destination

  The second is the most basic (and probably what you want). The first is useful
  when you want to pass through an authority (such as gmail.com or your own
  mail exchange server) to send an email to a destination.
