### PR TITLE
[new release] xdg-basedir (0.0.5)

### DIFF
--- a/packages/xdg-basedir/xdg-basedir.0.0.5/opam
+++ b/packages/xdg-basedir/xdg-basedir.0.0.5/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "XDG basedir location for data/cache/configuration files"
+description: """
+This library implements the xdg-basedir specification. It helps to
+define standard locations for configuration, cache and data files in
+the user directory and on the system. It is a straightforward
+implementation on UNIX platforms and try to apply consistent policies
+with regard to Windows directories. It is inspired by the Haskell
+implementation of this specification, and it follows the same choices
+for Windows directories. See he [xdg-basedir specification][spec] and
+the [Haskell implementation][haskell].
+[haskell]: https://github.com/willdonnelly/xdg-basedir
+[spec]: https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+"""
+maintainer: ["Sylvain Le Gall <sylvain@le-gall.net>"]
+authors: ["Sylvain Le Gall"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-xdg-basedir"
+bug-reports: "https://github.com/gildor478/ocaml-xdg-basedir/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "fileutils"
+  "base-unix"
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/gildor478/ocaml-xdg-basedir.git"
+url {
+  src:
+    "https://github.com/gildor478/ocaml-xdg-basedir/releases/download/v0.0.5/xdg-basedir-0.0.5.tbz"
+  checksum: [
+    "sha256=84f39ff2c470dcd5e36f1c50a77fbf1b417aae3263a1bd440d3e86dedd0382be"
+    "sha512=be38ff2331badcd7ef4861e71566d6355961f3fec7cd4e05e5aaa75b998afab29d4c05ad424a0df2bda6ecea9c014cc4b46839c5c2e6811ed15737bae9de03f7"
+  ]
+}
+x-commit-hash: "0f5198b7f98fa218a1b868c46ef234298d3deb6f"


### PR DESCRIPTION
XDG basedir location for data/cache/configuration files

- Project page: <a href="https://github.com/gildor478/ocaml-xdg-basedir">https://github.com/gildor478/ocaml-xdg-basedir</a>

##### CHANGES:

### Fixed

- use OUnit2 (thanks to MisterDA).
- add a not on the feature freeze for this library in README.md.
