### PR TITLE
[new release] git-kv (0.1.0)

### DIFF
--- a/packages/git-kv/git-kv.0.1.0/opam
+++ b/packages/git-kv/git-kv.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur Team <team@robur.coop>"
+authors: [ "Robur Team <team@robur.coop>" ]
+license: "MIT"
+homepage: "https://github.com/robur-coop/git-kv"
+dev-repo: "git+https://github.com/robur-coop/git-kv.git"
+bug-reports: "https://github.com/robur-coop/git-kv/issues"
+synopsis: "A Mirage_kv implementation using git"
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.9.0"}
+  "git"               {>= "3.10.0"}
+  "mirage-kv"         {>= "6.0.0"}
+  "carton"            {>= "0.7.0"}
+  "carton-lwt"        {>= "0.7.0"}
+  "fmt"               {>= "0.8.7"}
+  "mirage-clock"      {>= "2.0.0"}
+  "ptime"
+  "hxd"               {with-test}
+  "conf-git"          {with-test}
+  "mirage-clock-unix" {with-test}
+  "git-unix"          {>= "3.10.0" & with-test}
+  "alcotest"          {>= "1.8.0" & with-test}
+  "bos"               {>= "0.2.1" & with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/robur-coop/git-kv/releases/download/v0.1.0/git-kv-0.1.0.tbz"
+  checksum: [
+    "sha256=cd8fd7987bb83d8c8c1eda15de07d060bcff9c5aa3f7bcda425b4f74849289eb"
+    "sha512=662db1dba6958d524a8d71cede62fa3f84fae962891ac78d1c1d926184864605d6d814244fea74a5f82e4f1290c02ea115e3557468d4f155e9644e68ed111192"
+  ]
+}
+x-commit-hash: "b7d18b77459f535f1078abff4e52ea76ddd9c011"

--- a/packages/git-kv/git-kv.0.1.0/opam
+++ b/packages/git-kv/git-kv.0.1.0/opam
@@ -9,7 +9,7 @@ synopsis: "A Mirage_kv implementation using git"
 
 depends: [
   "ocaml"             {>= "4.08.0"}
-  "dune"              {>= "2.9.0"}
+  "dune"              {>= "3.16.0"}
   "git"               {>= "3.10.0"}
   "mirage-kv"         {>= "6.0.0"}
   "carton"            {>= "0.7.0"}


### PR DESCRIPTION
A Mirage_kv implementation using git

- Project page: <a href="https://github.com/robur-coop/git-kv">https://github.com/robur-coop/git-kv</a>

##### CHANGES:

- Refine change_and_push semantics (fixing on GitHub robur-coop/git-kv#1 robur-coop/git-kv#2 - @reynir @dinosaure @hannesm git.robur.coop robur-coop/git-kv#2)
  - only a single task may execute it at once (using a Lwt_mutex.t to protect this)
  - abort if the state is updated in parallel by a different task while change_and_push is executing
- Do the rename inside a change_and_push (so only a single commit from a rename), git.robur.coop robur-coop/git-kv#3
- Add alcotest unit tests
- Fix CRAM tests
