### PR TITLE
dune-rpc-lwt 3.0.3 has an incorrect bound on result

### DIFF
--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.0.3/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.0.3/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.0"}
   "dune-rpc" {= version}
-  "result" {>= "1.5.0"}
+  "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
   "lwt" {>= "5.3.0" & < "5.7.0"}
   "odoc" {with-doc}


### PR DESCRIPTION
Which makes it uninstallable