### PR TITLE
Package operf-micro.1.1.3

### DIFF
--- a/packages/operf-micro/operf-micro.1.1.3/opam
+++ b/packages/operf-micro/operf-micro.1.1.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Pierre Chambart <pierre.chambart@ocamlpro.com>"
+authors: "Pierre Chambart <pierre.chambart@ocamlpro.com>"
+homepage: "http://www.typerex.org/operf-micro.html"
+bug-reports: "http://github.com/OCamlPro/operf-micro/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/OCamlPro/operf-micro"
+substs: "Makefile.conf"
+build: [make]
+install: [make "install"]
+remove: [make "uninstall"]
+synopsis: "Simple tool for benchmarking the OCaml compiler"
+description: """
+operf-micro is a small tool coming with a set of micro benchmarks for the OCaml
+compiler. It provides a minimal framework to compare the performances of
+different versions of the compiler."""
+depends: [
+  "ocaml" { >= "4.07.0" }
+]
+url {
+  src:
+    "https://github.com/OCamlPro/operf-micro/archive/refs/tags/operf-micro.1.1.3.tar.gz"
+  checksum: [
+    "md5=a289a3c7edabe5416ee591b817d1cde4"
+    "sha512=f9aed0530b315822167742100cbfbbaeed2e738be6dc4d6c4552e8625bbd7fbccf6ed76e11578f630345757bfb0c0168a65d03ff92e60fe4fa9e9246ec9c4431"
+  ]
+}


### PR DESCRIPTION
### `operf-micro.1.1.3`
Simple tool for benchmarking the OCaml compiler
operf-micro is a small tool coming with a set of micro benchmarks for the OCaml
compiler. It provides a minimal framework to compare the performances of
different versions of the compiler.



---
* Homepage: http://www.typerex.org/operf-micro.html
* Source repo: git+https://github.com/OCamlPro/operf-micro
* Bug tracker: http://github.com/OCamlPro/operf-micro/issues

---
:camel: Pull-request generated by opam-publish v2.5.0