### PR TITLE
[new release] kdl (0.2.0)

### DIFF
--- a/packages/kdl/kdl.0.2.0/opam
+++ b/packages/kdl/kdl.0.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "OCaml implementation of the KDL Document Language"
+maintainer: "eilvelia <hi@eilvelia.cat>"
+authors: "eilvelia <hi@eilvelia.cat>"
+license: "MPL-2.0"
+tags: ["data-serialization-format" "configuration-format" "org:eilvelia"]
+homepage: "https://github.com/eilvelia/ocaml-kdl"
+bug-reports: "https://github.com/eilvelia/ocaml-kdl/issues"
+dev-repo: "git+https://github.com/eilvelia/ocaml-kdl.git"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0"}
+  "menhir"
+  "menhirLib"
+  "sexplib0"
+  "ppx_expect" {with-test}
+  "zarith" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/eilvelia/ocaml-kdl/archive/refs/tags/v0.2.0.tar.gz"
+  checksum: [
+    "sha256=c6bff16d8b9194f1d99789ad45aaee948cdf3ebeba1a3e839d261e341329c4c7"
+  ]
+}


### PR DESCRIPTION
ocaml-kdl: https://github.com/eilvelia/ocaml-kdl, now updated to support [kdl](https://github.com/kdl-org/kdl) v2.