### PR TITLE
[new release] git-kv (0.1.2)

### DIFF
--- a/packages/git-kv/git-kv.0.1.0/opam
+++ b/packages/git-kv/git-kv.0.1.0/opam
@@ -28,7 +28,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test} # disabled due to sandbox issues (opens a TCP socket)
 ]
 url {
   src:

--- a/packages/git-kv/git-kv.0.1.1/opam
+++ b/packages/git-kv/git-kv.0.1.1/opam
@@ -28,7 +28,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test} # disabled due to sandbox issues (opens a TCP socket)
 ]
 url {
   src:

--- a/packages/git-kv/git-kv.0.1.2/opam
+++ b/packages/git-kv/git-kv.0.1.2/opam
@@ -28,7 +28,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test} # disabled due to sandbox issues (opens a TCP socket)
 ]
 x-maintenance-intent: [ "(latest)" ]
 url {

--- a/packages/git-kv/git-kv.0.1.2/opam
+++ b/packages/git-kv/git-kv.0.1.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Robur Team <team@robur.coop>"
+authors: [ "Robur Team <team@robur.coop>" ]
+license: "MIT"
+homepage: "https://github.com/robur-coop/git-kv"
+dev-repo: "git+https://github.com/robur-coop/git-kv.git"
+bug-reports: "https://github.com/robur-coop/git-kv/issues"
+synopsis: "A Mirage_kv implementation using git"
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.9.0"}
+  "git"               {>= "3.10.0"}
+  "mirage-kv"         {>= "6.0.0"}
+  "carton"            {>= "0.7.0"}
+  "carton-lwt"        {>= "0.7.0"}
+  "fmt"               {>= "0.8.7"}
+  "mirage-clock"      {>= "2.0.0"}
+  "ptime"
+  "hxd"               {with-test}
+  "conf-git"          {with-test}
+  "mirage-clock-unix" {with-test}
+  "git-unix"          {>= "3.10.0" & with-test}
+  "alcotest"          {>= "1.8.0" & with-test}
+  "bos"               {>= "0.2.1" & with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/git-kv/releases/download/v0.1.2/git-kv-0.1.2.tbz"
+  checksum: [
+    "sha256=45ee4a462a96c26c06fcf2df2490a3785a14ad5d26a9816f4adf18f80418c8c1"
+    "sha512=28d8fd173a248490d55ad46686853f67b8525ef2d654a25a21509eef19ccc8a50a076a2519894c38aa8b13d805a7fa84f3e291da7f5626e4eb2d0e1af03a0a66"
+  ]
+}
+x-commit-hash: "75e609ed054df28697990b68797136e57ab8e60f"


### PR DESCRIPTION
A Mirage_kv implementation using git

- Project page: <a href="https://github.com/robur-coop/git-kv">https://github.com/robur-coop/git-kv</a>

##### CHANGES:

- example app/mgit.exe: initialize the RNG and add an mtime repl command (!9 - @reynir, review by @hannesm)
- **BUG FIX**: make `last_modified` return the commit date when on a clean commit.
  This restores the behavior before v0.1.0 (!10 - @reynir, review by @hannesm, @dinosaure)
