### PR TITLE
8 packages from ocaml/opam at 2.3.0~beta2

### DIFF
--- a/packages/opam-client/opam-client.2.3.0~beta2/opam
+++ b/packages/opam-client/opam-client.2.3.0~beta2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Client library for opam 2.3"
+description:
+  "Actions on the opam root, switches, installations, and front-end."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@outlook.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "opam-state" {= version}
+  "opam-solver" {= version}
+  "base64" {>= "3.1.0"}
+  "opam-repository" {= version}
+  "re" {>= "1.10.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.8.0"}
+]
+conflicts: [
+  "extlib" {< "1.7.8"}
+  "extlib-compat"
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.3.0-beta2.tar.gz"
+  checksum: [
+    "md5=1820f557c273561f325b753023bf56a9"
+    "sha512=cbde4f86264e4724e0e789963f2522ddfbfe7bd91c420d694d96157121a9e11f45130c0f81b3dea9a0fbf003c0836f14c66721b5ac6b82e4ad9cf4ade96b2713"
+  ]
+}

--- a/packages/opam-core/opam-core.2.3.0~beta2/opam
+++ b/packages/opam-core/opam-core.2.3.0~beta2/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Core library for opam 2.3"
+description:
+  "Small standard library extensions, and generic system interaction modules used by opam."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@outlook.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "ocamlgraph"
+  "re" {>= "1.9.0"}
+  "dune" {>= "2.8.0"}
+  "sha" {>= "1.13"}
+  "jsonm"
+  "swhid_core"
+  "uutf"
+  (("host-system-mingw" {os = "win32" & os-distribution != "cygwinports"} &
+    "conf-mingw-w64-gcc-i686"
+      {os = "win32" & os-distribution != "cygwinports"} &
+    "conf-mingw-w64-gcc-x86_64"
+      {os = "win32" & os-distribution != "cygwinports"}) |
+   ("host-system-msvc" {os = "win32" & os-distribution != "cygwinports"} &
+    "conf-msvc32" {os = "win32" & os-distribution != "cygwinports"} &
+    "conf-msvc64" {os = "win32" & os-distribution != "cygwinports"}))
+]
+conflicts: ["extlib-compat"]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.3.0-beta2.tar.gz"
+  checksum: [
+    "md5=1820f557c273561f325b753023bf56a9"
+    "sha512=cbde4f86264e4724e0e789963f2522ddfbfe7bd91c420d694d96157121a9e11f45130c0f81b3dea9a0fbf003c0836f14c66721b5ac6b82e4ad9cf4ade96b2713"
+  ]
+}

--- a/packages/opam-devel/opam-devel.2.3.0~beta2/opam
+++ b/packages/opam-devel/opam-devel.2.3.0~beta2/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Bootstrapped development binary for opam 2.3"
+description:
+  "This package compiles (bootstraps) opam. For consistency and safety of the installation, the binaries are not installed into the PATH, but into lib/opam-devel, from where the user can manually install them system-wide."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@outlook.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "opam-client" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.8.0"}
+  "conf-openssl" {with-test}
+  "conf-diffutils" {with-test}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+post-messages:
+  """\
+The development version of opam has been successfully compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/opam /usr/local/bin
+
+If you just want to give it a try without altering your current installation, you could use instead:
+    alias opam2="OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""""
+    {success}
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.3.0-beta2.tar.gz"
+  checksum: [
+    "md5=1820f557c273561f325b753023bf56a9"
+    "sha512=cbde4f86264e4724e0e789963f2522ddfbfe7bd91c420d694d96157121a9e11f45130c0f81b3dea9a0fbf003c0836f14c66721b5ac6b82e4ad9cf4ade96b2713"
+  ]
+}

--- a/packages/opam-format/opam-format.2.3.0~beta2/opam
+++ b/packages/opam-format/opam-format.2.3.0~beta2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Format library for opam 2.3"
+description: "Definition of opam datastructures and its file interface."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@outlook.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "opam-core" {= version}
+  "opam-file-format" {>= "2.1.4"}
+  "re" {>= "1.9.0"}
+  "dune" {>= "2.8.0"}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.3.0-beta2.tar.gz"
+  checksum: [
+    "md5=1820f557c273561f325b753023bf56a9"
+    "sha512=cbde4f86264e4724e0e789963f2522ddfbfe7bd91c420d694d96157121a9e11f45130c0f81b3dea9a0fbf003c0836f14c66721b5ac6b82e4ad9cf4ade96b2713"
+  ]
+}

--- a/packages/opam-installer/opam-installer.2.3.0~beta2/opam
+++ b/packages/opam-installer/opam-installer.2.3.0~beta2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Installation of files to a prefix, following opam conventions"
+description: """\
+opam-installer is a small tool that can read *.install files, as defined by opam [1], and execute them to install or remove package files without going through opam.
+
+[1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@outlook.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "opam-format" {= version}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {>= "2.8.0"}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.3.0-beta2.tar.gz"
+  checksum: [
+    "md5=1820f557c273561f325b753023bf56a9"
+    "sha512=cbde4f86264e4724e0e789963f2522ddfbfe7bd91c420d694d96157121a9e11f45130c0f81b3dea9a0fbf003c0836f14c66721b5ac6b82e4ad9cf4ade96b2713"
+  ]
+}

--- a/packages/opam-repository/opam-repository.2.3.0~beta2/opam
+++ b/packages/opam-repository/opam-repository.2.3.0~beta2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Repository library for opam 2.3"
+description:
+  "This library includes repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@outlook.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "opam-format" {= version}
+  "dune" {>= "2.8.0"}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.3.0-beta2.tar.gz"
+  checksum: [
+    "md5=1820f557c273561f325b753023bf56a9"
+    "sha512=cbde4f86264e4724e0e789963f2522ddfbfe7bd91c420d694d96157121a9e11f45130c0f81b3dea9a0fbf003c0836f14c66721b5ac6b82e4ad9cf4ade96b2713"
+  ]
+}

--- a/packages/opam-solver/opam-solver.2.3.0~beta2/opam
+++ b/packages/opam-solver/opam-solver.2.3.0~beta2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Solver library for opam 2.3"
+description:
+  "Solver and Cudf interaction. This library is based on the Cudf and Dose libraries, and handles calls to the external solver from opam."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@outlook.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "opam-format" {= version}
+  "mccs" {>= "1.1+17"}
+  "dose3" {>= "6.1"}
+  "cudf" {>= "0.7"}
+  "re" {>= "1.9.0"}
+  "dune" {>= "2.8.0"}
+  "opam-0install-cudf" {>= "0.5.0"}
+]
+depopts: ["z3"]
+conflicts: [
+  "z3" {< "4.8.4"}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.3.0-beta2.tar.gz"
+  checksum: [
+    "md5=1820f557c273561f325b753023bf56a9"
+    "sha512=cbde4f86264e4724e0e789963f2522ddfbfe7bd91c420d694d96157121a9e11f45130c0f81b3dea9a0fbf003c0836f14c66721b5ac6b82e4ad9cf4ade96b2713"
+  ]
+}

--- a/packages/opam-state/opam-state.2.3.0~beta2/opam
+++ b/packages/opam-state/opam-state.2.3.0~beta2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "State library for opam 2.3"
+description:
+  "Handling of the ~/.opam hierarchy, repository and switch states."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@outlook.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "opam-repository" {= version}
+  "re" {>= "1.9.0"}
+  "spdx_licenses" {>= "1.0.0"}
+  "dune" {>= "2.8.0"}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.3.0-beta2.tar.gz"
+  checksum: [
+    "md5=1820f557c273561f325b753023bf56a9"
+    "sha512=cbde4f86264e4724e0e789963f2522ddfbfe7bd91c420d694d96157121a9e11f45130c0f81b3dea9a0fbf003c0836f14c66721b5ac6b82e4ad9cf4ade96b2713"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `opam-client.2.3.0~beta2`: Client library for opam 2.3
- `opam-core.2.3.0~beta2`: Core library for opam 2.3
- `opam-devel.2.3.0~beta2`: Bootstrapped development binary for opam 2.3
- `opam-format.2.3.0~beta2`: Format library for opam 2.3
- `opam-installer.2.3.0~beta2`: Installation of files to a prefix, following opam conventions
- `opam-repository.2.3.0~beta2`: Repository library for opam 2.3
- `opam-solver.2.3.0~beta2`: Solver library for opam 2.3
- `opam-state.2.3.0~beta2`: State library for opam 2.3



---
* Homepage: https://opam.ocaml.org
* Source repo: git+https://github.com/ocaml/opam.git
* Bug tracker: https://github.com/ocaml/opam/issues

---
:camel: Pull-request generated by opam-publish v2.4.0