### PR TITLE
[new release] lacaml (11.1.1)

### DIFF
--- a/packages/lacaml/lacaml.11.1.1/opam
+++ b/packages/lacaml/lacaml.11.1.1/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Lacaml - OCaml-bindings to BLAS and LAPACK"
+description: """
+Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
+LAPACK-library (Linear Algebra routines).  It also contains many additional
+convenience functions for vectors and matrices."""
+maintainer: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+]
+authors: [
+  "Egbert Ammicht <eammicht@lucent.com>"
+  "Patrick Cousot <Patrick.Cousot@ens.fr>"
+  "Sam Ehrlichman <sehrlichman@janestreet.com>"
+  "Florent Hoareau <h.florent@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Liam Stewart <liam@cs.toronto.edu>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Oleg Trott <ot14@columbia.edu>"
+  "Martin Willensdorfer <ma.wi@gmx.at>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+tags: ["clib:lapack" "clib:blas"]
+homepage: "https://mmottl.github.io/lacaml"
+doc: "https://mmottl.github.io/lacaml/api"
+bug-reports: "https://github.com/mmottl/lacaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "dune-configurator"
+  "conf-blas" {build}
+  "conf-lapack" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/lacaml.git"
+url {
+  src:
+    "https://github.com/mmottl/lacaml/releases/download/11.1.1/lacaml-11.1.1.tbz"
+  checksum: [
+    "sha256=344b3b03f95f03ef0013a935f443d6d367b5a6c78313b1e86c6481fd9c0b7287"
+    "sha512=7d02861c256350e776296b2eb540edfac7f37cad414057283f9f7f9cef987593d371de3b45e37a5ed9f8adea69d872819ca43666327c53c1afab408e88bfac9b"
+  ]
+}
+x-commit-hash: "9e9f115a1ec2d8f5671d53f5dec8e469843c1250"


### PR DESCRIPTION
Lacaml - OCaml-bindings to BLAS and LAPACK

- Project page: <a href="https://mmottl.github.io/lacaml">https://mmottl.github.io/lacaml</a>
- Documentation: <a href="https://mmottl.github.io/lacaml/api">https://mmottl.github.io/lacaml/api</a>

##### CHANGES:

- Removed obsolete `base-bytes` and `base-bigarray` dependencies
