### PR TITLE
Update Js_of_ocaml upper bounds in preparation to release 6.0.0

### DIFF
--- a/packages/async_js/async_js.v0.15.1/opam
+++ b/packages/async_js/async_js.v0.15.1/opam
@@ -15,7 +15,7 @@ depends: [
   "async_rpc_kernel" {>= "v0.15" & < "v0.16"}
   "ppx_jane"         {>= "v0.15" & < "v0.16"}
   "dune"             {>= "2.0.0"}
-  "js_of_ocaml"      {>= "3.9.0"}
+  "js_of_ocaml"      {>= "3.9.0" & < "6.0.0"}
   "js_of_ocaml-ppx"  {>= "3.9.0"}
   "uri"              {>= "3.0.0"}
   "uri-sexp"         {>= "3.0.0"}

--- a/packages/async_js/async_js.v0.16.0/opam
+++ b/packages/async_js/async_js.v0.16.0/opam
@@ -15,7 +15,7 @@ depends: [
   "async_rpc_kernel" {>= "v0.16" & < "v0.17"}
   "ppx_jane"         {>= "v0.16" & < "v0.17"}
   "dune"             {>= "2.0.0"}
-  "js_of_ocaml"      {>= "5.1.1"}
+  "js_of_ocaml"      {>= "5.1.1" & < "6.0.0"}
   "js_of_ocaml-ppx"  {>= "5.1.1"}
   "uri"              {>= "3.0.0"}
   "uri-sexp"         {>= "3.0.0"}

--- a/packages/ezjs_extension/ezjs_extension.0.1/opam
+++ b/packages/ezjs_extension/ezjs_extension.0.1/opam
@@ -10,6 +10,7 @@ depends: [
   "dune" {>= "2.0"}
   "ezjs_min" {>= "0.2"}
 ]
+conflicts: ["js_of_ocaml" {>= "6.0.0"}]
 depopts: ["lwt"]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/jsoo_storage/jsoo_storage.1.0.1/opam
+++ b/packages/jsoo_storage/jsoo_storage.1.0.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/xvw/jsoo_storage/issues"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "js_of_ocaml" {>= "2.8.4"}
+  "js_of_ocaml" {>= "2.8.4" & < "6.0.0"}
   "js_of_ocaml-ppx"
   "lwt"
   "dune" {>= "1.11"}

--- a/packages/virtual_dom/virtual_dom.v0.15.1/opam
+++ b/packages/virtual_dom/virtual_dom.v0.15.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_jane"        {>= "v0.15" & < "v0.16"}
   "dune"            {>= "2.0.0"}
   "gen_js_api"      {>= "1.0.8"}
-  "js_of_ocaml"     {>= "3.9.0"}
+  "js_of_ocaml"     {>= "3.9.0" & < "6.0.0"}
   "js_of_ocaml-ppx" {>= "3.9.0"}
   "lambdasoup"      {>= "0.6.3"}
   "tyxml"           {>= "4.3.0"}

--- a/packages/virtual_dom/virtual_dom.v0.16.0/opam
+++ b/packages/virtual_dom/virtual_dom.v0.16.0/opam
@@ -20,7 +20,7 @@ depends: [
   "base64"              {>= "3.4.0"}
   "dune"                {>= "2.0.0"}
   "gen_js_api"          {>= "1.0.8"}
-  "js_of_ocaml"         {>= "5.1.1"}
+  "js_of_ocaml"         {>= "5.1.1" & < "6.0.0"}
   "js_of_ocaml-ppx"     {>= "5.1.1"}
   "lambdasoup"          {>= "0.6.3"}
   "tyxml"               {>= "4.3.0"}


### PR DESCRIPTION
We are making more breaking API changes (https://github.com/ocsigen/js_of_ocaml/pull/1769). Below are some errors this produces.

https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/22026917fe3999cd41b20dc51481253aab1fa1c5/variant/compilers,4.14,js_of_ocaml-compiler.6.0.0,revdeps,async_js.v0.15.1
```
# File "src/http.ml", line 142, characters 14-26:
# 142 |   Optdef.iter req##.upload (fun upload ->
#                     ^^^^^^^^^^^^
# Error: This expression has type
#          Js_of_ocaml.XmlHttpRequest.xmlHttpRequestUpload Js_of_ocaml__.Js.t =
#            Js_of_ocaml.XmlHttpRequest.xmlHttpRequestUpload Js_of_ocaml.Js.t
#        but an expression was expected of type
#          'a Optdef.t = 'a Js_of_ocaml.Js.optdef
```

https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/22026917fe3999cd41b20dc51481253aab1fa1c5/variant/compilers,4.14,js_of_ocaml-compiler.6.0.0,revdeps,ezjs_extension.0.1
```
# File "src/local/storage_local.ml", line 4, characters 25-55:
# 4 |   match Optdef.to_option Dom_html.window##.localStorage with
#                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: This expression has type
#          Ezjs_min.Dom_html.storage Js_of_ocaml__.Js.t =
#            Ezjs_min.Dom_html.storage Js_of_ocaml.Js.t
#        but an expression was expected of type
#          'a Ezjs_min.Optdef.t = 'a Js_of_ocaml.Js.optdef
```

https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/22026917fe3999cd41b20dc51481253aab1fa1c5/variant/compilers,4.14,js_of_ocaml-compiler.6.0.0,revdeps,jsoo_storage.1.0.1
```
# File "src/webStorage.ml", line 261, characters 15-77:
# 261 | module Local = Make (struct let handler = Dom_html.window##.localStorage end)
#                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Modules do not match:
#        sig val handler : Js_of_ocaml.Dom_html.storage Js_of_ocaml__.Js.t end
#      is not included in sig val handler : t Js_of_ocaml.Js.optdef end
#      Values do not match:
#        val handler : Js_of_ocaml.Dom_html.storage Js_of_ocaml__.Js.t
#      is not included in
#        val handler : t Js_of_ocaml.Js.optdef
#      The type
#        Js_of_ocaml.Dom_html.storage Js_of_ocaml__.Js.t =
#          Js_of_ocaml.Dom_html.storage Js_of_ocaml.Js.t
#      is not compatible with the type t Js_of_ocaml.Js.optdef
#      File "src/webStorage.ml", line 102, characters 21-46:
#        Expected declaration
#      File "src/webStorage.ml", line 261, characters 32-39: Actual declaration
```

https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/22026917fe3999cd41b20dc51481253aab1fa1c5/variant/compilers,4.14,js_of_ocaml-compiler.6.0.0,revdeps,virtual_dom.v0.16.0
```
# File "src/attr.ml", line 513, characters 23-37:
# 513 |         Js.Optdef.case target##.files const_ignore (fun files -> handler ev files))))
#                              ^^^^^^^^^^^^^^
# Error: This expression has type
#          Js_of_ocaml__.File.fileList Js_of_ocaml__.Js.t =
#            Js_of_ocaml__.File.fileList Js_of_ocaml.Js.t
#        but an expression was expected of type
#          'a Js_of_ocaml.Js.Optdef.t = 'a Js_of_ocaml.Js.optdef
```