### PR TITLE
correct opam file for liblinear

### DIFF
--- a/packages/liblinear/liblinear.2.47/opam
+++ b/packages/liblinear/liblinear.2.47/opam
@@ -20,7 +20,7 @@ available: os != "win32"
 synopsis: "User-space installer for liblinear"
 description: """
 Attempt a user-space installation of liblinear.
-If successful, liblinear-train and liblinear-predict will be installed
+If successful, liblinear_train and liblinear_predict will be installed
 into opam's bin directory.
 Note: liblinear is a C++ software which is required by some OCaml
 software in opam-repository.

--- a/packages/liblinear/liblinear.2.47/opam
+++ b/packages/liblinear/liblinear.2.47/opam
@@ -7,6 +7,8 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "BSD-3-Clause"
 build: [
   [make]
+]
+install: [
   ["cp" "train"   "%{bin}%/liblinear_train"]
   ["cp" "predict" "%{bin}%/liblinear_predict"]
 ]


### PR DESCRIPTION
copy commands must be part of the install stage; _not_ the build stage. opam lint doesn't pick such errors