### PR TITLE
dream-httpaf 1.0.0~alpha2 does not compile with OCaml 5.3:

### DIFF
--- a/packages/dream-httpaf/dream-httpaf.1.0.0~alpha2/opam
+++ b/packages/dream-httpaf/dream-httpaf.1.0.0~alpha2/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt"
   "lwt_ppx" {>= "1.2.2"}
   "lwt_ssl"
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3"}
   "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
 
   # Currently vendored.


### PR DESCRIPTION
```
File "src/vendor/h2/hpack/util/gen_huffman.ml", line 113, characters 27-70:
113 |             [ Exp.constant (Pconst_integer (string_of_int code, None))
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: This expression should not be a constructor, the expected type is
       Parsetree.constant
```

observed in https://ocaml.ci.dev/github/robur-coop/builder-web/commit/75f337b995bd470f7b557bffafb4e6e241728d2c/variant/debian-12-5.3~beta1_opam-2.3