### PR TITLE
[new release] hxd (0.3.3)

### DIFF
--- a/packages/hxd/hxd.0.3.3/opam
+++ b/packages/hxd/hxd.0.3.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/hxd"
+bug-reports:  "https://github.com/dinosaure/hxd/issues"
+dev-repo:     "git+https://github.com/dinosaure/hxd.git"
+doc:          "https://dinosaure.github.io/hxd/"
+license:      "MIT"
+synopsis:     "Hexdump in OCaml"
+description: """Please, help me to debug ocaml-git
+"""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.7"}
+  "dune-configurator" {>= "2.7"}
+  "cmdliner"          {>= "1.1.0"}
+]
+
+depopts: [
+  "lwt"
+]
+url {
+  src:
+    "https://github.com/dinosaure/hxd/releases/download/v0.3.3/hxd-0.3.3.tbz"
+  checksum: [
+    "sha256=4ede235296a5e2a2599776c8bceb4853c164ef7e573570a1edc68a4c0c90433e"
+    "sha512=39d42632ea7acc2e9418faefdef91085e420a03c3aa03e04e75f99c9d24a4deb96ff71ad948d208ce562077dd3f6f92f975dc7c006a97cd7eabc1e8a7f5381d0"
+  ]
+}
+x-commit-hash: "0770a4ce07fa2939fba513a7bf8a9518d8039a5b"


### PR DESCRIPTION
Hexdump in OCaml

- Project page: <a href="https://github.com/dinosaure/hxd">https://github.com/dinosaure/hxd</a>
- Documentation: <a href="https://dinosaure.github.io/hxd/">https://dinosaure.github.io/hxd/</a>

##### CHANGES:

* Fix the usage of formatters to be composable with `fmt` (@dinosaure, dinosaure/hxd#14)
* Update the codebase with `ocamlformat.0.27.0` (@dinosaure, dinosaure/hxd#14)
