### PR TITLE
[new release] bitwuzla-cxx (0.6.1)

### DIFF
--- a/packages/bitwuzla-cxx/bitwuzla-cxx.0.6.1/opam
+++ b/packages/bitwuzla-cxx/bitwuzla-cxx.0.6.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "SMT solver for AUFBVFP (C++ API)"
+description: """
+
+OCaml binding for the SMT solver Bitwuzla C++ API.
+
+Bitwuzla is a Satisfiability Modulo Theories (SMT) solver for the theories of fixed-size bit-vectors, arrays and uninterpreted functions and their combinations. Its name is derived from an Austrian dialect expression that can be translated as “someone who tinkers with bits”."""
+maintainer: ["Frédéric Recoules <frederic.recoules@cea.fr>"]
+authors: ["Frédéric Recoules"]
+license: "MIT"
+tags: ["SMT solver" "AUFBVFP"]
+homepage: "https://bitwuzla.github.io"
+doc: "https://bitwuzla.github.io/docs/ocaml/"
+bug-reports: "https://github.com/bitwuzla/ocaml-bitwuzla/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.12"}
+  "conf-git" {build}
+  "conf-gcc" {build}
+  "conf-g++" {build}
+  "zarith"
+  "ppx_inline_test" {with-test & >= "v0.13"}
+  "ppx_expect" {with-test & >= "v0.13"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
+available: [ arch != "arm32" & (os = "linux" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) | os = "macos" & os-distribution = "homebrew") ]
+url {
+  src:
+    "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/0.6.1/bitwuzla-cxx-0.6.1.tbz"
+  checksum: [
+    "sha256=420672d1ae103d5920881fa5844c38d2913d4deb8e39e328c2d51bd05f8137a7"
+    "sha512=99fb414c9bba4f120d10696f83a915c6bd14661f7e424792e0a30f0ff2bd4a59832207d83ad4004bed36da827023c54e588de566d3ec97ed305b7f2e121f611e"
+  ]
+}
+x-commit-hash: "6642f7a47551185e924d99a3979b793950ccb18f"


### PR DESCRIPTION
SMT solver for AUFBVFP (C++ API)

- Project page: <a href="https://bitwuzla.github.io">https://bitwuzla.github.io</a>
- Documentation: <a href="https://bitwuzla.github.io/docs/ocaml/">https://bitwuzla.github.io/docs/ocaml/</a>

##### CHANGES:

Update [Bitwuzla](https://github.com/bitwuzla/bitwuzla/releases/tag/0.6.1) sources.

Vendor submodules:
- [Bitwuzla](https://github.com/bitwuzla/bitwuzla) tag:0.6.1
