### PR TITLE
[new release] pcre (7.5.1)

### DIFF
--- a/packages/pcre/pcre.7.5.1/opam
+++ b/packages/pcre/pcre.7.5.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Bindings to the Perl Compatibility Regular Expressions library"
+description: """
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: ["Markus Mottl <markus.mottl@gmail.com>"]
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "dune-configurator"
+  "conf-libpcre" {build}
+  "base-bytes"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/pcre-ocaml/releases/download/7.5.1/pcre-7.5.1.tbz"
+  checksum: [
+    "sha256=db3c3e913ece7b2ac94c3722b7167a6d4ce8eba7f94abc9d38be502cd3187994"
+    "sha512=305ab73863cf05e8c520888fe6e42cbd46162bb7253a2699bc71423ac401ff8a3261d91ba0222f9390d7dfb61559d1a610746809dd410027e0d3a4de2f72188f"
+  ]
+}
+x-commit-hash: "7299a80a8c3ebcec4cd90e9b3a45ea89baa63bae"


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library

- Project page: <a href="https://mmottl.github.io/pcre-ocaml">https://mmottl.github.io/pcre-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/pcre-ocaml/api">https://mmottl.github.io/pcre-ocaml/api</a>

##### CHANGES:

- Added GitHub workflow for automated CI/CD.
- Reformatted all OCaml and C-files for consistency.
- Improved and fixed documentation.
- Enhanced README and example README for clarity.
- Fixed macro instantiation formatting and minor C preprocessing issues.
- Corrected license typo.
