### PR TITLE
Release pa ppx regexp 0.04 (to fixup errors in 0.03 release)

### DIFF
--- a/packages/pa_ppx_regexp/pa_ppx_regexp.0.03/opam
+++ b/packages/pa_ppx_regexp/pa_ppx_regexp.0.03/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml"       { >= "4.10.0" }
   "camlp5-buildscripts" { >= "0.02" }
   "camlp5"      { >= "8.01.00" }
-  "pa_ppx"      { = "0.15" }
+  "pa_ppx"      { >= "0.15" }
   "pa_ppx_migrate"      { >= "0.10" }
   "pa_ppx_static" { >= "0.01" }
   "not-ocamlfind" { >= "0.10" }

--- a/packages/pa_ppx_regexp/pa_ppx_regexp.0.04/opam
+++ b/packages/pa_ppx_regexp/pa_ppx_regexp.0.04/opam
@@ -14,7 +14,7 @@ license: "BSD-3-Clause"
 bug-reports: "https://github.com/camlp5/pa_ppx_regexp/issues"
 dev-repo: "git+https://github.com/camlp5/pa_ppx_regexp.git"
 doc: "https://github.com/camlp5/pa_ppx_regexp/doc"
-available: false
+
 depends: [
   "ocaml"       { >= "4.10.0" }
   "camlp5-buildscripts" { >= "0.02" }
@@ -26,8 +26,8 @@ depends: [
   "ounit" { >= "2.2.7" }
   "mdx" {>= "2.3.0" & with-test}
   "fmt"
-  "pcre"
-  "pcre2"
+  "pcre" { >= "8.0.1" }
+  "pcre2" { >= "8.0.1" }
   "re" { >= "1.12.0" }
 ]
 build: [
@@ -36,8 +36,8 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/camlp5/pa_ppx_regexp/archive/refs/tags/0.03.tar.gz"
+  src: "https://github.com/camlp5/pa_ppx_regexp/archive/refs/tags/0.04.tar.gz"
   checksum: [
-    "sha512=74a3b28c5edf836fe7078504c674d2d9bc8fbb977d0f07365f8725016214b9c895e7b2171a11d937d91653616c172d763c670d0426464703878c35c7841dc7d2"
+    "sha512=ccb7e9293959123cb9fe8e7c9525a6b5c059c750d764d1a9155b6afeec9b4531c4b5ea6b458395c8937c595ccc4c81e0c55c83a1c95252eff0354a55aa597047"
   ]
 }


### PR DESCRIPTION
I forgot:

(1) release constraint on pa_ppx version
(2) add constraints on pcre, pcre2 versions (b/c they fixed bugs)
(3) update one of several tests to correspond to those bugfixes

Argh.