### PR TITLE
Add upper-bounds on capnp-rpc-{net,unix}

### DIFF
--- a/packages/current_examples/current_examples.0.1/opam
+++ b/packages/current_examples/current_examples.0.1/opam
@@ -28,7 +28,7 @@ depends: [
   "current_github" {= version}
   "current_docker" {= version}
   "current_rpc" {= version}
-  "capnp-rpc-unix" {>= "0.5"}
+  "capnp-rpc-unix" {>= "0.5" & < "2.0"}
   "dune" {>= "1.9"}
 ]
 url {

--- a/packages/current_examples/current_examples.0.2/opam
+++ b/packages/current_examples/current_examples.0.2/opam
@@ -28,7 +28,7 @@ depends: [
   "current_github" {= version}
   "current_docker" {= version}
   "current_rpc" {= version}
-  "capnp-rpc-unix" {>= "0.5"}
+  "capnp-rpc-unix" {>= "0.5" & < "2.0"}
   "dune" {>= "1.9"}
 ]
 url {

--- a/packages/current_examples/current_examples.0.3/opam
+++ b/packages/current_examples/current_examples.0.3/opam
@@ -28,7 +28,7 @@ depends: [
   "current_github" {= version}
   "current_docker" {= version}
   "current_rpc" {= version}
-  "capnp-rpc-unix" {>= "0.5"}
+  "capnp-rpc-unix" {>= "0.5" & < "2.0"}
   "dune" {>= "2.0"}
 ]
 url {

--- a/packages/current_examples/current_examples.0.4/opam
+++ b/packages/current_examples/current_examples.0.4/opam
@@ -23,11 +23,11 @@ depends: [
   "current_github" {= version}
   "current_docker" {= version}
   "current_rpc" {= version}
-  "capnp-rpc-unix" {>= "0.5"}
+  "capnp-rpc-unix" {>= "0.5" & < "2.0"}
   "dune" {>= "2.0"}
   "capnp-rpc" {>= "0.8.0"}
   "capnp-rpc-lwt" {>= "0.8.0"}
-  "capnp-rpc-net" {>= "0.8.0"}
+  "capnp-rpc-net" {>= "0.8.0" & < "2.0"}
   "dockerfile" {>= "7.0.0"}
   "fpath" {>= "0.7.3"}
   "logs" {>= "0.7.0"}

--- a/packages/current_examples/current_examples.0.5/opam
+++ b/packages/current_examples/current_examples.0.5/opam
@@ -23,11 +23,11 @@ depends: [
   "current_github" {= version}
   "current_docker" {= version}
   "current_rpc" {= version}
-  "capnp-rpc-unix" {>= "0.5"}
+  "capnp-rpc-unix" {>= "0.5" & < "2.0"}
   "dune" {>= "2.0"}
   "capnp-rpc" {>= "0.8.0"}
   "capnp-rpc-lwt" {>= "0.8.0"}
-  "capnp-rpc-net" {>= "0.8.0"}
+  "capnp-rpc-net" {>= "0.8.0" & < "2.0"}
   "dockerfile" {>= "7.0.0"}
   "fpath" {>= "0.7.3"}
   "logs" {>= "0.7.0"}

--- a/packages/current_examples/current_examples.0.6.1/opam
+++ b/packages/current_examples/current_examples.0.6.1/opam
@@ -24,11 +24,11 @@ depends: [
   "current_gitlab" {= version}
   "current_docker" {= version}
   "current_rpc" {= version}
-  "capnp-rpc-unix" {>= "0.5"}
+  "capnp-rpc-unix" {>= "0.5" & < "2.0"}
   "dune" {>= "2.9"}
   "capnp-rpc" {>= "0.8.0"}
   "capnp-rpc-lwt" {>= "0.8.0"}
-  "capnp-rpc-net" {>= "0.8.0"}
+  "capnp-rpc-net" {>= "0.8.0" & < "2.0"}
   "dockerfile" {>= "7.0.0"}
   "fpath" {>= "0.7.3"}
   "logs" {>= "0.7.0"}

--- a/packages/current_examples/current_examples.0.6.2/opam
+++ b/packages/current_examples/current_examples.0.6.2/opam
@@ -25,11 +25,11 @@ depends: [
   "current_gitlab" {= version}
   "current_docker" {= version}
   "current_rpc" {= version}
-  "capnp-rpc-unix" {>= "0.5"}
+  "capnp-rpc-unix" {>= "0.5" & < "2.0"}
   "dune" {>= "2.9"}
   "capnp-rpc" {>= "0.8.0"}
   "capnp-rpc-lwt" {>= "0.8.0"}
-  "capnp-rpc-net" {>= "0.8.0"}
+  "capnp-rpc-net" {>= "0.8.0" & < "2.0"}
   "dockerfile" {>= "7.0.0"}
   "fpath" {>= "0.7.3"}
   "logs" {>= "0.7.0"}

--- a/packages/current_examples/current_examples.0.6.4/opam
+++ b/packages/current_examples/current_examples.0.6.4/opam
@@ -25,8 +25,8 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "capnp-rpc" {>= "1.2.3"}
   "capnp-rpc-lwt" {>= "1.2.3"}
-  "capnp-rpc-net" {>= "1.2.3"}
-  "capnp-rpc-unix" {>= "1.2.3"}
+  "capnp-rpc-net" {>= "1.2.3" & < "2.0"}
+  "capnp-rpc-unix" {>= "1.2.3" & < "2.0"}
   "cmdliner" {>= "1.1.0"}
   "duration"
   "dockerfile" {>= "7.0.0"}

--- a/packages/current_examples/current_examples.0.6.6/opam
+++ b/packages/current_examples/current_examples.0.6.6/opam
@@ -53,8 +53,8 @@ depends: [
   "ocaml" {>= "4.12.0"}
   "capnp-rpc" {>= "1.2.3"}
   "capnp-rpc-lwt" {>= "1.2.3"}
-  "capnp-rpc-net" {>= "1.2.3"}
-  "capnp-rpc-unix" {>= "1.2.3"}
+  "capnp-rpc-net" {>= "1.2.3" & < "2.0"}
+  "capnp-rpc-unix" {>= "1.2.3" & < "2.0"}
   "cmdliner" {>= "1.1.0"}
   "duration"
   "dockerfile" {>= "7.0.0"}

--- a/packages/current_examples/current_examples.0.6/opam
+++ b/packages/current_examples/current_examples.0.6/opam
@@ -24,11 +24,11 @@ depends: [
   "current_gitlab" {= version}
   "current_docker" {= version}
   "current_rpc" {= version}
-  "capnp-rpc-unix" {>= "0.5"}
+  "capnp-rpc-unix" {>= "0.5" & < "2.0"}
   "dune" {>= "2.9"}
   "capnp-rpc" {>= "0.8.0"}
   "capnp-rpc-lwt" {>= "0.8.0"}
-  "capnp-rpc-net" {>= "0.8.0"}
+  "capnp-rpc-net" {>= "0.8.0" & < "2.0"}
   "dockerfile" {>= "7.0.0"}
   "fpath" {>= "0.7.3"}
   "logs" {>= "0.7.0"}

--- a/packages/current_ocluster/current_ocluster.0.1/opam
+++ b/packages/current_ocluster/current_ocluster.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "lwt"
   "current" {>= "0.3"}
   "current_git" {>= "0.3"}
-  "capnp-rpc-unix" {>= "0.9.0"}
+  "capnp-rpc-unix" {>= "0.9.0" & < "2.0"}
   "duration"
   "logs"
   "fmt"

--- a/packages/current_ocluster/current_ocluster.0.2.1/opam
+++ b/packages/current_ocluster/current_ocluster.0.2.1/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.3"}
   "ocluster-api" {= version}
   "ocaml" {>= "4.12.0"}
-  "capnp-rpc-unix" {>= "1.2.3"}
+  "capnp-rpc-unix" {>= "1.2.3" & < "2.0"}
   "current" {>= "0.6.4"}
   "current_git" {>= "0.6.4"}
   "duration"

--- a/packages/current_ocluster/current_ocluster.0.2/opam
+++ b/packages/current_ocluster/current_ocluster.0.2/opam
@@ -16,7 +16,7 @@ depends: [
   "current_git" {>= "0.6"}
   "current_web" {>= "0.6" & with-test}
   "current_github" {>= "0.6" & with-test}
-  "capnp-rpc-unix" {>= "1.2"}
+  "capnp-rpc-unix" {>= "1.2" & < "2.0"}
   "duration"
   "logs"
   "fmt"

--- a/packages/current_ocluster/current_ocluster.0.3.0/opam
+++ b/packages/current_ocluster/current_ocluster.0.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "3.7"}
   "ocluster-api" {= version}
   "ocaml" {>= "4.14.1"}
-  "capnp-rpc-unix" {>= "1.2.3"}
+  "capnp-rpc-unix" {>= "1.2.3" & < "2.0"}
   "current" {>= "0.6.4"}
   "current_git" {>= "0.6.4"}
   "duration"

--- a/packages/current_rpc/current_rpc.0.2/opam
+++ b/packages/current_rpc/current_rpc.0.2/opam
@@ -16,7 +16,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.08.0"}
-  "capnp-rpc-lwt" {>= "0.4"}
+  "capnp-rpc-lwt" {>= "0.4" & < "2.0"}
   "fpath"
   "dune" {>= "1.9"}
 ]

--- a/packages/current_rpc/current_rpc.0.3/opam
+++ b/packages/current_rpc/current_rpc.0.3/opam
@@ -16,7 +16,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.08.0"}
-  "capnp-rpc-lwt" {>= "0.4"}
+  "capnp-rpc-lwt" {>= "0.4" & < "2.0"}
   "fpath"
   "dune" {>= "2.0"}
 ]

--- a/packages/current_rpc/current_rpc.0.4/opam
+++ b/packages/current_rpc/current_rpc.0.4/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "capnp" {>= "3.4.0"}
   "capnp-rpc" {>= "0.8.0"}
-  "capnp-rpc-lwt" {>= "0.4"}
+  "capnp-rpc-lwt" {>= "0.4" & < "2.0"}
   "fpath"
   "dune" {>= "2.0"}
   "fmt" {>= "0.8.9"}

--- a/packages/current_rpc/current_rpc.0.5/opam
+++ b/packages/current_rpc/current_rpc.0.5/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "capnp" {>= "3.4.0"}
   "capnp-rpc" {>= "0.8.0"}
-  "capnp-rpc-lwt" {>= "0.4"}
+  "capnp-rpc-lwt" {>= "0.4" & < "2.0"}
   "fpath"
   "dune" {>= "2.0"}
   "fmt" {>= "0.8.9"}

--- a/packages/ocluster/ocluster.0.1/opam
+++ b/packages/ocluster/ocluster.0.1/opam
@@ -22,8 +22,8 @@ depends: [
   "ocluster-api" {= version}
   "lwt"
   "capnp-rpc-lwt"
-  "capnp-rpc-net"
-  "capnp-rpc-unix" {>= "0.9.0"}
+  "capnp-rpc-net" {< "2.0"}
+  "capnp-rpc-unix" {>= "0.9.0" & < "2.0"}
   "logs"
   "fmt"
   "conf-libev" {os != "win32"}

--- a/packages/ocluster/ocluster.0.2.1/opam
+++ b/packages/ocluster/ocluster.0.2.1/opam
@@ -22,8 +22,8 @@ depends: [
   "ocluster-worker" {= version}
   "ocaml" {>= "4.12.0"}
   "capnp-rpc-lwt" {>= "1.2.3"}
-  "capnp-rpc-net" {>= "1.2.3"}
-  "capnp-rpc-unix" {>= "1.2.3"}
+  "capnp-rpc-net" {>= "1.2.3" & < "2.0"}
+  "capnp-rpc-unix" {>= "1.2.3" & < "2.0"}
   "cmdliner" {>= "1.1.0"}
   "conf-libev" {os != "win32"}
   "digestif" {>= "0.8"}

--- a/packages/ocluster/ocluster.0.2/opam
+++ b/packages/ocluster/ocluster.0.2/opam
@@ -24,8 +24,8 @@ depends: [
   "ocluster-api" {= version}
   "lwt" {>= "5.6.1"}
   "capnp-rpc-lwt"
-  "capnp-rpc-net"
-  "capnp-rpc-unix" {>= "1.2"}
+  "capnp-rpc-net" {< "2.0"}
+  "capnp-rpc-unix" {>= "1.2" & < "2.0"}
   "extunix" {>= "0.4.1"}
   "winsvc" {>= "1.0.1" & os = "win32"}
   "cmdliner" {>= "1.1.0"}

--- a/packages/ocluster/ocluster.0.3.0/opam
+++ b/packages/ocluster/ocluster.0.3.0/opam
@@ -31,8 +31,8 @@ depends: [
   "ocluster-worker" {= version}
   "ocaml" {>= "4.14.1"}
   "capnp-rpc-lwt" {>= "1.2.3"}
-  "capnp-rpc-net" {>= "1.2.3"}
-  "capnp-rpc-unix" {>= "1.2.3"}
+  "capnp-rpc-net" {>= "1.2.3" & < "2.0"}
+  "capnp-rpc-unix" {>= "1.2.3" & < "2.0"}
   "cmdliner" {>= "1.2.0"}
   "conf-libev" {os != "win32"}
   "digestif" {>= "0.8"}


### PR DESCRIPTION
The new 2.0 API will be incompatible.

Some old versions of `current_rpc` used `implicit_transitive_deps`, so they need bounds even with `capnp-rpc-lwt`.

I split this from #27002 to make it easier to see where the real errors are. Since this is just adding upper bounds that don't affect anything at present, any errors must be pre-existing problems.

I'll update #27002 once this is merged.