### PR TITLE
[new release] capnp-rpc (4 packages) (1.2.4)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.1.2.4/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.1.2.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Lwt for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "stdint" {>= "0.6.0"}
+  "lwt" {>= "5.6.1"}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "asetmap"
+  "uri" {>= "1.6.0"}
+  "dune" {>= "3.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2.4/capnp-rpc-1.2.4.tbz"
+  checksum: [
+    "sha256=59e60afec37c378d0361bf324fdc9b8a28fa2794946b987ca0ce8857d1573b58"
+    "sha512=bb4187884ca5f216de7073eadcc07b44c9a7934065e9159f7751de8cf01ba1dfe87d88488b1f9b7b59efa312274ad1ecfdf5603c0135f8d26fa230dac1aa9866"
+  ]
+}
+x-commit-hash: "ec9899ae9e34f5d77f59e5b644907a940d621e68"

--- a/packages/capnp-rpc-net/capnp-rpc-net.1.2.4/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.1.2.4/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides support for using Cap'n Proto services over a network,
+optionally using TLS."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "capnp-rpc-lwt" {= version}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "asetmap"
+  "cstruct" {>= "6.0.0"}
+  "mirage-flow" {>= "4.0.2"}
+  "tls" {>= "1.0.2"}
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "prometheus" {>= "0.5"}
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "1.0.3"}
+  "tls-mirage"
+  "dune" {>= "3.0"}
+  "mirage-crypto" {>= "1.1.0"}
+  "mirage-crypto-rng" {>= "1.1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2.4/capnp-rpc-1.2.4.tbz"
+  checksum: [
+    "sha256=59e60afec37c378d0361bf324fdc9b8a28fa2794946b987ca0ce8857d1573b58"
+    "sha512=bb4187884ca5f216de7073eadcc07b44c9a7934065e9159f7751de8cf01ba1dfe87d88488b1f9b7b59efa312274ad1ecfdf5603c0135f8d26fa230dac1aa9866"
+  ]
+}
+x-commit-hash: "ec9899ae9e34f5d77f59e5b644907a940d621e68"

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.1.2.4/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.1.2.4/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+doc: "https://mirage.github.io/capnp-rpc/"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp-rpc-net" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "cstruct-lwt"
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "extunix"
+  "base64" {>= "3.0.0"}
+  "dune" {>= "3.0"}
+  "alcotest" {>= "1.6.0" & with-test}
+  "alcotest-lwt" { >= "1.6.0" & with-test}
+  "mirage-crypto-rng-lwt" {>= "0.11.0"}
+  "mdx" {>= "2.2.1" & with-test}
+  "lwt" {>= "5.6.1"}
+  "asetmap" {with-test}
+]
+conflicts: [
+  "jbuilder"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2.4/capnp-rpc-1.2.4.tbz"
+  checksum: [
+    "sha256=59e60afec37c378d0361bf324fdc9b8a28fa2794946b987ca0ce8857d1573b58"
+    "sha512=bb4187884ca5f216de7073eadcc07b44c9a7934065e9159f7751de8cf01ba1dfe87d88488b1f9b7b59efa312274ad1ecfdf5603c0135f8d26fa230dac1aa9866"
+  ]
+}
+x-commit-hash: "ec9899ae9e34f5d77f59e5b644907a940d621e68"

--- a/packages/capnp-rpc/capnp-rpc.1.2.4/opam
+++ b/packages/capnp-rpc/capnp-rpc.1.2.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package contains the core protocol.
+Users will normally want to use `capnp-rpc-lwt` and, in most cases,
+`capnp-rpc-unix` rather than using this one directly."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "stdint"
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "asetmap"
+  "dune" {>= "3.0"}
+  "alcotest" {>= "1.6.0" & with-test}
+  "afl-persistent" {with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2.4/capnp-rpc-1.2.4.tbz"
+  checksum: [
+    "sha256=59e60afec37c378d0361bf324fdc9b8a28fa2794946b987ca0ce8857d1573b58"
+    "sha512=bb4187884ca5f216de7073eadcc07b44c9a7934065e9159f7751de8cf01ba1dfe87d88488b1f9b7b59efa312274ad1ecfdf5603c0135f8d26fa230dac1aa9866"
+  ]
+}
+x-commit-hash: "ec9899ae9e34f5d77f59e5b644907a940d621e68"


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

- Update dependencies and remove capnp-rpc-mirage (@talex5 mirage/capnp-rpc#276).
  - Update for breaking changes in tls, mirage-crypto and mirage-flow.
  - capnp-rpc-mirage isn't used much, and won't be needed after switching to Eio.

- Update tests to Cap'n Proto 1.0.1 (@MisterDA mirage/capnp-rpc#274).

- Update links to ocaml-ci and capnp-ocaml (@tmcgilchrist mirage/capnp-rpc#271).

- Opam doesn't allow with-test in conflicts (@talex5 mirage/capnp-rpc#269).

- Disable opam tests on macos (@talex5 mirage/capnp-rpc#268).

- Update CI (@MisterDA mirage/capnp-rpc#272, @talex5 mirage/capnp-rpc#277).
