### PR TITLE
[new release] lsp (3 packages) (1.20.0)

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.20.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.20.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.20.0/lsp-1.20.0.tbz"
+  checksum: [
+    "sha256=91d6d40fdacec6915e0238c983e4cb88940f7bd3dd36c812386732a3b1782c94"
+    "sha512=1fc39a47eabf1980ab68ebdbe79d8a4427246128b4db7db4669f2958e87f261141b4d858b3c13567dacd819b04f4e1e70bf468e2cfa76f65297344ed46b1e653"
+  ]
+}
+x-commit-hash: "09eb7b5d1bf2325f4c04512582587877d5162e85"

--- a/packages/lsp/lsp.1.20.0/opam
+++ b/packages/lsp/lsp.1.20.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "jsonrpc" {= version}
+  "yojson"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "cinaps" {with-test}
+  "ppx_expect" {>= "v0.17.0" & with-test}
+  "uutf" {>= "1.0.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.14"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.20.0/lsp-1.20.0.tbz"
+  checksum: [
+    "sha256=91d6d40fdacec6915e0238c983e4cb88940f7bd3dd36c812386732a3b1782c94"
+    "sha512=1fc39a47eabf1980ab68ebdbe79d8a4427246128b4db7db4669f2958e87f261141b4d858b3c13567dacd819b04f4e1e70bf468e2cfa76f65297344ed46b1e653"
+  ]
+}
+x-commit-hash: "09eb7b5d1bf2325f4c04512582587877d5162e85"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.20.0-4.14/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.20.0-4.14/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson"
+  "base" {>= "v0.16.0"}
+  "lsp" {= "1.20.0"}
+  "jsonrpc" {= "1.20.0"}
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc" {>= "3.4.0"}
+  "chrome-trace" {>= "3.3.0"}
+  "dyn"
+  "stdune"
+  "fiber" {>= "3.1.1" & < "4.0.0"}
+  "ocaml" {>= "4.14.0" & < "5.0"}
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "astring"
+  "camlp-streams"
+  "ppx_expect" {>= "v0.15.0" & < "0.17.0" & with-test}
+  "ocamlformat" {with-test & = "0.26.2"}
+  "ocamlc-loc" {>= "3.7.0"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "merlin-lib" {>= "4.18" & < "5.0"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.20.0-4.14/lsp-1.20.0-4.14.tbz"
+  checksum: [
+    "sha256=e537624c1357a7136ad99e9958baae0cc2ba4d4ddbbdaf521878054619fb7285"
+    "sha512=e1043b60ba03fb2dede8252ed230c6ccd52292406df00430c42eacb9f0fd6dd74d054397a256d3ba337abd36463c43c4ea59435f063106b5f7f9f8d87626bec6"
+  ]
+}
+x-commit-hash: "83cdcd60f19466f2fbfff5f61b37643d69746fb6"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.20.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.20.0/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
   "dune" {>= "3.0"}
   "yojson"
-  "base"
+  "base" {>= "v0.16.0"}
   "lsp" {= version}
   "jsonrpc" {= version}
   "re" {>= "1.5.0"}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.20.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.20.0/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson"
+  "base"
+  "lsp" {= version}
+  "jsonrpc" {= version}
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc" {>= "3.4.0"}
+  "chrome-trace" {>= "3.3.0"}
+  "dyn"
+  "stdune"
+  "fiber" {>= "3.1.1" & < "4.0.0"}
+  "ocaml" {>= "5.2.0"}
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "astring"
+  "camlp-streams"
+  "ppx_expect" {>= "v0.17.0" & with-test}
+  "ocamlformat" {with-test & = "0.26.2"}
+  "ocamlc-loc" {>= "3.7.0"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "merlin-lib" {>= "5.2" & < "6.0"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.20.0/lsp-1.20.0.tbz"
+  checksum: [
+    "sha256=91d6d40fdacec6915e0238c983e4cb88940f7bd3dd36c812386732a3b1782c94"
+    "sha512=1fc39a47eabf1980ab68ebdbe79d8a4427246128b4db7db4669f2958e87f261141b4d858b3c13567dacd819b04f4e1e70bf468e2cfa76f65297344ed46b1e653"
+  ]
+}
+x-commit-hash: "09eb7b5d1bf2325f4c04512582587877d5162e85"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.20.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.20.0/opam
@@ -30,7 +30,7 @@ depends: [
   "dyn"
   "stdune"
   "fiber" {>= "3.1.1" & < "4.0.0"}
-  "ocaml" {>= "5.2.0"}
+  "ocaml" {>= "5.2.0" & < "5.3~"}
   "xdg"
   "ordering"
   "dune-build-info"


### PR DESCRIPTION
CHANGES:

## Features

- Add custom [`ocamllsp/typeSearch`](/ocaml-lsp-server/docs/ocamllsp/typeSearch-spec.md) request (ocaml/ocaml-lsp#1369)

- Make MerlinJump code action configurable (ocaml/ocaml-lsp#1376)

- Add custom [`ocamllsp/jump`](/ocaml-lsp-server/docs/ocamllsp/merlinJump-spec.md) request (ocaml/ocaml-lsp#1374)

## Fixes

- Fix fd leak in running external processes for preprocessing (ocaml/ocaml-lsp#1349)

- Fix prefix parsing for completion of object methods (ocaml/ocaml-lsp#1363, fixes ocaml/ocaml-lsp#1358)

- Remove some duplicates in the `selectionRange` answers (ocaml/ocaml-lsp#1368)