### PR TITLE
2 packages from bcpierce00/unison at 2.53.6

### DIFF
--- a/packages/unison-gui/unison-gui.2.53.6/opam
+++ b/packages/unison-gui/unison-gui.2.53.6/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "unison-hackers@lists.seas.upenn.edu"
+authors: [
+  "Trevor Jim"
+  "Benjamin C. Pierce"
+  "Jérôme Vouillon"
+]
+license: "GPL-3.0-or-later"
+homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
+bug-reports: "https://github.com/bcpierce00/unison/issues"
+dev-repo: "git://github.com/bcpierce00/unison.git"
+depends: [
+  "unison" {= version}
+  "lablgtk3"
+  "ocamlfind"
+]
+synopsis: "Pseudo-package for Unison GUI"
+description: """
+Unison is a file-synchronization tool for Unix and Windows. It allows
+two replicas of a collection of files and directories to be stored on
+different hosts (or different disks on the same host), modified
+separately, and then brought up to date by propagating the changes in
+each replica to the other."""
+url {
+  src:
+    "https://github.com/bcpierce00/unison/archive/refs/tags/v2.53.6.tar.gz"
+  checksum: [
+    "md5=8329a8b09ece728c350e02c808db7d60"
+    "sha512=1bd696eb82d489cbcef3d01426a565943957062f35f2ba17e62c984f30b7ca1e6173274db456014c44943c0e3c07c1d727855e8aae2fd42b67af6f1cd814a7c1"
+  ]
+}

--- a/packages/unison/unison.2.53.6/opam
+++ b/packages/unison/unison.2.53.6/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "unison-hackers@lists.seas.upenn.edu"
+authors: [
+  "Trevor Jim"
+  "Benjamin C. Pierce"
+  "Jérôme Vouillon"
+]
+license: "GPL-3.0-or-later"
+homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
+bug-reports: "https://github.com/bcpierce00/unison/issues"
+dev-repo: "git://github.com/bcpierce00/unison.git"
+build: [make "NATIVE=%{ocaml:native}%" "-j" jobs]
+install: [make "NATIVE=%{ocaml:native}%" "PREFIX=%{prefix}%" "install"]
+depends: [
+  "ocaml" {>= "4.08"}
+]
+depopts: [
+  "lablgtk3" {>= "3.1.0"}
+  "ocamlfind"
+]
+synopsis: "File-synchronization tool for Unix and Windows"
+description: """
+Unison is a file-synchronization tool for Unix and Windows. It allows
+two replicas of a collection of files and directories to be stored on
+different hosts (or different disks on the same host), modified
+separately, and then brought up to date by propagating the changes in
+each replica to the other."""
+url {
+  src:
+    "https://github.com/bcpierce00/unison/archive/refs/tags/v2.53.6.tar.gz"
+  checksum: [
+    "md5=8329a8b09ece728c350e02c808db7d60"
+    "sha512=1bd696eb82d489cbcef3d01426a565943957062f35f2ba17e62c984f30b7ca1e6173274db456014c44943c0e3c07c1d727855e8aae2fd42b67af6f1cd814a7c1"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `unison.2.53.6`: File-synchronization tool for Unix and Windows
- `unison-gui.2.53.6`: Pseudo-package for Unison GUI



---
* Homepage: https://www.cis.upenn.edu/~bcpierce/unison/
* Source repo: git://github.com/bcpierce00/unison.git
* Bug tracker: https://github.com/bcpierce00/unison/issues

---
:camel: Pull-request generated by opam-publish v2.3.0