### PR TITLE
Update description for opam-graph

### DIFF
--- a/packages/opam-graph/opam-graph.0.1.1/opam
+++ b/packages/opam-graph/opam-graph.0.1.1/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis: "Graphing dependencies of opam packages"
 description: """\
 This package outputs dependency graphs (in svg and dot) of opam package
-universes (opam switch export)."""
+universes (opam switch export --full --freeze)."""
 maintainer: "Robur <team@robur.coop>"
 authors: "Robur <team@robur.coop>"
 license: "ISC"


### PR DESCRIPTION
Opam-graph makes strong assumptions on the opam switch export output so we should be more explicit in the example in its opam package description. In particular, it will not work without the `--full` flag.