### PR TITLE
utop 2.15.0: switch to the archive with the substituted version number

### DIFF
--- a/packages/utop/utop.2.15.0-1/opam
+++ b/packages/utop/utop.2.15.0-1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Universal toplevel for OCaml"
+description:
+  "utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for OCaml. It can run in a terminal or in Emacs. It supports line edition, history, real-time and context sensitive completion, colors, and more. It integrates with the Tuareg mode in Emacs."
+maintainer: ["jeremie@dimino.org"]
+authors: ["Jérémie Dimino"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/utop"
+doc: "https://ocaml-community.github.io/utop/"
+bug-reports: "https://github.com/ocaml-community/utop/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.11.0"}
+  "base-unix"
+  "base-threads"
+  "ocamlfind" {>= "1.7.2"}
+  "lambda-term" {>= "3.1.0" & < "4.0"}
+  "logs"
+  "lwt"
+  "lwt_react"
+  "zed" {>= "3.2.0"}
+  "react" {>= "1.0.0"}
+  "cppo" {>= "1.1.2"}
+  "alcotest" {with-test}
+  "xdg" {>= "3.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-community/utop.git"
+url {
+  src:
+    "https://github.com/ocaml-community/utop/releases/download/2.15.0/utop-2.15.0-1.tar.gz"
+  checksum: [
+    "sha256=a11844563c36efefc466076f6f5f114d30eff6f032aec2fbe0dcbd20255d204d"
+    "sha512=07991b7a837bb3cae4d0ca2977d011a34f1bb9a7b3b472787010f788aae3b8d7960bc3c5b7f19c3153249dc8f229934b5f48c37d16f93b50eb4d6b5da65dfe7b"
+  ]
+}

--- a/packages/utop/utop.2.15.0/opam
+++ b/packages/utop/utop.2.15.0/opam
@@ -42,9 +42,9 @@ build: [
 dev-repo: "git+https://github.com/ocaml-community/utop.git"
 url {
   src:
-    "https://github.com/ocaml-community/utop/releases/download/2.15.0/utop-2.15.0.tar.gz"
+    "https://github.com/ocaml-community/utop/releases/download/2.15.0/utop-2.15.0-1.tar.gz"
   checksum: [
-    "sha256=7659dea0a7f7a5b16e30024ee681445179f8c0f87630e5cdae554280dacd6fac"
-    "sha512=f05aa85fbec3a4ecda6068b1ed350f61a0b3626969641c37508fde0fdeeffa80abd50b406c36884a81bc965d91d97d797490da1fe4edea0daa3936d47bbb1c70"
+    "sha256=a11844563c36efefc466076f6f5f114d30eff6f032aec2fbe0dcbd20255d204d"
+    "sha512=07991b7a837bb3cae4d0ca2977d011a34f1bb9a7b3b472787010f788aae3b8d7960bc3c5b7f19c3153249dc8f229934b5f48c37d16f93b50eb4d6b5da65dfe7b"
   ]
 }

--- a/packages/utop/utop.2.15.0/opam
+++ b/packages/utop/utop.2.15.0/opam
@@ -42,9 +42,9 @@ build: [
 dev-repo: "git+https://github.com/ocaml-community/utop.git"
 url {
   src:
-    "https://github.com/ocaml-community/utop/releases/download/2.15.0/utop-2.15.0-1.tar.gz"
+    "https://github.com/ocaml-community/utop/releases/download/2.15.0/utop-2.15.0.tar.gz"
   checksum: [
-    "sha256=a11844563c36efefc466076f6f5f114d30eff6f032aec2fbe0dcbd20255d204d"
-    "sha512=07991b7a837bb3cae4d0ca2977d011a34f1bb9a7b3b472787010f788aae3b8d7960bc3c5b7f19c3153249dc8f229934b5f48c37d16f93b50eb4d6b5da65dfe7b"
+    "sha256=7659dea0a7f7a5b16e30024ee681445179f8c0f87630e5cdae554280dacd6fac"
+    "sha512=f05aa85fbec3a4ecda6068b1ed350f61a0b3626969641c37508fde0fdeeffa80abd50b406c36884a81bc965d91d97d797490da1fe4edea0daa3936d47bbb1c70"
   ]
 }


### PR DESCRIPTION
This small PR points the opam package for utop 2.15.0 to the updated release archive for utop 2.15.0 in which the utop version number has been correctly substituted.

This avoids leaving %%VERSION%% in the utop banner

> Welcome to utop version %%VERSION%% (using OCaml version 5.3.0)!"