### PR TITLE
[new release] eio (5 packages) (1.2)

### DIFF
--- a/packages/eio/eio.1.2/opam
+++ b/packages/eio/eio.1.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "5.1.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "hmap" {>= "0.8.1"}
+  "domain-local-await" {>= "0.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "2.0.0"}
+  "mdx" {>= "2.4.1" & with-test}
+  "dscheck" {>= "0.1.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "seq" {< "0.3"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.2/eio-1.2.tbz"
+  checksum: [
+    "sha256=3792e912bd8d494bb2e38f73081825e4d212b1970cf2c1f1b2966caa9fd6bc40"
+    "sha512=4a80dbcf8cf2663bdad0f2970871844f37bd293c56bd1ce602910e0a613754945f1f942719f9630906453be7c73c1732dc97526c6c90b0b36100d04fd5e871e4"
+  ]
+}
+x-commit-hash: "f26d70d64265a6bed7416d3db3bd14a5e090b6d6"

--- a/packages/eio_linux/eio_linux.1.2/opam
+++ b/packages/eio_linux/eio_linux.1.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An Eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "eio" {= version}
+  "mdx" {>= "2.4.1" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "0.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+available: [os = "linux"]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.2/eio-1.2.tbz"
+  checksum: [
+    "sha256=3792e912bd8d494bb2e38f73081825e4d212b1970cf2c1f1b2966caa9fd6bc40"
+    "sha512=4a80dbcf8cf2663bdad0f2970871844f37bd293c56bd1ce602910e0a613754945f1f942719f9630906453be7c73c1732dc97526c6c90b0b36100d04fd5e871e4"
+  ]
+}
+x-commit-hash: "f26d70d64265a6bed7416d3db3bd14a5e090b6d6"

--- a/packages/eio_main/eio_main.1.2/opam
+++ b/packages/eio_main/eio_main.1.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "mdx" {>= "2.4.1" & with-test}
+  "kcas" {>= "0.3.0" & with-test}
+  "yojson" {>= "2.0.2" & with-test}
+  "eio_linux"
+    {= version & os = "linux" &
+     (os-distribution != "centos" | os-version > "7")}
+  "eio_posix" {= version & os != "win32"}
+  "eio_windows" {= version & os = "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+x-ci-accept-failures: ["macos-homebrew"]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.2/eio-1.2.tbz"
+  checksum: [
+    "sha256=3792e912bd8d494bb2e38f73081825e4d212b1970cf2c1f1b2966caa9fd6bc40"
+    "sha512=4a80dbcf8cf2663bdad0f2970871844f37bd293c56bd1ce602910e0a613754945f1f942719f9630906453be7c73c1732dc97526c6c90b0b36100d04fd5e871e4"
+  ]
+}
+x-commit-hash: "f26d70d64265a6bed7416d3db3bd14a5e090b6d6"

--- a/packages/eio_posix/eio_posix.1.2/opam
+++ b/packages/eio_posix/eio_posix.1.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for POSIX systems"
+description: "An Eio implementation for most Unix-like platforms"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "iomux" {>= "0.2"}
+  "mdx" {>= "2.4.1" & with-test}
+  "conf-bash" {with-test}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.2/eio-1.2.tbz"
+  checksum: [
+    "sha256=3792e912bd8d494bb2e38f73081825e4d212b1970cf2c1f1b2966caa9fd6bc40"
+    "sha512=4a80dbcf8cf2663bdad0f2970871844f37bd293c56bd1ce602910e0a613754945f1f942719f9630906453be7c73c1732dc97526c6c90b0b36100d04fd5e871e4"
+  ]
+}
+x-commit-hash: "f26d70d64265a6bed7416d3db3bd14a5e090b6d6"

--- a/packages/eio_windows/eio_windows.1.2/opam
+++ b/packages/eio_windows/eio_windows.1.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Windows"
+description: "An Eio implementation using OCaml's Unix.select"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "fmt" {>= "0.8.9"}
+  "kcas" {>= "0.3.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.2/eio-1.2.tbz"
+  checksum: [
+    "sha256=3792e912bd8d494bb2e38f73081825e4d212b1970cf2c1f1b2966caa9fd6bc40"
+    "sha512=4a80dbcf8cf2663bdad0f2970871844f37bd293c56bd1ce602910e0a613754945f1f942719f9630906453be7c73c1732dc97526c6c90b0b36100d04fd5e871e4"
+  ]
+}
+x-commit-hash: "f26d70d64265a6bed7416d3db3bd14a5e090b6d6"
+available: [os = "win32"]


### PR DESCRIPTION
Effect-based direct-style IO API for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/eio">https://github.com/ocaml-multicore/eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/eio/">https://ocaml-multicore.github.io/eio/</a>

##### CHANGES:

Changes:

- Make `fork_action.h` a public header (@patricoferris ocaml-multicore/eio#769, reviewed by @talex5).
  Allows other libraries to add new actions.

- Record trace event when spawning processes (@talex5 ocaml-multicore/eio#749).
  Spawning a subprocess can take a long time in some cases, so show it clearly in the traces.

- Eio_unix.Net: make some return types more polymorphic (@talex5 ocaml-multicore/eio#744).

Bug fixes:

- Preserve backtraces in `fork_daemon` (@talex5 ocaml-multicore/eio#779).

- Eio.Path: always use "/" as separator (@talex5 ocaml-multicore/eio#743).

Linux backend:

- Allow `alloc_fixed_or_wait` to be cancelled (@talex5 ocaml-multicore/eio#753).

- Avoid triggering a (harmless) TSan warning (@talex5 ocaml-multicore/eio#754, reported by @avsm).

Windows backend:

- Unregister FDs on cancel (@talex5 ocaml-multicore/eio#756).
  Fixes `exception Unix.Unix_error(Unix.ENOTSOCK, "select", "")`.

- Work around problems in `Unix.getaddrinfo` (@talex5 ocaml-multicore/eio#780).
  Fixes e.g. `No addresses found for host name "127.0.0.1"`.

- Group `ECONNABORTED` with other connection reset errors (@talex5 ocaml-multicore/eio#783).

- Check `has_symlink` for tests (@create2000 ocaml-multicore/eio#771, reviewed by @patricoferris and @talex5).

- Improve `openat` error handling (@talex5 ocaml-multicore/eio#742, reported by @kentookura).
  Fixes `exception Unix.Unix_error(Unix.ENOENT, "openat", "")`.

Documentation:

- examples/fs: show how to read files while scanning (@talex5 ocaml-multicore/eio#745).

- Add example to `Buf_read.seq` documentation (@talex5 ocaml-multicore/eio#739, requested by @darrenldl and @rizo).

Build and test:

- Fix tests on OpenBSD (@talex5 ocaml-multicore/eio#782).

- Add advice about using AI for code generation (@patricoferris ocaml-multicore/eio#765, reviewed by @avsm and @talex5).

- Minor code cleanups (@talex5 ocaml-multicore/eio#755).

- Define `struct clone_args` for linux-lts versions that don't have it (@copy ocaml-multicore/eio#741, reviewed by @talex5).

- eio_linux: refactor fixed buffer code (@talex5 ocaml-multicore/eio#752).
