### PR TITLE
pkg-config: attempt to mitigate issue on github runners

### DIFF
--- a/packages/conf-pkg-config/conf-pkg-config.4/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+authors: ["Francois Berenger"]
+homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+depends: [
+  ("host-arch-x86_64" {os = "win32" & os-distribution = "msys2"} & "conf-mingw-w64-pkgconf-x86_64" {os = "win32" & os-distribution = "msys2"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution = "msys2"} & "conf-mingw-w64-pkgconf-i686" {os = "win32" & os-distribution = "msys2"})
+]
+build: [
+  ["pkg-config" "--help"] {os != "openbsd" & os != "win32" & !(os = "macos" & os-distribution = "homebrew")}
+  ["pkgconf" "--version"] {(os = "win32" & os-distribution != "msys2") | (os = "macos" & os-distribution = "homebrew")}
+]
+depexts: [
+  ["pkg-config"] {os-family = "debian" | os-family = "ubuntu"}
+  ["pkgconf"] {os-distribution = "arch"}
+  ["pkgconf-pkg-config"] {os-distribution = "fedora"}
+  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
+  ["pkgconf-pkg-config"] {os-distribution = "mageia"}
+  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "ol" & os-version <= "7"}
+  ["pkgconf"] {os-distribution = "alpine"}
+  ["pkg-config"] {os-distribution = "nixos"}
+  ["pkgconf"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
+  ["pkgconf"] {os = "freebsd"}
+  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "ol" & os-version >= "8"}
+  ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
+  ["pkgconf"] {os-distribution = "cygwin"}
+]
+synopsis: "Check if pkg-config is installed and create an opam switch local pkgconfig folder"
+description: """
+This package can only install if the pkg-config package is installed
+on the system."""
+flags: conf


### PR DESCRIPTION
This will not fix the issue completely unfortunately.

## Problem

On homebrew the package `pkg-config` has been replaced by `pkgconf`, the executable `pkg-config` is now a symlink to `pkgconf`. On GitHub macos runner, `pkg-config` comes preinstalled and conflicts with the installation of the new package `pkgconf`, making the CIs fail:
```
::error::Cannot install pkgconf because conflicting formulae are installed.%0A  pkg-config: because both install `pkg.m4` file%0A%0APlease `brew unlink pkg-config` before continuing.%0A%0AUnlinking removes a formula's symlinks from /opt/homebrew. You can%0Alink the formula again after the install finishes. You can `--force` this%0Ainstall, but the build may fail or cause obscure side effects in the%0Aresulting software.%0A
            brew install pkgconf
```
Moreover, if `pkg-config` is uninstalled and `pkgconf` is manually installed, it seems that the symlink to `pkg-config` that is installed with it is not executable (at least it cannot be found by `opam`).

## Current Solutions
The only solutions, currently, are to either force the installation of `conf-pkg-config.2` on macos which uses the old name for the depext, or execute `brew unlink pkg-config; brew install pkgconf; brew unlink pkgconf; brew link pkg-config;` before installing anything. 

UPDATE: there is another solution (see https://github.com/ocaml/opam-repository/pull/26891#issuecomment-2486598516) that is running `brew update; brew upgrade; brew install pkgconf` beforehand

## This change
Not changing the package name in the depext, means that the package is broken on any new installation on macos with homebrew, while changing it means that it is broken on GitHub runners. This new version should install fine on both cases, provided that the GitHub runners unlink or remove the old package beforehand: `brew uninstall pkg-config`. It does not guarantee that `pkg-config` is a working executable though, that is either a bug in homebrew or in the GitHub runners that we have no control over.

See also the discussions in https://github.com/ocaml/opam-repository/pull/26891