### PR TITLE
[new release] res (5.0.2)

### DIFF
--- a/packages/res/res.5.0.2/opam
+++ b/packages/res/res.5.0.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "RES - Library for resizable, contiguous datastructures"
+description:
+  "RES is a library containing resizable arrays, strings, and bitvectors."
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: ["Markus Mottl <markus.mottl@gmail.com>"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/res"
+doc: "https://mmottl.github.io/res/api"
+bug-reports: "https://github.com/mmottl/res/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/res.git"
+url {
+  src: "https://github.com/mmottl/res/releases/download/5.0.2/res-5.0.2.tbz"
+  checksum: [
+    "sha256=850c51113098c72ed91da879720f971ed1f7c028ffa1fab5547c6c3c7bbdd455"
+    "sha512=20c32ca9782ca9f1a345ffdbd94286741da6fde711c11bc9678e23365a1654c20e85bd8929354f98c85857976784dedd7b08060a25e0f223176f3eee21dbf532"
+  ]
+}
+x-commit-hash: "72b8cde143b3ab2d427c1b35340d181fd0daf34e"


### PR DESCRIPTION
RES - Library for resizable, contiguous datastructures

- Project page: <a href="https://mmottl.github.io/res">https://mmottl.github.io/res</a>
- Documentation: <a href="https://mmottl.github.io/res/api">https://mmottl.github.io/res/api</a>

##### CHANGES:

- Switched to OPAM file generation via `dune-project`.

- Used packed float array implementation for resizable float arrays.

- Removed `bytes` dependency (thanks to Marek Kubica).

- Fixed closure allocation due to match on mutable (thanks to Luke Palmer).

- Used ocamlformat to format code, and fixed OCaml doc problems.

- Added GitHub workflow for CI.
