### PR TITLE
Fix PostgreSQL on Cygwin

### DIFF
--- a/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
+++ b/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "http://www.postgresql.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "postgresql"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" "libpq"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-postgresql-x86_64/conf-mingw-w64-postgresql-x86_64.1/opam
+++ b/packages/conf-mingw-w64-postgresql-x86_64/conf-mingw-w64-postgresql-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "http://www.postgresql.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "postgresql"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" "libpq"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}


### PR DESCRIPTION
The PostgreSQL library is called `libpq` not `postgresql`.