### PR TITLE
mark solo5 packages that use -Werror as avoid-version

### DIFF
--- a/packages/solo5/solo5.0.7.0/opam
+++ b/packages/solo5/solo5.0.7.0/opam
@@ -52,3 +52,4 @@ url {
   src: "https://github.com/Solo5/solo5/releases/download/v0.7.0/solo5-v0.7.0.tar.gz"
   checksum: "sha512=7d89539d4964c4c2133bddf82fab865db523b069845b2f6367f3f2bf68e743cfe97e5ffff6fa90a217cc9392078b52de63ecd8e540e9a50c39f435fded0717d0"
 }
+flags: [ avoid-version ] # uses -Werror

--- a/packages/solo5/solo5.0.7.1/opam
+++ b/packages/solo5/solo5.0.7.1/opam
@@ -50,3 +50,4 @@ url {
   src: "https://github.com/Solo5/solo5/releases/download/v0.7.1/solo5-v0.7.1.tar.gz"
   checksum: "sha512=ccbe136a402b856dc99e5da449f62c1ed24f49b676ebae0a715a1f043cb0762ac404754f0887039d3dbdef1cd413a0a7e4d92b8dee562f06d3932fcb668180ed"
 }
+flags: [ avoid-version ] # uses -Werror

--- a/packages/solo5/solo5.0.7.2/opam
+++ b/packages/solo5/solo5.0.7.2/opam
@@ -50,3 +50,4 @@ url {
   src: "https://github.com/Solo5/solo5/releases/download/v0.7.2/solo5-v0.7.2.tar.gz"
   checksum: "sha512=376d5d6caebf824928949a2e8be9b879dd924a6ce30128e183ebdfb99d812a42f528196315d85b0bee4ddec87ea92264ed763f74548cf3f9519c94fd13abb4b9"
 }
+flags: [ avoid-version ] # uses -Werror

--- a/packages/solo5/solo5.0.7.3/opam
+++ b/packages/solo5/solo5.0.7.3/opam
@@ -50,3 +50,4 @@ url {
   src: "https://github.com/Solo5/solo5/releases/download/v0.7.3/solo5-v0.7.3.tar.gz"
   checksum: "sha512=cafc590923b7bb53f27d46255914af620e47f14ce772c2e03afb0badf3c89abe06e625db290a8ccfaf280320ad4e63cf4876106f5d1d8a7801b13ccb5c033f2d"
 }
+flags: [ avoid-version ] # uses -Werror

--- a/packages/solo5/solo5.0.7.4/opam
+++ b/packages/solo5/solo5.0.7.4/opam
@@ -51,3 +51,4 @@ url {
   src: "https://github.com/Solo5/solo5/releases/download/v0.7.4/solo5-v0.7.4.tar.gz"
   checksum: "sha512=1a47ee4a9e08704ae7aa5f48efdd79e33ae83d4d2f60a2c8ef7db33c85412cd1f0b023b4acc0ad6123377933a2ce6841590cf127fd2c062ff8d1594f36cddda1"
 }
+flags: [ avoid-version ] # uses -Werror

--- a/packages/solo5/solo5.0.7.5/opam
+++ b/packages/solo5/solo5.0.7.5/opam
@@ -51,3 +51,4 @@ url {
   src: "https://github.com/Solo5/solo5/releases/download/v0.7.5/solo5-v0.7.5.tar.gz"
   checksum: "sha512=1e8be23e84e54f8fdb364e8d2a20933150930b43f91085b4dd378ed6445718ef38abca98bcfd0a1e68cdbda747bf829551f0b2a31cdcfe13db219e332512ff79"
 }
+flags: [ avoid-version ] # uses -Werror

--- a/packages/solo5/solo5.0.8.0/opam
+++ b/packages/solo5/solo5.0.8.0/opam
@@ -51,3 +51,4 @@ url {
   src: "https://github.com/Solo5/solo5/releases/download/v0.8.0/solo5-v0.8.0.tar.gz"
   checksum: "sha512=d819d66407b84b56d46b5e534d5424903f15b124aa1c24d546abe1d9adb5a622ceee93cb1303a14ebf7811c7b5dad2d94a490cabbde489245efd66114617c39b"
 }
+flags: [ avoid-version ] # uses -Werror


### PR DESCRIPTION
since solo5 0.8.1, there's no more `-Werror` for releases