### PR TITLE
[new release] merlin (4 packages) (5.4-503) and OCaml-LSP

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.5.4-503/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.4-503/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" }
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.4-503/merlin-5.4-503.tbz"
+  checksum: [
+    "sha256=f2e4780c9a9ca54c403292e7ff7e0fa33d3afeae0c4e735e14f3f9cb74af2cbc"
+    "sha512=d81598359e33776d0388838f62175f704d96fc6e497d22a72508ea1f53bb7f0815561ae4fbfa6fd9c1a8ada94b8d0d4c7c03c35c4d8c0fbb323e94260ddd4885"
+  ]
+}
+x-commit-hash: "3b3d3d1682f9334396a8ad6e245d95ae3be353ef"

--- a/packages/jsonrpc/jsonrpc.1.15.0~5.0preview1/opam
+++ b/packages/jsonrpc/jsonrpc.1.15.0~5.0preview1/opam
@@ -17,6 +17,7 @@ authors: [
 license: "ISC"
 homepage: "https://github.com/ocaml/ocaml-lsp"
 bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+flags: avoid-version
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.08"}

--- a/packages/jsonrpc/jsonrpc.1.22.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.22.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: [ "(latest)" "(latest)-414" ]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.22.0/lsp-1.22.0.tbz"
+  checksum: [
+    "sha256=519dc3577d15dc2210defa580481a743579118d50693b691bb10cbc8203fb581"
+    "sha512=9477f47c6b9344b46ac22b2a4fc2fa0444cc2917c62307dc4c91b70440ab6192101e02038cd58e8b65b67088a0c4e235cad6a791c1333b3fe529aeb441bf8a5d"
+  ]
+}
+x-commit-hash: "aae6986391a8519de3da6a7a341f2bd3376e0d2f"

--- a/packages/lsp/lsp.1.15.0~5.0preview1/opam
+++ b/packages/lsp/lsp.1.15.0~5.0preview1/opam
@@ -21,6 +21,7 @@ authors: [
 license: "ISC"
 homepage: "https://github.com/ocaml/ocaml-lsp"
 bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+flags: avoid-version
 depends: [
   "dune" {>= "3.0"}
   "jsonrpc" {= version}

--- a/packages/lsp/lsp.1.22.0/opam
+++ b/packages/lsp/lsp.1.22.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "jsonrpc" {= version}
+  "yojson"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "cinaps" {with-test}
+  "ppx_expect" {>= "v0.17.0" & with-test}
+  "uutf" {>= "1.0.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.14"}
+  "ppx_yojson_conv" {with-dev-setup}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: [ "(latest)" "(latest)-414" ]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.22.0/lsp-1.22.0.tbz"
+  checksum: [
+    "sha256=519dc3577d15dc2210defa580481a743579118d50693b691bb10cbc8203fb581"
+    "sha512=9477f47c6b9344b46ac22b2a4fc2fa0444cc2917c62307dc4c91b70440ab6192101e02038cd58e8b65b67088a0c4e235cad6a791c1333b3fe529aeb441bf8a5d"
+  ]
+}
+x-commit-hash: "aae6986391a8519de3da6a7a341f2bd3376e0d2f"

--- a/packages/merlin-lib/merlin-lib.5.4-503/opam
+++ b/packages/merlin-lib/merlin-lib.5.4-503/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="5.3" & <"5.4"}
+  "dune" {>= "3.0.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test & >= "1.3.0" }
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.4-503/merlin-5.4-503.tbz"
+  checksum: [
+    "sha256=f2e4780c9a9ca54c403292e7ff7e0fa33d3afeae0c4e735e14f3f9cb74af2cbc"
+    "sha512=d81598359e33776d0388838f62175f704d96fc6e497d22a72508ea1f53bb7f0815561ae4fbfa6fd9c1a8ada94b8d0d4c7c03c35c4d8c0fbb323e94260ddd4885"
+  ]
+}
+x-commit-hash: "3b3d3d1682f9334396a8ad6e245d95ae3be353ef"

--- a/packages/merlin/merlin.5.4-503/opam
+++ b/packages/merlin/merlin.5.4-503/opam
@@ -1,0 +1,80 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {= version}
+  "ocaml-index" {>= "1.0" & post}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.4-503/merlin-5.4-503.tbz"
+  checksum: [
+    "sha256=f2e4780c9a9ca54c403292e7ff7e0fa33d3afeae0c4e735e14f3f9cb74af2cbc"
+    "sha512=d81598359e33776d0388838f62175f704d96fc6e497d22a72508ea1f53bb7f0815561ae4fbfa6fd9c1a8ada94b8d0d4c7c03c35c4d8c0fbb323e94260ddd4885"
+  ]
+}
+x-commit-hash: "3b3d3d1682f9334396a8ad6e245d95ae3be353ef"

--- a/packages/merlin/merlin.5.4-503/opam
+++ b/packages/merlin/merlin.5.4-503/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "3.0.0"}
   "merlin-lib" {= version}
   "dot-merlin-reader" {= version}
-  "ocaml-index" {>= "1.0" & post}
+  "ocaml-index" {= version & post}
   "yojson" {>= "2.0.0"}
   "conf-jq" {with-test}
   "ppxlib" {with-test}

--- a/packages/ocaml-index/ocaml-index.1.1/opam
+++ b/packages/ocaml-index/ocaml-index.1.1/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/merlin"
 bug-reports: "https://github.com/ocaml/merlin/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "5.2" & < "5.3" }
   "merlin-lib" {>= "5.2.1-502"}
   "odoc" {with-doc}
   "alcotest" {with-test}

--- a/packages/ocaml-index/ocaml-index.5.4-503/opam
+++ b/packages/ocaml-index/ocaml-index.5.4-503/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A tool that indexes value usages from cmt files"
+description:
+  "ocaml-index should integrate with the build system to index codebase and allow tools such as Merlin to perform project-wide occurrences queries."
+maintainer: ["ulysse@tarides.com"]
+authors: ["ulysse@tarides.com"]
+license: "MIT"
+homepage: "https://github.com/ocaml/merlin/ocaml-index"
+bug-reports: "https://github.com/ocaml/merlin/issues"
+depends: [
+  "dune" {>= "3.0.0"}
+  "ocaml" {>= "5.2"}
+  "merlin-lib" {>= "5.1-502"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.4-503/merlin-5.4-503.tbz"
+  checksum: [
+    "sha256=f2e4780c9a9ca54c403292e7ff7e0fa33d3afeae0c4e735e14f3f9cb74af2cbc"
+    "sha512=d81598359e33776d0388838f62175f704d96fc6e497d22a72508ea1f53bb7f0815561ae4fbfa6fd9c1a8ada94b8d0d4c7c03c35c4d8c0fbb323e94260ddd4885"
+  ]
+}
+x-commit-hash: "3b3d3d1682f9334396a8ad6e245d95ae3be353ef"

--- a/packages/ocaml-index/ocaml-index.5.4-503/opam
+++ b/packages/ocaml-index/ocaml-index.5.4-503/opam
@@ -9,8 +9,8 @@ homepage: "https://github.com/ocaml/merlin/ocaml-index"
 bug-reports: "https://github.com/ocaml/merlin/issues"
 depends: [
   "dune" {>= "3.0.0"}
-  "ocaml" {>= "5.2"}
-  "merlin-lib" {>= "5.1-502"}
+  "ocaml" {>= "5.3"}
+  "merlin-lib" {= version}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.15.0~5.0preview1/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.15.0~5.0preview1/opam
@@ -17,6 +17,7 @@ authors: [
 license: "ISC"
 homepage: "https://github.com/ocaml/ocaml-lsp"
 bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+flags: avoid-version
 depends: [
   "dune" {>= "3.0"}
   "yojson"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0~5.2preview/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0~5.2preview/opam
@@ -17,6 +17,7 @@ authors: [
 license: "ISC"
 homepage: "https://github.com/ocaml/ocaml-lsp"
 bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+flags: avoid-version
 depends: [
   "dune" {>= "3.0"}
   "yojson"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.22.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.22.0/opam
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson"
+  "base" {>= "v0.16.0"}
+  "lsp" {= version}
+  "jsonrpc" {= version}
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc" {>= "3.4.0"}
+  "chrome-trace" {>= "3.3.0"}
+  "dyn"
+  "stdune"
+  "fiber" {>= "3.1.1" & < "4.0.0"}
+  "ocaml" {>= "5.3" & < "5.4"}
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "astring"
+  "camlp-streams"
+  "ppx_expect" {>= "v0.17.0" & with-test}
+  "ocamlformat" {with-test & = "0.27.0"}
+  "ocamlc-loc" {>= "3.7.0"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "merlin-lib" {>= "5.4" & < "6.0"}
+  "ppx_yojson_conv" {with-dev-setup}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: [ "(latest)" "(latest)-414" ]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.22.0/lsp-1.22.0.tbz"
+  checksum: [
+    "sha256=519dc3577d15dc2210defa580481a743579118d50693b691bb10cbc8203fb581"
+    "sha512=9477f47c6b9344b46ac22b2a4fc2fa0444cc2917c62307dc4c91b70440ab6192101e02038cd58e8b65b67088a0c4e235cad6a791c1333b3fe529aeb441bf8a5d"
+  ]
+}
+x-commit-hash: "aae6986391a8519de3da6a7a341f2bd3376e0d2f"


### PR DESCRIPTION
Editor helper, provides completion, typing and source browsing in Vim and Emacs

- Project page: <a href="https://github.com/ocaml/merlin">https://github.com/ocaml/merlin</a>

##### CHANGES:

Fri Jan 10 17:55:42 CET 2025

  + merlin binary
    - Support for OCaml 5.3
    - Use new 5.3 features to improve locate behavior in some cases. Merlin no
      longer confuses uids from interfaces and implementations. (ocaml/merlin#1857)
    - Perform less merges in the indexer (ocaml/merlin#1881)
    - Add initial support for project-wide renaming: occurrences can now return
      all usages of all related definitions. (ocaml/merlin#1877)
  + vim plugin
    - Added support for search-by-type (ocaml/merlin#1846)
      This is exposed through the existing `:MerlinSearch` command, that
      switches between search-by-type and polarity search depending on the
      first character of the query.

##### OCAML-LSP CHANGES:

###### Features

- Enable experimental project-wide renaming of identifiers (https://github.com/ocaml/ocaml-lsp/pull/1431)