### PR TITLE
[new release] lacaml (11.1.0)

### DIFF
--- a/packages/lacaml/lacaml.11.1.0/opam
+++ b/packages/lacaml/lacaml.11.1.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "Lacaml - OCaml-bindings to BLAS and LAPACK"
+description: """
+Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
+LAPACK-library (Linear Algebra routines).  It also contains many additional
+convenience functions for vectors and matrices."""
+maintainer: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+]
+authors: [
+  "Egbert Ammicht <eammicht@lucent.com>"
+  "Patrick Cousot <Patrick.Cousot@ens.fr>"
+  "Sam Ehrlichman <sehrlichman@janestreet.com>"
+  "Florent Hoareau <h.florent@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Liam Stewart <liam@cs.toronto.edu>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Oleg Trott <ot14@columbia.edu>"
+  "Martin Willensdorfer <ma.wi@gmx.at>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+tags: ["clib:lapack" "clib:blas"]
+homepage: "https://mmottl.github.io/lacaml"
+doc: "https://mmottl.github.io/lacaml/api"
+bug-reports: "https://github.com/mmottl/lacaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "dune-configurator"
+  "conf-blas" {build}
+  "conf-lapack" {build}
+  "base-bytes"
+  "base-bigarray"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/lacaml.git"
+url {
+  src:
+    "https://github.com/mmottl/lacaml/releases/download/11.1.0/lacaml-11.1.0.tbz"
+  checksum: [
+    "sha256=df0b945fde36c325965dbe4c8df787661c76fe44bffb724555dd384f2fd9b700"
+    "sha512=9cb60f3797eadc62daf946c527f79de9722f002f34b2b24efaef1fefc1846f780a3769da888eaa0bcc45993159f810de8b50244f59bf34f434c8a068527a5935"
+  ]
+}
+x-commit-hash: "0ae604976520f0106f96cea7457bca212ebb73bb"


### PR DESCRIPTION
Lacaml - OCaml-bindings to BLAS and LAPACK

- Project page: <a href="https://mmottl.github.io/lacaml">https://mmottl.github.io/lacaml</a>
- Documentation: <a href="https://mmottl.github.io/lacaml/api">https://mmottl.github.io/lacaml/api</a>

##### CHANGES:

- Bug fix: moved incorrect `Bool_val` out of blocking section.

- Removed -O3, -ffast-math, and -march=native flags. They may be too risky as
  defaults.

- Rewrote README and improved changelog.

- Reformatted all C-code using `clang-format` and OCaml code using
  `ocamlformat`.

- Added GitHub workflow.
