### PR TITLE
Try fixing dream lower bound breakage

### DIFF
--- a/packages/dream-httpaf/dream-httpaf.1.0.0~alpha4/opam
+++ b/packages/dream-httpaf/dream-httpaf.1.0.0~alpha4/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "2.7.0"}  # --instrument-with.
   "gluten"
   "gluten-lwt-unix"
-  "h2" {< "0.13.0"}
+  "h2" {= "0.12.0"}
   "h2-lwt-unix"
   "httpun" {< "0.2.0"}
   "httpun-lwt-unix"

--- a/packages/dream-httpaf/dream-httpaf.1.0.0~alpha4/opam
+++ b/packages/dream-httpaf/dream-httpaf.1.0.0~alpha4/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "2.7.0"}  # --instrument-with.
   "gluten"
   "gluten-lwt-unix"
-  "h2" {= "0.12.0"}
+  "h2" {>= 0.9.0 & < "0.13.0"}
   "h2-lwt-unix"
   "httpun" {< "0.2.0"}
   "httpun-lwt-unix"

--- a/packages/dream-httpaf/dream-httpaf.1.0.0~alpha4/opam
+++ b/packages/dream-httpaf/dream-httpaf.1.0.0~alpha4/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "2.7.0"}  # --instrument-with.
   "gluten"
   "gluten-lwt-unix"
-  "h2" {>= 0.9.0 & < "0.13.0"}
+  "h2" {>= "0.9.0" & < "0.13.0"}
   "h2-lwt-unix"
   "httpun" {< "0.2.0"}
   "httpun-lwt-unix"


### PR DESCRIPTION
In https://github.com/ocaml/opam-repository/pull/27194#issuecomment-2566752221 we noticed a CI build breakage caused by dream-httpaf not setting a lower bound on the `h2` package. Setting it here.