### PR TITLE
some opam packages pointed to tarballs where GitHub replied with "multiple choices"

### DIFF
--- a/packages/mparser/mparser.1.0.1/opam
+++ b/packages/mparser/mparser.1.0.1/opam
@@ -18,6 +18,9 @@ parser combinator library similar to the Parsec library for Haskell by Daan
 Leijen and the FParsec library for FSharp by Stephan Tolksdorf."""
 flags: light-uninstall
 url {
-  src: "https://github.com/cakeplus/mparser/archive/1.0.1.tar.gz"
-  checksum: "md5=17b10733cccc86bbf7ddfab7ff61b9de"
+  src: "https://github.com/murmour/mparser/archive/refs/tags/1.0.1.tar.gz"
+  checksum: [
+    "md5=17b10733cccc86bbf7ddfab7ff61b9de"
+    "sha256=e860337adf1154e72cc11ef8ae4498a0682f4715050316f8a2cd5b7ef7524c39"
+  ]
 }

--- a/packages/mparser/mparser.1.0/opam
+++ b/packages/mparser/mparser.1.0/opam
@@ -17,6 +17,9 @@ parser combinator library similar to the Parsec library for Haskell by Daan
 Leijen and the FParsec library for FSharp by Stephan Tolksdorf."""
 flags: light-uninstall
 url {
-  src: "https://github.com/cakeplus/mparser/archive/1.0.tar.gz"
-  checksum: "md5=36ba9257179c1c13884d713131169141"
+  src: "https://github.com/murmour/mparser/archive/refs/tags/1.0.tar.gz"
+  checksum: [
+    "md5=36ba9257179c1c13884d713131169141"
+    "sha256=2da4204fdd5bba9bc5ce0c15e0ce1470bcce998c6562e774c7891d4a1bee1bca"
+  ]
 }

--- a/packages/mparser/mparser.1.1/opam
+++ b/packages/mparser/mparser.1.1/opam
@@ -33,6 +33,9 @@ parser combinator library similar to the Parsec library for Haskell by Daan
 Leijen and the FParsec library for FSharp by Stephan Tolksdorf."""
 flags: light-uninstall
 url {
-  src: "https://github.com/cakeplus/mparser/archive/1.1.tar.gz"
-  checksum: "md5=2f1213bd3f1f7f14ed0919318f501a1a"
+  src: "https://github.com/murmour/mparser/archive/refs/tags/1.1.tar.gz"
+  checksum: [
+    "md5=2f1213bd3f1f7f14ed0919318f501a1a"
+    "sha256=024ac47afa180eb4d0cf774810b1ddeb80c0fa0038652f56c83e09e243a4be4b"
+  ]
 }

--- a/packages/ocamlformat/ocamlformat.0.2/opam
+++ b/packages/ocamlformat/ocamlformat.0.2/opam
@@ -24,6 +24,9 @@ synopsis: "Auto-formatter for OCaml code"
 description:
   "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
 url {
-  src: "https://github.com/ocaml-ppx/ocamlformat/archive/v0.2.tar.gz"
-  checksum: "md5=0da94dc86b60ade10c2d3c1824ffabc4"
+  src: "https://github.com/ocaml-ppx/ocamlformat/archive/refs/tags/v0.2.tar.gz"
+  checksum: [
+    "md5=0da94dc86b60ade10c2d3c1824ffabc4"
+    "sha256=69f1c20605e0b1595fcc6ff5618900f0c9d1041b412a5b9201b7332d29aa12ab"
+  ]
 }

--- a/packages/ocamlformat_support/ocamlformat_support.0.2/opam
+++ b/packages/ocamlformat_support/ocamlformat_support.0.2/opam
@@ -14,6 +14,9 @@ synopsis: "Support package for OCamlFormat"
 description:
   "Consists of a patched version of the OCaml standard library Format module."
 url {
-  src: "https://github.com/ocaml-ppx/ocamlformat/archive/support.0.2.tar.gz"
-  checksum: "md5=162086e6ef309a7ea98943c189dc3a6d"
+  src: "https://github.com/ocaml-ppx/ocamlformat/archive/refs/tags/support.0.2.tar.gz"
+  checksum: [
+    "md5=162086e6ef309a7ea98943c189dc3a6d"
+    "sha256=8b773ea2a4f1d59a0827f0c9f05ba5d67b1b538cc04f32da095c2c3aa3d3efd0"
+  ]
 }

--- a/packages/ocp-indent/ocp-indent.1.5/opam
+++ b/packages/ocp-indent/ocp-indent.1.5/opam
@@ -39,6 +39,9 @@ Includes:
 * A library that can be directly used by editor writers, or just for
 approximate parsing."""
 url {
-  src: "https://github.com/OCamlPro/ocp-indent/archive/1.5.tar.gz"
-  checksum: "md5=4fffaf408044ef3a7add15c40ad0aa37"
+  src: "https://github.com/OCamlPro/ocp-indent/archive/refs/tags/1.5.tar.gz"
+  checksum: [
+    "md5=4fffaf408044ef3a7add15c40ad0aa37"
+    "sha256=60f899b327b619b3cfc1e92f1bd78309f32101989a6c7b920da88bd723ebd45b"
+  ]
 }

--- a/packages/oloop/oloop.0.1.2/opam
+++ b/packages/oloop/oloop.0.1.2/opam
@@ -38,6 +38,9 @@ synopsis:
   "Evaluate code through the OCaml toploop for inclusion in educational material."
 flags: light-uninstall
 url {
-  src: "https://github.com/ocaml/oloop/archive/0.1.2.tar.gz"
-  checksum: "md5=94fa6040cf7d4c4304cb06fa5902a1aa"
+  src: "https://github.com/ocaml/oloop/archive/refs/tags/0.1.2.tar.gz"
+  checksum: [
+    "md5=94fa6040cf7d4c4304cb06fa5902a1aa"
+    "sha256=66cc8e2e645640c4ecd76202b1e50b5a882a4e4c2b865524076b92afd902e050"
+  ]
 }

--- a/packages/rubytt/rubytt.0.1/opam
+++ b/packages/rubytt/rubytt.0.1/opam
@@ -24,8 +24,11 @@ synopsis: "rubytt is a static code analyzer for Ruby."
 description:
   "rubytt dump out Ruby code type annotation, and analysis unused variable bugs."
 url {
-  src: "https://github.com/chenyukang/rubytt/archive/v0.1.tar.gz"
-  checksum: "md5=b42dfee18d5d061583736a3b644133e6"
+  src: "https://github.com/chenyukang/rubytt/archive/refs/tags/v0.1.tar.gz"
+  checksum: [
+    "md5=b42dfee18d5d061583736a3b644133e6"
+    "sha256=75e8b46b99302834cd6c6fec9f67d7c5d13170a499092c627be5d46ce999ca6e"
+  ]
 }
 extra-source "rubytt.install" {
   src:

--- a/packages/tcpip/tcpip.2.8.1/opam
+++ b/packages/tcpip/tcpip.2.8.1/opam
@@ -77,6 +77,9 @@ library operating system that supports IPv4, IPv6, ARPv4,
 DHCPv4 and TCP/IP."""
 flags: light-uninstall
 url {
-  src: "https://github.com/mirage/mirage-tcpip/archive/v2.8.1.tar.gz"
-  checksum: "md5=1704b769cc0debc071bd50fcd4e8379c"
+  src: "https://github.com/mirage/mirage-tcpip/archive/refs/tags/v2.8.1.tar.gz"
+  checksum: [
+    "md5=1704b769cc0debc071bd50fcd4e8379c"
+    "sha256=6988f7f9e1f28610f7bf4855e425d662c6147c6bf5333174f940358190d878cc"
+  ]
 }


### PR DESCRIPTION
thanks that we have the checksum, I figured alternative download urls and also added the sha256 checksum to these tarballs

powered by https://opam.robur.coop/status where md5 is reported as d41d8cd98f00b204e9800998ecf8427e