### PR TITLE
[new release] icalendar (0.1.9)

### DIFF
--- a/packages/icalendar/icalendar.0.1.9/opam
+++ b/packages/icalendar/icalendar.0.1.9/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/robur-coop/icalendar"
+bug-reports: "https://github.com/robur-coop/icalendar/issues"
+dev-repo: "git+https://github.com/robur-coop/icalendar.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://robur-coop.github.io/icalendar/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.3"}
+  "alcotest" {with-test}
+  "fmt"
+  "angstrom" {>= "0.14.0"}
+  "re" {>= "1.7.2"}
+  "uri"
+  "ptime"
+  "ppx_deriving"
+  "gmap" {>= "0.3.0"}
+]
+
+synopsis: "A library to parse and print the iCalendar (RFC 5545) format"
+description: """
+Parse and print .ics files as specified in RFC 5545.
+Supports recurrent events, but only to the day level of detail.
+Does not support vJournal components.
+"""
+url {
+  src:
+    "https://github.com/robur-coop/icalendar/releases/download/v0.1.9/icalendar-0.1.9.tbz"
+  checksum: [
+    "sha256=b5849bc9f2c83219d60c1c3d5d62dedffbaeebf986cc23228eee2029ec201764"
+    "sha512=e7cce3721022b3145fea4a5392eea84ec0ce287850a25f1e0ae624609b0d5da1ea25fe40b8c2ac05fe02389bdb78dae8393355e0560974791459eca906b3d8c8"
+  ]
+}
+x-commit-hash: "dd6eb025f6923cc3821b328a07dd207c2d95bc5b"


### PR DESCRIPTION
A library to parse and print the iCalendar (RFC 5545) format

- Project page: <a href="https://github.com/robur-coop/icalendar">https://github.com/robur-coop/icalendar</a>
- Documentation: <a href="https://robur-coop.github.io/icalendar/">https://robur-coop.github.io/icalendar/</a>

##### CHANGES:

* BUGFIX: allow empty text values (e.g. in DESCRIPTION), as observed by
  "iCal import/export" (Android app) (robur-coop/icalendar#11 @hannesm)
