### PR TITLE
riot is not compatible with OCaml 5.3

### DIFF
--- a/packages/riot/riot.0.0.2/opam
+++ b/packages/riot/riot.0.0.2/opam
@@ -11,7 +11,7 @@ tags: ["topics" "multicore" "erlang" "actor" "message-passing" "processes"]
 homepage: "https://github.com/leostera/riot"
 bug-reports: "https://github.com/leostera/riot/issues"
 depends: [
-  "ocaml" {>= "5.1"}
+  "ocaml" {>= "5.1" & < "5.3"}
   "dune" {>= "3.10"}
   "ptime" {>= "1.1.0"}
   "iomux" {>= "0.3"}

--- a/packages/riot/riot.0.0.3/opam
+++ b/packages/riot/riot.0.0.3/opam
@@ -9,7 +9,7 @@ tags: ["topics" "multicore" "erlang" "actor" "message-passing" "processes"]
 homepage: "https://github.com/leostera/riot"
 bug-reports: "https://github.com/leostera/riot/issues"
 depends: [
-  "ocaml" {>= "5.1"}
+  "ocaml" {>= "5.1" & < "5.3"}
   "dune" {>= "3.10"}
   "ptime" {>= "1.1.0"}
   "iomux" {>= "0.3"}

--- a/packages/riot/riot.0.0.4/opam
+++ b/packages/riot/riot.0.0.4/opam
@@ -9,7 +9,7 @@ tags: ["topics" "multicore" "erlang" "actor" "message-passing" "processes"]
 homepage: "https://github.com/leostera/riot"
 bug-reports: "https://github.com/leostera/riot/issues"
 depends: [
-  "ocaml" {>= "5.1"}
+  "ocaml" {>= "5.1" & < "5.3"}
   "dune" {>= "3.10"}
   "ptime" {>= "1.1.0"}
   "iomux" {>= "0.3"}

--- a/packages/riot/riot.0.0.5/opam
+++ b/packages/riot/riot.0.0.5/opam
@@ -9,7 +9,7 @@ tags: ["topics" "multicore" "erlang" "actor" "message-passing" "processes"]
 homepage: "https://github.com/leostera/riot"
 bug-reports: "https://github.com/leostera/riot/issues"
 depends: [
-  "ocaml" {>= "5.1"}
+  "ocaml" {>= "5.1" & < "5.3"}
   "dune" {>= "3.10"}
   "ptime" {>= "1.1.0"}
   "iomux" {>= "0.3"}

--- a/packages/riot/riot.0.0.7/opam
+++ b/packages/riot/riot.0.0.7/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/leostera/riot/issues"
 depends: [
   "cstruct" {>= "6.2.0"}
   "mdx" {with-test & >= "2.3.1"}
-  "ocaml" {>= "5.1"}
+  "ocaml" {>= "5.1" & < "5.3"}
   "odoc" {with-doc & >= "2.2.2"}
   "poll" {>= "0.3.1"}
   "ptime" {>= "1.1.0"}

--- a/packages/riot/riot.0.0.8/opam
+++ b/packages/riot/riot.0.0.8/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-crypto" {>= "0.11.2" & < "1.0.0"}
   "mirage-crypto-rng" {>= "0.11.2" & < "1.0.0"}
   "mtime" {>= "2.0.0"}
-  "ocaml" {>= "5.1"}
+  "ocaml" {>= "5.1" & < "5.3"}
   "odoc" {with-doc & >= "2.2.2"}
   "ptime" {>= "1.1.0"}
   "randomconv" {>= "0.1.3" & < "0.2.0"}

--- a/packages/riot/riot.0.0.9/opam
+++ b/packages/riot/riot.0.0.9/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-crypto" {>= "0.11.2" & < "1.0.0"}
   "mirage-crypto-rng" {>= "0.11.2" & < "1.0.0"}
   "mtime" {>= "2.0.0"}
-  "ocaml" {>= "5.1"}
+  "ocaml" {>= "5.1" & < "5.3"}
   "odoc" {with-doc & >= "2.2.2"}
   "ptime" {>= "1.1.0"}
   "randomconv" {= "0.2.0"}


### PR DESCRIPTION
expects effect to be a valid identifier name
```
#=== ERROR while compiling riot.0.0.9 =========================================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/riot.0.0.9
# command              ~/.opam/5.3/bin/dune build -p riot -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/riot-13-fc4998.env
# output-file          ~/.opam/log/riot-13-fc4998.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl riot/runtime/scheduler/scheduler.ml) > _build/default/riot/runtime/scheduler/.scheduler.objs/scheduler.impl.d
# File "riot/runtime/scheduler/scheduler.ml", line 288, characters 15-17:
# 288 |       | effect ->
#                      ^^
# Error: Syntax error
```