### PR TITLE
Update windows build instructions for conf-libcurl 

### DIFF
--- a/packages/conf-libcurl/conf-libcurl.2/opam
+++ b/packages/conf-libcurl/conf-libcurl.2/opam
@@ -4,7 +4,11 @@ authors: ["Daniel Stenberg"]
 homepage: "http://curl.haxx.se/"
 license: "BSD-like"
 build: [
-  ["sh" "-exc" "curl-config --libs"] {os = "win32" & os-distribution != "cygwinports"}
+  ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution != "cygwin"}
+   "--print-errors" "--exists" "lbcurl"]
   ["curl-config" "--libs"] {os != "win32" | os-distribution = "cygwinports"}
 ]
 depexts: [

--- a/packages/conf-libcurl/conf-libcurl.2/opam
+++ b/packages/conf-libcurl/conf-libcurl.2/opam
@@ -7,7 +7,7 @@ build: [
   ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
    "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
    "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
-   "--print-errors" "--exists" "libcurl"]
+   "libcurl"]
   ["curl-config" "--libs"] {os != "win32" | os-distribution = "cygwinports"}
 ]
 depexts: [

--- a/packages/conf-libcurl/conf-libcurl.2/opam
+++ b/packages/conf-libcurl/conf-libcurl.2/opam
@@ -7,7 +7,6 @@ build: [
   ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
    "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
    "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
-   "pkg-config" {os != "win32" | os-distribution != "cygwin"}
    "--print-errors" "--exists" "libcurl"]
   ["curl-config" "--libs"] {os != "win32" | os-distribution = "cygwinports"}
 ]

--- a/packages/conf-libcurl/conf-libcurl.2/opam
+++ b/packages/conf-libcurl/conf-libcurl.2/opam
@@ -8,7 +8,7 @@ build: [
    "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
    "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
    "pkg-config" {os != "win32" | os-distribution != "cygwin"}
-   "--print-errors" "--exists" "lbcurl"]
+   "--print-errors" "--exists" "libcurl"]
   ["curl-config" "--libs"] {os != "win32" | os-distribution = "cygwinports"}
 ]
 depexts: [

--- a/packages/conf-libcurl/conf-libcurl.2/opam
+++ b/packages/conf-libcurl/conf-libcurl.2/opam
@@ -7,7 +7,7 @@ build: [
   ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
    "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
    "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
-   "libcurl"]
+   "libcurl" {os = "win32" & os-distribution = "cygwin"}]
   ["curl-config" "--libs"] {os != "win32" | os-distribution = "cygwinports"}
 ]
 depexts: [

--- a/packages/conf-libcurl/conf-libcurl.2/opam
+++ b/packages/conf-libcurl/conf-libcurl.2/opam
@@ -4,9 +4,10 @@ authors: ["Daniel Stenberg"]
 homepage: "http://curl.haxx.se/"
 license: "BSD-like"
 build: [
-  ["pkgconf"
+  ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
    "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
    "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution != "cygwin"}
    "--print-errors" "--exists" "libcurl"]
   ["curl-config" "--libs"] {os != "win32" | os-distribution = "cygwinports"}
 ]

--- a/packages/conf-libcurl/conf-libcurl.2/opam
+++ b/packages/conf-libcurl/conf-libcurl.2/opam
@@ -4,10 +4,9 @@ authors: ["Daniel Stenberg"]
 homepage: "http://curl.haxx.se/"
 license: "BSD-like"
 build: [
-  ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
+  ["pkgconf"
    "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
    "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
-   "pkg-config" {os != "win32" | os-distribution != "cygwin"}
    "--print-errors" "--exists" "libcurl"]
   ["curl-config" "--libs"] {os != "win32" | os-distribution = "cygwinports"}
 ]

--- a/packages/conf-libcurl/conf-libcurl.3/opam
+++ b/packages/conf-libcurl/conf-libcurl.3/opam
@@ -4,7 +4,10 @@ authors: ["Daniel Stenberg"]
 homepage: "http://curl.haxx.se/"
 license: "BSD-like"
 build: [
-  ["sh" "-exc" "curl-config --libs"] {os = "win32" & os-distribution != "cygwinports"}
+  ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
+   "libcurl" {os = "win32" & os-distribution = "cygwin"}]
   ["curl-config" "--libs"] {os != "win32" | os-distribution = "cygwinports"}
 ]
 depexts: [


### PR DESCRIPTION
related to: #26893

This just updates the build instructions for windows to use `pkgconf` instead of `curl-conf`, which I ran into issues with when using `setup-ocaml`. Similar testing plan to #26893. 
