### PR TITLE
[new release] postgresql (5.1.0)

### DIFF
--- a/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
+++ b/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "postgresql for i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of postgresql for the mingw-w64 project is available"
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "Markus Mottl"
+license: "blessing"
+homepage: "http://www.postgresql.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32"
+build: ["pkgconf" "--personality=i686-w64-mingw32" "postgresql"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-i686" {build}
+]
+depexts: [
+  ["mingw64-i686-postgresql"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-i686-postgresql"] {os = "win32" & os-distribution = "msys2"}
+]

--- a/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
+++ b/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "postgresql for i686 mingw-w64 (32-bit x86)"
+synopsis: "Postgresql for i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of postgresql for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: "Markus Mottl"

--- a/packages/conf-mingw-w64-postgresql-x86_64/conf-mingw-w64-postgresql-x86_64.1/opam
+++ b/packages/conf-mingw-w64-postgresql-x86_64/conf-mingw-w64-postgresql-x86_64.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "postgresql for x86_64 mingw-w64 (64-bit x86_64)"
+synopsis: "Postgresql for x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of postgresql for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: "Markus Mottl"

--- a/packages/conf-mingw-w64-postgresql-x86_64/conf-mingw-w64-postgresql-x86_64.1/opam
+++ b/packages/conf-mingw-w64-postgresql-x86_64/conf-mingw-w64-postgresql-x86_64.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "postgresql for x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of postgresql for the mingw-w64 project is available"
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "Markus Mottl"
+license: "blessing"
+homepage: "http://www.postgresql.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32"
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" "postgresql"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-x86_64" {build}
+]
+depexts: [
+  ["mingw64-x86_64-postgresql"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-x86_64-postgresql"] {os = "win32" & os-distribution = "msys2"}
+]

--- a/packages/conf-postgresql/conf-postgresql.2/opam
+++ b/packages/conf-postgresql/conf-postgresql.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+authors: "Markus Mottl <markus.mottl@gmail.com>"
+homepage: "https://www.postgresql.org"
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+license: "blessing"
+build: [
+  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution != "cygwin"}
+  "libpq"]
+]
+depends: [
+  "conf-pkg-config" {build}
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-postgresql-i686" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-postgresql-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+]
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+
+depexts: [
+  ["libpq-dev"] {os-family = "debian"}
+  ["libpq-dev"] {os-family = "ubuntu"}
+  ["libpq-devel"] {os-distribution = "centos" & os-version >= "8"}
+  ["libpq-devel"] {os-distribution = "rhel" & os-version >= "8"}
+  ["libpq-devel"] {os-distribution = "ol" & os-version >= "8"}
+  ["libpq-devel"] {os-distribution = "fedora" & os-version >= "30"}
+  ["postgresql15-client"] {os-distribution = "freebsd" & os-version >= "13"}
+  ["postgresql96-client"] {os-distribution = "freebsd" & os-version < "13"}
+  ["postgresql96-client"] {os-distribution = "openbsd"}
+  ["postgresql-devel"] {os-distribution = "centos" & os-version < "8"}
+  ["postgresql-devel"] {os-distribution = "rhel" & os-version < "8"}
+  ["postgresql-devel"] {os-distribution = "ol" & os-version < "8"}
+  ["postgresql-devel"] {os-distribution = "fedora" & os-version < "30"}
+  ["postgresql-server-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["postgresql-dev"] {os-distribution = "alpine" & os-version < "3.15"}
+  ["postgresql14-dev"] {os-distribution = "alpine" & os-version >= "3.15"}
+  ["postgresql"] {os = "win32" & os-distribution = "cygwinports"}
+  ["postgresql-libs"] {os-family = "arch"}
+  ["libpq"] {os = "macos" & os-distribution = "homebrew"}
+  ["postgresql96"] {os = "macos" & os-distribution = "macports"}
+  ["postgresql"] {os-distribution = "nixos"}
+]
+post-messages: [
+  """If this package failed with "Command not found: pg_config", you might need to call "brew link postgresql@15" and retry to install this package afterwards.""" {failure & os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "Virtual package relying on a PostgreSQL system installation"
+description:
+  "This package can only install if PostgreSQL is installed on the system."
+flags: conf

--- a/packages/postgresql/postgresql.5.1.0/opam
+++ b/packages/postgresql/postgresql.5.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Bindings to the PostgreSQL library"
+description:
+  "Postgresql offers library functions for accessing PostgreSQL databases."
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "dune-configurator"
+  "conf-postgresql" {build}
+  "base-bytes"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/postgresql-ocaml/releases/download/5.1.0/postgresql-5.1.0.tbz"
+  checksum: [
+    "sha256=7f8ab728833529f16108a6c120ebb3012a57f4ecd9465fea8a9aee5783b1168b"
+    "sha512=2afa90243f489db64a30dc7c4866d4e06d7d8987718d27255c6e0cd5aae66bea567f1ef5b09e5384b40f21990657bde44faea0c214a97cf51a4216b3a943dd24"
+  ]
+}
+x-commit-hash: "177cc25b1630664bd94efa8371c5d8843189e085"


### PR DESCRIPTION
Bindings to the PostgreSQL library

- Project page: <a href="https://mmottl.github.io/postgresql-ocaml">https://mmottl.github.io/postgresql-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/postgresql-ocaml/api">https://mmottl.github.io/postgresql-ocaml/api</a>

##### CHANGES:

- Made Postgresql.null a now unique, empty string.

- Fixed license format and a typo.

- Fixed some odoc references.

- Added GitHub workflows.

- Added automatic formatting with ocamlformat and clang-format.

- Ported the config discovery script to pkg-config

  Thanks to Antonio Nuno Monteiro for the patch.

- Improved Dune rules.

- Used new OCaml 4.12 C-macros.

- Switched to Dune lang 2.7.
