### PR TITLE
alt-ergo*2.5.0: mark as deprecated instead of avoid-version

### DIFF
--- a/packages/alt-ergo-lib/alt-ergo-lib.2.5.0/opam
+++ b/packages/alt-ergo-lib/alt-ergo-lib.2.5.0/opam
@@ -12,7 +12,7 @@ homepage: "https://alt-ergo.ocamlpro.com/"
 doc: "https://ocamlpro.github.io/alt-ergo"
 bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
 available: opam-version >= "2.1.0"
-flags: [ avoid-version ]
+flags: [ deprecated ]
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "3.0"}

--- a/packages/alt-ergo-parsers/alt-ergo-parsers.2.5.0/opam
+++ b/packages/alt-ergo-parsers/alt-ergo-parsers.2.5.0/opam
@@ -12,7 +12,7 @@ homepage: "https://alt-ergo.ocamlpro.com/"
 doc: "https://ocamlpro.github.io/alt-ergo"
 bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
 available: opam-version >= "2.1.0"
-flags: [ avoid-version ]
+flags: [ deprecated ]
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "3.0"}

--- a/packages/alt-ergo-plugin-ab-why3/alt-ergo-plugin-ab-why3.2.5.0/opam
+++ b/packages/alt-ergo-plugin-ab-why3/alt-ergo-plugin-ab-why3.2.5.0/opam
@@ -12,7 +12,7 @@ homepage: "https://alt-ergo.ocamlpro.com/"
 doc: "https://ocamlpro.github.io/alt-ergo"
 bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
 available: opam-version >= "2.1.0"
-flags: [ avoid-version ]
+flags: [ deprecated ]
 depends: [
   "dune" {>= "3.0"}
   "alt-ergo" {= version}

--- a/packages/alt-ergo/alt-ergo.2.5.0/opam
+++ b/packages/alt-ergo/alt-ergo.2.5.0/opam
@@ -10,7 +10,7 @@ homepage: "https://alt-ergo.ocamlpro.com/"
 doc: "https://ocamlpro.github.io/alt-ergo"
 bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
 available: opam-version >= "2.1.0"
-flags: [ avoid-version ]
+flags: [ deprecated ]
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "3.0"}


### PR DESCRIPTION
//cc @Halbaroth hope that is the intention