### PR TITLE
arrayjit, neural_nets_lib: revdeps failures for ppx_minidebug.2.0.3

### DIFF
--- a/packages/arrayjit/arrayjit.0.3.3/opam
+++ b/packages/arrayjit/arrayjit.0.3.3/opam
@@ -21,8 +21,8 @@ depends: [
   "ctypes" {>= "0.20"}
   "ctypes-foreign" {>= "0.20"}
   "gccjit" {>= "0.3.2"}
-  "printbox" {< 0.12}
-  "printbox-text" {< 0.12}
+  "printbox" {< "0.12"}
+  "printbox-text" {< "0.12"}
   "ocannl_npy"
   "stdio"
   "num"

--- a/packages/arrayjit/arrayjit.0.3.3/opam
+++ b/packages/arrayjit/arrayjit.0.3.3/opam
@@ -11,6 +11,8 @@ tags: ["deeplearning" "array" "jit" "gccjit" "CUDA"]
 homepage: "https://github.com/lukstafi/ocannl"
 doc: "https://github.com/lukstafi/ocannl/blob/master/README.md"
 bug-reports: "https://github.com/lukstafi/ocannl/issues"
+x-maintenance-intent: "(latest)"
+flags: [ deprecated ]
 depends: [
   "ocaml" {>= "5.1.0"}
   "dune" {>= "3.11"}
@@ -19,8 +21,8 @@ depends: [
   "ctypes" {>= "0.20"}
   "ctypes-foreign" {>= "0.20"}
   "gccjit" {>= "0.3.2"}
-  "printbox"
-  "printbox-text"
+  "printbox" {< 0.12}
+  "printbox-text" {< 0.12}
   "ocannl_npy"
   "stdio"
   "num"

--- a/packages/arrayjit/arrayjit.0.4.0/opam
+++ b/packages/arrayjit/arrayjit.0.4.0/opam
@@ -11,6 +11,8 @@ tags: ["deeplearning" "array" "jit" "CUDA"]
 homepage: "https://github.com/lukstafi/ocannl"
 doc: "https://github.com/lukstafi/ocannl/blob/master/README.md"
 bug-reports: "https://github.com/lukstafi/ocannl/issues"
+flags: [ deprecated ]
+x-maintenance-intent: ["(latest)"]
 depends: [
   "ocaml" {>= "5.1.0"}
   "dune" {>= "3.11"}
@@ -18,15 +20,15 @@ depends: [
   "core"
   "ctypes" {>= "0.20"}
   "ctypes-foreign" {>= "0.20"}
-  "printbox"
-  "printbox-text"
+  "printbox" {< 0.12}
+  "printbox-text" {< 0.12}
   "ocannl_npy"
   "stdio"
   "num"
   "ppxlib"
   "ppx_jane"
   "ppx_expect"
-  "ppx_minidebug" {>= "2.0.0"}
+  "ppx_minidebug" {>= "2.0.0" & < "2.0.3"}
   "odoc" {with-doc}
 ]
 depopts: [

--- a/packages/arrayjit/arrayjit.0.4.0/opam
+++ b/packages/arrayjit/arrayjit.0.4.0/opam
@@ -20,8 +20,8 @@ depends: [
   "core"
   "ctypes" {>= "0.20"}
   "ctypes-foreign" {>= "0.20"}
-  "printbox" {< 0.12}
-  "printbox-text" {< 0.12}
+  "printbox" {< "0.12"}
+  "printbox-text" {< "0.12"}
   "ocannl_npy"
   "stdio"
   "num"

--- a/packages/arrayjit/arrayjit.0.4.1/opam
+++ b/packages/arrayjit/arrayjit.0.4.1/opam
@@ -11,6 +11,7 @@ tags: ["deeplearning" "array" "jit" "CUDA"]
 homepage: "https://github.com/lukstafi/ocannl"
 doc: "https://github.com/lukstafi/ocannl/blob/master/README.md"
 bug-reports: "https://github.com/lukstafi/ocannl/issues"
+x-maintenance-intent: ["(latest)"]
 depends: [
   "ocaml" {>= "5.2.0"}
   "dune" {>= "3.11"}

--- a/packages/neural_nets_lib/neural_nets_lib.0.3.3/opam
+++ b/packages/neural_nets_lib/neural_nets_lib.0.3.3/opam
@@ -11,14 +11,16 @@ tags: ["deeplearning" "tensor" "backprop" "jit" "gccjit" "CUDA"]
 homepage: "https://github.com/lukstafi/ocannl"
 doc: "https://github.com/lukstafi/ocannl/blob/master/README.md"
 bug-reports: "https://github.com/lukstafi/ocannl/issues"
+x-maintenance-intent: ["(latest)"]
+flags: [ deprecated ]
 depends: [
   "ocaml" {>= "5.1.0"}
   "dune" {>= "3.11"}
   "base"
   "core"
   "arrayjit" {= "0.3.3"}
-  "printbox"
-  "printbox-text"
+  "printbox" {< 0.12}
+  "printbox-text" {< 0.12}
   "ocannl_npy"
   "angstrom" {>= "0.15"}
   "stdio"

--- a/packages/neural_nets_lib/neural_nets_lib.0.3.3/opam
+++ b/packages/neural_nets_lib/neural_nets_lib.0.3.3/opam
@@ -19,8 +19,8 @@ depends: [
   "base"
   "core"
   "arrayjit" {= "0.3.3"}
-  "printbox" {< 0.12}
-  "printbox-text" {< 0.12}
+  "printbox" {< "0.12"}
+  "printbox-text" {< "0.12"}
   "ocannl_npy"
   "angstrom" {>= "0.15"}
   "stdio"

--- a/packages/neural_nets_lib/neural_nets_lib.0.4.0/opam
+++ b/packages/neural_nets_lib/neural_nets_lib.0.4.0/opam
@@ -11,14 +11,16 @@ tags: ["deeplearning" "tensor" "backprop" "jit" "gccjit" "CUDA"]
 homepage: "https://github.com/lukstafi/ocannl"
 doc: "https://github.com/lukstafi/ocannl/blob/master/README.md"
 bug-reports: "https://github.com/lukstafi/ocannl/issues"
+x-maintenance-intent: ["(latest)"]
+flags: [ deprecated ]
 depends: [
   "ocaml" {>= "5.1.0"}
   "dune" {>= "3.11"}
   "base"
   "core"
   "arrayjit" {= "0.4.0"}
-  "printbox"
-  "printbox-text"
+  "printbox" {< 0.12}
+  "printbox-text" {< 0.12}
   "ocannl_npy"
   "angstrom" {>= "0.15"}
   "stdio"
@@ -26,7 +28,7 @@ depends: [
   "ppxlib"
   "ppx_jane"
   "ppx_expect"
-  "ppx_minidebug" {>= "2.0.0"}
+  "ppx_minidebug" {>= "2.0.0" & < "2.0.3"}
   "patdiff" {>= "v0.15.0"}
   "odoc" {with-doc}
   "md2mld" {with-doc}

--- a/packages/neural_nets_lib/neural_nets_lib.0.4.0/opam
+++ b/packages/neural_nets_lib/neural_nets_lib.0.4.0/opam
@@ -19,8 +19,8 @@ depends: [
   "base"
   "core"
   "arrayjit" {= "0.4.0"}
-  "printbox" {< 0.12}
-  "printbox-text" {< 0.12}
+  "printbox" {< "0.12"}
+  "printbox-text" {< "0.12"}
   "ocannl_npy"
   "angstrom" {>= "0.15"}
   "stdio"

--- a/packages/neural_nets_lib/neural_nets_lib.0.4.1/opam
+++ b/packages/neural_nets_lib/neural_nets_lib.0.4.1/opam
@@ -11,14 +11,15 @@ tags: ["deeplearning" "tensor" "backprop" "jit" "gccjit" "CUDA"]
 homepage: "https://github.com/lukstafi/ocannl"
 doc: "https://github.com/lukstafi/ocannl/blob/master/README.md"
 bug-reports: "https://github.com/lukstafi/ocannl/issues"
+x-maintenance-intent: ["(latest)"]
 depends: [
   "ocaml" {>= "5.2.0"}
   "dune" {>= "3.11"}
   "base" {>= "v0.17.0"}
   "core" {>= "v0.17.0"}
   "arrayjit" {>= "0.4.1"}
-  "printbox"
-  "printbox-text"
+  "printbox" {< 0.12}
+  "printbox-text" {< 0.12}
   "ocannl_npy"
   "angstrom" {>= "0.15"}
   "stdio"
@@ -26,7 +27,7 @@ depends: [
   "ppxlib"
   "ppx_jane"
   "ppx_expect"
-  "ppx_minidebug" {>= "2.0.0"}
+  "ppx_minidebug" {>= "2.0.0" & < "2.0.3"}
   "patdiff" {>= "v0.15.0"}
   "odoc" {with-doc}
   "md2mld" {with-doc}

--- a/packages/neural_nets_lib/neural_nets_lib.0.4.1/opam
+++ b/packages/neural_nets_lib/neural_nets_lib.0.4.1/opam
@@ -18,8 +18,8 @@ depends: [
   "base" {>= "v0.17.0"}
   "core" {>= "v0.17.0"}
   "arrayjit" {>= "0.4.1"}
-  "printbox" {< 0.12}
-  "printbox-text" {< 0.12}
+  "printbox" {< "0.12"}
+  "printbox-text" {< "0.12"}
   "ocannl_npy"
   "angstrom" {>= "0.15"}
   "stdio"


### PR DESCRIPTION
Prevent reverse deps failures for ppx_minidebug.2.0.3
and update maintenance intent for OCANNL: arrayjit and neural_nets_lib.