### PR TITLE
owl: fix availability

### DIFF
--- a/packages/owl/owl.0.10.0/opam
+++ b/packages/owl/owl.0.10.0/opam
@@ -35,6 +35,7 @@ depends: [
   "stdio" {build}
   "npy"
 ]
+available: arch = "x86_64"
 x-commit-hash: "acca58e85f1091799c67afc8c0d59a692acc187f"
 url {
   src:

--- a/packages/owl/owl.0.3.0/opam
+++ b/packages/owl/owl.0.3.0/opam
@@ -24,6 +24,7 @@ depends: [
   "conf-openblas"
   "conf-gfortran"
 ]
+available: arch = "x86_64"
 synopsis: "Scientific computing library"
 description:
   "Owl is an OCaml numerical library for scientific computing. Owl supports both dense and sparse matrices of real and complex numbers, and various maths, stats, matrix, regression, optimisation, and fft operations. Owl also includes an integrated plotting module."

--- a/packages/owl/owl.0.5.0/opam
+++ b/packages/owl/owl.0.5.0/opam
@@ -21,7 +21,7 @@ build: [
 #  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 # Tests incompatible with the opam sandbox
 ]
-available: arch != "arm32" & arch != "arm64"
+available: arch = "x86_64"
 depends: [
   "ocaml" {>= "4.06.0"}
 #  "alcotest" {with-test & < "1.0.0"}

--- a/packages/owl/owl.0.5.0/opam
+++ b/packages/owl/owl.0.5.0/opam
@@ -29,7 +29,7 @@ depends: [
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
   "ctypes" {< "0.17.0"}
-  "dune" {>= "1.2.1"}
+  "dune" {>= "2.0"}
   "dune-configurator"
   "eigen" {>= "0.1.0"}
   "owl-base" {>= "0.5.0" & < "0.6.0"}

--- a/packages/owl/owl.0.6.0/opam
+++ b/packages/owl/owl.0.6.0/opam
@@ -27,7 +27,7 @@ depends: [
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
   "ctypes" {< "0.17.0"}
-  "dune" {>= "1.2.1"}
+  "dune" {>= "2.0"}
   "dune-configurator"
   "eigen" {>= "0.1.0"}
   "owl-base" {= version}

--- a/packages/owl/owl.0.6.0/opam
+++ b/packages/owl/owl.0.6.0/opam
@@ -33,6 +33,7 @@ depends: [
   "owl-base" {= version}
   "stdio" {build}
 ]
+available: arch = "x86_64"
 url {
   src: "https://github.com/owlbarn/owl/archive/0.6.0.tar.gz"
   checksum: [

--- a/packages/owl/owl.0.7.0/opam
+++ b/packages/owl/owl.0.7.0/opam
@@ -27,7 +27,7 @@ depends: [
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
   "ctypes" {< "0.17.0"}
-  "dune" {>= "1.7.0"}
+  "dune" {>= "2.0"}
   "dune-configurator"
   "eigen" {>= "0.1.0"}
   "owl-base" {= version}

--- a/packages/owl/owl.0.7.0/opam
+++ b/packages/owl/owl.0.7.0/opam
@@ -34,6 +34,7 @@ depends: [
   "stdio" {build}
   "stdlib-shims"
 ]
+available: arch = "x86_64"
 url {
   src: "https://github.com/owlbarn/owl/releases/download/0.7.0/owl-0.7.0.tbz"
   checksum: [

--- a/packages/owl/owl.0.7.1/opam
+++ b/packages/owl/owl.0.7.1/opam
@@ -34,6 +34,7 @@ depends: [
   "stdio" {build}
   "stdlib-shims"
 ]
+available: arch = "x86_64"
 url {
   src: "https://github.com/owlbarn/owl/releases/download/0.7.1/owl-0.7.1.tbz"
   checksum: [

--- a/packages/owl/owl.0.7.1/opam
+++ b/packages/owl/owl.0.7.1/opam
@@ -27,7 +27,7 @@ depends: [
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
   "ctypes" {< "0.17.0"}
-  "dune" {>= "1.7.0"}
+  "dune" {>= "2.0"}
   "dune-configurator"
   "eigen" {>= "0.1.0"}
   "owl-base" {= version}

--- a/packages/owl/owl.0.7.2/opam
+++ b/packages/owl/owl.0.7.2/opam
@@ -28,7 +28,7 @@ depends: [
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
   "ctypes" {< "0.17.0"}
-  "dune" {>= "1.7.0"}
+  "dune" {>= "2.0"}
   "dune-configurator"
   "eigen" {>= "0.1.0"}
   "owl-base" {= version}

--- a/packages/owl/owl.0.7.2/opam
+++ b/packages/owl/owl.0.7.2/opam
@@ -35,6 +35,7 @@ depends: [
   "stdio" {build}
   "stdlib-shims"
 ]
+available: arch = "x86_64"
 url {
   src: "https://github.com/owlbarn/owl/releases/download/0.7.2/owl-0.7.2.tbz"
   checksum: [

--- a/packages/owl/owl.0.8.0/opam
+++ b/packages/owl/owl.0.8.0/opam
@@ -36,6 +36,7 @@ depends: [
   "stdlib-shims"
   "npy"
 ]
+available: arch = "x86_64"
 url {
   src: "https://github.com/owlbarn/owl/releases/download/0.8.0/owl-0.8.0.tbz"
   checksum: [

--- a/packages/owl/owl.0.9.0/opam
+++ b/packages/owl/owl.0.9.0/opam
@@ -36,7 +36,7 @@ depends: [
   "stdlib-shims"
   "npy"
 ]
-available: arch != "arm64" & arch != "arm32" & arch != "s390x"
+available: arch = "x86_64"
 url {
   src: "https://github.com/owlbarn/owl/releases/download/0.9.0/owl-0.9.0.tbz"
   checksum: [

--- a/packages/owl/owl.1.0.0/opam
+++ b/packages/owl/owl.1.0.0/opam
@@ -35,7 +35,7 @@ depends: [
   "stdio" {build}
   "npy"
 ]
-available: arch != "arm64" & arch != "arm32" & arch != "s390x"
+available: arch = "x86_64"
 x-commit-hash: "f164864baf68f94a19a09b19ed377db433d7aa2a"
 url {
   src: "https://github.com/owlbarn/owl/releases/download/1.0.0/owl-1.0.0.tbz"

--- a/packages/owl/owl.1.0.2-1/opam
+++ b/packages/owl/owl.1.0.2-1/opam
@@ -37,6 +37,7 @@ depends: [
   "stdio" {build}
   "npy"
 ]
+available: arch = "x86_64"
 x-commit-hash: "dc77f1d3b7a4b81beba5bcfc4366317e044bce6d"
 url {
   src: "https://github.com/owlbarn/owl/releases/download/1.0.2/owl-1.0.2.tbz"

--- a/packages/owl/owl.1.0.2/opam
+++ b/packages/owl/owl.1.0.2/opam
@@ -35,6 +35,7 @@ depends: [
   "stdio" {build}
   "npy"
 ]
+available: arch = "x86_64"
 x-commit-hash: "dc77f1d3b7a4b81beba5bcfc4366317e044bce6d"
 url {
   src: "https://github.com/owlbarn/owl/releases/download/1.0.2/owl-1.0.2.tbz"

--- a/packages/owl/owl.1.1/opam
+++ b/packages/owl/owl.1.1/opam
@@ -34,7 +34,7 @@ depends: [
   "stdio" {build}
   "npy"
 ]
-available: arch = "x86_32" | arch = "x86_64"
+available: arch = "x86_64"
 url {
   src: "https://github.com/owlbarn/owl/releases/download/1.1/owl-1.1.tbz"
   checksum: [


### PR DESCRIPTION
The old version was strictly x86_64. The new one with broader support is not yet released