### PR TITLE
OCaml 5.3 and some Dune versions conflict

### DIFF
--- a/packages/dune/dune.3.12.2/opam
+++ b/packages/dune/dune.3.12.2/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.3"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]


### PR DESCRIPTION
The failure is when attempting to build #27303: https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/11d3942f386dfac85f2eed8d46af2800c6ae57f5/variant/distributions,debian-testing-ocaml-5.3,baguette_sharp.2.2.1-1

```
    === ERROR while compiling dune.3.12.2 ========================================#
     context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-base-compiler.5.3.0 | file:///home/opam/opam-repository
     path                 ~/.opam/5.3/.opam-switch/build/dune.3.12.2
     command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml boot/bootstrap.ml -j 71
     exit-code            2
     env-file             ~/.opam/log/dune-7-ac7e4a.env
     output-file          ~/.opam/log/dune-7-ac7e4a.out
    ## output ###
     ocamlc -output-complete-exe -w -24 -g -o .duneboot.exe -I boot -I +unix unix.cma boot/libs.ml boot/duneboot.ml
     ./.duneboot.exe -j 71
     cd _boot && /home/opam/.opam/5.3/bin/ocamlopt.opt -c -g -I +unix -I +threads dune_digest_stubs.c
     In file included from /home/opam/.opam/5.3/lib/ocaml/caml/io.h:28,
                      from /home/opam/.opam/5.3/lib/ocaml/caml/md5.h:24,
                      from src/dune_digest/dune_digest_stubs.c:10:
     /home/opam/.opam/5.3/lib/ocaml/caml/platform.h: In function 'caml_plat_latch_is_released':
     /home/opam/.opam/5.3/lib/ocaml/caml/platform.h:222:10: error: implicit declaration of function 'atomic_load_acquire' [-Wimplicit-function-declaration]
       222 |   return atomic_load_acquire(&latch->value) == Latch_released;
           |          ^~~~~~~~~~~~~~~~~~~
     /home/opam/.opam/5.3/lib/ocaml/caml/platform.h: In function 'caml_plat_latch_set':
     /home/opam/.opam/5.3/lib/ocaml/caml/platform.h:230:3: error: implicit declaration of function 'atomic_store_release'; did you mean 'atomic_store_explicit'? [-Wimplicit-function-declaration]
       230 |   atomic_store_release(&latch->value, Latch_unreleased);
           |   ^~~~~~~~~~~~~~~~~~~~
           |   atomic_store_explicit
```

I have yet to test other Dune versions, but I suspect a lot of older versions are affected.