### PR TITLE
Package ocamleditor.1.16.0-ocaml414

### DIFF
--- a/packages/ocamleditor/ocamleditor.1.16.0-ocaml414/opam
+++ b/packages/ocamleditor/ocamleditor.1.16.0-ocaml414/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+
+synopsis:
+  "OCamlEditor is a GTK+ source code editor and build tool for OCaml"
+description:
+  """It provides many features to facilitate editing code, accessing API reference
+directly from the editor and compiling projects."""
+
+authors: ["OCamlEditor developers"]
+maintainer: ["OCamlEditor developers"]
+
+license: "LGPL-3.0-only"
+homepage: "https://github.com/ocamleditor/ocamleditor"
+bug-reports: "https://github.com/ocamleditor/ocamleditor/issues"
+dev-repo: "git+https://github.com/ocamleditor/ocamleditor.git"
+
+build: [["ocaml" "build.ml" "ocamleditor"]]
+install: [["ocaml" "tools/install.ml" "-prefix" prefix]]
+
+depends: [
+  "ocaml" {>= "4.14" & < "5"}
+  "ocamlfind" {>= "1.4.0"}
+  "lablgtk" {>= "2.18.0"}
+  "ocp-indent" { >= "1.8.0" }
+  "xml-light" {>= "2.5"}
+  "yojson" {>= "2.1"}
+  "atdgen" {>= "2.12"}
+  "ocamldiff" {>= "1.2"}
+  "merlin" {>= "4.9"}
+]
+depopts: [
+  "ocurl"
+]
+url {
+  src:
+    "https://github.com/ocamleditor/ocamleditor/archive/refs/tags/1.16.0-ocaml414.tar.gz"
+  checksum: [
+    "md5=f1e6b14829fec858bc6e506f65db9981"
+    "sha512=40123f79680c62350f2b0ad69c28ce1ecb65bd31823b9fda0e55db686b9aba01834a58714faf8efe61e1f32df564473207ea187ec30a522d1d551cff807f61c9"
+  ]
+}


### PR DESCRIPTION
### `ocamleditor.1.16.0-ocaml414`
OCamlEditor is a GTK+ source code editor and build tool for OCaml
It provides many features to facilitate editing code, accessing API reference
directly from the editor and compiling projects.



---
* Homepage: https://github.com/ocamleditor/ocamleditor
* Source repo: git+https://github.com/ocamleditor/ocamleditor.git
* Bug tracker: https://github.com/ocamleditor/ocamleditor/issues

---
:camel: Pull-request generated by opam-publish v2.5.0