### PR TITLE
Package coq-waterproof.2.2.0+8.17

### DIFF
--- a/packages/coq-waterproof/coq-waterproof.2.2.0+8.17/opam
+++ b/packages/coq-waterproof/coq-waterproof.2.2.0+8.17/opam
@@ -31,7 +31,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs "@install"]
 ]
 
-available: arch != "s390x"
+available: (arch != "s390x") & (arch != "ppc64") & (os != "win")
 
 tags: [
   "keyword:mathematics education"

--- a/packages/coq-waterproof/coq-waterproof.2.2.0+8.17/opam
+++ b/packages/coq-waterproof/coq-waterproof.2.2.0+8.17/opam
@@ -31,7 +31,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs "@install"]
 ]
 
-available: (arch != "s390x") & (arch != "ppc64") & (os != "win")
+available: (arch != "s390x") & (arch != "ppc64") & (os != "win32")
 
 tags: [
   "keyword:mathematics education"

--- a/packages/coq-waterproof/coq-waterproof.2.2.0+8.17/opam
+++ b/packages/coq-waterproof/coq-waterproof.2.2.0+8.17/opam
@@ -24,7 +24,7 @@ bug-reports: "https://github.com/impermeable/coq-waterproof/issues"
 depends: [
   "ocaml" {>= "4.09.0"}
   "coq" {>= "8.17" & < "8.18"}
-  "dune" {>= "3.6."}
+  "dune" {>= "3.6"}
 ]
 
 build: [

--- a/packages/coq-waterproof/coq-waterproof.2.2.0+8.17/opam
+++ b/packages/coq-waterproof/coq-waterproof.2.2.0+8.17/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Jim Portegies <j.w.portegies@tue.nl>"
+authors: [
+  "Jelle Wemmenhove"
+  "Pim Otte"
+  "Balthazar Pathiachvili"
+  "Cosmin Manea"
+  "Lulof Pirée"
+  "Adrian Vrămuleţ"
+  "Tudor Voicu"
+  "Jim Portegies <j.w.portegies@tue.nl>"
+]
+
+synopsis: "Coq proofs in a style that resembles non-mechanized mathematical proofs"
+description: """
+The Waterproof plugin for the Coq proof assistant allows you to write Coq proofs in a style that resembles handwritten mathematical proofs, designed to help university students with learning how to prove mathematical statements.
+"""
+
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/impermeable/coq-waterproof"
+dev-repo: "git+https://github.com/impermeable/coq-waterproof.git"
+bug-reports: "https://github.com/impermeable/coq-waterproof/issues"
+
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "coq" {>= "8.17" & < "8.18"}
+  "dune" {>= "3.6."}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install"]
+]
+
+available: arch != "s390x"
+
+tags: [
+  "keyword:mathematics education"
+  "category:Mathematics/Education"
+  "date:2023-11-04"
+  "logpath:Waterproof"
+]
+url {
+  src:
+    "https://github.com/impermeable/coq-waterproof/archive/refs/tags/2.2.0+8.17.tar.gz"
+  checksum: [
+    "md5=cd4867e94e20eba727bd6deea06130cd"
+    "sha512=1205227101bb30f3e8c4ec05217920dcda1e3631ecd0428f2ac820c9a2811f91526d68623aaf01dd9aa1e81e8adfc083af01152d7f7a6e48894caa829bc3f440"
+  ]
+}


### PR DESCRIPTION
### `coq-waterproof.2.2.0+8.17`
Coq proofs in a style that resembles non-mechanized mathematical proofs
The Waterproof plugin for the Coq proof assistant allows you to write Coq proofs in a style that resembles handwritten mathematical proofs, designed to help university students with learning how to prove mathematical statements.



---
* Homepage: https://github.com/impermeable/coq-waterproof
* Source repo: git+https://github.com/impermeable/coq-waterproof.git
* Bug tracker: https://github.com/impermeable/coq-waterproof/issues

---
:camel: Pull-request generated by opam-publish v2.2.0