### PR TITLE
2 packages from bcpierce00/unison at 2.53.7

### DIFF
--- a/packages/unison-gui/unison-gui.2.53.7/opam
+++ b/packages/unison-gui/unison-gui.2.53.7/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "unison-hackers@lists.seas.upenn.edu"
+authors: [
+  "Trevor Jim"
+  "Benjamin C. Pierce"
+  "Jérôme Vouillon"
+]
+license: "GPL-3.0-or-later"
+homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
+bug-reports: "https://github.com/bcpierce00/unison/issues"
+dev-repo: "git://github.com/bcpierce00/unison.git"
+depends: [
+  "unison" {= version}
+  "lablgtk3"
+  "ocamlfind"
+]
+synopsis: "Pseudo-package for Unison GUI"
+description: """
+Unison is a file-synchronization tool for Unix and Windows. It allows
+two replicas of a collection of files and directories to be stored on
+different hosts (or different disks on the same host), modified
+separately, and then brought up to date by propagating the changes in
+each replica to the other."""
+url {
+  src:
+    "https://github.com/bcpierce00/unison/archive/refs/tags/v2.53.7.tar.gz"
+  checksum: [
+    "md5=e49a78c1e159d4d2315fb5264c83ed59"
+    "sha512=11bd1d2792fb84fa2b29426516d7b91a2295febcb84052118d492a29d9ddaa23265b66cc88113019ec6782f3edcf596f7a37c8637e673b2928188248b9d63d60"
+  ]
+}

--- a/packages/unison/unison.2.53.7/opam
+++ b/packages/unison/unison.2.53.7/opam
@@ -11,6 +11,7 @@ bug-reports: "https://github.com/bcpierce00/unison/issues"
 dev-repo: "git://github.com/bcpierce00/unison.git"
 build: [make "NATIVE=%{ocaml:native}%" "-j" jobs]
 install: [make "NATIVE=%{ocaml:native}%" "PREFIX=%{prefix}%" "install"]
+available: os != "win32"
 depends: [
   "ocaml" {>= "4.08"}
 ]

--- a/packages/unison/unison.2.53.7/opam
+++ b/packages/unison/unison.2.53.7/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "unison-hackers@lists.seas.upenn.edu"
+authors: [
+  "Trevor Jim"
+  "Benjamin C. Pierce"
+  "Jérôme Vouillon"
+]
+license: "GPL-3.0-or-later"
+homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
+bug-reports: "https://github.com/bcpierce00/unison/issues"
+dev-repo: "git://github.com/bcpierce00/unison.git"
+build: [make "NATIVE=%{ocaml:native}%" "-j" jobs]
+install: [make "NATIVE=%{ocaml:native}%" "PREFIX=%{prefix}%" "install"]
+depends: [
+  "ocaml" {>= "4.08"}
+]
+depopts: [
+  "lablgtk3" {>= "3.1.0"}
+  "ocamlfind"
+]
+synopsis: "File-synchronization tool for Unix and Windows"
+description: """
+Unison is a file-synchronization tool for Unix and Windows. It allows
+two replicas of a collection of files and directories to be stored on
+different hosts (or different disks on the same host), modified
+separately, and then brought up to date by propagating the changes in
+each replica to the other."""
+url {
+  src:
+    "https://github.com/bcpierce00/unison/archive/refs/tags/v2.53.7.tar.gz"
+  checksum: [
+    "md5=e49a78c1e159d4d2315fb5264c83ed59"
+    "sha512=11bd1d2792fb84fa2b29426516d7b91a2295febcb84052118d492a29d9ddaa23265b66cc88113019ec6782f3edcf596f7a37c8637e673b2928188248b9d63d60"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `unison.2.53.7`: File-synchronization tool for Unix and Windows
- `unison-gui.2.53.7`: Pseudo-package for Unison GUI



---
* Homepage: https://www.cis.upenn.edu/~bcpierce/unison/
* Source repo: git://github.com/bcpierce00/unison.git
* Bug tracker: https://github.com/bcpierce00/unison/issues

---
:camel: Pull-request generated by opam-publish v2.3.0