### PR TITLE
Package torch.v0.17.1

### DIFF
--- a/packages/torch/torch.v0.17.1/opam
+++ b/packages/torch/torch.v0.17.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/torch"
+bug-reports: "https://github.com/janestreet/torch/issues"
+dev-repo: "git+https://github.com/janestreet/torch.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/torch/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"               {>= "5.1.0"}
+  "base"                {>= "v0.17" & < "v0.18"}
+  "core"                {>= "v0.17" & < "v0.18"}
+  "core_unix"           {>= "v0.17" & < "v0.18"}
+  "ppx_bench"           {>= "v0.17" & < "v0.18"}
+  "ppx_inline_test"     {>= "v0.17" & < "v0.18"}
+  "ppx_jane"            {>= "v0.17" & < "v0.18"}
+  "ppx_string"          {>= "v0.17" & < "v0.18"}
+  "stdio"               {>= "v0.17" & < "v0.18"}
+  "ctypes"              {>= "0.18.0"}
+  "ctypes-foreign"
+  "dune"                {>= "3.11.0"}
+  "dune-configurator"
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "libtorch"            {>= "2.3.0" & < "2.4.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Torch bindings for OCaml"
+description: "
+The ocaml-torch project provides some OCaml bindings for the Torch library.
+This brings to OCaml NumPy-like tensor computations with GPU acceleration and
+tape-based automatic differentiation.
+"
+url {
+  src: "https://github.com/janestreet/torch/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=34ef5494e9625a3bcb34146581f9385c"
+    "sha512=ddf7226001fd746d124c28e8430bb2af4565337144b71d5a6026e22c1ac301f68765717ff77603e4caf57a9e73ceb72db20da8891034b66889d4e1225ffc880d"
+  ]
+}


### PR DESCRIPTION
### `torch.v0.17.1`
Torch bindings for OCaml
The ocaml-torch project provides some OCaml bindings for the Torch library.
This brings to OCaml NumPy-like tensor computations with GPU acceleration and
tape-based automatic differentiation.



---
* Homepage: https://github.com/janestreet/torch
* Source repo: git+https://github.com/janestreet/torch.git
* Bug tracker: https://github.com/janestreet/torch/issues

---
:camel: Pull-request generated by opam-publish v2.4.0