### PR TITLE
Add support for conf-mbedtls on windows

### DIFF
--- a/packages/conf-mbedtls/conf-mbedtls.2/opam
+++ b/packages/conf-mbedtls/conf-mbedtls.2/opam
@@ -4,6 +4,7 @@ maintainer: "Andy Li <andy@onthewings.net>"
 homepage: "https://www.trustedfirmware.org/projects/mbed-tls/"
 bug-reports: "https://github.com/Mbed-TLS/mbedtls/issues"
 license: "Apache-2.0"
+available: os-distribution != "cygwin"
 build: [
   ["cc" {os != "win32"} "gcc" {os = "win32"} "-I/usr/local/include" "test.c"] { os != "macos" | os-distribution != "homebrew" }
   ["sh" "-c" "cc -I\"$(brew --prefix mbedtls)/include\" test.c"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-mbedtls/conf-mbedtls.2/opam
+++ b/packages/conf-mbedtls/conf-mbedtls.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+authors: "Mbedtls contributors"
+maintainer: "Andy Li <andy@onthewings.net>"
+homepage: "https://www.trustedfirmware.org/projects/mbed-tls/"
+bug-reports: "https://github.com/Mbed-TLS/mbedtls/issues"
+license: "Apache-2.0"
+build: [
+  ["cc" {os != "win32"} "gcc" {os = "win32"} "-I/usr/local/include" "test.c"] { os != "macos" | os-distribution != "homebrew" }
+  ["sh" "-c" "cc -I\"$(brew --prefix mbedtls)/include\" test.c"] {os = "macos" & os-distribution = "homebrew"}
+]
+depends: [
+  "host-arch-x86_64" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}
+  "conf-mingw-w64-mbedtls-x86_64" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}
+]
+depexts: [
+  ["mbedtls-dev"] {os-distribution = "alpine"}
+  ["libmbedtls-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["mbedtls-devel"] {os-distribution = "fedora"}
+  ["mbedtls-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["mbedtls-devel" "epel-release"] {os-distribution = "centos"}
+  ["mbedtls"] {os-distribution = "nixos"}
+  ["mbedtls"] {os-distribution = "homebrew" & os = "macos"}
+  ["mbedtls"] {os-distribution = "arch"}
+  ["mbedtls"] {os = "freebsd"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-7"
+  "oraclelinux-8"
+  "oraclelinux-9"
+]
+synopsis: "Virtual package relying on an mbedtls system installation"
+description:
+  "This package can only install if mbedtls is installed on the system."
+flags: conf
+extra-source "test.c" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-mbedtls/test.c"
+  checksum: [
+    "sha256=7bd6968f4a0264bc191462dffc813782abc06d2cdcd050111142521a6402a5a1"
+    "md5=1cbe1f446c204d636761cb3302fb232a"
+  ]
+}

--- a/packages/conf-mingw-w64-mbedtls-x86_64/conf-mingw-w64-mbedtls-x86_64.1/opam
+++ b/packages/conf-mingw-w64-mbedtls-x86_64/conf-mingw-w64-mbedtls-x86_64.1/opam
@@ -7,7 +7,7 @@ homepage: "https://www.trustedfirmware.org/projects/mbed-tls/"
 bug-reports: "https://github.com/Mbed-TLS/mbedtls/issues"
 license: "Apache-2.0"
 flags: conf
-available: os = "win32"
+available: os = "win32" & os-distribution != "cygwin"
 build: [
   ["pkgconf" "--personality=x86_64-w64-mingw32" "mbedtls"]
 ]

--- a/packages/conf-mingw-w64-mbedtls-x86_64/conf-mingw-w64-mbedtls-x86_64.1/opam
+++ b/packages/conf-mingw-w64-mbedtls-x86_64/conf-mingw-w64-mbedtls-x86_64.1/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "Libmbedtls for x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of libmbedtls for the mingw-w64 project is available"
+maintainer: "tobil4sk"
+authors: "Mbedtls contributors"
+homepage: "https://www.trustedfirmware.org/projects/mbed-tls/"
+bug-reports: "https://github.com/Mbed-TLS/mbedtls/issues"
+license: "Apache-2.0"
+flags: conf
+available: os = "win32"
+build: [
+  ["pkgconf" "--personality=x86_64-w64-mingw32" "mbedtls"]
+]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-x86_64" {build}
+]
+depexts: [
+#   ["mingw64-x86_64-mbedtls"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-x86_64-mbedtls"] {os = "win32" & os-distribution = "msys2"}
+]


### PR DESCRIPTION
Updates conf-mbedtls with the following updates:
- Uses gcc instead of cc on windows, since there is no cc symlink
- Updated metadata
- Removed duplicate macos homebrew dependency.
- Depends on new `conf-mingw-w64-mbedtls-x86_64` package.

There is no official `mingw64-x86_64-mbedtls` package for cygwin, however, it's possible that it has been installed from source.