### PR TITLE
gptar.1.0.0: remove excess whitespace in description

### DIFF
--- a/packages/gptar/gptar.1.0.0/opam
+++ b/packages/gptar/gptar.1.0.0/opam
@@ -2,11 +2,11 @@ opam-version: "2.0"
 synopsis: "GPT headers that are also valid tar headers"
 description: """
 Marshaling GPT headers such that they are a valid tar archive.
-              The archive will contain a dummy file named `GPTAR` whose content
-              is (at least) the GPT header and the partition table entries.
-              Put a tar-partition at the first available space, and you can
-              inspect the tar archive using regular tar utilities on the disk
-              image with the caveat of the added `GPTAR` dummy file."""
+The archive will contain a dummy file named `GPTAR` whose content
+is (at least) the GPT header and the partition table entries.
+Put a tar-partition at the first available space, and you can
+inspect the tar archive using regular tar utilities on the disk
+image with the caveat of the added `GPTAR` dummy file."""
 maintainer: ["Reynir Björnsson <reynir@reynir.dk>"]
 authors: ["Reynir Björnsson <reynir@reynir.dk>"]
 license: "BSD-2-Clause"


### PR DESCRIPTION
This is not a big problem, but I noticed the opam file I published has a loooot of leading spaces. This looks silly in `opam show gptar`.

This removes the excess white space. I hope this does not cause issues to modify the opam file after it's published. Please feel free to reject this PR in that case.