### PR TITLE
pa_ppx_regexp: pin re version on tests only

### DIFF
--- a/packages/pa_ppx_regexp/pa_ppx_regexp.0.02/opam
+++ b/packages/pa_ppx_regexp/pa_ppx_regexp.0.02/opam
@@ -29,7 +29,8 @@ depends: [
   "fmt"
   "pcre"
   "pcre2"
-  "re" { = "1.11.0" }
+  "re" { >= "1.11.0" }
+  "re" { = "1.11.0" & with-test }
 ]
 build: [
   [make "sys"]


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/27119

This should pin re only on the tests, if I understood correctly the issue only concerns a test. Ping @chetmurthy 
