### PR TITLE
[new release] odoc-parser and odoc (2.4.4)

### DIFF
--- a/packages/odoc-parser/odoc-parser.2.4.4/opam
+++ b/packages/odoc-parser/odoc-parser.2.4.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Parser for ocaml documentation comments"
+description: """
+Odoc_parser is a library for parsing the contents of OCaml documentation
+comments, formatted using 'odoc' syntax, an extension of the language
+understood by ocamldoc."""
+maintainer: ["Jon Ludlam <jon@recoil.org>"]
+authors: ["Anton Bachin <antonbachin@yahoo.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml/odoc"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+doc: "https://ocaml.github.io/odoc/odoc_parser"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.02.0" & < "5.4"}
+  "astring"
+  "result"
+  "camlp-streams"
+  "ppx_expect" {with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    # Tests are not all associated with a package and would be run if using the
+    # default '@runtest'.
+    "@src/parser/runtest" {with-test}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/2.4.4/odoc-2.4.4.tbz"
+  checksum: [
+    "sha256=7e253a55b5c8f610f9e0b48940ecdaf21c01553143af93b40c998c30499e51f3"
+    "sha512=d5b1e6786c9cb371cb207da91728336a4746c8f3f07d817bb8259b32404445cd99ba2455ad51cbaffedf98e24cec68743fb7b02ad44643b1718d3d875b5580ee"
+  ]
+}
+x-commit-hash: "795902d7ee58e86b599e45ed3e763792ee9bf13d"

--- a/packages/odoc/odoc.2.4.4/opam
+++ b/packages/odoc/odoc.2.4.4/opam
@@ -1,0 +1,84 @@
+opam-version: "2.0"
+homepage: "https://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+maintainer: [
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+]
+authors: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Leo White <leo@lpw25.net>"
+  "Lubega Simon <lubegasimon73@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+  "Thomas Refis <trefis@janestreet.com>"
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml Documentation Generator"
+description: """
+**odoc** is a powerful and flexible documentation generator for OCaml. It reads *doc comments*, demarcated by `(** ... *)`, and transforms them into a variety of output formats, including HTML, LaTeX, and man pages.
+
+- **Output Formats:** Odoc generates HTML for web browsing, LaTeX for PDF generation, and man pages for use on Unix-like systems.
+- **Cross-References:** odoc uses the `ocamldoc` markup, which allows to create links for functions, types, modules, and documentation pages.
+- **Link to Source Code:** Documentation generated includes links to the source code of functions, providing an easy way to navigate from the docs to the actual implementation.
+- **Code Highlighting:** odoc automatically highlights syntax in code snippets for different languages.
+
+odoc is part of the [OCaml Platform](https://ocaml.org/docs/platform), the recommended set of tools for OCaml.
+"""
+
+
+depends: [
+  "odoc-parser" {= version}
+  "astring"
+  "cmdliner" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "3.7.0"}
+  "fpath"
+  "ocaml" {>= "4.02.0" & < "5.4"}
+  "result"
+  "tyxml" {>= "4.4.0"}
+  "fmt"
+
+  "ocamlfind" {with-test}
+  "yojson" {>= "1.6.0" & with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+  "conf-jq" {with-test}
+
+  "ppx_expect" {with-test}
+  "bos" {with-test}
+  "crunch" {> "2.0.0"}
+
+  ("ocaml" {< "4.07.0" & with-test} | "bisect_ppx" {with-test & > "2.5.0"})
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/2.4.4/odoc-2.4.4.tbz"
+  checksum: [
+    "sha256=7e253a55b5c8f610f9e0b48940ecdaf21c01553143af93b40c998c30499e51f3"
+    "sha512=d5b1e6786c9cb371cb207da91728336a4746c8f3f07d817bb8259b32404445cd99ba2455ad51cbaffedf98e24cec68743fb7b02ad44643b1718d3d875b5580ee"
+  ]
+}
+x-commit-hash: "795902d7ee58e86b599e45ed3e763792ee9bf13d"


### PR DESCRIPTION
OCaml Documentation Generator

- Project page: <a href="https://github.com/ocaml/odoc">https://github.com/ocaml/odoc</a>
- Documentation: <a href="https://ocaml.github.io/odoc/">https://ocaml.github.io/odoc/</a>

##### CHANGES:

### Added

- OCaml 5.3.0 compatibility (@Julow, ocaml/odoc#1202, ocaml/odoc#1254)
