### PR TITLE
Fix an oversight in opam file for pa_ppx_regexp.0.03

### DIFF
--- a/packages/pa_ppx_regexp/pa_ppx_regexp.0.03/opam
+++ b/packages/pa_ppx_regexp/pa_ppx_regexp.0.03/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml"       { >= "4.10.0" }
   "camlp5-buildscripts" { >= "0.02" }
   "camlp5"      { >= "8.01.00" }
-  "pa_ppx"      { = "0.15" }
+  "pa_ppx"      { >= "0.15" }
   "pa_ppx_migrate"      { >= "0.10" }
   "pa_ppx_static" { >= "0.01" }
   "not-ocamlfind" { >= "0.10" }


### PR DESCRIPTION
the version constraint for pa_ppx was "= 0.15", but needed to be ">=".