### PR TITLE
Package ocamlfind.1.9.8

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.9.8/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.8/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "A library manager for OCaml"
+description: """\
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts."""
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+license: "MIT"
+homepage: "http://projects.camlcity.org/projects/findlib.html"
+bug-reports: "https://github.com/ocaml/ocamlfind/issues"
+depends: [
+  "ocaml" {>= "3.08.0"}
+]
+depopts: ["graphics"]
+build: [
+  [
+    "./configure"
+    "-bindir"
+    bin
+    "-sitelib"
+    lib
+    "-mandir"
+    man
+    "-config"
+    "%{lib}%/findlib.conf"
+    "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
+    "-no-topfind" {ocaml:preinstalled}
+  ]
+  [make "all"]
+  [make "opt"] {ocaml:native}
+]
+install: [
+  [make "install"]
+  ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
+]
+dev-repo: "git+https://github.com/ocaml/ocamlfind.git"
+url {
+  src:
+    "https://github.com/ocaml/ocamlfind/archive/refs/tags/findlib-1.9.8.tar.gz"
+  checksum: [
+    "md5=ca770e5806032a96131b670f6e07f146"
+    "sha512=8967986de2ab4ec5993f437b0a4206742adf37aa7a292a3bba0a04438d78539b84d001191e60b2d5bde98a695b38cba2593b7051f7749adbdb964a0df3c4b661"
+  ]
+}


### PR DESCRIPTION
### `ocamlfind.1.9.8`
A library manager for OCaml
Findlib is a library manager for OCaml. It provides a convention how
to store libraries, and a file format ("META") to describe the
properties of libraries. There is also a tool (ocamlfind) for
interpreting the META files, so that it is very easy to use libraries
in programs and scripts.



---
* Homepage: http://projects.camlcity.org/projects/findlib.html
* Source repo: git+https://github.com/ocaml/ocamlfind.git
* Bug tracker: https://github.com/ocaml/ocamlfind/issues

---
:camel: Pull-request generated by opam-publish v2.5.0