### PR TITLE
Package ppx_expect.v0.16.1

### DIFF
--- a/packages/ppx_expect/ppx_expect.v0.16.1/opam
+++ b/packages/ppx_expect/ppx_expect.v0.16.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_expect"
+bug-reports: "https://github.com/janestreet/ppx_expect/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_expect.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_expect/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"           {>= "4.14.0"}
+  "base"            {>= "v0.16" & < "v0.17"}
+  "ppx_here"        {>= "v0.16" & < "v0.17"}
+  "ppx_inline_test" {>= "v0.16" & < "v0.17"}
+  "stdio"           {>= "v0.16" & < "v0.17"}
+  "dune"            {>= "2.0.0"}
+  "ppxlib"          {>= "0.28.0"}
+  "re"              {>= "1.8.0"}
+]
+conflicts: [
+  "js_of_ocaml-compiler" {< "5.8"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Cram like framework for OCaml"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_expect/archive/refs/tags/v0.16.1.tar.gz"
+  checksum: [
+    "md5=f2db0b9091a532f2f67a2bf0b8d8b268"
+    "sha512=b24df7db91ef0d72f3bf753b526b7a21c8fd06c8814367f4f06e2356bace7353891207dd5f4ccaa60542000fb2c6a179b38ffd9908803274c169e3b95a754ece"
+  ]
+}


### PR DESCRIPTION
### `ppx_expect.v0.16.1`
Cram like framework for OCaml
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_expect
* Source repo: git+https://github.com/janestreet/ppx_expect.git
* Bug tracker: https://github.com/janestreet/ppx_expect/issues

---
:camel: Pull-request generated by opam-publish v2.4.0