### PR TITLE
morbig 0.9.* is not compatible with ocaml >= 5.1

### DIFF
--- a/packages/morbig/morbig.0.9.1/opam
+++ b/packages/morbig/morbig.0.9.1/opam
@@ -25,7 +25,7 @@ available: [os != "macos"]
 x-ci-accept-failures: ["debian-unstable"]
 depends: [
   "menhir"               {>= "20151023"}
-  "ocaml"                {build & >= "4.03"}
+  "ocaml"                {build & >= "4.03" & < "5.1"}
   "ocamlbuild"           {build}
   "ppx_deriving_yojson"
   "visitors"             {>= "20170308"}

--- a/packages/morbig/morbig.0.9/opam
+++ b/packages/morbig/morbig.0.9/opam
@@ -24,7 +24,7 @@ dev-repo: "git+https://github.com/colis-anr/morbig.git"
 available: [os != "macos"]
 depends: [
   "menhir"               {build & >= "20151023"}
-  "ocaml"                {build & >= "4.03"}
+  "ocaml"                {build & >= "4.03" & < "5.1"}
   "ocamlbuild"           {build}
   "ppx_deriving_yojson"
   "visitors"             {>= "20170308"}


### PR DESCRIPTION
Fails with
```
ar: /home/opam/.opam/5.2/lib/ocaml/libcamlstr.a: No such file or directory
```