### PR TITLE
[new release] dockerfile (3 packages) (8.2.5)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.8.2.5/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.2.5/opam
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- generation support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically.
+"""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile-cmd/"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "bos" {>= "0.2"}
+  "cmdliner"
+  "dockerfile-opam" {= version}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.2.5/dockerfile-8.2.5.tbz"
+  checksum: [
+    "sha256=4b4f450ac1332b32dc13975434592139c68f45657b6623b56cfaf1da7d714f26"
+    "sha512=cc69a3e535c304b33c9af18b50d8550160184deb0b0a81aedc16c52a148cee0a99283ec8d350286fce64c316b473693372b565c809d4c590d4f698e8e395a98d"
+  ]
+}
+x-commit-hash: "2e407583a707ae7382b4e5bb3ea5a772f4f6b04d"

--- a/packages/dockerfile-opam/dockerfile-opam.8.2.5/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.8.2.5/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution support
+for generating dockerfiles.
+"""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile-opam/"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "astring"
+  "dockerfile" {= version}
+  "fmt" {>= "0.8.7"}
+  "ocaml-version" {>= "3.5.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.2.5/dockerfile-8.2.5.tbz"
+  checksum: [
+    "sha256=4b4f450ac1332b32dc13975434592139c68f45657b6623b56cfaf1da7d714f26"
+    "sha512=cc69a3e535c304b33c9af18b50d8550160184deb0b0a81aedc16c52a148cee0a99283ec8d350286fce64c316b473693372b565c809d4c590d4f698e8e395a98d"
+  ]
+}
+x-commit-hash: "2e407583a707ae7382b4e5bb3ea5a772f4f6b04d"

--- a/packages/dockerfile/dockerfile.8.2.5/opam
+++ b/packages/dockerfile/dockerfile.8.2.5/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+"""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile/"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "fmt" {>= "0.8.7"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.2.5/dockerfile-8.2.5.tbz"
+  checksum: [
+    "sha256=4b4f450ac1332b32dc13975434592139c68f45657b6623b56cfaf1da7d714f26"
+    "sha512=cc69a3e535c304b33c9af18b50d8550160184deb0b0a81aedc16c52a148cee0a99283ec8d350286fce64c316b473693372b565c809d4c590d4f698e8e395a98d"
+  ]
+}
+x-commit-hash: "2e407583a707ae7382b4e5bb3ea5a772f4f6b04d"


### PR DESCRIPTION
Dockerfile eDSL in OCaml

- Project page: <a href="https://github.com/ocurrent/ocaml-dockerfile">https://github.com/ocurrent/ocaml-dockerfile</a>
- Documentation: <a href="https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile/">https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile/</a>

##### CHANGES:

- Add Alpine 3.21, deprecate Alpine 3.20. (@MisterDA, ocurrent/ocaml-dockerfile#225)
