### PR TITLE
[new release] extunix (0.4.3)

### DIFF
--- a/packages/extunix/extunix.0.4.3/opam
+++ b/packages/extunix/extunix.0.4.3/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "Collection of thin bindings to various low-level system API"
+description: """
+Motto: "Be to Unix, what extlib is to stdlib"
+
+* Implement thin C bindings that directly map to underlying system API.
+* Provide common consistent ocaml interface: naming convention, exceptions.
+* Simple to build - no extra dependencies.
+"""
+maintainer: ["ygrek@autistici.org" "Antonin Décimo <antonin@tarides.com>"]
+authors: [
+  "Andre Nathan"
+  "Antonin Décimo"
+  "Dmitry Grebeniuk"
+  "François Bobot"
+  "Gerd Stolpmann"
+  "Goswin von Brederlow"
+  "Joshua Smith"
+  "Kaustuv Chaudhuri"
+  "Markus W. Weissmann"
+  "Mehdi Dogguy"
+  "Niki Yoshiuchi"
+  "Pierre Chambart"
+  "Roman Vorobets"
+  "Stéphane Glondu"
+  "Sylvain Le Gall"
+  "Teague Hansen"
+  "ygrek"
+  "Zhenya Lykhovyd"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+tags: ["org:ygrek"]
+homepage: "https://github.com/ygrek/extunix"
+bug-reports: "https://github.com/ygrek/extunix/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.06"}
+  "dune-configurator" {>= "2.9" & build}
+  "ppxlib" {>= "0.18" & build}
+  "ounit2" {with-test}
+  "base-bytes"
+  "base-bigarray"
+  "base-unix"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ygrek/extunix.git"
+depexts: [["libexecinfo-dev"] {os = "alpine" & "3.5" <= os-version & os-version < "3.17"}]
+url {
+  src:
+    "https://github.com/ygrek/extunix/releases/download/v0.4.3/extunix-0.4.3.tbz"
+  checksum: [
+    "sha256=1460638595b86bd045295e69b969e2e45e8f76017415a97c73b3355ba8e2e9c4"
+    "sha512=9c5c5e56e24250b7bb1c0feda7592dc307433eb485e7d6aa02fc65e4c83bd04ae73675ce8a18aeb878a34363612d56562933df612c08b1584741ecc510a400e5"
+  ]
+}
+x-commit-hash: "8dfa7b6a72954543ae5e07e85bf6a42364aa287c"


### PR DESCRIPTION
Collection of thin bindings to various low-level system API

- Project page: <a href="https://github.com/ygrek/extunix">https://github.com/ygrek/extunix</a>

##### CHANGES:

* Move macros accessing values outside of blocking sections
* Use caml_stat_* functions instead of malloc/free for heap data
* Support renameat2
