### PR TITLE
melange is not compatible with OCaml 5.3

### DIFF
--- a/packages/melange/melange.4.0.0-52/opam
+++ b/packages/melange/melange.4.0.0-52/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/melange-re/melange"
 bug-reports: "https://github.com/melange-re/melange/issues"
 depends: [
   "dune" {>= "3.16"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "5.2" & < "5.3"}
   "cmdliner" {>= "1.1.0"}
   "dune-build-info"
   "cppo" {build}

--- a/packages/melange/melange.4.0.1-52/opam
+++ b/packages/melange/melange.4.0.1-52/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/melange-re/melange"
 bug-reports: "https://github.com/melange-re/melange/issues"
 depends: [
   "dune" {>= "3.13"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "5.2" & < "5.3"}
   "cmdliner" {>= "1.1.0"}
   "dune-build-info"
   "cppo" {build}


### PR DESCRIPTION
Per the package's version suffix (`-52`) these versions of melange only support OCaml 5.2