### PR TITLE
ezjs_d3pie is not compatible with OCaml 5.3

### DIFF
--- a/packages/ezjs_d3pie/ezjs_d3pie.0.1/opam
+++ b/packages/ezjs_d3pie/ezjs_d3pie.0.1/opam
@@ -7,7 +7,7 @@ license: "LGPL-2.1-only"
 homepage: "https://github.com/ocamlpro/ezjs_d3pie"
 bug-reports: "https://github.com/ocamlpro/ezjs_d3pie/issues"
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.05" & < "5.3"}
   "dune" {>= "2.0"}
   "js_of_ocaml" {>= "3.6"}
   "js_of_ocaml-ppx" {>= "3.6"}


### PR DESCRIPTION
Expects the effect keyword to be a identifier
```
#=== ERROR while compiling ezjs_d3pie.0.1 =====================================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/ezjs_d3pie.0.1
# command              ~/.opam/5.3/bin/dune build -p ezjs_d3pie -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/ezjs_d3pie-13-db8bc6.env
# output-file          ~/.opam/log/ezjs_d3pie-13-db8bc6.out
### output ###
# (cd _build/default && .ppx/7b799aed44581cc79b02033532c5f775/ppx.exe --cookie 'library-name="ezjs_d3pie"' -o src/d3pie.pp.ml --impl src/d3pie.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "src/d3pie.ml", line 342, characters 23-29:
# 342 | let create_load_effect effect speed =
#                              ^^^^^^
# Error: Syntax error
# (cd _build/default && .ppx/7b799aed44581cc79b02033532c5f775/ppx.exe --cookie 'library-name="ezjs_d3pie"' -o src/d3pie_types.pp.mli --intf src/d3pie_types.mli -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# File "src/d3pie_types.mli", line 79, characters 9-15:
# 79 |   method effect : Js.js_string Js.t Js.prop
#               ^^^^^^
# Error: Syntax error
```
Upstream ticket: https://github.com/OCamlPro/ezjs_d3pie/issues/1