### PR TITLE
Package areas-and-adversaries.1.0

### DIFF
--- a/packages/areas-and-adversaries/areas-and-adversaries.1.0/opam
+++ b/packages/areas-and-adversaries/areas-and-adversaries.1.0/opam
@@ -13,6 +13,9 @@ depends: [
   "cmdliner" {>= "1.2.0"}
   "astring" {>= "0.8"}
 ]
+conflicts: [
+  "ocaml-options-bytecode-only"
+]
 build: [ [make] ]
 url {
   src:

--- a/packages/areas-and-adversaries/areas-and-adversaries.1.0/opam
+++ b/packages/areas-and-adversaries/areas-and-adversaries.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "TTRPG title generator"
+description: "Generate names for table-top role-playing games."
+license: "MIT"
+homepage: "https://gitlab.com/raphael-proust/areas-and-adversaries"
+doc: "https://gitlab.com/raphael-proust/areas-and-adversaries"
+bug-reports: "https://gitlab.com/raphael-proust/areas-and-adversaries/-/issues"
+authors: [ "Raphaël Proust <code@bnwr.net>" ]
+maintainer: [ "Raphaël Proust <code@bnwr.net>" ]
+dev-repo: "git+https://gitlab.com/raphael-proust/areas-and-adversaries.git"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "cmdliner" {>= "1.2.0"}
+  "astring" {>= "0.8"}
+]
+build: [ [make] ]
+url {
+  src:
+    "https://gitlab.com/raphael-proust/areas-and-adversaries/-/archive/1.0/areas-and-adversaries-1.0.tar.gz"
+  checksum: [
+    "md5=f267598a7d50ef55be9e7b95e3011f80"
+    "sha512=e2d6d795eb5fe0d2aade47b8c2763554631e0945580fa9bfe08b6696fb1adc4f4b0fd3f60bad2966416a5827b022840697d1c3413cb55387565044e7d9ad94c8"
+  ]
+}

--- a/packages/areas-and-adversaries/areas-and-adversaries.1.0/opam
+++ b/packages/areas-and-adversaries/areas-and-adversaries.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "astring" {>= "0.8"}
 ]
 conflicts: [
-  "ocaml-options-bytecode-only"
+  "ocaml-option-bytecode-only"
 ]
 build: [ [make] ]
 url {

--- a/packages/areas-and-adversaries/areas-and-adversaries.1.0/opam
+++ b/packages/areas-and-adversaries/areas-and-adversaries.1.0/opam
@@ -9,7 +9,7 @@ authors: [ "Raphaël Proust <code@bnwr.net>" ]
 maintainer: [ "Raphaël Proust <code@bnwr.net>" ]
 dev-repo: "git+https://gitlab.com/raphael-proust/areas-and-adversaries.git"
 depends: [
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "5.1.0"}
   "cmdliner" {>= "1.2.0"}
   "astring" {>= "0.8"}
 ]


### PR DESCRIPTION
### `areas-and-adversaries.1.0`
TTRPG title generator
Generate names for table-top role-playing games.



---
* Homepage: https://gitlab.com/raphael-proust/areas-and-adversaries
* Source repo: git+https://gitlab.com/raphael-proust/areas-and-adversaries.git
* Bug tracker: https://gitlab.com/raphael-proust/areas-and-adversaries/-/issues

---
:camel: Pull-request generated by opam-publish v2.3.0