### PR TITLE
apron: mark as deprecated (instead of avoid-version)

### DIFF
--- a/packages/apron/apron.0.9.14/opam
+++ b/packages/apron/apron.0.9.14/opam
@@ -40,7 +40,7 @@ depopts: [
   "conf-ppl"
 ]
 available: opam-version >= "2.1.0"
-flags: avoid-version
+flags: deprecated
 description:"""
 Apron is a library to represent properties of numeric variables, such as variable bounds or linear relations between variables, and to manipulate these properties through semantic operations, such as variable assignments, tests, conjunctions, entailment. Apron is intended to be used in static program analyzers, in order to infer invariants of numeric variables, i.e., properties that hold for all executions of a program. It is based on the theory of Abstract Interpretation."""
 url {


### PR DESCRIPTION
the version number here, 0.9.14, has been modified with the same archive to v0.9.14

//cc @mseri