### PR TITLE
Mark opam-lib (opam 1.x) as deprecated

### DIFF
--- a/packages/opam-lib/opam-lib.0.9.1/opam
+++ b/packages/opam-lib/opam-lib.0.9.1/opam
@@ -42,7 +42,7 @@ simultaneous compiler installations, flexible package constraints, and
 a Git-friendly development workflow.
 
 This package contains only the libraries of OPAM and *not* the binary."""
-flags: light-uninstall
+flags: [light-uninstall deprecated]
 url {
   src: "https://github.com/OCamlPro/opam/archive/0.9.1.tar.gz"
   checksum: [

--- a/packages/opam-lib/opam-lib.0.9.3/opam
+++ b/packages/opam-lib/opam-lib.0.9.3/opam
@@ -43,7 +43,7 @@ simultaneous compiler installations, flexible package constraints, and
 a Git-friendly development workflow.
 
 This package contains only the libraries of OPAM and *not* the binary."""
-flags: light-uninstall
+flags: [light-uninstall deprecated]
 url {
   src: "https://github.com/OCamlPro/opam/archive/0.9.3.tar.gz"
   checksum: [

--- a/packages/opam-lib/opam-lib.0.9.4/opam
+++ b/packages/opam-lib/opam-lib.0.9.4/opam
@@ -47,7 +47,7 @@ simultaneous compiler installations, flexible package constraints, and
 a Git-friendly development workflow.
 
 This package contains only the libraries of OPAM and *not* the binary."""
-flags: light-uninstall
+flags: [light-uninstall deprecated]
 url {
   src: "https://github.com/OCamlPro/opam/archive/0.9.4.tar.gz"
   checksum: [

--- a/packages/opam-lib/opam-lib.0.9.6/opam
+++ b/packages/opam-lib/opam-lib.0.9.6/opam
@@ -42,7 +42,7 @@ simultaneous compiler installations, flexible package constraints, and
 a Git-friendly development workflow.
 
 This package contains only the libraries of OPAM and *not* the binary."""
-flags: light-uninstall
+flags: [light-uninstall deprecated]
 url {
   src: "https://github.com/OCamlPro/opam/archive/0.9.6.tar.gz"
   checksum: [

--- a/packages/opam-lib/opam-lib.1.0.0/opam
+++ b/packages/opam-lib/opam-lib.1.0.0/opam
@@ -42,7 +42,7 @@ simultaneous compiler installations, flexible package constraints, and
 a Git-friendly development workflow.
 
 This package contains only the libraries of OPAM and *not* the binary."""
-flags: light-uninstall
+flags: [light-uninstall deprecated]
 url {
   src: "https://github.com/OCamlPro/opam/archive/1.0.0.tar.gz"
   checksum: [

--- a/packages/opam-lib/opam-lib.1.1.0/opam
+++ b/packages/opam-lib/opam-lib.1.1.0/opam
@@ -42,7 +42,7 @@ simultaneous compiler installations, flexible package constraints, and
 a Git-friendly development workflow.
 
 This package contains only the libraries of OPAM and *not* the binary."""
-flags: light-uninstall
+flags: [light-uninstall deprecated]
 url {
   src: "https://github.com/OCamlPro/opam/archive/1.1.0.tar.gz"
   checksum: [

--- a/packages/opam-lib/opam-lib.1.1.1/opam
+++ b/packages/opam-lib/opam-lib.1.1.1/opam
@@ -42,7 +42,7 @@ simultaneous compiler installations, flexible package constraints, and
 a Git-friendly development workflow.
 
 This package contains only the libraries of OPAM and *not* the binary."""
-flags: light-uninstall
+flags: [light-uninstall deprecated]
 url {
   src: "https://github.com/OCamlPro/opam/archive/1.1.1.tar.gz"
   checksum: [

--- a/packages/opam-lib/opam-lib.1.2.0/opam
+++ b/packages/opam-lib/opam-lib.1.2.0/opam
@@ -29,6 +29,7 @@ depends: [
   "jsonm"
   "ocamlbuild" {build}
 ]
+flags: deprecated
 patches: [ "fix-wait.diff"]
 synopsis: "The OCaml PAckage Manager (OPAM)"
 description: """

--- a/packages/opam-lib/opam-lib.1.2.1/opam
+++ b/packages/opam-lib/opam-lib.1.2.1/opam
@@ -28,6 +28,7 @@ depends: [
   "jsonm"
   "ocamlbuild" {build}
 ]
+flags: deprecated
 install: [make "-C" "src" "../opam-lib.install"]
 synopsis: "The OPAM library"
 description: """

--- a/packages/opam-lib/opam-lib.1.2.2/opam
+++ b/packages/opam-lib/opam-lib.1.2.2/opam
@@ -29,6 +29,7 @@ depends: [
   "jsonm"
   "ocamlbuild" {build}
 ]
+flags: deprecated
 install: [make "-C" "src" "../opam-lib.install"]
 synopsis: "The OPAM library"
 description: """

--- a/packages/opam-lib/opam-lib.1.3.0/opam
+++ b/packages/opam-lib/opam-lib.1.3.0/opam
@@ -28,6 +28,7 @@ depends: [
   "ocamlfind" {build}
   "jsonm"
 ]
+flags: deprecated
 synopsis: "The OPAM library"
 description: """
 OPAM is The OCaml PAckage Manager. This package contains the OPAM

--- a/packages/opam-lib/opam-lib.1.3.1/opam
+++ b/packages/opam-lib/opam-lib.1.3.1/opam
@@ -28,6 +28,7 @@ depends: [
   "ocamlfind" {build}
   "jsonm"
 ]
+flags: deprecated
 synopsis: "The OPAM library"
 description: """
 OPAM is The OCaml PAckage Manager. This package contains the OPAM


### PR DESCRIPTION
Similarly to https://github.com/ocaml/opam-repository/pull/27228