### PR TITLE
41 packages (chamo.4.2.0, css.0.3.0, etc.)

### DIFF
--- a/packages/chamo/chamo.4.2.0/opam
+++ b/packages/chamo/chamo.4.2.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "A kind of emacs-like editor, using OCaml instead of lisp"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/chamo/"
+doc: "https://zoggy.frama.io/chamo/doc.html"
+bug-reports: "https://framagit.org/zoggy/chamo/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.2.0"}
+  "fmt" {>= "0.9.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.2"}
+  "ocf" {>= "0.9.0"}
+  "ocf_ppx" {>= "0.9.0"}
+  "ppx_blob" {>= "0.7.2"}
+  "re" {>= "1.10.4"}
+  "pcre" {>= "7.5.0"}
+  "sedlex" {>= "2.3"}
+  "stk" {>= "0.4.0"}
+  "stk_iconv" {>= "0.4.0"}
+  "stk_ocf" {>= "0.4.0"}
+  "tsdl" {>= "1.1.0"}
+  "tsdl-image" {>= "0.5"}
+  "tsdl-ttf" {>= "0.5"}
+  "uutf" {>= "1.0.0"}
+  "xmlm" {>= "1.4"}
+  "xtmpl" {>= "1.0.0"}
+  "xtmpl_ppx" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/chamo.git"
+url {
+  src: "https://zoggy.frama.io/chamo/releases/chamo-4.2.0.tar.bz2"
+  checksum: [
+    "md5=e2e9a58e6cd4f406f3ad10881fd3f1dc"
+    "sha512=9a52178ab25ad20dae4f7162475bd2ae9eec02cf75a10ddf3680f778850fa7c1117aa831adaa834c4b3b20c7e6aa44cfc9c51918ddb94276b32b200a446ad246"
+  ]
+}

--- a/packages/css/css.0.3.0/opam
+++ b/packages/css/css.0.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "CSS parser and printer"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-css/"
+doc: "https://zoggy.frama.io/ocaml-css/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-css/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "angstrom" {>= "0.16.0"}
+  "fmt" {>= "0.9.0"}
+  "iri" {>= "1.0.0"}
+  "logs" {>= "0.7.0"}
+  "rdf" {>= "1.0.0"}
+  "alcotest" {with-test}
+  "lwt_ppx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-css.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-css/releases/ocaml-css-0.3.0.tar.bz2"
+  checksum: [
+    "md5=70981bffdf5df82fd8ed20eb61b62e4d"
+    "sha512=45083ab20d89e3289bfdee0eb32717b8e37f7b0aedf6652afaa7a96008c9b35981c451be82d63d070e27c7ec0087619f2c0271301645907a8897163b8f49fd3d"
+  ]
+}

--- a/packages/higlo/higlo.0.10.0/opam
+++ b/packages/higlo/higlo.0.10.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Syntax highlighting library"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/higlo/"
+doc: "https://zoggy.frama.io/higlo/doc.html"
+bug-reports: "https://framagit.org/zoggy/higlo/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "sedlex" {>= "1.2"}
+  "xtmpl" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/higlo.git"
+url {
+  src: "https://zoggy.frama.io/higlo/releases/higlo-0.10.0.tar.bz2"
+  checksum: [
+    "md5=8e6ad939c2e0fd0640efd4a10e4137fd"
+    "sha512=fdccc8aaebe084f0b5e5dfbeabf5a1b94186ef023431492c2083d9949237761946c7e9e195a4a81fc0f72032224f4942d3adb2590aa22ff35804b2d9bc2ea902"
+  ]
+}

--- a/packages/ldp/ldp.0.4.0/opam
+++ b/packages/ldp/ldp.0.4.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "cohttp-lwt" {>= "5.3.0"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.3"}
+  "ocaml" {>= "4.14.0"}
+  "ocf" {>= "0.8.0"}
+  "ocf_ppx" {>= "0.8.0"}
+  "rdf" {>= "1.0.0"}
+  "rdf_ppx" {>= "1.0.0"}
+  "sedlex" {>= "2.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.4.0.tar.gz"
+  checksum: [
+    "md5=241a1682aea9bb1ca78494ea82baf515"
+    "sha512=6792ea5c05cc9fac42567c533a0dcefa203dfbd285cdea226f57298a85b8b676e230f92152fc5a91edcc8961a66902923402964a7eb8d3b2c614123e4d0dc283"
+  ]
+}

--- a/packages/ldp_curl/ldp_curl.0.4.0/opam
+++ b/packages/ldp_curl/ldp_curl.0.4.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications using Curl"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "ocurl" {>= "0.9.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.4.0.tar.gz"
+  checksum: [
+    "md5=241a1682aea9bb1ca78494ea82baf515"
+    "sha512=6792ea5c05cc9fac42567c533a0dcefa203dfbd285cdea226f57298a85b8b676e230f92152fc5a91edcc8961a66902923402964a7eb8d3b2c614123e4d0dc283"
+  ]
+}

--- a/packages/ldp_js/ldp_js.0.4.0/opam
+++ b/packages/ldp_js/ldp_js.0.4.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications in JS"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "js_of_ocaml" {>= "3.9.0"}
+  "js_of_ocaml-ppx" {>= "3.9.0"}
+  "cohttp-lwt-jsoo" {>= "5.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.4.0.tar.gz"
+  checksum: [
+    "md5=241a1682aea9bb1ca78494ea82baf515"
+    "sha512=6792ea5c05cc9fac42567c533a0dcefa203dfbd285cdea226f57298a85b8b676e230f92152fc5a91edcc8961a66902923402964a7eb8d3b2c614123e4d0dc283"
+  ]
+}

--- a/packages/ldp_tls/ldp_tls.0.4.0/opam
+++ b/packages/ldp_tls/ldp_tls.0.4.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications using TLS"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "tls-lwt" {>= "1.0.2"}
+  "tls" {>= "1.0.2"}
+  "ppx_sexp_conv"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.4.0.tar.gz"
+  checksum: [
+    "md5=241a1682aea9bb1ca78494ea82baf515"
+    "sha512=6792ea5c05cc9fac42567c533a0dcefa203dfbd285cdea226f57298a85b8b676e230f92152fc5a91edcc8961a66902923402964a7eb8d3b2c614123e4d0dc283"
+  ]
+}

--- a/packages/ojs_base/ojs_base.0.8.0/opam
+++ b/packages/ojs_base/ojs_base.0.8.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Base library for developing OCaml web apps based on websockets and js_of_ocaml"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+tags: ["javascript" "web" "components"]
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "js_of_ocaml" {>= "5.5.0"}
+  "js_of_ocaml-ppx" {>= "5.5.0"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.2"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "websocket" {>= "2.14"}
+  "websocket-lwt-unix" {>= "2.14"}
+  "xtmpl" {>= "1.0.0"}
+  "xtmpl_ppx" {>= "1.0.0"}
+  "yojson" {>= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src: "https://zoggy.frama.io/ojs-base/releases/ojs-base-0.8.0.tar.bz2"
+  checksum: [
+    "md5=e706f1f9ec2f935d29c6b6e4832c8bdf"
+    "sha512=2596f6c59bea9c6b89923099c604a0e095a96880e7e91b06357e1de50867ae7e0261c87c35f608b7e426bddd6dd025a9868c07499287116ed458de4a0b9e9f30"
+  ]
+}

--- a/packages/ojs_base_all/ojs_base_all.0.8.0/opam
+++ b/packages/ojs_base_all/ojs_base_all.0.8.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install all ojs_base packages"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ojs_base" {= version}
+  "ojs_filetree" {= version}
+  "ojs_list" {= version}
+  "ojs_ed" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src: "https://zoggy.frama.io/ojs-base/releases/ojs-base-0.8.0.tar.bz2"
+  checksum: [
+    "md5=e706f1f9ec2f935d29c6b6e4832c8bdf"
+    "sha512=2596f6c59bea9c6b89923099c604a0e095a96880e7e91b06357e1de50867ae7e0261c87c35f608b7e426bddd6dd025a9868c07499287116ed458de4a0b9e9f30"
+  ]
+}

--- a/packages/ojs_base_ppx/ojs_base_ppx.0.8.0/opam
+++ b/packages/ojs_base_ppx/ojs_base_ppx.0.8.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "PPx extension for the Ojs_base library"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "ojs_base" {= version}
+  "ppxlib"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src: "https://zoggy.frama.io/ojs-base/releases/ojs-base-0.8.0.tar.bz2"
+  checksum: [
+    "md5=e706f1f9ec2f935d29c6b6e4832c8bdf"
+    "sha512=2596f6c59bea9c6b89923099c604a0e095a96880e7e91b06357e1de50867ae7e0261c87c35f608b7e426bddd6dd025a9868c07499287116ed458de4a0b9e9f30"
+  ]
+}

--- a/packages/ojs_ed/ojs_ed.0.8.0/opam
+++ b/packages/ojs_ed/ojs_ed.0.8.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Using file editor in ojs_base applications, common part"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ojs_base" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src: "https://zoggy.frama.io/ojs-base/releases/ojs-base-0.8.0.tar.bz2"
+  checksum: [
+    "md5=e706f1f9ec2f935d29c6b6e4832c8bdf"
+    "sha512=2596f6c59bea9c6b89923099c604a0e095a96880e7e91b06357e1de50867ae7e0261c87c35f608b7e426bddd6dd025a9868c07499287116ed458de4a0b9e9f30"
+  ]
+}

--- a/packages/ojs_filetree/ojs_filetree.0.8.0/opam
+++ b/packages/ojs_filetree/ojs_filetree.0.8.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Using filetrees in ojs_base applications, common part"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ojs_base" {= version}
+  "magic-mime" {>= "1.2.0"}
+  "base64" {>= "3.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src: "https://zoggy.frama.io/ojs-base/releases/ojs-base-0.8.0.tar.bz2"
+  checksum: [
+    "md5=e706f1f9ec2f935d29c6b6e4832c8bdf"
+    "sha512=2596f6c59bea9c6b89923099c604a0e095a96880e7e91b06357e1de50867ae7e0261c87c35f608b7e426bddd6dd025a9868c07499287116ed458de4a0b9e9f30"
+  ]
+}

--- a/packages/ojs_list/ojs_list.0.8.0/opam
+++ b/packages/ojs_list/ojs_list.0.8.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Using lists in ojs_base applications, common part"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ojs_base" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src: "https://zoggy.frama.io/ojs-base/releases/ojs-base-0.8.0.tar.bz2"
+  checksum: [
+    "md5=e706f1f9ec2f935d29c6b6e4832c8bdf"
+    "sha512=2596f6c59bea9c6b89923099c604a0e095a96880e7e91b06357e1de50867ae7e0261c87c35f608b7e426bddd6dd025a9868c07499287116ed458de4a0b9e9f30"
+  ]
+}

--- a/packages/solid/solid.0.4.0/opam
+++ b/packages/solid/solid.0.4.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Library to build SOLID applications"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.4.0.tar.gz"
+  checksum: [
+    "md5=241a1682aea9bb1ca78494ea82baf515"
+    "sha512=6792ea5c05cc9fac42567c533a0dcefa203dfbd285cdea226f57298a85b8b676e230f92152fc5a91edcc8961a66902923402964a7eb8d3b2c614123e4d0dc283"
+  ]
+}

--- a/packages/solid_server/solid_server.0.4.0/opam
+++ b/packages/solid_server/solid_server.0.4.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "SOLID server under development"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "calendar" {>= "2.04"}
+  "cohttp-lwt-unix" {>= "5.3.0"}
+  "cryptokit" {>= "1.16.1"}
+  "fpath" {>= "0.7.3"}
+  "git-unix" {>= "3.4.0"}
+  "ldp_curl" {= version}
+  "ldp_tls" {= version}
+  "ocaml" {>= "4.14.0"}
+  "ppx_blob" {>= "0.7.2"}
+  "solid" {= version}
+  "webmachine" {>= "0.7.0"}
+  "xtmpl" {>= "0.19.0"}
+  "xtmpl_ppx" {>= "0.19.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.4.0.tar.gz"
+  checksum: [
+    "md5=241a1682aea9bb1ca78494ea82baf515"
+    "sha512=6792ea5c05cc9fac42567c533a0dcefa203dfbd285cdea226f57298a85b8b676e230f92152fc5a91edcc8961a66902923402964a7eb8d3b2c614123e4d0dc283"
+  ]
+}

--- a/packages/solid_tools/solid_tools.0.4.0/opam
+++ b/packages/solid_tools/solid_tools.0.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Library to build SOLID tools"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.14.0"}
+  "ldp_curl" {= version}
+  "ldp_tls" {= version}
+  "solid" {= version}
+  "ocf" {>= "0.8.0"}
+  "ocf_ppx" {>= "0.8.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.4.0.tar.gz"
+  checksum: [
+    "md5=241a1682aea9bb1ca78494ea82baf515"
+    "sha512=6792ea5c05cc9fac42567c533a0dcefa203dfbd285cdea226f57298a85b8b676e230f92152fc5a91edcc8961a66902923402964a7eb8d3b2c614123e4d0dc283"
+  ]
+}

--- a/packages/stk/stk.0.4.0/opam
+++ b/packages/stk/stk.0.4.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "SDL-based GUI toolkit"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.2.0"}
+  "css" {>= "0.3.0"}
+  "fmt" {>= "0.9.0"}
+  "higlo" {>= "0.10.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.2"}
+  "pcre" {>= "7.5.0"}
+  "ocf" {>= "0.9.0"}
+  "ocf_ppx" {>= "0.9.0"}
+  "ppx_blob" {>= "0.7.2"}
+  "ptime" {>= "1.1.0"}
+  "sedlex" {>= "1.2"}
+  "stk_ppx" {= version}
+  "tsdl" {>= "1.1.0"}
+  "tsdl-image" {>= "0.3.2"}
+  "tsdl-ttf" {>= "0.3.2"}
+  "uunf" {>= "15.0.0"}
+  "uutf" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.4.0.tar.bz2"
+  checksum: [
+    "md5=114ffc6a92cc5ce6a07682c76bba27e3"
+    "sha512=9e7edeefc91d3f47e190a57d74d7845e63e7b9bda0a5ebfa243bed65ff727b0fa0df0c41019736bf9cff9d91387ef210d8459ac0e16c4daeebc2e23f02c79b15"
+  ]
+}

--- a/packages/stk_iconv/stk_iconv.0.4.0/opam
+++ b/packages/stk_iconv/stk_iconv.0.4.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Bindings to GNU libiconv"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ctypes" {>= "0.20.1"}
+  "ctypes-foreign" {>= "0.18.0"}
+  "logs" {>= "0.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.4.0.tar.bz2"
+  checksum: [
+    "md5=114ffc6a92cc5ce6a07682c76bba27e3"
+    "sha512=9e7edeefc91d3f47e190a57d74d7845e63e7b9bda0a5ebfa243bed65ff727b0fa0df0c41019736bf9cff9d91387ef210d8459ac0e16c4daeebc2e23f02c79b15"
+  ]
+}

--- a/packages/stk_ocf/stk_ocf.0.4.0/opam
+++ b/packages/stk_ocf/stk_ocf.0.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Utils to build GUI above Ocf"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocf" {>= "0.9.0"}
+  "stk" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.4.0.tar.bz2"
+  checksum: [
+    "md5=114ffc6a92cc5ce6a07682c76bba27e3"
+    "sha512=9e7edeefc91d3f47e190a57d74d7845e63e7b9bda0a5ebfa243bed65ff727b0fa0df0c41019736bf9cff9d91387ef210d8459ac0e16c4daeebc2e23f02c79b15"
+  ]
+}

--- a/packages/stk_ppx/stk_ppx.0.4.0/opam
+++ b/packages/stk_ppx/stk_ppx.0.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "PPX used for debug logging in Stk"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.2.0"}
+  "ppxlib"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.4.0.tar.bz2"
+  checksum: [
+    "md5=114ffc6a92cc5ce6a07682c76bba27e3"
+    "sha512=9e7edeefc91d3f47e190a57d74d7845e63e7b9bda0a5ebfa243bed65ff727b0fa0df0c41019736bf9cff9d91387ef210d8459ac0e16c4daeebc2e23f02c79b15"
+  ]
+}

--- a/packages/stk_rdf/stk_rdf.0.4.0/opam
+++ b/packages/stk_rdf/stk_rdf.0.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Utilities to display and edit RDF data"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "rdf" {>= "1.0.0"}
+  "stk" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.4.0.tar.bz2"
+  checksum: [
+    "md5=114ffc6a92cc5ce6a07682c76bba27e3"
+    "sha512=9e7edeefc91d3f47e190a57d74d7845e63e7b9bda0a5ebfa243bed65ff727b0fa0df0c41019736bf9cff9d91387ef210d8459ac0e16c4daeebc2e23f02c79b15"
+  ]
+}

--- a/packages/stk_xml/stk_xml.0.4.0/opam
+++ b/packages/stk_xml/stk_xml.0.4.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Library to display xml/html"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ldp" {>= "0.4.0"}
+  "ppx_blob" {>= "0.7.2"}
+  "stk" {= version}
+  "stk_rdf" {= version}
+  "xtmpl" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.4.0.tar.bz2"
+  checksum: [
+    "md5=114ffc6a92cc5ce6a07682c76bba27e3"
+    "sha512=9e7edeefc91d3f47e190a57d74d7845e63e7b9bda0a5ebfa243bed65ff727b0fa0df0c41019736bf9cff9d91387ef210d8459ac0e16c4daeebc2e23f02c79b15"
+  ]
+}

--- a/packages/stog/stog.1.1.0/opam
+++ b/packages/stog/stog.1.1.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis:
+  "Static web site compiler, able to handle blog posts as well as regular pages or any XML document in general"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.0.0"}
+  "dune-build-info" {>= "2.9.1"}
+  "dune-site" {>= "2.9.1"}
+  "fmt" {>= "0.9.0"}
+  "higlo" {>= "0.9"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.7.0"}
+  "lwt_ppx" {>= "2.1.0"}
+  "menhir" {>= "20231231"}
+  "ocf" {>= "0.8.0"}
+  "ocf_ppx" {>= "0.8.0"}
+  "ppx_blob" {>= "0.7.2"}
+  "ptime" {>= "1.1.0"}
+  "uri" {>= "4.4.0"}
+  "uutf" {>= "1.0.3"}
+  "xtmpl" {>= "1.0.0"}
+  "xtmpl_ppx" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/stog_all/stog_all.1.1.0/opam
+++ b/packages/stog_all/stog_all.1.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install all Stog libraries, tools and plugins"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "stog_server" {= version}
+  "stog_server_multi" {= version}
+  "stog_plugins" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/stog_asy/stog_asy.1.1.0/opam
+++ b/packages/stog_asy/stog_asy.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to include Asymptote results in documents"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/stog_dot/stog_dot.1.1.0/opam
+++ b/packages/stog_dot/stog_dot.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to generate and include graphviz graphs in documents"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/stog_extern/stog_extern.1.1.0/opam
+++ b/packages/stog_extern/stog_extern.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to pipe documents in external commands"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/stog_markdown/stog_markdown.1.1.0/opam
+++ b/packages/stog_markdown/stog_markdown.1.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to use markdown syntax"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "omd" {>= "1.9.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/stog_multi_doc/stog_multi_doc.1.1.0/opam
+++ b/packages/stog_multi_doc/stog_multi_doc.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to define various documents in one file"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/stog_nocaml/stog_nocaml.1.1.0/opam
+++ b/packages/stog_nocaml/stog_nocaml.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to block commands executing ocaml code"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/stog_noexec/stog_noexec.1.1.0/opam
+++ b/packages/stog_noexec/stog_noexec.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to prevent running command with <exec>"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/stog_plugins/stog_plugins.1.1.0/opam
+++ b/packages/stog_plugins/stog_plugins.1.1.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install all Stog plugins"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog_asy" {= version}
+  "stog_dot" {= version}
+  "stog_extern" {= version}
+  "stog_markdown" {= version}
+  "stog_multi_doc" {= version}
+  "stog_nocaml" {= version}
+  "stog_noexec" {= version}
+  "stog_rel_href" {= version}
+  "stog_sitemap" {= version}
+  "stog_writing" {= version}
+  "odoc" {with-doc}
+]
+depopts: [
+  "stog_rdf" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/stog_rdf/stog_rdf.1.1.0/opam
+++ b/packages/stog_rdf/stog_rdf.1.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to generate rdf triples and execute sparql queries"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "rdf" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/stog_rel_href/stog_rel_href.1.1.0/opam
+++ b/packages/stog_rel_href/stog_rel_href.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to generate relative urls"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/stog_server/stog_server.1.1.0/opam
+++ b/packages/stog_server/stog_server.1.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Stog server library"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "conduit-lwt-unix" {>= "6.2.1"}
+  "cryptokit" {>= "1.19"}
+  "ppx_deriving_yojson" {>= "3.7.0"}
+  "ojs_base_all" {>= "0.8.0"}
+  "websocket" {>= "2.16"}
+  "xmldiff" {>= "0.7.0"}
+  "xmldiff_js" {>= "0.7.0"}
+  "xtmpl_js" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/stog_server_multi/stog_server_multi.1.1.0/opam
+++ b/packages/stog_server_multi/stog_server_multi.1.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Stog multi server library"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "stog_server" {= version}
+  "ojs_base_ppx" {>= "0.8.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/stog_sitemap/stog_sitemap.1.1.0/opam
+++ b/packages/stog_sitemap/stog_sitemap.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to generate a sitemap file"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/stog_writing/stog_writing.1.1.0/opam
+++ b/packages/stog_writing/stog_writing.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to generate table of contents and bibliographies"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://www.good-eris.net/stog/releases/stog-1.1.0.tar.bz2"
+  checksum: [
+    "md5=9d7012ff976218dcaa174dc9788d1155"
+    "sha512=ce8c04c45be0572aebb1df63f168a28bdd56e2f7b763541fca1e22315f71cf2250e0653fe01e5967cf4ff7f2dde7e53ddd1304e2921420c64e64221a285792fc"
+  ]
+}

--- a/packages/xtmpl/xtmpl.1.0.0/opam
+++ b/packages/xtmpl/xtmpl.1.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Xml templating library"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/xtmpl/"
+doc: "https://www.good-eris.net/xtmpl/doc.html"
+bug-reports: "https://framagit.org/zoggy/xtmpl/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "sedlex" {>= "2.3"}
+  "uutf" {>= "1.0.0"}
+  "re" {>= "1.10.3"}
+  "iri" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/xtmpl.git"
+url {
+  src: "https://www.good-eris.net/xtmpl/releases/xtmpl-1.0.0.tar.bz2"
+  checksum: [
+    "md5=11bd8dac1bb7161d637230045692306c"
+    "sha512=d4f9340b694a504c4799937f663dc955fcf1fb466adc6b0200bb357fe6b35d5e20e3e7670550cce7db76b3a7c02fb28167f344ef808b4d17001618b4c4aa9a28"
+  ]
+}

--- a/packages/xtmpl_js/xtmpl_js.1.0.0/opam
+++ b/packages/xtmpl_js/xtmpl_js.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Xml templating library, javascript library"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/xtmpl/"
+doc: "https://www.good-eris.net/xtmpl/doc.html"
+bug-reports: "https://framagit.org/zoggy/xtmpl/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "xtmpl" {= version}
+  "js_of_ocaml" {>= "5.8.2"}
+  "js_of_ocaml-ppx" {>= "5.8.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/xtmpl.git"
+url {
+  src: "https://www.good-eris.net/xtmpl/releases/xtmpl-1.0.0.tar.bz2"
+  checksum: [
+    "md5=11bd8dac1bb7161d637230045692306c"
+    "sha512=d4f9340b694a504c4799937f663dc955fcf1fb466adc6b0200bb357fe6b35d5e20e3e7670550cce7db76b3a7c02fb28167f344ef808b4d17001618b4c4aa9a28"
+  ]
+}

--- a/packages/xtmpl_ppx/xtmpl_ppx.1.0.0/opam
+++ b/packages/xtmpl_ppx/xtmpl_ppx.1.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Xml templating library, ppx extension"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/xtmpl/"
+doc: "https://www.good-eris.net/xtmpl/doc.html"
+bug-reports: "https://framagit.org/zoggy/xtmpl/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "xtmpl" {= version}
+  "ppxlib" {>= "0.23.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/xtmpl.git"
+url {
+  src: "https://www.good-eris.net/xtmpl/releases/xtmpl-1.0.0.tar.bz2"
+  checksum: [
+    "md5=11bd8dac1bb7161d637230045692306c"
+    "sha512=d4f9340b694a504c4799937f663dc955fcf1fb466adc6b0200bb357fe6b35d5e20e3e7670550cce7db76b3a7c02fb28167f344ef808b4d17001618b4c4aa9a28"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `chamo.4.2.0`: A kind of emacs-like editor, using OCaml instead of lisp
- `css.0.3.0`: CSS parser and printer
- `higlo.0.10.0`: Syntax highlighting library
- `ldp.0.4.0`: Library to build LDP applications
- `ldp_curl.0.4.0`: Library to build LDP applications using Curl
- `ldp_js.0.4.0`: Library to build LDP applications in JS
- `ldp_tls.0.4.0`: Library to build LDP applications using TLS
- `ojs_base.0.8.0`: Base library for developing OCaml web apps based on websockets and js_of_ocaml
- `ojs_base_all.0.8.0`: Virtual package to install all ojs_base packages
- `ojs_base_ppx.0.8.0`: PPx extension for the Ojs_base library
- `ojs_ed.0.8.0`: Using file editor in ojs_base applications, common part
- `ojs_filetree.0.8.0`: Using filetrees in ojs_base applications, common part
- `ojs_list.0.8.0`: Using lists in ojs_base applications, common part
- `solid.0.4.0`: Library to build SOLID applications
- `solid_server.0.4.0`: SOLID server under development
- `solid_tools.0.4.0`: Library to build SOLID tools
- `stk.0.4.0`: SDL-based GUI toolkit
- `stk_iconv.0.4.0`: Bindings to GNU libiconv
- `stk_ocf.0.4.0`: Utils to build GUI above Ocf
- `stk_ppx.0.4.0`: PPX used for debug logging in Stk
- `stk_rdf.0.4.0`: Utilities to display and edit RDF data
- `stk_xml.0.4.0`: Library to display xml/html
- `stog.1.1.0`: Static web site compiler, able to handle blog posts as well as regular pages or any XML
  document in general
- `stog_all.1.1.0`: Virtual package to install all Stog libraries, tools and plugins
- `stog_asy.1.1.0`: Stog plugin to include Asymptote results in documents
- `stog_dot.1.1.0`: Stog plugin to generate and include graphviz graphs in documents
- `stog_extern.1.1.0`: Stog plugin to pipe documents in external commands
- `stog_markdown.1.1.0`: Stog plugin to use markdown syntax
- `stog_multi_doc.1.1.0`: Stog plugin to define various documents in one file
- `stog_nocaml.1.1.0`: Stog plugin to block commands executing ocaml code
- `stog_noexec.1.1.0`: Stog plugin to prevent running command with <exec>
- `stog_plugins.1.1.0`: Virtual package to install all Stog plugins
- `stog_rdf.1.1.0`: Stog plugin to generate rdf triples and execute sparql queries
- `stog_rel_href.1.1.0`: Stog plugin to generate relative urls
- `stog_server.1.1.0`: Stog server library
- `stog_server_multi.1.1.0`: Stog multi server library
- `stog_sitemap.1.1.0`: Stog plugin to generate a sitemap file
- `stog_writing.1.1.0`: Stog plugin to generate table of contents and bibliographies
- `xtmpl.1.0.0`: Xml templating library
- `xtmpl_js.1.0.0`: Xml templating library, javascript library
- `xtmpl_ppx.1.0.0`: Xml templating library, ppx extension



---

---
:camel: Pull-request generated by opam-publish v2.5.0