### PR TITLE
Add new conf-gcc-multilib package

### DIFF
--- a/packages/conf-gcc-multilib/conf-gcc-multilib.1.0/opam
+++ b/packages/conf-gcc-multilib/conf-gcc-multilib.1.0/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+maintainer: "Simmo Saan <simmo.saan@gmail.com>"
+authors: ["Simmo Saan"]
+homepage: "https://github.com/ocaml/opam-repository"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-2.0-or-later"
+build: [
+  ["sh" "-exc" "echo '#include <limits.h>' | cpp -m32 -"]
+  ["sh" "-exc" "echo '#include <limits.h>' | cpp -m64 -"]
+]
+depexts: [
+  ["gcc-multilib"] {os-distribution = "debian"}
+  ["gcc-multilib"] {os-distribution = "ubuntu"}
+]
+synopsis: "Virtual package relying on the gcc compiler multilib support"
+description:
+  "This package can only install if the gcc compiler multilib support is installed on the system."
+flags: conf

--- a/packages/conf-gcc-multilib/conf-gcc-multilib.1.0/opam
+++ b/packages/conf-gcc-multilib/conf-gcc-multilib.1.0/opam
@@ -9,9 +9,14 @@ build: [
   ["sh" "-exc" "echo '#include <limits.h>' | cpp -m64 -"]
 ]
 depexts: [
+  ["glibc-devel.i686"] {os-distribution = "centos"}
+  ["glibc-devel.i686"] {os-distribution = "fedora"}
+  ["gcc-32bit"] {os-family = "suse" | os-distribution = "opensuse"}
   ["gcc-multilib"] {os-distribution = "debian"}
   ["gcc-multilib"] {os-distribution = "ubuntu"}
+  ["lib32-glibc"] {os-distribution = "archlinux"}
 ]
+available: arch != "s390x"
 synopsis: "Virtual package relying on the gcc compiler multilib support"
 description:
   "This package can only install if the gcc compiler multilib support is installed on the system."

--- a/packages/conf-gcc-multilib/conf-gcc-multilib.1.0/opam
+++ b/packages/conf-gcc-multilib/conf-gcc-multilib.1.0/opam
@@ -11,10 +11,10 @@ build: [
 depexts: [
   ["glibc-devel.i686"] {os-distribution = "centos"}
   ["glibc-devel.i686"] {os-distribution = "fedora"}
-  ["gcc-32bit"] {os-family = "suse" | os-distribution = "opensuse"}
+  ["gcc-32bit"] {os-family = "suse" | os-family = "opensuse"}
   ["gcc-multilib"] {os-distribution = "debian"}
   ["gcc-multilib"] {os-distribution = "ubuntu"}
-  ["lib32-glibc"] {os-distribution = "archlinux"}
+  ["lib32-glibc"] {os-family = "arch"}
 ]
 available: arch != "s390x"
 synopsis: "Virtual package relying on the gcc compiler multilib support"

--- a/packages/conf-gcc-multilib/conf-gcc-multilib.1.0/opam
+++ b/packages/conf-gcc-multilib/conf-gcc-multilib.1.0/opam
@@ -16,7 +16,7 @@ depexts: [
   ["gcc-multilib"] {os-distribution = "ubuntu"}
   ["lib32-glibc"] {os-family = "arch"}
 ]
-available: arch != "s390x"
+available: arch != "s390x" & arch != "riscv64"
 synopsis: "Virtual package relying on the gcc compiler multilib support"
 description:
   "This package can only install if the gcc compiler multilib support is installed on the system."


### PR DESCRIPTION
goblint-cil.2.0.5 does some optional compilation based on whether `cpp -m32` and `cpp -m64` work, so it might make sense for it to have an optional dependency on such conf-gcc-multilib package.
ocaml-option-32bit.1 has an explicit depext for gcc-multilib (and also g++-multilib). In the spirit of #20793 it might also make sense for the depext to be delegated to a conf-* package.

So this is my attempt at making such package, although I'm not particularly confident about it. Most non-debian-based distributions don't seem to offer such a package (or I couldn't easily find one).
Also I'm not too sure about the build checks being general/flexible/necessary.

Thus, this is very open to feedback.

**EDIT:** I did some digging to find packages for more distros, although it made me realize that perhaps gcc-multilib itself is the odd one out. It might be 32bit glibc that I've really aimed at here.