### PR TITLE
[new release] vcs (5 packages) (0.0.9)

### DIFF
--- a/packages/vcs-base/vcs-base.0.0.9/opam
+++ b/packages/vcs-base/vcs-base.0.0.9/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "An Extension of Vcs to use with Base"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.2"}
+  "base" {>= "v0.17" & < "v0.18"}
+  "fpath" {>= "0.7.3"}
+  "fpath-base" {>= "0.2.2"}
+  "ppx_compare" {>= "v0.17" & < "v0.18"}
+  "ppx_enumerate" {>= "v0.17" & < "v0.18"}
+  "ppx_hash" {>= "v0.17" & < "v0.18"}
+  "ppx_here" {>= "v0.17" & < "v0.18"}
+  "ppx_let" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
+  "ppxlib" {>= "0.33"}
+  "provider" {>= "0.0.8"}
+  "vcs" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+url {
+  src: "https://github.com/mbarbin/vcs/releases/download/0.0.9/vcs-0.0.9.tbz"
+  checksum: [
+    "sha256=34127caaca89cb10e3cc61b6add782745fbf619039f4cc99a898b663f8e96512"
+    "sha512=95b5ce7ea7581a7307e5f9c6f3566e28be5316981f5720df17ee6fd7bb3f7498885a493bab54bc853ab57dcecc47887bfaea32ec695ef27a8069fda0955cf7b6"
+  ]
+}
+x-commit-hash: "6c961d8bfca6ecd45aba8700b4e818755efcfe86"

--- a/packages/vcs-git-blocking/vcs-git-blocking.0.0.9/opam
+++ b/packages/vcs-git-blocking/vcs-git-blocking.0.0.9/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "A Git provider for Vcs based on Vcs_git_provider for blocking programs"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.2"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.2.2"}
+  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
+  "ppxlib" {>= "0.33"}
+  "provider" {>= "0.0.8"}
+  "sexplib0" {>= "v0.17" & < "v0.18"}
+  "vcs" {= version}
+  "vcs-git-provider" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+url {
+  src: "https://github.com/mbarbin/vcs/releases/download/0.0.9/vcs-0.0.9.tbz"
+  checksum: [
+    "sha256=34127caaca89cb10e3cc61b6add782745fbf619039f4cc99a898b663f8e96512"
+    "sha512=95b5ce7ea7581a7307e5f9c6f3566e28be5316981f5720df17ee6fd7bb3f7498885a493bab54bc853ab57dcecc47887bfaea32ec695ef27a8069fda0955cf7b6"
+  ]
+}
+x-commit-hash: "6c961d8bfca6ecd45aba8700b4e818755efcfe86"

--- a/packages/vcs-git-eio/vcs-git-eio.0.0.9/opam
+++ b/packages/vcs-git-eio/vcs-git-eio.0.0.9/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "A Git provider for Vcs based on Vcs_git_provider for Eio programs"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.2"}
+  "eio" {>= "1.0"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.2.2"}
+  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
+  "ppxlib" {>= "0.33"}
+  "provider" {>= "0.0.8"}
+  "sexplib0" {>= "v0.17" & < "v0.18"}
+  "vcs" {= version}
+  "vcs-git-provider" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+url {
+  src: "https://github.com/mbarbin/vcs/releases/download/0.0.9/vcs-0.0.9.tbz"
+  checksum: [
+    "sha256=34127caaca89cb10e3cc61b6add782745fbf619039f4cc99a898b663f8e96512"
+    "sha512=95b5ce7ea7581a7307e5f9c6f3566e28be5316981f5720df17ee6fd7bb3f7498885a493bab54bc853ab57dcecc47887bfaea32ec695ef27a8069fda0955cf7b6"
+  ]
+}
+x-commit-hash: "6c961d8bfca6ecd45aba8700b4e818755efcfe86"

--- a/packages/vcs-git-provider/vcs-git-provider.0.0.9/opam
+++ b/packages/vcs-git-provider/vcs-git-provider.0.0.9/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "An IO-free library that parses the output of Git commands"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.2"}
+  "astring" {>= "0.8.5"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.2.2"}
+  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
+  "ppxlib" {>= "0.33"}
+  "sexplib0" {>= "v0.17" & < "v0.18"}
+  "vcs" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+url {
+  src: "https://github.com/mbarbin/vcs/releases/download/0.0.9/vcs-0.0.9.tbz"
+  checksum: [
+    "sha256=34127caaca89cb10e3cc61b6add782745fbf619039f4cc99a898b663f8e96512"
+    "sha512=95b5ce7ea7581a7307e5f9c6f3566e28be5316981f5720df17ee6fd7bb3f7498885a493bab54bc853ab57dcecc47887bfaea32ec695ef27a8069fda0955cf7b6"
+  ]
+}
+x-commit-hash: "6c961d8bfca6ecd45aba8700b4e818755efcfe86"

--- a/packages/vcs/vcs.0.0.9/opam
+++ b/packages/vcs/vcs.0.0.9/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A Versatile OCaml Library for Git Operations"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.2"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.2.2"}
+  "ppx_enumerate" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
+  "ppxlib" {>= "0.33"}
+  "provider" {>= "0.0.8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+url {
+  src: "https://github.com/mbarbin/vcs/releases/download/0.0.9/vcs-0.0.9.tbz"
+  checksum: [
+    "sha256=34127caaca89cb10e3cc61b6add782745fbf619039f4cc99a898b663f8e96512"
+    "sha512=95b5ce7ea7581a7307e5f9c6f3566e28be5316981f5720df17ee6fd7bb3f7498885a493bab54bc853ab57dcecc47887bfaea32ec695ef27a8069fda0955cf7b6"
+  ]
+}
+x-commit-hash: "6c961d8bfca6ecd45aba8700b4e818755efcfe86"


### PR DESCRIPTION
This is the initial release for 5 packages providing a type-safe and direct-style API to programmatically perform Git operations. More information at https://github.com/mbarbin/vcs. Short synopsis below:

## Synopsis

**vcs** the user facing library for the system, with reduced dependencies.

**vcs-git-provider** a helper library for building providers for the vcs library.

**vcs-git-blocking** a provider for the vcs library built with OCam's Stdlib and offering blocking calls to git.

**vcs-git-eio** a provider for the vcs library built atop Eio for non blocking calls to git.

**vcs-base** an extension of `Vcs` for base users.