### PR TITLE
[new release] passage (0.1.5)

### DIFF
--- a/packages/passage/passage.0.1.5/opam
+++ b/packages/passage/passage.0.1.5/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Passage - used to store and manage access to shared secrets"
+description: "Passage - used to store and manage access to shared secrets"
+maintainer: ["Ahrefs Pte Ltd <github@ahrefs.com>"]
+authors: ["Ahrefs Pte Ltd <github@ahrefs.com>"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/passage"
+bug-reports: "https://github.com/ahrefs/passage/issues"
+depends: [
+  "cmdliner" {>= "1.1.0"}
+  "ocaml" {>= "4.14"}
+  "conf-age"
+  "dune" {>= "3.9"}
+  "devkit" {>= "1.20240429"}
+  "extunix"
+  "fileutils"
+  "fpath"
+  "lwt"
+  "lwt_ppx"
+  "menhir" {>= "20231231"}
+  "ppx_expect"
+  "ocamlformat" {with-dev-setup & = "0.26.2"}
+  "qrc"
+  "re2"
+  "sedlex"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/passage.git"
+available: os != "win32"
+x-ci-accept-failures: [
+  "alpine-3.20"
+  "archlinux"
+  "debian-11"
+  "fedora-39"
+  "fedora-40"
+  "opensuse-15.6"
+  "opensuse-tumbleweed"
+]
+url {
+  src:
+    "https://github.com/ahrefs/passage/releases/download/0.1.5/passage-0.1.5.tbz"
+  checksum: [
+    "sha256=ad105078efacf001de3793838cc694041727567e2d91b588820a8c21bf3aca95"
+    "sha512=2eedfa450cbc42001d12247f87762c83b89ae7b57a6ea02415a6603d6c1b88e3d0b4e446f544e1b4930b89967c46524b3f2cea69982ba5b8299a4abaac18661e"
+  ]
+}
+x-commit-hash: "3a473c2407a0ab0b320d7a6061b629510b31a60c"


### PR DESCRIPTION
Passage - used to store and manage access to shared secrets

- Project page: <a href="https://github.com/ahrefs/passage">https://github.com/ahrefs/passage</a>

##### CHANGES:

- Add replace-comment command
- Make new and edit commands usage uniform
- Remove bash completions opam install. Moved to debian package.
