### PR TITLE
[new release] charrua (4 packages) (1.6.0)

### DIFF
--- a/packages/charrua-client/charrua-client.1.6.0/opam
+++ b/packages/charrua-client/charrua-client.1.6.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "DHCP client implementation"
+description: """\
+charrua-client is a DHCP client powered by [charrua](https://github.com/mirage/charrua).
+
+The base library exposes a simple state machine in `Dhcp_client`
+for use in acquiring a DHCP lease."""
+maintainer: "Mindy Preston"
+authors: "Mindy Preston"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/charrua"
+doc: "https://docs.mirage.io"
+bug-reports: "https://github.com/mirage/charrua/issues"
+depends: [
+  "dune" {>= "1.4.0"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {with-test}
+  "cstruct-unix" {with-test}
+  "mirage-crypto-rng" {with-test & >= "1.0.0"}
+  "mirage-crypto-rng-lwt" {with-test & >= "1.0.0"}
+  "charrua-server" {= version & with-test}
+  "charrua" {= version}
+  "cstruct" {>= "6.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "mirage-crypto-rng-mirage" {>= "1.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "randomconv" {>= "0.2.0"}
+  "duration"
+  "logs"
+  "fmt"
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "tcpip" {>= "8.1.0"}
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/charrua.git"
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.6.0/charrua-1.6.0.tbz"
+  checksum: [
+    "sha256=1f6f7c1211a45ebbbd56a78b12fdbceaa98efae97ac3bd6f4855da47a3a3ac34"
+    "sha512=6ea3cb92efca7c33ee9aa1411223bec9045ece9939657594ebc47ae93408c4d87e8b40812751fc86555061d91ccd338b3fbcfe6059e1dd770303329b5e527a96"
+  ]
+}
+x-commit-hash: "9967d56b92d0a578656414ca7c94df52a42b7dab"

--- a/packages/charrua-server/charrua-server.1.6.0/opam
+++ b/packages/charrua-server/charrua-server.1.6.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "DHCP server"
+description: """\
+Charrua-server consists of a single `Dhcp_server` module used for constructing DHCP
+servers.
+
+[dhcp](https://github.com/mirage/mirage-skeleton/tree/master/applications/dhcp)
+is a Mirage DHCP unikernel server based on charrua, included as a part of the MirageOS unikernel example and starting-point repository.
+
+#### Features
+
+* `Dhcp_server` supports a stripped down ISC dhcpd.conf, so you can probably just
+  use your old `dhcpd.conf`. It also supports manual configuration building in
+  OCaml.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in OCaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America."""
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+doc: "https://mirage.github.io/charrua/"
+bug-reports: "https://github.com/mirage/charrua/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.4.0"}
+  "menhir" {build & >= "20180523"}
+  "charrua" {= version}
+  "cstruct" {>= "6.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "cstruct-unix" {with-test}
+  "tcpip" {>= "7.0.0" & with-test}
+  "alcotest" {with-test & >= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/charrua.git"
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.6.0/charrua-1.6.0.tbz"
+  checksum: [
+    "sha256=1f6f7c1211a45ebbbd56a78b12fdbceaa98efae97ac3bd6f4855da47a3a3ac34"
+    "sha512=6ea3cb92efca7c33ee9aa1411223bec9045ece9939657594ebc47ae93408c4d87e8b40812751fc86555061d91ccd338b3fbcfe6059e1dd770303329b5e527a96"
+  ]
+}
+x-commit-hash: "9967d56b92d0a578656414ca7c94df52a42b7dab"

--- a/packages/charrua-unix/charrua-unix.1.6.0/opam
+++ b/packages/charrua-unix/charrua-unix.1.6.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Unix DHCP daemon"
+description: """\
+charrua-unix is an _ISC-licensed_ Unix DHCP daemon based on
+[charrua](http://www.github.com/mirage/charrua)."""
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+bug-reports: "https://github.com/mirage/charrua/issues"
+depends: [
+  "dune" {>= "1.4.0"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "3.0.0"}
+  "lwt_log"
+  "charrua" {= version}
+  "charrua-server" {= version}
+  "cstruct-unix"
+  "cmdliner" {>= "1.1.0"}
+  "rawlink-lwt" {>= "2.0"}
+  "tuntap" {>= "2.0.0"}
+  "mtime" {>= "2.0.0"}
+  "duration"
+  "cstruct-lwt" {>= "6.0.0"}
+  "ipaddr" {>= "5.1.0"}
+  "tcpip" {>= "7.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/charrua.git"
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.6.0/charrua-1.6.0.tbz"
+  checksum: [
+    "sha256=1f6f7c1211a45ebbbd56a78b12fdbceaa98efae97ac3bd6f4855da47a3a3ac34"
+    "sha512=6ea3cb92efca7c33ee9aa1411223bec9045ece9939657594ebc47ae93408c4d87e8b40812751fc86555061d91ccd338b3fbcfe6059e1dd770303329b5e527a96"
+  ]
+}
+x-commit-hash: "9967d56b92d0a578656414ca7c94df52a42b7dab"

--- a/packages/charrua/charrua.1.6.0/opam
+++ b/packages/charrua/charrua.1.6.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"         {>= "4.08.0"}
+  "ocaml"         {>= "4.13.0"}
   "dune"          {>= "1.4.0"}
   "cstruct"       {>= "6.0.0"}
   "ipaddr"        {>= "5.0.0"}

--- a/packages/charrua/charrua.1.6.0/opam
+++ b/packages/charrua/charrua.1.6.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+bug-reports: "https://github.com/mirage/charrua/issues"
+dev-repo: "git+https://github.com/mirage/charrua.git"
+doc: "https://mirage.github.io/charrua/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"         {>= "4.08.0"}
+  "dune"          {>= "1.4.0"}
+  "cstruct"       {>= "6.0.0"}
+  "ipaddr"        {>= "5.0.0"}
+  "macaddr"       {>= "4.0.0"}
+  "ethernet"      {>= "3.0.0"}
+  "tcpip"         {>= "7.0.0"}
+  "ohex"          {>= "0.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "DHCP wire frame encoder and decoder"
+description: """
+Charrua consists a single modules, `Dhcp_wire` responsible for parsing and
+constructing DHCP messages
+
+You can browse the API for [charrua](http://www.github.com/mirage/charrua) at
+https://mirage.github.io/charrua/
+
+#### Features
+
+* `Dhcp_wire` provides marshalling and unmarshalling utilities for DHCP.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in OCaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America.
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.6.0/charrua-1.6.0.tbz"
+  checksum: [
+    "sha256=1f6f7c1211a45ebbbd56a78b12fdbceaa98efae97ac3bd6f4855da47a3a3ac34"
+    "sha512=6ea3cb92efca7c33ee9aa1411223bec9045ece9939657594ebc47ae93408c4d87e8b40812751fc86555061d91ccd338b3fbcfe6059e1dd770303329b5e527a96"
+  ]
+}
+x-commit-hash: "9967d56b92d0a578656414ca7c94df52a42b7dab"


### PR DESCRIPTION
DHCP wire frame encoder and decoder

- Project page: <a href="https://github.com/mirage/charrua">https://github.com/mirage/charrua</a>
- Documentation: <a href="https://mirage.github.io/charrua/">https://mirage.github.io/charrua/</a>

##### CHANGES:

* charruad: update to new cmdliner (mirage/charrua#117 @haesbaert)
* support mtime >= 2.0.0 (mirage/charrua#121 @haesbaert, @tmcgilchrist)
* charrua-unix: use duration package (mirage/charrua#122 @hannesm)
* replace Cstruct.copy by Cstruct.to_string (mirage/charrua#123 @gridbugs)
* use mirage-crypto-rng instead of mirage-random-test (mirage/charrua#126 @hannesm)
* remove mirage-random dependency, use mirage-crypto-rng instead - and update
  to mirage-crypto-rng >= 1.0.0 (mirage/charrua#127 @hannesm)
* remove ppx_cstruct and sexplib from dependency cone (mirage/charrua#128 @hannesm)
* charrua-client: update to tcpip >= 8.1.0 (mirage/charrua#129 @hannesm)
