### PR TITLE
[new release] ansifmt (0.1.1)

### DIFF
--- a/packages/ansifmt/ansifmt.0.1.1/opam
+++ b/packages/ansifmt/ansifmt.0.1.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A simple, lightweight library for ANSI formatting"
+description:
+  "A simple, lightweight library for ANSI formatting with powerful features such as a tokenization-based system for pretty-printing code in the terminal."
+maintainer: ["Qexat <contact@qexat.com>"]
+authors: ["Qexat <contact@qexat.com>"]
+license: "MIT"
+tags: ["ansi" "formatting" "pretty-printing" "terminal"]
+homepage: "https://github.com/qexat/ansifmt"
+bug-reports: "https://github.com/qexat/ansifmt/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/qexat/ansifmt.git"
+url {
+  src:
+    "https://github.com/qexat/ansifmt/releases/download/0.1.1/ansifmt-0.1.1.tbz"
+  checksum: [
+    "sha256=4014e73df5a6ab865d79ddb5b5d8da3e47dae7c6d5a7e3b7ca8a8c3b7f31b647"
+    "sha512=e7bd0c2be4e174be83f7637f8c3f16ec6a7d9402de82bf50eb4c45a9bc5609650cb07bc9b0f8099c83fd5bb4573c94c8a5152208c069dbd54df5f52f07c2754e"
+  ]
+}
+x-commit-hash: "3d366cefe5e06f2d4d3d6637fb27aaadf8597759"


### PR DESCRIPTION
A simple, lightweight library for ANSI formatting

- Project page: <a href="https://github.com/qexat/ansifmt">https://github.com/qexat/ansifmt</a>

##### CHANGES:

## Features

- Added `print_formatted` and the `IO` submodule.
