### PR TITLE
Release of OCaml 5.2.1

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.1/opam
@@ -1,0 +1,88 @@
+opam-version: "2.0"
+synopsis: "Official release 5.2.1"
+maintainer: [
+  "David Allsopp <david@tarides.com>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml#5.2"
+depends: [
+  # This is OCaml 5.2.1
+  "ocaml" {= "5.2.1" & post}
+
+  # General base- packages
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  "host-arch-x86_64" {os != "win32" & arch = "x86_64" & post}
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+  # i686 mingw-w64 only
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
+  "ocaml-options-vanilla" {post}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
+]
+conflicts: "system-msvc"
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
+build: [
+  [
+    "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/releases/download/5.2.1/ocaml-5.2.1.tar.gz"
+  checksum: "sha256=2d0f8090951a97a2c0e5b8a11e90096c0e1791d2e471e4a67f87e3b974044cd0"
+}
+extra-source "ocaml-base-compiler.install" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"
+  checksum: [
+    "sha256=79f2a1a5044a91350a0eb6ce12e261a72a2855c094c425cddf3860e58c486678"
+    "md5=3e969b841df1f51ca448e6e6295cb451"
+  ]
+}

--- a/packages/ocaml-system/ocaml-system.5.2.1/opam
+++ b/packages/ocaml-system/ocaml-system.5.2.1/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (system version, from outside of opam)"
+maintainer: [
+  "David Allsopp <david@tarides.com>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  # This is OCaml 5.2.1
+  "ocaml" {= "5.2.1" & post}
+
+  # General base- packages
+  "base-unix" {post}
+  "base-threads" {post}
+  "base-bigarray" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+
+  # Architecture
+  "host-arch-arm32" {?sys-ocaml-arch & sys-ocaml-arch = "arm" & post}
+  "host-arch-arm64" {?sys-ocaml-arch & sys-ocaml-arch = "arm64" & post}
+  "host-arch-ppc64" {?sys-ocaml-arch & sys-ocaml-arch = "power" & post}
+  "host-arch-riscv64" {?sys-ocaml-arch & sys-ocaml-arch = "riscv" & post}
+  "host-arch-s390x" {?sys-ocaml-arch & sys-ocaml-arch = "s390x" & post}
+  "host-arch-x86_32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & post}
+  "host-arch-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & post}
+  "host-arch-unknown" {!(?sys-ocaml-arch) |
+                       sys-ocaml-arch != "arm" &
+                       sys-ocaml-arch != "arm64" &
+                       sys-ocaml-arch != "power" &
+                       sys-ocaml-arch != "riscv" &
+                       sys-ocaml-arch != "s390x" &
+                       sys-ocaml-arch != "i686" &
+                       sys-ocaml-arch != "x86_64" & post}
+
+  # System (Windows-only at present)
+  "host-system-mingw" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  # There is no official MSVC support for 5.2.1
+  "host-system-msvc" {?sys-ocaml-arch & sys-ocaml-cc = "msvc" & post}
+  "host-system-other" {?sys-ocaml-arch & sys-ocaml-libc != "msvc" & post}
+
+  # Environment configuration (Windows-only)
+  # NB There are not "system" distributions of OCaml on Windows; the support
+  # here is intended for binary caching setups, choosing to install a build
+  # of OCaml external to opam, but still using opam to provide the C compiler
+  # configuration.
+  "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-zstd-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-zstd-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
+  "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
+]
+conflict-class: "ocaml-core-compiler"
+available: sys-ocaml-version = "5.2.1" & (os != "win32" | sys-ocaml-libc = "msvc")
+flags: compiler
+build: ["ocaml" "gen_ocaml_config.ml"]
+substs: "gen_ocaml_config.ml"
+extra-source "gen_ocaml_config.ml.in" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-system/gen_ocaml_config.ml.in"
+  checksum: [
+    "sha256=71bcd3d35e28cbf71eda81991c8741268f4b87ced71573b2e75f64f136cebfc1"
+    "md5=093e7bec1ec95f9e4c6a313d73c5d840"
+  ]
+}

--- a/packages/ocaml-variants/ocaml-variants.5.2.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.1+options/opam
@@ -1,0 +1,136 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "Official release of OCaml 5.2.1"
+maintainer: [
+  "David Allsopp <david@tarides.com>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.2"
+depends: [
+  # This is OCaml 5.2.1
+  "ocaml" {= "5.2.1" & post}
+
+  # General base- packages
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+  # i686 mingw-w64 only
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
+build-env: [
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--without-zstd" {ocaml-option-no-compression:installed}
+    "--enable-tsan" {ocaml-option-tsan:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed & arch!="arm64"}
+    "CFLAGS=-Os -mno-outline-atomics" {ocaml-option-musl:installed & arch="arm64"}
+    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/releases/download/5.2.1/ocaml-5.2.1.tar.gz"
+  checksum: "sha256=2d0f8090951a97a2c0e5b8a11e90096c0e1791d2e471e4a67f87e3b974044cd0"
+}
+conflicts: [
+  "system-msvc"
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-no-compression"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+  "ocaml-option-tsan"
+]
+extra-source "ocaml-variants.install" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"
+  checksum: [
+    "sha256=79f2a1a5044a91350a0eb6ce12e261a72a2855c094c425cddf3860e58c486678"
+    "md5=3e969b841df1f51ca448e6e6295cb451"
+  ]
+}

--- a/packages/ocaml-variants/ocaml-variants.5.2.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.1+trunk/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
-synopsis: "Latest 5.2 development"
+synopsis: "5.2.0 obsolete development package"
+description: "Replaced with ocaml-variants.5.2.2+trunk"
 maintainer: [
   "David Allsopp <david@tarides.com>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
@@ -16,114 +17,5 @@ authors: [
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#5.2"
-depends: [
-  # This is OCaml 5.2.1
-  "ocaml" {= "5.2.1" & post}
-
-  # General base- packages
-  "base-unix" {post}
-  "base-bigarray" {post}
-  "base-threads" {post}
-  "base-domains" {post}
-  "base-nnp" {post}
-
-  "ocaml-beta" {opam-version < "2.1.0"}
-
-  # Architecture (non-Windows)
-  # opam-repository at present requires that ocaml-base-compiler is installed
-  # using an architecture which matches the machine's, since arch is used in
-  # available fields. Cross-compilation at this stage is an unstable accident.
-  "host-arch-arm32" {arch = "arm32" & post}
-  "host-arch-arm64" {arch = "arm64" & post}
-  "host-arch-ppc64" {arch = "ppc64" & post}
-  "host-arch-riscv64" {arch = "riscv64" & post}
-  "host-arch-s390x" {arch = "s390x" & post}
-  # The Windows ports explicitly select the architecture (see below) this
-  # facility is not yet available for other platforms.
-  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
-   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
-  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
-
-  # Port selection (Windows)
-  # amd64 mingw-w64 only
-  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
-  # i686 mingw-w64 only
-   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
-  # Non-Windows systems
-   "host-system-other" {os != "win32" & post})
-
-  # All the 32-bit architectures are bytecode-only
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
-
-  # Support Packages
-  "flexdll" {>= "0.42" & os = "win32"}
-]
-conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
-setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
-x-env-path-rewrite: [
-  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
-]
-build-env: [
-  [MSYS2_ARG_CONV_EXCL = "*"]
-  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
-  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
-]
-build: [
-  [
-    "./configure"
-    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
-    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
-    "--prefix=%{prefix}%"
-    "--docdir=%{doc}%/ocaml"
-    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
-    "-C"
-    "--with-afl" {ocaml-option-afl:installed}
-    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
-    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
-    "--enable-flambda" {ocaml-option-flambda:installed}
-    "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--without-zstd" {ocaml-option-no-compression:installed}
-    "--enable-tsan" {ocaml-option-tsan:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
-    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
-    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
-    "CFLAGS=-Os" {ocaml-option-musl:installed}
-    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
-    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
-    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
-    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
-    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
-    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
-    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
-    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
-    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
-    "LIBS=-static" {ocaml-option-static:installed}
-    "--disable-warn-error"
-  ]
-  [make "-j%{jobs}%"]
-]
-install: [make "install"]
-url {
-  src: "https://github.com/ocaml/ocaml/archive/5.2.tar.gz"
-}
-conflicts: [
-  "system-msvc"
-]
-depopts: [
-  "ocaml-option-32bit"
-  "ocaml-option-afl"
-  "ocaml-option-bytecode-only"
-  "ocaml-option-no-flat-float-array"
-  "ocaml-option-flambda"
-  "ocaml-option-fp"
-  "ocaml-option-no-compression"
-  "ocaml-option-musl"
-  "ocaml-option-leak-sanitizer"
-  "ocaml-option-address-sanitizer"
-  "ocaml-option-static"
-  "ocaml-option-tsan"
-]
+available: false

--- a/packages/ocaml-variants/ocaml-variants.5.2.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.2+trunk/opam
@@ -1,0 +1,129 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "Latest 5.2 development"
+maintainer: [
+  "David Allsopp <david@tarides.com>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.2"
+depends: [
+  # This is OCaml 5.2.2
+  "ocaml" {= "5.2.2" & post}
+
+  # General base- packages
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 only
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+  # i686 mingw-w64 only
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
+build-env: [
+  [MSYS2_ARG_CONV_EXCL = "*"]
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    "./configure"
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--without-zstd" {ocaml-option-no-compression:installed}
+    "--enable-tsan" {ocaml-option-tsan:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.2.tar.gz"
+}
+conflicts: [
+  "system-msvc"
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-no-compression"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+  "ocaml-option-tsan"
+]

--- a/packages/ocaml/ocaml.5.2.2/opam
+++ b/packages/ocaml/ocaml.5.2.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "David Allsopp <david@tarides.com>"
+depends: [
+  "ocaml-config" {>= "3"}
+  "ocaml-base-compiler" {>= "5.2.2~" & < "5.2.3~" } |
+  "ocaml-variants" {>= "5.2.2~" & < "5.2.3~"} |
+  "ocaml-system" {>= "5.2.2~" & < "5.2.3~"} |
+  "dkml-base-compiler" {>= "5.2.2~" & < "5.2.3~"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build-env: [
+  [CAML_LD_LIBRARY_PATH = ""]
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+flags: conf


### PR DESCRIPTION
This PR adds the base package for the release of OCaml 5.2.1. 

As a notable changescompared to previous releases is that I have switched the reference url to an explicit binary archive rather than using the archive generated on demand by Github in order to avoid depending on the `Github` archive format.

Except for this change, we have the usual 3 base packages:

- ocaml-system.5.2.1
- ocaml-base-compiler.5.2.1
- ocaml-variants.5.2.1+options

The PR also switches the active trunk package from

- ocaml-variants.5.2.1+trunk

to
- ocaml-variants.5.2.2+trunk

which requires to add the `ocaml` 5.2.2 metapackage

- ocaml.5.2.2

The `ocaml-src` is not included in this release, since it is dependendent on a PR to the `opam-source-repository`.