### PR TITLE
Mark all jbuilder packages as depracted

### DIFF
--- a/packages/jbuilder/jbuilder.1.0+beta1/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta1/opam
@@ -9,6 +9,8 @@ build: [
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "-j" "1"]
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta10/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta10/opam
@@ -14,6 +14,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta11/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta11/opam
@@ -14,6 +14,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta12/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta12/opam
@@ -14,6 +14,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta13/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta13/opam
@@ -14,6 +14,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta14/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta14/opam
@@ -14,6 +14,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta15/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta15/opam
@@ -14,6 +14,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta16/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta16/opam
@@ -14,6 +14,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta17/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta17/opam
@@ -14,6 +14,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta18.1/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta18.1/opam
@@ -14,6 +14,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta18/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta18/opam
@@ -14,6 +14,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta19.1/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta19.1/opam
@@ -11,6 +11,8 @@ build: [
   ["./boot.exe" "--subst"] {pinned}
   ["./boot.exe" "-j" jobs]
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta19/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta19/opam
@@ -11,6 +11,8 @@ build: [
   ["./boot.exe" "--subst"] {pinned}
   ["./boot.exe" "-j" jobs]
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta2/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta2/opam
@@ -9,6 +9,8 @@ build: [
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "-j" "1"]
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta20.1/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta20.1/opam
@@ -11,6 +11,8 @@ build: [
   ["./boot.exe" "--subst"] {pinned}
   ["./boot.exe" "-j" jobs]
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta20.2/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta20.2/opam
@@ -11,6 +11,8 @@ build: [
   ["./boot.exe" "--subst"] {pinned}
   ["./boot.exe" "-j" jobs]
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta20/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta20/opam
@@ -11,6 +11,8 @@ build: [
   ["./boot.exe" "--subst"] {pinned}
   ["./boot.exe" "-j" jobs]
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta3/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta3/opam
@@ -9,6 +9,8 @@ build: [
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "-j" "1"]
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta4/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta4/opam
@@ -9,6 +9,8 @@ build: [
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "-j" "1"]
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta5/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta5/opam
@@ -13,6 +13,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta6/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta6/opam
@@ -13,6 +13,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta7/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta7/opam
@@ -13,6 +13,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta8/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta8/opam
@@ -13,6 +13,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.1.0+beta9/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta9/opam
@@ -14,6 +14,8 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.08.0"}
   "ocamlfind" {build}
 ]
+# Replaced by Dune
+flags: deprecated
 synopsis: "Fast, portable and opinionated build system"
 description: """
 jbuilder is a build system that was designed to simplify the release

--- a/packages/jbuilder/jbuilder.transition/opam
+++ b/packages/jbuilder/jbuilder.transition/opam
@@ -9,6 +9,8 @@ depends: [
   "ocaml"
   "dune" {< "2.0"}
 ]
+# Replaced by Dune
+flags: deprecated
 post-messages: [
   "Jbuilder has been renamed and the jbuilder package is now a transition \
    package. Use the dune package instead."


### PR DESCRIPTION
Following the discussion on [this Dune issue](https://github.com/ocaml/dune/issues/11272), this PR is the first step to make clearer the intention about the maintenance policy of Dune.

This PR marks all the `jbuilder` packages as `deprecated` as Dune should be used instead.
