### PR TITLE
Add rocq-native

### DIFF
--- a/packages/rocq-native/rocq-native.1/opam
+++ b/packages/rocq-native/rocq-native.1/opam
@@ -1,23 +1,19 @@
 opam-version: "2.0"
 maintainer: "Erik Martin-Dorel"
-authors: "Coq"
+authors: "Rocq"
 license: "LGPL-2.1-only"
 homepage: "https://coq.inria.fr/"
 bug-reports: "https://github.com/coq/coq/issues"
-depends: [
-  "rocq-native"
-]
 conflicts: [
-  "coq" {< "8.5"}
   "base-nnp"
   "ocaml-option-nnpchecker"
 ]
-synopsis: "Package flag enabling coq's native-compiler flag"
+synopsis: "Package flag enabling rocq's native-compiler flag"
 description: """
 This package acts as a package flag for the ambient switch, taken into
-account by coq (and possibly any coq library) to enable native_compute
+account by rocq (and possibly any rocq library) to enable native_compute
 at configure time, triggering the installation of .coq-native/* files
-for the coq standard library and subsequent coq libraries.
+for the rocq libraries.
 
 This implements item 1 of CEP #48 <https://github.com/coq/ceps/pull/48>.
 
@@ -27,9 +23,6 @@ Remarks:
    see <https://github.com/coq/coq/issues/11178>.
 2. this package is not intended to be used as a dependency of other
    packages (notably as installing or uninstalling this package may
-   trigger a rebuild of all coq packages in the ambient switch).
+   trigger a rebuild of all rocq packages in the ambient switch).
 3. the option set by this package will be automatically propagated to
-   coqc for coq >= 8.13 (but the packaging of coq libraries for
-   earlier versions of coq may need an update: for details, see item 3
-   of CEP #48 <https://github.com/coq/ceps/pull/48>).
-"""
+   rocq compile."""


### PR DESCRIPTION
In preparation of the future release of Rocq 9.0 (renaming of Coq).