### PR TITLE
Package cpdf.2.8

### DIFF
--- a/packages/cpdf/cpdf.2.8/opam
+++ b/packages/cpdf/cpdf.2.8/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "contact@coherentgraphics.co.uk"
+license: "AGPL-3.0-or-later"
+build: [[make]]
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "ocamlfind" {build}
+  "camlpdf" {= version}
+]
+homepage: "http://github.com/johnwhitington/cpdf-source"
+authors: ["John Whitington"]
+bug-reports: "http://github.com/johnwhitington/cpdf-source/issues"
+dev-repo: "git+https://github.com/johnwhitington/cpdf-source"
+install: [[make "install"]]
+synopsis: "PDF command line tools"
+url {
+  src:
+    "https://github.com/johnwhitington/cpdf-source/archive/refs/tags/v2.8.tar.gz"
+  checksum: [
+    "md5=d79b6abd10bd4a231f1f91cdbefb3998"
+    "sha512=0a77525252a5acb8ac4fdcbdd1620d2e14b5309235521089c7183e73e95d0efba104e5afc3dc890a73b965d7a644d190c2b611ab39aa3fde3cfdaf651980ba6b"
+  ]
+}


### PR DESCRIPTION
### `cpdf.2.8`
PDF command line tools



---
* Homepage: http://github.com/johnwhitington/cpdf-source
* Source repo: git+https://github.com/johnwhitington/cpdf-source
* Bug tracker: http://github.com/johnwhitington/cpdf-source/issues

---
:camel: Pull-request generated by opam-publish v2.4.0