### PR TITLE
first release of pa_ppx_migrate_ocaml_parsetree, 0.01

### DIFF
--- a/packages/pa_ppx_migrate_ocaml_parsetree/pa_ppx_migrate_ocaml_parsetree.0.01/opam
+++ b/packages/pa_ppx_migrate_ocaml_parsetree/pa_ppx_migrate_ocaml_parsetree.0.01/opam
@@ -35,6 +35,6 @@ install: [make "install"]
 url {
   src: "https://github.com/camlp5/pa_ppx_migrate_ocaml_parsetree/archive/refs/tags/0.01.tar.gz"
   checksum: [
-    "sha512=a80f9647a9484bd09ea7d10497ac0619ac7e1a596d789a469ed6d8e8048087296feec0462b58c8539fc9824d98e196a9c25df9e3ee47f227dbe31e1898f8173b"
+    "sha512=0f9313842c6eb07ae6719f49c27858e3a2a94f8cc1dd6d00a4aec27d85b1c44c0a664a9eae511d0edd37c638754ca8a47b1ee5d2ee1cd9b2b38d0cd9e5f03381"
   ]
 }

--- a/packages/pa_ppx_migrate_ocaml_parsetree/pa_ppx_migrate_ocaml_parsetree.0.01/opam
+++ b/packages/pa_ppx_migrate_ocaml_parsetree/pa_ppx_migrate_ocaml_parsetree.0.01/opam
@@ -1,0 +1,39 @@
+
+synopsis: "Migrations from one version of the OCaml AST to another"
+description:
+"""
+This package provides migrations from one version of the OCaml AST to another,
+using Camlp5-based pa_ppx_migrate to do the actual heavy lifting.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_migrate_ocaml_parsetree"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_migrate_ocaml_parsetree/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_migrate_ocaml_parsetree.git"
+doc: "https://github.com/camlp5/pa_ppx_migrate_ocaml_parsetree/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" }
+  "cppo" { >= "1.6.9" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.03.00" }
+  "pa_ppx_migrate"      { >= "0.12" }
+  "not-ocamlfind" { >= "0.10" }
+  "ounit" { >= "2.2.7" & with-test}
+  "fmt"
+  "bos" { >= "0.2.0" }
+]
+build: [
+  [make "-j%{jobs}%" "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_migrate_ocaml_parsetree/archive/refs/tags/0.01.tar.gz"
+  checksum: [
+    "sha512=1be729af306f505295a055e86b1bdc7eed899cd4c8c9a818f710038001ce6b61f8c6d954abb88ff3f7789c688e8318cbdb4a48372c10e6adc4a285db21cbf5ce"
+  ]
+}

--- a/packages/pa_ppx_migrate_ocaml_parsetree/pa_ppx_migrate_ocaml_parsetree.0.01/opam
+++ b/packages/pa_ppx_migrate_ocaml_parsetree/pa_ppx_migrate_ocaml_parsetree.0.01/opam
@@ -34,6 +34,6 @@ install: [make "install"]
 url {
   src: "https://github.com/camlp5/pa_ppx_migrate_ocaml_parsetree/archive/refs/tags/0.01.tar.gz"
   checksum: [
-    "sha512=1be729af306f505295a055e86b1bdc7eed899cd4c8c9a818f710038001ce6b61f8c6d954abb88ff3f7789c688e8318cbdb4a48372c10e6adc4a285db21cbf5ce"
+    "sha512=195e6940df01730b8bc9df76066a5755222ad9609335f078ce04367bdc5697b30efc59daba89fabfdbc64a48a4a67c2cec19f3b5c673f0a493506cb9f8498b5c"
   ]
 }

--- a/packages/pa_ppx_migrate_ocaml_parsetree/pa_ppx_migrate_ocaml_parsetree.0.01/opam
+++ b/packages/pa_ppx_migrate_ocaml_parsetree/pa_ppx_migrate_ocaml_parsetree.0.01/opam
@@ -7,6 +7,7 @@ using Camlp5-based pa_ppx_migrate to do the actual heavy lifting.
 
 """
 opam-version: "2.0"
+x-maintenance-intent: [ "(latest)" ]
 maintainer: "Chet Murthy <chetsky@gmail.com>"
 authors: ["Chet Murthy"]
 homepage: "https://github.com/camlp5/pa_ppx_migrate_ocaml_parsetree"
@@ -34,6 +35,6 @@ install: [make "install"]
 url {
   src: "https://github.com/camlp5/pa_ppx_migrate_ocaml_parsetree/archive/refs/tags/0.01.tar.gz"
   checksum: [
-    "sha512=195e6940df01730b8bc9df76066a5755222ad9609335f078ce04367bdc5697b30efc59daba89fabfdbc64a48a4a67c2cec19f3b5c673f0a493506cb9f8498b5c"
+    "sha512=a80f9647a9484bd09ea7d10497ac0619ac7e1a596d789a469ed6d8e8048087296feec0462b58c8539fc9824d98e196a9c25df9e3ee47f227dbe31e1898f8173b"
   ]
 }


### PR DESCRIPTION
This is broken out of pa_ppx_migrate (to make that build much faster), provides migrations between ocaml 4.02.0 <-> 5.3.0 and all intermediate versions.