### PR TITLE
[new release] spawn (0.17.0)

### DIFF
--- a/packages/spawn/spawn.0.17.0/opam
+++ b/packages/spawn/spawn.0.17.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Spawning sub-processes"
+description: """
+Spawn is a small library exposing only one functionality: spawning sub-process.
+
+It has three main goals:
+
+1. provide missing features of Unix.create_process such as providing a
+working directory
+
+2. provide better errors when a system call fails in the
+sub-process. For instance if a command is not found, you get a proper
+[Unix.Unix_error] exception
+
+3. improve performance by using vfork when available. It is often
+claimed that nowadays fork is as fast as vfork, however in practice
+fork takes time proportional to the process memory while vfork is
+constant time. In application using a lot of memory, vfork can be
+thousands of times faster than fork.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/janestreet/spawn"
+doc: "https://janestreet.github.io/spawn/"
+bug-reports: "https://github.com/janestreet/spawn/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {with-test}
+  "ocaml" {>= "4.05"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/janestreet/spawn.git"
+url {
+  src:
+    "https://github.com/janestreet/spawn/releases/download/0.17.0/spawn-0.17.0.tbz"
+  checksum: [
+    "sha256=7df88098d786bc8bf22b4422e965bd0645763fa3cae5abd889a3e15929134874"
+    "sha512=85a1e5fe3849728fbbdee559cc61fde7bac1ffa73d7e506be1da128ebbb28bb1e65587656e5f78e4bac08b58fbd89f196a7ba00897fa99afa992ceb43d0b35d4"
+  ]
+}
+x-commit-hash: "085ea6d333be59451c5fde6b50d9e4e1264fbb9c"


### PR DESCRIPTION
Spawning sub-processes

- Project page: <a href="https://github.com/janestreet/spawn">https://github.com/janestreet/spawn</a>
- Documentation: <a href="https://janestreet.github.io/spawn/">https://janestreet.github.io/spawn/</a>

##### CHANGES:

- Support older GCC like 4.8.5 (janestreet/spawn#59)

- Fix spawning processes on Windows when environment contains non-ascii
  characters (janestreet/spawn#58)

- Skip calls to pthread_cancelstate on android, as its not available (janestreet/spawn#52)

- Fix compatibility with systems that do not define `PIPE_BUF`. Use
  `_POSIX_PIPE_BUF` as a fallback. (janestreet/spawn#49)

- [haiku] Fix compilation on Haiku OS. The header sys/syscalls.h isn't
  available, neither is pipe2()

- Allow setting the sigprocmask for spawned processes (janestreet/spawn#32)
