### PR TITLE
twirp_core, smaws-lib: there's no with-dev, only with-dev-setup

### DIFF
--- a/packages/smaws-lib/smaws-lib.0.1~preview1/opam
+++ b/packages/smaws-lib/smaws-lib.0.1~preview1/opam
@@ -23,7 +23,7 @@ depends: [
   "stdio" {>= "v0.17.0"}
   "ppx_deriving" {>= "5.0"}
   "alcotest" {with-test}
-  "eio_main" {with-dev}
+  "eio_main" {with-dev-setup}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/twirp_core/twirp_core.0.1/opam
+++ b/packages/twirp_core/twirp_core.0.1/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/c-cube/ocaml-twirp/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.9"}
-  "ocaml-protoc" {>= "3.0" & with-dev}
+  "ocaml-protoc" {>= "3.0" & with-dev-setup}
   "logs"
   "pbrt" {>= "3.0"}
   "pbrt_yojson" {>= "3.0"}


### PR DESCRIPTION
/cc @c-cube for twirp_core, and @chris-armstrong for smaws-lib (who may want to push such a change to their upstream repository)

See https://opam.ocaml.org/doc/Manual.html#pkgvar-with-dev-setup for the available opam variables.