### PR TITLE
Package eugener-test-ocaml.0.1.0

### DIFF
--- a/packages/eugener-test-ocaml/eugener-test-ocaml.0.1.0/opam
+++ b/packages/eugener-test-ocaml/eugener-test-ocaml.0.1.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "test project. don't download"
+description:
+  "test project. don't downloadtest project. don't downloadtest project. don't downloadtest project. don't download"
+maintainer: "your-email@example.com"
+authors: "Your Name"
+license: "MIT"
+homepage: "hhttps://github.com/pypi/warehouse"
+bug-reports: "https://github.com/pypi/warehouse/issues"
+depends: [
+  "dune" {>= "2.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+install: ["dune" "install" "-p" name "--prefix=%{prefix}%"]
+dev-repo: "git+https://github.com/pypi/warehouse.git"
+url {
+  src:
+    "https://github.com/eugenebmx/eugener-test-ocaml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=be0f872053897add61744ff874cb6241"
+    "sha512=d78aec041ffabc03e6c4563bf8ef2e3c4ea9e9bb29c3589c51d154919b1495249aa762778036ec8c2ebcd03625e37d4de3cd6f27f08ebfe624f0a0dd25929606"
+  ]
+}


### PR DESCRIPTION
### `eugener-test-ocaml.0.1.0`
test project. don't download
test project. don't downloadtest project. don't downloadtest project. don't downloadtest project. don't download



---
* Homepage: hhttps://github.com/pypi/warehouse
* Source repo: git+https://github.com/pypi/warehouse.git
* Bug tracker: https://github.com/pypi/warehouse/issues

---
:camel: Pull-request generated by opam-publish v2.4.0