### PR TITLE
camlpdf 2.7.2: not compatible with native windows

### DIFF
--- a/packages/camlpdf/camlpdf.2.7.2/opam
+++ b/packages/camlpdf/camlpdf.2.7.2/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind" {build}
 ]
 synopsis: "Read, write and modify PDF files"
-available: os-distribution != "msys2"
+available: os != "win32"
 url {
   src:
     "https://github.com/johnwhitington/camlpdf/archive/refs/tags/v2.7.1.tar.gz"


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/26794