### PR TITLE
[new release] dns (13 packages) (9.1.0)

### DIFF
--- a/packages/dns-certify/dns-certify.9.1.0/opam
+++ b/packages/dns-certify/dns-certify.9.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.2.0"}
+  "duration" {>= "0.1.2"}
+  "x509" {>= "1.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "8.2.0"}
+  "logs"
+  "mirage-crypto-ec"
+  "mirage-crypto-pk" {>= "1.0.0"}
+  "mirage-crypto-rng-mirage" {>= "1.0.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "MirageOS let's encrypt certificate retrieval"
+description: """
+A function to retrieve a certificate when providing a hostname, TSIG key, server
+IP, and an optional key seed. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v9.1.0/dns-9.1.0.tbz"
+  checksum: [
+    "sha256=8f3ec95acf14f574219b5440a689eae1acc2a49cb1d8a066f9b23a7ac68f44f0"
+    "sha512=7bf2d099919a410f270d157a04a8d2e1c499269cca868e19a80396cdfc84a9b844c353267cf9183f585bb9b975445b8e2d0a6dd64d85b8de19e7752ec495cbe9"
+  ]
+}
+x-commit-hash: "1247f26253614393f4b9a71a3b4db02a2806677e"

--- a/packages/dns-cli/dns-cli.9.1.0/opam
+++ b/packages/dns-cli/dns-cli.9.1.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns" {= version}
+  "dnssec" {= version}
+  "dns-tsig" {= version}
+  "dns-client-lwt" {= version}
+  "dns-server" {= version}
+  "dns-certify" {= version}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.0"}
+  "fpath" {>= "0.7.2"}
+  "x509" {>= "1.0.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-pk" {>= "1.0.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "ohex" {>= "0.2.0"}
+  "ptime" {>= "0.8.5"}
+  "mtime" {>= "1.2.0"}
+  "logs" {>= "0.6.3"}
+  "fmt" {>= "0.8.8"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.0.0"}
+  "randomconv" {>= "0.2.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Unix command line utilities using uDNS"
+description: """
+'oupdate' sends a DNS update frome to a DNS server that sets 'hostname A ip'.
+For authentication via TSIG, a hmac secret needs to be provided.
+
+'ocertify' updates DNS with a certificate signing request, and polls a matching
+certificate. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v9.1.0/dns-9.1.0.tbz"
+  checksum: [
+    "sha256=8f3ec95acf14f574219b5440a689eae1acc2a49cb1d8a066f9b23a7ac68f44f0"
+    "sha512=7bf2d099919a410f270d157a04a8d2e1c499269cca868e19a80396cdfc84a9b844c353267cf9183f585bb9b975445b8e2d0a6dd64d85b8de19e7752ec495cbe9"
+  ]
+}
+x-commit-hash: "1247f26253614393f4b9a71a3b4db02a2806677e"

--- a/packages/dns-client-lwt/dns-client-lwt.9.1.0/opam
+++ b/packages/dns-client-lwt/dns-client-lwt.9.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns-client" {= version}
+  "dns" {= version}
+  "ipaddr" {>= "5.3.0"}
+  "lwt" {>= "4.2.1"}
+  "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng-lwt" {>= "1.0.0"}
+  "happy-eyeballs-lwt" {>= "1.1.0"}
+  "happy-eyeballs" {>= "1.0.0"}
+  "tls-lwt" {>= "1.0.0"}
+  "ca-certs" {>= "1.0.0"}
+]
+synopsis: "DNS client API using lwt"
+description: """
+A client implementation using uDNS and lwt for side effects.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v9.1.0/dns-9.1.0.tbz"
+  checksum: [
+    "sha256=8f3ec95acf14f574219b5440a689eae1acc2a49cb1d8a066f9b23a7ac68f44f0"
+    "sha512=7bf2d099919a410f270d157a04a8d2e1c499269cca868e19a80396cdfc84a9b844c353267cf9183f585bb9b975445b8e2d0a6dd64d85b8de19e7752ec495cbe9"
+  ]
+}
+x-commit-hash: "1247f26253614393f4b9a71a3b4db02a2806677e"

--- a/packages/dns-client-miou-unix/dns-client-miou-unix.9.1.0/opam
+++ b/packages/dns-client-miou-unix/dns-client-miou-unix.9.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.0.0"}
+  "ocaml" {>= "5.0.0"}
+  "dns-client" {= version}
+  "domain-name" {>= "0.4.0"}
+  "ipaddr" {>= "5.3.0"}
+  "miou" {>= "0.1.0"}
+  "tls-miou-unix"
+  "happy-eyeballs" {>= "0.6.0"}
+  "happy-eyeballs-miou-unix"
+]
+synopsis: "DNS client API for Miou"
+description: """
+A client implementation using uDNS using Miou.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v9.1.0/dns-9.1.0.tbz"
+  checksum: [
+    "sha256=8f3ec95acf14f574219b5440a689eae1acc2a49cb1d8a066f9b23a7ac68f44f0"
+    "sha512=7bf2d099919a410f270d157a04a8d2e1c499269cca868e19a80396cdfc84a9b844c353267cf9183f585bb9b975445b8e2d0a6dd64d85b8de19e7752ec495cbe9"
+  ]
+}
+x-commit-hash: "1247f26253614393f4b9a71a3b4db02a2806677e"

--- a/packages/dns-client-mirage/dns-client-mirage.9.1.0/opam
+++ b/packages/dns-client-mirage/dns-client-mirage.9.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns-client" {= version}
+  "domain-name" {>= "0.4.0"}
+  "ipaddr" {>= "5.3.0"}
+  "lwt" {>= "4.2.1"}
+  "tcpip" {>= "8.2.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "happy-eyeballs-mirage" {>= "1.1.0"}
+  "happy-eyeballs" {>= "1.0.0"}
+  "tls-mirage" {>= "1.0.0"}
+  "x509" {>= "1.0.0"}
+  "ca-certs-nss" {>= "3.101-1"}
+  "mirage-crypto-rng-mirage" {>= "1.0.0"}
+]
+synopsis: "DNS client API for MirageOS"
+description: """
+A client implementation using uDNS using MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v9.1.0/dns-9.1.0.tbz"
+  checksum: [
+    "sha256=8f3ec95acf14f574219b5440a689eae1acc2a49cb1d8a066f9b23a7ac68f44f0"
+    "sha512=7bf2d099919a410f270d157a04a8d2e1c499269cca868e19a80396cdfc84a9b844c353267cf9183f585bb9b975445b8e2d0a6dd64d85b8de19e7752ec495cbe9"
+  ]
+}
+x-commit-hash: "1247f26253614393f4b9a71a3b4db02a2806677e"

--- a/packages/dns-client/dns-client.9.1.0/opam
+++ b/packages/dns-client/dns-client.9.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns" {= version}
+  "randomconv" {>= "0.2.0"}
+  "domain-name" {>= "0.4.0"}
+  "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "fmt" {>= "0.9.0"}
+  "ipaddr" {>= "5.5.0"}
+  "alcotest" {with-test}
+]
+synopsis: "DNS client API"
+description: """
+A client implementation using uDNS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v9.1.0/dns-9.1.0.tbz"
+  checksum: [
+    "sha256=8f3ec95acf14f574219b5440a689eae1acc2a49cb1d8a066f9b23a7ac68f44f0"
+    "sha512=7bf2d099919a410f270d157a04a8d2e1c499269cca868e19a80396cdfc84a9b844c353267cf9183f585bb9b975445b8e2d0a6dd64d85b8de19e7752ec495cbe9"
+  ]
+}
+x-commit-hash: "1247f26253614393f4b9a71a3b4db02a2806677e"

--- a/packages/dns-mirage/dns-mirage.9.1.0/opam
+++ b/packages/dns-mirage/dns-mirage.9.1.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "ipaddr" {>= "5.2.0"}
+  "lwt" {>= "4.2.1"}
+  "tcpip" {>= "8.2.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.robur.coop/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v9.1.0/dns-9.1.0.tbz"
+  checksum: [
+    "sha256=8f3ec95acf14f574219b5440a689eae1acc2a49cb1d8a066f9b23a7ac68f44f0"
+    "sha512=7bf2d099919a410f270d157a04a8d2e1c499269cca868e19a80396cdfc84a9b844c353267cf9183f585bb9b975445b8e2d0a6dd64d85b8de19e7752ec495cbe9"
+  ]
+}
+x-commit-hash: "1247f26253614393f4b9a71a3b4db02a2806677e"

--- a/packages/dns-resolver/dns-resolver.9.1.0/opam
+++ b/packages/dns-resolver/dns-resolver.9.1.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns" {= version}
+  "dns-server" {= version}
+  "dns-mirage" {= version}
+  "dnssec" {= version}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.2.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "8.2.0"}
+  "alcotest" {with-test}
+  "tls" {>= "1.0.0"}
+  "tls-mirage" {>= "1.0.0"}
+  "mirage-crypto-rng-mirage" {>= "1.0.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS resolver business logic"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v9.1.0/dns-9.1.0.tbz"
+  checksum: [
+    "sha256=8f3ec95acf14f574219b5440a689eae1acc2a49cb1d8a066f9b23a7ac68f44f0"
+    "sha512=7bf2d099919a410f270d157a04a8d2e1c499269cca868e19a80396cdfc84a9b844c353267cf9183f585bb9b975445b8e2d0a6dd64d85b8de19e7752ec495cbe9"
+  ]
+}
+x-commit-hash: "1247f26253614393f4b9a71a3b4db02a2806677e"

--- a/packages/dns-server/dns-server.9.1.0/opam
+++ b/packages/dns-server/dns-server.9.1.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.2.0"}
+  "duration" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "8.2.0"}
+  "mirage-crypto-rng" {with-test & >= "1.0.0"}
+  "alcotest" {with-test}
+  "dns-tsig" {with-test}
+  "base64" {with-test & >= "3.0.0"}
+  "metrics"
+  "logs" {>= "0.7.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS server, primary and secondary"
+description: """
+Primary and secondary DNS server implemented in value-passing style. Needs an
+effectful layer to be useful.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v9.1.0/dns-9.1.0.tbz"
+  checksum: [
+    "sha256=8f3ec95acf14f574219b5440a689eae1acc2a49cb1d8a066f9b23a7ac68f44f0"
+    "sha512=7bf2d099919a410f270d157a04a8d2e1c499269cca868e19a80396cdfc84a9b844c353267cf9183f585bb9b975445b8e2d0a6dd64d85b8de19e7752ec495cbe9"
+  ]
+}
+x-commit-hash: "1247f26253614393f4b9a71a3b4db02a2806677e"

--- a/packages/dns-stub/dns-stub.9.1.0/opam
+++ b/packages/dns-stub/dns-stub.9.1.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dns-client-mirage" {= version}
+  "dns-mirage" {= version}
+  "dns-resolver" {= version}
+  "dns-tsig" {= version}
+  "dns-server" {= version}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.2.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "8.2.0"}
+  "metrics"
+  "mirage-crypto-rng-mirage" {>= "1.0.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS stub resolver"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v9.1.0/dns-9.1.0.tbz"
+  checksum: [
+    "sha256=8f3ec95acf14f574219b5440a689eae1acc2a49cb1d8a066f9b23a7ac68f44f0"
+    "sha512=7bf2d099919a410f270d157a04a8d2e1c499269cca868e19a80396cdfc84a9b844c353267cf9183f585bb9b975445b8e2d0a6dd64d85b8de19e7752ec495cbe9"
+  ]
+}
+x-commit-hash: "1247f26253614393f4b9a71a3b4db02a2806677e"

--- a/packages/dns-tsig/dns-tsig.9.1.0/opam
+++ b/packages/dns-tsig/dns-tsig.9.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns" {= version}
+  "digestif" {>= "1.2.0"}
+  "base64" {>= "3.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "TSIG support for DNS"
+description: """
+TSIG is used to authenticate nsupdate frames using a HMAC.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v9.1.0/dns-9.1.0.tbz"
+  checksum: [
+    "sha256=8f3ec95acf14f574219b5440a689eae1acc2a49cb1d8a066f9b23a7ac68f44f0"
+    "sha512=7bf2d099919a410f270d157a04a8d2e1c499269cca868e19a80396cdfc84a9b844c353267cf9183f585bb9b975445b8e2d0a6dd64d85b8de19e7752ec495cbe9"
+  ]
+}
+x-commit-hash: "1247f26253614393f4b9a71a3b4db02a2806677e"

--- a/packages/dns/dns.9.1.0/opam
+++ b/packages/dns/dns.9.1.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "logs" "ptime"
+  "fmt" {>= "0.8.8"}
+  "domain-name" {>= "0.4.0"}
+  "gmap" {>= "0.3.0"}
+  "ipaddr" {>= "5.2.0"}
+  "alcotest" {with-test}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "metrics"
+  "ohex" {>= "0.2.0"}
+  "base64" {>= "3.3.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.robur.coop/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v9.1.0/dns-9.1.0.tbz"
+  checksum: [
+    "sha256=8f3ec95acf14f574219b5440a689eae1acc2a49cb1d8a066f9b23a7ac68f44f0"
+    "sha512=7bf2d099919a410f270d157a04a8d2e1c499269cca868e19a80396cdfc84a9b844c353267cf9183f585bb9b975445b8e2d0a6dd64d85b8de19e7752ec495cbe9"
+  ]
+}
+x-commit-hash: "1247f26253614393f4b9a71a3b4db02a2806677e"

--- a/packages/dnssec/dnssec.9.1.0/opam
+++ b/packages/dnssec/dnssec.9.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns" {= version}
+  "alcotest" {with-test}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-pk" {>= "1.0.0"}
+  "mirage-crypto-ec" {>= "1.0.0"}
+  "domain-name" {>= "0.4.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "logs" {>= "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNSSec support for OCaml-DNS"
+description: """
+DNSSec (DNS security extensions) for OCaml-DNS, including
+signing and verifying of RRSIG records.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v9.1.0/dns-9.1.0.tbz"
+  checksum: [
+    "sha256=8f3ec95acf14f574219b5440a689eae1acc2a49cb1d8a066f9b23a7ac68f44f0"
+    "sha512=7bf2d099919a410f270d157a04a8d2e1c499269cca868e19a80396cdfc84a9b844c353267cf9183f585bb9b975445b8e2d0a6dd64d85b8de19e7752ec495cbe9"
+  ]
+}
+x-commit-hash: "1247f26253614393f4b9a71a3b4db02a2806677e"

--- a/packages/irmin-client/irmin-client.3.9.0/opam
+++ b/packages/irmin-client/irmin-client.3.9.0/opam
@@ -22,6 +22,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "lwt" {>= "5.7.0"}
   "irmin-test" {= version & with-test}
+  "mirage-crypto-rng-lwt" {with-test & <= "0.11.3"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
An opinionated Domain Name System (DNS) library

- Project page: <a href="https://github.com/mirage/ocaml-dns">https://github.com/mirage/ocaml-dns</a>
- Documentation: <a href="https://mirage.github.io/ocaml-dns/">https://mirage.github.io/ocaml-dns/</a>

##### CHANGES:

* Dns.Dnskey: provide to_string and name_key_to_string (@hannesm, @dinosaure,
  mirage/ocaml-dns#356 - fixes mirage/ocaml-dns#355)
* BREAKING: Dns.Dnskey remove pp_name_key (unused, irritating, mirage/ocaml-dns#356)
* BREAKING Dns_certify_mirage.retrieve_certificate use separate dns_key_name
  and dns_key arguments, avoid string decoding in that function (mirage/ocaml-dns#356)
