### PR TITLE
[new release] yocaml (12 packages) (2.1.0)

### DIFF
--- a/packages/yocaml/yocaml.2.1.0/opam
+++ b/packages/yocaml/yocaml.2.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Core engine of the YOCaml Static Site Generator"
+description: "YOCaml is a build system dedicated to generate static document"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "odoc" {with-doc}
+  "sherlodoc" {with-doc}
+  "fmt" {with-test}
+  "alcotest" {with-test & >= "1.3.0"}
+  "qcheck" {with-test}
+  "qcheck-alcotest" {with-test}
+  "ppx_expect"
+  "mdx" {with-test & = "2.5.0"}
+  "ocamlformat" {with-dev-setup}
+  "ocp-indent" {with-dev-setup}
+  "merlin" {with-dev-setup}
+  "utop" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.1.0/yocaml-2.1.0.tbz"
+  checksum: [
+    "sha256=e5ab173efd4c356dfee3e9af2165762ec4f1b5d38bdf1000d13e5eb6f18edbae"
+    "sha512=77ce2f269a6058c91ed75dee164cf9073147aa5d48c5dbdb2d6b282fc184d3a9b8155e772dd24acb8c0618ef7e47c0222bf65e13ecc3e08fab87351ea4f27192"
+  ]
+}
+x-commit-hash: "1fbb78d2b5f872909d236851e55cf9cb78310384"

--- a/packages/yocaml_cmarkit/yocaml_cmarkit.2.1.0/opam
+++ b/packages/yocaml_cmarkit/yocaml_cmarkit.2.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Yocaml plugin for using Markdown (via Cmarkit package) as a Markup language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.5.0"}
+  "yocaml" {= version}
+  "cmarkit"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.1.0/yocaml-2.1.0.tbz"
+  checksum: [
+    "sha256=e5ab173efd4c356dfee3e9af2165762ec4f1b5d38bdf1000d13e5eb6f18edbae"
+    "sha512=77ce2f269a6058c91ed75dee164cf9073147aa5d48c5dbdb2d6b282fc184d3a9b8155e772dd24acb8c0618ef7e47c0222bf65e13ecc3e08fab87351ea4f27192"
+  ]
+}
+x-commit-hash: "1fbb78d2b5f872909d236851e55cf9cb78310384"

--- a/packages/yocaml_eio/yocaml_eio.2.1.0/opam
+++ b/packages/yocaml_eio/yocaml_eio.2.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "The Eio runtime YOCaml"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.5.0"}
+  "yocaml" {= version}
+  "yocaml_runtime" {= version}
+  "eio" {= "1.1"}
+  "eio_main" {= "1.1"}
+  "cohttp-eio" {>= "6.0.0~beta2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.1.0/yocaml-2.1.0.tbz"
+  checksum: [
+    "sha256=e5ab173efd4c356dfee3e9af2165762ec4f1b5d38bdf1000d13e5eb6f18edbae"
+    "sha512=77ce2f269a6058c91ed75dee164cf9073147aa5d48c5dbdb2d6b282fc184d3a9b8155e772dd24acb8c0618ef7e47c0222bf65e13ecc3e08fab87351ea4f27192"
+  ]
+}
+x-commit-hash: "1fbb78d2b5f872909d236851e55cf9cb78310384"

--- a/packages/yocaml_git/yocaml_git.2.1.0/opam
+++ b/packages/yocaml_git/yocaml_git.2.1.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "Yocaml plugins for generating Yocaml program into a Git repository"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.5.0"}
+  "lwt" {>= "5.7.0"}
+  "mimic" {>= "0.0.9"}
+  "cstruct" {>= "6.2.0"}
+  "git-kv" {>= "0.0.5"}
+  "git-unix" {>= "3.16.1"}
+  "mirage-clock" {>= "4.2.0"}
+  "yocaml" {= version}
+  "yocaml_runtime" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.1.0/yocaml-2.1.0.tbz"
+  checksum: [
+    "sha256=e5ab173efd4c356dfee3e9af2165762ec4f1b5d38bdf1000d13e5eb6f18edbae"
+    "sha512=77ce2f269a6058c91ed75dee164cf9073147aa5d48c5dbdb2d6b282fc184d3a9b8155e772dd24acb8c0618ef7e47c0222bf65e13ecc3e08fab87351ea4f27192"
+  ]
+}
+x-commit-hash: "1fbb78d2b5f872909d236851e55cf9cb78310384"

--- a/packages/yocaml_jingoo/yocaml_jingoo.2.1.0/opam
+++ b/packages/yocaml_jingoo/yocaml_jingoo.2.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for using Jingoo as a template language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.5.0"}
+  "yocaml" {= version}
+  "jingoo" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.1.0/yocaml-2.1.0.tbz"
+  checksum: [
+    "sha256=e5ab173efd4c356dfee3e9af2165762ec4f1b5d38bdf1000d13e5eb6f18edbae"
+    "sha512=77ce2f269a6058c91ed75dee164cf9073147aa5d48c5dbdb2d6b282fc184d3a9b8155e772dd24acb8c0618ef7e47c0222bf65e13ecc3e08fab87351ea4f27192"
+  ]
+}
+x-commit-hash: "1fbb78d2b5f872909d236851e55cf9cb78310384"

--- a/packages/yocaml_mustache/yocaml_mustache.2.1.0/opam
+++ b/packages/yocaml_mustache/yocaml_mustache.2.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for using Mustache as a template language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.5.0"}
+  "yocaml" {= version}
+  "mustache" {= "3.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.1.0/yocaml-2.1.0.tbz"
+  checksum: [
+    "sha256=e5ab173efd4c356dfee3e9af2165762ec4f1b5d38bdf1000d13e5eb6f18edbae"
+    "sha512=77ce2f269a6058c91ed75dee164cf9073147aa5d48c5dbdb2d6b282fc184d3a9b8155e772dd24acb8c0618ef7e47c0222bf65e13ecc3e08fab87351ea4f27192"
+  ]
+}
+x-commit-hash: "1fbb78d2b5f872909d236851e55cf9cb78310384"

--- a/packages/yocaml_omd/yocaml_omd.2.1.0/opam
+++ b/packages/yocaml_omd/yocaml_omd.2.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Yocaml plugin for using Markdown (via OMD package) as a Markup language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.5.0"}
+  "yocaml" {= version}
+  "omd" {>= "2.0.0~alpha4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.1.0/yocaml-2.1.0.tbz"
+  checksum: [
+    "sha256=e5ab173efd4c356dfee3e9af2165762ec4f1b5d38bdf1000d13e5eb6f18edbae"
+    "sha512=77ce2f269a6058c91ed75dee164cf9073147aa5d48c5dbdb2d6b282fc184d3a9b8155e772dd24acb8c0618ef7e47c0222bf65e13ecc3e08fab87351ea4f27192"
+  ]
+}
+x-commit-hash: "1fbb78d2b5f872909d236851e55cf9cb78310384"

--- a/packages/yocaml_otoml/yocaml_otoml.2.1.0/opam
+++ b/packages/yocaml_otoml/yocaml_otoml.2.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for dealing with TOML as metadata provider"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.5.0"}
+  "yocaml" {= version}
+  "otoml" {>= "1.0.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.1.0/yocaml-2.1.0.tbz"
+  checksum: [
+    "sha256=e5ab173efd4c356dfee3e9af2165762ec4f1b5d38bdf1000d13e5eb6f18edbae"
+    "sha512=77ce2f269a6058c91ed75dee164cf9073147aa5d48c5dbdb2d6b282fc184d3a9b8155e772dd24acb8c0618ef7e47c0222bf65e13ecc3e08fab87351ea4f27192"
+  ]
+}
+x-commit-hash: "1fbb78d2b5f872909d236851e55cf9cb78310384"

--- a/packages/yocaml_runtime/yocaml_runtime.2.1.0/opam
+++ b/packages/yocaml_runtime/yocaml_runtime.2.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Tool for describing runtimes (using Logs and Digestif)"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.5.0"}
+  "yocaml" {= version}
+  "cohttp" {>= "5.3.11"}
+  "magic-mime" {>= "1.3.1"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.9.0"}
+  "digestif" {>= "1.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.1.0/yocaml-2.1.0.tbz"
+  checksum: [
+    "sha256=e5ab173efd4c356dfee3e9af2165762ec4f1b5d38bdf1000d13e5eb6f18edbae"
+    "sha512=77ce2f269a6058c91ed75dee164cf9073147aa5d48c5dbdb2d6b282fc184d3a9b8155e772dd24acb8c0618ef7e47c0222bf65e13ecc3e08fab87351ea4f27192"
+  ]
+}
+x-commit-hash: "1fbb78d2b5f872909d236851e55cf9cb78310384"

--- a/packages/yocaml_syndication/yocaml_syndication.2.1.0/opam
+++ b/packages/yocaml_syndication/yocaml_syndication.2.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for dealing with RSS and Atom feed"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "yocaml" {= version}
+  "fmt" {with-test}
+  "alcotest" {with-test & >= "1.3.0"}
+  "qcheck" {with-test}
+  "qcheck-alcotest" {with-test}
+  "ppx_expect"
+  "mdx" {with-test & = "2.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.1.0/yocaml-2.1.0.tbz"
+  checksum: [
+    "sha256=e5ab173efd4c356dfee3e9af2165762ec4f1b5d38bdf1000d13e5eb6f18edbae"
+    "sha512=77ce2f269a6058c91ed75dee164cf9073147aa5d48c5dbdb2d6b282fc184d3a9b8155e772dd24acb8c0618ef7e47c0222bf65e13ecc3e08fab87351ea4f27192"
+  ]
+}
+x-commit-hash: "1fbb78d2b5f872909d236851e55cf9cb78310384"

--- a/packages/yocaml_unix/yocaml_unix.2.1.0/opam
+++ b/packages/yocaml_unix/yocaml_unix.2.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "The Unix runtime for YOCaml"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.5.0"}
+  "httpcats" {>= "0.0.1"}
+  "yocaml" {= version}
+  "yocaml_runtime" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.1.0/yocaml-2.1.0.tbz"
+  checksum: [
+    "sha256=e5ab173efd4c356dfee3e9af2165762ec4f1b5d38bdf1000d13e5eb6f18edbae"
+    "sha512=77ce2f269a6058c91ed75dee164cf9073147aa5d48c5dbdb2d6b282fc184d3a9b8155e772dd24acb8c0618ef7e47c0222bf65e13ecc3e08fab87351ea4f27192"
+  ]
+}
+x-commit-hash: "1fbb78d2b5f872909d236851e55cf9cb78310384"

--- a/packages/yocaml_yaml/yocaml_yaml.2.1.0/opam
+++ b/packages/yocaml_yaml/yocaml_yaml.2.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for dealing with Yaml as metadata provider"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.5.0"}
+  "yocaml" {= version}
+  "yaml" {>= "3.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.1.0/yocaml-2.1.0.tbz"
+  checksum: [
+    "sha256=e5ab173efd4c356dfee3e9af2165762ec4f1b5d38bdf1000d13e5eb6f18edbae"
+    "sha512=77ce2f269a6058c91ed75dee164cf9073147aa5d48c5dbdb2d6b282fc184d3a9b8155e772dd24acb8c0618ef7e47c0222bf65e13ecc3e08fab87351ea4f27192"
+  ]
+}
+x-commit-hash: "1fbb78d2b5f872909d236851e55cf9cb78310384"


### PR DESCRIPTION
Core engine of the YOCaml Static Site Generator

- Project page: <a href="https://github.com/xhtmlboi/yocaml">https://github.com/xhtmlboi/yocaml</a>

##### CHANGES:

- Support for OCaml `5.3.0` (by [kit-ty-kate](https://github.com/kit-ty-kate))
