### PR TITLE
[new release] jekyll-format (0.3.4)

### DIFF
--- a/packages/jekyll-format/jekyll-format.0.3.4/opam
+++ b/packages/jekyll-format/jekyll-format.0.3.4/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Jekyll post parsing library"
+description: """
+This library provides an OCaml interface to parsing
+posts in the Jekyll format."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: ["Anil Madhavapeddy" "Patrick Ferris"]
+license: "MIT"
+homepage: "https://github.com/avsm/jekyll-format"
+bug-reports: "https://github.com/avsm/jekyll-format/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "yaml-sexp" {>= "3.0.0"}
+  "yaml" {>= "3.0.0"}
+  "sexplib"
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "rresult"
+  "ptime"
+  "fpath"
+  "ezjsonm" {>= "1.1.0"}
+  "alcotest" {with-test}
+  "bos" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/avsm/jekyll-format.git"
+url {
+  src:
+    "https://github.com/avsm/jekyll-format/releases/download/v0.3.4/jekyll-format-0.3.4.tbz"
+  checksum: [
+    "sha256=1cf13770011e7e0db1e59f24633faf3f594cae045db1efb5cf1f1fef2b8abc67"
+    "sha512=a8ebab47bba3e14fa2f365002825b6b71754ef807be8419620a1167e509929bd59e25fcefbfb8b169a20716423bb4f1a07f9a8592768d6f2268a1bc869fad687"
+  ]
+}
+x-commit-hash: "84ddf2cd200f27fecbf337bb9342637c4ebb3dc9"


### PR DESCRIPTION
Jekyll post parsing library

- Project page: <a href="https://github.com/avsm/jekyll-format">https://github.com/avsm/jekyll-format</a>

##### CHANGES:

- Improve slug inference by working on files of the form
  `name.md` (without a date component). For these files, if the
  `date` field is present but no `slug` field, then the `slug`
  field is assigned as the filename (sans extension).
