### PR TITLE
Update the archive URLs for `checked_oint` & `mazeppa`

### DIFF
--- a/packages/checked_oint/checked_oint.0.1.0/opam
+++ b/packages/checked_oint/checked_oint.0.1.0/opam
@@ -35,7 +35,7 @@ build: [
 dev-repo: "git+https://github.com/hirrolot/checked_oint.git"
 url {
   src:
-    "https://github.com/hirrolot/checked_oint/archive/refs/tags/v0.1.0.tar.gz"
+    "https://github.com/hirrolot/checked_oint/releases/download/v0.1.0/checked_oint-0.1.0.tar.gz"
   checksum: [
     "md5=015b6838aefc5191eda3cc069722fcfd"
     "sha512=856404be0b5272e9df6530aa771f80676431142a5758951cb58068088d34b30e9848271611a9fff7b3d6e7ca979db4ac342e8f3eb5d83f4df0b71eaac3726a2a"

--- a/packages/checked_oint/checked_oint.0.1.1/opam
+++ b/packages/checked_oint/checked_oint.0.1.1/opam
@@ -35,7 +35,7 @@ build: [
 dev-repo: "git+https://github.com/hirrolot/checked_oint.git"
 url {
   src:
-    "https://github.com/hirrolot/checked_oint/archive/refs/tags/v0.1.1.tar.gz"
+    "https://github.com/hirrolot/checked_oint/releases/download/v0.1.1/checked_oint-0.1.1.tar.gz"
   checksum: [
     "md5=8c5bd9e10faffd495037c4ecd0f8e6ea"
     "sha512=e0179cbb8ea6d3f1a5ed87e190c88cd5a95a5cca817ef786b945e0fd8ffaaea46d34b64ea673b6c184fae27860f9a44ad0b66dc974fbfc9558de9025eb84d6f2"

--- a/packages/checked_oint/checked_oint.0.1.2/opam
+++ b/packages/checked_oint/checked_oint.0.1.2/opam
@@ -35,7 +35,7 @@ build: [
 dev-repo: "git+https://github.com/hirrolot/checked_oint.git"
 url {
   src:
-    "https://github.com/hirrolot/checked_oint/archive/refs/tags/v0.1.2.tar.gz"
+    "https://github.com/hirrolot/checked_oint/releases/download/v0.1.2/checked_oint-0.1.2.tar.gz"
   checksum: [
     "md5=c4dab38d7d8b37987679308225374fad"
     "sha512=8d416cd33a030fab4722a155f10ae44b9080de20be761927c9bb20d1c35ec1668ff1774121861156d16735ca1a22ee850f3762e8f2df8d06257b75367fb2d91f"

--- a/packages/checked_oint/checked_oint.0.2.0/opam
+++ b/packages/checked_oint/checked_oint.0.2.0/opam
@@ -35,7 +35,7 @@ build: [
 dev-repo: "git+https://github.com/hirrolot/checked_oint.git"
 url {
   src:
-    "https://github.com/hirrolot/checked_oint/archive/refs/tags/v0.2.0.tar.gz"
+    "https://github.com/hirrolot/checked_oint/releases/download/v0.2.0/checked_oint-0.2.0.tar.gz"
   checksum: [
     "md5=5ee41b2897b3f2eba115bcbcdfd5c678"
     "sha512=c8d33fad538fea814c1fc89981bc57132025e544d83bdce41133f2c3660dba7f0a94c25626f6619d06d657345867acb779bef45353dfc03a59e698e4a8644432"

--- a/packages/checked_oint/checked_oint.0.2.1/opam
+++ b/packages/checked_oint/checked_oint.0.2.1/opam
@@ -35,7 +35,7 @@ build: [
 dev-repo: "git+https://github.com/hirrolot/checked_oint.git"
 url {
   src:
-    "https://github.com/hirrolot/checked_oint/archive/refs/tags/v0.2.1.tar.gz"
+    "https://github.com/hirrolot/checked_oint/releases/download/v0.2.1/checked_oint-0.2.1.tar.gz"
   checksum: [
     "md5=79c7b1b3d9aadaafa0e22b8803697875"
     "sha512=9a1da14a0473a8354dd8bfc376d4e49c111f58c471683745606c41b80b04d89bdacce0c51d1e83534431bd15d67fa1a9ac354c9d2182d10a0e19a3dc475a1b21"

--- a/packages/checked_oint/checked_oint.0.2.2/opam
+++ b/packages/checked_oint/checked_oint.0.2.2/opam
@@ -35,7 +35,7 @@ build: [
 dev-repo: "git+https://github.com/hirrolot/checked_oint.git"
 url {
   src:
-    "https://github.com/hirrolot/checked_oint/archive/refs/tags/v0.2.2.tar.gz"
+    "https://github.com/hirrolot/checked_oint/releases/download/v0.2.2/checked_oint-0.2.2.tar.gz"
   checksum: [
     "md5=0c1932db96a75660802f3965fa17ef20"
     "sha512=33218a9f5f5e31eaea8c1443f542456f7d988c0ab1ebe9025df107906f073906be012f21f35dead1f193a3fe4d394e02b0cd0de8c47f214f44990458f369cea4"

--- a/packages/checked_oint/checked_oint.0.3.0/opam
+++ b/packages/checked_oint/checked_oint.0.3.0/opam
@@ -35,7 +35,7 @@ build: [
 dev-repo: "git+https://github.com/hirrolot/checked_oint.git"
 url {
   src:
-    "https://github.com/hirrolot/checked_oint/archive/refs/tags/v0.3.0.tar.gz"
+    "https://github.com/hirrolot/checked_oint/releases/download/v0.3.0/checked_oint-0.3.0.tar.gz"
   checksum: [
     "md5=3b95c21cd6dd84dc2ecd5d282ab93af4"
     "sha512=fd32690a0b99b4113349177b7c0201de4a405fe60d94b22a338575f4a9bd3f45c14576ae216be6a26390f305ed52e6db5bdc15787402be546f9143a4af26fee3"

--- a/packages/mazeppa/mazeppa.0.3.3/opam
+++ b/packages/mazeppa/mazeppa.0.3.3/opam
@@ -40,7 +40,7 @@ build: [
 dev-repo: "git+https://github.com/mazeppa-dev/mazeppa.git"
 url {
   src:
-    "https://github.com/mazeppa-dev/mazeppa/archive/refs/tags/v0.3.3.tar.gz"
+    "https://github.com/mazeppa-dev/mazeppa/releases/download/v0.3.3/mazeppa-0.3.3.tar.gz"
   checksum: [
     "md5=e732cb5cca65b4c8c489f9a9f557e0b6"
     "sha512=1150bf0c72e9116bba485a344c35c5a5bc39266ef16b989110a162b86b2097b4a49c1cc6250491d89f7c8fa21fe3ae5daa76b570ce795f503eb64a6189d02c19"

--- a/packages/mazeppa/mazeppa.0.3.4/opam
+++ b/packages/mazeppa/mazeppa.0.3.4/opam
@@ -40,7 +40,7 @@ build: [
 dev-repo: "git+https://github.com/mazeppa-dev/mazeppa.git"
 url {
   src:
-    "https://github.com/mazeppa-dev/mazeppa/archive/refs/tags/v0.3.4.tar.gz"
+    "https://github.com/mazeppa-dev/mazeppa/releases/download/v0.3.4/mazeppa-0.3.4.tar.gz"
   checksum: [
     "md5=483618360742d6679c0408a8620a5a89"
     "sha512=53846649886b8d06eef35c486b82398165edf0d942a07007d1a17da98427a86a27dafaa4e203e39904415291a5ed2c0ee675bed9d659f68d1309e9ecccade315"

--- a/packages/mazeppa/mazeppa.0.4.1/opam
+++ b/packages/mazeppa/mazeppa.0.4.1/opam
@@ -40,7 +40,7 @@ build: [
 dev-repo: "git+https://github.com/mazeppa-dev/mazeppa.git"
 url {
   src:
-    "https://github.com/mazeppa-dev/mazeppa/archive/refs/tags/v0.4.1.tar.gz"
+    "https://github.com/mazeppa-dev/mazeppa/releases/download/v0.4.1/mazeppa-0.4.1.tar.gz"
   checksum: [
     "md5=258c6ec22fa9128eecebbd71badb0900"
     "sha512=a841a9a7e608130126f316b799153a95d1ca4bce7d2b8521a4a66aac207e86ee38af9a98b8306657004215ca9b66a247920303ad966a7c2dd4bee3bd62e67957"

--- a/packages/mazeppa/mazeppa.0.4.2/opam
+++ b/packages/mazeppa/mazeppa.0.4.2/opam
@@ -40,7 +40,7 @@ build: [
 dev-repo: "git+https://github.com/mazeppa-dev/mazeppa.git"
 url {
   src:
-    "https://github.com/mazeppa-dev/mazeppa/archive/refs/tags/v0.4.2.tar.gz"
+    "https://github.com/mazeppa-dev/mazeppa/releases/download/v0.4.2/mazeppa-0.4.2.tar.gz"
   checksum: [
     "md5=9681403e6ce9929c8b853df58070ce54"
     "sha512=821610f54f8086302cadcb531a7d0b74270e61e33f887f0d748a5dc226700e9e1247a12c29252b172acd64f58ec1a7e781c42a50f74718a1f6468bb295335d7e"

--- a/packages/mazeppa/mazeppa.0.4.3/opam
+++ b/packages/mazeppa/mazeppa.0.4.3/opam
@@ -40,7 +40,7 @@ build: [
 dev-repo: "git+https://github.com/mazeppa-dev/mazeppa.git"
 url {
   src:
-    "https://github.com/mazeppa-dev/mazeppa/archive/refs/tags/v0.4.3.tar.gz"
+    "https://github.com/mazeppa-dev/mazeppa/releases/download/v0.4.3/mazeppa-0.4.3.tar.gz"
   checksum: [
     "md5=6c66f3bcf750bfc08f73b7f13d1b601b"
     "sha512=329238ea2e2fa3200a417838bd36f2832e528cb7e12354af574796f565b4edd6ebf4e2d9cdb759c133f09a956baea48d58445a5b53e6974de0bb21b7e3b73895"


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/26944.

For the curious, the new and old archives were different byte-wise because GitHub inserts the commit's SHA-1 into a custom `.tar` metadata field called `comment`:

```bash
$ gzip -d mazeppa-0.4.3.tar.gz
$ gzip -d mazeppa-0.4.3-old.tar.gz
$ md5sum mazeppa-0.4.3.tar
da53390343565823e32ce43dfb2d805b  mazeppa-0.4.3.tar
$ md5sum mazeppa-0.4.3-old.tar
8c989a48fc858f7441e3cd4e33332142  mazeppa-0.4.3-old.tar
$ head -c 2048 mazeppa-0.4.3.tar | grep -ao "comment=[^[:space:]]*"
comment=0c4e7b577d3607433340a46344427bac8780c0e1
$ head -c 2048 mazeppa-0.4.3-old.tar | grep -ao "comment=[^[:space:]]*"
comment=b3d044040f82d4611c475930da889e4e804ed956
```

If we compare the decompressed folders, they will be the same content-wise:

```bash
$ mkdir new old
$ tar -xf mazeppa-0.4.3.tar -C new
$ tar -xf mazeppa-0.4.3-old.tar -C old
$ diff -r new old
# Empty output.
```

In the future, I'll attach custom GitHub release archives to make sure they don't change under any circumstances. The current PR implements it for the existing versions of `checked_oint` and `mazeppa`.
