### PR TITLE
Fix dream upper bound

### DIFF
--- a/packages/dream/dream.1.0.0~alpha5/opam
+++ b/packages/dream/dream.1.0.0~alpha5/opam
@@ -52,6 +52,7 @@ depends: [
   "caqti-lwt"
   "conf-libev" {os != "win32"}
   "cstruct" {>= "6.0.0"}
+  "digestif"
   "dream-httpaf" {>= "1.0.0~alpha2"}
   "dream-pure" {>= "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}  # --instrument-with.

--- a/packages/dream/dream.1.0.0~alpha5/opam
+++ b/packages/dream/dream.1.0.0~alpha5/opam
@@ -53,7 +53,7 @@ depends: [
   "conf-libev" {os != "win32"}
   "cstruct" {>= "6.0.0"}
   "digestif" {>= "0.7"}  # to_raw_string.
-  "dream-httpaf" {>= "1.0.0~alpha5"}
+  "dream-httpaf" {>= "1.0.0~alpha2"}
   "dream-pure" {>= "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}  # --instrument-with.
   "fmt" {>= "0.8.7"}  # `Italic.

--- a/packages/dream/dream.1.0.0~alpha5/opam
+++ b/packages/dream/dream.1.0.0~alpha5/opam
@@ -52,8 +52,8 @@ depends: [
   "caqti-lwt"
   "conf-libev" {os != "win32"}
   "cstruct" {>= "6.0.0"}
-  "digestif"
-  "dream-httpaf" {>= "1.0.0~alpha2"}
+  "digestif" {>= "0.7"}  # to_raw_string.
+  "dream-httpaf" {>= "1.0.0~alpha5"}
   "dream-pure" {>= "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}  # --instrument-with.
   "fmt" {>= "0.8.7"}  # `Italic.

--- a/packages/dream/dream.1.0.0~alpha6/opam
+++ b/packages/dream/dream.1.0.0~alpha6/opam
@@ -53,7 +53,7 @@ depends: [
   ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
   "cstruct" {>= "6.0.0"}
   "digestif" {>= "0.7"}  # to_raw_string.
-  "dream-httpaf" {>= "1.0.0~alpha5"}
+  "dream-httpaf" {>= "1.0.0~alpha2"}
   "dream-pure" {>= "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}  # --instrument-with.
   "fmt" {>= "0.8.7"}  # `Italic.

--- a/packages/dream/dream.1.0.0~alpha6/opam
+++ b/packages/dream/dream.1.0.0~alpha6/opam
@@ -52,6 +52,7 @@ depends: [
   "caqti-lwt" {>= "2.0.0"}
   ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
   "cstruct" {>= "6.0.0"}
+  "digestif"
   "dream-httpaf" {>= "1.0.0~alpha3"}
   "dream-pure" {>= "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}  # --instrument-with.

--- a/packages/dream/dream.1.0.0~alpha6/opam
+++ b/packages/dream/dream.1.0.0~alpha6/opam
@@ -52,8 +52,8 @@ depends: [
   "caqti-lwt" {>= "2.0.0"}
   ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
   "cstruct" {>= "6.0.0"}
-  "digestif"
-  "dream-httpaf" {>= "1.0.0~alpha3"}
+  "digestif" {>= "0.7"}  # to_raw_string.
+  "dream-httpaf" {>= "1.0.0~alpha5"}
   "dream-pure" {>= "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}  # --instrument-with.
   "fmt" {>= "0.8.7"}  # `Italic.

--- a/packages/dream/dream.1.0.0~alpha7/opam
+++ b/packages/dream/dream.1.0.0~alpha7/opam
@@ -55,7 +55,7 @@ depends: [
   ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
   "cstruct" {>= "6.0.0"}
   "digestif" {>= "0.7"}  # to_raw_string.
-  "dream-httpaf" {>= "1.0.0~alpha5"}
+  "dream-httpaf" {>= "1.0.0~alpha2"}
   "dream-pure" {>= "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}  # --instrument-with.
   "fmt" {>= "0.8.7"}  # `Italic.

--- a/packages/dream/dream.1.0.0~alpha7/opam
+++ b/packages/dream/dream.1.0.0~alpha7/opam
@@ -55,7 +55,7 @@ depends: [
   ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
   "cstruct" {>= "6.0.0"}
   "digestif" {>= "0.7"}  # to_raw_string.
-  "dream-httpaf" {>= "1.0.0~alpha6"}
+  "dream-httpaf" {>= "1.0.0~alpha5"}
   "dream-pure" {>= "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}  # --instrument-with.
   "fmt" {>= "0.8.7"}  # `Italic.

--- a/packages/dream/dream.1.0.0~alpha7/opam
+++ b/packages/dream/dream.1.0.0~alpha7/opam
@@ -55,7 +55,7 @@ depends: [
   ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
   "cstruct" {>= "6.0.0"}
   "digestif" {>= "0.7"}  # to_raw_string.
-  "dream-httpaf" {>= "1.0.0~alpha3"}
+  "dream-httpaf" {>= "1.0.0~alpha6"}
   "dream-pure" {>= "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}  # --instrument-with.
   "fmt" {>= "0.8.7"}  # `Italic.


### PR DESCRIPTION
```
#=== ERROR while compiling dream.1.0.0~alpha7 =================================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/dream.1.0.0~alpha7
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p dream -j 31
# exit-code            1
# env-file             ~/.opam/log/dream-7-f4d543.env
# output-file          ~/.opam/log/dream-7-f4d543.out
### output ###
# File "src/http/dune", line 21, characters 2-32:
# 21 |   dream-httpaf.dream-websocketaf
#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Library "dream-httpaf.dream-websocketaf" not found.
# -> required by library "dream.http" in _build/default/src/http
# -> required by _build/default/META.dream
# -> required by _build/install/default/lib/dream/META
# -> required by _build/default/dream.install
# -> required by alias install
```
and
```
#=== ERROR while compiling dream.1.0.0~alpha5 =================================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/dream.1.0.0~alpha5
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p dream -j 31
# exit-code            1
# env-file             ~/.opam/log/dream-7-83053e.env
# output-file          ~/.opam/log/dream-7-83053e.out
### output ###
# File "src/server/dune", line 5, characters 2-10:
# 5 |   digestif
#       ^^^^^^^^
# Error: Library "digestif" not found.
# -> required by library "dream.server" in _build/default/src/server
# -> required by _build/default/META.dream
# -> required by _build/install/default/lib/dream/META
# -> required by _build/default/dream.install
# -> required by alias install
# File "src/http/dune", line 21, characters 2-32:
# 21 |   dream-httpaf.dream-websocketaf
#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Library "dream-httpaf.dream-websocketaf" not found.
# -> required by library "dream.http" in _build/default/src/http
# -> required by _build/default/META.dream
# -> required by _build/install/default/lib/dream/META
# -> required by _build/default/dream.install
# -> required by alias install
# File "src/unix/dune", line 5, characters 2-10:
# 5 |   digestif
#       ^^^^^^^^
# Error: Library "digestif" not found.
# -> required by library "dream.unix" in _build/default/src/unix
# -> required by _build/default/META.dream
# -> required by _build/install/default/lib/dream/META
# -> required by _build/default/dream.install
# -> required by alias install
```