### PR TITLE
git-cohttp/git-http/git-cohttp-unix/git-cohttp-mirage: deprecate

### DIFF
--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.0.0/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.0.0/opam
@@ -45,3 +45,5 @@ url {
     "sha512=451687a8a4bd4149afb4d68941998d700858d56b4fe3d9247efd1ef301b0bb15c5b11fd2fa01ff4226a0f58a31d1e68fe462952513f65f9cf9a3caa581b92c0a"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.1.0/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.1.0/opam
@@ -45,3 +45,5 @@ url {
     "sha512=d703b5456f5157b26d599c35cb01e8480e22a1287c61c43001f4aa6185f15c9b7840a95a2469846cd61d1cf831b4fe77207be7e48d0b0d00d38a1e8f063e96fd"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.1.1/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.1.1/opam
@@ -44,3 +44,5 @@ url {
     "sha512=dad22e05313c4245f0ed45c632b68208cff9ad9ea1c3214ae0e32c6a945324363257679bf3760ad9d9383ae444a0371712fe8ef4f0e20181ebb42f893997bfc9"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.2.0/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.2.0/opam
@@ -41,3 +41,5 @@ url {
     "sha512=fa19fe952331a50ad75b1a16193c46e3de2950c537e54b9e9d167b03502616bee10e36d8a114365645a8e4032b78a58d0567692106e9d6fb69f17b9964ebc3cb"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.0/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.0/opam
@@ -41,3 +41,5 @@ url {
     "sha512=b3beedffc9ec7f85d0c503f9d5f4115ce84bb75a6d1df8ed0fae214acec6922959be603e9ae869fb5ce6bd9da266973911889e2a4cd10b4c254d83a0f21bbaf4"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.1/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.1/opam
@@ -41,3 +41,5 @@ url {
     "sha512=1b7a6972cf7bd85464095419c636a3f195621e81dfd980aebb40ce283cf1177979b2d953915cf2401bf8827394071be55845ee76e86d67508bfff618660a1898"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.2/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.2/opam
@@ -41,3 +41,5 @@ url {
     "sha512=2f59ddd2add60c8d37637e3cad1871e88307aabcaf5b5dd0a9387da99abcd55c0da58137e39e23b77362e3f91923ba83e70007f65ed0f9f6384a15fe922e1b85"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.3/opam
+++ b/packages/git-cohttp-mirage/git-cohttp-mirage.3.3.3/opam
@@ -41,3 +41,5 @@ url {
     "sha512=f627ca0aaad112c08831280d44edcaf7324e9e6d48a7fe13cb0d54bb2385b038bbd5d8d334a93b7a56087618debea289d6f99010e1ed09b88c95ac38c8d3d641"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.0.0/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.0.0/opam
@@ -43,3 +43,5 @@ url {
     "sha512=451687a8a4bd4149afb4d68941998d700858d56b4fe3d9247efd1ef301b0bb15c5b11fd2fa01ff4226a0f58a31d1e68fe462952513f65f9cf9a3caa581b92c0a"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.1.0/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.1.0/opam
@@ -43,3 +43,5 @@ url {
     "sha512=d703b5456f5157b26d599c35cb01e8480e22a1287c61c43001f4aa6185f15c9b7840a95a2469846cd61d1cf831b4fe77207be7e48d0b0d00d38a1e8f063e96fd"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.1.1/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.1.1/opam
@@ -42,3 +42,5 @@ url {
     "sha512=dad22e05313c4245f0ed45c632b68208cff9ad9ea1c3214ae0e32c6a945324363257679bf3760ad9d9383ae444a0371712fe8ef4f0e20181ebb42f893997bfc9"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.2.0/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.2.0/opam
@@ -41,3 +41,5 @@ url {
     "sha512=fa19fe952331a50ad75b1a16193c46e3de2950c537e54b9e9d167b03502616bee10e36d8a114365645a8e4032b78a58d0567692106e9d6fb69f17b9964ebc3cb"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.3.0/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.3.0/opam
@@ -41,3 +41,5 @@ url {
     "sha512=b3beedffc9ec7f85d0c503f9d5f4115ce84bb75a6d1df8ed0fae214acec6922959be603e9ae869fb5ce6bd9da266973911889e2a4cd10b4c254d83a0f21bbaf4"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.3.1/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.3.1/opam
@@ -41,3 +41,5 @@ url {
     "sha512=1b7a6972cf7bd85464095419c636a3f195621e81dfd980aebb40ce283cf1177979b2d953915cf2401bf8827394071be55845ee76e86d67508bfff618660a1898"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.3.2/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.3.2/opam
@@ -41,3 +41,5 @@ url {
     "sha512=2f59ddd2add60c8d37637e3cad1871e88307aabcaf5b5dd0a9387da99abcd55c0da58137e39e23b77362e3f91923ba83e70007f65ed0f9f6384a15fe922e1b85"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.3.3/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.3.3/opam
@@ -41,3 +41,5 @@ url {
     "sha512=f627ca0aaad112c08831280d44edcaf7324e9e6d48a7fe13cb0d54bb2385b038bbd5d8d334a93b7a56087618debea289d6f99010e1ed09b88c95ac38c8d3d641"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.4.0/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.4.0/opam
@@ -41,3 +41,5 @@ url {
     "sha512=5fc02e4ea5fccf2386ddfcf5a15f1c11f49c982ffce0296bd5c00ba3f6510de3515e1ac80add7fe20cc8e3dc6516bbf233156ab9dd70eab7a12f7097ae49da27"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.5.0/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.5.0/opam
@@ -41,3 +41,5 @@ url {
   ]
 }
 x-commit-hash: "1908383243210d71d3595e0d2f239aaf2ca60c34"
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp-unix/git-cohttp-unix.3.6.0/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.6.0/opam
@@ -41,3 +41,5 @@ url {
     "sha512=73e0a7ab2bf00102653ac14d47ac62f3dddcdb0e24f7c5e33226801331cf608bcbfba2f058b5cb612ba9313d6ab12b2d01556169239e5fb18ef1c14a9b1c1eaf"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp/git-cohttp.3.0.0/opam
+++ b/packages/git-cohttp/git-cohttp.3.0.0/opam
@@ -41,3 +41,5 @@ url {
     "sha512=451687a8a4bd4149afb4d68941998d700858d56b4fe3d9247efd1ef301b0bb15c5b11fd2fa01ff4226a0f58a31d1e68fe462952513f65f9cf9a3caa581b92c0a"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp/git-cohttp.3.1.0/opam
+++ b/packages/git-cohttp/git-cohttp.3.1.0/opam
@@ -41,3 +41,5 @@ url {
     "sha512=d703b5456f5157b26d599c35cb01e8480e22a1287c61c43001f4aa6185f15c9b7840a95a2469846cd61d1cf831b4fe77207be7e48d0b0d00d38a1e8f063e96fd"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp/git-cohttp.3.1.1/opam
+++ b/packages/git-cohttp/git-cohttp.3.1.1/opam
@@ -40,3 +40,5 @@ url {
     "sha512=dad22e05313c4245f0ed45c632b68208cff9ad9ea1c3214ae0e32c6a945324363257679bf3760ad9d9383ae444a0371712fe8ef4f0e20181ebb42f893997bfc9"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp/git-cohttp.3.2.0/opam
+++ b/packages/git-cohttp/git-cohttp.3.2.0/opam
@@ -39,3 +39,5 @@ url {
     "sha512=fa19fe952331a50ad75b1a16193c46e3de2950c537e54b9e9d167b03502616bee10e36d8a114365645a8e4032b78a58d0567692106e9d6fb69f17b9964ebc3cb"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp/git-cohttp.3.3.0/opam
+++ b/packages/git-cohttp/git-cohttp.3.3.0/opam
@@ -39,3 +39,5 @@ url {
     "sha512=b3beedffc9ec7f85d0c503f9d5f4115ce84bb75a6d1df8ed0fae214acec6922959be603e9ae869fb5ce6bd9da266973911889e2a4cd10b4c254d83a0f21bbaf4"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp/git-cohttp.3.3.1/opam
+++ b/packages/git-cohttp/git-cohttp.3.3.1/opam
@@ -39,3 +39,5 @@ url {
     "sha512=1b7a6972cf7bd85464095419c636a3f195621e81dfd980aebb40ce283cf1177979b2d953915cf2401bf8827394071be55845ee76e86d67508bfff618660a1898"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp/git-cohttp.3.3.2/opam
+++ b/packages/git-cohttp/git-cohttp.3.3.2/opam
@@ -39,3 +39,5 @@ url {
     "sha512=2f59ddd2add60c8d37637e3cad1871e88307aabcaf5b5dd0a9387da99abcd55c0da58137e39e23b77362e3f91923ba83e70007f65ed0f9f6384a15fe922e1b85"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp/git-cohttp.3.3.3/opam
+++ b/packages/git-cohttp/git-cohttp.3.3.3/opam
@@ -39,3 +39,5 @@ url {
     "sha512=f627ca0aaad112c08831280d44edcaf7324e9e6d48a7fe13cb0d54bb2385b038bbd5d8d334a93b7a56087618debea289d6f99010e1ed09b88c95ac38c8d3d641"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp/git-cohttp.3.4.0/opam
+++ b/packages/git-cohttp/git-cohttp.3.4.0/opam
@@ -39,3 +39,5 @@ url {
     "sha512=5fc02e4ea5fccf2386ddfcf5a15f1c11f49c982ffce0296bd5c00ba3f6510de3515e1ac80add7fe20cc8e3dc6516bbf233156ab9dd70eab7a12f7097ae49da27"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp/git-cohttp.3.5.0/opam
+++ b/packages/git-cohttp/git-cohttp.3.5.0/opam
@@ -39,3 +39,5 @@ url {
   ]
 }
 x-commit-hash: "1908383243210d71d3595e0d2f239aaf2ca60c34"
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-cohttp/git-cohttp.3.6.0/opam
+++ b/packages/git-cohttp/git-cohttp.3.6.0/opam
@@ -39,3 +39,5 @@ url {
     "sha512=73e0a7ab2bf00102653ac14d47ac62f3dddcdb0e24f7c5e33226801331cf608bcbfba2f058b5cb612ba9313d6ab12b2d01556169239e5fb18ef1c14a9b1c1eaf"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-http/git-http.1.10.0/opam
+++ b/packages/git-http/git-http.1.10.0/opam
@@ -25,3 +25,5 @@ url {
     "md5=7838f197b08016a50940ee36cf1c11df"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-http/git-http.1.11.0/opam
+++ b/packages/git-http/git-http.1.11.0/opam
@@ -25,3 +25,5 @@ url {
     "md5=3058529840aed0053fec7899069d3974"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-http/git-http.1.11.2/opam
+++ b/packages/git-http/git-http.1.11.2/opam
@@ -25,3 +25,5 @@ url {
     "md5=9cbc7705f6182e9198f05e577014d643"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-http/git-http.1.11.4/opam
+++ b/packages/git-http/git-http.1.11.4/opam
@@ -26,3 +26,5 @@ url {
     "md5=8996056ecacbc5bbdd226a3708f11232"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-http/git-http.2.0.0/opam
+++ b/packages/git-http/git-http.2.0.0/opam
@@ -30,3 +30,5 @@ url {
     "md5=9d7200e8eb15325e3bf37199f6255826"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-http/git-http.2.1.0/opam
+++ b/packages/git-http/git-http.2.1.0/opam
@@ -29,3 +29,5 @@ url {
     "sha512=7ac19137197a0620f4a1398e325895a37bc1d52d9e32ed756488e01b55ae95f37f930c80d11bc29203b30ee6becf49b67826afd31c1389eb37e2c7f892b40864"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-http/git-http.2.1.1/opam
+++ b/packages/git-http/git-http.2.1.1/opam
@@ -29,3 +29,5 @@ url {
     "sha512=ae73f03138455d2bbd3617c9740c2d950f6f6e848dc9f76fbc608cc17f57eab041e1fbdb338a82f94c5121e7dacb733618a40585959097e2dce9c8c87e9f10d0"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-http/git-http.2.1.2/opam
+++ b/packages/git-http/git-http.2.1.2/opam
@@ -29,3 +29,5 @@ url {
     "sha512=bb3306f2728d3ac4975b4ba347b53aec26a831a96445ed4812685e9991c46ed45393c107f1b4cb42ca77fed1cbb2a06ffb41036fd7284d812270630c3ac3dc6f"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated

--- a/packages/git-http/git-http.2.1.3/opam
+++ b/packages/git-http/git-http.2.1.3/opam
@@ -29,3 +29,5 @@ url {
     "sha512=9a863552ad7fddfa37d92738dd1c793e888a3c544f97a7634aa9ed5cef1ca22db4e6bfa1908c58986af0bf1dcd665ba63308c1656e68397b7a87f1a09e94fe97"
   ]
 }
+available: opam-version >= "2.2.0"
+flags: deprecated


### PR DESCRIPTION
these packages are no longer part of the upstream ocaml-git project, since they're now part of git-paf

//cc @dinosaure for approval