### PR TITLE
Add the indexer as a post-dependency to ocaml-lsp-server

### DIFF
--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.22.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.22.0/opam
@@ -45,6 +45,7 @@ depends: [
   "ocamlformat-rpc-lib" {>= "0.21.0"}
   "odoc" {with-doc}
   "merlin-lib" {>= "5.4" & < "6.0"}
+  "ocaml-index" {>= "5.4" & < "6.0" & post}
   "ppx_yojson_conv" {with-dev-setup}
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"


### PR DESCRIPTION
Latest Merlin and OCaml-LSP enable project-wide renaming and it requires an additional binary to be installed.