### PR TITLE
mark old releases of mpp and glical as unavailable.

### DIFF
--- a/packages/glical/glical.0.0.1/opam
+++ b/packages/glical/glical.0.0.1/opam
@@ -24,3 +24,4 @@ url {
   src: "http://pw374.github.io/distrib/glical/glical-0.0.1.tar.gz"
   checksum: "md5=c4c53088559797ce7956aff1658e46c2"
 }
+available: false # source tarball not available

--- a/packages/glical/glical.0.0.2/opam
+++ b/packages/glical/glical.0.0.2/opam
@@ -24,3 +24,4 @@ url {
   src: "http://pw374.github.io/distrib/glical/glical-0.0.2.tar.gz"
   checksum: "md5=e0abc6b8188cfd75263ad151acb68337"
 }
+available: false # source tarball not available

--- a/packages/glical/glical.0.0.3/opam
+++ b/packages/glical/glical.0.0.3/opam
@@ -24,3 +24,4 @@ url {
   src: "http://pw374.github.io/distrib/glical/glical-0.0.3.tar.gz"
   checksum: "md5=3277552ee387d0fa35db96d9fd79f04a"
 }
+available: false # source tarball not available

--- a/packages/mpp/mpp.0.1.0/opam
+++ b/packages/mpp/mpp.0.1.0/opam
@@ -30,3 +30,4 @@ extra-source "mpp.install" {
     "md5=fc6ae660c4cc6b1a0341c94ba8d91b8f"
   ]
 }
+available: false # source tarball not available

--- a/packages/mpp/mpp.0.1.1/opam
+++ b/packages/mpp/mpp.0.1.1/opam
@@ -30,3 +30,4 @@ extra-source "mpp.install" {
     "md5=fc6ae660c4cc6b1a0341c94ba8d91b8f"
   ]
 }
+available: false # source tarball not available

--- a/packages/mpp/mpp.0.1.2/opam
+++ b/packages/mpp/mpp.0.1.2/opam
@@ -30,3 +30,4 @@ extra-source "mpp.install" {
     "md5=fc6ae660c4cc6b1a0341c94ba8d91b8f"
   ]
 }
+available: false # source tarball not available

--- a/packages/mpp/mpp.0.1.3/opam
+++ b/packages/mpp/mpp.0.1.3/opam
@@ -30,3 +30,4 @@ extra-source "mpp.install" {
     "md5=fc6ae660c4cc6b1a0341c94ba8d91b8f"
   ]
 }
+available: false # source tarball not available

--- a/packages/mpp/mpp.0.1.4/opam
+++ b/packages/mpp/mpp.0.1.4/opam
@@ -37,3 +37,4 @@ extra-source "mpp.install" {
     "md5=fc6ae660c4cc6b1a0341c94ba8d91b8f"
   ]
 }
+available: false # source tarball not available

--- a/packages/mpp/mpp.0.1.5/opam
+++ b/packages/mpp/mpp.0.1.5/opam
@@ -40,3 +40,4 @@ extra-source "mpp.install" {
     "md5=fc6ae660c4cc6b1a0341c94ba8d91b8f"
   ]
 }
+available: false # source tarball not available

--- a/packages/mpp/mpp.0.1.7/opam
+++ b/packages/mpp/mpp.0.1.7/opam
@@ -49,3 +49,4 @@ extra-source "_oasis_remove_.ml" {
     "md5=6100ca146fa97d2196eb49a2631d0796"
   ]
 }
+available: false # source tarball not available

--- a/packages/mpp/mpp.0.1.8/opam
+++ b/packages/mpp/mpp.0.1.8/opam
@@ -49,3 +49,4 @@ extra-source "_oasis_remove_.ml" {
     "md5=6100ca146fa97d2196eb49a2631d0796"
   ]
 }
+available: false # source tarball not available

--- a/packages/mpp/mpp.0.2.0/opam
+++ b/packages/mpp/mpp.0.2.0/opam
@@ -49,3 +49,4 @@ extra-source "_oasis_remove_.ml" {
     "md5=6100ca146fa97d2196eb49a2631d0796"
   ]
 }
+available: false # source tarball not available

--- a/packages/mpp/mpp.0.2.1/opam
+++ b/packages/mpp/mpp.0.2.1/opam
@@ -49,3 +49,4 @@ extra-source "_oasis_remove_.ml" {
     "md5=6100ca146fa97d2196eb49a2631d0796"
   ]
 }
+available: false # source tarball not available

--- a/packages/mpp/mpp.0.3.0/opam
+++ b/packages/mpp/mpp.0.3.0/opam
@@ -49,3 +49,4 @@ extra-source "_oasis_remove_.ml" {
     "md5=6100ca146fa97d2196eb49a2631d0796"
   ]
 }
+available: false # source tarball not available


### PR DESCRIPTION
the reasoning is that the source tarballs are unavailable.

discovered via https://opam.robur.coop/status -- also manually tried to download these archives without success.