### PR TITLE
Package operf-micro.1.1.2

### DIFF
--- a/packages/operf-micro/operf-micro.1.1.2/opam
+++ b/packages/operf-micro/operf-micro.1.1.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Pierre Chambart <pierre.chambart@ocamlpro.com>"
+authors: "Pierre Chambart <pierre.chambart@ocamlpro.com>"
+homepage: "http://www.typerex.org/operf-micro.html"
+bug-reports: "http://github.com/OCamlPro/operf-micro/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/OCamlPro/operf-micro"
+substs: "Makefile.conf"
+build: [make]
+install: [make "install"]
+remove: [make "uninstall"]
+synopsis: "Simple tool for benchmarking the OCaml compiler"
+description: """
+operf-micro is a small tool coming with a set of micro benchmarks for the OCaml
+compiler. It provides a minimal framework to compare the performances of
+different versions of the compiler."""
+depends: [
+  "ocaml" { >= "4.07.0" }
+]
+url {
+  src:
+    "https://github.com/OCamlPro/operf-micro/archive/refs/tags/operf-micro.1.1.2.tar.gz"
+  checksum: [
+    "md5=7fc218d21e33d4a1835df6be6711851a"
+    "sha512=a5276d460c85154bdd1e9ace4afc113c9ac62e61dc114f0386f9c74aa2b03da151956d9788f4fb8f6c4375a365a729c4f13c570c0b58bc1033e75e45dbc7477d"
+  ]
+}


### PR DESCRIPTION
### `operf-micro.1.1.2`
Simple tool for benchmarking the OCaml compiler
operf-micro is a small tool coming with a set of micro benchmarks for the OCaml
compiler. It provides a minimal framework to compare the performances of
different versions of the compiler.



---
* Homepage: http://www.typerex.org/operf-micro.html
* Source repo: git+https://github.com/OCamlPro/operf-micro
* Bug tracker: http://github.com/OCamlPro/operf-micro/issues

---
:camel: Pull-request generated by opam-publish v2.5.0