### PR TITLE
fix eliom constraint on jsoo

### DIFF
--- a/packages/eliom/eliom.10.0.0/opam
+++ b/packages/eliom/eliom.10.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.10.1.0/opam
+++ b/packages/eliom/eliom.10.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.10.1.2/opam
+++ b/packages/eliom/eliom.10.1.2/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.10.2.0/opam
+++ b/packages/eliom/eliom.10.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.10.3.0/opam
+++ b/packages/eliom/eliom.10.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.10.3.1/opam
+++ b/packages/eliom/eliom.10.3.1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.10.4.0/opam
+++ b/packages/eliom/eliom.10.4.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0" & < "6.0.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.10.4.1/opam
+++ b/packages/eliom/eliom.10.4.1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0" & < "6.0.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.11.0.0/opam
+++ b/packages/eliom/eliom.11.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0" & < "6.0.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.11.0.1/opam
+++ b/packages/eliom/eliom.11.0.1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0" & < "6.0.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.11.1.0/opam
+++ b/packages/eliom/eliom.11.1.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "5.5.0"}
+  "js_of_ocaml-compiler" {>= "5.5.0" & != "5.9.0"}
   "js_of_ocaml" {>= "5.5.0" & < "6.0.0"}
   "js_of_ocaml-lwt" {>= "5.5.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.7.0.0/opam
+++ b/packages/eliom/eliom.7.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "5.2"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.8.4.8/opam
+++ b/packages/eliom/eliom.8.4.8/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "5.2"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.8.6.0/opam
+++ b/packages/eliom/eliom.8.6.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "5.2"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.8.8.0/opam
+++ b/packages/eliom/eliom.8.8.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "5.2"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.8.8.1/opam
+++ b/packages/eliom/eliom.8.8.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "5.2"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.8.9.0/opam
+++ b/packages/eliom/eliom.8.9.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.9.0.0/opam
+++ b/packages/eliom/eliom.9.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.9.2.1/opam
+++ b/packages/eliom/eliom.9.2.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.9.3.0/opam
+++ b/packages/eliom/eliom.9.3.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}

--- a/packages/eliom/eliom.9.4.0/opam
+++ b/packages/eliom/eliom.9.4.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.15.0"}
-  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0" & < "5.9.0"}
   "js_of_ocaml" {>= "3.6.0"}
   "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}


### PR DESCRIPTION
- Add an upper bound on jsoo to all old eliom version.
- Make the latest eliom release (11.1.0) incompatible with the latest jsoo release (5.9.0) (see https://github.com/ocsigen/ocsigen-start/issues/684)
