### PR TITLE
Add `ocaml-manual.5.2.1`

### DIFF
--- a/packages/ocaml-manual/ocaml-manual.5.2.1/opam
+++ b/packages/ocaml-manual/ocaml-manual.5.2.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "Xavier Leroy"
+           "Damien Doligez"
+           "Alain Frisch"
+           "Jacques Garrigue"
+           "Didier Rémy"
+           "Jérôme Vouillon" ]
+homepage: "http://ocaml.org/"
+doc: "https://ocaml.org/manual/"
+license: "CC-BY-SA-4.0"
+dev-repo: "git+https://github.com/ocaml/ocaml.git"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+install: ["cp" "-R" "." _:doc]
+synopsis: "The OCaml system manual"
+depends: [
+  "ocaml" {= version}
+]
+url {
+  src: "http://caml.inria.fr/distrib/ocaml-5.2/ocaml-5.2-refman-html.tar.gz"
+  checksum: "sha256=361b7096d0092b11b96f0beee217af2b8c6fe3981145a2c4b4d43d656e4dcaf5"
+}


### PR DESCRIPTION
The manual didn’t change between 5.2.0 and 5.2.1 so the same source archive can be used.