### PR TITLE
Package catala-format.0.1.0

### DIFF
--- a/packages/catala-format/catala-format.0.1.0/opam
+++ b/packages/catala-format/catala-format.0.1.0/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/CatalaLang/catala-format.git"
 
 license: "Apache-2.0"
 depends: [
-  "topiary" {>= "0.3.0"}
+  "topiary" {>= "0.5.1"}
 ]
 
 build:[
@@ -35,9 +35,9 @@ Topiary repository: https://github.com/tweag/topiary
 """
 url {
   src:
-    "https://github.com/CatalaLang/catala-format/archive/refs/tags/catala-format.0.1.0.tar.gz"
+    "https://github.com/CatalaLang/catala-format/archive/refs/tags/catala-format.0.1.1.tar.gz"
   checksum: [
-    "md5=69c85b554fcaf781b238175d705ed96a"
-    "sha512=ab52a31158c55289f5b22abcd529e7589161977c8890f16826a2024b8cd4e9c91996752ea157a8388f13a75123eedb609530b2508710df7575ee6d79553753c9"
+    "md5=f7ad5c4c9316059ad1793bfbabfd4387"
+    "sha512=d9b0e78b292970348d262933e1fa706f18a332fc30d41c8a0f95cf5dbdfe440ffeb5ceea1b03d666b7eea48ebfee36362d314e619f65f0287b2c0e3103f5deaf"
   ]
 }


### PR DESCRIPTION
### `catala-format.0.1.0`
A formatter for Catala based on the Topiary universal formatting engine
A formatter for Catala based on the Topiary universal formatting engine.

Topiary repository: https://github.com/tweag/topiary



---
* Homepage: https://github.com/CatalaLang/catala-format
* Source repo: git+https://github.com/CatalaLang/catala-format.git
* Bug tracker: https://github.com/CatalaLang/catala-format

---
:camel: Pull-request generated by opam-publish v2.3.0