### PR TITLE
Package catala-format.0.1.1

### DIFF
--- a/packages/catala-format/catala-format.0.1.1/opam
+++ b/packages/catala-format/catala-format.0.1.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "vincent.botbol@inria.fr"
+authors: [ "Vincent Botbol" ]
+
+homepage: "https://github.com/CatalaLang/catala-format"
+bug-reports: "https://github.com/CatalaLang/catala-format"
+dev-repo: "git+https://github.com/CatalaLang/catala-format.git"
+
+license: "Apache-2.0"
+depends: [
+  "topiary" {>= "0.5.1"}
+]
+
+build:[
+  [ "sh" "make-wrapper.sh"
+         "--query-file" "%{share}%/topiary/queries/catala.scm"
+         "--config-file" "%{share}%/topiary/configs/catala.ncl"
+         "--topiary-wrapped" "%{bin}%/.topiary-wrapped/topiary"
+         "--output-file" "catala-format" ]
+]
+
+install: [
+  [ "cp" "catala-format" "%{bin}%/catala-format" ]
+  [ "mkdir" "-p" "%{share}%/topiary/queries" ]
+  [ "cp" "catala.scm" "%{share}%/topiary/queries" ]
+  [ "mkdir" "-p" "%{share}%/topiary/configs" ]
+  [ "cp" "catala.ncl" "%{share}%/topiary/configs" ]
+]
+
+synopsis: "A formatter for Catala based on the Topiary universal formatting engine"
+description: """
+A formatter for Catala based on the Topiary universal formatting engine.
+
+Topiary repository: https://github.com/tweag/topiary
+"""
+url {
+  src:
+    "https://github.com/CatalaLang/catala-format/archive/refs/tags/catala-format.0.1.1.tar.gz"
+  checksum: [
+    "md5=ccd5058b4deb05364a530c37aee8bdbc"
+    "sha512=27ee1d7e95d6d5cba567fab5fc0450d1c6722033187ed538c252127925fb60098682edab1778fbeb806ae8259ed9e913daf8923ac7e4478f010acb17159a84f5"
+  ]
+}


### PR DESCRIPTION
### `catala-format.0.1.1`
A formatter for Catala based on the Topiary universal formatting engine
A formatter for Catala based on the Topiary universal formatting engine.

Topiary repository: https://github.com/tweag/topiary



---
* Homepage: https://github.com/CatalaLang/catala-format
* Source repo: git+https://github.com/CatalaLang/catala-format.git
* Bug tracker: https://github.com/CatalaLang/catala-format

---
:camel: Pull-request generated by opam-publish v2.3.0