### PR TITLE
[new release] trs (1.0.0)

### DIFF
--- a/packages/trs/trs.1.0.0/opam
+++ b/packages/trs/trs.1.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Parsing library for the TRS format, the format for first-order rewrite systems"
+description:
+  "trs is a parsing library for the TRS format, the format for first-order rewrite systems."
+maintainer: ["Soichi Yajima"]
+authors: ["Soichi Yajima"]
+license: "MIT"
+tags: ["trs" "rewrite systems"]
+homepage: "https://github.com/jajimajp/trs"
+bug-reports: "https://github.com/jajimajp/trs/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.7" & >= "3.7"}
+  "menhir" {>= "20211012"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jajimajp/trs.git"
+url {
+  src:
+    "https://github.com/jajimajp/trs/releases/download/v1.0.0/trs-1.0.0.tbz"
+  checksum: [
+    "sha256=64485215b163040f369ebe1023b0f067a22fbbfe3a5f9db08aa265d639fe7ff9"
+    "sha512=e0b19221479a6a3091c871dcbba5c525ef81d63bca095127fe0332b1eba2cfc04c8bfca8ae88ec8db2e53170d29ded1b1d9643b06f949cf6900f49373e8ff2d1"
+  ]
+}
+x-commit-hash: "ff3ffa27230984c4362002bf6e15244f6a720865"


### PR DESCRIPTION
Parsing library for the TRS format, the format for first-order rewrite systems

- Project page: <a href="https://github.com/jajimajp/trs">https://github.com/jajimajp/trs</a>

##### CHANGES:

- Initial public release
