### PR TITLE
Package why3find.1.1.0

### DIFF
--- a/packages/why3find/why3find.1.1.0/opam
+++ b/packages/why3find/why3find.1.1.0/opam
@@ -8,7 +8,7 @@ authors: [
   "Benjamin Jorge <benjamin.jorge@cea.fr>"
 ]
 license: "LGPL-2.1-only"
-tags: ["topics" "why3"]
+tags: ["why3"]
 homepage: "https://git.frama-c.com/pub/why3find"
 doc: "https://git.frama-c.com/pub/why3find"
 bug-reports: "https://git.frama-c.com/pub/why3find/issues"

--- a/packages/why3find/why3find.1.1.0/opam
+++ b/packages/why3find/why3find.1.1.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "A Why3 Package Manager"
+description:
+  "The why3find utility is designed for managing packages for why3 developpers and associated OCaml extracted code."
+maintainer: ["benjamin.jorge@cea.fr" "loic.correnson@cea.fr"]
+authors: [
+  "Loïc Correnson <loic.correnson@cea.fr>"
+  "Benjamin Jorge <benjamin.jorge@cea.fr>"
+]
+license: "LGPL-2.1-only"
+tags: ["topics" "why3"]
+homepage: "https://git.frama-c.com/pub/why3find"
+doc: "https://git.frama-c.com/pub/why3find"
+bug-reports: "https://git.frama-c.com/pub/why3find/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "dune-site" {>= "3.12"}
+  "why3" {>= "1.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "yojson" {>= "1.7.0"}
+  "zmq" {>= "5.0.0"}
+  "terminal_size" {>= "0.2.0"}
+  "alt-ergo" {with-test & = "2.4.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com:pub/why3find.git"
+url {
+  src:
+    "https://git.frama-c.com/pub/why3find/-/archive/1.1.0/why3find-1.1.0.tar.gz"
+  checksum: [
+    "md5=d0a9d93c87e9cd87a3ca9131c6d1f088"
+    "sha512=38de62fb97f4e52a1dfb7d4d8b4efad007ea04595068c5d842e11e659811ea3489497a04e627c420b41c381f8005935749b1af7575d007bdaf6ba03ed1ad7bfc"
+  ]
+}


### PR DESCRIPTION
### `why3find.1.1.0`
A Why3 Package Manager
The why3find utility is designed for managing packages for why3 developpers and associated OCaml extracted code.



---
* Homepage: https://git.frama-c.com/pub/why3find
* Source repo: git+https://git.frama-c.com:pub/why3find.git
* Bug tracker: https://git.frama-c.com/pub/why3find/issues

---
:camel: Pull-request generated by opam-publish v2.5.0