### PR TITLE
[new release] dream-html (2 packages) (3.9.1)

### DIFF
--- a/packages/dream-html/dream-html.3.9.1/opam
+++ b/packages/dream-html/dream-html.3.9.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha3"}
+  "fmt" {with-test}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.9.1/dream-html-3.9.1.tbz"
+  checksum: [
+    "sha256=d8033458fdbffba770e9b6a2ee339131537a6a3685d8fdde7c951460cf121d2d"
+    "sha512=57573a644feb86d14ba1177d3201c78bc9ef44cabf333c41d1d81a468370518e06187a06777a73659910d2fe27f602004ac269efd507bebd24ec6c730b616137"
+  ]
+}
+x-commit-hash: "486413dbbf7ecc2473875e499fa559fbd9705a43"

--- a/packages/pure-html/pure-html.3.9.1/opam
+++ b/packages/pure-html/pure-html.3.9.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.9.1/dream-html-3.9.1.tbz"
+  checksum: [
+    "sha256=d8033458fdbffba770e9b6a2ee339131537a6a3685d8fdde7c951460cf121d2d"
+    "sha512=57573a644feb86d14ba1177d3201c78bc9ef44cabf333c41d1d81a468370518e06187a06777a73659910d2fe27f602004ac269efd507bebd24ec6c730b616137"
+  ]
+}
+x-commit-hash: "486413dbbf7ecc2473875e499fa559fbd9705a43"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

See https://github.com/yawaramin/dream-html/tags
