### PR TITLE
Add the missing avoid-version flag to the pre-releases of some of cohttp sub-packages

### DIFF
--- a/packages/cohttp-curl-async/cohttp-curl-async.6.0.0~alpha2/opam
+++ b/packages/cohttp-curl-async/cohttp-curl-async.6.0.0~alpha2/opam
@@ -35,6 +35,8 @@ depends: [
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: avoid-version
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cohttp-curl-lwt/cohttp-curl-lwt.6.0.0~alpha2/opam
+++ b/packages/cohttp-curl-lwt/cohttp-curl-lwt.6.0.0~alpha2/opam
@@ -35,6 +35,8 @@ depends: [
   "ounit" {with-test}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: avoid-version
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.6.0.0~alpha2/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.6.0.0~alpha2/opam
@@ -36,6 +36,8 @@ depends: [
   "js_of_ocaml-lwt" {>= "3.5.0"}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: avoid-version
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha2/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha2/opam
@@ -43,6 +43,8 @@ depends: [
   "ounit" {with-test}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: avoid-version
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cohttp-server-lwt-unix/cohttp-server-lwt-unix.6.0.0~alpha2/opam
+++ b/packages/cohttp-server-lwt-unix/cohttp-server-lwt-unix.6.0.0~alpha2/opam
@@ -30,6 +30,8 @@ depends: [
   "lwt"
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: avoid-version
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cohttp-top/cohttp-top.6.0.0~alpha2/opam
+++ b/packages/cohttp-top/cohttp-top.6.0.0~alpha2/opam
@@ -27,6 +27,8 @@ depends: [
   "cohttp" {= version}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: avoid-version
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
The rest of the (sub-)packages have it