### PR TITLE
mark old oma release as deprecated instead of avoid-version

### DIFF
--- a/packages/oma/oma.20240106/opam
+++ b/packages/oma/oma.20240106/opam
@@ -34,4 +34,4 @@ url {
     "sha512=81337806021c6d239cce7fc141097b84536ed43dcc45e0e7c94f9f29789c0924fe3873f047c14d86bdf330f322ec3e1cd7f601523a3af18291e76499f619f418"
   ]
 }
-flags: [ avoid-version ]
+flags: [ deprecated ]


### PR DESCRIPTION
//cc @fpottier -- this is just some bookkeeping (avoid-version is used for lots of things, while deprecated has a clear intention/meaning)