### PR TITLE
conf-clang-format: Fix installation on alpine 3.21

### DIFF
--- a/packages/conf-clang-format/conf-clang-format.1/opam
+++ b/packages/conf-clang-format/conf-clang-format.1/opam
@@ -11,7 +11,8 @@ depexts: [
   ["clang-extra-tools"] {os-distribution = "alpine" & os-version < "3.17" }
   ["clang15-extra-tools"] {os-distribution = "alpine" & os-version = "3.17" }
   ["clang16-extra-tools"] {os-distribution = "alpine" & os-version = "3.18" }
-  ["clang17-extra-tools"] {os-distribution = "alpine" & os-version >= "3.19" }
+  ["clang17-extra-tools"] {os-distribution = "alpine" & os-version >= "3.19" & os-version < "3.21" }
+  ["clang19-extra-tools"] {os-distribution = "alpine" & os-version >= "3.21" }
   ["clang-tools"] {os-family = "suse" | os-family = "opensuse"}
   ["clang"] {os-distribution = "arch"}
   ["clang-format"] {os-distribution = "homebrew" & os = "macos"}


### PR DESCRIPTION
```
+ ./opam install conf-clang-format.1
The following actions will be performed:
=== install 1 package
  - install conf-clang-format 1

The following system packages will first need to be installed:
    clang17-extra-tools

<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><><><>

opam believes some required external dependencies are missing. opam can:
> 1. Run apk to install them (may need root/sudo access)
  2. Display the recommended apk command and wait while you run it manually (e.g. in another terminal)
  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
  4. Abort the installation

[1/2/3/4] 1

+ /sbin/apk "add" "clang17-extra-tools"
- (1/7) Installing libffi (3.4.6-r0)
- (2/7) Installing libxml2 (2.13.4-r3)
- (3/7) Installing llvm17-libs (17.0.6-r2)
- (4/7) Installing clang17-libs (17.0.6-r2)
- (5/7) Installing clang17-headers (17.0.6-r2)
- (6/7) Installing clang17-libclang (17.0.6-r2)
- (7/7) Installing clang17-extra-tools (17.0.6-r2)
- OK: 893 MiB in 77 packages

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>

#=== ERROR while compiling conf-clang-format.1 ================================#
"clang-format": command not found.
```
The `clang-format` binary is only available through the `clang19-extra-tools` instead of `clang17-extra-tools`. See https://pkgs.alpinelinux.org/contents?file=clang-format&path=&name=&branch=v3.21&repo=&arch=