### PR TITLE
[new release] dream-html (2 packages) (3.7.0)

### DIFF
--- a/packages/dream-html/dream-html.3.7.0/opam
+++ b/packages/dream-html/dream-html.3.7.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.7.0/dream-html-3.7.0.tbz"
+  checksum: [
+    "sha256=3eacd1e1ebed0158f7ac06c42ee0deafd3f64a873b92b43d0b2c8f47bf707a4f"
+    "sha512=556abbd3c022ba2c890d5999f85521ea95443d8df17e956ac0a71b68bda7c4a0858980bea7a421066cc67b036ef5aba43bf24b326d042ef597c2ec2dc441e97d"
+  ]
+}
+x-commit-hash: "1643cfec24a70cabe2439ae056fcb34112757fac"

--- a/packages/pure-html/pure-html.3.7.0/opam
+++ b/packages/pure-html/pure-html.3.7.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.7.0/dream-html-3.7.0.tbz"
+  checksum: [
+    "sha256=3eacd1e1ebed0158f7ac06c42ee0deafd3f64a873b92b43d0b2c8f47bf707a4f"
+    "sha512=556abbd3c022ba2c890d5999f85521ea95443d8df17e956ac0a71b68bda7c4a0858980bea7a421066cc67b036ef5aba43bf24b326d042ef597c2ec2dc441e97d"
+  ]
+}
+x-commit-hash: "1643cfec24a70cabe2439ae056fcb34112757fac"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
