### PR TITLE
[new release] fpath-base (2 packages) (0.2.2)

### DIFF
--- a/packages/fpath-base/fpath-base.0.2.2/opam
+++ b/packages/fpath-base/fpath-base.0.2.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Adds a few functions to Fpath to use alongside Base"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/fpath-base"
+doc: "https://mbarbin.github.io/fpath-base/"
+bug-reports: "https://github.com/mbarbin/fpath-base/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.2"}
+  "base" {>= "v0.17" & < "v0.18"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/fpath-base.git"
+url {
+  src:
+    "https://github.com/mbarbin/fpath-base/releases/download/0.2.2/fpath-base-0.2.2.tbz"
+  checksum: [
+    "sha256=7f8449d02a658a44ef268f075f44fd9be006625a8a6ea88176b6326adae85cdd"
+    "sha512=a130ac15ed957d373bd7d958c39daf9134d9b16aa75ad793c3cf6596a6bc12cbe3054e8259cf3a17eadf67e368a617e316fea83ad650b527565b98f17cc8156c"
+  ]
+}
+x-commit-hash: "8975fa50024dafa2baaa71db6b7cdd291e23f7c9"

--- a/packages/fpath-sexp0/fpath-sexp0.0.2.2/opam
+++ b/packages/fpath-sexp0/fpath-sexp0.0.2.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "Adds Fpath.sexp_of_t and defines 3 new modules: Fsegment, Absolute_path and Relative_path"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/fpath-base"
+doc: "https://mbarbin.github.io/fpath-base/"
+bug-reports: "https://github.com/mbarbin/fpath-base/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.2"}
+  "fpath" {>= "0.7.3"}
+  "sexplib0" {>= "v0.17" & < "v0.18"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/fpath-base.git"
+url {
+  src:
+    "https://github.com/mbarbin/fpath-base/releases/download/0.2.2/fpath-base-0.2.2.tbz"
+  checksum: [
+    "sha256=7f8449d02a658a44ef268f075f44fd9be006625a8a6ea88176b6326adae85cdd"
+    "sha512=a130ac15ed957d373bd7d958c39daf9134d9b16aa75ad793c3cf6596a6bc12cbe3054e8259cf3a17eadf67e368a617e316fea83ad650b527565b98f17cc8156c"
+  ]
+}
+x-commit-hash: "8975fa50024dafa2baaa71db6b7cdd291e23f7c9"


### PR DESCRIPTION
### Added

- Added `rem_empty_seg` to `Absolute_path` and `Relative_path`.
- In `fpath-sexp0` export hash keys interfaces compatible with stdlib hash functors.

### Changed

- Rename `Fpart` to `Fsegment` to fit `Fpath` terminology (keep previous alias as backward compatibility for now).

### Fixed

- Fix occurrence of hard coded dir separator.