### PR TITLE
fix another typo: 'win32 ' will never match, but 'win32' will

### DIFF
--- a/packages/lwt/lwt.5.5.0/opam
+++ b/packages/lwt/lwt.5.5.0/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "1.8.0"}
   "dune-configurator"
   "mmap" {>= "1.1.0" & "os" != "win32"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
-  "ocaml" {(>= "4.02.0" & "os" != "win32 " | >= "4.06.0") & < "5.0"}
+  "ocaml" {(>= "4.02.0" & "os" != "win32" | >= "4.06.0") & < "5.0"}
   ("ocaml" {>= "4.08.0"} | "ocaml-syntax-shims")
   "ocplib-endian"
   "result" # result is needed as long as Lwt supports OCaml 4.02.


### PR DESCRIPTION
separated from #27101