### PR TITLE
Replace pkg-config with pkgconf when the distribution is brew

### DIFF
--- a/packages/conf-pkg-config/conf-pkg-config.1.0/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.0/opam
@@ -18,7 +18,7 @@ depexts: [
   ["pkgconf"] {os-distribution = "alpine"}
   ["pkg-config"] {os-distribution = "nixos"}
   ["devel/pkgconf"] {os = "openbsd"}
-  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconf"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconf"] {os = "freebsd"}
   ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
   ["pkgconf"] {os = "cygwin"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.1/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.1/opam
@@ -28,7 +28,7 @@ depexts: [
   ["pkgconf"] {os-distribution = "alpine"}
   ["pkg-config"] {os-distribution = "nixos"}
   ["devel/pkgconf"] {os = "openbsd"}
-  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconf"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconf"] {os = "freebsd"}
   ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
   ["pkgconf"] {os = "cygwin"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.2/opam
@@ -28,7 +28,7 @@ depexts: [
   ["pkgconf"] {os-distribution = "alpine"}
   ["pkg-config"] {os-distribution = "nixos"}
   ["devel/pkgconf"] {os = "openbsd"}
-  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconf"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconf"] {os = "freebsd"}
   ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
   ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.3/opam
@@ -28,7 +28,7 @@ depexts: [
   ["pkgconf"] {os-distribution = "alpine"}
   ["pkg-config"] {os-distribution = "nixos"}
   ["devel/pkgconf"] {os = "openbsd"}
-  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconf"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
   ["pkgconf"] {os = "freebsd"}
   ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}

--- a/packages/conf-pkg-config/conf-pkg-config.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.2/opam
@@ -28,7 +28,7 @@ depexts: [
   ["pkgconf"] {os-distribution = "alpine"}
   ["pkg-config"] {os-distribution = "nixos"}
   ["devel/pkgconf"] {os = "openbsd"}
-  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconf"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
   ["pkgconf"] {os = "freebsd"}
   ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}

--- a/packages/conf-pkg-config/conf-pkg-config.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.3/opam
@@ -22,7 +22,7 @@ depexts: [
   ["pkgconfig"] {os-distribution = "ol" & os-version <= "7"}
   ["pkgconf"] {os-distribution = "alpine"}
   ["pkg-config"] {os-distribution = "nixos"}
-  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconf"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
   ["pkgconf"] {os = "freebsd"}
   ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}


### PR DESCRIPTION
Homebrew has deprecated pkg-config. `brew install pkg-config` now installs pkgconf. Accordingly, this PR adjusts the expectations of `conf-pkg-config` to depend on `pkgconf`.