### PR TITLE
Add governance and policy documents to repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,8 +171,8 @@ As an external contributor looking to patch a package, whose maintainer do not a
 Governance
 ----------
 
-The current points of contact and the full list of maintainers is available in [wiki/Governance](https://github.com/ocaml/opam-repository/wiki/Governance).
-Informations about the infrastructure is available in [wiki/Infrastructure-info](https://github.com/ocaml/opam-repository/wiki/Infrastructure-info).
+The current points of contact and the full list of maintainers is available in [./governance/README.md](./governance/README.md).
+Information about the infrastructure is available in [wiki/Infrastructure-info](https://github.com/ocaml/opam-repository/wiki/Infrastructure-info).
 
 Typically maintainers gather weekly to discuss ongoing topics, review PRs together and train maintainers in training.
 If you wish to help and become an opam-repository maintainer, you can send a message to the maintainers listed above and you will be invited to the next meeting in which they will explain how things work.
@@ -181,7 +181,7 @@ Policies
 --------
 
 Maintainers enforce a certain number of policies applied on packages in opam-repository.
-You can read about them in [wiki/Policies](https://github.com/ocaml/opam-repository/wiki/Policies).
+You can read about them in [./governance/policies/](./governance/policies/).
 
 How to deal with CI
 -------------------

--- a/governance/README.md
+++ b/governance/README.md
@@ -1,0 +1,42 @@
+# opam Repository Governance
+
+This directory holds documents codifying the governance of the opam package
+repository.
+
+## Policies
+
+See the [./policies/](./policies/) directory.
+
+## Maintenance
+
+### Main active maintainers
+
+You are very likely to interact with those maintainers when publishing your package. Don't
+hesitate to get in touch with them if you have questions about the publishing process,
+the CI results, or something else.
+
+- [@mseri](https://github.com/mseri)
+- [@raphael-proust](https://github.com/raphael-proust)
+- [@shonfeder](https://github.com/shonfeder)
+- [@haochenx](https://github.com/haochenx) (in training)
+- [@arbipher](https://github.com/arbipher) (in training)
+
+To contact the maintainers in a more synchronous way you can join the [#opam-repository channel on the OCaml Discord](https://discord.gg/vDH7bMjjYW)
+
+### Full list of all maintainers
+
+- everyone listed above
+- [@avsm](https://github.com/avsm) (repository administrator)
+- [@samoht](https://github.com/samoht) (repository administrator)
+- [@dinosaure](https://github.com/dinosaure)
+- [@damiendoligez](https://github.com/damiendoligez)
+- [@djs55](https://github.com/djs55)
+- [@hcarty](https://github.com/hcarty)
+- [@yallop](https://github.com/yallop)
+- [@dra27](https://github.com/dra27)
+- [@smorimoto](https://github.com/smorimoto)
+- [@dbuenzli](https://github.com/dbuenzli) (triage)
+- [@axrwl](https://github.com/axrwl) (triage)
+- [@octachron](https://github.com/Octachron)
+- The opam developement team (for safe-keeping)
+- [@kit-ty-kate](https://github.com/kit-ty-kate) (retiring maintainer)

--- a/governance/README.md
+++ b/governance/README.md
@@ -39,4 +39,4 @@ To contact the maintainers in a more synchronous way you can join the [#opam-rep
 - [@axrwl](https://github.com/axrwl) (triage)
 - [@octachron](https://github.com/Octachron)
 - The opam developement team (for safe-keeping)
-- [@kit-ty-kate](https://github.com/kit-ty-kate) (retiring maintainer)
+- [@kit-ty-kate](https://github.com/kit-ty-kate) (former maintainer)

--- a/governance/policies/README.md
+++ b/governance/policies/README.md
@@ -9,7 +9,7 @@ of the opam repository.
 ## 0. Packages must meet the criteria for inclusion
 
 Packages in this repository should meet the [criteria for inclusion](./archiving.md#inclusion-criteria)
-enumerated in the [archiving policy](./archiving.md#inclusion-criteria "ttp-equiv='Content-Type' content='text/html; charset=utf-8' /").
+enumerated in the [archiving policy](./archiving.md).
 
 ## 1. Removal of packages should be avoided
 

--- a/governance/policies/README.md
+++ b/governance/policies/README.md
@@ -1,0 +1,179 @@
+# opam Repository Policies
+
+This document lists the explicit policies governing the maintenance and curation
+of the opam repository.
+
+*NOTE*: This policy is not static and will be updated as needed.
+
+<a name="policy-0"></a>
+## 0. Packages must meet the criteria for inclusion
+
+Packages in this repository should meet the [criteria for inclusion](./archiving.md#inclusion-criteria)
+enumerated in the [archiving policy](./archiving.md#inclusion-criteria "ttp-equiv='Content-Type' content='text/html; charset=utf-8' /").
+
+## 1. Removal of packages should be avoided
+
+#### Exceptions:
+
+* Packages that no longer satisfy [policy 0](#policy-0).
+* In case of a mistake, reverting a PR is allowed if the revert happened reasonably soon after the merge (e.g. < 1 day), to make sure a minimal number of users have pulled the repository in a state where the PR was in.
+* Packages that are irredeemably broken can be marked with `available: false`
+* Packages whose author want inaccessible for security reasons can be marked with `available: false`
+* Packages whose author want gone from opam-repository can make their case with a PR marking them with `available: false`. If the package(s) in question are not used by any other packages the PR should be good to merge, otherwise, a case by case basis, at the discretion of the opam-repository maintainers, is applied.
+* Case by case basis
+
+#### Reasoning:
+
+* Users should be able to rely on any versions that have ever been available without breakage.
+* Users that use opam < 2.1.6 or opam < 2.2.0~beta2 on macOS can sometimes lack GNU patch. The default macOS patch command does not support removal of files and would make `opam update` fail.
+
+## 2. Packages should not be modified in a way that makes it uninstallable with an existing and working setup
+
+#### Exceptions:
+
+* Known security issues with a combination of dependencies
+* Non-deterministic or hard to properly fix failures
+* Case by case basis
+
+#### Reasoning:
+
+* Users should be able to rely on any versions that have ever been available without breakage.
+* Users should be able to keep the packages that they have installed if they are working fine.
+
+## 3. Packages should provide some sort of utility for users
+
+#### Exceptions:
+
+* Case by case basis
+
+#### Reasoning:
+
+* Packages providing very little utility (e.g. one module with just one function defined as a one liner) do not seem justified to go in opam-repository and take one of the available names and space in the git repository that every user has to download
+* opam-repository is a curated package repository, we hope to provide useful packages for the large majority of OCaml users
+
+## 4. Namesquatting practices and misleading names are forbidden
+
+#### Exceptions:
+
+* Case by case basis
+
+#### Reasoning:
+
+* Being misled when installing a package is pretty frustrating for users.
+* If a package has a compatible interface as another and users mixup their name often, it can become a security risk.
+* Developers spending time on a software, to find a package with the same name exists in opam-repository already and was added with malicious intents by another person, would be extremely frustrating for the developer and confusing for users if the project had been publicly announced prior.
+
+## 5. Strict dependency constraints should be avoided (=, > or preventive upper bounds)
+
+#### Exceptions:
+
+* Strict equality constraints with packages that live in the same source repository (`{= version}`) are accepted (and even encouraged) if the maintainer in planning to publish all the packages in that repository at once everytime there is some change. While this leads to a number of packages that are the same as their previous versions, this simplifies releases for maintainers that are in those cases, and makes the link simpler between the tag in their source repository and the version number in opam-repository.
+* Early `<` constraints are allowed if it is known for sure that the package will not be compatible with said upcoming version or to prevent likely runtime failures with a next major version for example.
+* Case by case basis
+
+#### Reasoning:
+
+* Strict constraints (in particular `=` and `<=`/`<`) make the user experience worse by disallowing the combination of several packages requiring different strict dependencies in the same opam switch.
+* Strict constraints also make the work of opam-repository maintainers harder by the sheer number of PR that would simply change the constraints of a package.
+* Strict constraints also make testing of the opam ecosystem worse by not testing the new releases of packages against packages that might be compatible with them (reverse dependencies, aka. revdeps).
+* It is prefered to use `>=` over `>` when writing dependency constraints because it makes constraints easier to read in most cases and would include potential package revisions or point-releases. For example `> "1.0.0"` would also include a potential `1.0.0-1` revision in the future, and `> "0.9"` would also include a potential `0.9.1` release that might not exists at the moment and that might not include the fix you need.
+* It is prefered to use `<` over `<=` when writing dependency constraints because it would ignore any revision packages. For example `<= "1.0.0"` would not take into account a potential `1.0.0-1`, and `<= "0.9"` would not take into account a potential `0.9.1` release.
+
+## 6. Version numbers should not have a v prefix (not v1.2.0 but 1.2.0)
+
+#### Exceptions:
+
+* Packages that are linked with already existing suite of packages that have adopted this version scheme for historical reasons.
+* Packages whose maintainers want/need to change the version scheme to a version number that would be below the latest available version. For example `sexplib.113.33.03` was the latest version of that package before Jane Street decided to reset the version scheme for readability reason to `0.9.0`, however 0.9.0 < 113.33.03 so the `v` prefix is here to make sure the order of version is kept, as 0.9.0 < 113.33.03 < v0.9.0. See [the opam manual section on version ordering](https://opam.ocaml.org/doc/Manual.html#version-ordering) for more details.
+* Case by case basis
+
+#### Reasoning:
+
+* It is much easier for users to write version constraints if they don't have to second guess for each dependencies if the version number contains a `v` prefix or not.
+
+## 7. New package names should avoid the ocaml prefix/suffix
+
+#### Exceptions:
+
+* Packages relating to the OCaml compiler
+* Packages for whom `ocaml` is historically a part of the name and not a simple suffix (e.g. ocamlfind, ocamlgraph, ocamldap, …)
+* Packages whose name without the prefix/suffix would evoke something else that might also be an opam package or lack context (e.g. ocaml-lsp-server, ocaml-manual, …)
+* Case by case basis
+
+#### Reasoning:
+
+* opam-repository is an OCaml focused repository, so while many projects' name start with `ocaml-` or end with `-ocaml`, if all of their package name would also include `ocaml` it would quickly become fairly annoying and redundant for users.
+
+## 8. Developement packages (e.g. pointing to a git branch) are to be avoided
+
+#### Exceptions:
+
+* OCaml compilers and related packages related to a fast moving branch are exempt
+* Case by case basis
+
+#### Reasoning:
+
+* Maintaining the metadata for many developement packages would mean too much work for the opam-repository maintainers.
+* The resulting package would be too brittle and would break easily
+* On the user's side, such package would lack checksum and thus have to be redownloaded and kept uptodate, everytime they do `opam update`
+
+## 9. Packages should only depend on packages they depend on at build time or runtime
+
+#### Exceptions:
+
+* Case by case basis
+
+#### Reasoning:
+
+* opam-repository currently strives to make installation as lightweight as possible for users of those packages. If a package were to install dependencies that is only used by (for example) developers of said package, it would be detrimental to their user experience, by having to compile and install packages they're not going to use. Example of such packages are: `ocamlformat`, `merlin`, …. Which are in 99% of cases only required when developing a package. For people who want to install developement dependencies however, opam 2.2 introduced the `with-dev-setup` variable.
+
+## 10. Binary packages should be avoided
+
+#### Exceptions:
+
+* Case by case basis
+
+#### Reasoning:
+
+* opam is a source based package manager, it is not currently designed to handle portable binary packages properly.
+* As it currently stands adding a binary package would require the facilities to ensure compatibilities with subarchitectures (e.g. x86_64 v1, …) which we do not have.
+* opam-repository currently strives to provide the same experience regardless of your platform. Binary package would go against that as each platform would have to be packaged separately, or downloaded all together and sort which one to use on site. Either of these solutions would make the user's experience worse and the maintainers life worse as well.
+
+## 11. Changes to a package's source archive are prohibited
+
+#### Exceptions:
+
+* Case by case basis
+
+#### Reasoning:
+
+* opam-repository packages are expected to be able to install at any time. Packages have a checksum to verify there hasn't been any malicious or unexpected changes to the archive after downloading it. If the source archive were to be changed, everyone who tries to install it would only receive failures, and even if it was fixed in a subsequent PR, it would still break users who have not used `opam update`.
+
+## 12. Extra-files are prohibited (patches in the `files/` subdirectory)
+
+The [extra-files field](https://opam.ocaml.org/doc/Manual.html#opamfield-extra-files) is not allowed in this repository. Please use [extra-source](https://opam.ocaml.org/doc/Manual.html#opamsection-extra-sources) if you need to include external files.
+
+#### Exceptions:
+
+* No exceptions
+
+#### Reasoning:
+
+* opam-repository is trying to use a minimal amount of files and size, thus any files not required are prohibited.
+* For cryptographic signing of the repository, not allowing extra-files reduces the complexity thereof.
+
+See the [announcement](https://discuss.ocaml.org/t/ann-opam-repository-policy-change-checksums-no-md5-and-no-extra-files/14720) and [discussion](https://github.com/ocaml/opam-repository/issues/25876) for further details.
+
+## 13. Weak hash algorithms (md5) are prohibited
+
+To prepare opam-repository for signing, adding only weak hash algorithms as checksums is prohibited.
+
+#### Exceptions:
+
+* No exceptions
+
+#### Reasoning:
+
+* Weak hash algorithms would induce that cryptographic signatures would be weak, or would need another set of checksums. This is costly and convolutes the repository.
+
+See the [announcement](https://discuss.ocaml.org/t/ann-opam-repository-policy-change-checksums-no-md5-and-no-extra-files/14720) and [discussion](https://github.com/ocaml/opam-repository/issues/25876) for further details.

--- a/governance/policies/archiving.md
+++ b/governance/policies/archiving.md
@@ -91,7 +91,7 @@ When it has been decided that a set of package versions (aka "versions") should 
         - `["(latest)" "(latest).(latest-1)"]` the maintainer will only maintain the latest `X.Y.Z` version and `X.(Y-1).Z`
         - `["(any).(latest)"]` the maintainer will maintain every major version X for each X.Y.Z
         - `["(latest).(any).(latest)"]` the maintainer will maintain every Y for each X.Y.Z (where X is the latest)
-        - `["(any)"]` the maintainer will maintain every single versions
+        - `["(any)"]` the maintainer will maintain every single version
         - `["(none)"]` the maintainer will not maintain any version
         - `["1.3"]` the maintainer will maintain the latest  version of "1.3.Z"
         - `["2.(latest)"]` the maintainer will maintain the latest minor version specifically of version "2" of the package

--- a/governance/policies/archiving.md
+++ b/governance/policies/archiving.md
@@ -15,7 +15,7 @@ last-updated: 2024-11-28
 - "Supported platforms" are those listed under [Tier 1 and Tier 2 by the OCaml compiler](https://github.com/ocaml/ocaml?tab=readme-ov-file#overview)
 - A package's "maximum compiler version" is the upper bound of the OCaml compiler versions supported by a package. Support is derived either based on explicit version bounds set on the `ocaml` dependency in a package's dependency cone, or implicitly based on failed installs detected through our CI and health check processes.
 - The "compiler cutoff threshold" is an OCaml compiler versions stipulated by the opam repository maintainers. It sets a lower bound on the compiler versions supported by the primary repo. 
-- A package is said to "meet the compiler cutoff thershold" iff its maximum compiler version is greater then or equal to the compiler cutoff threshold.
+- A package is said to "meet the compiler cutoff threshold" iff its maximum compiler version is greater then or equal to the compiler cutoff threshold.
 - The "maintenance intent" of a package refers to the explicitly declared intent of a maintainer to support versions of a package, recorded in the packages `opam` file metadata.
 
 ## Policy
@@ -31,10 +31,10 @@ This threshold is subject to change by the opam repo maintainers based on the ol
 
 A version of a package may be published on the primary repo, and will continue to remain listed there, so long as the following criteria hold:
 
-1. `ocaml-version`: The package version satisfies the current compiler cutoff threshold.
-2. `source-available`: The sources of the package version are available.
-3. `maintenance-intent`: The package version falls within a package's maintenance intent, or is a dependency of a package satisfying the primary repo criteria.
-4. `installable`: The package version is installable on at least one of the supported platforms. (Note that it is not required that CI tests are passing, since working installation may require manual system configuration.)
+1. The package meets the compiler cutoff threshold.
+2. The sources of the package version are available.
+3. The package version falls within a package's maintenance intent, or is a dependency of a package satisfying the primary repo criteria.
+4. The package version is installable on at least one of the supported platforms. (Note that it is not required that CI tests are passing, since working installation may require manual system configuration.)
 
 Note that this property is transitive along a package's dependency tree: if a package satisfies the primary repo criteria, then its dependencies do as well. 
 
@@ -68,9 +68,19 @@ When it has been decided that a set of package versions (aka "versions") should 
 ### Specification of the `x-` fields used in the archiving process
 
 - `x-reason-for-archival`: 
-    - Allowed values: A list of strings matching the [primary repo criteria](#primary-repo-criteria) IDs. 
-    - Meaning: Records the unmet [primary repo criteria](#primary-repo-criteria) motivating the archiving.
-    - Example: `["ocaml-version", "maintenance-intent"]`
+    - Allowed values: a list of containing one more of the following strings
+      `ocaml-version`, `source-unavailable`, `maintenance-intent`, or
+      `uninstallable`.
+    - Meaning: Records the unmet [primary repo criteria](#primary-repo-criteria)
+      motivating the archiving, as follows:
+        1. `ocaml-version`: The package no longer met the compiler cutoff threshold.
+        2. `source-unavailable`: The sources of the package version became unavailable.
+        3. `maintenance-intent`: The package version falls outside of a
+           package's maintenance intent, and it is not a dependency of a package
+           satisfying any of the primary repo criteria.
+        4. `uninstallable`: The package version is not installable on any
+           of the supported platforms.
+    - Example: `["ocaml-version", "source-unavailable"]`
 - `x-opam-repository-commit-hash-at-time-of-archival`:
     - Allowed values: a string
     - Meaning: Records the commit hash of the primary repo at the time a package version is archived.

--- a/governance/policies/archiving.md
+++ b/governance/policies/archiving.md
@@ -1,8 +1,3 @@
-```
-status: propsal
-last-updated: 2024-11-28
-```
-
 # opam Repository Archiving Policy
 
 *NOTE*: This policy is not static and will be updated as the process matures.
@@ -71,7 +66,7 @@ When it has been decided that a set of package versions (aka "versions") should 
     - Allowed values: a list of containing one more of the following strings
       `ocaml-version`, `source-unavailable`, `maintenance-intent`, or
       `uninstallable`.
-    - Meaning: Records the unmet [primary repo criteria](#primary-repo-criteria)
+    - Meaning: Records the unmet [primary repo criteria](#inclusion-criteria)
       motivating the archiving, as follows:
         1. `ocaml-version`: The package no longer met the compiler cutoff threshold.
         2. `source-unavailable`: The sources of the package version became unavailable.

--- a/governance/policies/archiving.md
+++ b/governance/policies/archiving.md
@@ -1,0 +1,97 @@
+```
+status: propsal
+last-updated: 2024-11-28
+```
+
+# opam Repository Archiving Policy
+
+*NOTE*: This policy is not static and will be updated as the process matures.
+
+## Terminology
+
+- The primary opam repository, (referred to here as the "primary repo") is located at [ocaml/opam-repository](https://github.com/ocaml/opam-repository). The primary repo is curated to ensure that compatible packages are co-installable on as many supported platforms as possible, and it is the default package repository.
+- "Primary repo criteria" refers to the criteria used to decide whether a version of a package is suitable for continued inclusion in the primary repo.
+- The archive opam repository, (referred to here as the "archive repo")" is located at [ocaml/opam-repository-archive](https://github.com/ocaml/opam-repository-archive) and records packages that were once in the primary repo, but no longer meet the primary repo criteria.
+- "Supported platforms" are those listed under [Tier 1 and Tier 2 by the OCaml compiler](https://github.com/ocaml/ocaml?tab=readme-ov-file#overview)
+- A package's "maximum compiler version" is the upper bound of the OCaml compiler versions supported by a package. Support is derived either based on explicit version bounds set on the `ocaml` dependency in a package's dependency cone, or implicitly based on failed installs detected through our CI and health check processes.
+- The "compiler cutoff threshold" is an OCaml compiler versions stipulated by the opam repository maintainers. It sets a lower bound on the compiler versions supported by the primary repo. 
+- A package is said to "meet the compiler cutoff thershold" iff its maximum compiler version is greater then or equal to the compiler cutoff threshold.
+- The "maintenance intent" of a package refers to the explicitly declared intent of a maintainer to support versions of a package, recorded in the packages `opam` file metadata.
+
+## Policy
+
+### Compiler cutoff threshold
+
+The current compiler cutoff threshold is `4.08`.
+
+This threshold is subject to change by the opam repo maintainers based on the oldest compiler available on maintained distributions.
+
+<a name="inclusion-criteria"></a>
+### Criteria for inclusion to the primary repo (the default `opam-repository`)
+
+A version of a package may be published on the primary repo, and will continue to remain listed there, so long as the following criteria hold:
+
+1. `ocaml-version`: The package version satisfies the current compiler cutoff threshold.
+2. `source-available`: The sources of the package version are available.
+3. `maintenance-intent`: The package version falls within a package's maintenance intent, or is a dependency of a package satisfying the primary repo criteria.
+4. `installable`: The package version is installable on at least one of the supported platforms. (Note that it is not required that CI tests are passing, since working installation may require manual system configuration.)
+
+Note that this property is transitive along a package's dependency tree: if a package satisfies the primary repo criteria, then its dependencies do as well. 
+
+### Periodic pruning process
+
+At regular intervals, no less than every six months, the opam repo maintainers will reevaluate all packages to determine if they satisfy the [primary repo criteria](#criteria-for-inclusion-to-the-primary-repo-the-default-opam-repository). Packages that do not will be subject to archiving, according to the following process:
+
+- If the package version falls outside the package's maintenance intent, it will be archived.
+- The package version's maintainers will be notified of the intent to archive.
+  - Maintainers will have two weeks to fix the version so that it satisfies the criteria or approve of the archiving.
+  - If two passes without hearing from the maintainers, the package will be marked as unmaintained and a call for a new maintainer will be submitted to the community via [discuss.ocaml.org under the opam-repository topic](https://discuss.ocaml.org/tag/opam-repository).
+  - If a new maintainer steps forward, they will have 1 week to fix the package version.
+  - Otherwise, the package will be archived.
+
+
+### Archiving a package
+
+When it has been decided that a set of package versions (aka "versions") should be archived, archiving will proceed according to the following process:
+
+- A PR will be made to add the archived versions to the archive repo. 
+    - The opam file of each version will be extended as follows:
+        - Any dependencies without upper bounds will have upper bounds added, recording the latest available version of the dependency in the primary repo at the time of archiving.
+        -  The field `x-reason-for-archival` will be added.
+        -  The field `x-opam-repository-commit-hash-at-time-of-archival` will be added.
+- A PR will be made to remove the versions from the primary repo:
+  - The removal PR should link to the corresponding archiving PR.
+  - The commit message should have the title `Archive packages` and its body should contain the hash of the commit that adds the packages to the archive.
+- A announcement will be made on discuss.ocaml.org
+- After waiting 1 week for feedback, the PRs will be merged.
+
+### Specification of the `x-` fields used in the archiving process
+
+- `x-reason-for-archival`: 
+    - Allowed values: A list of strings matching the [primary repo criteria](#primary-repo-criteria) IDs. 
+    - Meaning: Records the unmet [primary repo criteria](#primary-repo-criteria) motivating the archiving.
+    - Example: `["ocaml-version", "maintenance-intent"]`
+- `x-opam-repository-commit-hash-at-time-of-archival`:
+    - Allowed values: a string
+    - Meaning: Records the commit hash of the primary repo at the time a package version is archived.
+    - Example: `"ca32ab3b976aa7abc00c7605548f78a30980d35b"`
+- `x-maintenance-intent`:
+    - Allowed values: a list of strings matching version numbers, possibly using the special keywords `(latest)`, `(any)` and `(none)`
+    - Meaning:
+        - Expresses the declared intent of the maintainers to maintain only certain versions ranges of a package.
+        - The value of the `x-maintenance-intent` on the latest published package will precedence.
+    - Examples:
+        - `["(latest)"]` the maintainer will only maintain the latest version
+        - `["(latest)" "(latest-1)"]` the maintainer will only maintain the latest `X.Y.Z` version and `(X-1).Y.Z`
+        - `["(latest)" "(latest).(latest-1)"]` the maintainer will only maintain the latest `X.Y.Z` version and `X.(Y-1).Z`
+        - `["(any).(latest)"]` the maintainer will maintain every major version X for each X.Y.Z
+        - `["(latest).(any).(latest)"]` the maintainer will maintain every Y for each X.Y.Z (where X is the latest)
+        - `["(any)"]` the maintainer will maintain every single versions
+        - `["(none)"]` the maintainer will not maintain any version
+        - `["1.3"]` the maintainer will maintain the latest  version of "1.3.Z"
+        - `["2.(latest)"]` the maintainer will maintain the latest minor version specifically of version "2" of the package
+
+## References
+
+- [Package Archiving: Plan](https://github.com/ocaml/opam-repository/wiki/Package-Archiving:-Plan)
+- [Originating issue and discussion](https://github.com/ocaml/opam-repository/issues/23789)

--- a/governance/policies/archiving.md
+++ b/governance/policies/archiving.md
@@ -57,8 +57,8 @@ When it has been decided that a set of package versions (aka "versions") should 
 - A PR will be made to add the archived versions to the archive repo. 
     - The opam file of each version will be extended as follows:
         - Any dependencies without upper bounds will have upper bounds added, recording the latest available version of the dependency in the primary repo at the time of archiving.
-        -  The field `x-reason-for-archival` will be added.
-        -  The field `x-opam-repository-commit-hash-at-time-of-archival` will be added.
+        -  The field `x-reason-for-archiving` will be added.
+        -  The field `x-opam-repository-commit-hash-at-time-of-archiving` will be added.
 - A PR will be made to remove the versions from the primary repo:
   - The removal PR should link to the corresponding archiving PR.
   - The commit message should have the title `Archive packages` and its body should contain the hash of the commit that adds the packages to the archive.
@@ -67,7 +67,7 @@ When it has been decided that a set of package versions (aka "versions") should 
 
 ### Specification of the `x-` fields used in the archiving process
 
-- `x-reason-for-archival`: 
+- `x-reason-for-archiving`:
     - Allowed values: a list of containing one more of the following strings
       `ocaml-version`, `source-unavailable`, `maintenance-intent`, or
       `uninstallable`.
@@ -81,7 +81,7 @@ When it has been decided that a set of package versions (aka "versions") should 
         4. `uninstallable`: The package version is not installable on any
            of the supported platforms.
     - Example: `["ocaml-version", "source-unavailable"]`
-- `x-opam-repository-commit-hash-at-time-of-archival`:
+- `x-opam-repository-commit-hash-at-time-of-archiving`:
     - Allowed values: a string
     - Meaning: Records the commit hash of the primary repo at the time a package version is archived.
     - Example: `"ca32ab3b976aa7abc00c7605548f78a30980d35b"`


### PR DESCRIPTION
Up to this point, the explicit documents of our policies and governance contacts have been kept in the [GitHub wiki](https://github.com/ocaml/opam-repository/wiki) associated with this repository.

However, in [today's opam repo maintenance
meeting](https://github.com/ocaml/opam-repository/wiki/Meeting-notes#2024-11-28),
we resolved that it would be beneficial to move the documents detailing
the policy and governance of this repository into the repository itself.
This provides the following benefits over the current practice:

- The policy will be visible when the repo is checked out, making it easy
  to consult locally and at the site of the work it governs.
- We can suggest and manage changes to the policy via PRs, which will
  - make it easier to discuss changes while leaving a record of those
    discussions, and
  - ensure that proposed changes are visible to users of the repository,
    and available for their commentary and questions.

This change adds the content of the following Wiki pages:

- https://github.com/ocaml/opam-repository/wiki/Governance
- https://github.com/ocaml/opam-repository/wiki/Policies
- https://github.com/ocaml/opam-repository/wiki/Package-Archiving:-Plan

In addition, this PR adds:

- a minor change to the archiving policy in https://github.com/ocaml/opam-repository/pull/26992/commits/aefd85291bd8d79a0639a1a14965a81d00c0cf9f
- a grammar fix to the `x-` fields in https://github.com/ocaml/opam-repository/pull/26992/commits/b7730b6dc40dd317be298ea67dd01dd8cde6852f

Assuming these changes are accepted, the next steps will be to remove this content from the wiki and update relevant links to point to these documents.
