### PR TITLE
[new release] opam-0install (0.5)

### DIFF
--- a/packages/opam-0install/opam-0install.0.5/opam
+++ b/packages/opam-0install/opam-0install.0.5/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Opam solver using 0install backend"
+description: """
+Opam's default solver is designed to maintain a set of packages
+over time, minimising disruption when installing new programs and
+finding a compromise solution across all packages.
+
+In many situations (e.g. CI, local roots or duniverse builds) this
+is not necessary, and we can get a solution much faster by using
+a different algorithm.
+
+This package uses 0install's solver algorithm with opam packages.
+"""
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "ISC"
+homepage: "https://github.com/ocaml-opam/opam-0install-solver"
+doc: "https://ocaml-opam.github.io/opam-0install-solver/"
+bug-reports: "https://github.com/ocaml-opam/opam-0install-solver/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "fmt" {>= "0.8.7"}
+  "cmdliner" {>= "1.1.0"}
+  "opam-state" {>= "2.2.1"}
+  "opam-format" {>= "2.2.1"}
+  "ocaml" {>= "4.10.0"}
+  "0install-solver"
+  "opam-file-format" {>= "2.1.1"}
+  "opam-client" {with-test & >= "2.2.1"}
+  "opam-solver" {with-test}
+  "astring" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-opam/opam-0install-solver.git"
+url {
+  src:
+    "https://github.com/ocaml-opam/opam-0install-solver/releases/download/v0.5/opam-0install-0.5.tbz"
+  checksum: [
+    "sha256=983177a9b34eaaab1efd07ef2b0f33347cdee624fa011def95a2497a61735962"
+    "sha512=78ca0d09181472d899f7c7a07cd79bf1bce15bfc2b36824f4ca99300cd318a1970b9702ccfb6cacd920684aaabc0c3fa3b11b810bd19d17a68aa38800c1e8906"
+  ]
+}
+x-commit-hash: "f4e5478242f9d70340b8d6e74a75ed035d4d544a"


### PR DESCRIPTION
Opam solver using 0install backend

- Project page: <a href="https://github.com/ocaml-opam/opam-0install-solver">https://github.com/ocaml-opam/opam-0install-solver</a>
- Documentation: <a href="https://ocaml-opam.github.io/opam-0install-solver/">https://ocaml-opam.github.io/opam-0install-solver/</a>

##### CHANGES:

- Update to opam 2.2.1 (@talex5 ocaml-opam/opam-0install-solver#59).
  The opam API changed and it had started failing with `Invalid_argument("filter_deps")`.

- When warning about "Unknown variable", say which package has the error (@talex5 ocaml-opam/opam-0install-solver#57).
