### PR TITLE
Package typerep.v0.17.1

### DIFF
--- a/packages/typerep/typerep.v0.17.1/opam
+++ b/packages/typerep/typerep.v0.17.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/typerep"
+bug-reports: "https://github.com/janestreet/typerep/issues"
+dev-repo: "git+https://github.com/janestreet/typerep.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/typerep/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "base"  {>= "v0.17" & < "v0.18"}
+  "dune"  {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Typerep is a library for runtime types"
+url {
+  src:
+    "https://github.com/janestreet/typerep/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=1123cda36764ea0a286af25308d1c3e4"
+    "sha512=e81434ced58ab1cf3cb61d0e2c2106d81c81fe040130cfe07bb79dc3dcc834b1f51dec0faf50e06ccf8cac831e39f31a2ff4ca3dabef7bbaa61f85f13d7f44f5"
+  ]
+}


### PR DESCRIPTION
### `typerep.v0.17.1`
Typerep is a library for runtime types



---
* Homepage: https://github.com/janestreet/typerep
* Source repo: git+https://github.com/janestreet/typerep.git
* Bug tracker: https://github.com/janestreet/typerep/issues

---
:camel: Pull-request generated by opam-publish v2.4.0