### PR TITLE
[new release] dream-html (2 packages) (3.9.0)

### DIFF
--- a/packages/dream-html/dream-html.3.9.0/opam
+++ b/packages/dream-html/dream-html.3.9.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha3"}
+  "fmt" {with-test}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.9.0/dream-html-3.9.0.tbz"
+  checksum: [
+    "sha256=1ec0d0304991236059ff453e78d54ea5394c215cd3712399677a704c819949c2"
+    "sha512=a009078d72dead64f90682def662c5782c9fceff76fad5bdf4f5e0043f162ddcf12a055e4f1030f0177ab5b93a558887e2f7ed54221cc7ceae09cbf3fd8d5b5f"
+  ]
+}
+x-commit-hash: "938f82369409829339bfd2fa23aa6e3cce8bbe0e"

--- a/packages/pure-html/pure-html.3.9.0/opam
+++ b/packages/pure-html/pure-html.3.9.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.9.0/dream-html-3.9.0.tbz"
+  checksum: [
+    "sha256=1ec0d0304991236059ff453e78d54ea5394c215cd3712399677a704c819949c2"
+    "sha512=a009078d72dead64f90682def662c5782c9fceff76fad5bdf4f5e0043f162ddcf12a055e4f1030f0177ab5b93a558887e2f7ed54221cc7ceae09cbf3fd8d5b5f"
+  ]
+}
+x-commit-hash: "938f82369409829339bfd2fa23aa6e3cce8bbe0e"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

See https://github.com/yawaramin/dream-html/tags
