### PR TITLE
[new release] postgresql (5.1.2)

### DIFF
--- a/packages/postgresql/postgresql.5.1.2/opam
+++ b/packages/postgresql/postgresql.5.1.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Bindings to the PostgreSQL library"
+description:
+  "Postgresql offers library functions for accessing PostgreSQL databases."
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "dune-configurator"
+  "conf-postgresql" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/postgresql-ocaml/releases/download/5.1.2/postgresql-5.1.2.tbz"
+  checksum: [
+    "sha256=ca840cce93ba7d92acd9c2a2024907020d5bba0ecf3dac9a77c7e42a2409600e"
+    "sha512=44aae3ddd379e8240047c73e9cd01de9fb6eb57d7d606c03bee7e56384e9ba387908db3e06932fc39780f67c3bf69a1ea8a97153702d8c7bd8b168ac08b034d3"
+  ]
+}
+x-commit-hash: "e828f1ca53e1d5786590cfd34e8a715dd9be6924"


### PR DESCRIPTION
Bindings to the PostgreSQL library

- Project page: <a href="https://mmottl.github.io/postgresql-ocaml">https://mmottl.github.io/postgresql-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/postgresql-ocaml/api">https://mmottl.github.io/postgresql-ocaml/api</a>

##### CHANGES:

- Fixed version discovery with pkg-config.
- Removed obsolete `base-bytes` dependency.
- Switched to ocamlformat 0.27.0.
- Fixed macro naming and instantiation formatting.
- Fixed copyright notices.
- Improved GitHub workflow.
