### PR TITLE
[new release] cmdlang (5 packages) (0.0.9)

### DIFF
--- a/packages/cmdlang-stdlib-runner/cmdlang-stdlib-runner.0.0.9/opam
+++ b/packages/cmdlang-stdlib-runner/cmdlang-stdlib-runner.0.0.9/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "A basic execution runner for cmdlang based on stdlib.arg"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "cmdlang" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+description: """\
+
+[Cmdlang_stdlib_runner] is an execution engine for running command
+line programs specified with [cmdlang].
+
+It has no dependencies other than [cmdlang] and is implemented using
+the [Arg] module from the OCaml standard library.
+
+This package may be useful as a lightweight alternative to translating
+cmdlang parsers to more feature-rich libraries such as [cmdliner],
+[climate], or [core.command].
+
+"""
+tags: [ "cli" "cmdlang" "stdlib.arg" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.9/cmdlang-0.0.9.tbz"
+  checksum: [
+    "sha256=44fc0027cc27a8d6b511bbde81b0d31306ec1a3d599476d5bd058510f39e87ef"
+    "sha512=e1a18905ff6035eb4c44aed71df0e3d42b8277db9a6e98fe571a3b17428c9ef0a26006cb27b729a60208a8357398decc6a8601caca74dabd2e6de7636bc60b31"
+  ]
+}
+x-commit-hash: "c9c2c1773e374f61f890b4ae36d09a1195010a4c"

--- a/packages/cmdlang-to-base/cmdlang-to-base.0.0.9/opam
+++ b/packages/cmdlang-to-base/cmdlang-to-base.0.0.9/opam
@@ -20,6 +20,7 @@ depends: [
   "ppx_let" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
+  "ppxlib" {>= "0.33"}
   "stdio" {>= "v0.17" & < "v0.18"}
   "odoc" {with-doc}
 ]

--- a/packages/cmdlang-to-base/cmdlang-to-base.0.0.9/opam
+++ b/packages/cmdlang-to-base/cmdlang-to-base.0.0.9/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Convert cmdlang Parsers to core.command"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.2"}
+  "base" {>= "v0.17" & < "v0.18"}
+  "cmdlang" {= version}
+  "core" {>= "v0.17" & < "v0.18"}
+  "ppx_compare" {>= "v0.17" & < "v0.18"}
+  "ppx_enumerate" {>= "v0.17" & < "v0.18"}
+  "ppx_expect" {>= "v0.17" & < "v0.18"}
+  "ppx_hash" {>= "v0.17" & < "v0.18"}
+  "ppx_here" {>= "v0.17" & < "v0.18"}
+  "ppx_let" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
+  "stdio" {>= "v0.17" & < "v0.18"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+description: """\
+
+[Cmdlang_to_base] allows translating command line programs specified
+with [cmdlang] into [core.command] commands suitable for execution.
+
+[core.command]: https://github.com/janestreet/core
+
+"""
+tags: [ "cli" "cmdlang" "core.command" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.9/cmdlang-0.0.9.tbz"
+  checksum: [
+    "sha256=44fc0027cc27a8d6b511bbde81b0d31306ec1a3d599476d5bd058510f39e87ef"
+    "sha512=e1a18905ff6035eb4c44aed71df0e3d42b8277db9a6e98fe571a3b17428c9ef0a26006cb27b729a60208a8357398decc6a8601caca74dabd2e6de7636bc60b31"
+  ]
+}
+x-commit-hash: "c9c2c1773e374f61f890b4ae36d09a1195010a4c"

--- a/packages/cmdlang-to-climate/cmdlang-to-climate.0.0.9/opam
+++ b/packages/cmdlang-to-climate/cmdlang-to-climate.0.0.9/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Convert cmdlang Parsers to climate"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "climate" {>= "0.3.0"}
+  "cmdlang" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+description: """\
+
+[Cmdlang_to_climate] allows translating command line programs
+specified with [cmdlang] into [climate] commands suitable for
+execution.
+
+[climate]: https://github.com/gridbugs/climate
+
+"""
+tags: [ "cli" "cmdlang" "climate" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.9/cmdlang-0.0.9.tbz"
+  checksum: [
+    "sha256=44fc0027cc27a8d6b511bbde81b0d31306ec1a3d599476d5bd058510f39e87ef"
+    "sha512=e1a18905ff6035eb4c44aed71df0e3d42b8277db9a6e98fe571a3b17428c9ef0a26006cb27b729a60208a8357398decc6a8601caca74dabd2e6de7636bc60b31"
+  ]
+}
+x-commit-hash: "c9c2c1773e374f61f890b4ae36d09a1195010a4c"

--- a/packages/cmdlang-to-cmdliner/cmdlang-to-cmdliner.0.0.9/opam
+++ b/packages/cmdlang-to-cmdliner/cmdlang-to-cmdliner.0.0.9/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Convert cmdlang Parsers to cmdliner"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "cmdlang" {= version}
+  "cmdliner" {>= "1.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+description: """\
+
+[Cmdlang_to_cmdliner] allows translating command line programs
+specified with [cmdlang] into [cmdliner] commands suitable for
+execution.
+
+[cmdliner]: https://github.com/dbuenzli/cmdliner
+
+"""
+tags: [ "cli" "cmdlang" "cmdliner" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.9/cmdlang-0.0.9.tbz"
+  checksum: [
+    "sha256=44fc0027cc27a8d6b511bbde81b0d31306ec1a3d599476d5bd058510f39e87ef"
+    "sha512=e1a18905ff6035eb4c44aed71df0e3d42b8277db9a6e98fe571a3b17428c9ef0a26006cb27b729a60208a8357398decc6a8601caca74dabd2e6de7636bc60b31"
+  ]
+}
+x-commit-hash: "c9c2c1773e374f61f890b4ae36d09a1195010a4c"

--- a/packages/cmdlang/cmdlang.0.0.9/opam
+++ b/packages/cmdlang/cmdlang.0.0.9/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Declarative Command-line Parsing for OCaml"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+description: """\
+
+Cmdlang is a library for creating command-line parsers in OCaml.
+Implemented as an OCaml EDSL, its declarative specification language
+lives at the intersection of other well-established similar libraries.
+
+Cmdlang doesn't include an execution engine. Instead, Cmdlang parsers
+are automatically translated to [cmdliner], [core.command], or
+[climate] commands for execution.
+
+[cmdliner]: https://github.com/dbuenzli/cmdliner
+[climate]: https://github.com/gridbugs/climate
+[core.command]: https://github.com/janestreet/core
+
+"""
+tags: [ "cli" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.9/cmdlang-0.0.9.tbz"
+  checksum: [
+    "sha256=44fc0027cc27a8d6b511bbde81b0d31306ec1a3d599476d5bd058510f39e87ef"
+    "sha512=e1a18905ff6035eb4c44aed71df0e3d42b8277db9a6e98fe571a3b17428c9ef0a26006cb27b729a60208a8357398decc6a8601caca74dabd2e6de7636bc60b31"
+  ]
+}
+x-commit-hash: "c9c2c1773e374f61f890b4ae36d09a1195010a4c"


### PR DESCRIPTION
I took the opportunity to improve the generation of opam files for the repo by using template files, so as to add tags, description and x-maintenance-intent fields.

## Changelog

### Added

- Added an example of migration from `core.command` to `climate`.
- Added migration utils.
- Improve code coverage, added tests.

### Changed

- Document presence in stdlib-runner help (required, default, etc.).
- Minor refactor in stdlib-runner.
- Upgrade to `climate.0.3.0`.

### Fixed

- Fix trailing dot additions in `to-cmdliner` for cases such as `?.` and `..`.

### Removed

- Removed config option `auto_add_short_aliases` from to-base translation (not useful).
