### PR TITLE
[new release] mirage (2 packages) (4.8.2)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.4.8.2/opam
+++ b/packages/mirage-runtime/mirage-runtime.4.8.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+available: opam-version >= "2.1.0"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.9.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "4.0.0"}
+  "ipaddr" {>= "5.5.0"}
+  "cmdliner" {>= "1.2.0"}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "ppxlib" {= "0.29.0"} #0.29.0 provides a vendored ppx_sexp_conv
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.8.2/mirage-4.8.2.tbz"
+  checksum: [
+    "sha256=edaddb27bc630c7ea4086075b337b5c4d364c1a231e471bb169e5988e6ba2fe1"
+    "sha512=7f1ae2ae226893041189b62850c763256ce2e330bf311fec54d74a714d26c819d98846ddf17028126ef16a91cff3cbc3d12edfccc46e882604a6865f34765961"
+  ]
+}
+x-commit-hash: "c41213110f4e6c16e817938f59da304fd0157ac7"

--- a/packages/mirage/mirage.4.8.2/opam
+++ b/packages/mirage/mirage.4.8.2/opam
@@ -19,6 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.13.0"}
+  "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
   "cmdliner" {>= "1.2.0"}

--- a/packages/mirage/mirage.4.8.2/opam
+++ b/packages/mirage/mirage.4.8.2/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+available: opam-version >= "2.1.0"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.9.0"}
+  "astring"
+  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {with-test & >= "1.3.0"}
+  "emile" {>= "1.1"}
+  "fmt" {>= "0.8.7"}
+  "ipaddr" {>= "5.0.0"}
+  "bos"
+  "fpath"
+  "rresult" {>= "0.7.0"}
+  "uri" {>= "4.2.0"}
+  "logs" {>= "0.7.0"}
+  "opam-monorepo" {>= "0.4.0"}
+  "alcotest" {with-test}
+  "mirage-runtime" {with-test & = version}
+]
+
+conflicts: [ "jbuilder" {with-test} ]
+
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.8.2/mirage-4.8.2.tbz"
+  checksum: [
+    "sha256=edaddb27bc630c7ea4086075b337b5c4d364c1a231e471bb169e5988e6ba2fe1"
+    "sha512=7f1ae2ae226893041189b62850c763256ce2e330bf311fec54d74a714d26c819d98846ddf17028126ef16a91cff3cbc3d12edfccc46e882604a6865f34765961"
+  ]
+}
+x-commit-hash: "c41213110f4e6c16e817938f59da304fd0157ac7"


### PR DESCRIPTION
The MirageOS library operating system

- Project page: <a href="https://github.com/mirage/mirage">https://github.com/mirage/mirage</a>
- Documentation: <a href="https://mirage.github.io/mirage/">https://mirage.github.io/mirage/</a>

##### CHANGES:

- allow ocaml-solo5 1.x (@hannesm mirage/mirage#1595)
- guide the user what to do next (mirage/mirage#1592 @hannesm, fixes mirage/mirage#921)
- revise syslog devices, add monitoring (mirage/mirage#1591 @hannesm)
- add `ipv4_of_dhcp` device (mirage/mirage#1593, @palainp)
- separate sections for DNS, happy-eyeballs, SSH, TLS, HTTP arguments in
  unikernel man pages (mirage/mirage#1590 @hannesm, fixes mirage/mirage#1587)
