### PR TITLE
 Replace pkg-config with pkgconf when the distribution is brew 

### DIFF
--- a/packages/conf-pkg-config/conf-pkg-config.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.3/opam
@@ -22,7 +22,7 @@ depexts: [
   ["pkgconfig"] {os-distribution = "ol" & os-version <= "7"}
   ["pkgconf"] {os-distribution = "alpine"}
   ["pkg-config"] {os-distribution = "nixos"}
-  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconf"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
   ["pkgconf"] {os = "freebsd"}
   ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}


### PR DESCRIPTION
Import #26878  with only the latest pkg-config-file updated (in case there are users still using older copies of homebrew)