### PR TITLE
[new release] dream-html (2 packages) (3.9.5)

### DIFF
--- a/packages/dream-html/dream-html.3.9.5/opam
+++ b/packages/dream-html/dream-html.3.9.5/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.14.0"}
+  "ppxlib" {>= "0.33.0" & < "1.0.0"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.9.5/dream-html-3.9.5.tbz"
+  checksum: [
+    "sha256=61218e64561b5f2f74b866af750018717046fe333bf48c7fa4192d632e1250e7"
+    "sha512=a0f35373434c3e847b0a3c527e7539aa587ea7b1bf36e627a0a753a44932eabba0865ba179b27259b58a3503070c17080de37fc5d9d73931ac8e6bb3b59a073f"
+  ]
+}
+x-commit-hash: "7504c0d53d464812b3056071894e93bf04c49b09"

--- a/packages/pure-html/pure-html.3.9.5/opam
+++ b/packages/pure-html/pure-html.3.9.5/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.9.5/dream-html-3.9.5.tbz"
+  checksum: [
+    "sha256=61218e64561b5f2f74b866af750018717046fe333bf48c7fa4192d632e1250e7"
+    "sha512=a0f35373434c3e847b0a3c527e7539aa587ea7b1bf36e627a0a753a44932eabba0865ba179b27259b58a3503070c17080de37fc5d9d73931ac8e6bb3b59a073f"
+  ]
+}
+x-commit-hash: "7504c0d53d464812b3056071894e93bf04c49b09"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

See https://github.com/yawaramin/dream-html/tags
