### PR TITLE
add ocaml-src 5.2.1

### DIFF
--- a/packages/ocaml-src/ocaml-src.5.2.1/opam
+++ b/packages/ocaml-src/ocaml-src.5.2.1/opam
@@ -1,0 +1,15 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "OCaml contributors"
+homepage: "http://ocaml.org/"
+build: [ "touch" "META" ]
+install: ["cp" "-r" "." "%{lib}%/ocaml-src"]
+synopsis: "Compiler sources"
+depends: [
+  "ocaml" {= "5.2.1"}
+]
+url {
+  src: "https://github.com/ocaml/ocaml/releases/download/5.2.1/ocaml-5.2.1.tar.gz"
+  checksum: "sha256=2d0f8090951a97a2c0e5b8a11e90096c0e1791d2e471e4a67f87e3b974044cd0"
+}


### PR DESCRIPTION
//cc @Octachron @shym @reynir

I tried to find the ocaml-src release instructions in the ocaml/ocaml repository, but couldn't.

The gist is, as discussed with @shym, that an empty META file is sufficient for `ocamlfind query` purposes. So, in this opam file we execute `touch META`.