### PR TITLE
gluten-lwt-unix: depots bounds should be conflicts

### DIFF
--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.4.0/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.4.0/opam
@@ -12,11 +12,12 @@ depends: [
   "faraday-lwt-unix" {>= "0.7.3"}
 ]
 depopts: [
-  "lwt_ssl" {>= "1.2.0"}
+  "lwt_ssl"
   "tls"
 ]
 conflicts: [
   "tls" {>= "0.16.0"}
+  "lwt_ssl" {< "1.2.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.4.1/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.4.1/opam
@@ -11,9 +11,6 @@ depends: [
   "gluten-lwt" {= version}
   "faraday-lwt-unix" {>= "0.7.3"}
 ]
-conflicts: [
-  "lwt_ssl" {< "1.2.0"}
-]
 depopts: [
   "lwt_ssl"
   "tls-lwt"
@@ -44,4 +41,5 @@ url {
 x-commit-hash: "e0651eb76a03737782d367e7e2587734fca0c9b6"
 conflicts: [
   "tls-lwt" {>= "1.0.0"}
+  "lwt_ssl" {< "1.2.0"}
 ]

--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.4.1/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.4.1/opam
@@ -11,8 +11,11 @@ depends: [
   "gluten-lwt" {= version}
   "faraday-lwt-unix" {>= "0.7.3"}
 ]
+conflicts: [
+  "lwt_ssl" {< "1.2.0"}
+]
 depopts: [
-  "lwt_ssl" {>= "1.2.0"}
+  "lwt_ssl"
   "tls-lwt"
 ]
 build: [

--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.0/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.0/opam
@@ -12,8 +12,9 @@ depends: [
   "faraday-lwt-unix" {>= "0.7.3"}
   "odoc" {with-doc}
 ]
+conflicts: [ "lwt_ssl" {< "1.2.0"} ]
 depopts: [
-  "lwt_ssl" {>= "1.2.0"}
+  "lwt_ssl"
   "tls-lwt"
 ]
 build: [

--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.0/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.0/opam
@@ -12,7 +12,10 @@ depends: [
   "faraday-lwt-unix" {>= "0.7.3"}
   "odoc" {with-doc}
 ]
-conflicts: [ "lwt_ssl" {< "1.2.0"} ]
+conflicts: [
+  "lwt_ssl" {< "1.2.0"}
+  "tls-lwt" {>= "1.0.0"}
+]
 depopts: [
   "lwt_ssl"
   "tls-lwt"
@@ -41,6 +44,3 @@ url {
   ]
 }
 x-commit-hash: "166e1e917710e1e43b04d33a368b6701a9f8b1f5"
-conflicts: [
-  "tls-lwt" {>= "1.0.0"}
-]

--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.1/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.1/opam
@@ -12,8 +12,9 @@ depends: [
   "faraday-lwt-unix" {>= "0.7.3"}
   "odoc" {with-doc}
 ]
+conflicts: [ "lwt_ssl" {< "1.2.0"} ]
 depopts: [
-  "lwt_ssl" {>= "1.2.0"}
+  "lwt_ssl"
   "tls-lwt"
 ]
 build: [

--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.1/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.1/opam
@@ -12,7 +12,10 @@ depends: [
   "faraday-lwt-unix" {>= "0.7.3"}
   "odoc" {with-doc}
 ]
-conflicts: [ "lwt_ssl" {< "1.2.0"} ]
+conflicts: [
+  "lwt_ssl" {< "1.2.0"}
+  "tls-lwt" {>= "1.0.0"}
+]
 depopts: [
   "lwt_ssl"
   "tls-lwt"
@@ -41,6 +44,3 @@ url {
   ]
 }
 x-commit-hash: "a2439efe4f187b8c43dee577299470660503a73d"
-conflicts: [
-  "tls-lwt" {>= "1.0.0"}
-]

--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.2/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.5.2/opam
@@ -12,9 +12,13 @@ depends: [
   "faraday-lwt-unix" {>= "0.7.3"}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "lwt_ssl" {< "1.2.0"}
+  "tls-lwt" {< "1.0.0"}
+]
 depopts: [
-  "lwt_ssl" {>= "1.2.0"}
-  "tls-lwt" {>= "1.0.0"}
+  "lwt_ssl"
+  "tls-lwt"
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
The bound on 0.5.0 is needed for this failure:
```
#=== ERROR while compiling gluten-lwt-unix.0.5.0 ==============================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/gluten-lwt-unix.0.5.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p gluten-lwt-unix -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/gluten-lwt-unix-7-11e308.env
# output-file          ~/.opam/log/gluten-lwt-unix-7-11e308.out
### output ###
# File "/home/opam/.opam/4.13/lib/faraday-lwt/faraday-lwt.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
# File "/home/opam/.opam/4.13/lib/lwt_ssl/lwt_ssl.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlc.opt -w -40 -g -bin-annot -I lwt-unix/.gluten_lwt_unix.objs/byte -I /home/opam/.opam/4.13/lib/bigstringaf -I /home/opam/.opam/4.13/lib/faraday -I /home/opam/.opam/4.13/lib/faraday-lwt -I /home/opam/.opam/4.13/lib/faraday-lwt-unix -I /home/opam/.opam/4.13/lib/gluten -I /home/opam/.opam/4.13/lib/gluten-lwt -I /home/opam/.opam/4.13/lib/lwt -I /home/opam/.opam/4.13/lib/lwt/unix -I /home/opam/.opam/4.13/lib/lwt_ssl -I /home/opam/.opam/4.13/lib/mmap -I /home/opam/.opam/4.13/lib/ocaml/threads -I /home/opam/.opam/4.13/lib/ocplib-endian -I /home/opam/.opam/4.13/lib/result -I /home/opam/.opam/4.13/lib/seq -I /home/opam/.opam/4.13/lib/ssl -no-alias-deps -open Gluten_lwt_unix__ -o lwt-unix/.gluten_lwt_unix.objs/byte/gluten_lwt_unix__Ssl_io.cmo -c -impl lwt-unix/ssl_io.ml)
# File "lwt-unix/ssl_io.real.ml", line 50, characters 11-31:
# Error: Unbound value Lwt_ssl.close_notify
```