### PR TITLE
[new release] pcre (8.0.2)

### DIFF
--- a/packages/pcre/pcre.8.0.2/opam
+++ b/packages/pcre/pcre.8.0.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Bindings to the Perl Compatibility Regular Expressions library"
+description: """
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: ["Markus Mottl <markus.mottl@gmail.com>"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "dune-configurator"
+  "conf-libpcre" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/pcre-ocaml/releases/download/8.0.2/pcre-8.0.2.tbz"
+  checksum: [
+    "sha256=2c19d365b98d99c66b6dc50ad7ea03fc7cfe62a0a60c2b7f5f6cf8e5b268bffe"
+    "sha512=fc6953e03fcd076bbff4ef4834cddaaeb6fdd5aae5003efd16d2f619b7cf72e9cff1f15fb17aa6a54449289afa4781d993202789f8d5cdd7fcf59de593691e8c"
+  ]
+}
+x-commit-hash: "817fb86f34ffd48274b9bdd950f01cc5a1fa6e76"


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library

- Project page: <a href="https://mmottl.github.io/pcre-ocaml">https://mmottl.github.io/pcre-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/pcre-ocaml/api">https://mmottl.github.io/pcre-ocaml/api</a>

##### CHANGES:

- Added support for OCaml 4.08.

  Thanks to Chet Murthy for this contribution.
