### PR TITLE
[new release] jose (0.10.0)

### DIFF
--- a/packages/jose/jose.0.10.0/opam
+++ b/packages/jose/jose.0.10.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "JOSE implementation for OCaml and ReasonML"
+description:
+  "JavaScript Object Signing and Encryption built ontop of pure OCaml libs"
+maintainer: [
+  "Ulrik Strid <ulrik.strid@outlook.com>"
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+]
+authors: ["Ulrik Strid"]
+license: "MIT"
+homepage: "https://ulrikstrid.github.io/ocaml-jose"
+doc: "https://ulrikstrid.github.io/ocaml-jose"
+bug-reports: "https://github.com/ulrikstrid/ocaml-jose/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "base64" {>= "3.3.0"}
+  "dune" {>= "2.8"}
+  "eqaf" {>= "0.7"}
+  "mirage-crypto" {>= "1.0.0"}
+  "x509" {>= "0.13.0"}
+  "astring"
+  "yojson" {>= "1.6.0"}
+  "zarith"
+  "ptime"
+  "mirage-crypto-rng" {with-test & >= "1.0.0"}
+  "digestif"
+  "containers" {with-test}
+  "bisect_ppx" {with-test}
+  "alcotest" {with-test}
+  "junit" {with-test}
+  "junit_alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ulrikstrid/ocaml-jose.git"
+url {
+  src:
+    "https://github.com/ulrikstrid/ocaml-jose/releases/download/v0.10.0/jose-0.10.0.tbz"
+  checksum: [
+    "sha256=17a39dab92574e403176a5771d0baca05fbdaefb78059cadb252a7b088c92c8f"
+    "sha512=7624892c015191226ee92d3f62361d88018477ecf625913b2367e9e86b3eb5540ce73e9bdcd36c3d2a75d6c08e81572dd79987a7ba41c9304648a6b64784a60e"
+  ]
+}
+x-commit-hash: "202920144dd6f649fc80281981c2bb5cc7cf183a"

--- a/packages/jose/jose.0.10.0/opam
+++ b/packages/jose/jose.0.10.0/opam
@@ -11,6 +11,7 @@ license: "MIT"
 homepage: "https://ulrikstrid.github.io/ocaml-jose"
 doc: "https://ulrikstrid.github.io/ocaml-jose"
 bug-reports: "https://github.com/ulrikstrid/ocaml-jose/issues"
+available: arch != "arm32"
 depends: [
   "ocaml" {>= "4.08.0"}
   "base64" {>= "3.3.0"}


### PR DESCRIPTION
JOSE implementation for OCaml and ReasonML

- Project page: <a href="https://ulrikstrid.github.io/ocaml-jose">https://ulrikstrid.github.io/ocaml-jose</a>
- Documentation: <a href="https://ulrikstrid.github.io/ocaml-jose">https://ulrikstrid.github.io/ocaml-jose</a>

##### CHANGES:

- Upgrade mirage-crypto and remove cstruct (by @anmonteiro, special thanks to @hannesm for help with debugging a unexpected test failure)
