### PR TITLE
Package ocsigen-toolkit.4.1.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.4.1.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.4.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+available: arch != "x86_32" & arch != "arm32"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "js_of_ocaml" {>= "5.5.0"}
+  "eliom" {>= "11.0.0"}
+  "calendar" {>= "2.0.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsigen-toolkit/archive/refs/tags/4.1.0.tar.gz"
+  checksum: [
+    "md5=d6690304b1fec1d84edf9c806609e581"
+    "sha512=d4686cf9305fb79b03628380b247c9478e9864d25c7d1895c89cef6dc179fe1b506135c7a7bb4ca58451b25c965f0e96374ed040444c4e53e9e368fd9197b26c"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.4.1.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.3.0