### PR TITLE
5 packages from c-cube/qcheck

### DIFF
--- a/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.5/opam
+++ b/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.5/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "PPX Deriver for QCheck"
+maintainer: "valentin.chb@gmail.com"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/-/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "ocaml" {>= "4.08.0"}
+  "qcheck-core" {>= "0.19"}
+  "ppxlib" {>= "0.22.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "odoc" {with-doc}
+  "alcotest" {with-test & >= "1.4.0"}
+  "qcheck-alcotest" {with-test & >= "0.17"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/vch9/ppx_deriving_qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.23.tar.gz"
+  checksum: [
+    "md5=25be98dd0e0e0b3f34cb4c9d72507563"
+    "sha512=e12ebc70cddc0fb0933fb331fef81ca6010340146d163bef673a2222a84bc3c5656c508a561702ac1f7fdb9d691ab0e423bc0c12361b81377c4cd682739e6e91"
+  ]
+}

--- a/packages/qcheck-alcotest/qcheck-alcotest.0.23/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.23/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Alcotest backend for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "quickcheck" "qcheck" "alcotest"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "qcheck-core" {= version}
+  "alcotest" {>= "1.2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.23.tar.gz"
+  checksum: [
+    "md5=25be98dd0e0e0b3f34cb4c9d72507563"
+    "sha512=e12ebc70cddc0fb0933fb331fef81ca6010340146d163bef673a2222a84bc3c5656c508a561702ac1f7fdb9d691ab0e423bc0c12361b81377c4cd682739e6e91"
+  ]
+}

--- a/packages/qcheck-core/qcheck-core.0.23/opam
+++ b/packages/qcheck-core/qcheck-core.0.23/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Core qcheck library"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "alcotest" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.23.tar.gz"
+  checksum: [
+    "md5=25be98dd0e0e0b3f34cb4c9d72507563"
+    "sha512=e12ebc70cddc0fb0933fb331fef81ca6010340146d163bef673a2222a84bc3c5656c508a561702ac1f7fdb9d691ab0e423bc0c12361b81377c4cd682739e6e91"
+  ]
+}

--- a/packages/qcheck-ounit/qcheck-ounit.0.23/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.23/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "OUnit backend for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["qcheck" "quickcheck" "ounit"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "qcheck-core" {= version}
+  "ounit2"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.23.tar.gz"
+  checksum: [
+    "md5=25be98dd0e0e0b3f34cb4c9d72507563"
+    "sha512=e12ebc70cddc0fb0933fb331fef81ca6010340146d163bef673a2222a84bc3c5656c508a561702ac1f7fdb9d691ab0e423bc0c12361b81377c4cd682739e6e91"
+  ]
+}

--- a/packages/qcheck/qcheck.0.23/opam
+++ b/packages/qcheck/qcheck.0.23/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Compatibility package for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "qcheck-core" {= version}
+  "qcheck-ounit" {= version}
+  "alcotest" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.23.tar.gz"
+  checksum: [
+    "md5=25be98dd0e0e0b3f34cb4c9d72507563"
+    "sha512=e12ebc70cddc0fb0933fb331fef81ca6010340146d163bef673a2222a84bc3c5656c508a561702ac1f7fdb9d691ab0e423bc0c12361b81377c4cd682739e6e91"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `ppx_deriving_qcheck.0.5`: PPX Deriver for QCheck
- `qcheck.0.23`: Compatibility package for qcheck
- `qcheck-alcotest.0.23`: Alcotest backend for qcheck
- `qcheck-core.0.23`: Core qcheck library
- `qcheck-ounit.0.23`: OUnit backend for qcheck



---
* Homepage: https://github.com/c-cube/qcheck/

---
:camel: Pull-request generated by opam-publish v2.4.0