### PR TITLE
[new release] odoc (5 packages) (3.0.0~beta1)

### DIFF
--- a/packages/odoc-driver/odoc-driver.3.0.0~beta1/opam
+++ b/packages/odoc-driver/odoc-driver.3.0.0~beta1/opam
@@ -34,6 +34,7 @@ documentation for installed packages.
 depends: [
   "ocaml" {>= "5.1.0"}
   "odoc" {>= "3.0.0"}
+  "dune" {>= "3.7.0"}
   "bos"
   "fpath"
   "yojson"

--- a/packages/odoc-driver/odoc-driver.3.0.0~beta1/opam
+++ b/packages/odoc-driver/odoc-driver.3.0.0~beta1/opam
@@ -35,6 +35,7 @@ depends: [
   "ocaml" {>= "5.1.0"}
   "odoc" {>= "3.0.0"}
   "dune" {>= "3.7.0"}
+  "odoc-md"
   "bos"
   "fpath"
   "yojson"

--- a/packages/odoc-driver/odoc-driver.3.0.0~beta1/opam
+++ b/packages/odoc-driver/odoc-driver.3.0.0~beta1/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+homepage: "https://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+flags: [ avoid-version ]
+
+maintainer: [
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+]
+authors: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Leo White <leo@lpw25.net>"
+  "Lubega Simon <lubegasimon73@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+  "Thomas Refis <trefis@janestreet.com>"
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml Documentation Generator - Driver"
+description: """
+The driver is a sample implementation of a tool to drive odoc to generate
+documentation for installed packages.
+"""
+
+
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "odoc" {>= "3.0.0"}
+  "bos"
+  "fpath"
+  "yojson"
+  "ocamlfind"
+  "opam-format"
+  "logs"
+  "eio_main"
+  "progress"
+  "cmdliner"
+  "sexplib"
+  "ppx_sexp_conv"
+  "sherlodoc"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml/odoc/releases/download/3.0.0_beta1/odoc-3.0.0.beta1.tbz"
+  checksum: [
+    "sha256=237473ccb54db660c0d476529268df4095a437906612f2ab5f01979852ca01ef"
+    "sha512=c758448306f867e90203634b5e4e63b83b4c14ab293f5e0623fb2d3a852b4e944998b174a4b0ea758b098eef588aab92882095e28a59ed6b430677c0497fd70b"
+  ]
+}
+x-commit-hash: "12ad5b5ff2a37d24070553180167d9cdbe631b80"
+

--- a/packages/odoc-driver/odoc-driver.3.0.0~beta1/opam
+++ b/packages/odoc-driver/odoc-driver.3.0.0~beta1/opam
@@ -38,15 +38,15 @@ depends: [
   "odoc-md"
   "bos"
   "fpath"
-  "yojson"
+  "yojson" {>= "2.0.0"}
   "ocamlfind"
-  "opam-format"
+  "opam-format" {>= "2.1.0"}
   "logs"
   "eio_main"
   "eio" {>= "1.0"}
   "progress"
-  "cmdliner"
-  "sexplib"
+  "cmdliner" {>= "1.1.0"}
+  "sexplib" 
   "ppx_sexp_conv"
   "sherlodoc"
 ]

--- a/packages/odoc-driver/odoc-driver.3.0.0~beta1/opam
+++ b/packages/odoc-driver/odoc-driver.3.0.0~beta1/opam
@@ -43,6 +43,7 @@ depends: [
   "opam-format"
   "logs"
   "eio_main"
+  "eio" {>= "1.0"}
   "progress"
   "cmdliner"
   "sexplib"
@@ -60,7 +61,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/odoc-driver/odoc-driver.3.0.0~beta1/opam
+++ b/packages/odoc-driver/odoc-driver.3.0.0~beta1/opam
@@ -33,7 +33,7 @@ documentation for installed packages.
 
 depends: [
   "ocaml" {>= "5.1.0"}
-  "odoc" {>= "3.0.0"}
+  "odoc" {= version}
   "dune" {>= "3.7.0"}
   "odoc-md"
   "bos"

--- a/packages/odoc-md/odoc-md.3.0.0~beta1/opam
+++ b/packages/odoc-md/odoc-md.3.0.0~beta1/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+homepage: "https://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+flags: [ avoid-version ]
+
+maintainer: [
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+]
+authors: [
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+  "Jon Ludlam <jon@recoil.org>"
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml Documentation Generator - Markdown support"
+description: """
+Odoc-md is part of the odoc suite of tools for generating documentation for OCaml packages.
+
+This package provides support for generating documentation from Markdown files.
+"""
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "odoc" {= version}
+  "cmarkit"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml/odoc/releases/download/3.0.0_beta1/odoc-3.0.0.beta1.tbz"
+  checksum: [
+    "sha256=237473ccb54db660c0d476529268df4095a437906612f2ab5f01979852ca01ef"
+    "sha512=c758448306f867e90203634b5e4e63b83b4c14ab293f5e0623fb2d3a852b4e944998b174a4b0ea758b098eef588aab92882095e28a59ed6b430677c0497fd70b"
+  ]
+}
+x-commit-hash: "12ad5b5ff2a37d24070553180167d9cdbe631b80"
+

--- a/packages/odoc-md/odoc-md.3.0.0~beta1/opam
+++ b/packages/odoc-md/odoc-md.3.0.0~beta1/opam
@@ -27,6 +27,7 @@ This package provides support for generating documentation from Markdown files.
 depends: [
   "ocaml" {>= "4.14.0"}
   "odoc" {= version}
+  "dune" {>= "3.7.0"}
   "cmarkit"
 ]
 

--- a/packages/odoc-md/odoc-md.3.0.0~beta1/opam
+++ b/packages/odoc-md/odoc-md.3.0.0~beta1/opam
@@ -40,7 +40,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/odoc-parser/odoc-parser.3.0.0~beta1/opam
+++ b/packages/odoc-parser/odoc-parser.3.0.0~beta1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Parser for ocaml documentation comments"
+description: """
+Odoc_parser is a library for parsing the contents of OCaml documentation
+comments, formatted using 'odoc' syntax, an extension of the language
+understood by ocamldoc."""
+maintainer: ["Jon Ludlam <jon@recoil.org>"]
+authors: ["Anton Bachin <antonbachin@yahoo.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml/odoc"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+doc: "https://ocaml.github.io/odoc/odoc_parser"
+flags: [ avoid-version ]
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.02.0" & < "5.4"}
+  "astring"
+  "result"
+  "camlp-streams"
+  "ppx_expect" {with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    # Tests are not all associated with a package and would be run if using the
+    # default '@runtest'.
+    "@src/parser/runtest" {with-test}
+  ]
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml/odoc/releases/download/3.0.0_beta1/odoc-3.0.0.beta1.tbz"
+  checksum: [
+    "sha256=237473ccb54db660c0d476529268df4095a437906612f2ab5f01979852ca01ef"
+    "sha512=c758448306f867e90203634b5e4e63b83b4c14ab293f5e0623fb2d3a852b4e944998b174a4b0ea758b098eef588aab92882095e28a59ed6b430677c0497fd70b"
+  ]
+}
+x-commit-hash: "12ad5b5ff2a37d24070553180167d9cdbe631b80"
+

--- a/packages/odoc/odoc.3.0.0~beta1/opam
+++ b/packages/odoc/odoc.3.0.0~beta1/opam
@@ -61,6 +61,11 @@ depends: [
   ("ocaml" {< "4.07.0" & with-test} | "bisect_ppx" {with-test & > "2.5.0"})
 ]
 
+depopts: [
+  "yojson" {>= "1.6.0"}
+]
+
+
 x-extra-doc-deps: [
   "odoc-driver" {= version}
   "sherlodoc" {= version}

--- a/packages/odoc/odoc.3.0.0~beta1/opam
+++ b/packages/odoc/odoc.3.0.0~beta1/opam
@@ -56,7 +56,7 @@ depends: [
 
   "ppx_expect" {with-test}
   "bos" {with-test}
-  "crunch" {> "1.1.0"}
+  "crunch" {> "2.0.0"}
 
   ("ocaml" {< "4.07.0" & with-test} | "bisect_ppx" {with-test & > "2.5.0"})
 ]

--- a/packages/odoc/odoc.3.0.0~beta1/opam
+++ b/packages/odoc/odoc.3.0.0~beta1/opam
@@ -1,0 +1,94 @@
+opam-version: "2.0"
+homepage: "https://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+flags: [ avoid-version ]
+
+maintainer: [
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+]
+authors: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Leo White <leo@lpw25.net>"
+  "Lubega Simon <lubegasimon73@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+  "Thomas Refis <trefis@janestreet.com>"
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml Documentation Generator"
+description: """
+**odoc** is a powerful and flexible documentation generator for OCaml. It reads *doc comments*, demarcated by `(** ... *)`, and transforms them into a variety of output formats, including HTML, LaTeX, and man pages.
+
+- **Output Formats:** Odoc generates HTML for web browsing, LaTeX for PDF generation, and man pages for use on Unix-like systems.
+- **Cross-References:** odoc uses the `ocamldoc` markup, which allows to create links for functions, types, modules, and documentation pages.
+- **Link to Source Code:** Documentation generated includes links to the source code of functions, providing an easy way to navigate from the docs to the actual implementation.
+- **Code Highlighting:** odoc automatically highlights syntax in code snippets for different languages.
+
+odoc is part of the [OCaml Platform](https://ocaml.org/docs/platform), the recommended set of tools for OCaml.
+"""
+
+
+depends: [
+  "odoc-parser" {= version}
+  "astring"
+  "cmdliner" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "3.7.0"}
+  "fpath"
+  "ocaml" {>= "4.02.0" & < "5.4"}
+  "result"
+  "tyxml" {>= "4.4.0"}
+  "fmt"
+
+  "ocamlfind" {with-test}
+  "yojson" {>= "2.1.0" & with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+  "conf-jq" {with-test}
+
+  "ppx_expect" {with-test}
+  "bos" {with-test}
+  "crunch" {> "1.1.0"}
+
+  ("ocaml" {< "4.07.0" & with-test} | "bisect_ppx" {with-test & > "2.5.0"})
+]
+
+x-extra-doc-deps: [
+  "odoc-driver" {= version}
+  "sherlodoc" {= version}
+  "odig"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml/odoc/releases/download/3.0.0_beta1/odoc-3.0.0.beta1.tbz"
+  checksum: [
+    "sha256=237473ccb54db660c0d476529268df4095a437906612f2ab5f01979852ca01ef"
+    "sha512=c758448306f867e90203634b5e4e63b83b4c14ab293f5e0623fb2d3a852b4e944998b174a4b0ea758b098eef588aab92882095e28a59ed6b430677c0497fd70b"
+  ]
+}
+x-commit-hash: "12ad5b5ff2a37d24070553180167d9cdbe631b80"
+

--- a/packages/odoc/odoc.3.0.0~beta1/opam
+++ b/packages/odoc/odoc.3.0.0~beta1/opam
@@ -61,6 +61,8 @@ depends: [
   ("ocaml" {< "4.07.0" & with-test} | "bisect_ppx" {with-test & > "2.5.0"})
 ]
 
+conflicts: [ "ocaml-option-bytecode-only" ]
+
 x-extra-doc-deps: [
   "odoc-driver" {= version}
   "sherlodoc" {= version}

--- a/packages/odoc/odoc.3.0.0~beta1/opam
+++ b/packages/odoc/odoc.3.0.0~beta1/opam
@@ -50,7 +50,7 @@ depends: [
   "fmt"
 
   "ocamlfind" {with-test}
-  "yojson" {>= "2.1.0" & with-test}
+  "yojson" {>= "2.1.0"}
   ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
   "conf-jq" {with-test}
 
@@ -60,11 +60,6 @@ depends: [
 
   ("ocaml" {< "4.07.0" & with-test} | "bisect_ppx" {with-test & > "2.5.0"})
 ]
-
-depopts: [
-  "yojson" {>= "1.6.0"}
-]
-
 
 x-extra-doc-deps: [
   "odoc-driver" {= version}

--- a/packages/sherlodoc/sherlodoc.0.2/opam
+++ b/packages/sherlodoc/sherlodoc.0.2/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/art-w/sherlodoc/issues"
 depends: [
   "dune" {>= "3.5"}
   "ocaml" {>= "4.0.8"}
-  "odoc" {>= "2.4.0"}
+  "odoc" {>= "2.4.0" & < "2.9.0"}
   "base64" {>= "3.5.1"}
   "bigstringaf" {>= "0.9.1"}
   "js_of_ocaml" {>= "5.6.0"}

--- a/packages/sherlodoc/sherlodoc.3.0.0~beta1/opam
+++ b/packages/sherlodoc/sherlodoc.3.0.0~beta1/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Search engine for OCaml documentation"
+maintainer: ["art.wendling@gmail.com"]
+authors: ["Arthur Wendling" "Emile Trotignon"]
+license: "MIT"
+homepage: "https://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+flags: [ avoid-version ]
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.0.8"}
+  "odoc" {= version}
+  "base64" {>= "3.5.1"}
+  "bigstringaf" {>= "0.9.1"}
+  "js_of_ocaml" {>= "5.6.0"}
+  "brr" {>= "0.0.6"}
+  "cmdliner" {>= "1.2.0"}
+  "decompress" {>= "1.5.3"}
+  "fpath" {>= "0.7.3"}
+  "lwt" {>= "5.7.0"}
+  "menhir" {>= "20230608"}
+  "ppx_blob" {>= "0.7.2"}
+  "tyxml" {>= "4.6.0"}
+  "result" {>= "1.5"}
+  "odig" {with-test}
+  "base" {with-test & = "v0.16.3"}
+  "alcotest" {with-test}
+]
+depopts: [
+  "ancient" {>= "0.9.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml/odoc/releases/download/3.0.0_beta1/odoc-3.0.0.beta1.tbz"
+  checksum: [
+    "sha256=237473ccb54db660c0d476529268df4095a437906612f2ab5f01979852ca01ef"
+    "sha512=c758448306f867e90203634b5e4e63b83b4c14ab293f5e0623fb2d3a852b4e944998b174a4b0ea758b098eef588aab92882095e28a59ed6b430677c0497fd70b"
+  ]
+}
+x-commit-hash: "12ad5b5ff2a37d24070553180167d9cdbe631b80"
+

--- a/packages/sherlodoc/sherlodoc.3.0.0~beta1/opam
+++ b/packages/sherlodoc/sherlodoc.3.0.0~beta1/opam
@@ -8,7 +8,7 @@ doc: "https://ocaml.github.io/odoc/"
 bug-reports: "https://github.com/ocaml/odoc/issues"
 flags: [ avoid-version ]
 depends: [
-  "dune" {>= "3.5"}
+  "dune" {>= "3.7"}
   "ocaml" {>= "4.0.8"}
   "odoc" {= version}
   "base64" {>= "3.5.1"}

--- a/packages/sherlodoc/sherlodoc.3.0.0~beta1/opam
+++ b/packages/sherlodoc/sherlodoc.3.0.0~beta1/opam
@@ -40,7 +40,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@sherlodoc/runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/sherlodoc/sherlodoc.3.0.0~beta1/opam
+++ b/packages/sherlodoc/sherlodoc.3.0.0~beta1/opam
@@ -20,7 +20,7 @@ depends: [
   "fpath" {>= "0.7.3"}
   "lwt" {>= "5.7.0"}
   "menhir" {>= "20230608"}
-  "ppx_blob" {>= "0.7.2"}
+  "ppx_blob" {>= "0.9.0"}
   "tyxml" {>= "4.6.0"}
   "result" {>= "1.5"}
   "odig" {with-test}


### PR DESCRIPTION
CHANGES:

- Hierarchical documentation (@jonludlam, @panglesd, @Julow) Pages can now be organized in a directory tree structure. Relative and absolute references are added: `{!./other_page.label}`, `{!//other_page}`.

- Improved sidebar and breadcrumbs navigation (@panglesd, @gpetiot) The documentation pages and the libraries of the entire package are shown on the left sidebar.

- Added support for images, videos, audio and other assets The syntax is `{image!/reference/to/asset}` or `{image:URL}` for images. The syntax for `{video...}` and `{audio...}` is the same. (@panglesd, @EmileTrotignon, ocaml/odoc#1170, ocaml/odoc#1171, ocaml/odoc#1184, ocaml/odoc#1185)

- Search using Sherlodoc (@panglesd, @EmileTrotignon, @Julow) A new search bar that supports full-text and type-based search.

- Experimental driver (@jonludlam, @panglesd) The driver builds the documentation for a collection of Opam packages using the newer Odoc features. It supports linking external packages to ocaml.org and markdown files. This is experimental and will break in the future.

- Cross-package references (@panglesd, @Julow) Pages and modules from other packages can be referenced: `{!/otherpackage/page}`, `{!/otherpackage/Module.t}`.

- Option to remap links to other packages to ocaml.org or other site. See the `--remap` option of the driver or the `--remap-file` option of `odoc html-generate`. (@jonludlam, ocaml/odoc#1189, ocaml/odoc#1248)

- Option to compute occurrences of use of each identifiers The commands `aggregate-occurrences` and `count-occurrences` are added. (@panglesd, ocaml/odoc#976, ocaml/odoc#1076, ocaml/odoc#1206)

- Added the `odoc classify` command (@jonludlam, ocaml/odoc#1121) Helps driver detecting which modules belong to which libraries.
- Added `--suppress-warnings` to the CLI to remove warnings from a unit, even if they end up being raised in another unit through expansion (@jonludlam, ocaml/odoc#1260)
- Add clock emoji before `@since` tag (@yawaramin, ocaml/odoc#1089)
- Navigation for the search bar : use '/' to enter search, up and down arrows to select a result, and enter to follow the selected link. (@EmileTrotignon, ocaml/odoc#1088)
- Fix a big gap between the preamble and the content of a page (@EmileTrotignon, ocaml/odoc#1147)
- Add a marshalled search index consumable by sherlodoc (@EmileTrotignon, @panglesd, ocaml/odoc#1084)
- Allow referencing of polymorphic constructors in polymorphic variant type aliases (@panglesd, ocaml/odoc#1115)
- Added a home icon in the breacrumbs (@panglesd, ocaml/odoc#1251) It can be disabled with a CLI option.
- Add a frontmatter syntax for mld pages (@panglesd, ocaml/odoc#1187, ocaml/odoc#1193, ocaml/odoc#1243, ocaml/odoc#1246, ocaml/odoc#1251) Allows to specify the title of a page, the order of sub-pages and other behaviors in the sidebar.
- Added `odoc-md` to process standalone Markdown pages (@jonludlam, ocaml/odoc#1234)

- The command line interface changed to support the new features.
  + Packages and libraries: `odoc link` must now be aware of packages and libraries with the `-L libname:path` and `-P pkgname:path` options. The module search path should still be passed with the `-I` option. The current package should be specified with `--current-package=pkgname`.
  + Hierarchy: `odoc compile` now outputs `.odoc` in the directory tree specified with `--output-dir=DIR` and the parent identifier must be specified with `--parent-id=PARENT`. The option `--source-parent-file` is removed.
  + Source code: Implementations are compiled with `compile-impl` instead of with `compile`. The options `--cmt=..` and `--source-name=..` are removed. Source code pages are generated with `html-generate-source`.
  + Assets: The commands `compile-asset`, `html-generate-asset` are added. The option `html-generate --asset` is removed.
  + Sidebar: The index is built using `compile-index`. The sidebar data is extracted from the index with `sidebar-generate` and passed to `html-generate --sidebar=..`.

- The syntax for `@tag` is now delimited (@panglesd, ocaml/odoc#1239) A `@tag` can now be followed by a paragraph or other elements.

- Updated colors for code fragments (@EmileTrotignon, ocaml/odoc#1023)
- Fixed complexity of looking up `.odoc` files (@panglesd, ocaml/odoc#1075)
- Normalize whitespaces in codespans (@gpetiot, ocaml/odoc#1085) A newline followed by any whitespaces is normalized as one space character.
- Reduce size of `Odoc_html_frontend` when compiled to javascript (@EmileTrotignon, ocaml/odoc#1072)
- Overhaul of module-type-of expansions and shadowing code (@jonludlam, ocaml/odoc#1081)
- Output file paths and labels in the man and latex backends changed to avoid name clashes (@Julow, ocaml/odoc#1191)

- Fix variant constructors being hidden if they contain hidden types (@jonludlam, ocaml/odoc#1105)
- Fix rare assertion failure due to optional parameters (@jonludlam, ocaml/odoc#1272, issue ocaml/odoc#1001)
- Fix resolution of module synopses in {!modules} lists that require --open (@jonludlam, ocaml/odoc#1104}
- Fix top comment not being taken from includes often enough (@panglesd, ocaml/odoc#1117)
- Fixed 404 links from search results (@panglesd, ocaml/odoc#1108)
- Fixed title content not being picked up across pages when rendering references (ocaml/odoc#1116, @panglesd)
- Fix wrong links to standalone comments in search results (ocaml/odoc#1118, @panglesd)
- Remove duplicated or unwanted comments with inline includes (@Julow, ocaml/odoc#1133)
- Fix bug where source rendering would cause odoc to fail completely if it encounters invalid syntax (@jonludlam ocaml/odoc#1208)
- Add missing parentheses in 'val (let*) : ...' (@Julow, ocaml/odoc#1268)
- Fix syntax highlighting not working for very large files (@jonludlam, @Julow, ocaml/odoc#1277)