### PR TITLE
Package opam-file-format.2.2.0~alpha1

### DIFF
--- a/packages/opam-file-format/opam-file-format.2.2.0~alpha1/opam
+++ b/packages/opam-file-format/opam-file-format.2.2.0~alpha1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Parser and printer for the opam file syntax"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-file-format/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "3.13"}
+  "menhir" {>= "20211230"}
+  "alcotest" {with-test & >= "0.4.8"}
+  "fmt" {with-test}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml/opam-file-format"
+url {
+  src:
+    "https://github.com/ocaml/opam-file-format/releases/download/2.2.0-alpha1/opam-file-format-2.2.0-alpha1.tar.gz"
+  checksum: [
+    "md5=e7454160b5f3982016ddaac2dfd5bf52"
+    "sha512=9dcf662a4aa8dc71eb74b88f42c0226b882e96137dc2380bf581c0607693907cf5afbe5d77d6dad87b7c500b270170a67b3e164095102afa5964a5afeb293ff6"
+  ]
+}


### PR DESCRIPTION
### `opam-file-format.2.2.0~alpha1`
Parser and printer for the opam file syntax



---
* Homepage: https://opam.ocaml.org
* Source repo: git+https://github.com/ocaml/opam-file-format
* Bug tracker: https://github.com/ocaml/opam-file-format/issues

---
:camel: Pull-request generated by opam-publish v2.5.0