### PR TITLE
conf-perl: add OS dep for cygwin

### DIFF
--- a/packages/conf-perl/conf-perl.2/opam
+++ b/packages/conf-perl/conf-perl.2/opam
@@ -15,6 +15,7 @@ depexts: [
   ["perl-Pod-Html"] {os-distribution = "centos" & os-version >= "8"}
   ["perl5"] {os-distribution = "macports" & os = "macos"}
   ["perl5"] {os = "freebsd"}
+  ["perl"] {os-distribution = "cygwin"}
 ]
 synopsis: "Virtual package relying on perl"
 description:


### PR DESCRIPTION
Previously on windows the package would fail with
```
#=== ERROR while compiling conf-perl.2 ========================================#
"perl": command not found.


<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
┌─ The following actions failed
│ λ build conf-perl 2
└─
╶─ No changes have been performed
```
but after this tweak it installs as I expect:
```
> opam pin add conf-perl .
[NOTE] Package conf-perl is already pinned to
       file://C:/Users/dave/github.com/djs55/opam-repository/packages/conf-perl/conf-perl.2 (version 2).
[conf-perl.2] synchronised (file://C:/Users/dave/github.com/djs55/opam-repository/packages/conf-perl/conf-perl.2)
conf-perl is now pinned to file://C:/Users/dave/github.com/djs55/opam-repository/packages/conf-perl/conf-perl.2 (version
 2)

The following actions will be performed:
=== install 1 package
  ∗ conf-perl 2 (pinned)

Proceed with ∗ 1 installation? [y/n] y

The following system packages will first need to be installed:
    perl

<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><>  🐫

+ C:\Users\dave\AppData\Local\opam\.cygwin\setup-x86_64.exe "--root" "C:\\Users\\dave\\AppData\\Local\\opam\\.cygwin\\root" "--quiet-mode" "noinput" "--no-shortcuts" "--no-startmenu" "--no-desktop" "--no-admin" "--no-version-check" "--no-write-registry" "--packages" "perl" "--upgrade-also" "--only-site" "--site" "https://cygwin.mirror.constant.com/" "--local-package-dir" "C:\\Users\\dave\\AppData\\Local\\opam\\.cygwin\\cache"
- Starting cygwin install, version 2.932
- User has NO backup/restore rights
- User has NO symlink creation right
- Current Directory: C:\Users\dave\AppData\Local\opam\.cygwin\cache
- root: C:\Users\dave\AppData\Local\opam\.cygwin\root user
- Changing gid back to original
- Selected local directory: C:\Users\dave\AppData\Local\opam\.cygwin\cache
- net: Preconfig
- site: https://cygwin.mirror.constant.com/
- solving: 1 tasks, update: yes, use test packages: no
- solving: 5 tasks, update: no, use test packages: no
- Augmented Transaction List:
-    0 install libdb18.1       18.1.40-1
-    1 install libgdbm_compat4 1.18.1-1
-    2 install perl_base       5.40.0-1
-    3 install perl_autorebase 5.40.0-1
-    4 install perl            5.40.0-1
- Downloaded C:\Users\dave\AppData\Local\opam\.cygwin\cache/https%3a%2f%2fcygwin.mirror.constant.com%2f/x86_64/release/db/libdb18.1/libdb18.1-18.1.40-1.tar.xz
- Downloaded C:\Users\dave\AppData\Local\opam\.cygwin\cache/https%3a%2f%2fcygwin.mirror.constant.com%2f/x86_64/release/gdbm/libgdbm_compat4/libgdbm_compat4-1.18.1-1.tar.xz
- Downloaded C:\Users\dave\AppData\Local\opam\.cygwin\cache/https%3a%2f%2fcygwin.mirror.constant.com%2f/x86_64/release/perl/perl_base/perl_base-5.40.0-1.tar.zst
- Downloaded C:\Users\dave\AppData\Local\opam\.cygwin\cache/https%3a%2f%2fcygwin.mirror.constant.com%2f/x86_64/release/perl/perl_autorebase/perl_autorebase-5.40.0-1.tar.zst
- Downloaded C:\Users\dave\AppData\Local\opam\.cygwin\cache/https%3a%2f%2fcygwin.mirror.constant.com%2f/x86_64/release/perl/perl-5.40.0-1.tar.zst
- Extracting from file://C:\Users\dave\AppData\Local\opam\.cygwin\cache/https%3a%2f%2fcygwin.mirror.constant.com%2f/x86_64/release/db/libdb18.1/libdb18.1-18.1.40-1.tar.xz
- Extracting from file://C:\Users\dave\AppData\Local\opam\.cygwin\cache/https%3a%2f%2fcygwin.mirror.constant.com%2f/x86_64/release/gdbm/libgdbm_compat4/libgdbm_compat4-1.18.1-1.tar.xz
- Extracting from file://C:\Users\dave\AppData\Local\opam\.cygwin\cache/https%3a%2f%2fcygwin.mirror.constant.com%2f/x86_64/release/perl/perl_base/perl_base-5.40.0-1.tar.zst
- Extracting from file://C:\Users\dave\AppData\Local\opam\.cygwin\cache/https%3a%2f%2fcygwin.mirror.constant.com%2f/x86_64/release/perl/perl_autorebase/perl_autorebase-5.40.0-1.tar.zst
- Extracting from file://C:\Users\dave\AppData\Local\opam\.cygwin\cache/https%3a%2f%2fcygwin.mirror.constant.com%2f/x86_64/release/perl/perl-5.40.0-1.tar.zst
- running: C:\Users\dave\AppData\Local\opam\.cygwin\root\bin\dash.exe "/etc/postinstall/0p_000_autorebase.dash"
- running: C:\Users\dave\AppData\Local\opam\.cygwin\root\bin\dash.exe "/etc/postinstall/0p_update-info-dir.dash"
- running: C:\Users\dave\AppData\Local\opam\.cygwin\root\bin\dash.exe "/etc/postinstall/zp_man-db-update-index.dash"
- Ending cygwin install

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
⬇ retrieved conf-perl.2  (file://C:/Users/dave/github.com/djs55/opam-repository/packages/conf-perl/conf-perl.2)
∗ installed conf-perl.2
Done.
```