### PR TITLE
Package malfunction.0.7

### DIFF
--- a/packages/malfunction/malfunction.0.7/opam
+++ b/packages/malfunction/malfunction.0.7/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "sdolan@janestreet.com"
+authors: ["Stephen Dolan"]
+homepage: "https://github.com/stedolan/malfunction"
+bug-reports: "https://github.com/stedolan/malfunction/issues"
+dev-repo: "git+https://github.com/stedolan/malfunction.git"
+license: "LGPL-2.0-or-later"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+conflicts: [ "ocaml-option-bytecode-only" ]
+depends: [
+  "ocaml" {>= "4.08" & < "5.4"}
+  "ocamlfind"
+  "dune" {>= "2.9.1"}
+  "cppo" {build}
+  "omd" {with-test & >= "2.0.0~"}
+  "zarith"
+]
+synopsis: "Compiler back-end for functional languages, based on OCaml"
+description: """
+Malfunction is a high-performance, low-level untyped program
+representation, designed as a target for compilers of functional
+programming languages."""
+url {
+  src:
+    "https://github.com/stedolan/malfunction/archive/refs/tags/v0.7.tar.gz"
+  checksum: [
+    "md5=e39bddf91323cccb979b525c8a994f3a"
+    "sha512=244346b3094d7cd6bffc02208d503bae1a2a6a7e99dee21a51c42bd458250e36ac6ec9832b4cc78447caf1249e4225a8d88b4dbb7b5ed4d340dc5073c65034f2"
+  ]
+}


### PR DESCRIPTION
### `malfunction.0.7`
> Compiler back-end for functional languages, based on OCaml
> Malfunction is a high-performance, low-level untyped program
> representation, designed as a target for compilers of functional
> programming languages.

(From this version onwards, I've started putting explicit upper bounds on `ocaml` in the opam file from release - Malfunction is extremely unlikely to ever work with an untested OCaml version since it uses so much of compiler-libs)