### PR TITLE
[new release] rust-staticlib-gen (3 packages) (0.2.2)

### DIFF
--- a/packages/dune-cargo-build/dune-cargo-build.0.2.2/opam
+++ b/packages/dune-cargo-build/dune-cargo-build.0.2.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Tool to invoke Cargo for building Rust crates within the dune sandbox"
+description:
+  "dune-cargo-build is a tool that runs cargo build in offline mode for a specified crate, ensuring compatibility with dune's/opam's sandboxing. It parses Cargo's JSON output to determine the produced artifacts and copies them to the current directory, renaming them to match what OCaml expects for foreign stubs. This tool is useful for integrating Rust build processes into OCaml projects managed by dune."
+maintainer: ["Konstantin Olkhovskiy <lupus@oxnull.net>"]
+authors: ["Konstantin Olkhovskiy <lupus@oxnull.net>"]
+license: "Apache-2.0"
+homepage: "https://github.com/Lupus/rust-staticlib-gen"
+bug-reports: "https://github.com/Lupus/rust-staticlib-gen/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.13"}
+  "yojson" {>= "2.2.2"}
+  "ocamlformat" {with-test & >= "0.26.2" & < "0.27.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Lupus/rust-staticlib-gen.git"
+url {
+  src:
+    "https://github.com/Lupus/rust-staticlib-gen/releases/download/0.2.2/rust-staticlib-gen-0.2.2.tbz"
+  checksum: [
+    "sha256=641c4c06b85a9b478098c5b00e36ff65445603a5cecb3e5eabfe8a8bc973b63c"
+    "sha512=d59fb760765bd28138963e8e52f373e33210f0d04f394f47a340fc6b7854a3cb5f59ec5734c94dd4e78eb01d8890b18f79f2574a6098be1190fd8bf058c8a609"
+  ]
+}
+x-commit-hash: "ea668cd4e4a7186ae3a05b37d6b9c661f8d7f23c"

--- a/packages/rust-staticlib-gen/rust-staticlib-gen.0.2.2/opam
+++ b/packages/rust-staticlib-gen/rust-staticlib-gen.0.2.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Utility for generating Rust static libraries for OCaml projects"
+description:
+  "rust-staticlib-gen is a tool designed to streamline the integration of Rust code into OCaml projects. It automates the generation of build files and orchestrates the build process, allowing OCaml code to seamlessly interface with Rust libraries. This tool extracts Rust crate dependencies from opam files, generates necessary dune and Cargo.toml files, and builds the Rust static libraries. It ensures compatibility between OCaml bindings and Rust crates by specifying exact versions in Cargo.toml."
+maintainer: ["Konstantin Olkhovskiy <lupus@oxnull.net>"]
+authors: ["Konstantin Olkhovskiy <lupus@oxnull.net>"]
+license: "Apache-2.0"
+homepage: "https://github.com/Lupus/rust-staticlib-gen"
+bug-reports: "https://github.com/Lupus/rust-staticlib-gen/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "toml" {>= "7.1.0"}
+  "yojson" {>= "2.2.2"}
+  "sexplib0" {>= "v0.16.0"}
+  "parsexp" {>= "v0.16.0"}
+  "opam-client" {>= "2.2.1" & < "2.3"}
+  "opam-state" {>= "2.2.1" & < "2.3"}
+  "opam-solver" {>= "2.2.1" & < "2.3"}
+  "fpath" {>= "0.7.3"}
+  "cmdliner" {>= "1.3.0"}
+  "ocamlformat" {with-test & >= "0.26.2" & < "0.27.0"}
+  "rust-staticlib-virtual" {= version}
+  "dune-cargo-build" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Lupus/rust-staticlib-gen.git"
+url {
+  src:
+    "https://github.com/Lupus/rust-staticlib-gen/releases/download/0.2.2/rust-staticlib-gen-0.2.2.tbz"
+  checksum: [
+    "sha256=641c4c06b85a9b478098c5b00e36ff65445603a5cecb3e5eabfe8a8bc973b63c"
+    "sha512=d59fb760765bd28138963e8e52f373e33210f0d04f394f47a340fc6b7854a3cb5f59ec5734c94dd4e78eb01d8890b18f79f2574a6098be1190fd8bf058c8a609"
+  ]
+}
+x-commit-hash: "ea668cd4e4a7186ae3a05b37d6b9c661f8d7f23c"

--- a/packages/rust-staticlib-virtual/rust-staticlib-virtual.0.2.2/opam
+++ b/packages/rust-staticlib-virtual/rust-staticlib-virtual.0.2.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "A Sentinel/marker package to define the rust staticlib virtual library"
+description:
+  "The rust-staticlib-virtual package is a sentinel/marker package that defines a virtual dune library that indicates presence of Rust dependencies somewhere down the dependency chain. To have an implementation of this virtual library in your project, please use `rust-staticlib-gen` tool: https://github.com/Lupus/rust-staticlib-gen"
+maintainer: ["Konstantin Olkhovskiy <lupus@oxnull.net>"]
+authors: ["Konstantin Olkhovskiy <lupus@oxnull.net>"]
+license: "Apache-2.0"
+homepage: "https://github.com/Lupus/rust-staticlib-gen"
+bug-reports: "https://github.com/Lupus/rust-staticlib-gen/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Lupus/rust-staticlib-gen.git"
+url {
+  src:
+    "https://github.com/Lupus/rust-staticlib-gen/releases/download/0.2.2/rust-staticlib-gen-0.2.2.tbz"
+  checksum: [
+    "sha256=641c4c06b85a9b478098c5b00e36ff65445603a5cecb3e5eabfe8a8bc973b63c"
+    "sha512=d59fb760765bd28138963e8e52f373e33210f0d04f394f47a340fc6b7854a3cb5f59ec5734c94dd4e78eb01d8890b18f79f2574a6098be1190fd8bf058c8a609"
+  ]
+}
+x-commit-hash: "ea668cd4e4a7186ae3a05b37d6b9c661f8d7f23c"


### PR DESCRIPTION
Utility for generating Rust static libraries for OCaml projects

- Project page: <a href="https://github.com/Lupus/rust-staticlib-gen">https://github.com/Lupus/rust-staticlib-gen</a>

##### CHANGES:

### Added

- **dune-cargo-build**
  - Support for copying of Cargo artifacts on macos and windows platforms

### Fixed

- **rust-staticlib-gen**
  - Dropped unused dune rule that prevented building on macos
