### PR TITLE
[new release] pcre (8.0.0)

### DIFF
--- a/packages/pcre/pcre.8.0.0/opam
+++ b/packages/pcre/pcre.8.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Bindings to the Perl Compatibility Regular Expressions library"
+description: """
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: ["Markus Mottl <markus.mottl@gmail.com>"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "dune-configurator"
+  "conf-libpcre" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/pcre-ocaml/releases/download/8.0.0/pcre-8.0.0.tbz"
+  checksum: [
+    "sha256=9fc0f346f1c8bb7314750fc530b7a556ac1fc08068c3c0c9743723d022f28dde"
+    "sha512=63a588e8495398f06735670fbc9fca2c3ef44cf85f5fd7c5607e201d2902587d90187a1875a197c2603036fc3bc5be2e6d56291bd54100d181ba6bcae8056564"
+  ]
+}
+x-commit-hash: "f9fdc4984439ccd73df6d77510466c88755fcfcd"


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library

- Project page: <a href="https://mmottl.github.io/pcre-ocaml">https://mmottl.github.io/pcre-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/pcre-ocaml/api">https://mmottl.github.io/pcre-ocaml/api</a>

##### CHANGES:

- Removed superfluous and buggy `subj_start` argument. This fixes a bug in
  the `full_split` function where non-capturing groups are not identified
  as such.
- Removed obsolete base-bytes dependency
