### PR TITLE
Release dot-merlin-reader 4.18-414

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.18-414/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.18-414/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.18-414/merlin-4.18-414.tbz"
+  checksum: [
+    "sha256=f6d6f7a266141e358c1a869612c8135c859185d547ea3ba5c9ad7bb67fe30cc1"
+    "sha512=4f272bdb028fd984fef406f7e1eadd0a3ab99d94016316f1b842782b1d1bba2bd50dcf3b4021c2096c6d9b5e5f9f6bae61bedcfd9f933f15c190e01777ef83a9"
+  ]
+}
+x-commit-hash: "2b9cd21c24a687ca4dc6d0a191942b13903eae82"

--- a/packages/merlin/merlin.4.18-414/opam
+++ b/packages/merlin/merlin.4.18-414/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.14" & < "4.15"}
   "dune" {>= "2.9.0"}
   "merlin-lib" {= version}
-  "dot-merlin-reader" {>= "4.17.1" < "5.0"}
+  "dot-merlin-reader" {= version}
   "yojson" {>= "2.0.0"}
   "conf-jq" {with-test}
   "ppxlib" {with-test}


### PR DESCRIPTION
merlin `4.18-414` and merlin-lib `4.18-414` were not co-installabe.

This should fix that issue by releasing a new version of dor-merlin-reader matching `4.18-414`.

We will switch to always release identical versions (with 
 {= version} constraints) for all merlin related packages in the future to prevent such issues. 