### PR TITLE
[new release] postgresql (5.1.1)

### DIFF
--- a/packages/postgresql/postgresql.5.1.1/opam
+++ b/packages/postgresql/postgresql.5.1.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Bindings to the PostgreSQL library"
+description:
+  "Postgresql offers library functions for accessing PostgreSQL databases."
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "dune-configurator"
+  "conf-postgresql" {build}
+  "base-bytes"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/postgresql-ocaml/releases/download/5.1.1/postgresql-5.1.1.tbz"
+  checksum: [
+    "sha256=ed6bbfcdc65ebeffa8e003e27d41f913aede8f8a359d20064cb51fa8320373dd"
+    "sha512=1ed5918393a219e007e050b0e165481565e4ec6bd9dea84633dfe1ebbc32876bb040199c9c29356a84ad0f043c60a020b9d3ab46d4e682d85fd63914e114e7ff"
+  ]
+}
+x-commit-hash: "7f65e09c242e67e31de5516c0054e5a71eb007ef"


### PR DESCRIPTION
Bindings to the PostgreSQL library

- Project page: <a href="https://mmottl.github.io/postgresql-ocaml">https://mmottl.github.io/postgresql-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/postgresql-ocaml/api">https://mmottl.github.io/postgresql-ocaml/api</a>

##### CHANGES:

- Fixed a rare, architecture-specific GC bug in `lo_seek`.
