### PR TITLE
[new release] ocamlformat-lib, ocamlformat and ocamlformat-rpc-lib (0.27.0)

### DIFF
--- a/packages/ocamlformat-lib/ocamlformat-lib.0.27.0/opam
+++ b/packages/ocamlformat-lib/ocamlformat-lib.0.27.0/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis: "OCaml Code Formatter"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: [
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+  "Emile Trotignon <emile@tarides.com>"
+]
+authors: [
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "alcotest" {with-test & >= "1.3.0"}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.8"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath" {>= "0.7.3"}
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.5.0"}
+  "ocamlformat-rpc-lib" {with-test & = version}
+  "ocp-indent" {with-test = "false" & >= "1.8.0" | with-test & >= "1.8.1"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "astring"
+  "camlp-streams"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+# OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.27.0/ocamlformat-0.27.0.tbz"
+  checksum: [
+    "sha256=ddbf484c076d08f99400ee84b790ec231f5c8fcbd5d3324a6400d5388e846d15"
+    "sha512=4d2a8965a7b7ad45f8f4e76c01cf38bfa68462b07dfa7bdb2db23bd3e3017b214e6780f036679fa8595dde4167a01d957e3af8837274320449014e306773f917"
+  ]
+}
+x-commit-hash: "5bac2e7f71d9b0a06bd1908dda9b13da1649eee1"

--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.27.0/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.27.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: [
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+  "Emile Trotignon <emile@tarides.com>"
+]
+authors: [
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08"}
+  "csexp" {>= "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.27.0/ocamlformat-0.27.0.tbz"
+  checksum: [
+    "sha256=ddbf484c076d08f99400ee84b790ec231f5c8fcbd5d3324a6400d5388e846d15"
+    "sha512=4d2a8965a7b7ad45f8f4e76c01cf38bfa68462b07dfa7bdb2db23bd3e3017b214e6780f036679fa8595dde4167a01d957e3af8837274320449014e306773f917"
+  ]
+}
+x-commit-hash: "5bac2e7f71d9b0a06bd1908dda9b13da1649eee1"

--- a/packages/ocamlformat/ocamlformat.0.27.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.27.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description: """
+**ocamlformat** is a code formatter for OCaml. It comes with opinionated default settings but is also fully customizable to suit your coding style.
+
+- **Profiles:** ocamlformat offers profiles we predefined formatting configurations. Profiles include `default`, `ocamlformat`, `janestreet`.
+- **Configurable:** Users can change the formatting profile and configure every option in their `.ocamlformat` configuration file.
+- **Format Comments:** ocamlformat can format comments, docstrings, and even code blocks in your comments.
+- **RPC:** ocamlformat provides an RPC server that can be used by other tools to easily format OCaml Code."""
+maintainer: [
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+  "Emile Trotignon <emile@tarides.com>"
+]
+authors: [
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "cmdliner" {with-test = "false" & >= "1.1.0" | with-test & >= "1.2.0"}
+  "csexp" {>= "1.4.0"}
+  "dune" {>= "2.8"}
+  "ocamlformat-lib" {= version}
+  "ocamlformat-rpc-lib" {with-test & = version}
+  "re" {>= "1.10.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+# OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.27.0/ocamlformat-0.27.0.tbz"
+  checksum: [
+    "sha256=ddbf484c076d08f99400ee84b790ec231f5c8fcbd5d3324a6400d5388e846d15"
+    "sha512=4d2a8965a7b7ad45f8f4e76c01cf38bfa68462b07dfa7bdb2db23bd3e3017b214e6780f036679fa8595dde4167a01d957e3af8837274320449014e306773f917"
+  ]
+}
+x-commit-hash: "5bac2e7f71d9b0a06bd1908dda9b13da1649eee1"


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

### Highlight

- \* Support OCaml 5.2 syntax (ocaml-ppx/ocamlformat#2519, ocaml-ppx/ocamlformat#2544, ocaml-ppx/ocamlformat#2590, ocaml-ppx/ocamlformat#2596, ocaml-ppx/ocamlformat#2621, ocaml-ppx/ocamlformat#2628, @Julow, @EmileTrotignon, @hhugo)
  This includes local open in types, raw identifiers, and the new
  representation for functions.
  This might change the formatting of some functions due to the formatting code
  being completely rewritten.

- Support OCaml 5.3 syntax (ocaml-ppx/ocamlformat#2609, ocaml-ppx/ocamlformat#2610, ocaml-ppx/ocamlformat#2611, ocaml-ppx/ocamlformat#2622, ocaml-ppx/ocamlformat#2623, ocaml-ppx/ocamlformat#2562, ocaml-ppx/ocamlformat#2624, ocaml-ppx/ocamlformat#2625, ocaml-ppx/ocamlformat#2627, @Julow, @Zeta611)
  This adds support for effect patterns, short functor type arguments and utf8
  identifiers.
  To format code using the new `effect` syntax, add this option to your
  `.ocamlformat`:
  ```
  ocaml-version = 5.3
  ```

- Documentation comments are now formatted by default (ocaml-ppx/ocamlformat#2390, @Julow)
  Use the option `parse-docstrings = false` to restore the previous behavior.

- \* Consistent indentation of polymorphic variant arguments (ocaml-ppx/ocamlformat#2427, @Julow)
  Increases the indentation by one to make the formatting consistent with
  normal variants. For example:
  ```
    ...
    (* before *)
      (`Msg
        (foo bar))
    (* after *)
      (`Msg
         (foo bar))
  ```

- Build on OCaml 5.3 (ocaml-ppx/ocamlformat#2603, @adamchol, @Julow)

### Added

- Improve the emacs plugin (ocaml-ppx/ocamlformat#2577, ocaml-ppx/ocamlformat#2600, @gridbugs, @thibautbenjamin)
  Allow a custom command to be used to run ocamlformat and add compatibility
  with emacs ocaml tree-sitter modes.

- Added option `let-binding-deindent-fun` (ocaml-ppx/ocamlformat#2521, @henrytill)
  to control the indentation of the `fun` in:
  ```
  let f =
   fun foo ->
    bar
  ```

- Added back the flag `--disable-outside-detected-project` (ocaml-ppx/ocamlformat#2439, @gpetiot)
  It was removed in version 0.22.

- Support newer Odoc syntax (ocaml-ppx/ocamlformat#2631, ocaml-ppx/ocamlformat#2632, ocaml-ppx/ocamlformat#2633, @Julow)

### Changed

- \* Consistent formatting of comments (ocaml-ppx/ocamlformat#2371, ocaml-ppx/ocamlformat#2550, @Julow)
  This is mostly an internal change but some comments might be formatted differently.

- \* Improve formatting of type constraints with type variables (ocaml-ppx/ocamlformat#2437, @gpetiot)
  For example:
  ```
  let f : type a b c.
      a -> b -> c =
    ...
  ```

- \* Improve formatting of functor arguments (ocaml-ppx/ocamlformat#2505, @Julow)
  This also reduce the indentation of functor arguments with long signatures.

- Improvements to the Janestreet profile (ocaml-ppx/ocamlformat#2445, ocaml-ppx/ocamlformat#2314, ocaml-ppx/ocamlformat#2460, ocaml-ppx/ocamlformat#2593, ocaml-ppx/ocamlformat#2612, @Julow, @tdelvecchio-jsc)

- \* Undo let-bindings and methods normalizations (ocaml-ppx/ocamlformat#2523, ocaml-ppx/ocamlformat#2529, @gpetiot)
  This remove the rewriting of some forms of let-bindings and methods:
  + `let f x = (x : int)` is no longer rewritten into `let f x : int = x`
  + `let f (type a) (type b) ...` is no longer rewritten into `let f (type a b) ...`
  + `let f = fun x -> ...` is no longer rewritten into `let f x = ...`

- \* The `break-colon` option is now taken into account for method type constraints (ocaml-ppx/ocamlformat#2529, @gpetiot)

- \* Force a break around comments following an infix operator (fix non-stabilizing comments) (ocaml-ppx/ocamlformat#2478, @gpetiot)
  This adds a line break:
  ```
    a
    ||
    (* this comment is now on its own line *)
    b
  ```

### Fixed

- Fix placement of comments in some cases (ocaml-ppx/ocamlformat#2471, ocaml-ppx/ocamlformat#2503, ocaml-ppx/ocamlformat#2506, ocaml-ppx/ocamlformat#2540, ocaml-ppx/ocamlformat#2541, ocaml-ppx/ocamlformat#2592, ocaml-ppx/ocamlformat#2617, @gpetiot, @Julow)
  Some comments were being moved or causing OCamlformat to crash.
  OCamlformat refuses to format if a comment would be missing in its output, to avoid loosing code.

- Fix attributes being dropped or moved (ocaml-ppx/ocamlformat#2247, ocaml-ppx/ocamlformat#2459, ocaml-ppx/ocamlformat#2551, ocaml-ppx/ocamlformat#2564, ocaml-ppx/ocamlformat#2602, @EmileTrotignon, @tdelvecchio-jsc, @Julow)
  OCamlformat refuses to format if the formatted code has a different meaning than the original code, for example, if an attribute is removed.
  We also try to avoid moving attributes even if that doesn't change the original code, for example we no longer format `open[@attr] M` as `open M [@@attr]`.

- Remove trailing space inside a wrapping empty signature (ocaml-ppx/ocamlformat#2443, @Julow)
- Fix extension-point spacing in structures (ocaml-ppx/ocamlformat#2450, @Julow)
- \* Consistent break after string constant argument (ocaml-ppx/ocamlformat#2453, @Julow)
- \* Fix cinaps comment formatting to not change multiline string contents (ocaml-ppx/ocamlformat#2463, @tdelvecchio-jsc)
- \* Fix the indentation of tuples in attributes and extensions (ocaml-ppx/ocamlformat#2488, @Julow)
- \* Fix weird indentation and line breaks after comments (ocaml-ppx/ocamlformat#2507, ocaml-ppx/ocamlformat#2589, ocaml-ppx/ocamlformat#2606, @Julow)
- \* Fix unwanted alignment in if-then-else (ocaml-ppx/ocamlformat#2511, @Julow)
- Fix missing parentheses around constraint expressions with attributes (ocaml-ppx/ocamlformat#2513, @alanechang)
- Fix formatting of type vars in GADT constructors (ocaml-ppx/ocamlformat#2518, @Julow)
- Fix `[@ocamlformat "disable"]` in some cases (ocaml-ppx/ocamlformat#2242, ocaml-ppx/ocamlformat#2525, @EmileTrotignon)
  This caused a bug inside `class type` constructs and when attached to a `let ... in`
- Display `a##b` instead of `a ## b` and similarly for operators that start with # (ocaml-ppx/ocamlformat#2580, @v-gb)
- \* Fix arrow type indentation with `break-separators=before` (ocaml-ppx/ocamlformat#2598, @Julow)
- Fix missing parentheses around a let in class expressions (ocaml-ppx/ocamlformat#2599, @Julow)
- Fix formatting of paragraphs in lists in documentation (ocaml-ppx/ocamlformat#2607, @Julow)
- Avoid unwanted space in references and links text in documentation (ocaml-ppx/ocamlformat#2608, @Julow)
- \* Improve the indentation of attributes in patterns (ocaml-ppx/ocamlformat#2613, @Julow)
- \* Avoid large indentation in patterns after `let%ext` (ocaml-ppx/ocamlformat#2615, @Julow)
