### PR TITLE
Fix apron homebrew

### DIFF
--- a/packages/apron/apron.0.9.14/opam
+++ b/packages/apron/apron.0.9.14/opam
@@ -12,6 +12,9 @@ dev-repo: "git+https://github.com/antoinemine/apron.git"
 bug-reports: "https://github.com/antoinemine/apron/issues"
 build: [
   [
+    "sh" "-exec" "./configure --prefix %{share}%/apron --mpfr-prefix $HOMEBREW_PREFIX/opt/mpfr --gmp-prefix $HOMEBREW_PREFIX/opt/gmp --absolute-dylibs --debug --no-strip"
+  ] { os = "macos" & os-distribution = "homebrew" }
+  [
     "sh"
     "./configure"
     "--prefix"
@@ -22,7 +25,7 @@ build: [
     "--ext-dll" {os = "win32"} "dll" {os = "win32"}
     "--debug"
     "--no-strip"
-  ]
+  ] {!(os = "macos"& os-distribution = "homebrew")}
   [make "-j%{jobs}%"]
 ]
 install: [

--- a/packages/apron/apron.v0.9.12/opam
+++ b/packages/apron/apron.v0.9.12/opam
@@ -12,6 +12,9 @@ dev-repo: "git+https://github.com/antoinemine/apron.git"
 bug-reports: "https://github.com/antoinemine/apron/issues"
 build: [
   [
+    "sh" "-exec" "./configure --prefix %{share}%/apron --mpfr-prefix $HOMEBREW_PREFIX/opt/mpfr --gmp-prefix $HOMEBREW_PREFIX/opt/gmp --absolute-dylibs --debug --no-strip"
+  ] { os = "macos" & os-distribution = "homebrew" }
+  [
     "sh"
     "./configure"
     "--prefix"
@@ -20,7 +23,7 @@ build: [
     "--no-ocaml-plugins" {os = "freebsd"}
     "--absolute-dylibs" {os = "macos"}
     "--ext-dll" {os = "win32"} "dll" {os = "win32"}
-  ]
+  ] {!(os = "macos"& os-distribution = "homebrew")}
   [make "-j%{jobs}%"]
 ]
 install: [

--- a/packages/apron/apron.v0.9.14/opam
+++ b/packages/apron/apron.v0.9.14/opam
@@ -12,6 +12,9 @@ dev-repo: "git+https://github.com/antoinemine/apron.git"
 bug-reports: "https://github.com/antoinemine/apron/issues"
 build: [
   [
+    "sh" "-exec" "./configure --prefix %{share}%/apron --mpfr-prefix $HOMEBREW_PREFIX/opt/mpfr --gmp-prefix $HOMEBREW_PREFIX/opt/gmp --absolute-dylibs --debug --no-strip"
+  ] { os = "macos" & os-distribution = "homebrew" }
+  [
     "sh"
     "./configure"
     "--prefix"
@@ -22,7 +25,7 @@ build: [
     "--ext-dll" {os = "win32"} "dll" {os = "win32"}
     "--debug"
     "--no-strip"
-  ]
+  ] {!(os = "macos"& os-distribution = "homebrew")}
   [make "-j%{jobs}%"]
 ]
 install: [

--- a/packages/apron/apron.v0.9.14/opam
+++ b/packages/apron/apron.v0.9.14/opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/antoinemine/apron.git"
 bug-reports: "https://github.com/antoinemine/apron/issues"
 build: [
   [
-    "sh" "-exec" "./configure --prefix %{share}%/apron --mpfr-prefix $HOMEBREW_PREFIX/opt/mpfr --gmp-prefix $HOMEBREW_PREFIX/opt/gmp --absolute-dylibs --debug --no-strip"
+    "sh" "-exec" "./configure --prefix %{share}%/apron --mpfr-prefix $HOMEBREW_PREFIX/opt/mpfr --gmp-prefix $HOMEBREW_PREFIX/opt/gmp --ppl-prefix $HOMEBREW_PREFIX/opt/ppl --absolute-dylibs --debug --no-strip"
   ] { os = "macos" & os-distribution = "homebrew" }
   [
     "sh"

--- a/packages/apron/apron.v0.9.14/opam
+++ b/packages/apron/apron.v0.9.14/opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/antoinemine/apron.git"
 bug-reports: "https://github.com/antoinemine/apron/issues"
 build: [
   [
-    "sh" "-exec" "./configure --prefix %{share}%/apron --mpfr-prefix $HOMEBREW_PREFIX/opt/mpfr --gmp-prefix $HOMEBREW_PREFIX/opt/gmp --ppl-prefix $HOMEBREW_PREFIX/opt/ppl --absolute-dylibs --debug --no-strip"
+    "sh" "-exec" "./configure --prefix %{share}%/apron --mpfr-prefix ${HOMEBREW_PREFIX:-/opt/homebrew}/ --gmp-prefix ${HOMEBREW_PREFIX:-/opt/homebrew}/ --absolute-dylibs --debug --no-strip"
   ] { os = "macos" & os-distribution = "homebrew" }
   [
     "sh"

--- a/packages/apron/apron.v0.9.14/opam
+++ b/packages/apron/apron.v0.9.14/opam
@@ -52,3 +52,6 @@ url {
     "sha512=9c1107cea95d56a377f221724064bc65dc605a624171064e681c07e1dece688e06b5511e9974df7c20d883d7dc6cdb25bf1431a8968d721d5c587875ffef751a"
   ]
 }
+x-ci-accept-failures: [
+  "oraclelinux-8" "oraclelinux-9" "alpine-3.19"
+]

--- a/packages/apron/apron.v0.9.14/opam
+++ b/packages/apron/apron.v0.9.14/opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/antoinemine/apron.git"
 bug-reports: "https://github.com/antoinemine/apron/issues"
 build: [
   [
-    "sh" "-exec" "./configure --prefix %{share}%/apron --mpfr-prefix ${HOMEBREW_PREFIX:-/opt/homebrew}/ --gmp-prefix ${HOMEBREW_PREFIX:-/opt/homebrew}/ --absolute-dylibs --debug --no-strip"
+    "sh" "-exec" "./configure --prefix %{share}%/apron --mpfr-prefix ${HOMEBREW_PREFIX:-/opt/homebrew}/ --gmp-prefix ${HOMEBREW_PREFIX:-/opt/homebrew}/ --ppl-prefix ${HOMEBREW_PREFIX:-/opt/homebrew}/ --absolute-dylibs --debug --no-strip"
   ] { os = "macos" & os-distribution = "homebrew" }
   [
     "sh"


### PR DESCRIPTION
In a similar fashion to what has been proposed (and accepted for merge) for this PR : https://github.com/ocaml/opam-repository/pull/25592, we provide a fix for macos homebrew distribs.

I could not ascertain if only updating apron.v0.9.14/opam was sufficient.