### PR TITLE
[new release] ansifmt (0.1.3)

### DIFF
--- a/packages/ansifmt/ansifmt.0.1.3/opam
+++ b/packages/ansifmt/ansifmt.0.1.3/opam
@@ -16,7 +16,6 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   [
-    "ocaml" { >= "4.08" }
     "dune"
     "build"
     "-p"

--- a/packages/ansifmt/ansifmt.0.1.3/opam
+++ b/packages/ansifmt/ansifmt.0.1.3/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/qexat/ansifmt"
 bug-reports: "https://github.com/qexat/ansifmt/issues"
 depends: [
   "dune" {>= "3.17"}
-  "ocaml"
+  "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ansifmt/ansifmt.0.1.3/opam
+++ b/packages/ansifmt/ansifmt.0.1.3/opam
@@ -16,6 +16,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   [
+    "ocaml" { >= "4.08" }
     "dune"
     "build"
     "-p"

--- a/packages/ansifmt/ansifmt.0.1.3/opam
+++ b/packages/ansifmt/ansifmt.0.1.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A simple, lightweight library for ANSI formatting"
+description:
+  "A simple, lightweight library for ANSI formatting with powerful features such as a tokenization-based system for pretty-printing code in the terminal."
+maintainer: ["Qexat <contact@qexat.com>"]
+authors: ["Qexat <contact@qexat.com>"]
+license: "MIT"
+tags: ["ansi" "formatting" "pretty-printing" "terminal"]
+homepage: "https://github.com/qexat/ansifmt"
+bug-reports: "https://github.com/qexat/ansifmt/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/qexat/ansifmt.git"
+url {
+  src:
+    "https://github.com/qexat/ansifmt/releases/download/0.1.3/ansifmt-0.1.3.tbz"
+  checksum: [
+    "sha256=88bfb44072d2de404757fd8e10b08b10c53c2b03b29bd7c040c32646bf209db0"
+    "sha512=a707c0aa0b1389af1e30bf252cc2d35a800dba9f9b80c3626791cd1b33d7a550f53727176bf64c3862cbfaff71ef651458da158f741d771b4cf006f5971c9671"
+  ]
+}
+x-commit-hash: "37457b258f25b5d1c012cf0f44fc5808c4cd34b6"


### PR DESCRIPTION
A simple, lightweight library for ANSI formatting

- Project page: <a href="https://github.com/qexat/ansifmt">https://github.com/qexat/ansifmt</a>

##### CHANGES:

## Fixes

- Fixed a bug where unwanted `m` characters would appear in the output before every colored token
