### PR TITLE
Package why3find.1.1.1

### DIFF
--- a/packages/why3find/why3find.1.1.1/opam
+++ b/packages/why3find/why3find.1.1.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "A Why3 Package Manager"
+description:
+  "The why3find utility is designed for managing packages for why3 developpers and associated OCaml extracted code."
+maintainer: ["benjamin.jorge@cea.fr" "loic.correnson@cea.fr"]
+authors: [
+  "Loïc Correnson <loic.correnson@cea.fr>"
+  "Benjamin Jorge <benjamin.jorge@cea.fr>"
+]
+license: "LGPL-2.1-only"
+tags: "why3"
+homepage: "https://git.frama-c.com/pub/why3find"
+doc: "https://git.frama-c.com/pub/why3find"
+bug-reports: "https://git.frama-c.com/pub/why3find/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "dune-site" {>= "3.12"}
+  "why3" {>= "1.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "yojson" {>= "1.7.0"}
+  "zmq" {>= "5.0.0"}
+  "terminal_size" {>= "0.2.0"}
+  "alt-ergo" {with-test & = "2.4.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/why3find.git"
+url {
+  src:
+    "https://git.frama-c.com/pub/why3find/-/archive/1.1.1/why3find-1.1.1.tar.gz"
+  checksum: [
+    "md5=1c67ccf5aecc83f64d70404eb85140b2"
+    "sha512=a805f182cae2543541591a98e48de8991276db97ee9933627cd2c1e16c83e4b549c8728b50cec3b6694b69f172b0cd04a3826e05550570266c18714fc1af162e"
+  ]
+}


### PR DESCRIPTION
### `why3find.1.1.1`
A Why3 Package Manager
The why3find utility is designed for managing packages for why3 developpers and associated OCaml extracted code.



---
* Homepage: https://git.frama-c.com/pub/why3find
* Source repo: git+https://git.frama-c.com/pub/why3find.git
* Bug tracker: https://git.frama-c.com/pub/why3find/issues

---
:camel: Pull-request generated by opam-publish v2.5.0