### PR TITLE
[new release] starred_ml (0.0.7)

### DIFF
--- a/packages/starred_ml/starred_ml.0.0.7/opam
+++ b/packages/starred_ml/starred_ml.0.0.7/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Generates a awesome list markdown"
+description: "Turn your starred items into a awesomeness list of repos"
+maintainer: ["Paulo Suzart"]
+authors: ["Paulo Suzart"]
+license: "CC0-1.0"
+homepage: "https://github.com/paulosuzart/starred_ml"
+bug-reports: "https://github.com/paulosuzart/starred_ml/issues"
+depends: [
+  "cmdliner" {>= "1.2.0"}
+  "re2" {>= "v0.16.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "yojson" {>= "2.1.2"}
+  "tls-eio" {>= "1.0.4"}
+  "ppx_deriving_yojson" {>= "3.7.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "mirage-crypto-rng-eio" {>= "1.1.0"}
+  "logs" {>= "0.7.0"}
+  "jingoo" {>= "1.5.0"}
+  "fmt" {>= "0.9.0"}
+  "eio_main" {>= "1.2"}
+  "eio" {>= "1.2"}
+  "cohttp-eio" {>= "6.0.0"}
+  "slug" {>= "1.0.1"}
+  "ocaml"
+  "dune" {>= "3.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/paulosuzart/starred_ml.git"
+url {
+  src:
+    "https://github.com/paulosuzart/starred_ml/releases/download/0.0.7/starred_ml-0.0.7.tbz"
+  checksum: [
+    "sha256=328826875736c07f39d2249739e660a1aae1c917b4a662aaa78bb2d6404db959"
+    "sha512=342a47569729b6a7a475ce95d8e7067ce8cd85029baaf82b9db854c0ebed48db6bfbff9f2b393d9f389b42547bfcbd7389f23aed9dfd9244ee5cba85f93b42b3"
+  ]
+}
+x-commit-hash: "54bcf912242c95009669d7e252bd91af383fc25d"


### PR DESCRIPTION
CHANGES:

- IMPORTANT: now use `starred_ml render` for rendering the template.
- Removed `slug` dependency that was actually not enough for the intention.
- Encourages raw jingoo filters for encoding urls. As in `item.language | urlencode`.
- The `dafault.jingoo` template now takes a the github repositories (the `starred list` type) and uses `groupby` Jingoo's feature to print each repository under the corresponding language.