### PR TITLE
Package catala-format.0.1.0

### DIFF
--- a/packages/catala-format/catala-format.0.1.0/opam
+++ b/packages/catala-format/catala-format.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "vincent.botbol@inria.fr"
+authors: [ "Vincent Botbol" ]
+
+homepage: "https://github.com/CatalaLang/catala-format"
+bug-reports: "https://github.com/CatalaLang/catala-format"
+dev-repo: "git+https://github.com/CatalaLang/catala-format.git"
+
+license: "Apache-2.0"
+depends: [
+  "topiary" {>= "0.3.0"}
+]
+
+build:[
+  [ "sh" "make-wrapper.sh"
+         "--query-file" "%{share}%/topiary/queries/catala.scm"
+         "--config-file" "%{share}%/topiary/configs/catala.ncl"
+         "--topiary-wrapped" "%{bin}%/.topiary-wrapped/topiary"
+         "--output-file" "catala-format" ]
+]
+
+install: [
+  [ "cp" "catala-format" "%{bin}%/catala-format" ]
+  [ "mkdir" "-p" "%{share}%/topiary/queries" ]
+  [ "cp" "catala.scm" "%{share}%/topiary/queries" ]
+  [ "mkdir" "-p" "%{share}%/topiary/configs" ]
+  [ "cp" "catala.ncl" "%{share}%/topiary/configs" ]
+]
+
+synopsis: "A formatter for Catala based on the Topiary universal formatting engine"
+description: """
+A formatter for Catala based on the Topiary universal formatting engine.
+
+Topiary repository: https://github.com/tweag/topiary
+"""
+url {
+  src:
+    "https://github.com/CatalaLang/catala-format/archive/refs/tags/catala-format.0.1.0.tar.gz"
+  checksum: [
+    "md5=69c85b554fcaf781b238175d705ed96a"
+    "sha512=ab52a31158c55289f5b22abcd529e7589161977c8890f16826a2024b8cd4e9c91996752ea157a8388f13a75123eedb609530b2508710df7575ee6d79553753c9"
+  ]
+}


### PR DESCRIPTION
### `catala-format.0.1.0`
A formatter for Catala based on the Topiary universal formatting engine

Topiary repository: https://github.com/tweag/topiary



---
* Homepage: https://github.com/CatalaLang/catala-format
* Source repo: git+https://github.com/CatalaLang/catala-format.git
* Bug tracker: https://github.com/CatalaLang/catala-format

---
:camel: Pull-request generated by opam-publish v2.3.0