### PR TITLE
Mark libev as unavailable on Windows

### DIFF
--- a/packages/conf-libev/conf-libev.4-12/opam
+++ b/packages/conf-libev/conf-libev.4-12/opam
@@ -28,6 +28,7 @@ Libev is modelled (very loosely) after libevent and the Event perl
 module, but is faster, scales better and is more correct, and also more
 featureful. And also smaller. Yay."""
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+available: os != "win32"
 flags: conf
 extra-source "discover.ml" {
   src:


### PR DESCRIPTION
`libev` is not available on Windows.  This PR matches the PR on `opam-repository-mingw` which applied the same change.  See https://github.com/ocaml-opam/opam-repository-mingw/commit/03b8a56036d0d12e03170cf58dce075b86589168#diff-d28ffb310327cc64ce95568cfcd7500d60b3226603a1306ff207c18d9ec39a89R34