### PR TITLE
[new release] loc (0.2.2)

### DIFF
--- a/packages/loc/loc.0.2.2/opam
+++ b/packages/loc/loc.0.2.2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Representing ranges of lexing positions from parsed files"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/loc"
+doc: "https://mbarbin.github.io/loc/"
+bug-reports: "https://github.com/mbarbin/loc/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "fpath" {>= "0.7.3"}
+  "sexplib0" {>= "v0.16"}
+  "stdune" {>= "3.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/loc.git"
+description: """\
+
+Loc is an OCaml library for manipulating code locations, which are
+ranges of lexing positions from a parsed file.
+
+Attaching locations to nodes manipulated by programs can be useful for
+various applications such as compilers, interpreters, linters, and
+refactoring tools.
+
+"""
+tags: [ "code-locations" "lexing" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src: "https://github.com/mbarbin/loc/releases/download/0.2.2/loc-0.2.2.tbz"
+  checksum: [
+    "sha256=3823c82f10c16278eb4b660a5621c59f4e920151c6d4c6a37976bbe9ba3a7934"
+    "sha512=aca370c2387e2afb6b116f911671f872cbc44713297713e98573dda5dcad0974bd7f22df4ad8a59243b19ba24a675d1ec98c66453176298baaaa3fdb56c5e1e4"
+  ]
+}
+x-commit-hash: "a994fd6793be972bb3c771d8986b708c363dceb9"


### PR DESCRIPTION
Skipping 0.2.1 released internally - releasing 0.2.2 directly in the opam-repo.

## 0.2.2 (2024-11-04)

### Fixed

- Fix `Offset.to_position` to allow the end-of-file offset instead of raising.

## 0.2.1 (2024-11-04)

### Added

- Add utils to build locs from file offsets and ranges.
- Make the library build with `ocaml.4.14`.
- Add new checks in CI (build checks on windows and macos).

### Changed

- Rename `Loc.in_file` to `Loc.of_file`; rename `Loc.in_file_line` to `Loc.of_file_line`.

### Deprecated

- Prepare `Loc.in_file` and `Loc.in_file_line` for deprecation.
