### PR TITLE
fixup pa_ppx_regexp.0.02 dependency (to avoid changed behaviour of re 0.11 -> 0.12)

### DIFF
--- a/packages/pa_ppx_regexp/pa_ppx_regexp.0.02/opam
+++ b/packages/pa_ppx_regexp/pa_ppx_regexp.0.02/opam
@@ -29,7 +29,7 @@ depends: [
   "fmt"
   "pcre"
   "pcre2"
-  "re" { >= "1.11.0" }
+  "re" { = "1.11.0" }
 ]
 build: [
   [make "sys"]


### PR DESCRIPTION
re.1.11 had a bug, so pa_ppx_regexp had test that relied on that bug's behaviour.  when re.1.12 fixed the bug, pa_ppx_regexp.0.03 updated the test. But pa_ppx_regexp.0.02 still has the old test, we need to cap the dependency on re.