### PR TITLE
[new release] dream-html (2 packages) (3.8.0)

### DIFF
--- a/packages/dream-html/dream-html.3.8.0/opam
+++ b/packages/dream-html/dream-html.3.8.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.8.0/dream-html-3.8.0.tbz"
+  checksum: [
+    "sha256=ab42048b8419afdf6d1a7b2445d388b3687e3b4049188145428ad6cda7231fe3"
+    "sha512=d24e3102765831cf4e0897793c28b26a5d8b7faf166ff8b724fb1b9dc7a32d95cac9f9d9385f19e882f6f6fd09df1922a8821e476a2971d59f933d054cf0f150"
+  ]
+}
+x-commit-hash: "6d1f63a903f284c55bbc86a44fd5c3c218ea2e3a"

--- a/packages/pure-html/pure-html.3.8.0/opam
+++ b/packages/pure-html/pure-html.3.8.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.8.0/dream-html-3.8.0.tbz"
+  checksum: [
+    "sha256=ab42048b8419afdf6d1a7b2445d388b3687e3b4049188145428ad6cda7231fe3"
+    "sha512=d24e3102765831cf4e0897793c28b26a5d8b7faf166ff8b724fb1b9dc7a32d95cac9f9d9385f19e882f6f6fd09df1922a8821e476a2971d59f933d054cf0f150"
+  ]
+}
+x-commit-hash: "6d1f63a903f284c55bbc86a44fd5c3c218ea2e3a"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

See https://github.com/yawaramin/dream-html/tags
