### PR TITLE
[new release] fileutils (0.6.5)

### DIFF
--- a/packages/fileutils/fileutils.0.6.5/opam
+++ b/packages/fileutils/fileutils.0.6.5/opam
@@ -15,8 +15,6 @@ build: [
 depends: [
   "ocaml" {>= "4.14"}
   "base-unix"
-  "stdlib-shims"
-  "seq"
   "dune" {>= "1.11.0"}
   "ounit2" {with-test & >= "2.0.0"}
 ]

--- a/packages/fileutils/fileutils.0.6.5/opam
+++ b/packages/fileutils/fileutils.0.6.5/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+homepage: "https://github.com/gildor478/ocaml-fileutils"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/gildor478/ocaml-fileutils.git"
+bug-reports: "https://github.com/gildor478/ocaml-fileutils/issues"
+doc: "https://gildor478.github.io/ocaml-fileutils/"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.14"}
+  "base-unix"
+  "stdlib-shims"
+  "seq"
+  "dune" {>= "1.11.0"}
+  "ounit2" {with-test & >= "2.0.0"}
+]
+synopsis: "API to manipulate files (POSIX like) and filenames"
+description: """
+This library provides an API to perform POSIX like operations on files like:
+
+- mv
+- cp
+- rm
+- mkdir
+- touch
+- which...
+
+It also provides a module to manipulate abstract filenames:
+
+- classification
+- make_relative: made a filename relative to another
+- make_absolute
+"""
+url {
+  src:
+    "https://github.com/gildor478/ocaml-fileutils/releases/download/v0.6.5/fileutils-0.6.5.tbz"
+  checksum: [
+    "sha256=e15704bdbd672d3594f2561b169b07c6ec7ababc74fcf2ca1d93295744387c3b"
+    "sha512=ba0d06c2b3a9cd3a9e3169b25295e8735959b4c8c7b811ff9f69cda014f1e172269b59502e0701fa07c3a936b14a2f0a34415e45e2f7022b5d982e4d0daee463"
+  ]
+}
+x-commit-hash: "84e7fecbe9b3b6b33988120a252055732cc712f4"

--- a/packages/fileutils/fileutils.0.6.5/opam
+++ b/packages/fileutils/fileutils.0.6.5/opam
@@ -15,6 +15,8 @@ build: [
 depends: [
   "ocaml" {>= "4.14"}
   "base-unix"
+  "stdlib-shims"
+  "seq"
   "dune" {>= "1.11.0"}
   "ounit2" {with-test & >= "2.0.0"}
 ]


### PR DESCRIPTION
API to manipulate files (POSIX like) and filenames

- Project page: <a href="https://github.com/gildor478/ocaml-fileutils">https://github.com/gildor478/ocaml-fileutils</a>
- Documentation: <a href="https://gildor478.github.io/ocaml-fileutils/">https://gildor478.github.io/ocaml-fileutils/</a>

##### CHANGES:

### Fixed

- `cmp` returns None when comparing two identical files and add some tests for
  that. (thanks to jamesjer).
- require OCaml > 4.14, which is now the default in Debian stable.
