### PR TITLE
guardian is not compatible with OCaml 5.3

### DIFF
--- a/packages/guardian/guardian.0.0.4/opam
+++ b/packages/guardian/guardian.0.0.4/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt" {>= "5.6.1"}
   "lwt_ppx" {>= "2.1.0"}
   "mariadb" {>= "1.1.4"}
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "5.3"}
   "ocamlformat" {>= "0.24.1"}
   "ppx_deriving" {>= "5.2.1"}
   "ppx_deriving_yojson" {>= "3.6.1"}

--- a/packages/guardian/guardian.0.0.5/opam
+++ b/packages/guardian/guardian.0.0.5/opam
@@ -20,7 +20,7 @@ depends: [
   "lwt" {>= "5.6.1"}
   "lwt_ppx" {>= "2.1.0"}
   "mariadb" {>= "1.1.4"}
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "5.3"}
   "ocamlformat" {>= "0.24.1"}
   "ppx_deriving" {>= "5.2.1"}
   "ppx_deriving_yojson" {>= "3.6.1"}

--- a/packages/guardian/guardian.0.1.0/opam
+++ b/packages/guardian/guardian.0.1.0/opam
@@ -20,7 +20,7 @@ depends: [
   "lwt" {>= "5.6.1"}
   "lwt_ppx" {>= "2.1.0"}
   "mariadb" {>= "1.1.4"}
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "5.3"}
   "ppx_deriving" {>= "5.2.1"}
   "ppx_deriving_yojson" {>= "3.6.1"}
   "uri" {>= "4.2.0"}


### PR DESCRIPTION
Expects the effect keyword to be a identifier
```
#=== ERROR while compiling guardian.0.1.0 =====================================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/guardian.0.1.0
# command              ~/.opam/5.3/bin/dune build -p guardian -j 1 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/guardian-14-3b027a.env
# output-file          ~/.opam/log/guardian-14-3b027a.out
### output ###
# (cd _build/default && .ppx/34809d7e251114d06ac070567359e16e/ppx.exe --cookie 'library-name="guardian"' -o lib/guardian.pp.mli --intf lib/guardian.mli -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "lib/guardian.mli", line 184, characters 16-22:
# 184 |        and type effect = Effect.t
#                       ^^^^^^
# Error: Syntax error
# (cd _build/default && .ppx/34809d7e251114d06ac070567359e16e/ppx.exe --cookie 'library-name="guardian"' -o lib/guardian_entity.pp.ml --impl lib/guardian_entity.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "lib/guardian_entity.ml", line 183, characters 14-20:
# 183 |      fun ?ctx effect ->
#                     ^^^^^^
# Error: Syntax error
# (cd _build/default && .ppx/34809d7e251114d06ac070567359e16e/ppx.exe --cookie 'library-name="guardian"' -o lib/persistence.pp.ml --impl lib/persistence.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "lib/persistence.ml", line 7, characters 7-13:
# 7 |   type effect
#            ^^^^^^
# Error: Syntax error
# (cd _build/default && .ppx/34809d7e251114d06ac070567359e16e/ppx.exe --cookie 'library-name="Guardian_backend"' -o backend/mariadb_backend.pp.ml --impl backend/mariadb_backend.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "backend/mariadb_backend.ml", line 82, characters 9-15:
# 82 |     type effect = Guard.Effect.t
#               ^^^^^^
# Error: Syntax error
```
Upstream ticket: https://github.com/uzh/guardian/issues/20