### PR TITLE
[new release] ppx_deriving_jsonschema (0.0.3)

### DIFF
--- a/packages/ppx_deriving_jsonschema/ppx_deriving_jsonschema.0.0.3/opam
+++ b/packages/ppx_deriving_jsonschema/ppx_deriving_jsonschema.0.0.3/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Jsonschema generator for ppx_deriving"
+description:
+  "ppx_deriving_jsonschema is a ppx rewriter that generates jsonschema from ocaml types"
+maintainer: [
+  "Louis Roché <louis.roche@ahrefs.com>" "Ahrefs <github@ahrefs.com>"
+]
+authors: [
+  "Louis Roché <louis.roche@ahrefs.com>" "Ahrefs <github@ahrefs.com>"
+]
+license: "MIT"
+tags: ["jsonschema" "org:ahrefs" "syntax"]
+homepage: "https://github.com/ahrefs/ppx_deriving_jsonschema"
+doc: "https://ahrefs.github.io/ppx_deriving_jsonschema/"
+bug-reports: "https://github.com/ahrefs/ppx_deriving_jsonschema/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.16"}
+  "ppxlib" {>= "0.24.0"}
+  "yojson" {with-test}
+  "ppx_expect" {with-test}
+  "ocamlformat" {with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ppx_deriving_jsonschema.git"
+url {
+  src:
+    "https://github.com/ahrefs/ppx_deriving_jsonschema/releases/download/0.0.3/ppx_deriving_jsonschema-0.0.3.tbz"
+  checksum: [
+    "sha256=d517fc97fabe39ef8eea49dcc91b9abec03e86fdcb53fcf37b046aa0954e4d1a"
+    "sha512=b9785ea7c0394946d4585839da4d137c2ea15642f2588df3c3506e514c08f4e8413a59dd075730d7e55e686dc165140c5cdce90e5eb349b439953dba9a142d76"
+  ]
+}
+x-commit-hash: "89001d35c53da2b93f1082de467b7c59846bdb93"


### PR DESCRIPTION
Jsonschema generator for ppx_deriving

- Project page: <a href="https://github.com/ahrefs/ppx_deriving_jsonschema">https://github.com/ahrefs/ppx_deriving_jsonschema</a>
- Documentation: <a href="https://ahrefs.github.io/ppx_deriving_jsonschema/">https://ahrefs.github.io/ppx_deriving_jsonschema/</a>

##### CHANGES:

- make the default format compatible with the deriving ppxes
