### PR TITLE
[new release] multicore-magic (2 packages) (2.3.1)

### DIFF
--- a/packages/multicore-magic-dscheck/multicore-magic-dscheck.2.3.1/opam
+++ b/packages/multicore-magic-dscheck/multicore-magic-dscheck.2.3.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "An implementation of multicore-magic API using the atomic module of DScheck to make DScheck tests possible in libraries using multicore-magic"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-magic"
+bug-reports: "https://github.com/ocaml-multicore/multicore-magic/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "4.12.0"}
+  "dscheck" {>= "0.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-magic.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-magic/releases/download/2.3.1/multicore-magic-2.3.1.tbz"
+  checksum: [
+    "sha256=01d7208bdc9f12187281b04ad381fa37da338373ba2495ab5eb0f533151c195f"
+    "sha512=40549ecaedfb62a683c95ad969fe0dc7d7c220b2be742e2e357fef43197ffbdd2972e648bf1c505b67954b3dd41fade8bd5a43b02be2bbdaaeee4bdf77f42471"
+  ]
+}
+x-commit-hash: "c87d608d18d09cb7f4b84249f27bf217aa69ce10"

--- a/packages/multicore-magic/multicore-magic.2.3.1/opam
+++ b/packages/multicore-magic/multicore-magic.2.3.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Low-level multicore utilities for OCaml"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-magic"
+bug-reports: "https://github.com/ocaml-multicore/multicore-magic/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "4.12.0"}
+  "domain_shims" {>= "0.1.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "js_of_ocaml" {>= "5.4.0" & with-test}
+  "conf-npm" {arch != "x86_32" & os != "win32" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-magic.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-magic/releases/download/2.3.1/multicore-magic-2.3.1.tbz"
+  checksum: [
+    "sha256=01d7208bdc9f12187281b04ad381fa37da338373ba2495ab5eb0f533151c195f"
+    "sha512=40549ecaedfb62a683c95ad969fe0dc7d7c220b2be742e2e357fef43197ffbdd2972e648bf1c505b67954b3dd41fade8bd5a43b02be2bbdaaeee4bdf77f42471"
+  ]
+}
+x-commit-hash: "c87d608d18d09cb7f4b84249f27bf217aa69ce10"


### PR DESCRIPTION
Low-level multicore utilities for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/multicore-magic">https://github.com/ocaml-multicore/multicore-magic</a>

##### CHANGES:

- Allow unboxed `Atomic_array` on 5.3 (@polytypic)
- Support js_of_ocaml (@polytypic)
