### PR TITLE
Package SZXX.4.2.0

### DIFF
--- a/packages/SZXX/SZXX.4.2.0/opam
+++ b/packages/SZXX/SZXX.4.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Asemio"
+authors: [
+  "Simon Grondin"
+]
+synopsis: "Streaming ZIP XML XLSX parser"
+description: """
+SZXX is a streaming and efficient XLSX, ZIP and XML parser built from the ground up for low and constant memory usage (<10Mb).
+SZXX is able to output XLSX rows while reading from a network socket without buffering any part of the file.
+It can also stream data (including network sockets) out of ZIP and XML files without buffering.
+"""
+license: "MIT"
+tags: ["XLSX" "Excel" "ZIP" "XML" "spreadsheet" "Stream" "Streaming"]
+homepage: "https://github.com/asemio/SZXX"
+dev-repo: "git://github.com/asemio/SZXX"
+doc: "https://github.com/asemio/SZXX"
+bug-reports: "https://github.com/asemio/SZXX/issues"
+depends: [
+  "ocaml" { >= "5.0.0" }
+  "dune" { >= "1.9.0" }
+
+  "angstrom" { >= "0.15.0" }
+  "base" { >= "v0.16.0" }
+  "ppx_sexp_conv" { >= "v0.16.0" }
+  "ppx_compare" { >= "v0.16.0" }
+  "ppx_custom_printf" { >= "v0.16.0" }
+  "decompress" { >= "1.4.1" }
+  "eio_main" { >= "0.12" }
+  "ptime" { >= "0.8.6" }
+
+  "alcotest" { with-test }
+  "yojson" { with-test }
+  "ppx_deriving_yojson" { >= "3.5.2" & with-test }
+  # "ocamlformat" { = "0.25.1" } # Development
+  # "ocaml-lsp-server" # Development
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/asemio/SZXX/archive/refs/tags/4.2.0.tar.gz"
+  checksum: [
+    "md5=032a69c6042b8dd4f3172a8ec6706a7b"
+    "sha512=69d96262b730ce8ec5f7dc2415ed5c86d6c1cb08cf3f8f0a2c97cbbc90663ae37c8c5eeae9610a269ad9ec5362c59278dab9d5632f11f91e6a0fffaf2e6f344e"
+  ]
+}


### PR DESCRIPTION
### `SZXX.4.2.0`
Streaming ZIP XML XLSX parser
SZXX is a streaming and efficient XLSX, ZIP and XML parser built from the ground up for low and constant memory usage (<10Mb).
SZXX is able to output XLSX rows while reading from a network socket without buffering any part of the file.
It can also stream data (including network sockets) out of ZIP and XML files without buffering.



---
* Homepage: https://github.com/asemio/SZXX
* Source repo: git://github.com/asemio/SZXX
* Bug tracker: https://github.com/asemio/SZXX/issues

---
:camel: Pull-request generated by opam-publish v2.5.0