### PR TITLE
[new release] datalog (0.7)

### DIFF
--- a/packages/datalog/datalog.0.7/opam
+++ b/packages/datalog/datalog.0.7/opam
@@ -13,7 +13,7 @@ depends: [
   "mdx" {>= "1.3" & with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/datalog/datalog.0.7/opam
+++ b/packages/datalog/datalog.0.7/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "An in-memory datalog implementation for OCaml"
+maintainer: ["simon.cruanes.2007@m4x.org"]
+authors: ["Simon Cruanes"]
+license: "BSD-2-Clause"
+tags: ["datalog" "relational" "query" "prolog"]
+homepage: "https://github.com/c-cube/datalog"
+bug-reports: "https://github.com/c-cube/datalog/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+  "mdx" {>= "1.3" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/datalog.git"
+url {
+  src:
+    "https://github.com/c-cube/datalog/releases/download/v0.7/datalog-0.7.tbz"
+  checksum: [
+    "sha256=13ca520bddf4f0c44d1468bc89347be72ec543be58fff29469a0da24956be541"
+    "sha512=25d6e9cb5abe8aa1110730d884abb9e51ae78bf681b3f21709efa32359b9cbdd97d9076761c91562580c090cbce12ce159c97533ae5d9d427c24cb329e950793"
+  ]
+}
+x-commit-hash: "048096974f9535d2966aee121b1227100b76d808"


### PR DESCRIPTION
An in-memory datalog implementation for OCaml

- Project page: <a href="https://github.com/c-cube/datalog">https://github.com/c-cube/datalog</a>
- Documentation: <a href="https://c-cube.github.io/datalog">https://c-cube.github.io/datalog</a>

##### CHANGES:

- compat with OCaml 5.2
- fix location reporting in parse errors
