### PR TITLE
[new release] mdx (2.5.0)

### DIFF
--- a/packages/mdx/mdx.2.5.0/opam
+++ b/packages/mdx/mdx.2.5.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Executable code blocks inside markdown files"
+description: """
+`ocaml-mdx` allows to execute code blocks inside markdown files.
+There are (currently) two sub-commands, corresponding
+to two modes of operations: pre-processing (`ocaml-mdx pp`)
+and tests (`ocaml-mdx test`).
+
+The pre-processor mode allows to mix documentation and code,
+and to practice "literate programming" using markdown and OCaml.
+
+The test mode allows to ensure that shell scripts and OCaml fragments
+in the documentation always stays up-to-date."""
+maintainer: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+license: "ISC"
+homepage: "https://github.com/realworldocaml/mdx"
+bug-reports: "https://github.com/realworldocaml/mdx/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind"
+  "fmt" {>= "0.8.7"}
+  "cppo" {build & >= "1.1.0"}
+  "csexp" {>= "1.3.2"}
+  "astring"
+  "logs" {>= "0.7.0"}
+  "cmdliner" {>= "1.1.0"}
+  "re" {>= "1.7.2"}
+  "ocaml-version" {>= "2.3.0"}
+  "lwt" {with-test}
+  "camlp-streams"
+  "result"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/realworldocaml/mdx.git"
+url {
+  src:
+    "https://github.com/realworldocaml/mdx/releases/download/2.5.0/mdx-2.5.0.tbz"
+  checksum: [
+    "sha256=c2da58d7d5182f15c046fb320bb02c16602d2ee7cb99f349e3f4841c26365029"
+    "sha512=d16d9ec2ac444880c7f6d08181fe055697f25fb405358acee396cd7ecba8011881f1de8b49bfa208d4adcd4904b600f4122d1a47d98bf26a8cb533770dd9350d"
+  ]
+}
+x-commit-hash: "1f83f73e06233ea8745cd0c9473613d40e6999bc"


### PR DESCRIPTION
Executable code blocks inside markdown files

- Project page: <a href="https://github.com/realworldocaml/mdx">https://github.com/realworldocaml/mdx</a>

##### CHANGES:

#### Added

- Support OCaml 5.3 (realworldocaml/mdx#457, @anmonteiro, @samoht, @voodoos)
- Support multiple version labels in block headers. The block is active if all
  the version formulaes are satisfied (realworldocaml/mdx#458, @samoht)

#### Fixed

- Avoid infinite loop in lexer on unclosed code block (realworldocaml/mdx#444, @edwintorok)
- Fix support for skipped blocks in mli and mld files (realworldocaml/mdx#462, @samoht)
