### PR TITLE
[new release] promise_jsoo (2 packages) (0.4.3)

### DIFF
--- a/packages/promise_jsoo/promise_jsoo.0.4.3/opam
+++ b/packages/promise_jsoo/promise_jsoo.0.4.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Js_of_ocaml bindings to JS Promises with supplemental functions"
+maintainer: ["Max Lantas <mnxndev@outlook.com>"]
+authors: ["Max Lantas <mnxndev@outlook.com>"]
+license: "MIT"
+homepage: "https://github.com/mnxn/promise_jsoo"
+doc: "https://mnxn.github.io/promise_jsoo/"
+bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml"
+  "gen_js_api" {>= "1.0.8"}
+  "webtest" {with-test}
+  "webtest-js" {with-test}
+  "conf-npm" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mnxn/promise_jsoo.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@%{name}%/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mnxn/promise_jsoo/releases/download/v0.4.3/promise_jsoo-0.4.3.tbz"
+  checksum: [
+    "sha256=7c889da114dd89eeb89d9d5a50ad895a1709a35fc50f33f852efa04c96a876d2"
+    "sha512=b3ebecd4789bf40d60b9efe5117535e58af663e0a1a9b51be25ecba41f15472b76de356472b2457eeca8a9d3b6deae4cb33eaf03be596af0606b5409d12ec3b6"
+  ]
+}
+x-commit-hash: "bbce5a719a3345eeff318bb2167edc8cedc83ee8"

--- a/packages/promise_jsoo_lwt/promise_jsoo_lwt.0.4.3/opam
+++ b/packages/promise_jsoo_lwt/promise_jsoo_lwt.0.4.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Conversion functions between JS Promises and Lwt Promises"
+maintainer: ["Max Lantas <mnxndev@outlook.com>"]
+authors: ["Max Lantas <mnxndev@outlook.com>"]
+license: "MIT"
+homepage: "https://github.com/mnxn/promise_jsoo"
+doc: "https://mnxn.github.io/promise_jsoo/"
+bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "promise_jsoo"
+  "lwt"
+  "gen_js_api" {>= "1.0.8"}
+  "webtest" {with-test}
+  "webtest-js" {with-test}
+  "conf-npm" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mnxn/promise_jsoo.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@%{name}%/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mnxn/promise_jsoo/releases/download/v0.4.3/promise_jsoo-0.4.3.tbz"
+  checksum: [
+    "sha256=7c889da114dd89eeb89d9d5a50ad895a1709a35fc50f33f852efa04c96a876d2"
+    "sha512=b3ebecd4789bf40d60b9efe5117535e58af663e0a1a9b51be25ecba41f15472b76de356472b2457eeca8a9d3b6deae4cb33eaf03be596af0606b5409d12ec3b6"
+  ]
+}
+x-commit-hash: "bbce5a719a3345eeff318bb2167edc8cedc83ee8"


### PR DESCRIPTION
Js_of_ocaml bindings to JS Promises with supplemental functions

- Project page: <a href="https://github.com/mnxn/promise_jsoo">https://github.com/mnxn/promise_jsoo</a>
- Documentation: <a href="https://mnxn.github.io/promise_jsoo/">https://mnxn.github.io/promise_jsoo/</a>

##### CHANGES:

- No longer rely on `joo_global_object` (mnxn/promise_jsoo#7)
