### PR TITLE
[new release] rust-staticlib-gen (3 packages) (0.2.0)

### DIFF
--- a/packages/dune-cargo-build/dune-cargo-build.0.2.0/opam
+++ b/packages/dune-cargo-build/dune-cargo-build.0.2.0/opam
@@ -9,6 +9,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/Lupus/rust-staticlib-gen"
 bug-reports: "https://github.com/Lupus/rust-staticlib-gen/issues"
 depends: [
+  "ocaml" {>= "4.13"}
   "dune" {>= "2.7"}
   "yojson" {>= "2.2.2"}
   "ocamlformat" {with-test & >= "0.26.2" & < "0.27.0"}

--- a/packages/dune-cargo-build/dune-cargo-build.0.2.0/opam
+++ b/packages/dune-cargo-build/dune-cargo-build.0.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "Tool to invoke Cargo for building Rust crates within the dune sandbox"
+description:
+  "dune-cargo-build is a tool that runs cargo build in offline mode for a specified crate, ensuring compatibility with dune's/opam's sandboxing. It parses Cargo's JSON output to determine the produced artifacts and copies them to the current directory, renaming them to match what OCaml expects for foreign stubs. This tool is useful for integrating Rust build processes into OCaml projects managed by dune."
+maintainer: ["Konstantin Olkhovskiy <lupus@oxnull.net>"]
+authors: ["Konstantin Olkhovskiy <lupus@oxnull.net>"]
+license: "Apache-2.0"
+homepage: "https://github.com/Lupus/rust-staticlib-gen"
+bug-reports: "https://github.com/Lupus/rust-staticlib-gen/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "yojson" {>= "2.2.2"}
+  "ocamlformat" {with-test & >= "0.26.2" & < "0.27.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Lupus/rust-staticlib-gen.git"
+url {
+  src:
+    "https://github.com/Lupus/rust-staticlib-gen/releases/download/0.2.0/rust-staticlib-gen-0.2.0.tbz"
+  checksum: [
+    "sha256=02d3bb345f83237df6bf68ffd32a277b4afc82cb90eedffb377b16e6ad42ab39"
+    "sha512=9c7df3da32085bfb7751e727148df8b81985d601ff1ede10e6685be3625d96e377e1fa1a5214361f6e857f2c1ffa45222d84bd603f1b90f4a7f593aea46a4101"
+  ]
+}
+x-commit-hash: "278416ae65ba47bbbaeedd507c7bee7ba679ad1d"

--- a/packages/rust-staticlib-gen/rust-staticlib-gen.0.2.0/opam
+++ b/packages/rust-staticlib-gen/rust-staticlib-gen.0.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Utility for generating Rust static libraries for OCaml projects"
+description:
+  "rust-staticlib-gen is a tool designed to streamline the integration of Rust code into OCaml projects. It automates the generation of build files and orchestrates the build process, allowing OCaml code to seamlessly interface with Rust libraries. This tool extracts Rust crate dependencies from opam files, generates necessary dune and Cargo.toml files, and builds the Rust static libraries. It ensures compatibility between OCaml bindings and Rust crates by specifying exact versions in Cargo.toml."
+maintainer: ["Konstantin Olkhovskiy <lupus@oxnull.net>"]
+authors: ["Konstantin Olkhovskiy <lupus@oxnull.net>"]
+license: "Apache-2.0"
+homepage: "https://github.com/Lupus/rust-staticlib-gen"
+bug-reports: "https://github.com/Lupus/rust-staticlib-gen/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "toml" {>= "7.1.0"}
+  "yojson" {>= "2.2.2"}
+  "sexplib0" {>= "v0.16.0"}
+  "parsexp" {>= "v0.16.0"}
+  "opam-client" {>= "2.2.1" & < "2.3"}
+  "opam-state" {>= "2.2.1" & < "2.3"}
+  "opam-solver" {>= "2.2.1" & < "2.3"}
+  "fpath" {>= "0.7.3"}
+  "cmdliner" {>= "1.3.0"}
+  "ocamlformat" {with-test & >= "0.26.2" & < "0.27.0"}
+  "rust-staticlib-virtual" {= version}
+  "dune-cargo-build" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Lupus/rust-staticlib-gen.git"
+url {
+  src:
+    "https://github.com/Lupus/rust-staticlib-gen/releases/download/0.2.0/rust-staticlib-gen-0.2.0.tbz"
+  checksum: [
+    "sha256=02d3bb345f83237df6bf68ffd32a277b4afc82cb90eedffb377b16e6ad42ab39"
+    "sha512=9c7df3da32085bfb7751e727148df8b81985d601ff1ede10e6685be3625d96e377e1fa1a5214361f6e857f2c1ffa45222d84bd603f1b90f4a7f593aea46a4101"
+  ]
+}
+x-commit-hash: "278416ae65ba47bbbaeedd507c7bee7ba679ad1d"

--- a/packages/rust-staticlib-virtual/rust-staticlib-virtual.0.2.0/opam
+++ b/packages/rust-staticlib-virtual/rust-staticlib-virtual.0.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "A Sentinel/marker package to define the rust staticlib virtual library"
+description:
+  "The rust-staticlib-virtual package is a sentinel/marker package that defines a virtual dune library that indicates presence of Rust dependencies somewhere down the dependency chain. To have an implementation of this virtual library in your project, please use `rust-staticlib-gen` tool: https://github.com/Lupus/rust-staticlib-gen"
+maintainer: ["Konstantin Olkhovskiy <lupus@oxnull.net>"]
+authors: ["Konstantin Olkhovskiy <lupus@oxnull.net>"]
+license: "Apache-2.0"
+homepage: "https://github.com/Lupus/rust-staticlib-gen"
+bug-reports: "https://github.com/Lupus/rust-staticlib-gen/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Lupus/rust-staticlib-gen.git"
+url {
+  src:
+    "https://github.com/Lupus/rust-staticlib-gen/releases/download/0.2.0/rust-staticlib-gen-0.2.0.tbz"
+  checksum: [
+    "sha256=02d3bb345f83237df6bf68ffd32a277b4afc82cb90eedffb377b16e6ad42ab39"
+    "sha512=9c7df3da32085bfb7751e727148df8b81985d601ff1ede10e6685be3625d96e377e1fa1a5214361f6e857f2c1ffa45222d84bd603f1b90f4a7f593aea46a4101"
+  ]
+}
+x-commit-hash: "278416ae65ba47bbbaeedd507c7bee7ba679ad1d"


### PR DESCRIPTION
Utility for generating Rust static libraries for OCaml projects

- Project page: <a href="https://github.com/Lupus/rust-staticlib-gen">https://github.com/Lupus/rust-staticlib-gen</a>

##### CHANGES:

### Added

- **rust-staticlib-gen**
  - Ensure we generate code for compatible versions of libs/tools

- **dune-cargo-build**
  - Emit debug output and exit with error when no artifacts are copied
  - Add -help option and detailed usage
  - Pass --offline to cargo only if network is unavailable (checks crates.io:443)
  - Add support for manifest path along with crate name to specify what to build
  - Add support for passing arbitrary flags to cargo after "--"
  - Add --profile flag to select release/debug build for cargo (compatible with dune profile naming)

### Fixed

- **rust-staticlib-gen**
  - Fix opam lib initialization (was not working in CI)
