### PR TITLE
[new release] multicore-bench (0.1.7)

### DIFF
--- a/packages/multicore-bench/multicore-bench.0.1.7/opam
+++ b/packages/multicore-bench/multicore-bench.0.1.7/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Framework for writing multicore benchmark executables to run on current-bench"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-bench"
+bug-reports: "https://github.com/ocaml-multicore/multicore-bench/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "domain-local-await" {>= "1.0.1"}
+  "multicore-magic" {>= "2.1.0"}
+  "mtime" {>= "2.0.0"}
+  "yojson" {>= "2.1.0"}
+  "domain_shims" {>= "0.1.0"}
+  "backoff" {>= "0.1.0"}
+  "mdx" {>= "2.4.0" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
+  "ocaml" {>= "4.12.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-bench.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-bench/releases/download/0.1.7/multicore-bench-0.1.7.tbz"
+  checksum: [
+    "sha256=beba7dca2b93c218a38588de0ca3c5446ca1ff92dec9d296252c8c2d94515c83"
+    "sha512=ad5081a860cc36859bf1bd81bdf04459f03d5c78969e500f7fbe73298acdced79b830c6fa4868e526f2c69d132c5121497867756592e419e81c9123448fc44cc"
+  ]
+}
+x-commit-hash: "223ae03bcaed968a492e7c0bf18501673831481a"


### PR DESCRIPTION
Framework for writing multicore benchmark executables to run on current-bench

- Project page: <a href="https://github.com/ocaml-multicore/multicore-bench">https://github.com/ocaml-multicore/multicore-bench</a>

##### CHANGES:

- Ported to OCaml 4.12 (@polytypic)
- Added scalable `Countdown` counter (@polytypic)
