### PR TITLE
Update `checked_oint` v0.4.0 to a stable archive URL

### DIFF
--- a/packages/checked_oint/checked_oint.0.4.0/opam
+++ b/packages/checked_oint/checked_oint.0.4.0/opam
@@ -35,7 +35,7 @@ build: [
 dev-repo: "git+https://github.com/hirrolot/checked_oint.git"
 url {
   src:
-    "https://github.com/hirrolot/checked_oint/archive/refs/tags/v0.4.0.tar.gz"
+    "https://github.com/hirrolot/checked_oint/releases/download/v0.4.0/checked_oint-0.4.0.tar.gz"
   checksum: [
     "md5=abc8c77a6e909ca0938206929c8b526d"
     "sha512=dc9d3509656e1fa99615e1ad78f1f7f537cfe115ccd439dbee8094f394373b49aed0cc513052a4a3e6ba68bf7ee2632456f9679dcb2da779b0792931af8862fd"


### PR DESCRIPTION
In https://github.com/ocaml/opam-repository/pull/26943, we forgot to update the package URL to a stable archive (not dynamically generated), in accordance with the approach implemented in https://github.com/ocaml/opam-repository/pull/26958.
