### PR TITLE
compiler packages for the OCaml 5.3.0~beta1

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.3.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.3.0~beta1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First beta release of OCaml 5.3.0"
+maintainer: [
+  "David Allsopp <david@tarides.com>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.3"
+depends: [
+  "ocaml-compiler" {= "5.3.0~beta1"}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
+  "ocaml-options-vanilla" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]

--- a/packages/ocaml-compiler/ocaml-compiler.5.3.0~beta1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3.0~beta1/opam
@@ -1,0 +1,142 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First beta release of OCaml 5.3.0"
+maintainer: [
+  "David Allsopp <david@tarides.com>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.3"
+depends: [
+  # This is OCaml 5.3.0
+  "ocaml" {= "5.3.0" & post}
+
+  # General base- packages
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "base-effects" {post}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
+  # i686 mingw-w64 / MSVC
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
+]
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
+build-env: [
+  [MSYS2_ARG_CONV_EXCL = "*"]
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
+    "--with-winpthreads-msvc=%{winpthreads:share}%" {system-msvc:installed}
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--without-zstd" {ocaml-option-no-compression:installed}
+    "--enable-tsan" {ocaml-option-tsan:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
+    "CFLAGS=-Os -mno-outline-atomics" {ocaml-option-musl:installed & arch = "arm64"}
+    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.3.0-beta1.tar.gz"
+  checksum: "sha256=c42294320b19dfc499382668d1b62a6b565b1fc17ed3317d9ebd2e6d159b31c1"
+}
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-no-compression"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+  "ocaml-option-tsan"
+]
+extra-source "ocaml-compiler.install" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/ocaml/899b8f3bece45f55161dad72eaa223c2bb7202e8/ocaml-variants.install"
+  checksum: [
+    "sha256=7af3dc34e6f9f3be2ffd8d32cd64fa650d6a036c86c4821a7033d24a90fba11c"
+    "md5=781ea69255fd0cb643a9617ff56fd6ba"
+  ]
+}

--- a/packages/ocaml-variants/ocaml-variants.5.3.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0~beta1+options/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First beta release of OCaml 5.3.0"
+maintainer: [
+  "David Allsopp <david@tarides.com>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.3"
+depends: [
+  "ocaml-compiler" {= "5.3.0~beta1"}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]


### PR DESCRIPTION
This PR adds three packages for the first beta release of OCaml 5.3.0:

- the usual `ocaml-base--compiler` and `ocaml-variants` packages
- the newish `ocaml-compiler` package

Compared to the first alpha, this beta includes 3  runtime fixes, 2 type system fix and a handful numbers of fixes for the runtime event library. This beta also adds a new `-keywords` compatibility flag in order to help compiling old code that are using the new keyword  `effect` as a standard identifier. 

-----------------------
Changes compared to the first alpha:

Runtime bug fixes
-----------------
- (13502): Fix misindexing related to `Gc.finalise_last` that could prevent
  finalisers from being run.
  (Nick Roberts, review by Mark Shinwell)

- (13402), (13512), (13549), (13553): Revise bytecode implementation of callbacks
  so that it no longer produces dangling registered bytecode fragments.
  (Xavier Leroy, report by Jan Midtgaard, analysis by Stephen Dolan,
   review by Miod Vallat)

- (13520): Fix compilation of native-code version of systhreads. Bytecode fields
  were being included in the thread descriptors.
  (David Allsopp, review by Sébastien Hinderer and Miod Vallat)

Type system bug fixes
---------------------
- (13579), (13583): Unsoundness involving non-injective types + gadts
  (Jacques Garrigue, report by @v-gb,
   review by Richard Eisenberg and Florian Angeletti)

- (13388), (13540): raises an error message (and not an internal compiler error)
  when two local substitutions are incompatible (for instance `module type
  S:=sig end type t:=(module S)`)
  (Florian Angeletti, report by Nailen Matschke, review by Gabriel Scherer, and
  Leo White)

Compiler CLI
------------

- (13471): add `-keywords <version?+list>` flag to define the list of keywords
  recognized by the lexer, for instance `-keywords 5.2` disable the `effect`
  keyword.
  (Florian Angeletti, review by Gabriel Scherer)

Runtime event library fixes
-------------------------

- (13419): Fix memory bugs in runtime events system.
  (B. Szilvasy and Nick Barnes, review by Miod Vallat, Nick Barnes,
   Tim McGilchrist, and Gabriel Scherer)

- (13407): Add Runtime_events.EV_EMPTY_MINOR
  (Thomas Leonard)

- (13522): Confirm runtime events ring is still active after callback.
  (KC Sivaramakrishnan, review by Sadiq Jaffer and Miod Vallat)

- (13529): Do not write to event ring after going out of stw participant set.
  (KC Sivaramakrishnan, review by Sadiq Jaffer)

Documentation
-------------

- (13424): Fix `Gc.quick_stat` documentation to clarify that returned fields
  `live_words`, `live_blocks`, `free_words`, and `fragments` are not zero.
  (Jan Midtgaard, review by Damien Doligez and KC Sivaramakrishnan)

- (13440): Update documentation of `Gc.{control,get,set}` to reflect fields
  not currently supported on OCaml 5.
  (Jan Midtgaard, review by Gabriel Scherer)

- (13469), (13474), (13535): Document that [Hashtbl.create n] creates a hash table
  with a default minimal size, even if [n] is very small or negative.
  (Antonin Décimo, Nick Bares, report by Nikolaus Huber and Jan Midtgaard,
   review by Florian Angeletti, Anil Madhavapeddy, Gabriel Scherer,
   and Miod Vallat)

Standard library internal fix
------------------------------

- (13543): Remove some String-Bytes conversion from the stdlib to behave better
  with js_of_ocaml
  (Hugo Heuzard, review by Gabriel Scherer)


Toplevel bug fix
---------------

- (13263), (13560): fix printing true and false in toplevel and error
  messages (no more unexpected \#true)
  (Florian Angeletti, report by Samuel Vivien, review by Gabriel Scherer)

Compiler internals
------------------

- (13391), (13551): fix a printing bug with `-dsource` when using
  raw literal inside a locally abstract type constraint
  (i.e. `let f: type \#for. ... `)
  (Florian Angeletti, report by Nick Roberts, review by Richard Eisenberg)

