### PR TITLE
result < 1.5: mark as available only with ocaml < 4.08

### DIFF
--- a/packages/result/result.1.0/opam
+++ b/packages/result/result.1.0/opam
@@ -12,7 +12,7 @@ description: """
 Projects that want to use the new result type defined in OCaml >= 4.03
 while staying compatible with older version of OCaml should use the
 Result module defined in this library."""
-depends: ["ocaml" {< "4.14"}]
+depends: ["ocaml" {< "4.08"}]
 url {
   src: "https://github.com/janestreet/result/archive/1.0.tar.gz"
   checksum: [

--- a/packages/result/result.1.1/opam
+++ b/packages/result/result.1.1/opam
@@ -11,7 +11,7 @@ description: """
 Projects that want to use the new result type defined in OCaml >= 4.03
 while staying compatible with older version of OCaml should use the
 Result module defined in this library."""
-depends: ["ocaml" {< "4.14"}]
+depends: ["ocaml" {< "4.08"}]
 url {
   src: "https://github.com/janestreet/result/archive/1.1.tar.gz"
   checksum: [

--- a/packages/result/result.1.2/opam
+++ b/packages/result/result.1.2/opam
@@ -14,7 +14,7 @@ description: """
 Projects that want to use the new result type defined in OCaml >= 4.03
 while staying compatible with older version of OCaml should use the
 Result module defined in this library."""
-depends: ["ocaml" {< "4.14"}]
+depends: ["ocaml" {< "4.08"}]
 url {
   src: "https://github.com/janestreet/result/archive/1.2.tar.gz"
   checksum: [

--- a/packages/result/result.1.3/opam
+++ b/packages/result/result.1.3/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/janestreet/result/issues"
 license: "BSD-3-Clause"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
-  "ocaml" {< "4.14"}
+  "ocaml" {< "4.08"}
   "jbuilder" {>= "1.0+beta11"}
 ]
 synopsis: "Compatibility Result module"

--- a/packages/result/result.1.4/opam
+++ b/packages/result/result.1.4/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/janestreet/result/issues"
 license: "BSD-3-Clause"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
-  "ocaml" {< "4.14"}
+  "ocaml" {< "4.08"}
   "dune" {>= "1.0"}
 ]
 synopsis: "Compatibility Result module"


### PR DESCRIPTION
Result is a compatibility package for OCaml versions that do not provide the Result module in the standard library (< 4.08). There's an issue with result < 1.5, namely that with OCaml compilers >= 4.08 it does lack the type equality which leads to compilation errors due to the Result.result (provided by the result package) not being compatible with the Result.t from the standard library.

Now, at [several](https://github.com/ocaml/opam-repository/pull/25603) [occasions](https://github.com/ocaml/opam-repository/pull/24868) there was an attempt to lower the lower bound - to avoid random packages failing in CI, and requiring the magic `conflicts: [ "result" {< "1.5"} ]` line in arbitrary opam files (see also [discussions](https://github.com/ocaml/opam-repository/issues/19880) and [more](https://github.com/ocaml/opam-repository/issues/24263)).

Time has moved on, we're now in the happy situation (thanks to https://github.com/ocaml/opam-repository/pull/25960 and https://github.com/ocaml/opam-repository/pull/27100) that we're able to remove packages. This is great.

Within our archival process, soon (Feb 1st) we'll move all our `< 4.08` packages to the archive. To avoid further burden on ocaml package developers, I propose (as discussed in opam-repository maintainers meetings) to lower the lower bound of earlier result packages - so we finally can close #24263.

Obviously since there has been some discussions and disapproval by @dra27 (and eventually others, asking for @avsm @kit-ty-kate opinions), my invitation is to discuss this PR - whether there are still concerns or the time is ready. From my discussions with the opam-repository maintainers, the timing is good.