### PR TITLE
Mark tezos-test-helpers.9.7 as unavailable due to a bad checksum

### DIFF
--- a/packages/tezos-test-helpers/tezos-test-helpers.9.7/opam
+++ b/packages/tezos-test-helpers/tezos-test-helpers.9.7/opam
@@ -19,7 +19,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] { with-test }
 ]
 synopsis: "Tezos-agnostic test helpers"
-
+available: false # bad checksum
 url {
   src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
   checksum: [


### PR DESCRIPTION
This just showed up again as a failure in #27038, roughly 6 months we saw it in #26196.

In addition, the corresponding tezos-stdlib.9.7 - originating from the same source package - was marked as `unavailable` 7 months ago in #25922