### PR TITLE
[new release] river (0.4)

### DIFF
--- a/packages/river/river.0.4/opam
+++ b/packages/river/river.0.4/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "RSS2 and Atom feed aggregator for OCaml"
+description: "RSS2 and Atom feed aggregator for OCaml"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "MIT"
+homepage: "https://github.com/tarides/river"
+doc: "https://tarides.github.io/river/"
+bug-reports: "https://github.com/tarides/river/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.0"}
+  "syndic" {>= "1.5"}
+  "cohttp" {>= "5.0.0"}
+  "cohttp-lwt" {>= "5.0.0"}
+  "cohttp-lwt-unix" {>= "5.0.0"}
+  "ptime"
+  "lwt"
+  "lambdasoup"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/river.git"
+url {
+  src: "https://github.com/tarides/river/releases/download/0.4/river-0.4.tbz"
+  checksum: [
+    "sha256=c11a290101c8b80cf3c482bf11f5be2a9de97e8b92d5859e12034358792dec51"
+    "sha512=7e53a3c339f2ff018a49026280d0833552b09c44df656633b49ed20a42709d1e559c2a8010c17681f479532d62c728840b71d34e973be6fc6b977f92bed15870"
+  ]
+}
+x-commit-hash: "4cbf56b9dc73f8c28ff9be708e4e28e07a2d23e2"


### PR DESCRIPTION
RSS2 and Atom feed aggregator for OCaml

- Project page: <a href="https://github.com/tarides/river">https://github.com/tarides/river</a>
- Documentation: <a href="https://tarides.github.io/river/">https://tarides.github.io/river/</a>

##### CHANGES:

- Replace ocamlnet HTML parser with Lambda Soup (tarides/river#15, @aantron)
