### PR TITLE
[new release] elpi (2.0.0)

### DIFF
--- a/packages/elpi/elpi.2.0.0/opam
+++ b/packages/elpi/elpi.2.0.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.08.0" }
+  "ocaml" {>= "4.13.0" }
   "stdlib-shims"
   "ppxlib" {>= "0.12.0" }
   "menhir" {>= "20211230" }

--- a/packages/elpi/elpi.2.0.0/opam
+++ b/packages/elpi/elpi.2.0.0/opam
@@ -1,0 +1,90 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Claudio Sacerdoti Coen" "Enrico Tassi" ]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/LPCIC/elpi"
+doc: "https://LPCIC.github.io/elpi/"
+dev-repo: "git+https://github.com/LPCIC/elpi.git"
+bug-reports: "https://github.com/LPCIC/elpi/issues"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  [make "tests" "DUNE_OPTS=-p %{name}%" "SKIP=performance_HO" "SKIP+=performance_FO" "SKIP+=elpi_api_performance"] {with-test & os != "macos" & os-distribution != "alpine" & os-distribution != "freebsd"}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0" }
+  "stdlib-shims"
+  "ppxlib" {>= "0.12.0" }
+  "menhir" {>= "20211230" }
+  "re" {>= "1.7.2"}
+  "ppx_deriving" {>= "4.3"}
+  "ANSITerminal" {with-test}
+  "cmdliner" {with-test}
+  "fileutils" {with-test}
+  "dune" {>= "2.8.0"}
+  "conf-time" {with-test}
+  "atdgen" {>= "2.10.0"}
+  "atdts" {>= "2.10.0"}
+  "odoc" {with-doc}
+]
+synopsis: "ELPI - Embeddable λProlog Interpreter"
+description: """
+ELPI implements a variant of λProlog enriched with Constraint Handling Rules,
+a programming language well suited to manipulate syntax trees with binders.
+
+ELPI is designed to be embedded into larger applications written in OCaml as
+an extension language. It comes with an API to drive the interpreter and 
+with an FFI for defining built-in predicates and data types, as well as
+quotations and similar goodies that are handy to adapt the language to the host
+application.
+
+This package provides both a command line interpreter (elpi) and a library to
+be linked in other applications (eg by passing -package elpi to ocamlfind).
+
+The ELPI programming language has the following features:
+
+- Native support for variable binding and substitution, via an Higher Order
+  Abstract Syntax (HOAS) embedding of the object language. The programmer
+  does not need to care about technical devices to handle bound variables,
+  like De Bruijn indices.
+
+- Native support for hypothetical context. When moving under a binder one can
+  attach to the bound variable extra information that is collected when the
+  variable gets out of scope. For example when writing a type-checker the
+  programmer needs not to care about managing the typing context.
+
+- Native support for higher order unification variables, again via HOAS.
+  Unification variables of the meta-language (λProlog) can be reused to
+  represent the unification variables of the object language. The programmer
+  does not need to care about the unification-variable assignment map and
+  cannot assign to a unification variable a term containing variables out of
+  scope, or build a circular assignment.
+
+- Native support for syntactic constraints and their meta-level handling rules.
+  The generative semantics of Prolog can be disabled by turning a goal into a
+  syntactic constraint (suspended goal). A syntactic constraint is resumed as
+  soon as relevant variables gets assigned. Syntactic constraints can be
+  manipulated by constraint handling rules (CHR).
+
+- Native support for backtracking. To ease implementation of search.
+
+- The constraint store is extensible.  The host application can declare
+  non-syntactic constraints and use custom constraint solvers to check their
+  consistency.
+
+- Clauses are graftable. The user is free to extend an existing program by
+  inserting/removing clauses, both at runtime (using implication) and at
+  "compilation" time by accumulating files.
+
+ELPI is free software released under the terms of LGPL 2.1 or above."""
+url {
+  src:
+    "https://github.com/LPCIC/elpi/releases/download/v2.0.0/elpi-2.0.0.tbz"
+  checksum: [
+    "sha256=923ca2cc0ffa3ea16afc28e2c863d347f78626e7a50fc1b207490c03115235e8"
+    "sha512=d629cf7cf9497ddd4ed983f043d555b8498bc4edb0cfd38b598a395b5bd3b9e40a48ff8df5840d3595074678e4f3f05233fd4d64854fb42017fa3ad849d7d738"
+  ]
+}
+x-commit-hash: "e8af0fa6e4892429e5b0883c1047bd507ce8206b"


### PR DESCRIPTION
ELPI - Embeddable λProlog Interpreter

- Project page: <a href="https://github.com/LPCIC/elpi">https://github.com/LPCIC/elpi</a>
- Documentation: <a href="https://LPCIC.github.io/elpi/">https://LPCIC.github.io/elpi/</a>

##### CHANGES:

Requires Menhir 20211230 and OCaml 4.08 or above.

- Compiler:
  - Change the pipeline completely to make unit relocation unnecessary. Current
    phases are (roughly):
    1. `Ast.program` —[`RecoverStructure`]—> `Ast.Structured.program`
    2. `Ast.Structured.program` —[`Scope`,`Quotation`,`Macro`]—> `Scoped.program` (aka `API.Compile.scoped_program`)
    3. `Scoped.program` —[`Flatten`]—> `Flat.program`
    4. `Flat.program` —[`Check`]—> `CheckedFlat.program` (aka `API.Compile.compilation_unit`)
    5. `CheckedFlat.program` —[`Spill`,`ToDbl`]—> `Assembled.program`

    Steps 4 and 5 operate on a base, that is an `Assembled.program` being
    extended. `ToDbl` is in charge of allocating constants (numbers) for global
    names and takes place when the unit is assembled on the base. These
    constants don't need to be relocated as in the previous backend that
    would allocate these constants much earlier.
  - Change compilation units can declare new builtin predicates
  - Fix macros are hygienic
  - New type checker written in OCaml. The new type checker is faster,
    reports error messages with a precise location and performs checking
    incrementally when the API for separate compilation is used.
    The new type checker is a bit less permissive since the old one would
    merged together all types declaration before type checking the entire
    program, while the new one type checks each unit using the types declared
    inside the unit or declared in the base it extends, but not the types
    declared in units that (will) follow it.
  - Remove the need of `typeabbrv string (ctype "string")` and similar
  - New type check types and kinds (used to be ignored).

- API:
  - Change quotations generate `Ast.Term.t` and not `RawData.t`. The data
    type `Ast.Term.t` contains locations (for locating type errors) and
    has named (bound) variables and type annotations in `Ast.Type.t`.
  - New `Compile.extend_signature` and `Compile.signature` to extend a
    program with the signature (the types, not the code) of a unit
  - New `Ast.Loc.t` carries a opaque payload defined by the host application
  - Remove `Query`, only `RawQuery` is available (or `Compile.query`)

- Parser:
  - Remove legacy parser
  - New `% elpi:if version op A.B.C` and `% elpi:endif` lexing directives
  - New warning for `A => B, C` to be disabled by putting parentheses
    around `A => B`.

- Language:
  - New infix `==>` standing for application but with "the right precedence™",
    i.e. `A ==> B, C` means `A => (B, C)`.
  - New `pred` is allowed in anonymous predicates, eg:
    `pred map i:list A, i:(pred i:A, o:B), o:list B` declares that the first
    argument of `map` is a predicate whose first argument is in input and
    the second in output. Currently the mode checker is still in development,
    annotations for higher order arguments are ignored.
  - New attribute `:functional` can be passed to predicates (but not types).
    For example, `:functional pred map i:list A, i:(:functional pred i:A, o:B), o:list B`
    declares `map` to be a functional predicate iff its higher order argument is
    functional. Currently the determinacy checker is still in development, these
    annotations are ignored.
  - New `func` keyword standing for `:functional pred`. The declaration above
    can be shortened to `func map i:list A, i:(func i:A, o:B), o:list B`.
  - New type annotations on variables quantified by `pi` as in `pi x : term \ ...`
  - New type casts on terms, as in `f (x : term)`
  - New attribute `:untyped` to skip the type checking of a rule.

- Stdlib:
  - New `std.list.init N E L` builds a list `L = [E, ..., E]` with length `N`
  - New `std.list.make N F L` builds the list `L = [F 0, F 1, ..., F (N-1)]`
  - New `triple` data type with constructor `triple` and projections `triple_1`...

- Builtins:
  - Remove `string_to_term`, `read`, `readterm`, `quote_syntax`

- REPL:
  - Remove `-no-tc`, `-legacy-parser`, `-legacy-parser-available`
  - New `-document-infix-syntax`
