### PR TITLE
[new release] earlybird (1.3.3)

### DIFF
--- a/packages/earlybird/earlybird.1.3.2/opam
+++ b/packages/earlybird/earlybird.1.3.2/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
 depends: [
   "dune" {>= "3.7"}
   "ocaml" {>= "4.12.0"}
-  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving" {>= "5.1" & < "5.3"}
   "ppx_deriving_yojson" {>= "3.6.1"}
   "menhir" {>= "20201216" & build}
   "menhirLib" {>= "20201216"}

--- a/packages/earlybird/earlybird.1.3.2/opam
+++ b/packages/earlybird/earlybird.1.3.2/opam
@@ -6,7 +6,7 @@ license: "MIT"
 homepage: "https://github.com/hackwaly/ocamlearlybird"
 bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
 depends: [
-  "dune" {>= "3.7"}
+  "dune" {>= "2.8"}
   "ocaml" {>= "4.12.0"}
   "ppx_deriving" {>= "5.1" & < "5.3"}
   "ppx_deriving_yojson" {>= "3.6.1"}

--- a/packages/earlybird/earlybird.1.3.3/opam
+++ b/packages/earlybird/earlybird.1.3.3/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "OCaml debug adapter"
+maintainer: ["Simmo Saan <simmo.saan@gmail.com>"]
+authors: ["hackwaly@qq.com"]
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.12.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "menhir" {>= "20201216" & build}
+  "menhirLib" {>= "20201216"}
+  "ocaml-compiler-libs" {>= "v0.12.3"}
+  "ppx_optcomp" {>= "v0.11"}
+  "iter" {>= "1.2.1"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.1"}
+  "lwt_react" {>= "1.1.3"}
+  "cmdliner" {>= "1.1.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "path_glob" {>= "0.2"}
+  "sexplib" {>= "v0.14.0"}
+  "csexp" {>= "1.3.2"}
+  "lru" {>= "0.3.0"}
+  "dap" {>= "1.0.6"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hackwaly/ocamlearlybird.git"
+url {
+  src:
+    "https://github.com/hackwaly/ocamlearlybird/releases/download/1.3.3/earlybird-1.3.3.tbz"
+  checksum: [
+    "sha256=f0861b655d79f5d982a5bbf1db7fa2bddeeccb4903f622783a9b6d534dc63ae9"
+    "sha512=df95c16b533883eddda30143ef372c133caa43f3b1d2f382402bd335cf8f685c8089ba2f2a60d9c557ede2900145c6c5a0a7688384730b47cc874835e3486095"
+  ]
+}
+x-commit-hash: "0292ccfe9f602c542362f082a83259368cf5d92d"


### PR DESCRIPTION
OCaml debug adapter

- Project page: <a href="https://github.com/hackwaly/ocamlearlybird">https://github.com/hackwaly/ocamlearlybird</a>

##### CHANGES:

### Added

* Add OCaml 5.3 support (hackwaly/ocamlearlybird#73).
