### PR TITLE
[new release] provider (0.0.11)

### DIFF
--- a/packages/provider/provider.0.0.11/opam
+++ b/packages/provider/provider.0.0.11/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Dynamic Dispatch with Traits"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "ISC"
+homepage: "https://github.com/mbarbin/provider"
+doc: "https://mbarbin.github.io/provider/"
+bug-reports: "https://github.com/mbarbin/provider/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "sexplib0" {>= "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/provider.git"
+url {
+  src:
+    "https://github.com/mbarbin/provider/releases/download/0.0.11/provider-0.0.11.tbz"
+  checksum: [
+    "sha256=80e346ccde7dbf39796c3140f914641713c445ccae0183ac2948e3feb18099f3"
+    "sha512=6e7ab4734add6543498cc7d4364a4c257c63dfd4c809e798857eec7b151778c4c307901571fb1bc05f2493af3c024efbfada21e98bc9b8d758e6d9a4b613f34f"
+  ]
+}
+x-commit-hash: "f81d0e4e6aabf40d7c42b1f13334f4ea68bf2a2c"


### PR DESCRIPTION
Skipping 0.0.10, publishing directly 0.0.11 on opam.

Detailed changelog available [here](https://github.com/mbarbin/provider/blob/main/CHANGES.md).

Blog post available [here](https://mbarbin.github.io/provider/blog/type-safe/).