### PR TITLE
[new release] dream-html (2 packages) (3.9.3)

### DIFF
--- a/packages/dream-html/dream-html.3.9.3/opam
+++ b/packages/dream-html/dream-html.3.9.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.9.3/dream-html-3.9.3.tbz"
+  checksum: [
+    "sha256=a457cbc17b57d01e6b3f51cce43590ee68528e3c54b75e48711237c76c7aa698"
+    "sha512=7ff1d51954c1d197f1bd5a918a7d00389df60ea91b80cebd519bd0857d0f2d529ab102c379d22c9aab6f3181fe59a76f14880237ff3f7dc3f293dd2051fe9985"
+  ]
+}
+x-commit-hash: "92ae81d15eec29f393b181cde640083229fb1dc1"

--- a/packages/pure-html/pure-html.3.9.3/opam
+++ b/packages/pure-html/pure-html.3.9.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.9.3/dream-html-3.9.3.tbz"
+  checksum: [
+    "sha256=a457cbc17b57d01e6b3f51cce43590ee68528e3c54b75e48711237c76c7aa698"
+    "sha512=7ff1d51954c1d197f1bd5a918a7d00389df60ea91b80cebd519bd0857d0f2d529ab102c379d22c9aab6f3181fe59a76f14880237ff3f7dc3f293dd2051fe9985"
+  ]
+}
+x-commit-hash: "92ae81d15eec29f393b181cde640083229fb1dc1"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

See https://github.com/yawaramin/dream-html/tags
