### PR TITLE
[new release] cmdlang (4 packages) (0.0.8)

### DIFF
--- a/packages/cmdlang-stdlib-runner/cmdlang-stdlib-runner.0.0.8/opam
+++ b/packages/cmdlang-stdlib-runner/cmdlang-stdlib-runner.0.0.8/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "A basic execution runner for cmdlang based on stdlib.arg"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "cmdlang" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.8/cmdlang-0.0.8.tbz"
+  checksum: [
+    "sha256=d28ebdf0d0405681a3227dce48946e15060190c616b8e404503fe54576c19cf7"
+    "sha512=57cf44ed4e9d35099ed6e5b67785a1ca21b6e301bb8cd4692b87b1ac420a6bd82e20fa4e639f14cb93a151e63dfbb24f00072ab87bf2463aff70e5b7e9fc0ed9"
+  ]
+}
+x-commit-hash: "4e10ab22c86e703edfd744c5214e88407652e415"

--- a/packages/cmdlang-to-climate/cmdlang-to-climate.0.0.8/opam
+++ b/packages/cmdlang-to-climate/cmdlang-to-climate.0.0.8/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Convert cmdlang Parsers to climate"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "climate" {>= "0.1.0"}
+  "cmdlang" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.8/cmdlang-0.0.8.tbz"
+  checksum: [
+    "sha256=d28ebdf0d0405681a3227dce48946e15060190c616b8e404503fe54576c19cf7"
+    "sha512=57cf44ed4e9d35099ed6e5b67785a1ca21b6e301bb8cd4692b87b1ac420a6bd82e20fa4e639f14cb93a151e63dfbb24f00072ab87bf2463aff70e5b7e9fc0ed9"
+  ]
+}
+x-commit-hash: "4e10ab22c86e703edfd744c5214e88407652e415"

--- a/packages/cmdlang-to-cmdliner/cmdlang-to-cmdliner.0.0.8/opam
+++ b/packages/cmdlang-to-cmdliner/cmdlang-to-cmdliner.0.0.8/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Convert cmdlang Parsers to cmdliner"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "cmdlang" {= version}
+  "cmdliner" {>= "1.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.8/cmdlang-0.0.8.tbz"
+  checksum: [
+    "sha256=d28ebdf0d0405681a3227dce48946e15060190c616b8e404503fe54576c19cf7"
+    "sha512=57cf44ed4e9d35099ed6e5b67785a1ca21b6e301bb8cd4692b87b1ac420a6bd82e20fa4e639f14cb93a151e63dfbb24f00072ab87bf2463aff70e5b7e9fc0ed9"
+  ]
+}
+x-commit-hash: "4e10ab22c86e703edfd744c5214e88407652e415"

--- a/packages/cmdlang/cmdlang.0.0.8/opam
+++ b/packages/cmdlang/cmdlang.0.0.8/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Declarative Command-line Parsing for OCaml"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.8/cmdlang-0.0.8.tbz"
+  checksum: [
+    "sha256=d28ebdf0d0405681a3227dce48946e15060190c616b8e404503fe54576c19cf7"
+    "sha512=57cf44ed4e9d35099ed6e5b67785a1ca21b6e301bb8cd4692b87b1ac420a6bd82e20fa4e639f14cb93a151e63dfbb24f00072ab87bf2463aff70e5b7e9fc0ed9"
+  ]
+}
+x-commit-hash: "4e10ab22c86e703edfd744c5214e88407652e415"


### PR DESCRIPTION
This is the initial release for packages providing an API to build declarative command-line parsers. More information at https://github.com/mbarbin/cmdlang. Short synopsis below:

## Synopsis

Cmdlang is a library for creating command-line parsers in OCaml. Implemented as an OCaml EDSL, its declarative specification language lives at the intersection of other well-established similar libraries.

Cmdlang doesn't include an execution engine. Instead, Cmdlang parsers are automatically translated to `cmdliner`, `core.command`, or `climate` commands for execution.

Our goal is to provide an approachable, flexible, and user-friendly interface while allowing users to choose the backend runtime that best suits their needs.

### Packages

**cmdlang** the user facing library to build the commands. It has no dependencies

**cmdlang-to-cmdliner** translate `cmdlang` commands to `cmdliner`

**cmdlang-to-climate** translate `cmdlang` commands to the newly released `climate` (compatibility checked with `0.1.0` & `0.2.0`)

**cmdlang-stdlib-runner** an execution engine implemented on top of `stdlib.arg`