### PR TITLE
Dream 1.0.0~alpha8: tidy Web framework

### DIFF
--- a/packages/dream-httpaf/dream-httpaf.1.0.0~alpha4/opam
+++ b/packages/dream-httpaf/dream-httpaf.1.0.0~alpha4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+
+synopsis: "Internal: shared http/af stack for Dream (server) and Hyper (client)"
+description: "This package does not have a stable API."
+
+license: "MIT"
+homepage: "https://github.com/aantron/dream"
+doc: "https://aantron.github.io/dream"
+bug-reports: "https://github.com/aantron/dream/issues"
+dev-repo: "git+https://github.com/aantron/dream.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "dream-pure"
+  "dune" {>= "2.7.0"}  # --instrument-with.
+  "gluten"
+  "gluten-lwt-unix"
+  "h2" {< "0.13.0"}
+  "h2-lwt-unix"
+  "httpun" {< "0.2.0"}
+  "httpun-lwt-unix"
+  "httpun-ws"
+  "lwt"
+  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ssl"
+  "ocaml" {>= "4.08.0"}
+  "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/dream/releases/download/1.0.0-alpha8/dream-1.0.0-alpha8.tar.gz"
+  checksum: "sha256=23ed812890c03fe5c9974a4961a9e8e62126bed7bc7d7d1440b84652c95cf296"
+}

--- a/packages/dream/dream.1.0.0~alpha8/opam
+++ b/packages/dream/dream.1.0.0~alpha8/opam
@@ -1,0 +1,106 @@
+opam-version: "2.0"
+
+synopsis: "Tidy, feature-complete Web framework"
+tags: ["http" "web" "framework" "websocket" "graphql" "server" "http2" "tls"]
+
+description: """
+Dream is a feature-complete Web framework with a simple programming
+model and no boilerplate. It provides only two data types, request and
+response.
+
+Almost everything else is either a built-in OCaml type, or an
+abbreviation for a bare function. For example, a Web app, known in
+Dream as a handler, is just an ordinary function from requests to
+responses. And a middleware is then just a function from handlers to
+handlers.
+
+Within this model, Dream adds:
+
+- Session management with pluggable back ends.
+- A fully composable router.
+- Support for HTTP/1.1, HTTP/2, and HTTPS.
+- WebSockets.
+- GraphQL, including subscriptions and a built-in GraphiQL editor.
+- SQL connection pool helpers.
+- Server-side HTML templates.
+- Automatic secure handling of cookies and forms.
+- Unified, internationalization-friendly error handling.
+- A neat log, and OCaml runtime configuration.
+- Helpers for Web formats, such as Base64url, and a modern cipher.
+
+Because of the simple programming model, everything is optional and
+composable. It is trivially possible to strip Dream down to just a
+bare driver of the various HTTP protocols.
+
+Dream is presented as a single module, whose API is documented on one
+page. In addition, Dream comes with a large number of examples.
+Security topics are introduced throughout, wherever they are
+applicable."""
+
+license: "MIT"
+homepage: "https://github.com/aantron/dream"
+doc: "https://aantron.github.io/dream"
+bug-reports: "https://github.com/aantron/dream/issues"
+dev-repo: "git+https://github.com/aantron/dream.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "base-unix"
+  "bigarray-compat"
+  "camlp-streams"
+  "caqti" {>= "2.0.0"}
+  "caqti-lwt" {>= "2.0.0"}
+  ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
+  "cstruct" {>= "6.0.0"}
+  "digestif" {>= "0.7"}  # to_raw_string.
+  "dream-httpaf" {>= "1.0.0~alpha4"}
+  "dream-pure" {>= "1.0.0~alpha2"}
+  "dune" {>= "2.7.0"}  # --instrument-with.
+  "fmt" {>= "0.8.7"}  # `Italic.
+  "graphql_parser"
+  "graphql-lwt"
+  "lambdasoup" {>= "0.6.1"}
+  "lwt"
+  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ssl"
+  "logs" {>= "0.5.0"}
+  "magic-mime"
+  "markup" {>= "1.0.2"}
+  "mirage-clock" {>= "3.0.0"}  # now_d_ps : unit -> int * int64.
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "mirage-crypto-rng-lwt"
+  "multipart_form" {>= "0.4.0"}
+  "multipart_form-lwt"
+  "ocaml" {>= "4.08.0"}
+  "ptime" {>= "0.8.1"}  # Ptime.v.
+  "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
+  "uri" {>= "4.2.0"}
+  "yojson"  # ...
+
+  # Testing, development.
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}  # --instrument-with.
+  "caqti-driver-postgresql" {with-test}
+  "caqti-driver-sqlite3" {with-test}
+  "crunch" {with-test}
+  "html_of_jsx" {with-test}
+  "js_of_ocaml" {with-test}
+  "js_of_ocaml-ppx" {with-test}
+  "ppx_expect" {with-test & >= "v0.15.0" & < "v0.17.0"}  # Breaking changes.
+  "ppx_yojson_conv" {with-test}
+  "reason" {with-test}
+  "tyxml" {with-test & >= "4.5.0"}
+  "tyxml-jsx" {with-test}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/dream/releases/download/1.0.0-alpha8/dream-1.0.0-alpha8.tar.gz"
+  checksum: "sha256=23ed812890c03fe5c9974a4961a9e8e62126bed7bc7d7d1440b84652c95cf296"
+}


### PR DESCRIPTION
The main prompt for this release is that Dream formerly vendored ocaml-h2 and hpack, and the vendored version of hpack was not compatible with OCaml 5.3. This release removes the vendored http/af stack in favor of httpun from opam, which is the renamed and released version of the stack (https://github.com/aantron/dream/issues/357).

From the [changelog](https://github.com/aantron/dream/releases/tag/1.0.0-alpha8):

> Additions and improvements
>
> - Replace vendored http/af stack with depending on httpun from opam (aantron/dream#351).
> - Log fd numbers for each request (aantron/dream#345).
>
> Examples
>
> - [mlx](https://github.com/aantron/dream/tree/master/example/w-mlx#folders-and-files) (aantron/dream#330, Andrey Popp @andreypopp).
> - [dream-html](https://github.com/aantron/dream/tree/master/example/w-dream-html#folders-and-files) (aantron/dream#323, Yawar Amin @yawaramin).
> - Satisfy opam lint in all examples (aantron/dream#356, @alxtuz).
> - Fix anchor in links to examples (aantron/dream#361, @alxtuz).
>
> Miscellaneous
>
> - Remove unused docstrings (aantron/dream#342, Max Große @maxRN).
> - Fix and update the CI (aantron/dream#337, with Max Große @maxRN).
> - Fix link into `e-json` example (aantron/dream#354, Emmanuel Ferdman @emmanuel-ferdman).