### PR TITLE
[new release] tcalc (1.1.1)

### DIFF
--- a/packages/tcalc/tcalc.1.1.1/opam
+++ b/packages/tcalc/tcalc.1.1.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Minimal desktop calculator for timestamps"
+description: """\
+TCalc implements a minimal desktop calculator that in addition to
+  floating point numbers recognises durations in hh:min:sec format and
+  converts them to seconds. This can simplify time-based calculations.
+  This command-line application provides command-line editing and
+  history. Command math functions line sin or exp are available."""
+maintainer: "Christian Lindig <lindig@gmail.com>"
+authors: "Christian Lindig <lindig@gmail.com>"
+license: "Unlicense"
+homepage: "https://github.com/lindig/tcalc"
+bug-reports: "https://github.com/lindig/tcalc/issues"
+depends: [
+  "dune" {>= "2.7" & >= "2.0"}
+  "ocaml" {>= "4.13.0"}
+  "linenoise" {>= "1.3.1"}
+  "odoc" {with-doc}
+]
+available: os-family != "windows"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lindig/tcalc.git"
+url {
+  src:
+    "https://github.com/lindig/tcalc/releases/download/1.1.1/tcalc-1.1.1.tbz"
+  checksum: [
+    "sha256=9808010647fd73a1ce1ce11e61ac2d5463e8eddba0fec8f69328d0ee923bad7d"
+    "sha512=54ab1d1e3d1f2ccf889f731ffcf61a2495653a819993782f940e4c827e17cb55b627e1b0a2425da20ec103e1735cc2f5ce493868db5fad803fac9214c17c558f"
+  ]
+}
+x-commit-hash: "9cf5e9c66b29408b3e9081e6d87d54404e970e9f"


### PR DESCRIPTION
Minimal desktop calculator for timestamps

- Project page: <a href="https://github.com/lindig/tcalc">https://github.com/lindig/tcalc</a>

##### CHANGES:

* Fix opam data
