### PR TITLE
release pa_ppx_regexp.0.03 (compat with new 're' bugfix release)

### DIFF
--- a/packages/pa_ppx_regexp/pa_ppx_regexp.0.03/opam
+++ b/packages/pa_ppx_regexp/pa_ppx_regexp.0.03/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml"       { >= "4.10.0" }
   "camlp5-buildscripts" { >= "0.02" }
   "camlp5"      { >= "8.01.00" }
-  "pa_ppx"      { >= "0.12" }
+  "pa_ppx"      { >= "0.15" }
   "pa_ppx_migrate"      { >= "0.10" }
   "pa_ppx_static" { >= "0.01" }
   "not-ocamlfind" { >= "0.10" }

--- a/packages/pa_ppx_regexp/pa_ppx_regexp.0.03/opam
+++ b/packages/pa_ppx_regexp/pa_ppx_regexp.0.03/opam
@@ -1,0 +1,42 @@
+
+synopsis: "A Camlp5 PPX Rewriter for Perl Regexp Workalikes "
+description:
+"""
+This is a PPX Rewriter for some workalikes to perl regexp operations,
+based on Camlp5 (so it's compatible with all the other Camlp5-based PPX rewriters).
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_regexp"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_regexp/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_regexp.git"
+doc: "https://github.com/camlp5/pa_ppx_regexp/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.01.00" }
+  "pa_ppx"      { >= "0.12" }
+  "pa_ppx_migrate"      { >= "0.10" }
+  "pa_ppx_static" { >= "0.01" }
+  "not-ocamlfind" { >= "0.10" }
+  "ounit" { >= "2.2.7" }
+  "mdx" {>= "2.3.0" & with-test}
+  "fmt"
+  "pcre"
+  "pcre2"
+  "re" { >= "1.12.0" }
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_regexp/archive/refs/tags/0.03.tar.gz"
+  checksum: [
+    "sha512=89912fcd2e383df52284db7effff58771eff1e9d152aa91447c569548cda6bfb31246e521461d4ae79d9d4b5bab017987bfa3dad56119a2acd80b3548fac97cd"
+  ]
+}

--- a/packages/pa_ppx_regexp/pa_ppx_regexp.0.03/opam
+++ b/packages/pa_ppx_regexp/pa_ppx_regexp.0.03/opam
@@ -37,6 +37,6 @@ install: [make "install"]
 url {
   src: "https://github.com/camlp5/pa_ppx_regexp/archive/refs/tags/0.03.tar.gz"
   checksum: [
-    "sha512=89912fcd2e383df52284db7effff58771eff1e9d152aa91447c569548cda6bfb31246e521461d4ae79d9d4b5bab017987bfa3dad56119a2acd80b3548fac97cd"
+    "sha512=74a3b28c5edf836fe7078504c674d2d9bc8fbb977d0f07365f8725016214b9c895e7b2171a11d937d91653616c172d763c670d0426464703878c35c7841dc7d2"
   ]
 }


### PR DESCRIPTION
re.1.12.0 fixed a bug that existed in 1.11.0; this fixes the tests so that they work with this new re.