### PR TITLE
[new release] reason (2 packages) (3.13.0)

### DIFF
--- a/packages/reason/reason.3.13.0/opam
+++ b/packages/reason/reason.3.13.0/opam
@@ -36,7 +36,6 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/reason/reason.3.13.0/opam
+++ b/packages/reason/reason.3.13.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Reason: Syntax & Toolchain for OCaml"
+description: """
+Reason gives OCaml a new syntax that is remniscient of languages like
+JavaScript. It's also the umbrella project for a set of tools for the OCaml &
+JavaScript ecosystem."""
+maintainer: [
+  "Jordan Walke <jordojw@gmail.com>"
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+]
+authors: ["Jordan Walke <jordojw@gmail.com>"]
+license: "MIT"
+homepage: "https://reasonml.github.io/"
+bug-reports: "https://github.com/reasonml/reason/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.06" & < "5.3"}
+  "ocamlfind" {build}
+  "dune-build-info" {>= "2.9.3"}
+  "menhir" {>= "20180523"}
+  "merlin-extend" {>= "0.6"}
+  "fix"
+  "ppx_derivers"
+  "cppo"
+  "ppxlib" {>= "0.28.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/reasonml/reason.git"
+url {
+  src:
+    "https://github.com/reasonml/reason/releases/download/3.13.0/reason-3.13.0.tbz"
+  checksum: [
+    "sha256=df2544606bc824a67082e2011826e7a1cde7af0ccb5ba457e937fe018c3ce7e4"
+    "sha512=ad6606defad2dcc2456b42e77eb77d5aee02ccda7ad32c313dcbb2c5d25953ff0c80719a3c6ef30b8443d8e6105b46aacdccc3607620c36ce8c8d0537574c21c"
+  ]
+}
+x-commit-hash: "9e71ba66b7ffea5faad2829cf90c9f307d9e2b99"

--- a/packages/rtop/rtop.3.13.0/opam
+++ b/packages/rtop/rtop.3.13.0/opam
@@ -29,7 +29,6 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/rtop/rtop.3.13.0/opam
+++ b/packages/rtop/rtop.3.13.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Reason toplevel"
+description:
+  "rtop is the toplevel (or REPL) for Reason, based on utop (https://github.com/ocaml-community/utop)."
+maintainer: [
+  "Jordan Walke <jordojw@gmail.com>"
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+]
+authors: ["Jordan Walke <jordojw@gmail.com>"]
+license: "MIT"
+homepage: "https://reasonml.github.io/"
+bug-reports: "https://github.com/reasonml/reason/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.06" & < "5.3"}
+  "reason" {= version}
+  "utop" {>= "2.0"}
+  "cppo"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/reasonml/reason.git"
+url {
+  src:
+    "https://github.com/reasonml/reason/releases/download/3.13.0/reason-3.13.0.tbz"
+  checksum: [
+    "sha256=df2544606bc824a67082e2011826e7a1cde7af0ccb5ba457e937fe018c3ce7e4"
+    "sha512=ad6606defad2dcc2456b42e77eb77d5aee02ccda7ad32c313dcbb2c5d25953ff0c80719a3c6ef30b8443d8e6105b46aacdccc3607620c36ce8c8d0537574c21c"
+  ]
+}
+x-commit-hash: "9e71ba66b7ffea5faad2829cf90c9f307d9e2b99"


### PR DESCRIPTION
Reason: Syntax & Toolchain for OCaml

- Project page: <a href="https://reasonml.github.io/">https://reasonml.github.io/</a>

##### CHANGES:

- Support `module%ppx` syntax (@anmonteiro,
  [reasonml/reason#2771](https://github.com/reasonml/reason/pull/2771))
- Extend open to arbitrary module expression (@anmonteiro,
  [reasonml/reason#2773](https://github.com/reasonml/reason/pull/2773))
- Wrap `let lazy patterns = ..` in parentheses (`let lazy(patterns) = ..`)
  (@anmonteiro, [reasonml/reason#2774](https://github.com/reasonml/reason/pull/2774))
- Print poly variants as normal variansts (@Sander Spies,
  [reasonml/reason#2708](https://github.com/reasonml/reason/pull/2708))
- Improve printing of anonymous function return type (@Sander Spies,
  [reasonml/reason#2686](https://github.com/reasonml/reason/pull/2686))
- Improve printing of destructuring with local open (@Sander Spies,
  [reasonml/reason#2684](https://github.com/reasonml/reason/pull/2684)).
- Parse and print attributes in binding `let` ops (@anmonteiro,
  [reasonml/reason#2777](https://github.com/reasonml/reason/pull/2777)).
- Parse polymorphic variants starting with `[|` (@anmonteiro,
  [reasonml/reason#2781](https://github.com/reasonml/reason/pull/2781))
- Always add a line break in records with 2 or more fields (@anmonteiro,
  [reasonml/reason#2779](https://github.com/reasonml/reason/pull/2779))
- Always break nonempty doc comments after `*/` (@anmonteiro,
  [reasonml/reason#2780](https://github.com/reasonml/reason/pull/2780))
- Improve printing of arrows with labelled arguments (@anmonteiro,
  [reasonml/reason#2778](https://github.com/reasonml/reason/pull/2778))
- Parse and print extensions in `open%foo` expressions and structure items
  (@anmonteiro, [reasonml/reason#2784](https://github.com/reasonml/reason/pull/2784))
- Add support for module type substitutions
  (@anmonteiro, [reasonml/reason#2785](https://github.com/reasonml/reason/pull/2785))
- Support `type%foo` extension sugar syntax (@anmonteiro,
  [reasonml/reason#2790](https://github.com/reasonml/reason/pull/2790))
- Support quoted extensions (@anmonteiro,
  [reasonml/reason#2794](https://github.com/reasonml/reason/pull/2794))
- Parse universal type variables in signature items (@anmonteiro,
  [reasonml/reason#2797](https://github.com/reasonml/reason/pull/2797))
- Fix formatting of callbacks with sequence expressions (@anmonteiro,
  [reasonml/reason#2799](https://github.com/reasonml/reason/pull/2799))
- Fix printing of attributes on module expressions (@anmonteiro,
  [reasonml/reason#2803](https://github.com/reasonml/reason/pull/2803))
