### PR TITLE
adapt the checksum of the ocaml 5.1 reference manual

### DIFF
--- a/packages/ocaml-manual/ocaml-manual.5.1.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.5.1.0/opam
@@ -22,5 +22,5 @@ depends: [
 ]
 url {
   src: "http://caml.inria.fr/distrib/ocaml-5.1/ocaml-5.1-refman-html.tar.gz"
-  checksum: "sha256=7fde7eea5281a649dd3abe55f2e853ebafe487f21cad6aaa8f56ae1de4808d90"
+  checksum: "sha256=ef07f27e1556ab783972fb3e06afce64a270bf24f620a258c7651febc20f5ec3"
 }


### PR DESCRIPTION
I'm not sure why the checksum changed (in december 2023) -- but since this is no code, only the reference manual, let's just use the artifact that caml.inria.fr provides.