### PR TITLE
Sync availability constraints for `checked_oint`

### DIFF
--- a/packages/checked_oint/checked_oint.0.1.0/opam
+++ b/packages/checked_oint/checked_oint.0.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ppx_deriving"
   "ppx_enumerate"
   "bisect_ppx"
-  "alcotest"
+  "alcotest" {>= "1.7.0"}
   "odoc" {with-doc}
 ]
 available: arch != "arm32" & arch != "x86_32" & arch != "ppc64" & os != "win32" & os != "freebsd" & os-distribution != "fedora" & os-distribution != "ol" & os-family != "opensuse" & os-family != "suse"

--- a/packages/checked_oint/checked_oint.0.1.0/opam
+++ b/packages/checked_oint/checked_oint.0.1.0/opam
@@ -4,8 +4,8 @@ synopsis: "An OCaml library for checked integer arithmetic"
 maintainer: ["Tima Kinsart <hirrolot@gmail.com>"]
 authors: ["Tima Kinsart <hirrolot@gmail.com>"]
 license: "MIT"
-homepage: "https://github.com/Hirrolot/checked_oint"
-bug-reports: "https://github.com/Hirrolot/checked_oint/issues"
+homepage: "https://github.com/hirrolot/checked_oint"
+bug-reports: "https://github.com/hirrolot/checked_oint/issues"
 depends: [
   "ocaml" {>= "4.13"}
   "dune" {>= "3.14"}
@@ -32,10 +32,10 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/Hirrolot/checked_oint.git"
+dev-repo: "git+https://github.com/hirrolot/checked_oint.git"
 url {
   src:
-    "https://github.com/Hirrolot/checked_oint/archive/refs/tags/v0.1.0.tar.gz"
+    "https://github.com/hirrolot/checked_oint/archive/refs/tags/v0.1.0.tar.gz"
   checksum: [
     "md5=015b6838aefc5191eda3cc069722fcfd"
     "sha512=856404be0b5272e9df6530aa771f80676431142a5758951cb58068088d34b30e9848271611a9fff7b3d6e7ca979db4ac342e8f3eb5d83f4df0b71eaac3726a2a"

--- a/packages/checked_oint/checked_oint.0.1.0/opam
+++ b/packages/checked_oint/checked_oint.0.1.0/opam
@@ -17,17 +17,7 @@ depends: [
   "alcotest"
   "odoc" {with-doc}
 ]
-available: arch != "arm32" & arch != "x86_32" & arch != "ppc64"
-x-ci-accept-failures: [
-  "fedora-38"
-  "fedora-39"
-  "fedora-40"
-  "opensuse-15.5"
-  "opensuse-tumbleweed"
-  "oraclelinux-8"
-  "oraclelinux-9"
-  "freebsd"
-]
+available: arch != "arm32" & arch != "x86_32" & arch != "ppc64" & os != "win32" & os != "freebsd" & os-distribution != "fedora" & os-distribution != "ol" & os-family != "opensuse" & os-family != "suse"
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/checked_oint/checked_oint.0.1.1/opam
+++ b/packages/checked_oint/checked_oint.0.1.1/opam
@@ -4,8 +4,8 @@ synopsis: "An OCaml library for checked integer arithmetic"
 maintainer: ["Tima Kinsart <hirrolot@gmail.com>"]
 authors: ["Tima Kinsart <hirrolot@gmail.com>"]
 license: "MIT"
-homepage: "https://github.com/Hirrolot/checked_oint"
-bug-reports: "https://github.com/Hirrolot/checked_oint/issues"
+homepage: "https://github.com/hirrolot/checked_oint"
+bug-reports: "https://github.com/hirrolot/checked_oint/issues"
 depends: [
   "ocaml" {>= "4.13"}
   "dune" {>= "3.14"}
@@ -32,10 +32,10 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/Hirrolot/checked_oint.git"
+dev-repo: "git+https://github.com/hirrolot/checked_oint.git"
 url {
   src:
-    "https://github.com/Hirrolot/checked_oint/archive/refs/tags/v0.1.1.tar.gz"
+    "https://github.com/hirrolot/checked_oint/archive/refs/tags/v0.1.1.tar.gz"
   checksum: [
     "md5=8c5bd9e10faffd495037c4ecd0f8e6ea"
     "sha512=e0179cbb8ea6d3f1a5ed87e190c88cd5a95a5cca817ef786b945e0fd8ffaaea46d34b64ea673b6c184fae27860f9a44ad0b66dc974fbfc9558de9025eb84d6f2"

--- a/packages/checked_oint/checked_oint.0.1.1/opam
+++ b/packages/checked_oint/checked_oint.0.1.1/opam
@@ -17,17 +17,7 @@ depends: [
   "alcotest" {>= "1.7.0"}
   "odoc" {with-doc}
 ]
-available: arch != "arm32" & arch != "x86_32" & arch != "ppc64"
-x-ci-accept-failures: [
-  "fedora-38"
-  "fedora-39"
-  "fedora-40"
-  "opensuse-15.5"
-  "opensuse-tumbleweed"
-  "oraclelinux-8"
-  "oraclelinux-9"
-  "freebsd"
-]
+available: arch != "arm32" & arch != "x86_32" & arch != "ppc64" & os != "win32" & os != "freebsd" & os-distribution != "fedora" & os-distribution != "ol" & os-family != "opensuse" & os-family != "suse"
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/checked_oint/checked_oint.0.1.2/opam
+++ b/packages/checked_oint/checked_oint.0.1.2/opam
@@ -17,17 +17,7 @@ depends: [
   "alcotest" {>= "1.7.0"}
   "odoc" {with-doc}
 ]
-available: arch != "arm32" & arch != "x86_32" & arch != "ppc64"
-x-ci-accept-failures: [
-  "fedora-38"
-  "fedora-39"
-  "fedora-40"
-  "opensuse-15.5"
-  "opensuse-tumbleweed"
-  "oraclelinux-8"
-  "oraclelinux-9"
-  "freebsd"
-]
+available: arch != "arm32" & arch != "x86_32" & arch != "ppc64" & os != "win32" & os != "freebsd" & os-distribution != "fedora" & os-distribution != "ol" & os-family != "opensuse" & os-family != "suse"
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/checked_oint/checked_oint.0.1.2/opam
+++ b/packages/checked_oint/checked_oint.0.1.2/opam
@@ -4,8 +4,8 @@ synopsis: "An OCaml library for checked integer arithmetic"
 maintainer: ["Tima Kinsart <hirrolot@gmail.com>"]
 authors: ["Tima Kinsart <hirrolot@gmail.com>"]
 license: "MIT"
-homepage: "https://github.com/Hirrolot/checked_oint"
-bug-reports: "https://github.com/Hirrolot/checked_oint/issues"
+homepage: "https://github.com/hirrolot/checked_oint"
+bug-reports: "https://github.com/hirrolot/checked_oint/issues"
 depends: [
   "ocaml" {>= "4.13"}
   "dune" {>= "3.14"}
@@ -32,10 +32,10 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/Hirrolot/checked_oint.git"
+dev-repo: "git+https://github.com/hirrolot/checked_oint.git"
 url {
   src:
-    "https://github.com/Hirrolot/checked_oint/archive/refs/tags/v0.1.2.tar.gz"
+    "https://github.com/hirrolot/checked_oint/archive/refs/tags/v0.1.2.tar.gz"
   checksum: [
     "md5=c4dab38d7d8b37987679308225374fad"
     "sha512=8d416cd33a030fab4722a155f10ae44b9080de20be761927c9bb20d1c35ec1668ff1774121861156d16735ca1a22ee850f3762e8f2df8d06257b75367fb2d91f"

--- a/packages/checked_oint/checked_oint.0.2.0/opam
+++ b/packages/checked_oint/checked_oint.0.2.0/opam
@@ -4,8 +4,8 @@ synopsis: "An OCaml library for checked integer arithmetic"
 maintainer: ["Tima Kinsart <hirrolot@gmail.com>"]
 authors: ["Tima Kinsart <hirrolot@gmail.com>"]
 license: "MIT"
-homepage: "https://github.com/Hirrolot/checked_oint"
-bug-reports: "https://github.com/Hirrolot/checked_oint/issues"
+homepage: "https://github.com/hirrolot/checked_oint"
+bug-reports: "https://github.com/hirrolot/checked_oint/issues"
 depends: [
   "ocaml" {>= "4.13"}
   "dune" {>= "3.14"}
@@ -32,10 +32,10 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/Hirrolot/checked_oint.git"
+dev-repo: "git+https://github.com/hirrolot/checked_oint.git"
 url {
   src:
-    "https://github.com/Hirrolot/checked_oint/archive/refs/tags/v0.2.0.tar.gz"
+    "https://github.com/hirrolot/checked_oint/archive/refs/tags/v0.2.0.tar.gz"
   checksum: [
     "md5=5ee41b2897b3f2eba115bcbcdfd5c678"
     "sha512=c8d33fad538fea814c1fc89981bc57132025e544d83bdce41133f2c3660dba7f0a94c25626f6619d06d657345867acb779bef45353dfc03a59e698e4a8644432"


### PR DESCRIPTION
All the existing `checked_oint` package versions should have the same availability constraints.
