### PR TITLE
add selfie 0.1

### DIFF
--- a/packages/selfie/selfie.0.1/opam
+++ b/packages/selfie/selfie.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Unix process snapshotting library"
+description: """
+Selfie exposes a function to write to disk an ELF executable that
+snapshots the current state.  When run, the output file continues
+as if the program had just returned from the selfie library.
+"""
+authors: "Quentin Carbonneaux"
+license: "MIT"
+homepage: "http://c9x.me/git/selfie.git"
+dev-repo: "git://c9x.me/selfie.git"
+bug-reports: "magnet0+opam@c9x.me"
+maintainer: ["magnet0+opam@c9x.me"]
+depends: [
+  "ocaml" {< "5.0.0" }
+  "ocamlfind" {build}
+]
+available: os = "linux"
+build: [
+  [make "selfie.cma"]
+]
+install: [
+  ["ocamlfind" "install" "selfie" "META" "selfie.cmi" "selfie.cma" "dllcaml_selfie.so"]
+]
+remove: [
+  ["ocamlfind" "remove" "selfie"]
+]
+url {
+  git: "git://c9x.me/selfie.git#47c30106cb3e74bff960fccc9974f4762d42b2c3"
+}

--- a/packages/selfie/selfie.0.1/opam
+++ b/packages/selfie/selfie.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {< "5.0.0" }
   "ocamlfind" {build}
 ]
-available: os = "linux"
+available: arch = "x86_64" & os = "linux" & os-family = "debian"
 build: [
   [make "selfie.cma"]
 ]

--- a/packages/selfie/selfie.0.1/opam
+++ b/packages/selfie/selfie.0.1/opam
@@ -26,5 +26,6 @@ remove: [
   ["ocamlfind" "remove" "selfie"]
 ]
 url {
-  git: "git://c9x.me/selfie.git#47c30106cb3e74bff960fccc9974f4762d42b2c3"
+  src: "http://c9x.me/selfie/release/selfie-0.1.tar.xz"
+  checksum: "sha256=3c32c16f70d25c643eef1699bb4e63a5bbd02314f22654766f54df7334e8fff0"
 }

--- a/packages/selfie/selfie.0.1/opam
+++ b/packages/selfie/selfie.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {< "5.0.0" }
   "ocamlfind" {build}
 ]
-available: arch = "x86_64" & os = "linux" & os-family = "debian"
+available: arch = "x86_64" & os = "linux" & os-family != "alpine"
 build: [
   [make "selfie.cma"]
 ]


### PR DESCRIPTION
An experimental process snapshotting library.

The build of `selfie.c` fails on alpine because of a missing include file `asm/prctl.h`, so I made the package unavailable for this distribution.