### PR TITLE
async_rpc_kernel incompatible with ocam 5.3~

### DIFF
--- a/packages/async_rpc_kernel/async_rpc_kernel.v0.17.0/opam
+++ b/packages/async_rpc_kernel/async_rpc_kernel.v0.17.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"                   {>= "5.1.0"}
+  "ocaml"                   {>= "5.1.0" & < "5.3~~"}
   "async_kernel"            {>= "v0.17" & < "v0.18"}
   "core"                    {>= "v0.17" & < "v0.18"}
   "core_kernel"             {>= "v0.17" & < "v0.18"}


### PR DESCRIPTION
Ping @d-kalinichenko 
I am not sure if this is a new thing introduced since 5.3: it now fails with
```
#=== ERROR while compiling async_rpc_kernel.v0.17.0 ===========================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-base-compiler.5.3.0~beta1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.3~beta1/.opam-switch/build/async_rpc_kernel.v0.17.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p async_rpc_kernel -j 255
# exit-code            1
# env-file             ~/.opam/log/async_rpc_kernel-7-8aaf04.env
# output-file          ~/.opam/log/async_rpc_kernel-7-8aaf04.out
### output ###
# (cd _build/.sandbox/970bd4de7e06bf51018c41a3c5849f17/default && .ppx/57ef275c515ec1fe105f6ff0979f5a61/ppx.exe --cookie 'library-name="async_rpc_kernel"' -o src/writer_with_length.pp.mli --intf src/writer_with_length.mli -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "src/writer_with_length.mli", line 1, characters 0-3:
# 1 | (** A hack to make the bin-prot representation of things look as though they are
#     ^^^
# Error: This comment contains an unterminated string literal
# File "src/writer_with_length.mli", line 8, characters 6-14:
# 8 |       {field1|field2|...|{length|content}}
#           ^^^^^^^^
#   String literal begins here
```