### PR TITLE
[new release] git-kv (0.1.1)

### DIFF
--- a/packages/git-kv/git-kv.0.1.1/opam
+++ b/packages/git-kv/git-kv.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur Team <team@robur.coop>"
+authors: [ "Robur Team <team@robur.coop>" ]
+license: "MIT"
+homepage: "https://github.com/robur-coop/git-kv"
+dev-repo: "git+https://github.com/robur-coop/git-kv.git"
+bug-reports: "https://github.com/robur-coop/git-kv/issues"
+synopsis: "A Mirage_kv implementation using git"
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.9.0"}
+  "git"               {>= "3.10.0"}
+  "mirage-kv"         {>= "6.0.0"}
+  "carton"            {>= "0.7.0"}
+  "carton-lwt"        {>= "0.7.0"}
+  "fmt"               {>= "0.8.7"}
+  "mirage-clock"      {>= "2.0.0"}
+  "ptime"
+  "hxd"               {with-test}
+  "conf-git"          {with-test}
+  "mirage-clock-unix" {with-test}
+  "git-unix"          {>= "3.10.0" & with-test}
+  "alcotest"          {>= "1.8.0" & with-test}
+  "bos"               {>= "0.2.1" & with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/robur-coop/git-kv/releases/download/v0.1.1/git-kv-0.1.1.tbz"
+  checksum: [
+    "sha256=54caaddc8a4ef8c581aa44a3fccc12b86220b6d521394e9f5bf27be0ccdf447e"
+    "sha512=b6358caf15e789709da5a26d79977b9b900b1c4a7476f833b435de21e307553c7ca6cf4281830bdb7eb4a157f335d1d9b0da3c965cb4fc8cc7c0cd01fb119921"
+  ]
+}
+x-commit-hash: "c6a821f9ad653e158f6a893e9f818206ccbbdfdb"


### PR DESCRIPTION
A Mirage_kv implementation using git

- Project page: <a href="https://github.com/robur-coop/git-kv">https://github.com/robur-coop/git-kv</a>

##### CHANGES:

- Remove unused code from test setup (!4 - @hannesm)
- **BUG FIX**: of_octets: create ring buffer earlier to avoid missing data (!5 - @hanensm, review by @dinosaure @reynir)
- Add function `commit : t -> Digestif.SHA1.t option` (!6 !8 - @hannesm @reynir, review by @dinosaure)
