### PR TITLE
archetype is not compatible with OCaml 5.3

### DIFF
--- a/packages/archetype/archetype.0.1.10/opam
+++ b/packages/archetype/archetype.0.1.10/opam
@@ -22,7 +22,7 @@ Archetype is a domain-specific language (DSL) to develop smart contracts
 on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune" {>= "1.10.0"}
   "menhir"
   "digestif" {>= "0.7.2"}

--- a/packages/archetype/archetype.0.1.10/opam
+++ b/packages/archetype/archetype.0.1.10/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "2.7"}
   "menhir"
   "digestif" {>= "0.7.2"}
   "num"

--- a/packages/archetype/archetype.0.1.11/opam
+++ b/packages/archetype/archetype.0.1.11/opam
@@ -22,7 +22,7 @@ Archetype is a domain-specific language (DSL) to develop smart contracts
 on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune" {>= "1.10.0"}
   "menhir"
   "digestif" {>= "0.7.2"}

--- a/packages/archetype/archetype.0.1.11/opam
+++ b/packages/archetype/archetype.0.1.11/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "2.7"}
   "menhir"
   "digestif" {>= "0.7.2"}
   "num"

--- a/packages/archetype/archetype.0.1.12/opam
+++ b/packages/archetype/archetype.0.1.12/opam
@@ -22,7 +22,7 @@ Archetype is a domain-specific language (DSL) to develop smart contracts
 on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune" {>= "1.10.0"}
   "menhir"
   "digestif" {>= "0.7.2"}

--- a/packages/archetype/archetype.0.1.12/opam
+++ b/packages/archetype/archetype.0.1.12/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "2.7"}
   "menhir"
   "digestif" {>= "0.7.2"}
   "num"

--- a/packages/archetype/archetype.0.1.13/opam
+++ b/packages/archetype/archetype.0.1.13/opam
@@ -22,7 +22,7 @@ Archetype is a domain-specific language (DSL) to develop smart contracts
 on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune" {>= "1.10.0"}
   "menhir"
   "digestif" {>= "0.7.2"}

--- a/packages/archetype/archetype.0.1.13/opam
+++ b/packages/archetype/archetype.0.1.13/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "2.7"}
   "menhir"
   "digestif" {>= "0.7.2"}
   "num"

--- a/packages/archetype/archetype.0.1.14/opam
+++ b/packages/archetype/archetype.0.1.14/opam
@@ -22,7 +22,7 @@ Archetype is a domain-specific language (DSL) to develop smart contracts
 on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune" {>= "1.10.0"}
   "menhir"
   "digestif" {>= "0.7.2"}

--- a/packages/archetype/archetype.0.1.14/opam
+++ b/packages/archetype/archetype.0.1.14/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "2.7"}
   "menhir"
   "digestif" {>= "0.7.2"}
   "num"

--- a/packages/archetype/archetype.0.1.3/opam
+++ b/packages/archetype/archetype.0.1.3/opam
@@ -20,7 +20,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"               { >= "4.07.0" }
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune"                { >= "1.10.0"  }
   "menhir"
   "uri"

--- a/packages/archetype/archetype.0.1.3/opam
+++ b/packages/archetype/archetype.0.1.3/opam
@@ -21,7 +21,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune"                { >= "1.10.0"  }
+  "dune"                { >= "2.7"  }
   "menhir"
   "uri"
   "digestif"            { >= "0.7.2" }

--- a/packages/archetype/archetype.0.1.4/opam
+++ b/packages/archetype/archetype.0.1.4/opam
@@ -20,7 +20,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"               { >= "4.07.0" }
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune"                { >= "1.10.0" }
   "menhir"
   "uri"

--- a/packages/archetype/archetype.0.1.4/opam
+++ b/packages/archetype/archetype.0.1.4/opam
@@ -21,7 +21,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune"                { >= "1.10.0" }
+  "dune"                { >= "2.7" }
   "menhir"
   "uri"
   "digestif"            { >= "0.7.2" }

--- a/packages/archetype/archetype.0.1.5/opam
+++ b/packages/archetype/archetype.0.1.5/opam
@@ -21,7 +21,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"               { >= "4.07.0" }
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune"                { >= "1.10.0" }
   "menhir"
   "digestif"            { >= "0.7.2" }

--- a/packages/archetype/archetype.0.1.5/opam
+++ b/packages/archetype/archetype.0.1.5/opam
@@ -22,7 +22,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune"                { >= "1.10.0" }
+  "dune"                { >= "2.7" }
   "menhir"
   "digestif"            { >= "0.7.2" }
   "num"

--- a/packages/archetype/archetype.0.1.5/opam
+++ b/packages/archetype/archetype.0.1.5/opam
@@ -16,7 +16,7 @@ license: "MIT"
 doc: "https://docs.archetype-lang.org/"
 
 build: [
-  [ "dune" "subst" ]
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/archetype/archetype.0.1.6/opam
+++ b/packages/archetype/archetype.0.1.6/opam
@@ -21,7 +21,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"               { >= "4.07.0" }
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune"                { >= "1.10.0" }
   "menhir"
   "digestif"            { >= "0.7.2" }

--- a/packages/archetype/archetype.0.1.6/opam
+++ b/packages/archetype/archetype.0.1.6/opam
@@ -22,7 +22,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune"                { >= "1.10.0" }
+  "dune"                { >= "2.7" }
   "menhir"
   "digestif"            { >= "0.7.2" }
   "num"

--- a/packages/archetype/archetype.0.1.6/opam
+++ b/packages/archetype/archetype.0.1.6/opam
@@ -16,7 +16,7 @@ license: "MIT"
 doc: "https://docs.archetype-lang.org/"
 
 build: [
-  [ "dune" "subst" ]
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/archetype/archetype.0.1.8/opam
+++ b/packages/archetype/archetype.0.1.8/opam
@@ -21,7 +21,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"               { >= "4.07.0" }
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune"                { >= "1.10.0" }
   "menhir"
   "digestif"            { >= "0.7.2" }

--- a/packages/archetype/archetype.0.1.8/opam
+++ b/packages/archetype/archetype.0.1.8/opam
@@ -16,13 +16,13 @@ license: "MIT"
 doc: "https://docs.archetype-lang.org/"
 
 build: [
-  [ "dune" "subst" ]
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune"                { >= "1.10.0" }
+  "dune"                { >= "2.7" }
   "menhir"
   "digestif"            { >= "0.7.2" }
   "num"

--- a/packages/archetype/archetype.0.1.9/opam
+++ b/packages/archetype/archetype.0.1.9/opam
@@ -22,7 +22,7 @@ Archetype is a domain-specific language (DSL) to develop smart contracts
 on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune" {>= "1.10.0"}
   "menhir"
   "digestif" {>= "0.7.2"}

--- a/packages/archetype/archetype.0.1.9/opam
+++ b/packages/archetype/archetype.0.1.9/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "2.7"}
   "menhir"
   "digestif" {>= "0.7.2"}
   "num"

--- a/packages/archetype/archetype.1.0.0/opam
+++ b/packages/archetype/archetype.1.0.0/opam
@@ -22,7 +22,7 @@ Archetype is a domain-specific language (DSL) to develop smart contracts
 on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune" {>= "1.10.0" & < "3.13"}
   "menhir" {>= "20180528"}
   "digestif" {>= "0.7.2" }

--- a/packages/archetype/archetype.1.0.0/opam
+++ b/packages/archetype/archetype.1.0.0/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune" {>= "1.10.0" & < "3.13"}
+  "dune" {>= "2.7" & < "3.13"}
   "menhir" {>= "20180528"}
   "digestif" {>= "0.7.2" }
   "num"

--- a/packages/archetype/archetype.1.1.0/opam
+++ b/packages/archetype/archetype.1.1.0/opam
@@ -22,7 +22,7 @@ Archetype is a domain-specific language (DSL) to develop smart contracts
 on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune" {>= "1.10.0" & < "3.13"}
   "menhir" {>= "20180528"}
   "digestif" {>= "0.7.2" }

--- a/packages/archetype/archetype.1.1.0/opam
+++ b/packages/archetype/archetype.1.1.0/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune" {>= "1.10.0" & < "3.13"}
+  "dune" {>= "2.7" & < "3.13"}
   "menhir" {>= "20180528"}
   "digestif" {>= "0.7.2" }
   "num"

--- a/packages/archetype/archetype.1.1.1/opam
+++ b/packages/archetype/archetype.1.1.1/opam
@@ -22,7 +22,7 @@ Archetype is a domain-specific language (DSL) to develop smart contracts
 on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune" {>= "1.10.0" & < "3.13"}
   "menhir" {>= "20180528"}
   "digestif" {>= "0.7.2"}

--- a/packages/archetype/archetype.1.1.1/opam
+++ b/packages/archetype/archetype.1.1.1/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune" {>= "1.10.0" & < "3.13"}
+  "dune" {>= "2.7" & < "3.13"}
   "menhir" {>= "20180528"}
   "digestif" {>= "0.7.2"}
   "num"

--- a/packages/archetype/archetype.1.1.2/opam
+++ b/packages/archetype/archetype.1.1.2/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune" {>= "1.10.0" & < "3.13"}
+  "dune" {>= "2.7" & < "3.13"}
   "digestif" {>= "0.7.2"}
   "menhir" {>= "20180528"}
   "num"

--- a/packages/archetype/archetype.1.1.2/opam
+++ b/packages/archetype/archetype.1.1.2/opam
@@ -22,7 +22,7 @@ Archetype is a domain-specific language (DSL) to develop smart contracts
 on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune" {>= "1.10.0" & < "3.13"}
   "digestif" {>= "0.7.2"}
   "menhir" {>= "20180528"}

--- a/packages/archetype/archetype.1.2.0/opam
+++ b/packages/archetype/archetype.1.2.0/opam
@@ -22,7 +22,7 @@ Archetype is a domain-specific language (DSL) to develop smart contracts
 on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune" {>= "1.10.0" & < "3.13"}
   "menhir" {>= "20180528"}
   "digestif" {>= "0.7.2"}

--- a/packages/archetype/archetype.1.2.0/opam
+++ b/packages/archetype/archetype.1.2.0/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune" {>= "1.10.0" & < "3.13"}
+  "dune" {>= "2.7" & < "3.13"}
   "menhir" {>= "20180528"}
   "digestif" {>= "0.7.2"}
   "num"

--- a/packages/archetype/archetype.1.2.1/opam
+++ b/packages/archetype/archetype.1.2.1/opam
@@ -22,7 +22,7 @@ Archetype is a domain-specific language (DSL) to develop smart contracts
 on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune" {>= "1.10.0"}
   "digestif" {>= "0.7.2"}
   "menhir"

--- a/packages/archetype/archetype.1.2.1/opam
+++ b/packages/archetype/archetype.1.2.1/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "2.7"}
   "digestif" {>= "0.7.2"}
   "menhir"
   "num"

--- a/packages/archetype/archetype.1.2.10/opam
+++ b/packages/archetype/archetype.1.2.10/opam
@@ -17,7 +17,7 @@ doc: "https://docs.archetype-lang.org/"
 bug-reports: "https://github.com/edukera/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.2.11/opam
+++ b/packages/archetype/archetype.1.2.11/opam
@@ -17,7 +17,7 @@ doc: "https://docs.archetype-lang.org/"
 bug-reports: "https://github.com/edukera/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.2.12/opam
+++ b/packages/archetype/archetype.1.2.12/opam
@@ -17,7 +17,7 @@ doc: "https://docs.archetype-lang.org/"
 bug-reports: "https://github.com/edukera/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.2.13/opam
+++ b/packages/archetype/archetype.1.2.13/opam
@@ -17,7 +17,7 @@ doc: "https://docs.archetype-lang.org/"
 bug-reports: "https://github.com/edukera/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.2.14/opam
+++ b/packages/archetype/archetype.1.2.14/opam
@@ -17,7 +17,7 @@ doc: "https://docs.archetype-lang.org/"
 bug-reports: "https://github.com/edukera/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.2.15/opam
+++ b/packages/archetype/archetype.1.2.15/opam
@@ -17,7 +17,7 @@ doc: "https://docs.archetype-lang.org/"
 bug-reports: "https://github.com/edukera/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.2.16/opam
+++ b/packages/archetype/archetype.1.2.16/opam
@@ -17,7 +17,7 @@ doc: "https://docs.archetype-lang.org/"
 bug-reports: "https://github.com/edukera/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.2.2/opam
+++ b/packages/archetype/archetype.1.2.2/opam
@@ -23,7 +23,7 @@ on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
   "ocaml" {>= "4.07.0" & < "5.3"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "2.7"}
   "menhir"
   "num"
   "yojson"

--- a/packages/archetype/archetype.1.2.2/opam
+++ b/packages/archetype/archetype.1.2.2/opam
@@ -22,7 +22,7 @@ Archetype is a domain-specific language (DSL) to develop smart contracts
 on the Tezos blockchain, with a specific focus on contract security
 """
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune" {>= "1.10.0"}
   "menhir"
   "num"

--- a/packages/archetype/archetype.1.2.3/opam
+++ b/packages/archetype/archetype.1.2.3/opam
@@ -15,7 +15,7 @@ homepage: "https://github.com/edukera/archetype-lang"
 doc: "https://docs.archetype-lang.org/"
 bug-reports: "https://github.com/edukera/archetype-lang/issues"
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune" {>= "2.7"}
   "menhir"
   "num"

--- a/packages/archetype/archetype.1.2.4/opam
+++ b/packages/archetype/archetype.1.2.4/opam
@@ -15,7 +15,7 @@ homepage: "https://github.com/edukera/archetype-lang"
 doc: "https://docs.archetype-lang.org/"
 bug-reports: "https://github.com/edukera/archetype-lang/issues"
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.3"}
   "dune" {>= "2.7"}
   "menhir"
   "num"

--- a/packages/archetype/archetype.1.2.5/opam
+++ b/packages/archetype/archetype.1.2.5/opam
@@ -16,7 +16,7 @@ doc: "https://docs.archetype-lang.org/"
 bug-reports: "https://github.com/edukera/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.2.6/opam
+++ b/packages/archetype/archetype.1.2.6/opam
@@ -16,7 +16,7 @@ doc: "https://docs.archetype-lang.org/"
 bug-reports: "https://github.com/edukera/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.2.7/opam
+++ b/packages/archetype/archetype.1.2.7/opam
@@ -17,7 +17,7 @@ doc: "https://docs.archetype-lang.org/"
 bug-reports: "https://github.com/edukera/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.2.8/opam
+++ b/packages/archetype/archetype.1.2.8/opam
@@ -17,7 +17,7 @@ doc: "https://docs.archetype-lang.org/"
 bug-reports: "https://github.com/edukera/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.2.9/opam
+++ b/packages/archetype/archetype.1.2.9/opam
@@ -17,7 +17,7 @@ doc: "https://docs.archetype-lang.org/"
 bug-reports: "https://github.com/edukera/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.3.0/opam
+++ b/packages/archetype/archetype.1.3.0/opam
@@ -17,7 +17,7 @@ doc: "https://archetype-lang.org"
 bug-reports: "https://github.com/completium/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.3.1/opam
+++ b/packages/archetype/archetype.1.3.1/opam
@@ -17,7 +17,7 @@ doc: "https://archetype-lang.org"
 bug-reports: "https://github.com/completium/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.3.2/opam
+++ b/packages/archetype/archetype.1.3.2/opam
@@ -17,7 +17,7 @@ doc: "https://archetype-lang.org"
 bug-reports: "https://github.com/completium/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.3.3/opam
+++ b/packages/archetype/archetype.1.3.3/opam
@@ -17,7 +17,7 @@ doc: "https://archetype-lang.org"
 bug-reports: "https://github.com/completium/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.3.4/opam
+++ b/packages/archetype/archetype.1.3.4/opam
@@ -17,7 +17,7 @@ doc: "https://archetype-lang.org"
 bug-reports: "https://github.com/completium/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.3.5/opam
+++ b/packages/archetype/archetype.1.3.5/opam
@@ -17,7 +17,7 @@ doc: "https://archetype-lang.org"
 bug-reports: "https://github.com/completium/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.3.6/opam
+++ b/packages/archetype/archetype.1.3.6/opam
@@ -17,7 +17,7 @@ doc: "https://archetype-lang.org"
 bug-reports: "https://github.com/completium/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.4.0/opam
+++ b/packages/archetype/archetype.1.4.0/opam
@@ -17,7 +17,7 @@ doc: "https://archetype-lang.org"
 bug-reports: "https://github.com/completium/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.4.1/opam
+++ b/packages/archetype/archetype.1.4.1/opam
@@ -17,7 +17,7 @@ doc: "https://archetype-lang.org"
 bug-reports: "https://github.com/completium/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.4.2/opam
+++ b/packages/archetype/archetype.1.4.2/opam
@@ -17,7 +17,7 @@ doc: "https://archetype-lang.org"
 bug-reports: "https://github.com/completium/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.4.3/opam
+++ b/packages/archetype/archetype.1.4.3/opam
@@ -17,7 +17,7 @@ doc: "https://archetype-lang.org"
 bug-reports: "https://github.com/completium/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.5.0/opam
+++ b/packages/archetype/archetype.1.5.0/opam
@@ -17,7 +17,7 @@ doc: "https://archetype-lang.org"
 bug-reports: "https://github.com/completium/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.5.1/opam
+++ b/packages/archetype/archetype.1.5.1/opam
@@ -17,7 +17,7 @@ doc: "https://archetype-lang.org"
 bug-reports: "https://github.com/completium/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}

--- a/packages/archetype/archetype.1.5.2/opam
+++ b/packages/archetype/archetype.1.5.2/opam
@@ -17,7 +17,7 @@ doc: "https://archetype-lang.org"
 bug-reports: "https://github.com/completium/archetype-lang/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "menhir" {>= "20180523"}
   "num"
   "yojson" {>= "1.6.0"}


### PR DESCRIPTION
Expects the effect keyword to be a identifier
```
#=== ERROR while compiling archetype.1.5.2 ====================================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/archetype.1.5.2
# command              ~/.opam/5.3/bin/dune build -p archetype -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/archetype-14-c06b60.env
# output-file          ~/.opam/log/archetype-14-c06b60.out
### output ###
# (cd _build/default && .ppx/6275b1ab6a7c2471cccae8471136173f/ppx.exe --cookie 'library-name="archetype"' -o src/ast.pp.ml --impl src/ast.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "src/ast.ml", line 588, characters 2-8:
# 588 |   effect          : instruction option;
#         ^^^^^^
# Error: Syntax error
# (cd _build/default && .ppx/6275b1ab6a7c2471cccae8471136173f/ppx.exe --cookie 'library-name="archetype"' -o src/gen_decompile.pp.ml --impl src/gen_decompile.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "src/gen_decompile.ml", line 429, characters 7-13:
# 429 |   type effect = [
#              ^^^^^^
# Error: Syntax error
# (cd _build/default && .ppx/6275b1ab6a7c2471cccae8471136173f/ppx.exe --cookie 'library-name="archetype"' -o src/gen_model.pp.ml --impl src/gen_model.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "src/gen_model.ml", line 1493, characters 48-54:
# 1493 |       match transaction.transition, transaction.effect with
#                                                        ^^^^^^
# Error: Syntax error
# (cd _build/default && .ppx/6275b1ab6a7c2471cccae8471136173f/ppx.exe --cookie 'library-name="archetype"' -o src/model.pp.ml --impl src/model.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "src/model.ml", line 4196, characters 5-11:
# 4196 | type effect = Eadded of ident | Eremoved of ident | Eupdated of ident
#             ^^^^^^
# Error: Syntax error
# (cd _build/default && .ppx/6275b1ab6a7c2471cccae8471136173f/ppx.exe --cookie 'library-name="archetype"' -o src/printer_ast.pp.ml --impl src/printer_ast.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "src/printer_ast.ml", line 1155, characters 98-104:
# 1155 |     (pp_option (fun fmt x -> Format.fprintf fmt "effect {@\n  @[%a@]@\n}@\n" pp_instruction x)) t.effect
#                                                                                                          ^^^^^^
# Error: Syntax error
# (cd _build/default && .ppx/6275b1ab6a7c2471cccae8471136173f/ppx.exe --cookie 'library-name="archetype"' -o src/printer_pt.pp.ml --impl src/printer_pt.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "src/printer_pt.ml", line 935, characters 34-35:
# 935 | let pp_to fmt ((to_, when_, effect) : (lident * expr option * expr option)) =
#                                         ^
# Error: Syntax error
# (cd _build/default && .ppx/6275b1ab6a7c2471cccae8471136173f/ppx.exe --cookie 'library-name="archetype"' -o src/typing.pp.ml --impl src/typing.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "src/typing.ml", line 6232, characters 74-75:
# 6232 | let for_effect ~(ret : A.type_ option) (kind : ekind) (env : env) (effect : PT.expr) =
#                                                                                  ^
# Error: Syntax error
```
Reported upstream in https://github.com/completium/archetype-lang/issues/367