### PR TITLE
Package ocamlfind.1.9.7

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.9.7/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.7/opam
@@ -1,11 +1,12 @@
 opam-version: "2.0"
 synopsis: "A library manager for OCaml"
-description: """\
+description: """
 Findlib is a library manager for OCaml. It provides a convention how
 to store libraries, and a file format ("META") to describe the
 properties of libraries. There is also a tool (ocamlfind) for
 interpreting the META files, so that it is very easy to use libraries
-in programs and scripts."""
+in programs and scripts.
+"""
 maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
 authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 license: "MIT"
@@ -18,16 +19,11 @@ depopts: ["graphics"]
 build: [
   [
     "./configure"
-    "-bindir"
-    bin
-    "-sitelib"
-    lib
-    "-mandir"
-    man
-    "-config"
-    "%{lib}%/findlib.conf"
-    "-with-relative-paths-at"
-    prefix
+    "-bindir" bin
+    "-sitelib" lib
+    "-mandir" man
+    "-config" "%{lib}%/findlib.conf"
+    "-with-relative-paths-at" prefix
     "-no-custom"
     "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}

--- a/packages/ocamlfind/ocamlfind.1.9.7/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.7/opam
@@ -23,7 +23,6 @@ build: [
     "-sitelib" lib
     "-mandir" man
     "-config" "%{lib}%/findlib.conf"
-    "-with-relative-paths-at" prefix
     "-no-custom"
     "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}

--- a/packages/ocamlfind/ocamlfind.1.9.7/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.7/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "A library manager for OCaml"
+description: """\
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts."""
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+license: "MIT"
+homepage: "http://projects.camlcity.org/projects/findlib.html"
+bug-reports: "https://github.com/ocaml/ocamlfind/issues"
+depends: [
+  "ocaml" {>= "3.08.0"}
+]
+depopts: ["graphics"]
+build: [
+  [
+    "./configure"
+    "-bindir"
+    bin
+    "-sitelib"
+    lib
+    "-mandir"
+    man
+    "-config"
+    "%{lib}%/findlib.conf"
+    "-with-relative-paths-at"
+    prefix
+    "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
+    "-no-topfind" {ocaml:preinstalled}
+  ]
+  [make "all"]
+  [make "opt"] {ocaml:native}
+]
+install: [
+  [make "install"]
+  ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
+]
+dev-repo: "git+https://github.com/ocaml/ocamlfind.git"
+url {
+  src: "http://download.camlcity.org/download/findlib-1.9.7.tar.gz"
+  checksum: [
+    "md5=b4542cf69e73308a311bd55e6baab5db"
+    "sha512=3aa1f06d5a230d7467b6f42257ba4b6a2481c8bd6cb5e51df87f86d652d47a08bd3efffe48edaeb9fcbb4b38a7aed65767f265901c5d6570acc131f7afce66bb"
+  ]
+}


### PR DESCRIPTION
### `ocamlfind.1.9.7`
A library manager for OCaml
Findlib is a library manager for OCaml. It provides a convention how
to store libraries, and a file format ("META") to describe the
properties of libraries. There is also a tool (ocamlfind) for
interpreting the META files, so that it is very easy to use libraries
in programs and scripts.



---
* Homepage: http://projects.camlcity.org/projects/findlib.html
* Source repo: git+https://github.com/ocaml/ocamlfind.git
* Bug tracker: https://github.com/ocaml/ocamlfind/issues

---
:camel: Pull-request generated by opam-publish v2.4.0