### PR TITLE
[new release] mirage-solo5 (0.9.4)

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.9.4/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.9.4/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-solo5"
+bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-solo5.git"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {>= "2.7.0"}
+  "bheap" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "2.4.3"}
+  "metrics"
+  "metrics-lwt" {>= "0.2.0"}
+  "mirage-runtime" {>= "4.0"}
+  "duration"
+]
+conflicts: [
+  "io-page" {< "2.4.0"}
+  "tcpip" {< "6.1.0"}
+]
+synopsis: "Solo5 core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+[Solo5](https://github.com/Solo5/solo5) targets, which handles the main loop
+and timers. It also provides the low level C startup code and C stubs required
+by the OCaml code.
+
+Currently this package also includes the C stubs used by the Solo5 `console`,
+`block` and `net` implementations.
+
+The OCaml runtime and C runtime required to support it are provided separately
+by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-solo5/releases/download/v0.9.4/mirage-solo5-0.9.4.tbz"
+  checksum: [
+    "sha256=6d83cd5a7112451e1af3aa420a3de66f9d0b13c761d908a3b1056da4a41503e4"
+    "sha512=6ad554629dce3a46bb1608576a2cd7777dd57a7f94b5c2f0df48641594ed4939279f272a8e2c78ab6f124bf2d970d9f8059325628d954e70dee09a52b5b7e59e"
+  ]
+}
+x-commit-hash: "6de2e38e0fa62e3dcef4d50467976257e91b9400"


### PR DESCRIPTION
Solo5 core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-solo5">https://github.com/mirage/mirage-solo5</a>

##### CHANGES:

* Remove dependency on cstruct (mirage/mirage-solo5#99 @palainp)
