### PR TITLE
avoid dependency to '"ocaml" {= "0"}'

### DIFF
--- a/packages/mirage-fs-unix/mirage-fs-unix.1.0.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.0.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/mirage/mirage-fs-unix"
 build: make
 remove: ["ocamlfind" "remove" "mirage-fs-unix"]
 depends: [
-  "ocaml" {= "0"}
+  "ocaml"
   "cstruct" {>= "0.8.1"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
@@ -25,3 +25,4 @@ url {
     "md5=cd6ae6b68718fdb1b85d9d7cfe1a4d2b"
   ]
 }
+available: false # insecure, not installable!

--- a/packages/mirage-fs-unix/mirage-fs-unix.1.1.0/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.1.1.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/mirage/mirage-fs-unix"
 build: make
 remove: ["ocamlfind" "remove" "mirage-fs-unix"]
 depends: [
-  "ocaml" {= "0"}
+  "ocaml"
   "cstruct" {>= "0.8.1" & < "3.4.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3"}
@@ -25,3 +25,4 @@ url {
     "md5=50f525cec6a18280aa7af05df6f60deb"
   ]
 }
+available: false # insecure, not installable!

--- a/packages/mirage-net-xen/mirage-net-xen.0.9.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.0.9.0/opam
@@ -6,7 +6,7 @@ maintainer: "anil@recoil.org"
 build: make
 remove: ["ocamlfind" "remove" "mirage-net-xen"]
 depends: [
-  "ocaml" {= "0"}
+  "ocaml"
   "ocamlfind"
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.1.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.1.0/opam
@@ -6,7 +6,7 @@ maintainer: "anil@recoil.org"
 build: make
 remove: ["ocamlfind" "remove" "mirage-net-xen"]
 depends: [
-  "ocaml" {= "0"}
+  "ocaml"
   "ocamlfind"
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.1.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.1.1/opam
@@ -6,7 +6,7 @@ maintainer: "anil@recoil.org"
 build: make
 remove: ["ocamlfind" "remove" "mirage-net-xen"]
 depends: [
-  "ocaml" {= "0"}
+  "ocaml"
   "ocamlfind"
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.1.2/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.1.2/opam
@@ -6,7 +6,7 @@ maintainer: "anil@recoil.org"
 build: make
 remove: ["ocamlfind" "remove" "mirage-net-xen"]
 depends: [
-  "ocaml" {= "0"}
+  "ocaml"
   "ocamlfind"
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.1.3/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.1.3/opam
@@ -6,7 +6,7 @@ maintainer: "anil@recoil.org"
 build: make
 remove: ["ocamlfind" "remove" "mirage-net-xen"]
 depends: [
-  "ocaml" {= "0"}
+  "ocaml"
   "ocamlfind"
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.2.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.2.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/mirage/mirage-net-xen.git"
 build: make
 remove: ["ocamlfind" "remove" "mirage-net-xen"]
 depends: [
-  "ocaml" {= "0"}
+  "ocaml"
   "ocamlfind"
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.3.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.3.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/mirage/mirage-net-xen.git"
 build: make
 remove: ["ocamlfind" "remove" "mirage-net-xen"]
 depends: [
-  "ocaml" {= "0"}
+  "ocaml"
   "ocamlfind"
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.4.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.4.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/mirage/mirage-net-xen.git"
 build: make
 remove: ["ocamlfind" "remove" "mirage-net-xen"]
 depends: [
-  "ocaml" {= "0"}
+  "ocaml"
   "ocamlfind"
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage-net-xen/mirage-net-xen.1.4.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.1.4.1/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/mirage/mirage-net-xen.git"
 build: make
 remove: ["ocamlfind" "remove" "mirage-net-xen"]
 depends: [
-  "ocaml" {= "0"}
+  "ocaml"
   "ocamlfind"
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}


### PR DESCRIPTION
This has been used for marking packages unavailable.