### PR TITLE
fix url for opam2web and pla

### DIFF
--- a/packages/opam2web/opam2web.2.0/opam
+++ b/packages/opam2web/opam2web.2.0/opam
@@ -28,7 +28,7 @@ depends: [
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/ocaml/opam2web.git"
 url {
-  src: "https://github.com/ocaml/opam2web/archive/2.0.tar.gz"
+  src: "https://github.com/ocaml-opam/opam2web/archive/refs/tags/2.0.tar.gz"
   checksum: [
     "md5=1f2aedca3e3a3ef7263a5d40733cdf23"
     "sha512=700454098409968a875eda5eac851ebfe89bbd41548df9e4c804d3a9b6f3f0d9b497fe14bbe0b36a82041f93083061a43573fbcf372c6d862eb3b783798a9bca"

--- a/packages/pla/pla.1.4/opam
+++ b/packages/pla/pla.1.4/opam
@@ -15,7 +15,7 @@ depends: [
 ]
 authors: "Leonardo Laguna Ruiz <modlfo@gmail.com>"
 url {
-  src: "https://github.com/modlfo/pla/archive/v1.4.tar.gz"
+  src: "https://github.com/modlfo/pla/archive/refs/tags/v1.4.tar.gz"
   checksum: [
     "md5=f4886e3fc2051f56f1bffe80a2687081"
     "sha512=b8b1ee2dfcc06923ed44bccbaf72e74ebd49b4c0daddb194d999bfac397b574ef65ba7493a4e53670d6c6ca9b2dd75a298d5c735689df220a7cc340c1731e1c9"


### PR DESCRIPTION
same as #26921 -- we get "multiple choices" since a branch and a tag exist with the same name.

now, we can specify a different URL and get the tarballs of the tag. that's what is done in this PR.