### PR TITLE
Flag every versions of the ocaml package that haven't been released yet with avoid-version

### DIFF
--- a/packages/ocaml/ocaml.4.02.4/opam
+++ b/packages/ocaml/ocaml.4.02.4/opam
@@ -28,4 +28,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.4.03.1/opam
+++ b/packages/ocaml/ocaml.4.03.1/opam
@@ -28,4 +28,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.4.04.3/opam
+++ b/packages/ocaml/ocaml.4.04.3/opam
@@ -28,4 +28,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.4.05.1/opam
+++ b/packages/ocaml/ocaml.4.05.1/opam
@@ -28,4 +28,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.4.06.2/opam
+++ b/packages/ocaml/ocaml.4.06.2/opam
@@ -28,4 +28,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.4.07.2/opam
+++ b/packages/ocaml/ocaml.4.07.2/opam
@@ -28,4 +28,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.4.08.2/opam
+++ b/packages/ocaml/ocaml.4.08.2/opam
@@ -28,4 +28,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.4.09.2/opam
+++ b/packages/ocaml/ocaml.4.09.2/opam
@@ -28,4 +28,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.4.10.3/opam
+++ b/packages/ocaml/ocaml.4.10.3/opam
@@ -28,4 +28,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.4.11.3/opam
+++ b/packages/ocaml/ocaml.4.11.3/opam
@@ -28,4 +28,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.4.12.2/opam
+++ b/packages/ocaml/ocaml.4.12.2/opam
@@ -28,4 +28,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.4.13.2/opam
+++ b/packages/ocaml/ocaml.4.13.2/opam
@@ -31,4 +31,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.4.14.3/opam
+++ b/packages/ocaml/ocaml.4.14.3/opam
@@ -32,4 +32,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.5.0.1/opam
+++ b/packages/ocaml/ocaml.5.0.1/opam
@@ -36,4 +36,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.5.1.2/opam
+++ b/packages/ocaml/ocaml.5.1.2/opam
@@ -36,4 +36,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.5.2.2/opam
+++ b/packages/ocaml/ocaml.5.2.2/opam
@@ -33,4 +33,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]

--- a/packages/ocaml/ocaml.5.3.1/opam
+++ b/packages/ocaml/ocaml.5.3.1/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml-system" {>= "5.3.1~" & < "5.3.2~"} |
   "dkml-base-compiler" {>= "5.3.1~" & < "5.3.2~"}
 ]
-flags: conf
+flags: [conf avoid-version]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]

--- a/packages/ocaml/ocaml.5.4.0/opam
+++ b/packages/ocaml/ocaml.5.4.0/opam
@@ -36,4 +36,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: conf
+flags: [conf avoid-version]


### PR DESCRIPTION
https://github.com/ocaml/opam/pull/6358 would display more clearly which packages are tagged with avoid-version/deprecated. However in the case of `ocaml` where we would expect `5.4.0` to be shown in the same way to avoid confusion as to which version is the latest, it is more complicated due to the fact that detecting if such a package needs to be displayed differently would need a request from the solver for each version which seems too costly.

Thus i'm proposing to tag the `ocaml` packages that are still unreleased or in their pre-release phase with `avoid-version` and to untag them at the same time as the final release (in this case 5.4.0).

cc @Octachron does that seem ok to you? If so this step would be to be added to the release documentation.

Not to be merged before https://github.com/ocaml/opam/pull/6358 has been discussed and merged.