### PR TITLE
[new release] ppx_protocol_conv (7 packages) (5.2.2)

### DIFF
--- a/packages/ppx_protocol_conv/ppx_protocol_conv.5.2.2/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.5.2.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.07"}
+  "base" {>= "v0.14.0" }
+  "dune" {>= "1.2"}
+  "ppxlib" {>= "0.9.0"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis:
+  "Ppx for generating serialisation and de-serialisation functions of ocaml types"
+description: """
+Ppx_protocol_conv generates code to serialize and de-serialize
+types. The ppx itself does not contain any protocol specific code,
+but relies on 'drivers' that defines serialisation and
+de-serialisation of basic types and structures.
+
+Pre-defined drivers are available in separate packages:
+ppx_protocol_conv_json (Yojson.Safe.json)
+ppx_protocol_conv_jsonm (Ezjson.value)
+ppx_protocol_conv_msgpack (Msgpck.t)
+ppx_protocol_conv_xml-light (Xml.xml)
+ppx_protocol_conv_xmlm (Xmlm.node)
+ppx_protocol_conv_yaml (Yaml.value)"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/releases/download/5.2.2/ppx_protocol_conv-5.2.2.tbz"
+  checksum: [
+    "sha256=994362c2185d12f732e522e1e457b7de67745e594b898368c878424e93f84587"
+    "sha512=237b236a257f35ad671194f6ee0690dfc85eef9b088a928e7b0582b23b5acc19b6727318be6b7abfa0f6c1052047b820e7a0345d8cadb3c0280e18dc3da6e453"
+  ]
+}
+x-commit-hash: "cc9f4879a9e258e9419fe61b3b901f2b9579b632"

--- a/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.5.2.2/opam
+++ b/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.5.2.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "ppx_protocol_conv" {= version}
+  "yojson" {>= "1.6.0"}
+  "dune" {>= "1.2"}
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "Json driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for json (Yojson.Safe.json)
+serialization and de-serialization using the yojson library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/releases/download/5.2.2/ppx_protocol_conv-5.2.2.tbz"
+  checksum: [
+    "sha256=994362c2185d12f732e522e1e457b7de67745e594b898368c878424e93f84587"
+    "sha512=237b236a257f35ad671194f6ee0690dfc85eef9b088a928e7b0582b23b5acc19b6727318be6b7abfa0f6c1052047b820e7a0345d8cadb3c0280e18dc3da6e453"
+  ]
+}
+x-commit-hash: "cc9f4879a9e258e9419fe61b3b901f2b9579b632"

--- a/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.5.2.2/opam
+++ b/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.5.2.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "ppx_protocol_conv" {= version}
+  "ezjsonm"
+  "dune" {>= "1.2"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "Jsonm driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for json (Ezjson.value)
+serialization and de-serialization using the Ezjson library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/releases/download/5.2.2/ppx_protocol_conv-5.2.2.tbz"
+  checksum: [
+    "sha256=994362c2185d12f732e522e1e457b7de67745e594b898368c878424e93f84587"
+    "sha512=237b236a257f35ad671194f6ee0690dfc85eef9b088a928e7b0582b23b5acc19b6727318be6b7abfa0f6c1052047b820e7a0345d8cadb3c0280e18dc3da6e453"
+  ]
+}
+x-commit-hash: "cc9f4879a9e258e9419fe61b3b901f2b9579b632"

--- a/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.5.2.2/opam
+++ b/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.5.2.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "ppx_protocol_conv" {= version}
+  "msgpck" {>= "1.3"}
+  "msgpck" {with-test & >= "1.7"}
+  "dune" {>= "1.2"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "MessagePack driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for message pack (Msgpck.t)
+serialization and deserialization using the msgpck library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/releases/download/5.2.2/ppx_protocol_conv-5.2.2.tbz"
+  checksum: [
+    "sha256=994362c2185d12f732e522e1e457b7de67745e594b898368c878424e93f84587"
+    "sha512=237b236a257f35ad671194f6ee0690dfc85eef9b088a928e7b0582b23b5acc19b6727318be6b7abfa0f6c1052047b820e7a0345d8cadb3c0280e18dc3da6e453"
+  ]
+}
+x-commit-hash: "cc9f4879a9e258e9419fe61b3b901f2b9579b632"

--- a/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.5.2.2/opam
+++ b/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.5.2.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "ppx_protocol_conv" {= version}
+  "xml-light"
+  "dune" {>= "1.2"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "Xml driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for xml (Xml.t) serialization and
+de-serialization using the xml-light library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/releases/download/5.2.2/ppx_protocol_conv-5.2.2.tbz"
+  checksum: [
+    "sha256=994362c2185d12f732e522e1e457b7de67745e594b898368c878424e93f84587"
+    "sha512=237b236a257f35ad671194f6ee0690dfc85eef9b088a928e7b0582b23b5acc19b6727318be6b7abfa0f6c1052047b820e7a0345d8cadb3c0280e18dc3da6e453"
+  ]
+}
+x-commit-hash: "cc9f4879a9e258e9419fe61b3b901f2b9579b632"

--- a/packages/ppx_protocol_conv_xmlm/ppx_protocol_conv_xmlm.5.2.2/opam
+++ b/packages/ppx_protocol_conv_xmlm/ppx_protocol_conv_xmlm.5.2.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: ["Anders Fugmann <anders@fugmann.net>" "Nick Betteridge <lists.nick.betteridge@gmail.com"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "ppx_protocol_conv" {= version}
+  "ezxmlm"
+  "dune" {>= "1.2"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "Xmlm driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for xmlm (Ezxmlm.node)
+serialization and de-serialization using the Ezxmlm library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/releases/download/5.2.2/ppx_protocol_conv-5.2.2.tbz"
+  checksum: [
+    "sha256=994362c2185d12f732e522e1e457b7de67745e594b898368c878424e93f84587"
+    "sha512=237b236a257f35ad671194f6ee0690dfc85eef9b088a928e7b0582b23b5acc19b6727318be6b7abfa0f6c1052047b820e7a0345d8cadb3c0280e18dc3da6e453"
+  ]
+}
+x-commit-hash: "cc9f4879a9e258e9419fe61b3b901f2b9579b632"

--- a/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.5.2.2/opam
+++ b/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.5.2.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.2"}
+  "ppx_protocol_conv" {= version}
+  "yaml" { >= "2.0.0"}
+  "yaml" {with-test & >= "3.0.0"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "Yaml driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for yaml (Yaml.value)
+serialization and de-serialization using the Yaml"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/releases/download/5.2.2/ppx_protocol_conv-5.2.2.tbz"
+  checksum: [
+    "sha256=994362c2185d12f732e522e1e457b7de67745e594b898368c878424e93f84587"
+    "sha512=237b236a257f35ad671194f6ee0690dfc85eef9b088a928e7b0582b23b5acc19b6727318be6b7abfa0f6c1052047b820e7a0345d8cadb3c0280e18dc3da6e453"
+  ]
+}
+x-commit-hash: "cc9f4879a9e258e9419fe61b3b901f2b9579b632"


### PR DESCRIPTION
Ppx for generating serialisation and de-serialisation functions of ocaml types

- Project page: <a href="https://github.com/andersfugmann/ppx_protocol_conv">https://github.com/andersfugmann/ppx_protocol_conv</a>

##### CHANGES:

- [x] Fix compatability with Ocaml 5
- [x] Avoid linking against ppxlib
