### PR TITLE
Package vscoq-language-server.2.2.2

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.2.2/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.2.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/coq-community/vscoq"
+bug-reports: "https://github.com/coq-community/vscoq/issues"
+dev-repo: "git+https://github.com/coq-community/vscoq"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { >= "4.14" }
+  "dune" { >= "3.5" }
+  "coq-core" { ((>= "8.18" < "8.21") | (= "dev")) }
+  "coq-stdlib" { ((>= "8.18" < "8.21") | (= "dev")) }
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "ppx_optcomp"
+  "result" { >= "1.5" }
+  "lsp" { >= "1.15"}
+  "sel" {>= "0.4.0"}
+]
+synopsis: "VSCoq language server"
+available: arch != "arm32" & arch != "x86_32"
+description: """
+LSP based language server for Coq and its VSCoq user interface
+"""
+url {
+  src:
+    "https://github.com/coq/vscoq/releases/download/v2.2.2/vscoq-language-server-2.2.2.tar.gz"
+  checksum: [
+    "md5=84c68e4a540245337cc2e4eea1181704"
+    "sha512=ff27be0fde2fda883912f49a8998ba1f73aaa765c2b805371e44258231d61d66a979ff276696a7edfaf6822d900ebac93dca32121b5cf73927a36d6e56a19e52"
+  ]
+}


### PR DESCRIPTION
### `vscoq-language-server.2.2.2`
VSCoq language server
LSP based language server for Coq and its VSCoq user interface



---
* Homepage: https://github.com/coq-community/vscoq
* Source repo: git+https://github.com/coq-community/vscoq
* Bug tracker: https://github.com/coq-community/vscoq/issues

---
:camel: Pull-request generated by opam-publish v2.5.0