### PR TITLE
Add: bytesrw.0.1.0

### DIFF
--- a/packages/bytesrw/bytesrw.0.1.0/opam
+++ b/packages/bytesrw/bytesrw.0.1.0/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+synopsis: "Composable byte stream readers and writers for OCaml"
+description: """\
+Bytesrw extends the OCaml `Bytes` module with composable, memory
+efficient, byte stream readers and writers compatible with effect
+based concurrency.
+
+Except for byte slice life-times, these abstractions intentionally
+separate away ressource management and the specifics of reading and
+writing bytes.
+
+Bytesrw distributed under the ISC license. It has no dependencies.
+
+Optional support for compressed and hashed bytes depend, at your wish, on 
+the C [`zlib`], [`libzstd`], [`blake3`], [`libmd`], [`xxhash`] and
+libraries.
+
+[`blake3`]: https://blake3.io
+[`libzstd`]: http://zstd.net
+[`libmd`]: https://www.hadrons.org/software/libmd/
+[`xxhash`]: https://xxhash.com/
+[`zlib`]: https://zlib.net
+
+Homepage: <https://erratique.ch/software/bytesrw/>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The bytesrw programmers"
+license: "ISC"
+tags: [
+  "bytes"
+  "streaming"
+  "zstd"
+  "zlib"
+  "gzip"
+  "deflate"
+  "sha1"
+  "sha2"
+  "compression"
+  "hashing"
+  "utf"
+  "xxhash"
+  "blake3"
+  "org:erratique"
+]
+homepage: "https://erratique.ch/software/bytesrw"
+doc: "https://erratique.ch/software/bytesrw/doc"
+bug-reports: "https://github.com/dbuenzli/bytesrw/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+]
+depopts: [
+  "conf-xxhash" "conf-zlib" "conf-zstd" "conf-libmd" "conf-libblake3"
+]
+conflicts: [
+  "conf-zstd" {< "1.3.8"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-conf-libblake3"
+  "%{conf-libblake3:installed}%"
+  "--with-conf-libmd"
+  "%{conf-libmd:installed}%"
+  "--with-conf-xxhash"
+  "%{conf-xxhash:installed}%"
+  "--with-conf-zlib"
+  "%{conf-zlib:installed}%"
+  "--with-conf-zstd"
+  "%{conf-zstd:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/bytesrw.git"
+url {
+  src: "https://erratique.ch/software/bytesrw/releases/bytesrw-0.1.0.tbz"
+  checksum:
+    "sha512=fd1ee852cf9d8c3b1800d4927c18453b18385b49354fb3ea71ae08f1ca640741c0594863c5db339432da55a9ee42e4fdbc8d6ef0afe29a375aac1ec6cee11c0b"
+}


### PR DESCRIPTION
* Add: `bytesrw.0.1.0` [home](https://erratique.ch/software/bytesrw), [doc](https://erratique.ch/software/bytesrw/doc), [issues](https://github.com/dbuenzli/bytesrw/issues)  
  *Composable byte stream readers and writers for OCaml*


---

#### `bytesrw` v0.1.0 2024-28-11 Zagreb


First release.

Supported by a grant from the OCaml Software Foundation.


---

Use `b0 -- .opam publish bytesrw.0.1.0` to update the pull request.