### PR TITLE
[new release] tar (4 packages) (3.2.0)

### DIFF
--- a/packages/tar-eio/tar-eio.3.2.0/opam
+++ b/packages/tar-eio/tar-eio.3.2.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files using Eio"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library uses Eio to provide a portable tar library.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.00.0"}
+  "eio" {>= "1.1"}
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.2.0/tar-3.2.0.tbz"
+  checksum: [
+    "sha256=1f50437635b2da21bbef4ed22b0f4ab764901c91671cfd8e937317bf72adf1bd"
+    "sha512=dd62a7e3cd7941ea48c7f71a578fe595cdf48d83fe9d64a9d7222bb208abe9aa1ad67f985198b7818d71728105943fe305512b581ec9e76be4876b97c46d9e1e"
+  ]
+}
+x-commit-hash: "d03f2ec0ab097dc7ed18c2b1c8bd690245d9c6b4"

--- a/packages/tar-mirage/tar-mirage.3.2.0/opam
+++ b/packages/tar-mirage/tar-mirage.3.2.0/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis: "Read and write tar format files via MirageOS interfaces"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library is functorised over external OS dependencies
+to facilitate embedding within MirageOS.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "5.6.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "mirage-kv" {>= "6.0.0"}
+  "optint"
+  "ptime"
+  "tar" {= version}
+  "mirage-block-unix" {with-test & >= "2.13.0"}
+  "mirage-clock-unix" {with-test & >= "4.0.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "alcotest-lwt" {>= "1.7.0" & with-test}
+  "tar-unix" {with-test & = version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.2.0/tar-3.2.0.tbz"
+  checksum: [
+    "sha256=1f50437635b2da21bbef4ed22b0f4ab764901c91671cfd8e937317bf72adf1bd"
+    "sha512=dd62a7e3cd7941ea48c7f71a578fe595cdf48d83fe9d64a9d7222bb208abe9aa1ad67f985198b7818d71728105943fe305512b581ec9e76be4876b97c46d9e1e"
+  ]
+}
+x-commit-hash: "d03f2ec0ab097dc7ed18c2b1c8bd690245d9c6b4"

--- a/packages/tar-unix/tar-unix.3.2.0/opam
+++ b/packages/tar-unix/tar-unix.3.2.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files from Unix"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library provides a Unix or Windows compatible interface.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.7.0"}
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.2.0/tar-3.2.0.tbz"
+  checksum: [
+    "sha256=1f50437635b2da21bbef4ed22b0f4ab764901c91671cfd8e937317bf72adf1bd"
+    "sha512=dd62a7e3cd7941ea48c7f71a578fe595cdf48d83fe9d64a9d7222bb208abe9aa1ad67f985198b7818d71728105943fe305512b581ec9e76be4876b97c46d9e1e"
+  ]
+}
+x-commit-hash: "d03f2ec0ab097dc7ed18c2b1c8bd690245d9c6b4"

--- a/packages/tar/tar.3.2.0/opam
+++ b/packages/tar/tar.3.2.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files in pure OCaml"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "decompress" {>= "1.5.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.2.0/tar-3.2.0.tbz"
+  checksum: [
+    "sha256=1f50437635b2da21bbef4ed22b0f4ab764901c91671cfd8e937317bf72adf1bd"
+    "sha512=dd62a7e3cd7941ea48c7f71a578fe595cdf48d83fe9d64a9d7222bb208abe9aa1ad67f985198b7818d71728105943fe305512b581ec9e76be4876b97c46d9e1e"
+  ]
+}
+x-commit-hash: "d03f2ec0ab097dc7ed18c2b1c8bd690245d9c6b4"


### PR DESCRIPTION
Decode and encode tar format files in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-tar">https://github.com/mirage/ocaml-tar</a>
- Documentation: <a href="https://mirage.github.io/ocaml-tar/">https://mirage.github.io/ocaml-tar/</a>

##### CHANGES:

- Fix the Tar monad with Tar_gz and allow the `read` operation (@dinosaure, @BChabanne, @reynir, mirage/ocaml-tar#161)
- Add `x-maintenance-intent` field into opam files (@hannesm, mirage/ocaml-tar#162)
- Defaults level per entries to the global level (@reynir, mirage/ocaml-tar#157)
- Update `Tar_eio` with the last version of `tar` (@patricoferris, mirage/ocaml-tar#159)
