### PR TITLE
[new release] dream-html (2 packages) (3.9.2)

### DIFF
--- a/packages/dream-html/dream-html.3.9.2/opam
+++ b/packages/dream-html/dream-html.3.9.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha3"}
+  "fmt" {with-test}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.9.2/dream-html-3.9.2.tbz"
+  checksum: [
+    "sha256=2381dd7ee9f2dc280e766c334cfc7d8ac07a171198b708f05a1e3fe2ba06354b"
+    "sha512=b77d227a20dc50b22e4e3f13252d48e6bbdedd6d03e5e3cf0090dbd1d90053686c7737fbadb1ea9c2987bdda11a5553d1b32bc5c35b787dd68b9c5bf6da72adf"
+  ]
+}
+x-commit-hash: "dcedb71d1bd913a475839c16253d54caf987047e"

--- a/packages/pure-html/pure-html.3.9.2/opam
+++ b/packages/pure-html/pure-html.3.9.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.9.2/dream-html-3.9.2.tbz"
+  checksum: [
+    "sha256=2381dd7ee9f2dc280e766c334cfc7d8ac07a171198b708f05a1e3fe2ba06354b"
+    "sha512=b77d227a20dc50b22e4e3f13252d48e6bbdedd6d03e5e3cf0090dbd1d90053686c7737fbadb1ea9c2987bdda11a5553d1b32bc5c35b787dd68b9c5bf6da72adf"
+  ]
+}
+x-commit-hash: "dcedb71d1bd913a475839c16253d54caf987047e"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

See https://github.com/yawaramin/dream-html/tags
