### PR TITLE
Prepare for LLVM 18, link to local repo for scripts and patches

### DIFF
--- a/packages/conf-llvm-shared/conf-llvm-shared.18/opam
+++ b/packages/conf-llvm-shared/conf-llvm-shared.18/opam
@@ -26,7 +26,7 @@ synopsis: "Virtual package relying on llvm shared library installation"
 flags: conf
 extra-source "configure.sh" {
   src:
-    "https://raw.githubusercontent.com/alan-j-hu/opam-source-archives/refs/heads/llvm-18-prep/patches/conf-llvm-static/configure.sh.18"
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/conf-llvm-static/configure.sh.18"
   checksum: [
     "sha256=13b22f406b6aa4be03cf5c70a55a8513bdb9bd804877a99c66d79cf0d6b2fbd2"
     "md5=a64daab3f3768dd671fcd046bd2c1a04"

--- a/packages/conf-llvm-shared/conf-llvm-shared.18/opam
+++ b/packages/conf-llvm-shared/conf-llvm-shared.18/opam
@@ -22,7 +22,7 @@ depexts: [
   ["llvm18-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm18"] {os = "freebsd"}
 ]
-synopsis: "Virtual package relying on llvm static library installation"
+synopsis: "Virtual package relying on llvm shared library installation"
 flags: conf
 extra-source "configure.sh" {
   src:

--- a/packages/conf-llvm-shared/conf-llvm-shared.18/opam
+++ b/packages/conf-llvm-shared/conf-llvm-shared.18/opam
@@ -20,7 +20,7 @@ depexts: [
   ["llvm18-devel"] {os-distribution = "fedora" & os-version >= "41"}
   ["llvm-devel"] {os-distribution = "fedora" & os-version = "40"}
   ["llvm18-devel" "epel-release"] {os-distribution = "centos"}
-  ["devel/llvm18" "zstd"] {os = "freebsd"}
+  ["devel/llvm18"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm shared library installation"
 flags: conf

--- a/packages/conf-llvm-shared/conf-llvm-shared.18/opam
+++ b/packages/conf-llvm-shared/conf-llvm-shared.18/opam
@@ -20,7 +20,7 @@ depexts: [
   ["llvm18-devel"] {os-distribution = "fedora" & os-version >= "41"}
   ["llvm-devel"] {os-distribution = "fedora" & os-version = "40"}
   ["llvm18-devel" "epel-release"] {os-distribution = "centos"}
-  ["devel/llvm18"] {os = "freebsd"}
+  ["devel/llvm18" "zstd"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm shared library installation"
 flags: conf

--- a/packages/conf-llvm-shared/conf-llvm-shared.18/opam
+++ b/packages/conf-llvm-shared/conf-llvm-shared.18/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Alan <ahulambda@gmail.com>"
+authors: "The LLVM team"
+homepage: "http://llvm.org"
+bug-reports: "https://llvm.org/bugs/"
+license: "MIT"
+build: [
+  ["bash" "configure.sh" version "shared"]
+]
+depends: [
+  "conf-bash" {build}
+]
+depexts: [
+  ["llvm@18" "zstd"] {os-distribution = "homebrew" & os = "macos"}
+  ["llvm-18"] {os-distribution = "macports" & os = "macos"}
+  ["llvm-18-dev" "zlib1g-dev" "libzstd-dev"] {os-family = "debian"}
+  ["llvm18-dev"] {os-distribution = "alpine"}
+  ["llvm18"] {os-family = "arch"}
+  ["llvm18-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["llvm18-devel"] {os-distribution = "fedora" & os-version >= "41"}
+  ["llvm-devel"] {os-distribution = "fedora" & os-version = "40"}
+  ["llvm18-devel" "epel-release"] {os-distribution = "centos"}
+  ["devel/llvm18"] {os = "freebsd"}
+]
+synopsis: "Virtual package relying on llvm static library installation"
+flags: conf
+extra-source "configure.sh" {
+  src:
+    "https://raw.githubusercontent.com/alan-j-hu/opam-source-archives/refs/heads/llvm-18-prep/patches/conf-llvm-static/configure.sh.18"
+  checksum: [
+    "sha256=13b22f406b6aa4be03cf5c70a55a8513bdb9bd804877a99c66d79cf0d6b2fbd2"
+    "md5=a64daab3f3768dd671fcd046bd2c1a04"
+  ]
+}

--- a/packages/conf-llvm-shared/conf-llvm-shared.18/opam
+++ b/packages/conf-llvm-shared/conf-llvm-shared.18/opam
@@ -26,9 +26,9 @@ synopsis: "Virtual package relying on llvm shared library installation"
 flags: conf
 extra-source "configure.sh" {
   src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/conf-llvm-static/configure.sh.18"
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/conf-llvm/configure.sh.18"
   checksum: [
-    "sha256=13b22f406b6aa4be03cf5c70a55a8513bdb9bd804877a99c66d79cf0d6b2fbd2"
-    "md5=a64daab3f3768dd671fcd046bd2c1a04"
+    "sha256=3675ad30b93aab67f1d57aa7c700800a3b5954768610ef9ef29bba7483f16936"
+    "md5=409c0a03dcea76a45719b80a06e2bd71"
   ]
 }

--- a/packages/conf-llvm-static/conf-llvm-static.18/opam
+++ b/packages/conf-llvm-static/conf-llvm-static.18/opam
@@ -26,9 +26,9 @@ synopsis: "Virtual package relying on llvm static library installation"
 flags: conf
 extra-source "configure.sh" {
   src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/conf-llvm-static/configure.sh.18"
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/conf-llvm/configure.sh.18"
   checksum: [
-    "sha256=13b22f406b6aa4be03cf5c70a55a8513bdb9bd804877a99c66d79cf0d6b2fbd2"
-    "md5=a64daab3f3768dd671fcd046bd2c1a04"
+    "sha256=3675ad30b93aab67f1d57aa7c700800a3b5954768610ef9ef29bba7483f16936"
+    "md5=409c0a03dcea76a45719b80a06e2bd71"
   ]
 }

--- a/packages/conf-llvm-static/conf-llvm-static.18/opam
+++ b/packages/conf-llvm-static/conf-llvm-static.18/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Alan <ahulambda@gmail.com>"
+authors: "The LLVM team"
+homepage: "http://llvm.org"
+bug-reports: "https://llvm.org/bugs/"
+license: "MIT"
+build: [
+  ["bash" "configure.sh" version "static"]
+]
+depends: [
+  "conf-bash" {build}
+]
+depexts: [
+  ["llvm@18" "zstd"] {os-distribution = "homebrew" & os = "macos"}
+  ["llvm-18"] {os-distribution = "macports" & os = "macos"}
+  ["llvm-18-dev" "zlib1g-dev" "libzstd-dev"] {os-family = "debian"}
+  ["llvm18-dev"] {os-distribution = "alpine"}
+  ["llvm18"] {os-family = "arch"}
+  ["llvm18-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["llvm18-devel"] {os-distribution = "fedora" & os-version >= "41"}
+  ["llvm-devel"] {os-distribution = "fedora" & os-version = "40"}
+  ["llvm18-devel" "epel-release"] {os-distribution = "centos"}
+  ["devel/llvm18"] {os = "freebsd"}
+]
+synopsis: "Virtual package relying on llvm static library installation"
+flags: conf
+extra-source "configure.sh" {
+  src:
+    "https://raw.githubusercontent.com/alan-j-hu/opam-source-archives/refs/heads/llvm-18-prep/patches/conf-llvm-static/configure.sh.18"
+  checksum: [
+    "sha256=13b22f406b6aa4be03cf5c70a55a8513bdb9bd804877a99c66d79cf0d6b2fbd2"
+    "md5=a64daab3f3768dd671fcd046bd2c1a04"
+  ]
+}

--- a/packages/conf-llvm-static/conf-llvm-static.18/opam
+++ b/packages/conf-llvm-static/conf-llvm-static.18/opam
@@ -26,7 +26,7 @@ synopsis: "Virtual package relying on llvm static library installation"
 flags: conf
 extra-source "configure.sh" {
   src:
-    "https://raw.githubusercontent.com/alan-j-hu/opam-source-archives/refs/heads/llvm-18-prep/patches/conf-llvm-static/configure.sh.18"
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/conf-llvm-static/configure.sh.18"
   checksum: [
     "sha256=13b22f406b6aa4be03cf5c70a55a8513bdb9bd804877a99c66d79cf0d6b2fbd2"
     "md5=a64daab3f3768dd671fcd046bd2c1a04"

--- a/packages/conf-llvm-static/conf-llvm-static.18/opam
+++ b/packages/conf-llvm-static/conf-llvm-static.18/opam
@@ -20,7 +20,7 @@ depexts: [
   ["llvm18-devel"] {os-distribution = "fedora" & os-version >= "41"}
   ["llvm-devel"] {os-distribution = "fedora" & os-version = "40"}
   ["llvm18-devel" "epel-release"] {os-distribution = "centos"}
-  ["devel/llvm18"] {os = "freebsd"}
+  ["devel/llvm18" "zstd"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm static library installation"
 flags: conf

--- a/packages/conf-llvm-static/conf-llvm-static.18/opam
+++ b/packages/conf-llvm-static/conf-llvm-static.18/opam
@@ -20,7 +20,7 @@ depexts: [
   ["llvm18-devel"] {os-distribution = "fedora" & os-version >= "41"}
   ["llvm-devel"] {os-distribution = "fedora" & os-version = "40"}
   ["llvm18-devel" "epel-release"] {os-distribution = "centos"}
-  ["devel/llvm18" "zstd"] {os = "freebsd"}
+  ["devel/llvm18"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm static library installation"
 flags: conf

--- a/packages/llvm/llvm.18-shared/opam
+++ b/packages/llvm/llvm.18-shared/opam
@@ -46,7 +46,7 @@ extra-source "AddOCaml.cmake.patch" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/llvm/AddOCaml.cmake.patch.18"
   checksum: [
-    "sha256=cf9023f52075bd7ec7fb808a12fdecb46ca0690cc24dd8d9defd051bcd506493"
-    "md5=667a95b875d607b5d7567d7c6cf7a494"
+    "sha256=a4fac2d6ebfaa707906dc576b99f80efe42ee8857647eb881a07f8fb5ebcddd2"
+    "md5=5a6c39055106cfc700eef2ad0255cba6"
   ]
 }

--- a/packages/llvm/llvm.18-shared/opam
+++ b/packages/llvm/llvm.18-shared/opam
@@ -36,7 +36,7 @@ url {
 }
 extra-source "install.sh" {
   src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/llvm/install.sh.18"
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/llvm/install.sh.18"
   checksum: [
     "sha256=91311c9a90258e6819adda4132f9f64df18f1f0b9df905e7f88be325ed18dce7"
     "md5=70201a5ad01e104f7572e1fa0d498eaa"
@@ -44,9 +44,9 @@ extra-source "install.sh" {
 }
 extra-source "AddOCaml.cmake.patch" {
   src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/llvm/AddOCaml.cmake.patch.18"
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/llvm/AddOCaml.cmake.patch.18"
   checksum: [
-    "sha256=3c9abe430b0868e5937e9944133d521f62677244e0a345e511f66cb9502e406a"
-    "md5=a9ef328c5a793812c25a5f8777316ad9"
+    "sha256=cf9023f52075bd7ec7fb808a12fdecb46ca0690cc24dd8d9defd051bcd506493"
+    "md5=667a95b875d607b5d7567d7c6cf7a494"
   ]
 }

--- a/packages/llvm/llvm.18-shared/opam
+++ b/packages/llvm/llvm.18-shared/opam
@@ -44,7 +44,7 @@ extra-source "install.sh" {
 }
 extra-source "AddOCaml.cmake.patch" {
   src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/llvm/AddOCaml.cmake.patch.18"
+    "https://github.com/alan-j-hu/opam-source-archives/raw/e5d49c1c15149d3a239d237634f5fc85d903718d/patches/llvm/AddOCaml.cmake.patch.18"
   checksum: [
     "sha256=a4fac2d6ebfaa707906dc576b99f80efe42ee8857647eb881a07f8fb5ebcddd2"
     "md5=5a6c39055106cfc700eef2ad0255cba6"

--- a/packages/llvm/llvm.18-shared/opam
+++ b/packages/llvm/llvm.18-shared/opam
@@ -36,7 +36,7 @@ url {
 }
 extra-source "install.sh" {
   src:
-    "https://raw.githubusercontent.com/alan-j-hu/opam-source-archives/refs/heads/llvm-18-prep/patches/llvm/install.sh.18"
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/llvm/install.sh.18"
   checksum: [
     "sha256=91311c9a90258e6819adda4132f9f64df18f1f0b9df905e7f88be325ed18dce7"
     "md5=70201a5ad01e104f7572e1fa0d498eaa"
@@ -44,7 +44,7 @@ extra-source "install.sh" {
 }
 extra-source "AddOCaml.cmake.patch" {
   src:
-    "https://raw.githubusercontent.com/alan-j-hu/opam-source-archives/refs/heads/llvm-18-prep/patches/llvm/AddOCaml.cmake.patch.18"
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/llvm/AddOCaml.cmake.patch.18"
   checksum: [
     "sha256=3c9abe430b0868e5937e9944133d521f62677244e0a345e511f66cb9502e406a"
     "md5=a9ef328c5a793812c25a5f8777316ad9"

--- a/packages/llvm/llvm.18-shared/opam
+++ b/packages/llvm/llvm.18-shared/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "Alan <ahulambda@gmail.com>"
+authors: [
+  "whitequark <whitequark@whitequark.org>"
+  "The LLVM team"
+]
+license: "MIT"
+bug-reports: "http://llvm.org/bugs/"
+dev-repo: "git+http://llvm.org/git/llvm.git"
+doc: "http://llvm.org"
+homepage: "http://llvm.org"
+build: [
+  ["bash" "-ex" "install.sh" "%{conf-llvm-shared:config}%" lib "%{conf-cmake:cmd}%" make "build" "shared"]
+]
+install: [
+  ["bash" "-ex" "install.sh" "%{conf-llvm-shared:config}%" lib "%{conf-cmake:cmd}%" make "install" "shared"]
+]
+depends: [
+  "ocaml" {>= "4.00.0"}
+  "ctypes" {>= "0.4"}
+  "ocamlfind" {build}
+  "conf-llvm-static" {build & = "18"}
+  "conf-cmake" {build}
+]
+patches: [
+  "AddOCaml.cmake.patch"
+]
+synopsis: "The OCaml bindings distributed with LLVM"
+description: "Note: LLVM should be installed first."
+url {
+  src: "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/llvm-project-18.1.8.src.tar.xz"
+  checksum: [
+    "sha256=0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"
+    "md5=81cd0be5ae6f1ad8961746116d426a96"
+  ]
+}
+extra-source "install.sh" {
+  src:
+    "https://raw.githubusercontent.com/alan-j-hu/opam-source-archives/refs/heads/llvm-18-prep/patches/llvm/install.sh.18"
+  checksum: [
+    "sha256=91311c9a90258e6819adda4132f9f64df18f1f0b9df905e7f88be325ed18dce7"
+    "md5=70201a5ad01e104f7572e1fa0d498eaa"
+  ]
+}
+extra-source "AddOCaml.cmake.patch" {
+  src:
+    "https://raw.githubusercontent.com/alan-j-hu/opam-source-archives/refs/heads/llvm-18-prep/patches/llvm/AddOCaml.cmake.patch.18"
+  checksum: [
+    "sha256=3c9abe430b0868e5937e9944133d521f62677244e0a345e511f66cb9502e406a"
+    "md5=a9ef328c5a793812c25a5f8777316ad9"
+  ]
+}

--- a/packages/llvm/llvm.18-shared/opam
+++ b/packages/llvm/llvm.18-shared/opam
@@ -10,10 +10,24 @@ dev-repo: "git+http://llvm.org/git/llvm.git"
 doc: "http://llvm.org"
 homepage: "http://llvm.org"
 build: [
-  ["bash" "-ex" "install.sh" "%{conf-llvm-shared:config}%" lib "%{conf-cmake:cmd}%" make "build" "shared"]
+  ["bash" "-ex" "install.sh" "build"
+     "--llvm-config" "%{conf-llvm-shared:config}%"
+     "--libdir" lib
+     "--cmake" "%{conf-cmake:cmd}%"
+     "--make" make
+     "--link-mode" "shared"
+     "--use-homebrew" {os-distribution = "homebrew"}
+  ]
 ]
 install: [
-  ["bash" "-ex" "install.sh" "%{conf-llvm-shared:config}%" lib "%{conf-cmake:cmd}%" make "install" "shared"]
+  ["bash" "-ex" "install.sh" "install"
+     "--llvm-config" "%{conf-llvm-shared:config}%"
+     "--libdir" lib
+     "--cmake" "%{conf-cmake:cmd}%"
+     "--make" make
+     "--link-mode" "shared"
+     "--use-homebrew" {os-distribution = "homebrew"}
+  ]
 ]
 depends: [
   "ocaml" {>= "4.00.0"}
@@ -38,15 +52,15 @@ extra-source "install.sh" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/llvm/install.sh.18"
   checksum: [
-    "sha256=91311c9a90258e6819adda4132f9f64df18f1f0b9df905e7f88be325ed18dce7"
-    "md5=70201a5ad01e104f7572e1fa0d498eaa"
+    "sha256=c1f95d0c7ae539fcbe97327c4ed64e7a86009143c34f7e721319407975965bae"
+    "md5=6e458426d1008d4696662cf7d3432d8b"
   ]
 }
 extra-source "AddOCaml.cmake.patch" {
   src:
-    "https://github.com/alan-j-hu/opam-source-archives/raw/e5d49c1c15149d3a239d237634f5fc85d903718d/patches/llvm/AddOCaml.cmake.patch.18"
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/llvm/AddOCaml.cmake.patch.18"
   checksum: [
-    "sha256=a4fac2d6ebfaa707906dc576b99f80efe42ee8857647eb881a07f8fb5ebcddd2"
-    "md5=5a6c39055106cfc700eef2ad0255cba6"
+    "sha256=a532adaa6938818fbd7f5a49d4de21c0a2d240ecb91636a76b2f745b4b8cb58f"
+    "md5=432ec376b6ffbac44e640c8fb659a7df"
   ]
 }

--- a/packages/llvm/llvm.18-shared/opam
+++ b/packages/llvm/llvm.18-shared/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.00.0"}
   "ctypes" {>= "0.4"}
   "ocamlfind" {build}
-  "conf-llvm-static" {build & = "18"}
+  "conf-llvm-shared" {build & = "18"}
   "conf-cmake" {build}
 ]
 patches: [

--- a/packages/llvm/llvm.18-static/opam
+++ b/packages/llvm/llvm.18-static/opam
@@ -36,7 +36,7 @@ url {
 }
 extra-source "install.sh" {
   src:
-    "https://raw.githubusercontent.com/alan-j-hu/opam-source-archives/refs/heads/llvm-18-prep/patches/llvm/install.sh.18"
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/llvm/install.sh.18"
   checksum: [
     "sha256=91311c9a90258e6819adda4132f9f64df18f1f0b9df905e7f88be325ed18dce7"
     "md5=70201a5ad01e104f7572e1fa0d498eaa"
@@ -44,7 +44,7 @@ extra-source "install.sh" {
 }
 extra-source "AddOCaml.cmake.patch" {
   src:
-    "https://raw.githubusercontent.com/alan-j-hu/opam-source-archives/refs/heads/llvm-18-prep/patches/llvm/AddOCaml.cmake.patch.18"
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/llvm/AddOCaml.cmake.patch.18"
   checksum: [
     "sha256=3c9abe430b0868e5937e9944133d521f62677244e0a345e511f66cb9502e406a"
     "md5=a9ef328c5a793812c25a5f8777316ad9"

--- a/packages/llvm/llvm.18-static/opam
+++ b/packages/llvm/llvm.18-static/opam
@@ -44,10 +44,11 @@ extra-source "install.sh" {
 }
 extra-source "AddOCaml.cmake.patch" {
   src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/llvm/AddOCaml.cmake.patch.18"
+    "https://github.com/alan-j-hu/opam-source-archives/raw/e5d49c1c15149d3a239d237634f5fc85d903718d/patches/llvm/AddOCaml.cmake.patch.18"
   checksum: [
-    "sha256=3c9abe430b0868e5937e9944133d521f62677244e0a345e511f66cb9502e406a"
-    "md5=a9ef328c5a793812c25a5f8777316ad9"
+    "sha256=a4fac2d6ebfaa707906dc576b99f80efe42ee8857647eb881a07f8fb5ebcddd2"
+    "md5=5a6c39055106cfc700eef2ad0255cba6"
   ]
 }
+
 

--- a/packages/llvm/llvm.18-static/opam
+++ b/packages/llvm/llvm.18-static/opam
@@ -10,10 +10,24 @@ dev-repo: "git+http://llvm.org/git/llvm.git"
 doc: "http://llvm.org"
 homepage: "http://llvm.org"
 build: [
-  ["bash" "-ex" "install.sh" "%{conf-llvm-static:config}%" lib "%{conf-cmake:cmd}%" make "build" "static"]
+  ["bash" "-ex" "install.sh" "build"
+     "--llvm-config" "%{conf-llvm-static:config}%"
+     "--libdir" lib
+     "--cmake" "%{conf-cmake:cmd}%"
+     "--make" make
+     "--link-mode" "static"
+     "--use-homebrew" {os-distribution = "homebrew"}
+  ]
 ]
 install: [
-  ["bash" "-ex" "install.sh" "%{conf-llvm-static:config}%" lib "%{conf-cmake:cmd}%" make "install" "static"]
+  ["bash" "-ex" "install.sh" "install"
+     "--llvm-config" "%{conf-llvm-static:config}%"
+     "--libdir" lib
+     "--cmake" "%{conf-cmake:cmd}%"
+     "--make" make
+     "--link-mode" "static"
+     "--use-homebrew" {os-distribution = "homebrew"}
+  ]
 ]
 depends: [
   "ocaml" {>= "4.00.0"}
@@ -36,19 +50,17 @@ url {
 }
 extra-source "install.sh" {
   src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/llvm/install.sh.18"
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/llvm/install.sh.18"
   checksum: [
-    "sha256=91311c9a90258e6819adda4132f9f64df18f1f0b9df905e7f88be325ed18dce7"
-    "md5=70201a5ad01e104f7572e1fa0d498eaa"
+    "sha256=c1f95d0c7ae539fcbe97327c4ed64e7a86009143c34f7e721319407975965bae"
+    "md5=6e458426d1008d4696662cf7d3432d8b"
   ]
 }
 extra-source "AddOCaml.cmake.patch" {
   src:
-    "https://github.com/alan-j-hu/opam-source-archives/raw/e5d49c1c15149d3a239d237634f5fc85d903718d/patches/llvm/AddOCaml.cmake.patch.18"
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/llvm/AddOCaml.cmake.patch.18"
   checksum: [
-    "sha256=a4fac2d6ebfaa707906dc576b99f80efe42ee8857647eb881a07f8fb5ebcddd2"
-    "md5=5a6c39055106cfc700eef2ad0255cba6"
+    "sha256=a532adaa6938818fbd7f5a49d4de21c0a2d240ecb91636a76b2f745b4b8cb58f"
+    "md5=432ec376b6ffbac44e640c8fb659a7df"
   ]
 }
-
-

--- a/packages/llvm/llvm.18-static/opam
+++ b/packages/llvm/llvm.18-static/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "Alan <ahulambda@gmail.com>"
+authors: [
+  "whitequark <whitequark@whitequark.org>"
+  "The LLVM team"
+]
+license: "MIT"
+bug-reports: "http://llvm.org/bugs/"
+dev-repo: "git+http://llvm.org/git/llvm.git"
+doc: "http://llvm.org"
+homepage: "http://llvm.org"
+build: [
+  ["bash" "-ex" "install.sh" "%{conf-llvm-static:config}%" lib "%{conf-cmake:cmd}%" make "build" "static"]
+]
+install: [
+  ["bash" "-ex" "install.sh" "%{conf-llvm-static:config}%" lib "%{conf-cmake:cmd}%" make "install" "static"]
+]
+depends: [
+  "ocaml" {>= "4.00.0"}
+  "ctypes" {>= "0.4"}
+  "ocamlfind" {build}
+  "conf-llvm-static" {build & = "18"}
+  "conf-cmake" {build}
+]
+patches: [
+  "AddOCaml.cmake.patch"
+]
+synopsis: "The OCaml bindings distributed with LLVM"
+description: "Note: LLVM should be installed first."
+url {
+  src: "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/llvm-project-18.1.8.src.tar.xz"
+  checksum: [
+    "sha256=0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"
+    "md5=81cd0be5ae6f1ad8961746116d426a96"
+  ]
+}
+extra-source "install.sh" {
+  src:
+    "https://raw.githubusercontent.com/alan-j-hu/opam-source-archives/refs/heads/llvm-18-prep/patches/llvm/install.sh.18"
+  checksum: [
+    "sha256=91311c9a90258e6819adda4132f9f64df18f1f0b9df905e7f88be325ed18dce7"
+    "md5=70201a5ad01e104f7572e1fa0d498eaa"
+  ]
+}
+extra-source "AddOCaml.cmake.patch" {
+  src:
+    "https://raw.githubusercontent.com/alan-j-hu/opam-source-archives/refs/heads/llvm-18-prep/patches/llvm/AddOCaml.cmake.patch.18"
+  checksum: [
+    "sha256=3c9abe430b0868e5937e9944133d521f62677244e0a345e511f66cb9502e406a"
+    "md5=a9ef328c5a793812c25a5f8777316ad9"
+  ]
+}
+


### PR DESCRIPTION
This references the scripts and patches for my fork of opam-source-archive, just so I can see if things work on CI... If this is accepted, they will need to be changed to point to ocaml/opam-source-archive.

Context: https://github.com/ocaml/opam-source-archives/pull/40