### PR TITLE
minor updates for the archiving policy as discussed today in the meeting

### DIFF
--- a/governance/policies/archiving.md
+++ b/governance/policies/archiving.md
@@ -4,7 +4,7 @@
 
 - The primary opam repository, (referred to here as the "primary repo") is located at [ocaml/opam-repository](https://github.com/ocaml/opam-repository). The primary repo is curated to ensure that compatible packages are co-installable on as many supported platforms as possible, and it is the default package repository.
 - "Primary repo criteria" refers to the criteria used to decide whether a version of a package is suitable for continued inclusion in the primary repo.
-- The archive opam repository, (referred to here as the "archive repo")" is located at [ocaml/opam-repository-archive](https://github.com/ocaml/opam-repository-archive) and records packages that were once in the primary repo, but no longer meet the primary repo criteria.
+- The archive opam repository, (referred to here as the "archive repo") is located at [ocaml/opam-repository-archive](https://github.com/ocaml/opam-repository-archive) and records packages that were once in the primary repo, but no longer meet the primary repo criteria.
 - "Supported platforms" are those listed under [Tier 1 and Tier 2 by the OCaml compiler](https://github.com/ocaml/ocaml?tab=readme-ov-file#overview)
 - A package's "maximum compiler version" is the upper bound of the OCaml compiler versions supported by a package. Support is derived either based on explicit version bounds set on the `ocaml` dependency in a package's dependency cone, or implicitly based on failed installs detected through our CI and health check processes.
 - The "compiler cutoff threshold" is an OCaml compiler versions stipulated by the opam repository maintainers. It sets a lower bound on the compiler versions supported by the primary repo. 
@@ -15,10 +15,10 @@
 
 ### Compiler cutoff threshold
 
-The current compiler cutoff threshold is `4.08`.
+The current (2025-02-01) compiler cutoff threshold is `4.08`.
 
 This threshold is subject to change by the opam repo maintainers.
-The threshold is based on the oldest ocaml compiler version available 
+The threshold is based on the oldest ocaml compiler version available
 in the maintained[^1] distributions. It determines the minimum
 compiler version used in tests for the opam-repository CI[^2].
 
@@ -34,7 +34,7 @@ A version of a package may be published on the primary repo, and will continue t
 3. The package version falls within a package's maintenance intent, or is a dependency of a package satisfying the primary repo criteria.
 4. The package version is installable on at least one of the supported platforms. (Note that it is not required that CI tests are passing, since working installation may require manual system configuration.)
 
-Note that this property is transitive along a package's dependency tree: if a package satisfies the primary repo criteria, then its dependencies do as well. 
+Note that this property is transitive along a package's dependency tree: if a package satisfies the primary repo criteria, then its dependencies do as well.
 
 ### Periodic pruning process
 
@@ -52,7 +52,7 @@ At regular intervals, no less than every six months, the opam repo maintainers w
 
 When it has been decided that a set of package versions (aka "versions") should be archived, archiving will proceed according to the following process:
 
-- A PR will be made to add the archived versions to the archive repo. 
+- A PR will be made to add the archived versions to the archive repo.
     - The opam file of each version will be extended as follows:
         - Any dependencies without upper bounds will have upper bounds added, recording the latest available version of the dependency in the primary repo at the time of archiving.
         -  The field `x-reason-for-archiving` will be added.
@@ -88,6 +88,7 @@ When it has been decided that a set of package versions (aka "versions") should 
     - Meaning:
         - Expresses the declared intent of the maintainers to maintain only certain versions ranges of a package.
         - The value of the `x-maintenance-intent` on the latest published package will precedence.
+    - Default value: ["(any)"] on 2025-01-17, please note that this default may change
     - Examples:
         - `["(latest)"]` the maintainer will only maintain the latest version
         - `["(latest)" "(latest-1)"]` the maintainer will only maintain the latest `X.Y.Z` version and `(X-1).Y.Z`
@@ -98,6 +99,16 @@ When it has been decided that a set of package versions (aka "versions") should 
         - `["(none)"]` the maintainer will not maintain any version
         - `["1.3"]` the maintainer will maintain the latest  version of "1.3.Z"
         - `["2.(latest)"]` the maintainer will maintain the latest minor version specifically of version "2" of the package
+- `x-maintained`:
+    - Allowed values: `true` and `false`
+    - Meaning:
+        - Expresses that this opam package version is maintained (if `true`) or not (if `false`).
+        - Overwrites the `x-maintenance-intent` field
+        - Useful to abandon pre-releases
+        - Also for packages that are used in private opam-repositories or developments
+    - Examples:
+        - `true # used by @bactrian, added on 2025-01-24` where @bactrian wants to keep this package in the opam-repository
+        - `false` if this meets the `x-maintenance-intent`, but is actually not maintained
 
 ## References
 


### PR DESCRIPTION
introduction of x-maintained field

Once merged, I plan to publish a discuss post (that will hopefully clarify some bits) -- suggestions / comments welcome:

## x-maintenance-intent

We've had some further discussions on Phase 3 and the semantics of the
`x-maintenance-intent` field.

### Goal

Our aim is to be not disruptive for the common OCaml programmer or user. The
opam-repository supports (from February 1st on) OCaml 4.08 and greater. This
means that if you install OCaml 4.08 you should be able to install all the
packages that have ever been released with 4.08 support.

This means the revised semantics of "(latest)" is "the latest version of this
package, so that every supported OCaml version will have an installation
candidate".

#### Example

Let me give you an example, consider the package "basic" which exists in three
versions:
basic.1.0.0 with the dependency "ocaml" {>= "4.05" & < "5"}
basic.1.0.1 with the dependency "ocaml" {>= "4.08" & < "5"}
basic.2.0.0 with the dependency "ocaml" {>= "4.14" & < "5"}

Here, if the `x-maintenance-intent: [ "(latest)" ]` is present, we will only
(try to) archive basic.1.0.0 -- since 1.0.1 is needed for OCaml 4.08 .. 4.13.
I hope this is clear.

### Default value

The default value of `x-maintenance-intent` will for now be `"(any)"` - so all
versions are kept. In the future, we may change this default to `"(latest)"`,
but will announce this ahead of the change with plenty of time.

This default value is agreed on by the non-disruptive agreement to cause the
least trouble.

## x-maintained

In addition to the `x-maintenance-intent` - which covers the semantics of all
versions of an opam package, we support another field, `x-maintained: BOOL`.
This is an overwrite for a specific opam package version, and allows to declare
whether it is maintained or not.

It is useful in the setting where you've lots of pre-releases that are no
longer maintained and you like to state this without writing a global intent
for the opam package (e.g. for the OCaml compiler packages, the alpha, beta, and
rc versions). Here, `x-maintained: false` is a nice setting. NB: earlier we
proposed `flags: deprecated` - but we stay away from the flags, since there may
be packages that are deprecated but still maintained (opam prints a warning if
you install a package with the deprecated flag).

If you have a private project and depend on a specific version of an opam
package, you can as well PR the `x-maintained: true` field for that opam file
(please specify when, who, and why). This will ensure that this opam file stays
in the opam repository.

## Phase 3

In Phase 3, we will consider all packages marked with `x-maintenance-intent`
(the versions not matching the intent) and `x-maintained: false` to be archived.

We plan to ensure that (a) all supported OCaml versions will retain an
installation candidate (b) all reverse dependencies will still be installable.
As a note, if you have an availability condition (some version will only work
on some OS), we won't take that into consideration -- you will need to specify
the `x-maintenance-intent` to cover your versions.

Our plan is to publish the list of packages to be archived by February 15th
on this discourse. It is likely we'll have candidate lists PRed to the
[opam-repository-archive](https://github.com/ocaml/opam-repository-archive)
earlier. We have lots of ideas and plans for CI systems to give feedback which
opam versions are falling into the maintenance intent when you open a PR to
the opam-repository (but we're not there yet).

## Future

As noted above, the default value of `x-maintenance-intent` may change in time.
If this is decided, we will announce this with plenty of time before.

Also, at some point in the future we will bump the OCaml lower bound (from
February 1st it is 4.08).

## Action

For the smooth shrinking of the opam-repository, please don't hesitate to fill
in your x-maintenance-intent (especially "(none)" and "(latest)" are fine
and safe choices).

If you want to contribute more, the opam-repository needs help for triaging and
merging PRs - why not become a maintainer? See the old but still valid
['call for new opam-repository maintainers'](https://discuss.ocaml.org/t/call-for-new-opam-repository-maintainers/12041)
if you're interested.
