### PR TITLE
[new release] http-lwt-client (0.3.1)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.3.1/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.3.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/http-lwt-client"
+dev-repo: "git+https://github.com/robur-coop/http-lwt-client.git"
+bug-reports: "https://github.com/robur-coop/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "lwt"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "1.0.0"}
+  "tls-lwt" {>= "1.0.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.10.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/robur-coop/http-lwt-client/releases/download/v0.3.1/http-lwt-client-0.3.1.tbz"
+  checksum: [
+    "sha256=8b9037b5ba757088783e4b831741112bed37d40a0c6707976cbb46e9ca8f344a"
+    "sha512=afe726b4c1d3f41e75062c8d4728272180f959dfe9f4654ca04ee520b6885ecc0b4a7c25ac5929e04335914fbf7c827846427ad277f19a69366672971537bb72"
+  ]
+}
+x-commit-hash: "7e91ce1166cf4222a4c5aa9e3b1a0847c158b2d9"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/robur-coop/http-lwt-client">https://github.com/robur-coop/http-lwt-client</a>

##### CHANGES:

* Body of a redirect is skipped ([f] is not called with the body) (robur-coop/http-lwt-client#26 @hannesm)
* hurl: --output must be a non-existing file (robur-coop/http-lwt-client#26 @hannesm)
