### PR TITLE
2 packages from extism/ocaml-sdk at 1.3.0

### DIFF
--- a/packages/extism-manifest/extism-manifest.1.3.0/opam
+++ b/packages/extism-manifest/extism-manifest.1.3.0/opam
@@ -5,7 +5,7 @@ description: "Bindings to the Extism manifest format"
 maintainer: ["Extism Authors <oss@extism.org>"]
 authors: ["Extism Authors <oss@extism.org>"]
 license: "BSD-3-Clause"
-tags: ["topics" "wasm" "plugin"]
+tags: ["wasm" "plugin"]
 homepage: "https://github.com/extism/ocaml-sdk"
 doc: "https://github.com/extism/ocaml-sdk"
 bug-reports: "https://github.com/extism/ocaml-sdk/issues"
@@ -35,7 +35,7 @@ dev-repo: "git+https://github.com/extism/ocaml-sdk.git"
 url {
   src: "https://github.com/extism/ocaml-sdk/archive/refs/tags/v1.3.0.tar.gz"
   checksum: [
-    "md5=21ee8d7196f68738741ab80da783613f"
-    "sha512=664ec9d592b8fbd2c7c89de63f419fd2f59b97c06a3f56cc4d3f08bf657d39ce78d9e320dd70d0ae39d3d6a943a9b4801557034f8f5ff0b2f2632c2bbfd22682"
+    "md5=496e470380cf20ef218dcfe1bbe50463"
+    "sha512=dfbc582e39546b08080acd73227d96017fdf70072ffe2f44f9b8aae204dfa0bef8b6f4e1970c9c30e2f1a60e3dcdcd27e040ef7596af4d70fac7ca5a1e1842e0"
   ]
 }

--- a/packages/extism/extism.1.3.0/opam
+++ b/packages/extism/extism.1.3.0/opam
@@ -5,7 +5,7 @@ description: "Bindings to Extism, the universal plugin system"
 maintainer: ["Extism Authors <oss@extism.org>"]
 authors: ["Extism Authors <oss@extism.org>"]
 license: "BSD-3-Clause"
-tags: ["topics" "wasm" "plugin"]
+tags: ["wasm" "plugin"]
 homepage: "https://github.com/extism/ocaml-sdk"
 doc: "https://github.com/extism/ocaml-sdk"
 bug-reports: "https://github.com/extism/ocaml-sdk/issues"
@@ -20,7 +20,7 @@ depends: [
   "extism-manifest" {= version}
   "ppx_inline_test" {>= "v0.15.0"}
   "cmdliner" {>= "1.1.1"}
-  "uuidm" {>= "0.9.8"}
+  "uuidm" {>= "0.9.9"}
   "mdx" {>= "2.3.0" & with-test}
   "odoc" {with-doc}
 ]
@@ -44,7 +44,7 @@ post-messages: ["See https://extism.org/docs/install/ for information about inst
 url {
   src: "https://github.com/extism/ocaml-sdk/archive/refs/tags/v1.3.0.tar.gz"
   checksum: [
-    "md5=21ee8d7196f68738741ab80da783613f"
-    "sha512=664ec9d592b8fbd2c7c89de63f419fd2f59b97c06a3f56cc4d3f08bf657d39ce78d9e320dd70d0ae39d3d6a943a9b4801557034f8f5ff0b2f2632c2bbfd22682"
+    "md5=496e470380cf20ef218dcfe1bbe50463"
+    "sha512=dfbc582e39546b08080acd73227d96017fdf70072ffe2f44f9b8aae204dfa0bef8b6f4e1970c9c30e2f1a60e3dcdcd27e040ef7596af4d70fac7ca5a1e1842e0"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
- `extism.1.3.0`: Extism bindings
- `extism-manifest.1.3.0`: Extism manifest bindings



---
* Homepage: https://github.com/extism/ocaml-sdk
* Source repo: git+https://github.com/extism/ocaml-sdk.git
* Bug tracker: https://github.com/extism/ocaml-sdk/issues

---
:camel: Pull-request generated by opam-publish v2.4.0