### PR TITLE
[new release] pcre (8.0.1)

### DIFF
--- a/packages/pcre/pcre.8.0.1/opam
+++ b/packages/pcre/pcre.8.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Bindings to the Perl Compatibility Regular Expressions library"
+description: """
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: ["Markus Mottl <markus.mottl@gmail.com>"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "dune-configurator"
+  "conf-libpcre" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/pcre-ocaml/releases/download/8.0.1/pcre-8.0.1.tbz"
+  checksum: [
+    "sha256=b38b7e44fd4ed1489c6bc36faefdc545122427336bd205b0332982e12e6532e5"
+    "sha512=b789e0a7e80b34ba07ce55adb9a2153555f56c3820cd068a7de76ec16644207e83ea5d12c18b441d13047828279e4e526f2c45c37be951c9733fea40579f48e5"
+  ]
+}
+x-commit-hash: "cd70e1b406b59c2c9c65fe0132b53152a3f998cf"


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library

- Project page: <a href="https://mmottl.github.io/pcre-ocaml">https://mmottl.github.io/pcre-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/pcre-ocaml/api">https://mmottl.github.io/pcre-ocaml/api</a>

##### CHANGES:

- Fixed a bug in the `full_split` function where non-capturing groups were
  not identified as such.
- Removed obsolete base-bytes dependency
