### PR TITLE
Fix install of conf-libclang.15 when using macports on macOS.

### DIFF
--- a/packages/conf-libclang/conf-libclang.15/opam
+++ b/packages/conf-libclang/conf-libclang.15/opam
@@ -14,7 +14,8 @@ depends: [
   "conf-bash" {build}
 ]
 depexts: [
-  ["llvm@15"] {os = "macos"}
+  ["llvm@15"] {os-distribution = "homebrew" & os = "macos"}
+  ["llvm-15"] {os-distribution = "macports" & os = "macos"}
   ["llvm15" "clang15"] {os-distribution = "arch"}
   ["libclang-15-dev" "libclang-cpp15-dev" "llvm-15-dev"]
     {(os-distribution = "ubuntu" & os-version >= "22.10")}


### PR DESCRIPTION
This PR makes it possible to install this package on macOS when using macports.