### PR TITLE
[new release] cmdlang (3 packages) (0.0.6)

### DIFF
--- a/packages/cmdlang-to-climate/cmdlang-to-climate.0.0.6/opam
+++ b/packages/cmdlang-to-climate/cmdlang-to-climate.0.0.6/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Convert cmdlang Parsers to climate"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "climate" {>= "0.1.0~" & < "0.2"}
+  "cmdlang" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.6/cmdlang-0.0.6.tbz"
+  checksum: [
+    "sha256=6dcec17f9ef2f5c254075595972f7f6b4ecd1d85092d15f9c3d2f6c1f7662441"
+    "sha512=b57dfb2558e4f4b8b10a26ec6b11da52d9ea0dc5e70f8ed224ef96fc4151e80c1aa8a2399a531abcb836a904d8105aed5479773abfdfb285c69bf6bacf0afd80"
+  ]
+}
+x-commit-hash: "f6438faadda0228cedf9208226cfdd407718f0dc"

--- a/packages/cmdlang-to-cmdliner/cmdlang-to-cmdliner.0.0.6/opam
+++ b/packages/cmdlang-to-cmdliner/cmdlang-to-cmdliner.0.0.6/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Convert cmdlang Parsers to cmdliner"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "cmdlang" {= version}
+  "cmdliner" {>= "1.3.0" & < "1.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.6/cmdlang-0.0.6.tbz"
+  checksum: [
+    "sha256=6dcec17f9ef2f5c254075595972f7f6b4ecd1d85092d15f9c3d2f6c1f7662441"
+    "sha512=b57dfb2558e4f4b8b10a26ec6b11da52d9ea0dc5e70f8ed224ef96fc4151e80c1aa8a2399a531abcb836a904d8105aed5479773abfdfb285c69bf6bacf0afd80"
+  ]
+}
+x-commit-hash: "f6438faadda0228cedf9208226cfdd407718f0dc"

--- a/packages/cmdlang/cmdlang.0.0.6/opam
+++ b/packages/cmdlang/cmdlang.0.0.6/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Declarative Command-line Parsing for OCaml"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.6/cmdlang-0.0.6.tbz"
+  checksum: [
+    "sha256=6dcec17f9ef2f5c254075595972f7f6b4ecd1d85092d15f9c3d2f6c1f7662441"
+    "sha512=b57dfb2558e4f4b8b10a26ec6b11da52d9ea0dc5e70f8ed224ef96fc4151e80c1aa8a2399a531abcb836a904d8105aed5479773abfdfb285c69bf6bacf0afd80"
+  ]
+}
+x-commit-hash: "f6438faadda0228cedf9208226cfdd407718f0dc"


### PR DESCRIPTION
This is the initial release for 3 packages providing an API to build declarative command-line parsers. More information at https://github.com/mbarbin/cmdlang. Short synopsis below:

## Synopsis

Cmdlang is a library for creating command-line parsers in OCaml. Implemented as an OCaml EDSL, its declarative specification language lives at the intersection of other well-established similar libraries.

Cmdlang doesn't include an execution engine. Instead, Cmdlang parsers are automatically translated to cmdliner, core.command, or climate commands for execution.

Our goal is to provide an approachable, flexible, and user-friendly interface while allowing users to choose the backend runtime that best suits their needs.

### Packages

**cmdlang** the user facing library to build the commands. It has no dependencies

**cmdlang-to-cmdliner** translate cmdlang commands to cmdliner

**cmdlang-to-climate** translate cmdlang commands to the newly released climate