### PR TITLE
[new release] mariadb (1.2.0)

### DIFF
--- a/packages/mariadb/mariadb.1.2.0/opam
+++ b/packages/mariadb/mariadb.1.2.0/opam
@@ -26,6 +26,7 @@ depends: [
   "async" {with-test}
   "lwt" {with-test}
 ]
+conflicts: [ "ocaml-option-bytecode-only" ]
 url {
   src:
     "https://github.com/ocaml-community/ocaml-mariadb/releases/download/1.2.0/mariadb-1.2.0.tbz"

--- a/packages/mariadb/mariadb.1.2.0/opam
+++ b/packages/mariadb/mariadb.1.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Andre Nathan <andrenth@gmail.com>"
+homepage: "https://github.com/ocaml-community/ocaml-mariadb"
+bug-reports: "https://github.com/ocaml-community/ocaml-mariadb/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/ocaml-community/ocaml-mariadb.git"
+synopsis: "OCaml bindings for MariaDB"
+description: "OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its nonblocking API."
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "ctypes" {>= "0.13.0"}
+  "conf-mariadb"
+  "conf-gcc"
+  "dune" {>= "3.15.0"}
+  "dune-configurator"
+  "async" {with-test}
+  "lwt" {with-test}
+]
+url {
+  src:
+    "https://github.com/ocaml-community/ocaml-mariadb/releases/download/1.2.0/mariadb-1.2.0.tbz"
+  checksum: [
+    "sha256=a06643a58924e4fb46c12c85ea1ad56d7d8f3185a8c0873283a1ee4c95a4fa69"
+    "sha512=44e8b43bb439201fbad5b654307c44304e6c9044886160fae36a7e07248b0919d683cb9691e791994f4fe2543517536360edcae429650693a290b80078382de7"
+  ]
+}
+x-commit-hash: "fa7ba4a6a7eea5ebc022bf6df348a4e2e9c2224d"


### PR DESCRIPTION
We have moved the mariadb (ocaml-community/meta#40) and I have taken over the maintenance (ocaml-community/ocaml-mariadb#63) and would like to make an OPAM release.  There are significant changes to the build system (converted from oasis to dune), so I'll take a look at CI.

CHANGES:

  - Added `Stmt.start_txn` (ocaml-community/ocaml-mariadb#59 by Corentin Leruth).
  - Added `Res.insert_id` as binding for `mysql_stmt_insert_id` (ocaml-community/ocaml-mariadb#58 by Corentin Leruth).
  - Updated to support recent OCaml versions (ocaml-community/ocaml-mariadb#45 by @kit-ty-kate).
  - Fixed too-early retrieval of statement metadata (ocaml-community/ocaml-mariadb#41 by Albert Peschar).
  - Fixed decoding bug for the integer type (ocaml-community/ocaml-mariadb#54 by Raman Varabets, tested by ocaml-community/ocaml-mariadb#61 by Corentin Leruth).
  - Fixed a memory leaks related to result metadata (ocaml-community/ocaml-mariadb#39 by Albert Peschar).
  - The build system is now dune and dune-configurator (ocaml-community/ocaml-mariadb#52 by Petter A. Urkedal) and some of the examples have been converted to a test suite (ocaml-community/ocaml-mariadb#60 by Petter A. Urkedal).
  - The project has been transferred to ocaml-community with Petter A. Urkedal as the new maintainer.