### PR TITLE
[new release] ppx_deriving_yaml (2 packages) (0.4.0)

### DIFF
--- a/packages/ppx_deriving_ezjsonm/ppx_deriving_ezjsonm.0.4.0/opam
+++ b/packages/ppx_deriving_ezjsonm/ppx_deriving_ezjsonm.0.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Ezjsonm PPX"
+description:
+  "Deriving conversion functions to and from JSON for your OCaml types."
+maintainer: ["patrick@sirref.org"]
+authors: ["Patrick Ferris"]
+license: "ISC"
+tags: ["ppx" "deriver" "json"]
+homepage: "https://github.com/patricoferris/ppx_deriving_yaml"
+bug-reports: "https://github.com/patricoferris/ppx_deriving_yaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ezjsonm"
+  "alcotest" {with-test}
+  "mdx" {with-test & >= "2.4.1"}
+  "ppx_deriving" {with-test}
+  "ocaml" {>= "4.08.1"}
+  "ppxlib" {>= "0.25.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/patricoferris/ppx_deriving_yaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v0.4.0/ppx_deriving_yaml-0.4.0.tbz"
+  checksum: [
+    "sha256=315c02140658f548b580e7247db6e3f3cdb0d9a9681c21a6261a4bd410d41008"
+    "sha512=950f765c9c221c2413e5d96f05dd14af1d64e218657041be22e9dcce30f2409a496a81661e84c9aed651b4a2444a0efc293ec2d306aa8b622ddd7d678a92cf20"
+  ]
+}
+x-commit-hash: "79bde82094a56790c89adeff77021b4a30b3fc7f"

--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.4.0/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Yaml PPX"
+description:
+  "Deriving conversion functions to and from yaml for your OCaml types."
+maintainer: ["patrick@sirref.org"]
+authors: ["Patrick Ferris"]
+license: "ISC"
+tags: ["ppx" "deriver" "yaml"]
+homepage: "https://github.com/patricoferris/ppx_deriving_yaml"
+bug-reports: "https://github.com/patricoferris/ppx_deriving_yaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "yaml"
+  "alcotest" {with-test}
+  "mdx" {with-test & >= "2.4.1"}
+  "ppx_deriving" {with-test}
+  "ocaml" {>= "4.08.1"}
+  "ppxlib" {>= "0.25.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/patricoferris/ppx_deriving_yaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v0.4.0/ppx_deriving_yaml-0.4.0.tbz"
+  checksum: [
+    "sha256=315c02140658f548b580e7247db6e3f3cdb0d9a9681c21a6261a4bd410d41008"
+    "sha512=950f765c9c221c2413e5d96f05dd14af1d64e218657041be22e9dcce30f2409a496a81661e84c9aed651b4a2444a0efc293ec2d306aa8b622ddd7d678a92cf20"
+  ]
+}
+x-commit-hash: "79bde82094a56790c89adeff77021b4a30b3fc7f"


### PR DESCRIPTION
Yaml PPX

- Project page: <a href="https://github.com/patricoferris/ppx_deriving_yaml">https://github.com/patricoferris/ppx_deriving_yaml</a>

##### CHANGES:

- Refactor library to support ppx_deriving_ezjsonm (a JSON backend) (patricoferris/ppx_deriving_yaml#59, @patricoferris)
