### PR TITLE
Add x-maintenance-intent to ctypes.

### DIFF
--- a/packages/ctypes/ctypes.0.23.0/opam
+++ b/packages/ctypes/ctypes.0.23.0/opam
@@ -63,3 +63,4 @@ url {
 conflicts: [
   "host-system-msvc"
 ]
+x-maintenance-intent: ["(any).(any).(latest)"]


### PR DESCRIPTION
Closes yallop/ocaml-ctypes#791.

Add `x-maintenance-intent` to the `ctypes` package.

I'm starting with a conservative policy that should make it possible to archive around 55% of the current `ctypes` versions.  I may switch to a more aggressive policy in the future.