### PR TITLE
[new release] dream-encoding (0.3.0)

### DIFF
--- a/packages/dream-encoding/dream-encoding.0.3.0/opam
+++ b/packages/dream-encoding/dream-encoding.0.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Encoding primitives for Dream"
+description: "Encoding primitives for Dream."
+maintainer: ["Thibaut Mattio"]
+authors: ["Thibaut Mattio"]
+license: "MIT"
+homepage: "https://github.com/tmattio/dream-encoding"
+doc: "https://tmattio.github.io/dream-encoding/"
+bug-reports: "https://github.com/tmattio/dream-encoding/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "dream" {>= "1.0.0~alpha3"}
+  "decompress" {>= "1.4.1"}
+  "lwt_ppx"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tmattio/dream-encoding.git"
+conflicts: [
+  "result" {< "1.5"} # Might use result through lwt and explicitly uses Result.bind 
+]
+url {
+  src:
+    "https://github.com/tmattio/dream-encoding/releases/download/0.3.0/dream-encoding-0.3.0.tbz"
+  checksum: [
+    "sha256=5778442d5d1e2cede3657151242fd2aac12176546fb76fc4d0a5181bd32605ef"
+    "sha512=085dfc2cd97ecb1cf94b84431639de3e394b315f728bac20590d22e4ce42be9536957dae641ad758d8637582f9853e4d5bfa1857620af596372bf172b6fe842a"
+  ]
+}
+x-commit-hash: "88fabc980ef5f6bcef813a0b39ef3d0aae7af6f2"


### PR DESCRIPTION
Encoding primitives for Dream

- Project page: <a href="https://github.com/tmattio/dream-encoding">https://github.com/tmattio/dream-encoding</a>
- Documentation: <a href="https://tmattio.github.io/dream-encoding/">https://tmattio.github.io/dream-encoding/</a>

##### CHANGES:

- Discard encoding with priority 0 (tmattio/dream-encoding#3 by @samoht)
- Use a sub_log and log at debug level (tmattio/dream-encoding#2 by @beajeanm)
