### PR TITLE
slack-backup: mark as deprecated

### DIFF
--- a/packages/slack-backup/slack-backup.0.1/opam
+++ b/packages/slack-backup/slack-backup.0.1/opam
@@ -48,3 +48,4 @@ extra-source "_oasis_remove_.ml" {
     "md5=6100ca146fa97d2196eb49a2631d0796"
   ]
 }
+flags: deprecated


### PR DESCRIPTION
This package doesn't build anymore and doesn't use existing slack api.