### PR TITLE
[new release] dream-html (2 packages) (3.9.4)

### DIFF
--- a/packages/dream-html/dream-html.3.9.4/opam
+++ b/packages/dream-html/dream-html.3.9.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.14.0"}
+  "ppxlib" {>= "0.33.0" & < "1.0.0"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.9.4/dream-html-3.9.4.tbz"
+  checksum: [
+    "sha256=4daede4ad6460010d1cf9038415105bc18a62da2a1acf05ea01858bc80af906d"
+    "sha512=f9d6300bf976acb32ba66a9420fcb29c347572c4ce39e468a37ee2da2195c3aa8b05ab90adf649afbf0dbb8d5368fdb8ac5d4580ab3728e75151245d68d4953b"
+  ]
+}
+x-commit-hash: "f50ecacb8236a4785823c7b239b0b151e6181bce"

--- a/packages/pure-html/pure-html.3.9.4/opam
+++ b/packages/pure-html/pure-html.3.9.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.9.4/dream-html-3.9.4.tbz"
+  checksum: [
+    "sha256=4daede4ad6460010d1cf9038415105bc18a62da2a1acf05ea01858bc80af906d"
+    "sha512=f9d6300bf976acb32ba66a9420fcb29c347572c4ce39e468a37ee2da2195c3aa8b05ab90adf649afbf0dbb8d5368fdb8ac5d4580ab3728e75151245d68d4953b"
+  ]
+}
+x-commit-hash: "f50ecacb8236a4785823c7b239b0b151e6181bce"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

See https://github.com/yawaramin/dream-html/tags
