### PR TITLE
Package ppxlib_jane.v0.17.2

### DIFF
--- a/packages/ppxlib_jane/ppxlib_jane.v0.17.2/opam
+++ b/packages/ppxlib_jane/ppxlib_jane.v0.17.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppxlib_jane"
+bug-reports: "https://github.com/janestreet/ppxlib_jane/issues"
+dev-repo: "git+https://github.com/janestreet/ppxlib_jane.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppxlib_jane/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.3.0"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Utilities for working with Jane Street AST constructs"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppxlib_jane/archive/refs/tags/v0.17.2.tar.gz"
+  checksum: [
+    "md5=abe0bba90ad28917f344c2e31b72c7fd"
+    "sha512=342e034d44d14958869e643befb0e749d4de3ca0040891ab51592e2583bc5bb827bdaa5bd06966ac536151d160997aef79baa090247d1649a6b5849a359744d8"
+  ]
+}


### PR DESCRIPTION
### `ppxlib_jane.v0.17.2`
Utilities for working with Jane Street AST constructs
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppxlib_jane
* Source repo: git+https://github.com/janestreet/ppxlib_jane.git
* Bug tracker: https://github.com/janestreet/ppxlib_jane/issues

---
:camel: Pull-request generated by opam-publish v2.3.0