### PR TITLE
Older datalog versions FTBFS on newer OCaml

### DIFF
--- a/packages/datalog/datalog.0.1/opam
+++ b/packages/datalog/datalog.0.1/opam
@@ -7,7 +7,7 @@ remove: [
   ["rm" "%{bin}%/datalog_cli"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.1"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/datalog/datalog.0.1/opam
+++ b/packages/datalog/datalog.0.1/opam
@@ -1,6 +1,9 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
+authors: ["Simon Cruanes"]
 homepage: "https://github.com/c-cube/datalog"
+bug-reports: "https://github.com/c-cube/datalog/issues"
+license: "BSD-2-Clause"
 build: make
 remove: [
   ["ocamlfind" "remove" "datalog"]
@@ -13,7 +16,7 @@ depends: [
 ]
 dev-repo: "git+https://github.com/c-cube/datalog"
 install: [make "BINDIR=%{bin}%" "install"]
-synopsis: "An in-memory datalog implementation for OCaml."
+synopsis: "An in-memory datalog implementation for OCaml"
 description: """
 It focuses on big sets of rules with small relations, with frequent updates of
 the relations. Therefore, it tries to achieve good behavior in presence of

--- a/packages/datalog/datalog.0.1/opam
+++ b/packages/datalog/datalog.0.1/opam
@@ -29,3 +29,4 @@ url {
     "md5=9d4cc94bb277665c41d2319ab14ec6ce"
   ]
 }
+available: arch != "arm32" & arch != "x86_32"

--- a/packages/datalog/datalog.0.2/opam
+++ b/packages/datalog/datalog.0.2/opam
@@ -7,7 +7,7 @@ remove: [
   ["rm" "%{bin}%/datalog_cli"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.1"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/datalog/datalog.0.2/opam
+++ b/packages/datalog/datalog.0.2/opam
@@ -1,6 +1,9 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
+authors: ["Simon Cruanes"]
 homepage: "https://github.com/c-cube/datalog"
+bug-reports: "https://github.com/c-cube/datalog/issues"
+license: "BSD-2-Clause"
 build: make
 remove: [
   ["ocamlfind" "remove" "datalog"]
@@ -13,7 +16,7 @@ depends: [
 ]
 dev-repo: "git+https://github.com/c-cube/datalog"
 install: [make "BINDIR=%{bin}%" "install"]
-synopsis: "An in-memory datalog implementation for OCaml."
+synopsis: "An in-memory datalog implementation for OCaml"
 description: """
 It focuses on big sets of rules with small relations, with frequent updates of
 the relations. Therefore, it tries to achieve good behavior in presence of

--- a/packages/datalog/datalog.0.3.1/opam
+++ b/packages/datalog/datalog.0.3.1/opam
@@ -7,7 +7,7 @@ remove: [
   ["rm" "%{bin}%/datalog_cli"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.1"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/datalog/datalog.0.3.1/opam
+++ b/packages/datalog/datalog.0.3.1/opam
@@ -1,6 +1,9 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
+authors: ["Simon Cruanes"]
 homepage: "https://github.com/c-cube/datalog"
+bug-reports: "https://github.com/c-cube/datalog/issues"
+license: "BSD-2-Clause"
 build: make
 remove: [
   ["ocamlfind" "remove" "datalog"]
@@ -13,7 +16,7 @@ depends: [
 ]
 dev-repo: "git+https://github.com/c-cube/datalog"
 install: [make "BINDIR=%{bin}%" "install"]
-synopsis: "An in-memory datalog implementation for OCaml."
+synopsis: "An in-memory datalog implementation for OCaml"
 description: """
 It focuses on big sets of rules with small relations, with frequent updates of
 the relations. Therefore, it tries to achieve good behavior in presence of

--- a/packages/datalog/datalog.0.3/opam
+++ b/packages/datalog/datalog.0.3/opam
@@ -7,7 +7,7 @@ remove: [
   ["rm" "%{bin}%/datalog_cli"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.1"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/datalog/datalog.0.3/opam
+++ b/packages/datalog/datalog.0.3/opam
@@ -1,6 +1,9 @@
 opam-version: "2.0"
 maintainer: "simon.cruanes@inria.fr"
+authors: ["Simon Cruanes"]
 homepage: "https://github.com/c-cube/datalog"
+bug-reports: "https://github.com/c-cube/datalog/issues"
+license: "BSD-2-Clause"
 build: make
 remove: [
   ["ocamlfind" "remove" "datalog"]
@@ -13,7 +16,7 @@ depends: [
 ]
 dev-repo: "git+https://github.com/c-cube/datalog"
 install: [make "BINDIR=%{bin}%" "install"]
-synopsis: "An in-memory datalog implementation for OCaml."
+synopsis: "An in-memory datalog implementation for OCaml"
 description: """
 It focuses on big sets of rules with small relations, with frequent updates of
 the relations. Therefore, it tries to achieve good behavior in presence of


### PR DESCRIPTION
Something about how it is built is wrong, a mix of `-for-pack` and not `-for-pack` causes it to fail:

```
File "datalog_cli.ml", line 1:
Error: "datalog/lexer.cmx" was built with "-for-pack Datalog", but the
       current unit "Datalog_cli" is not
Command exited with code 2.
```

This seems to work on 4.14 and 5.0, but not on 5.1. Newer versions of Datalog that use Dune don't seem to be affected.

[Example of failing build](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/ed800ba87cfbe293bcb59dfb40db5252bc65f6f5/variant/compilers,5.2,dune-configurator.3.16.1,revdeps,datalog.0.1).