### PR TITLE
[new release] capnp-rpc (4 packages) (2.0)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.2.0/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This deprecated package provides Lwt shims around capnp-rpc, to ease the transition."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "5.2"}
+  "capnp-rpc" {>= version}
+  "lwt_eio" {>= "0.5.1"}
+  "dune" {>= "3.16"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v2.0/capnp-rpc-2.0.tbz"
+  checksum: [
+    "sha256=2afc32a9c5643bc85796b2c511b400d60d1b6d8dd331e5dbf50931e4a436473e"
+    "sha512=691d17cf8743a119d21aa0c47f66e7feef68f5f801e51d5f8f00cccff70463989e53c2ec91e813fe1fbf53bbadcb5708c06ad6d327b6ae26db53a97ac360d1ba"
+  ]
+}
+x-commit-hash: "252fd9b064367270a48d6bc73cbcd8f188f353d9"

--- a/packages/capnp-rpc-net/capnp-rpc-net.2.0/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.2.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides support for using Cap'n Proto services over a network,
+optionally using TLS."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "5.2"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.6.0"}
+  "capnp-rpc" {= version}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "cstruct" {>= "6.0.0"}
+  "tls-eio" {>= "1.0.2"}
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "prometheus" {>= "0.5"}
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "1.0.3"}
+  "dune" {>= "3.16"}
+  "mirage-crypto" {>= "1.1.0"}
+  "mirage-crypto-rng" {>= "1.1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v2.0/capnp-rpc-2.0.tbz"
+  checksum: [
+    "sha256=2afc32a9c5643bc85796b2c511b400d60d1b6d8dd331e5dbf50931e4a436473e"
+    "sha512=691d17cf8743a119d21aa0c47f66e7feef68f5f801e51d5f8f00cccff70463989e53c2ec91e813fe1fbf53bbadcb5708c06ad6d327b6ae26db53a97ac360d1ba"
+  ]
+}
+x-commit-hash: "252fd9b064367270a48d6bc73cbcd8f188f353d9"

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.2.0/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.2.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+doc: "https://mirage.github.io/capnp-rpc/"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+depends: [
+  "ocaml" {>= "5.2"}
+  "capnp-rpc-net" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "cstruct" {>= "6.2.0"}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "extunix"
+  "base64" {>= "3.0.0"}
+  "dune" {>= "3.16"}
+  "ipaddr" {>= "5.3.0"}
+  "alcotest" {>= "1.6.0" & with-test}
+  "mirage-crypto-rng-eio" {>= "1.1.0" & with-test}
+  "mdx" {>= "2.4.1" & with-test}
+  "eio_main" {with-test}
+  "eio" {>= "1.2"}
+]
+conflicts: [
+  "jbuilder"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v2.0/capnp-rpc-2.0.tbz"
+  checksum: [
+    "sha256=2afc32a9c5643bc85796b2c511b400d60d1b6d8dd331e5dbf50931e4a436473e"
+    "sha512=691d17cf8743a119d21aa0c47f66e7feef68f5f801e51d5f8f00cccff70463989e53c2ec91e813fe1fbf53bbadcb5708c06ad6d327b6ae26db53a97ac360d1ba"
+  ]
+}
+x-commit-hash: "252fd9b064367270a48d6bc73cbcd8f188f353d9"

--- a/packages/capnp-rpc/capnp-rpc.2.0/opam
+++ b/packages/capnp-rpc/capnp-rpc.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Eio for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "5.2"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.6.0"}
+  "stdint" {>= "0.6.0"}
+  "eio" {>= "1.2"}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "uri" {>= "1.6.0"}
+  "dune" {>= "3.16"}
+  "alcotest" {>= "1.6.0" & with-test}
+  "afl-persistent" {with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v2.0/capnp-rpc-2.0.tbz"
+  checksum: [
+    "sha256=2afc32a9c5643bc85796b2c511b400d60d1b6d8dd331e5dbf50931e4a436473e"
+    "sha512=691d17cf8743a119d21aa0c47f66e7feef68f5f801e51d5f8f00cccff70463989e53c2ec91e813fe1fbf53bbadcb5708c06ad6d327b6ae26db53a97ac360d1ba"
+  ]
+}
+x-commit-hash: "252fd9b064367270a48d6bc73cbcd8f188f353d9"


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

capnp-rpc 2.0 switches from using Lwt to Eio.
The `capnp-rpc-lwt` package is now just Lwt wrappers around the Eio functions in `capnp-rpc`.
This allows libraries using the old Lwt API to be used with applications and libraries using the new Eio one,
in the same binary.
Because Lwt libraries (using `capnp-rpc-lwt`) can be used with Eio applications (using `capnp-rpc-unix`),
you should first upgrade your application and then upgrade the libraries afterwards.

It is recommended to upgrade in stages, checking your application still works after each step:

1. Upgrade to the latest Lwt version (`opam install capnp-rpc-unix.1.2.4`).
   This uses the new version of mirage-crypto, tls, etc,
   which may be incompatible with other libraries you are using.
   Get that sorted out before switching to capnp-rpc 2.0.

2. Use [lwt_eio][] to allow using Eio and Lwt together in your application.
   This means replacing your call to `Lwt_main.run` with code to run Eio and Lwt together,
   as explained at the start of the `lwt_eio` README.

3. Upgrade your main application to capnp-rpc-unix 2.0.
   Calls to functions in the `Capnp_rpc_unix` and `Capnp_rpc_net` modules will need minor updates.
   They were previously called from Lwt context, so you'll need to wrap them with `Lwt_eio.run_eio`
   (or remove a `Lwt_eio.run_lwt` if you already updated the surrounding code).
   You should also use `mirage-crypto-rng-eio` to ensure randomness is available
   (`capnp-rpc-unix` no longer does this, although some other library might).

4. Upgrade code and libraries using `Capnp_rpc_lwt`:

   1. Replace `open Capnp_rpc_lwt` with `open Capnp_rpc.Std`.
   2. Replace all other uses of `Capnp_rpc_lwt` with just `Capnp_rpc`.
   3. In `dune` and `opam` files, replace `capnp-rpc-lwt` with `capnp-rpc`.
   4. Some modules are in `Capnp_rpc` but not the `Capnp_rpc.Std` subset.
      Those should now be fully qualified (e.g. replace `Persistence` with
      `Capnp_rpc.Persistence`).
   5. Replace `Service.return_lwt` with `Lwt_eio.run_lwt`.
      Replace `Lwt.return (Ok x)` with `Service.return x`.

Once all Lwt code is gone, you can remove the dependencies on `lwt` and `lwt_eio`.

New features:

- Allow numeric IPv6 listen addresses (@talex5 mirage/capnp-rpc#296, requested by @BChabanne).

API changes:

- Eio port (@talex5 mirage/capnp-rpc#280 mirage/capnp-rpc#284 mirage/capnp-rpc#298 mirage/capnp-rpc#292 mirage/capnp-rpc#297 mirage/capnp-rpc#300 mirage/capnp-rpc#304).

  This switches capnp-rpc from Lwt to Eio.
  One particularly nice side effect of this is that `Service.return_lwt` has gone,
  as there is no distinction now between concurrent and non-concurrent service methods.

  Uses of `Capnp_rpc_lwt` should be replaced by uses of `Capnp_rpc`
  (and the old `Capnp_rpc` is now an internal module, `Capnp_rpc_proto`).
  The new `Capnp_rpc` now provides `Error`, `Exception` and `Debug` aliases to the same modules in `Capnp_rpc_proto`,
  so that `Capnp_rpc_proto` doesn't need to be used directly.

  `Capnp_rpc_lwt` now provides (deprecated) compatibility wrappers, using `lwt_eio`.

  This also adds `Capnp_rpc.Std` with some common module aliases,
  to reduce the need to `open Capnp_rpc` (which is rather large).

- Deprecate `Debug.failf` (@talex5 mirage/capnp-rpc#291).

Performance and bug fixes:

- Add buffering of outgoing messages (@talex5 mirage/capnp-rpc#287 mirage/capnp-rpc#303).
  Sending each message in its own TCP packet isn't very efficient, and also interacts very badly with Nagle's algorithm.
  See <https://roscidus.com/blog/blog/2024/07/22/performance/> for details.

- Only disconnect socket when sending is done (@talex5 mirage/capnp-rpc#295).
  Allows sending the reason for the disconnection in some cases.

- Fix type of `Capability.call` (@talex5 mirage/capnp-rpc#293).
  It was previously unusable.

- Work around FreeBSD `close` problem (@talex5 mirage/capnp-rpc#302).

Build:

- Update to capnp 3.6.0 (@talex5 mirage/capnp-rpc#285).

- Update to dune 3.16 and fix warnings (@talex5 mirage/capnp-rpc#282).

- Use `String.starts_with` instead of `Astring` (@talex5 mirage/capnp-rpc#290).

- Remove unused `tls-mirage` dependency (@talex5 mirage/capnp-rpc#289).

- Remove `asetmap` dependency (@talex5 mirage/capnp-rpc#288).

[lwt_eio]: https://github.com/ocaml-multicore/lwt_eio
