### PR TITLE
picos 0.2.0 should be archived

### DIFF
--- a/packages/picos/picos.0.2.0/opam
+++ b/packages/picos/picos.0.2.0/opam
@@ -52,4 +52,5 @@ url {
     "sha512=0859345ab2a1feb4468515491aae99e390015f3b83019f6f3a13b061305deb19f0868ffa51fb6513b7071bba6fed4ef08c2a464b406bebf4dcde4cc70a9088d4"
   ]
 }
+x-maintained: false
 x-commit-hash: "a53cd12c7e2515a4ebea9844fe6a45aed4d609ac"


### PR DESCRIPTION
See discussion in https://github.com/ocaml/opam-repository/pull/27301#issuecomment-2608093379