### PR TITLE
[new release] saturn (1.0.0)

### DIFF
--- a/packages/saturn/saturn.1.0.0/opam
+++ b/packages/saturn/saturn.1.0.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Collection of concurent-safe data structures for Multicore OCaml"
+maintainer: ["Carine Morel" "KC Sivaramakrishnan" "Sudha Parimala"]
+authors: ["KC Sivaramakrishnan"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/saturn"
+doc: "https://ocaml-multicore.github.io/saturn/"
+bug-reports: "https://github.com/ocaml-multicore/saturn/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "4.14" & < "5.0.0" | >= "5.2.0"}
+  "backoff" {>= "0.1.1"}
+  "multicore-magic" {>= "2.3.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "domain_shims" {>= "0.1.0" & with-test}
+  "dscheck" {>= "0.5.0" & with-test}
+  "mdx" {>= "0.4" & with-test}
+  "multicore-bench" {>= "0.1.7" & with-test}
+  "multicore-magic-dscheck" {>= "2.3.0" & with-test}
+  "qcheck" {>= "0.21.3" & with-test}
+  "qcheck-alcotest" {>= "0.21.3" & with-test}
+  "qcheck-core" {>= "0.21.3" & with-test}
+  "qcheck-stm" {>= "0.4" & with-test}
+  "qcheck-multicoretests-util" {>= "0.4" & with-test}
+  "yojson" {>= "2.0.2" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/saturn.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/saturn/releases/download/1.0.0/saturn-1.0.0.tbz"
+  checksum: [
+    "sha256=2d9e4f6713f98cead53f147895c4eb5adc301f10cc828c52f272494da6072a08"
+    "sha512=925104a4293326d345701e80932ace2b5d2da02ca6406271d33cd54f9e9c6583f35b060bc42c640357c98669f5bc42e8447dbd21614ae02ce5b5efaa8f04a132"
+  ]
+}
+x-commit-hash: "ed0a45d8decfb48114d96007d8f6716591d26cd6"


### PR DESCRIPTION
Collection of concurent-safe data structures for Multicore OCaml

- Project page: <a href="https://github.com/ocaml-multicore/saturn">https://github.com/ocaml-multicore/saturn</a>
- Documentation: <a href="https://ocaml-multicore.github.io/saturn/">https://ocaml-multicore.github.io/saturn/</a>

##### CHANGES:

- Add lockfree Bag (@lyrm, @polytypic)
- Update Skiplist with better documentation and additional functions (@lyrm)
- Update Mpsc with better documentation and additional functions (@lyrm, @art-w)
- Update Michael-Scott queue with better documentation and additional functions (@lyrm, @art-w)
- Update Ws_deque with better documentation and additional functions (@lyrm, @art-w)
- Update Spsc with better documentation and additional functions (@lyrm, @art-w)
- Optimization of Ws_deque (@polytypic, @lyrm)
- Add Bounded Queue (@lyrm, @polytypic, @art-w)
- Add Bounded Stack (@lyrm, @art-w)
- Update Treiber Stack with better documentation and additional functions (@lyrm, @art-w)
- Remove Saturn_lockfree package (@lyrm)
- Remove relaxed_queue and M module in ws_deque (@lyrm)
- Add Htbl from Picos (@lyrm, @polytypic)

