### PR TITLE
Add maintenance intent field to ppxlib and ppxlib-tools

### DIFF
--- a/packages/ppxlib-tools/ppxlib-tools.0.34.0/opam
+++ b/packages/ppxlib-tools/ppxlib-tools.0.34.0/opam
@@ -34,6 +34,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+x-maintenance-intent: ["(latest)"]
 url {
   src:
     "https://github.com/ocaml-ppx/ppxlib/releases/download/0.34.0/ppxlib-0.34.0.tbz"

--- a/packages/ppxlib/ppxlib.0.34.0/opam
+++ b/packages/ppxlib/ppxlib.0.34.0/opam
@@ -52,6 +52,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+x-maintenance-intent: ["(latest)"]
 url {
   src:
     "https://github.com/ocaml-ppx/ppxlib/releases/download/0.34.0/ppxlib-0.34.0.tbz"


### PR DESCRIPTION
As requested in ocaml-ppx/ppxlib#549, I'm adding the field to the latest released version of ppxlib's packages.

I think `(latest)` describes best our maintenance policy so far but I'll gladly update this if I misinterpreted the maintenance policies!