### PR TITLE
[new release] pomap (4.1.2)

### DIFF
--- a/packages/pomap/pomap.4.1.2/opam
+++ b/packages/pomap/pomap.4.1.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "POMAP - Partially Ordered Maps for OCaml"
+description: """
+POMAP supports creating and manipulating partially ordered maps in a purely
+functional and efficient way."""
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: ["Markus Mottl <markus.mottl@gmail.com>"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/pomap"
+doc: "https://mmottl.github.io/pomap/api"
+bug-reports: "https://github.com/mmottl/pomap/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/pomap.git"
+url {
+  src:
+    "https://github.com/mmottl/pomap/releases/download/4.1.2/pomap-4.1.2.tbz"
+  checksum: [
+    "sha256=9ef7cf136c2b80d9041127d25a8950e70f8d9a2852cfb40edd77d8396dbbfdfc"
+    "sha512=9c83e4789101fb8cea2fa4b2e7aa084aec09def6b424912b0c0f5c00b8e922749c0367665d4b7a1b90ad686421c57afcb7edc9e631554d002cc1b4e786049eb8"
+  ]
+}
+x-commit-hash: "559ed9e528c1aff93857d6037bf0d93e74fe76c6"


### PR DESCRIPTION
POMAP - Partially Ordered Maps for OCaml

- Project page: <a href="https://mmottl.github.io/pomap">https://mmottl.github.io/pomap</a>
- Documentation: <a href="https://mmottl.github.io/pomap/api">https://mmottl.github.io/pomap/api</a>

##### CHANGES:

- Improved documentation

- Formatted all OCaml code with `ocamlformat`

- Switched to OPAM file generation via `dune-project`
