### PR TITLE
[new release] miou (0.3.1)

### DIFF
--- a/packages/miou/miou.0.3.1/opam
+++ b/packages/miou/miou.0.3.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://git.robur.coop/robur/miou"
+bug-reports:  "https://git.robur.coop/robur/miou/issues"
+dev-repo:     "git+https://github.com/robur-coop/miou.git"
+doc:          "https://docs.osau.re/miou/"
+license:      "MIT"
+synopsis:     "Composable concurrency primitives for OCaml"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"             {>= "5.0.0"}
+  "dune"              {>= "2.8.0"}
+  "dscheck"           {with-test & >= "0.4.0"}
+  "digestif"          {with-test}
+  "happy-eyeballs"    {with-test & >= "0.6.0"}
+  "dns-client"        {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test}
+  "ipaddr"            {with-test}
+  "logs"              {with-test & >= "0.7.0"}
+  "dns"               {with-test}
+  "dns-client"        {with-test}
+  "mtime"             {with-test & >= "2.0.0"}
+  "ocamlformat"       {with-dev-setup & = "0.27.0"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/miou/releases/download/v0.3.1/miou-0.3.1.tbz"
+  checksum: [
+    "sha256=2b7a2d52ec0599156b6e7c586190cc99dd964d840799763f6f2407bb83e39471"
+    "sha512=eba70cb4c5484ef4c5fce522b106d32f20482fe55a9252c82cf7b85d69cd1359d97a9d7279f39c05f3b2365d87cdfec39fbe2a0780167506d1eaeaf618227895"
+  ]
+}
+x-commit-hash: "2f77245890e58272c5d54bfc311b02793a666295"


### PR DESCRIPTION
Composable concurrency primitives for OCaml

- Project page: <a href="https://git.robur.coop/robur/miou">https://git.robur.coop/robur/miou</a>
- Documentation: <a href="https://docs.osau.re/miou/">https://docs.osau.re/miou/</a>

##### CHANGES:

- Notice the domain if it needs to look into the shared heap if a task is ready
  to be transfered (@dinosaure, robur-coop/miou#41)
- Don't use `Option.value` but `match .. with` to calculate the optional length
  for `Miou_unix.{read,write}` (@kit-ty-kate, robur-coop/miou#44)
- Use `List.iter` instead of `Hashtbl.iter` for internal kept file-descriptors
  of `Miou_unix` (@dinosaure, robur-coop/miou#45)
- Improve the documentation of `Miou_unix` about suspended syscalls (@dinosaure,
  @kit-ty-kate, robur-coop/miou#43)
- Export `reraise` (@dinosaure, robur-coop/miou#46)
- Fix an issue on the `dom0` and observe if some tasks must be transfered to it
  (@dinosaure, robur-coop/miou#48)
- Fix documentation (@mbarbin, robur-coop/miou#47)
- Fix the formatter (@mbarbin, robur-coop/miou#51)
- Upgrade miou to `ocamlformat.0.27.0` (@mbarbin, robur-coop/miou#52)
- Add `x-maintenance-intent` (@hannesm, robur-coop/miou#56)
- Improve the documentation and some `odoc` warnings (@mbarbin, robur-coop/miou#53, robur-coop/miou#54)
