### PR TITLE
mark compiler prereleases as deprecated

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,7 +44,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,7 +44,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha3/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,7 +44,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,7 +44,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta2/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,7 +44,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~rc1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,7 +44,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~alpha1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,7 +44,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~alpha2/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,7 +44,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~beta1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,7 +44,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,7 +44,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc2/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,7 +44,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~alpha1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -45,7 +45,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~alpha2/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -45,7 +45,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~beta1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -45,7 +45,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~rc1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -45,7 +45,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~rc2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~rc2/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -45,7 +45,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1~rc1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -45,7 +45,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha0/opam
@@ -23,7 +23,7 @@ conflicts: [
   "dune" {>= "3.4.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,7 +50,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha1/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -47,7 +47,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~beta1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +48,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~beta2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~beta2/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +48,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~rc1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +48,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +48,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha2/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +48,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~beta1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +48,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~rc1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +48,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~rc2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~rc2/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +48,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~rc3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~rc3/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +48,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1~rc1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +48,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & opam-version >= "2.0.5"}
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-base-compiler.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~alpha1/opam
@@ -56,7 +56,7 @@ depends: [
 ]
 conflicts: "system-msvc"
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
@@ -97,3 +97,4 @@ extra-source "ocaml-base-compiler.install" {
     "md5=3e969b841df1f51ca448e6e6295cb451"
   ]
 }
+available: opam-version >= "2.2.0"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta1/opam
@@ -56,7 +56,7 @@ depends: [
 ]
 conflicts: "system-msvc"
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
@@ -97,3 +97,4 @@ extra-source "ocaml-base-compiler.install" {
     "md5=3e969b841df1f51ca448e6e6295cb451"
   ]
 }
+available: opam-version >= "2.2.0"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~beta2/opam
@@ -56,7 +56,7 @@ depends: [
 ]
 conflicts: "system-msvc"
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
@@ -97,3 +97,4 @@ extra-source "ocaml-base-compiler.install" {
     "md5=3e969b841df1f51ca448e6e6295cb451"
   ]
 }
+available: opam-version >= "2.2.0"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0~rc1/opam
@@ -56,7 +56,7 @@ depends: [
 ]
 conflicts: "system-msvc"
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
@@ -97,3 +97,4 @@ extra-source "ocaml-base-compiler.install" {
     "md5=3e969b841df1f51ca448e6e6295cb451"
   ]
 }
+available: opam-version >= "2.2.0"

--- a/packages/ocaml-variants/ocaml-variants.4.02.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.0+rc1/opam
@@ -9,7 +9,6 @@ depends: [
   "base-ocamlbuild" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ url {
     "md5=a18e89606d032a6442f68fc640541ab6"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.02.2+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.2+rc1/opam
@@ -9,7 +9,6 @@ depends: [
   "base-ocamlbuild" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ url {
     "md5=5444ee57d65d457d3524d293a51f3ae8"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta1+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,7 +42,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
@@ -52,3 +52,4 @@ extra-source "fix-gcc10.patch" {
     "md5=4370afea8ee2dea768b0fcba52394a2f"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta1-no-debug/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta1-no-debug/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,7 +41,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
@@ -51,3 +51,4 @@ extra-source "fix-gcc10.patch" {
     "md5=4370afea8ee2dea768b0fcba52394a2f"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta1/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,7 +41,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
@@ -51,3 +51,4 @@ extra-source "fix-gcc10.patch" {
     "md5=4370afea8ee2dea768b0fcba52394a2f"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta2+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,7 +42,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
@@ -52,3 +52,4 @@ extra-source "fix-gcc10.patch" {
     "md5=4370afea8ee2dea768b0fcba52394a2f"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta2-no-debug/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta2-no-debug/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,7 +41,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
@@ -51,3 +51,4 @@ extra-source "fix-gcc10.patch" {
     "md5=4370afea8ee2dea768b0fcba52394a2f"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+beta2/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,7 +41,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.03.0"
@@ -51,3 +51,4 @@ extra-source "fix-gcc10.patch" {
     "md5=4370afea8ee2dea768b0fcba52394a2f"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta1+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,7 +42,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
@@ -52,3 +52,4 @@ extra-source "fix-gcc10.patch" {
     "md5=8b0606a5733be21ee8ae2a19ce67059e"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta1/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,7 +41,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
@@ -51,3 +51,4 @@ extra-source "fix-gcc10.patch" {
     "md5=8b0606a5733be21ee8ae2a19ce67059e"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta2+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,7 +42,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
@@ -52,3 +52,4 @@ extra-source "fix-gcc10.patch" {
     "md5=8b0606a5733be21ee8ae2a19ce67059e"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+beta2/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,7 +41,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.04.0"
@@ -51,3 +51,4 @@ extra-source "fix-gcc10.patch" {
     "md5=8b0606a5733be21ee8ae2a19ce67059e"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta1+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,7 +42,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
@@ -52,3 +52,4 @@ extra-source "fix-gcc10.patch" {
     "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta1/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,7 +41,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
@@ -51,3 +51,4 @@ extra-source "fix-gcc10.patch" {
     "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta2+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,7 +42,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
@@ -52,3 +52,4 @@ extra-source "fix-gcc10.patch" {
     "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta2/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,7 +41,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
@@ -51,3 +51,4 @@ extra-source "fix-gcc10.patch" {
     "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+beta3/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,7 +41,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.05.0"
@@ -51,3 +51,4 @@ extra-source "fix-gcc10.patch" {
     "md5=3791e3c17d11ec0f246fc6c5c5e5e2f3"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+rc1+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ url {
     "md5=83868514b06c3583cfe33f8ca4e8eb89"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+rc1/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -41,4 +40,6 @@ url {
     "md5=83868514b06c3583cfe33f8ca4e8eb89"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+afl/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,7 +41,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
@@ -51,3 +51,4 @@ extra-source "fix-gcc10.patch" {
     "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+default-unsafe-string/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +47,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
@@ -57,3 +57,4 @@ extra-source "fix-gcc10.patch" {
     "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,7 +42,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
@@ -52,3 +52,4 @@ extra-source "fix-gcc10.patch" {
     "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+force-safe-string/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ url {
     "md5=150d27e8c053e1f2794be668895fcf1f"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,7 +49,7 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
@@ -59,3 +58,4 @@ extra-source "fix-gcc10.patch" {
     "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1+fp/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +47,7 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
@@ -57,3 +56,4 @@ extra-source "fix-gcc10.patch" {
     "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta1/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,7 +41,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
@@ -51,3 +51,4 @@ extra-source "fix-gcc10.patch" {
     "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+afl/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,7 +41,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
@@ -51,3 +51,4 @@ extra-source "fix-gcc10.patch" {
     "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+default-unsafe-string/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +47,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
@@ -57,3 +57,4 @@ extra-source "fix-gcc10.patch" {
     "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,7 +42,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
@@ -52,3 +52,4 @@ extra-source "fix-gcc10.patch" {
     "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+force-safe-string/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ url {
     "md5=d3beca2a7d12c42c6b2585557ba59c4a"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,7 +49,7 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
@@ -59,3 +58,4 @@ extra-source "fix-gcc10.patch" {
     "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2+fp/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +47,7 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
@@ -57,3 +56,4 @@ extra-source "fix-gcc10.patch" {
     "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+beta2/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,7 +41,8 @@ url {
   ]
 }
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.06.0"
@@ -51,3 +51,4 @@ extra-source "fix-gcc10.patch" {
     "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+afl/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -41,4 +40,6 @@ url {
     "md5=4789f3147cbe82656459fea0f1b0b1a9"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+default-unsafe-string/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,4 +47,6 @@ url {
     "md5=4789f3147cbe82656459fea0f1b0b1a9"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ url {
     "md5=4789f3147cbe82656459fea0f1b0b1a9"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+force-safe-string/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ url {
     "md5=4789f3147cbe82656459fea0f1b0b1a9"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+fp+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -49,4 +48,5 @@ url {
     "md5=4789f3147cbe82656459fea0f1b0b1a9"
   ]
 }
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1+fp/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -47,4 +46,5 @@ url {
     "md5=4789f3147cbe82656459fea0f1b0b1a9"
   ]
 }
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+rc1/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -41,4 +40,6 @@ url {
     "md5=4789f3147cbe82656459fea0f1b0b1a9"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+afl/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -41,4 +40,6 @@ url {
     "md5=7a8d77a43528224fa589e962604bd184"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+default-unsafe-string/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,4 +47,6 @@ url {
     "md5=7a8d77a43528224fa589e962604bd184"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ url {
     "md5=7a8d77a43528224fa589e962604bd184"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+force-safe-string/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ url {
     "md5=7a8d77a43528224fa589e962604bd184"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+fp+flambda/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,5 @@ url {
     "md5=7a8d77a43528224fa589e962604bd184"
   ]
 }
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1+fp/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -47,4 +46,5 @@ url {
     "md5=7a8d77a43528224fa589e962604bd184"
   ]
 }
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc1/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -41,4 +40,6 @@ url {
     "md5=7a8d77a43528224fa589e962604bd184"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+afl/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ url {
     "md5=8befb315cd6d4dbfad130061b5a34a66"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+default-unsafe-string/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,4 +47,6 @@ url {
     "md5=8befb315cd6d4dbfad130061b5a34a66"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ url {
     "md5=8befb315cd6d4dbfad130061b5a34a66"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+force-safe-string/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ url {
     "md5=8befb315cd6d4dbfad130061b5a34a66"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+fp+flambda/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,5 @@ url {
     "md5=8befb315cd6d4dbfad130061b5a34a66"
   ]
 }
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2+fp/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -47,4 +46,5 @@ url {
     "md5=8befb315cd6d4dbfad130061b5a34a66"
   ]
 }
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rc2/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -41,4 +40,6 @@ url {
     "md5=8befb315cd6d4dbfad130061b5a34a66"
   ]
 }
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+afl/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -51,7 +50,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
@@ -60,3 +60,4 @@ extra-source "fix-gcc10.patch" {
     "md5=b054fa6b6651763edc8e16b6bc4c58f6"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+default-unsafe-string/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -57,7 +56,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
@@ -66,3 +66,4 @@ extra-source "fix-gcc10.patch" {
     "md5=b054fa6b6651763edc8e16b6bc4c58f6"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -52,7 +51,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
@@ -61,3 +61,4 @@ extra-source "fix-gcc10.patch" {
     "md5=b054fa6b6651763edc8e16b6bc4c58f6"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+force-safe-string/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -51,4 +50,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -59,7 +58,7 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
@@ -68,3 +67,4 @@ extra-source "fix-gcc10.patch" {
     "md5=b054fa6b6651763edc8e16b6bc4c58f6"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2+fp/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -57,7 +56,7 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
@@ -66,3 +65,4 @@ extra-source "fix-gcc10.patch" {
     "md5=b054fa6b6651763edc8e16b6bc4c58f6"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+beta2/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -51,7 +50,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.0"
@@ -60,3 +60,4 @@ extra-source "fix-gcc10.patch" {
     "md5=b054fa6b6651763edc8e16b6bc4c58f6"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+afl/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+default-unsafe-string/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -57,4 +56,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -51,4 +50,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+force-safe-string/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -52,4 +51,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp+flambda/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -59,4 +58,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1+fp/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -56,4 +55,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc1/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+afl/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+default-unsafe-string/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -57,4 +56,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -51,4 +50,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+force-safe-string/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -52,4 +51,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp+flambda/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -59,4 +58,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2+fp/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -56,4 +55,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+rc2/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+32bit/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -70,7 +69,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
@@ -79,3 +79,4 @@ extra-source "fix-gcc10.patch" {
     "md5=7f467849e5a4714f49a11517b187184f"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+afl/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -51,7 +50,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
@@ -60,3 +60,4 @@ extra-source "fix-gcc10.patch" {
     "md5=7f467849e5a4714f49a11517b187184f"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+default-unsafe-string/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -58,7 +57,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
@@ -67,3 +67,4 @@ extra-source "fix-gcc10.patch" {
     "md5=7f467849e5a4714f49a11517b187184f"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda+no-flat-float-array/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -60,7 +59,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
@@ -69,3 +69,4 @@ extra-source "fix-gcc10.patch" {
     "md5=7f467849e5a4714f49a11517b187184f"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+flambda/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -52,7 +51,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
@@ -61,3 +61,4 @@ extra-source "fix-gcc10.patch" {
     "md5=7f467849e5a4714f49a11517b187184f"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+force-safe-string/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -53,7 +52,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
@@ -62,3 +62,4 @@ extra-source "fix-gcc10.patch" {
     "md5=7f467849e5a4714f49a11517b187184f"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp+flambda/opam
@@ -9,7 +9,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -60,7 +59,7 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
@@ -69,3 +68,4 @@ extra-source "fix-gcc10.patch" {
     "md5=7f467849e5a4714f49a11517b187184f"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1+fp/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -57,7 +56,7 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
@@ -66,3 +65,4 @@ extra-source "fix-gcc10.patch" {
     "md5=7f467849e5a4714f49a11517b187184f"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+rc1/opam
@@ -8,7 +8,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -51,7 +50,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.07.1"
@@ -60,3 +60,4 @@ extra-source "fix-gcc10.patch" {
     "md5=7f467849e5a4714f49a11517b187184f"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -46,7 +45,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -55,3 +55,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,7 +49,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -59,3 +59,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -45,7 +44,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -54,3 +54,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,7 +49,7 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -59,3 +58,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +47,7 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -57,3 +56,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -44,7 +43,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -53,3 +53,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+afl/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -46,7 +45,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -55,3 +55,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+default-unsafe-string/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,7 +49,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -59,3 +59,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+flambda/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -45,7 +44,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -54,3 +54,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp+flambda/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,7 +49,7 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -59,3 +58,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2+fp/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +47,7 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -57,3 +56,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta2/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -44,7 +43,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -53,3 +53,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+afl/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -44,7 +43,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -53,3 +53,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+default-unsafe-string/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,7 +49,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -59,3 +59,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+flambda/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -45,7 +44,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -54,3 +54,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp+flambda/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,7 +49,7 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -59,3 +58,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3+fp/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,7 +47,7 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -57,3 +56,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta3/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -44,7 +43,8 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch"]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
 extra-source "fix-gcc10.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/fix-gcc10.patch.4.08.0"
@@ -53,3 +53,4 @@ extra-source "fix-gcc10.patch" {
     "md5=f406119ae0091835cdf158d7d0ff53f7"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+afl/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -45,4 +44,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+default-unsafe-string/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -49,4 +48,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+flambda/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -44,4 +43,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp+flambda/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -49,4 +48,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1+fp/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -47,4 +46,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc1/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -43,4 +42,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -49,4 +48,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+default-unsafe-string/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -53,4 +52,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -48,4 +47,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -53,4 +52,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -51,4 +50,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+rc2/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -47,4 +46,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+no-flat-float-array/opam
@@ -16,7 +16,6 @@ depends: [
   "base-threads" {post}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--disable-flat-float-array"]
@@ -49,7 +48,7 @@ post-messages: [
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
-available: !(os = "macos" & arch = "arm64")
+available: opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
@@ -63,3 +62,4 @@ extra-source "fix-gcc10.patch" {
     "md5=17ecd696a8f5647a4c543280599f6974"
   ]
 }
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" ]
@@ -48,4 +47,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+default-unsafe-string/opam
@@ -17,7 +17,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "DEFAULT_STRING=unsafe"]
@@ -49,4 +48,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -48,4 +47,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+force-safe-string/opam
@@ -17,7 +17,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-force-safe-string"]
@@ -49,4 +48,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -53,4 +52,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -51,4 +50,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc1/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -47,4 +46,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" ]
@@ -48,4 +47,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+default-unsafe-string/opam
@@ -17,7 +17,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "DEFAULT_STRING=unsafe"]
@@ -49,4 +48,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -48,4 +47,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+force-safe-string/opam
@@ -17,7 +17,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-force-safe-string"]
@@ -49,4 +48,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -53,4 +52,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -51,4 +50,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc2/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -47,4 +46,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" ]
@@ -48,4 +47,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+default-unsafe-string/opam
@@ -17,7 +17,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "DEFAULT_STRING=unsafe"]
@@ -49,4 +48,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -48,4 +47,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+force-safe-string/opam
@@ -17,7 +17,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-force-safe-string"]
@@ -49,4 +48,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -53,4 +52,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -51,4 +50,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+rc3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+rc3/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -47,4 +46,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -49,4 +48,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+default-unsafe-string/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -53,4 +52,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -48,4 +47,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -53,4 +52,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -51,4 +50,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta1/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -47,4 +46,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -46,4 +45,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+default-unsafe-string/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -45,4 +44,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,4 +47,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+beta2/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -44,4 +43,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -46,4 +45,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -45,4 +44,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,4 +47,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta1/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -44,4 +43,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -46,4 +45,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -45,4 +44,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,4 +47,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+beta2/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -44,4 +43,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -46,4 +45,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -45,4 +44,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,4 +47,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc1/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -44,4 +43,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -46,4 +45,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -45,4 +44,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,4 +47,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+rc2/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -44,4 +43,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,4 +42,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,4 +43,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,4 +42,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+rc1/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -46,4 +45,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -45,4 +44,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,4 +47,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha1/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -44,4 +43,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -46,4 +45,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -45,4 +44,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,4 +47,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha2/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -44,4 +43,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -46,4 +45,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -45,4 +44,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,4 +47,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+alpha3/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -44,4 +43,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -46,4 +45,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -45,4 +44,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,4 +47,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta1/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -44,4 +43,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
@@ -46,4 +45,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
@@ -45,4 +44,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -50,4 +49,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -48,4 +47,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta2/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
@@ -44,4 +43,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,4 +43,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,4 +42,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,4 +43,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,4 +42,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+beta3/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+beta3/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,4 +43,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,4 +42,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,4 +43,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,4 +42,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc1/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+afl/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,4 +43,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,4 +42,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+fp+flambda/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -44,4 +43,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2+fp/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -43,4 +42,5 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: os = "linux" & arch = "x86_64"
+available: opam-version >= "2.2.0" & os = "linux" & arch = "x86_64"
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+rc2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+rc2/opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml-beta"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -42,4 +41,6 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-available: !(os = "macos" & arch = "arm64" | os = "win32")
+available:
+  opam-version >= "2.2.0" & !(os = "macos" & arch = "arm64" | os = "win32")
+flags: [compiler deprecated]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha1+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -76,7 +76,7 @@ depopts: [
   "ocaml-option-static"
   "ocaml-option-nnp"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -76,7 +76,7 @@ depopts: [
   "ocaml-option-static"
   "ocaml-option-nnp"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -76,7 +76,7 @@ depopts: [
   "ocaml-option-static"
   "ocaml-option-nnp"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -78,7 +78,7 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -78,7 +78,7 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~rc1+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -78,7 +78,7 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~alpha1+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -78,7 +78,7 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~alpha2+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -78,7 +78,7 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~beta1+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -78,7 +78,7 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~rc1+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -78,7 +78,7 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~rc2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~rc2+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -78,7 +78,7 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~alpha1+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -79,7 +79,7 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~alpha2+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -79,7 +79,7 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~beta1+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -79,7 +79,7 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~rc1+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -79,7 +79,7 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~rc2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~rc2+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -79,7 +79,7 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.4.14.1~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1~rc1+options/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [
@@ -79,7 +79,7 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~alpha0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~alpha0+options/opam
@@ -24,7 +24,7 @@ conflicts: [
   "ocaml-option-fp"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -89,7 +89,7 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~alpha1+options/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -86,7 +86,7 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~beta1+options/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -86,7 +86,7 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~beta2+options/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -86,7 +86,7 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~rc1+options/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -86,7 +86,7 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~alpha1+options/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -86,7 +86,7 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -86,7 +86,7 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~beta1+options/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -86,7 +86,7 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~rc1+options/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -86,7 +86,7 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~rc2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~rc2+options/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -78,7 +78,7 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~rc3+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~rc3+options/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -78,7 +78,7 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~rc3+tsan/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~rc3+tsan/opam
@@ -20,7 +20,7 @@ depends: [
   "conf-unwind"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -85,7 +85,7 @@ extra-source "check-tsan-distinguish-volatile.patch" {
   src: "https://github.com/ocaml-multicore/ocaml-tsan/commit/abb8fdb186773b2fc6e4e41b122d1df4c29b058c.patch?full_index=1"
   checksum: "sha256=efa4449d37c3843c488caffcd06f5ebd2a7569e06f9cf98f79458506c549bd2c"
 }
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.5.1.1~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1~rc1+options/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build-env: [
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
@@ -78,7 +78,7 @@ depopts: [
   "ocaml-option-address-sanitizer"
   "ocaml-option-static"
 ]
-available: os != "win32"
+available: opam-version >= "2.2.0" & os != "win32"
 extra-source "ocaml-variants.install" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-variants/ocaml-variants.install"

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~alpha1+options/opam
@@ -62,7 +62,7 @@ depends: [
   "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
@@ -135,3 +135,4 @@ extra-source "ocaml-variants.install" {
     "md5=3e969b841df1f51ca448e6e6295cb451"
   ]
 }
+available: opam-version >= "2.2.0"

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~beta1+options/opam
@@ -62,7 +62,7 @@ depends: [
   "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
@@ -135,3 +135,4 @@ extra-source "ocaml-variants.install" {
     "md5=3e969b841df1f51ca448e6e6295cb451"
   ]
 }
+available: opam-version >= "2.2.0"

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~beta2+options/opam
@@ -62,7 +62,7 @@ depends: [
   "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
@@ -135,3 +135,4 @@ extra-source "ocaml-variants.install" {
     "md5=3e969b841df1f51ca448e6e6295cb451"
   ]
 }
+available: opam-version >= "2.2.0"

--- a/packages/ocaml-variants/ocaml-variants.5.2.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0~rc1+options/opam
@@ -62,7 +62,7 @@ depends: [
   "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version ]
+flags: [ compiler deprecated ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
@@ -135,3 +135,4 @@ extra-source "ocaml-variants.install" {
     "md5=3e969b841df1f51ca448e6e6295cb451"
   ]
 }
+available: opam-version >= "2.2.0"


### PR DESCRIPTION
alpha/beta/rc of compiler releases are deprecated now

as discussed earlier today with @Octachron 