### PR TITLE
Mark `rml` unavailable as sources are unavailable

### DIFF
--- a/packages/rml/rml.1.08.04/opam
+++ b/packages/rml/rml.1.08.04/opam
@@ -23,3 +23,4 @@ url {
     "md5=00a7a14f24a7640089f78ad52f532002"
   ]
 }
+available: false

--- a/packages/rml/rml.1.08.05/opam
+++ b/packages/rml/rml.1.08.05/opam
@@ -30,3 +30,4 @@ url {
     "md5=6c41f9d5458d1032a0ed7712b95d1f21"
   ]
 }
+available: false

--- a/packages/rml/rml.1.08.06/opam
+++ b/packages/rml/rml.1.08.06/opam
@@ -30,3 +30,4 @@ url {
     "md5=cd657e07d27cdc67fd5ed051d60b712c"
   ]
 }
+available: false

--- a/packages/rml/rml.1.09.00/opam
+++ b/packages/rml/rml.1.09.00/opam
@@ -8,7 +8,7 @@ build: [
 remove: [[make "uninstall"]]
 depends: ["ocaml" "ocamlfind" "ocamlbuild" "num"]
 install: [make "install"]
-available: [ os != "linux" ]
+available: [ os != "linux" & false ]
 synopsis:
   "ReactiveML: a programming language for implementing interactive systems."
 description: """

--- a/packages/rml/rml.1.09.01/opam
+++ b/packages/rml/rml.1.09.01/opam
@@ -8,7 +8,7 @@ build: [
 remove: [[make "uninstall"]]
 depends: ["ocaml" "ocamlfind" "ocamlbuild" "num"]
 install: [make "install"]
-available: [ os != "linux" ]
+available: [ os != "linux" & false ]
 synopsis:
   "ReactiveML: a programming language for implementing interactive systems."
 description: """

--- a/packages/rml/rml.1.09.02/opam
+++ b/packages/rml/rml.1.09.02/opam
@@ -10,7 +10,7 @@ remove: [
 ]
 depends: ["ocaml" "ocamlfind" "ocamlbuild" "num"]
 install: [make "install"]
-available: [ os != "linux" ]
+available: [ os != "linux" & false ]
 synopsis:
   "ReactiveML: a programming language for implementing interactive systems."
 description: """

--- a/packages/rml/rml.1.09.03/opam
+++ b/packages/rml/rml.1.09.03/opam
@@ -11,7 +11,7 @@ remove: [
 ]
 depends: ["ocaml" "ocamlbuild" "num"]
 install: [make "install"]
-available: [ os != "linux" ]
+available: [ os != "linux" & false ]
 synopsis:
   "ReactiveML: a programming language for implementing interactive systems."
 description: """

--- a/packages/rml/rml.1.09.04/opam
+++ b/packages/rml/rml.1.09.04/opam
@@ -35,3 +35,4 @@ url {
     "md5=ae95d5367ed8524b0161b11bbef83e60"
   ]
 }
+available: false

--- a/packages/rml/rml.1.09.05/opam
+++ b/packages/rml/rml.1.09.05/opam
@@ -35,3 +35,4 @@ url {
     "md5=55b0603d353f833254faa9721c9d2db6"
   ]
 }
+available: false

--- a/packages/rml/rml.1.09.06/opam
+++ b/packages/rml/rml.1.09.06/opam
@@ -30,3 +30,4 @@ url {
     "md5=af5bfc1f6bd75e528f2ff7793e34284c"
   ]
 }
+available: false

--- a/packages/rml/rml.1.09.07/opam
+++ b/packages/rml/rml.1.09.07/opam
@@ -13,7 +13,7 @@ install: [
  [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.07" & < "5.1"}
+  "ocaml" {>= "4.07"}
   "num"
 ]
 depexts: ["patch"] {os-distribution = "alpine"}
@@ -27,9 +27,10 @@ In ReactiveML, the reactive model is integrated at the language level
 (not as a library) which leads to safer and more natural programming."""
 authors: "Louis Mandel louis@reactiveml.org"
 url {
-  src: "https://github.com/reactiveml/rml/archive/refs/tags/rml-1.09.07-2021-07-26.tar.gz"
+  src: "http://rml.lri.fr/distrib/rml-1.09.07-2021-07-26.tar.gz"
   checksum: [
-    "sha256=5beeb70dbd8688597999377b54342c1306ac92a3eefb68978a38311c531de5ca"
-    "md5=dcaa4a0d0e51a300e29bb903f656477e"
+    "sha256=74acc5319df33b4694d6894b0b8023c1ce3f8f0749c6f4dc587a42c102d809b0"
+    "md5=4fc5ca8f941f6a7f060fb9252389b8b4"
   ]
 }
+available: false

--- a/packages/rml/rml.1.09.07/opam
+++ b/packages/rml/rml.1.09.07/opam
@@ -13,7 +13,7 @@ install: [
  [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "5.1"}
   "num"
 ]
 depexts: ["patch"] {os-distribution = "alpine"}

--- a/packages/rml/rml.1.09.07/opam
+++ b/packages/rml/rml.1.09.07/opam
@@ -27,9 +27,9 @@ In ReactiveML, the reactive model is integrated at the language level
 (not as a library) which leads to safer and more natural programming."""
 authors: "Louis Mandel louis@reactiveml.org"
 url {
-  src: "http://rml.lri.fr/distrib/rml-1.09.07-2021-07-26.tar.gz"
+  src: "https://github.com/reactiveml/rml/archive/refs/tags/rml-1.09.07-2021-07-26.tar.gz"
   checksum: [
-    "sha256=74acc5319df33b4694d6894b0b8023c1ce3f8f0749c6f4dc587a42c102d809b0"
-    "md5=4fc5ca8f941f6a7f060fb9252389b8b4"
+    "sha256=5beeb70dbd8688597999377b54342c1306ac92a3eefb68978a38311c531de5ca"
+    "md5=dcaa4a0d0e51a300e29bb903f656477e"
   ]
 }


### PR DESCRIPTION
`rml.lri.fr` and `reactiveml.org` are both dead/redirecting to Github and the tarballs are 404'ing. The OPAM cache doesn't have them so the best bet seems to point to the Github releases.

I've noticed that while inspecting the revdeps of Dune in #26816.