### PR TITLE
miou < 0.2.0 didn't support OCaml 5.3

### DIFF
--- a/packages/miou/miou.0.0.1~beta1/opam
+++ b/packages/miou/miou.0.0.1~beta1/opam
@@ -12,7 +12,7 @@ build: [ "dune" "build" "-p" name "-j" jobs ]
 run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
-  "ocaml"             {>= "5.0.0"}
+  "ocaml" {>= "5.0.0" & < "5.3"}
   "dune"              {>= "2.8.0"}
   "digestif"          {with-test}
   "happy-eyeballs"    {with-test}

--- a/packages/miou/miou.0.0.1~beta2/opam
+++ b/packages/miou/miou.0.0.1~beta2/opam
@@ -12,7 +12,7 @@ build: [ "dune" "build" "-p" name "-j" jobs ]
 run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
-  "ocaml"             {>= "5.0.0"}
+  "ocaml" {>= "5.0.0" & < "5.3"}
   "dune"              {>= "2.8.0"}
   "digestif"          {with-test}
   "happy-eyeballs"    {with-test}

--- a/packages/miou/miou.0.1.0/opam
+++ b/packages/miou/miou.0.1.0/opam
@@ -12,7 +12,7 @@ build: [ "dune" "build" "-p" name "-j" jobs ]
 run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
-  "ocaml"             {>= "5.0.0"}
+  "ocaml" {>= "5.0.0" & < "5.3"}
   "dune"              {>= "2.8.0"}
   "dscheck"           {with-test & >= "0.4.0"}
   "digestif"          {with-test}


### PR DESCRIPTION
expects effect to be a valid identifier
```
#=== ERROR while compiling miou.0.1.0 =========================================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/miou.0.1.0
# command              ~/.opam/5.3/bin/dune build -p miou -j 1
# exit-code            1
# env-file             ~/.opam/log/miou-13-7b98fd.env
# output-file          ~/.opam/log/miou-13-7b98fd.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl lib/miou.ml) > _build/default/lib/.miou.objs/miou.impl.d
# File "lib/miou.ml", line 506, characters 15-17:
# 506 |       | effect -> k (Operation.perform effect)
#                      ^^
# Error: Syntax error
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamldep.opt -modules -impl lib/state.ml) > _build/default/lib/.miou.objs/miou__State.impl.d
# File "lib/state.ml", line 27, characters 7-13:
# 27 |    fun effect -> Some (effc effect)
#             ^^^^^^
# Error: Syntax error
```