### PR TITLE
[new release] dune (15 packages) (3.17.0)

### DIFF
--- a/packages/chrome-trace/chrome-trace.3.17.0/opam
+++ b/packages/chrome-trace/chrome-trace.3.17.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Chrome trace event generation library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz"
+  checksum: [
+    "sha256=2c3aa6c41ed39e3d6c1a292d75f4806bd80310841afc51673aa59ce9c816507c"
+    "sha512=29398bd5d7b5893937b6250356ea710c949aef37ffa8c9fae340a9b9234d6b896bbc161983ed34404b7e1fedc02794a064e1c92d1d5835b21a8d0c01ef2ca46c"
+  ]
+}
+x-commit-hash: "af1f4247450ea87eaa67c90bfcdd659c690058ec"

--- a/packages/dune-action-plugin/dune-action-plugin.3.17.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.17.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "dune-glob" {= version}
+  "csexp" {>= "1.5.0"}
+  "ppx_expect" {with-test}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "dune-rpc" {= version}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz"
+  checksum: [
+    "sha256=2c3aa6c41ed39e3d6c1a292d75f4806bd80310841afc51673aa59ce9c816507c"
+    "sha512=29398bd5d7b5893937b6250356ea710c949aef37ffa8c9fae340a9b9234d6b896bbc161983ed34404b7e1fedc02794a064e1c92d1d5835b21a8d0c01ef2ca46c"
+  ]
+}
+x-commit-hash: "af1f4247450ea87eaa67c90bfcdd659c690058ec"

--- a/packages/dune-build-info/dune-build-info.3.17.0/opam
+++ b/packages/dune-build-info/dune-build-info.3.17.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Embed build information inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz"
+  checksum: [
+    "sha256=2c3aa6c41ed39e3d6c1a292d75f4806bd80310841afc51673aa59ce9c816507c"
+    "sha512=29398bd5d7b5893937b6250356ea710c949aef37ffa8c9fae340a9b9234d6b896bbc161983ed34404b7e1fedc02794a064e1c92d1d5835b21a8d0c01ef2ca46c"
+  ]
+}
+x-commit-hash: "af1f4247450ea87eaa67c90bfcdd659c690058ec"

--- a/packages/dune-configurator/dune-configurator.3.17.0/opam
+++ b/packages/dune-configurator/dune-configurator.3.17.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.04.0"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz"
+  checksum: [
+    "sha256=2c3aa6c41ed39e3d6c1a292d75f4806bd80310841afc51673aa59ce9c816507c"
+    "sha512=29398bd5d7b5893937b6250356ea710c949aef37ffa8c9fae340a9b9234d6b896bbc161983ed34404b7e1fedc02794a064e1c92d1d5835b21a8d0c01ef2ca46c"
+  ]
+}
+x-commit-hash: "af1f4247450ea87eaa67c90bfcdd659c690058ec"

--- a/packages/dune-glob/dune-glob.3.17.0/opam
+++ b/packages/dune-glob/dune-glob.3.17.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "stdune" {= version}
+  "dyn"
+  "ordering"
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz"
+  checksum: [
+    "sha256=2c3aa6c41ed39e3d6c1a292d75f4806bd80310841afc51673aa59ce9c816507c"
+    "sha512=29398bd5d7b5893937b6250356ea710c949aef37ffa8c9fae340a9b9234d6b896bbc161983ed34404b7e1fedc02794a064e1c92d1d5835b21a8d0c01ef2ca46c"
+  ]
+}
+x-commit-hash: "af1f4247450ea87eaa67c90bfcdd659c690058ec"

--- a/packages/dune-private-libs/dune-private-libs.3.17.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.3.17.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "csexp" {>= "1.5.0"}
+  "pp" {>= "1.1.0"}
+  "dyn" {= version}
+  "stdune" {= version}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz"
+  checksum: [
+    "sha256=2c3aa6c41ed39e3d6c1a292d75f4806bd80310841afc51673aa59ce9c816507c"
+    "sha512=29398bd5d7b5893937b6250356ea710c949aef37ffa8c9fae340a9b9234d6b896bbc161983ed34404b7e1fedc02794a064e1c92d1d5835b21a8d0c01ef2ca46c"
+  ]
+}
+x-commit-hash: "af1f4247450ea87eaa67c90bfcdd659c690058ec"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.17.0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.17.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc and Lwt"
+description: "Specialization of dune-rpc to Lwt"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "dune-rpc" {= version}
+  "csexp" {>= "1.5.0"}
+  "lwt" {>= "5.6.0"}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz"
+  checksum: [
+    "sha256=2c3aa6c41ed39e3d6c1a292d75f4806bd80310841afc51673aa59ce9c816507c"
+    "sha512=29398bd5d7b5893937b6250356ea710c949aef37ffa8c9fae340a9b9234d6b896bbc161983ed34404b7e1fedc02794a064e1c92d1d5835b21a8d0c01ef2ca46c"
+  ]
+}
+x-commit-hash: "af1f4247450ea87eaa67c90bfcdd659c690058ec"

--- a/packages/dune-rpc/dune-rpc.3.17.0/opam
+++ b/packages/dune-rpc/dune-rpc.3.17.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz"
+  checksum: [
+    "sha256=2c3aa6c41ed39e3d6c1a292d75f4806bd80310841afc51673aa59ce9c816507c"
+    "sha512=29398bd5d7b5893937b6250356ea710c949aef37ffa8c9fae340a9b9234d6b896bbc161983ed34404b7e1fedc02794a064e1c92d1d5835b21a8d0c01ef2ca46c"
+  ]
+}
+x-commit-hash: "af1f4247450ea87eaa67c90bfcdd659c690058ec"

--- a/packages/dune-site/dune-site.3.17.0/opam
+++ b/packages/dune-site/dune-site.3.17.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Embed locations information inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz"
+  checksum: [
+    "sha256=2c3aa6c41ed39e3d6c1a292d75f4806bd80310841afc51673aa59ce9c816507c"
+    "sha512=29398bd5d7b5893937b6250356ea710c949aef37ffa8c9fae340a9b9234d6b896bbc161983ed34404b7e1fedc02794a064e1c92d1d5835b21a8d0c01ef2ca46c"
+  ]
+}
+x-commit-hash: "af1f4247450ea87eaa67c90bfcdd659c690058ec"

--- a/packages/dune/dune.3.17.0/opam
+++ b/packages/dune/dune.3.17.0/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+Dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+Dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+Dune is composable; supporting multi-package development by simply
+dropping multiple repositories into the same directory.
+
+Dune also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
+  "base-unix"
+  "base-threads"
+  "lwt" { with-dev-setup & os != "win32" }
+  "cinaps" { with-dev-setup }
+  "csexp" { with-dev-setup & >= "1.3.0" }
+  "js_of_ocaml" { with-dev-setup & os != "win32" }
+  "js_of_ocaml-compiler" { with-dev-setup & os != "win32" }
+  "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
+  "menhir" { with-dev-setup & os != "win32" }
+  "ocamlfind" { with-dev-setup & os != "win32" }
+  "odoc" { with-dev-setup & >= "2.4.0" & os != "win32" }
+  "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
+  "ppx_inline_test" { with-dev-setup & os != "win32" }
+  "ppxlib" { with-dev-setup & os != "win32" }
+  "ctypes" { with-dev-setup & os != "win32" }
+  "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
+  "melange" { with-dev-setup & >= "4.0.0-51" & os != "win32" }
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz"
+  checksum: [
+    "sha256=2c3aa6c41ed39e3d6c1a292d75f4806bd80310841afc51673aa59ce9c816507c"
+    "sha512=29398bd5d7b5893937b6250356ea710c949aef37ffa8c9fae340a9b9234d6b896bbc161983ed34404b7e1fedc02794a064e1c92d1d5835b21a8d0c01ef2ca46c"
+  ]
+}
+x-commit-hash: "af1f4247450ea87eaa67c90bfcdd659c690058ec"

--- a/packages/dyn/dyn.3.17.0/opam
+++ b/packages/dyn/dyn.3.17.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz"
+  checksum: [
+    "sha256=2c3aa6c41ed39e3d6c1a292d75f4806bd80310841afc51673aa59ce9c816507c"
+    "sha512=29398bd5d7b5893937b6250356ea710c949aef37ffa8c9fae340a9b9234d6b896bbc161983ed34404b7e1fedc02794a064e1c92d1d5835b21a8d0c01ef2ca46c"
+  ]
+}
+x-commit-hash: "af1f4247450ea87eaa67c90bfcdd659c690058ec"

--- a/packages/ocamlc-loc/ocamlc-loc.3.17.0/opam
+++ b/packages/ocamlc-loc/ocamlc-loc.3.17.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Parse ocaml compiler output into structured form"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-lsp-server" {< "1.15.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz"
+  checksum: [
+    "sha256=2c3aa6c41ed39e3d6c1a292d75f4806bd80310841afc51673aa59ce9c816507c"
+    "sha512=29398bd5d7b5893937b6250356ea710c949aef37ffa8c9fae340a9b9234d6b896bbc161983ed34404b7e1fedc02794a064e1c92d1d5835b21a8d0c01ef2ca46c"
+  ]
+}
+x-commit-hash: "af1f4247450ea87eaa67c90bfcdd659c690058ec"

--- a/packages/ordering/ordering.3.17.0/opam
+++ b/packages/ordering/ordering.3.17.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz"
+  checksum: [
+    "sha256=2c3aa6c41ed39e3d6c1a292d75f4806bd80310841afc51673aa59ce9c816507c"
+    "sha512=29398bd5d7b5893937b6250356ea710c949aef37ffa8c9fae340a9b9234d6b896bbc161983ed34404b7e1fedc02794a064e1c92d1d5835b21a8d0c01ef2ca46c"
+  ]
+}
+x-commit-hash: "af1f4247450ea87eaa67c90bfcdd659c690058ec"

--- a/packages/stdune/stdune.3.17.0/opam
+++ b/packages/stdune/stdune.3.17.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "dyn" {= version}
+  "ordering" {= version}
+  "pp" {>= "2.0.0"}
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz"
+  checksum: [
+    "sha256=2c3aa6c41ed39e3d6c1a292d75f4806bd80310841afc51673aa59ce9c816507c"
+    "sha512=29398bd5d7b5893937b6250356ea710c949aef37ffa8c9fae340a9b9234d6b896bbc161983ed34404b7e1fedc02794a064e1c92d1d5835b21a8d0c01ef2ca46c"
+  ]
+}
+x-commit-hash: "af1f4247450ea87eaa67c90bfcdd659c690058ec"

--- a/packages/xdg/xdg.3.17.0/opam
+++ b/packages/xdg/xdg.3.17.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz"
+  checksum: [
+    "sha256=2c3aa6c41ed39e3d6c1a292d75f4806bd80310841afc51673aa59ce9c816507c"
+    "sha512=29398bd5d7b5893937b6250356ea710c949aef37ffa8c9fae340a9b9234d6b896bbc161983ed34404b7e1fedc02794a064e1c92d1d5835b21a8d0c01ef2ca46c"
+  ]
+}
+x-commit-hash: "af1f4247450ea87eaa67c90bfcdd659c690058ec"


### PR DESCRIPTION
Fast, portable, and opinionated build system

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

### Fixed

- Show the context name for errors happening in non-default contexts.
  (ocaml/dune#10414, fixes ocaml/dune#10378, @jchavarri)

- Correctly declare dependencies of indexes so that they are rebuilt when
  needed. (ocaml/dune#10623, @voodoos)

- Don't depend on coq-stdlib being installed when expanding variables
  of the `coq.version` family (ocaml/dune#10631, fixes ocaml/dune#10629, @gares)

- Error out if no files are found when using `copy_files`. (ocaml/dune#10649, @jchavarri)

- Re_export dune-section private library in the dune-site library stanza,
  in order to avoid failure when generating and building sites modules
  with implicit_transitive_deps = false. (ocaml/dune#10650, fixes ocaml/dune#9661, @MA0100)

- Expect test fixes: support multiple modes and fix dependencies when there is
  a custom runner (ocaml/dune#10671, @vouillon)

- In a `(library)` stanza with `(extra_objects)` and `(foreign_stubs)`, avoid
  double linking the extra object files in the final executable.
  (ocaml/dune#10783, fixes ocaml/dune#10785, @nojb)

- Map `(re_export)` library dependencies to the `exports` field in `META` files,
  and vice-versa. This field was proposed in to
  https://discuss.ocaml.org/t/proposal-a-new-exports-field-in-findlib-meta-files/13947.
  The field is included in Dune-generated `META` files only when the Dune lang
  version is >= 3.17.
  (ocaml/dune#10831, fixes ocaml/dune#10830, @nojb)

- Fix staged pps preprocessors on Windows (which were not working at all
  previously) (ocaml/dune#10869, fixes ocaml/dune#10867, @nojb)

- Fix `dune describe` when an executable is disabled with `enabled_if`.
  (ocaml/dune#10881, fixes ocaml/dune#10779, @moyodiallo)

- Fix an issue where C stubs would be rebuilt whenever the stderr of Dune was
  redirected. (ocaml/dune#10883, fixes ocaml/dune#10882, @nojb)

- Fix the URL opened by the command `dune ocaml doc`. (ocaml/dune#10897, @gridbugs)

- Fix the file referred to in the error/warning message displayed due to the
  dune configuration version not supporting a particular configuration
  stanza in use. (ocaml/dune#10923, @H-ANSEN)

- Fix `enabled_if` when it uses `env` variable. (ocaml/dune#10936, fixes ocaml/dune#10905, @moyodiallo)

- Fix exec -w for relative paths with --root argument (ocaml/dune#10982, @gridbugs)

- Do not ignore the `(locks ..)` field in the `test` and `tests` stanza
  (ocaml/dune#11081, @rgrinberg)

- Tolerate files without extension when generating merlin rules.
  (ocaml/dune#11128, @anmonteiro)

### Added

- Make Merlin/OCaml-LSP aware of "hidden" dependencies used by
  `(implicit_transitive_deps false)` via the `-H` compiler flag. (ocaml/dune#10535, @voodoos)

- Add support for the -H flag (introduced in OCaml compiler 5.2) in dune
  (requires lang versions 3.17). This adaptation gives
  the correct semantics for `(implicit_transitive_deps false)`.
  (ocaml/dune#10644, fixes ocaml/dune#9333, ocsigen/tyxml#274, ocaml/dune#2733, ocaml/dune#4963, @MA0100)

- Add support for specifying Gitlab organization repositories in `source`
  stanzas (ocaml/dune#10766, fixes ocaml/dune#6723, @H-ANSEN)

- New option to control jsoo sourcemap generation in env and executable stanza
  (ocaml/dune#10777, fixes ocaml/dune#10673, @hhugo)

- One can now control jsoo compilation_mode inside an executable stanza
  (ocaml/dune#10777, fixes ocaml/dune#10673, @hhugo)

- Add support for specifying default values of the `authors`, `maintainers`, and
  `license` stanzas of the `dune-project` file via the dune config file. Default
  values are set using the `(project_defaults)` stanza (ocaml/dune#10835, @H-ANSEN)

- Add names to source tree events in performance traces (ocaml/dune#10884, @jchavarri)

- Add `codeberg` as an option for defining project sources in dune-project
  files. For example, `(source (codeberg user/repo))`. (ocaml/dune#10904, @nlordell)

- `dune runtest` can now run individual tests with `dune runtest mytest.t`
  (ocaml/dune#11041, @Alizter).

- Wasm_of_ocaml support (ocaml/dune#11093, @vouillon)

- Add a `coqdep_flags` field to the `coq` field of the `env` stanza, and to the `coq.theory` stanza, allowing to configure `coqdep` flags.
  (ocaml/dune#11094, @rlepigre)

### Changed

- Remove all remnants of the experimental `patch-back-source-tree`. (ocaml/dune#10771,
  @rgrinberg)

- Change the preset value for author and maintainer fields in the
  `dune-project` file to encourage including emails. (ocaml/dune#10848, @punchagan)

- Tweak the preset value for tags in the `dune-project` file to hint at topics
  not having a special meaning. (ocaml/dune#10849, @punchagan)

- Change some colors to improve readability in light-mode terminals
  (ocaml/dune#10890, @gridbugs)

- Forward the linkall flag to jsoo in whole program compilation as well (ocaml/dune#10935, @hhugo)

- Configurator uses `pkgconf` as pkg-config implementation when available
  and forwards it the `target` of `ocamlc -config`. (ocaml/dune#10937, @pirbo)

- Enable Dune cache by default. Add a new Dune cache setting
  `enabled-except-user-rules`, which enables the Dune cache, but excludes
  user-written rules from it. This is a conservative choice that can avoid
  breaking rules whose dependencies are not correctly specified. This is the
  current default. (ocaml/dune#10944, ocaml/dune#10710, @nojb, @ElectreAAS)

- Do not add `dune` dependency in `dune-project` when creating projects with
  `dune init proj`. The Dune dependency is implicitely added when generating
  opam files (ocaml/dune#11129, @Leonidas-from-XIV)
