### PR TITLE
Package ocp-indent-nlfork.1.5.5

### DIFF
--- a/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.5/opam
+++ b/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.5/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "contact@ocamlpro.com"
+authors: [
+  "Grégoire Henry <gregoire.henry@ocamlpro.com>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Jun Furuse"
+]
+homepage: "http://www.typerex.org/ocp-indent.html"
+bug-reports: "https://github.com/OCamlPro/ocp-indent/issues"
+license: "LGPL-3.0-or-later"
+tags: ["org:ocamlpro" "org:typerex"]
+dev-repo: "git+https://github.com/OCamlPro/ocp-indent.git#nlfork"
+build: ["dune" "build" "-j" jobs "-p" name]
+depends: [
+  ("ocaml" {>= "4.04.2" & < "5.0"} | "ocaml" {>= "5.0"} & "base-bytes")
+  "dune" {>= "1.0"}
+  "cmdliner" {>= "1.0.0"}
+]
+synopsis: """`ocp-indent` library, "newline tokens" fork"""
+description: """
+This is a modified version of the ocp-indent library, which is based on a
+different lexer, using newline tokens and banning multi-line ones, which is more
+convenient for some applications.
+
+The library is exported as `ocp-indent-nlfork`, so as not to interfere with
+canonical ocp-indent installations.
+
+This package does *not* install an ocp-indent binary or related tools."""
+url {
+  src:
+    "https://github.com/OCamlPro/ocp-indent/archive/refs/tags/nlfork-1.5.5.tar.gz"
+  checksum: [
+    "md5=d3ab3fc0b28674bdd2debe9ada1e5564"
+    "sha512=dc13da22e286b8f8005b2ec50e790ff48e80535747fe84a832a29879e482de32d14185a30dd1c8eaf7a6e5c6a700144eb862bb7fab4c8e1c99b7eb5fc271a09f"
+  ]
+}


### PR DESCRIPTION
### `ocp-indent-nlfork.1.5.5`
`ocp-indent` library, "newline tokens" fork
This is a modified version of the ocp-indent library, which is based on a
different lexer, using newline tokens and banning multi-line ones, which is more
convenient for some applications.

The library is exported as `ocp-indent-nlfork`, so as not to interfere with
canonical ocp-indent installations.

This package does *not* install an ocp-indent binary or related tools.



---
* Homepage: http://www.typerex.org/ocp-indent.html
* Source repo: git+https://github.com/OCamlPro/ocp-indent.git#nlfork
* Bug tracker: https://github.com/OCamlPro/ocp-indent/issues

---
:camel: Pull-request generated by opam-publish v2.1.0