### PR TITLE
10 packages from ocurrent/ocurrent at 0.6.7

### DIFF
--- a/packages/current/current.0.6.7/opam
+++ b/packages/current/current.0.6.7/opam
@@ -1,0 +1,94 @@
+opam-version: "2.0"
+synopsis: "Pipeline language for keeping things up-to-date"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+It is used in ocaml-ci (which provides CI for OCaml projects on GitHub),
+and in docker-base-images (a pipeline that builds Docker images for various
+Linux distributions, OCaml compiler versions and CPU types, and pushes them
+to Docker Hub).
+
+A pipeline is written much like you would write a one-shot sequential script,
+but OCurrent will automatically re-run steps when the inputs change, and will
+run steps in parallel where possible."""
+maintainer: "Tim McGilchrist <timmcgil@gmail.com>"
+authors: [
+  "Thomas Leonard <talex5@gmail.com>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+  "Craig Ferguson <me@craigfe.io>"
+  "Etienne MARAIS <etienne@maiste.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Ewan Mellor <ewan@tarides.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Puneeth Chaganti <punchagan@muse-amuse.in>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Navin Keswani <navin@novemberkilo.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Arthur Wendling <art.wendling@gmail.com>"
+  "Anurag Soni <anurag@sonianurag.com>"
+  "Ambre Austen Suhamy <ambre@tarides.com>"
+  "Ben Andrew <benmandrew@gmail.com>"
+  "Gargi Sharma <gs051095@gmail.com>"
+  "Jonathan Coates <git@squiddev.cc>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Magnus Skjegstad <magnus@skjegstad.com>"
+  "Shon Feder <shon.feder@gmail.com>"
+  "smolck <46855713+smolck@users.noreply.github.com>"
+  "tatchi <corentin.leruth@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.12.0"}
+  "astring" {>= "0.8.5"}
+  "bos"
+  "cmdliner" {>= "1.1.0"}
+  "conf-libev" {os != "win32"}
+  "current_incr" {>= "0.6.1"}
+  "duration"
+  "fmt" {>= "0.8.9"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.7"}
+  "lwt-dllist"
+  "ppx_deriving"
+  "prometheus"
+  "re" {>= "1.9.0"}
+  "result" {>= "1.5"}
+  "sqlite3"
+  "alcotest" {with-test & >= "1.2.0"}
+  "alcotest-lwt" {with-test & >= "1.2.0"}
+  "prometheus-app" {with-test & >= "1.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.6.7/ocurrent-0.6.7.tbz"
+  checksum: [
+    "md5=0015136df813bfee115b021dcba31048"
+    "sha512=748ac97617a472c370ab7ca256e866e9c04d4d3611951c9ec2ca9f5541a7e2cec7b30da42fa3d74255a3a087d350df682409bd5332435bb559a1f6a716d1c090"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/current_docker/current_docker.0.6.7/opam
+++ b/packages/current_docker/current_docker.0.6.7/opam
@@ -1,0 +1,83 @@
+opam-version: "2.0"
+synopsis: "OCurrent Docker plugin"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a plugin for interacting with Docker.
+It can pull, build, run and push images, and can coordinate
+multiple Docker Engine instances."""
+maintainer: "Tim McGilchrist <timmcgil@gmail.com>"
+authors: [
+  "Thomas Leonard <talex5@gmail.com>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+  "Craig Ferguson <me@craigfe.io>"
+  "Etienne MARAIS <etienne@maiste.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Ewan Mellor <ewan@tarides.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Puneeth Chaganti <punchagan@muse-amuse.in>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Navin Keswani <navin@novemberkilo.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Arthur Wendling <art.wendling@gmail.com>"
+  "Anurag Soni <anurag@sonianurag.com>"
+  "Ambre Austen Suhamy <ambre@tarides.com>"
+  "Ben Andrew <benmandrew@gmail.com>"
+  "Gargi Sharma <gs051095@gmail.com>"
+  "Jonathan Coates <git@squiddev.cc>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Magnus Skjegstad <magnus@skjegstad.com>"
+  "Shon Feder <shon.feder@gmail.com>"
+  "smolck <46855713+smolck@users.noreply.github.com>"
+  "tatchi <corentin.leruth@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "current" {= version}
+  "current_git" {= version}
+  "ocaml" {>= "4.12.0"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "duration" {>= "0.1.3"}
+  "fmt" {>= "0.8.9"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.7"}
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "result" {>= "1.5"}
+  "yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.6.7/ocurrent-0.6.7.tbz"
+  checksum: [
+    "md5=0015136df813bfee115b021dcba31048"
+    "sha512=748ac97617a472c370ab7ca256e866e9c04d4d3611951c9ec2ca9f5541a7e2cec7b30da42fa3d74255a3a087d350df682409bd5332435bb559a1f6a716d1c090"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/current_examples/current_examples.0.6.7/opam
+++ b/packages/current_examples/current_examples.0.6.7/opam
@@ -1,0 +1,98 @@
+opam-version: "2.0"
+synopsis: "Example pipelines for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides some example pipelines.
+It exists mainly to test the integration of various OCurrent
+plugins."""
+maintainer: "Tim McGilchrist <timmcgil@gmail.com>"
+authors: [
+  "Thomas Leonard <talex5@gmail.com>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+  "Craig Ferguson <me@craigfe.io>"
+  "Etienne MARAIS <etienne@maiste.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Ewan Mellor <ewan@tarides.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Puneeth Chaganti <punchagan@muse-amuse.in>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Navin Keswani <navin@novemberkilo.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Arthur Wendling <art.wendling@gmail.com>"
+  "Anurag Soni <anurag@sonianurag.com>"
+  "Ambre Austen Suhamy <ambre@tarides.com>"
+  "Ben Andrew <benmandrew@gmail.com>"
+  "Gargi Sharma <gs051095@gmail.com>"
+  "Jonathan Coates <git@squiddev.cc>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Magnus Skjegstad <magnus@skjegstad.com>"
+  "Shon Feder <shon.feder@gmail.com>"
+  "smolck <46855713+smolck@users.noreply.github.com>"
+  "tatchi <corentin.leruth@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "current" {= version}
+  "current_docker" {= version}
+  "current_git" {= version}
+  "current_github" {= version}
+  "current_gitlab" {= version}
+  "current_rpc" {= version}
+  "current_web" {= version}
+  "current_ssh" {= version}
+  "ocaml" {>= "4.12.0"}
+  "capnp-rpc" {>= "1.2.3"}
+  "capnp-rpc-lwt" {>= "1.2.3"}
+  "capnp-rpc-net" {>= "1.2.3"}
+  "capnp-rpc-unix" {>= "1.2.3"}
+  "cmdliner" {>= "1.1.0"}
+  "duration"
+  "dockerfile" {>= "7.0.0"}
+  "fmt" {>= "0.8.9"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.7"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "prometheus-app" {>= "1.2"}
+  "result" {>= "1.5"}
+  "routes" {>= "2.0.0"}
+  "uri" {>= "4.0.0"}
+  "yojson" {>= "1.7.0"}
+  "mdx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.6.7/ocurrent-0.6.7.tbz"
+  checksum: [
+    "md5=0015136df813bfee115b021dcba31048"
+    "sha512=748ac97617a472c370ab7ca256e866e9c04d4d3611951c9ec2ca9f5541a7e2cec7b30da42fa3d74255a3a087d350df682409bd5332435bb559a1f6a716d1c090"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/current_git/current_git.0.6.7/opam
+++ b/packages/current_git/current_git.0.6.7/opam
@@ -1,0 +1,87 @@
+opam-version: "2.0"
+synopsis: "Git plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Git.
+It can pull from remote repositories, or monitor local ones for changes."""
+maintainer: "Tim McGilchrist <timmcgil@gmail.com>"
+authors: [
+  "Thomas Leonard <talex5@gmail.com>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+  "Craig Ferguson <me@craigfe.io>"
+  "Etienne MARAIS <etienne@maiste.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Ewan Mellor <ewan@tarides.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Puneeth Chaganti <punchagan@muse-amuse.in>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Navin Keswani <navin@novemberkilo.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Arthur Wendling <art.wendling@gmail.com>"
+  "Anurag Soni <anurag@sonianurag.com>"
+  "Ambre Austen Suhamy <ambre@tarides.com>"
+  "Ben Andrew <benmandrew@gmail.com>"
+  "Gargi Sharma <gs051095@gmail.com>"
+  "Jonathan Coates <git@squiddev.cc>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Magnus Skjegstad <magnus@skjegstad.com>"
+  "Shon Feder <shon.feder@gmail.com>"
+  "smolck <46855713+smolck@users.noreply.github.com>"
+  "tatchi <corentin.leruth@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "current" {= version}
+  "ocaml" {>= "4.12.0"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "conf-git"
+  "cstruct" {>= "6.0.0"}
+  "fmt" {>= "0.8.9"}
+  "fpath" {>= "0.7.3"}
+  "irmin-watcher"
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.7"}
+  "mirage-crypto" {>= "0.8.0"}
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "result" {>= "1.5"}
+  "yojson"
+  "mdx" {with-test}
+  "alcotest" {with-test & >= "1.2.0"}
+  "alcotest-lwt" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.6.7/ocurrent-0.6.7.tbz"
+  checksum: [
+    "md5=0015136df813bfee115b021dcba31048"
+    "sha512=748ac97617a472c370ab7ca256e866e9c04d4d3611951c9ec2ca9f5541a7e2cec7b30da42fa3d74255a3a087d350df682409bd5332435bb559a1f6a716d1c090"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/current_github/current_github.0.6.7/opam
+++ b/packages/current_github/current_github.0.6.7/opam
@@ -1,0 +1,97 @@
+opam-version: "2.0"
+synopsis: "GitHub plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with GitHub.
+It can monitor and clone remote GitHub repositories, and can
+push GitHub status messages to show the results of testing
+PRs and branches."""
+maintainer: "Tim McGilchrist <timmcgil@gmail.com>"
+authors: [
+  "Thomas Leonard <talex5@gmail.com>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+  "Craig Ferguson <me@craigfe.io>"
+  "Etienne MARAIS <etienne@maiste.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Ewan Mellor <ewan@tarides.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Puneeth Chaganti <punchagan@muse-amuse.in>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Navin Keswani <navin@novemberkilo.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Arthur Wendling <art.wendling@gmail.com>"
+  "Anurag Soni <anurag@sonianurag.com>"
+  "Ambre Austen Suhamy <ambre@tarides.com>"
+  "Ben Andrew <benmandrew@gmail.com>"
+  "Gargi Sharma <gs051095@gmail.com>"
+  "Jonathan Coates <git@squiddev.cc>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Magnus Skjegstad <magnus@skjegstad.com>"
+  "Shon Feder <shon.feder@gmail.com>"
+  "smolck <46855713+smolck@users.noreply.github.com>"
+  "tatchi <corentin.leruth@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "current" {= version}
+  "current_git" {= version}
+  "current_web" {= version}
+  "ocaml" {>= "4.12.0"}
+  "astring" {>= "0.8.5"}
+  "base64" {>= "3.4.0"}
+  "cmdliner" {>= "1.1.0"}
+  "cohttp-lwt-unix" {>= "6.0.0"}
+  "cstruct" {>= "5.2.0"}
+  "duration"
+  "fmt" {>= "0.8.9"}
+  "github-unix" {>= "4.4.0"}
+  "hex" {>= "1.4.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.7"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "ptime"
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "tyxml" {>= "4.6.0"}
+  "uri" {>= "4.0.0"}
+  "x509" {>= "0.10.0"}
+  "yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.6.7/ocurrent-0.6.7.tbz"
+  checksum: [
+    "md5=0015136df813bfee115b021dcba31048"
+    "sha512=748ac97617a472c370ab7ca256e866e9c04d4d3611951c9ec2ca9f5541a7e2cec7b30da42fa3d74255a3a087d350df682409bd5332435bb559a1f6a716d1c090"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/current_gitlab/current_gitlab.0.6.7/opam
+++ b/packages/current_gitlab/current_gitlab.0.6.7/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "GitLab plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with GitLab.
+It can monitor and clone remote GitLab repositories, and can
+push GitLab status messages to show the results of testing
+PRs and branches."""
+maintainer: "Tim McGilchrist <timmcgil@gmail.com>"
+authors: "Tim McGilchrist <timmcgil@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "current" {= version}
+  "current_git" {= version}
+  "current_web" {= version}
+  "ocaml" {>= "4.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "cohttp-lwt-unix" {>= "6.0.0"}
+  "fmt" {>= "0.8.9"}
+  "gitlab-unix" {>= "0.1.8"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.7"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "ptime"
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.6.7/ocurrent-0.6.7.tbz"
+  checksum: [
+    "md5=0015136df813bfee115b021dcba31048"
+    "sha512=748ac97617a472c370ab7ca256e866e9c04d4d3611951c9ec2ca9f5541a7e2cec7b30da42fa3d74255a3a087d350df682409bd5332435bb559a1f6a716d1c090"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/current_rpc/current_rpc.0.6.7/opam
+++ b/packages/current_rpc/current_rpc.0.6.7/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+synopsis: "Cap'n Proto RPC plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a Cap'n Proto RPC interface, allowing
+an OCurrent engine to be controlled remotely."""
+maintainer: "Tim McGilchrist <timmcgil@gmail.com>"
+authors: [
+  "Thomas Leonard <talex5@gmail.com>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+  "Craig Ferguson <me@craigfe.io>"
+  "Etienne MARAIS <etienne@maiste.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Ewan Mellor <ewan@tarides.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Puneeth Chaganti <punchagan@muse-amuse.in>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Navin Keswani <navin@novemberkilo.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Arthur Wendling <art.wendling@gmail.com>"
+  "Anurag Soni <anurag@sonianurag.com>"
+  "Ambre Austen Suhamy <ambre@tarides.com>"
+  "Ben Andrew <benmandrew@gmail.com>"
+  "Gargi Sharma <gs051095@gmail.com>"
+  "Jonathan Coates <git@squiddev.cc>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Magnus Skjegstad <magnus@skjegstad.com>"
+  "Shon Feder <shon.feder@gmail.com>"
+  "smolck <46855713+smolck@users.noreply.github.com>"
+  "tatchi <corentin.leruth@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.12.0"}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {>= "1.2.3"}
+  "capnp-rpc-lwt" {>= "1.2.3"}
+  "fmt" {>= "0.8.9"}
+  "fpath"
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.7"}
+  "result" {>= "1.5"}
+  "stdint" {>= "0.7.0"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "x509" {= "0.11.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.6.7/ocurrent-0.6.7.tbz"
+  checksum: [
+    "md5=0015136df813bfee115b021dcba31048"
+    "sha512=748ac97617a472c370ab7ca256e866e9c04d4d3611951c9ec2ca9f5541a7e2cec7b30da42fa3d74255a3a087d350df682409bd5332435bb559a1f6a716d1c090"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/current_slack/current_slack.0.6.7/opam
+++ b/packages/current_slack/current_slack.0.6.7/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+synopsis: "Slack plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Slack.
+It can post messages to slack channels."""
+maintainer: "Tim McGilchrist <timmcgil@gmail.com>"
+authors: [
+  "Thomas Leonard <talex5@gmail.com>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+  "Craig Ferguson <me@craigfe.io>"
+  "Etienne MARAIS <etienne@maiste.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Ewan Mellor <ewan@tarides.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Puneeth Chaganti <punchagan@muse-amuse.in>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Navin Keswani <navin@novemberkilo.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Arthur Wendling <art.wendling@gmail.com>"
+  "Anurag Soni <anurag@sonianurag.com>"
+  "Ambre Austen Suhamy <ambre@tarides.com>"
+  "Ben Andrew <benmandrew@gmail.com>"
+  "Gargi Sharma <gs051095@gmail.com>"
+  "Jonathan Coates <git@squiddev.cc>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Magnus Skjegstad <magnus@skjegstad.com>"
+  "Shon Feder <shon.feder@gmail.com>"
+  "smolck <46855713+smolck@users.noreply.github.com>"
+  "tatchi <corentin.leruth@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "current" {= version}
+  "ocaml" {>= "4.12.0"}
+  "cohttp-lwt-unix" {>= "6.0.0"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.7"}
+  "tls-lwt" {>= "0.16.0"}
+  "uri" {>= "4.0.0"}
+  "yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.6.7/ocurrent-0.6.7.tbz"
+  checksum: [
+    "md5=0015136df813bfee115b021dcba31048"
+    "sha512=748ac97617a472c370ab7ca256e866e9c04d4d3611951c9ec2ca9f5541a7e2cec7b30da42fa3d74255a3a087d350df682409bd5332435bb559a1f6a716d1c090"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/current_ssh/current_ssh.0.6.7/opam
+++ b/packages/current_ssh/current_ssh.0.6.7/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "SSH plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a plugin for running ssh commands."""
+maintainer: "Mark Elvers <mark.elvers@tunbury.org>"
+authors: "Mark Elvers <mark.elvers@tunbury.org>"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "current" {= version}
+  "ocaml" {>= "4.12.0"}
+  "yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.6.7/ocurrent-0.6.7.tbz"
+  checksum: [
+    "md5=0015136df813bfee115b021dcba31048"
+    "sha512=748ac97617a472c370ab7ca256e866e9c04d4d3611951c9ec2ca9f5541a7e2cec7b30da42fa3d74255a3a087d350df682409bd5332435bb559a1f6a716d1c090"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/current_web/current_web.0.6.7/opam
+++ b/packages/current_web/current_web.0.6.7/opam
@@ -1,0 +1,105 @@
+opam-version: "2.0"
+synopsis: "Test web UI for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a basic web UI for service administrators.
+It shows the current pipeline visually and allows viewing job
+logs and configuring the log analyser."""
+maintainer: "Tim McGilchrist <timmcgil@gmail.com>"
+authors: [
+  "Thomas Leonard <talex5@gmail.com>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+  "Craig Ferguson <me@craigfe.io>"
+  "Etienne MARAIS <etienne@maiste.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Ewan Mellor <ewan@tarides.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Puneeth Chaganti <punchagan@muse-amuse.in>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Navin Keswani <navin@novemberkilo.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Arthur Wendling <art.wendling@gmail.com>"
+  "Anurag Soni <anurag@sonianurag.com>"
+  "Ambre Austen Suhamy <ambre@tarides.com>"
+  "Ben Andrew <benmandrew@gmail.com>"
+  "Gargi Sharma <gs051095@gmail.com>"
+  "Jonathan Coates <git@squiddev.cc>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Magnus Skjegstad <magnus@skjegstad.com>"
+  "Shon Feder <shon.feder@gmail.com>"
+  "smolck <46855713+smolck@users.noreply.github.com>"
+  "tatchi <corentin.leruth@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "crunch" {build & >= "3.3.0"}
+  "current" {= version}
+  "ocaml" {>= "4.12.0"}
+  "ansi" {>= "0.5.0"}
+  "astring" {>= "0.8.5"}
+  "base64"
+  "bos"
+  "cmdliner" {>= "1.1.0"}
+  "cohttp-lwt-unix" {>= "6.0.0"}
+  "conduit-lwt-unix" {>= "2.2.2"}
+  "conf-graphviz"
+  "cstruct" {>= "5.2.0"}
+  "csv" {>= "2.4"}
+  "fmt" {>= "0.8.9"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.7"}
+  "mirage-crypto" {>= "0.8.7"}
+  "mirage-crypto-rng" {>= "0.11.0"}
+  "mirage-crypto-rng-lwt" {>= "0.11.0"}
+  "multipart_form-lwt" {>= "0.4.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "ppx_sexp_conv" {>= "v0.14.1"}
+  "prometheus" {>= "0.7"}
+  "prometheus-app" {>= "1.2"}
+  "re" {>= "1.9.0"}
+  "result" {>= "1.5"}
+  "routes" {>= "2.0.0"}
+  "session"
+  "session-cohttp-lwt"
+  "sexplib" {>= "v0.14.0"}
+  "sqlite3" {>= "5.0.2"}
+  "tyxml" {>= "4.6.0"}
+  "uri" {>= "4.0.0"}
+  "yojson" {>= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/v0.6.7/ocurrent-0.6.7.tbz"
+  checksum: [
+    "md5=0015136df813bfee115b021dcba31048"
+    "sha512=748ac97617a472c370ab7ca256e866e9c04d4d3611951c9ec2ca9f5541a7e2cec7b30da42fa3d74255a3a087d350df682409bd5332435bb559a1f6a716d1c090"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `current.0.6.7`: Pipeline language for keeping things up-to-date
- `current_docker.0.6.7`: OCurrent Docker plugin
- `current_examples.0.6.7`: Example pipelines for OCurrent
- `current_git.0.6.7`: Git plugin for OCurrent
- `current_github.0.6.7`: GitHub plugin for OCurrent
- `current_gitlab.0.6.7`: GitLab plugin for OCurrent
- `current_rpc.0.6.7`: Cap'n Proto RPC plugin for OCurrent
- `current_slack.0.6.7`: Slack plugin for OCurrent
- `current_ssh.0.6.7`: SSH plugin for OCurrent
- `current_web.0.6.7`: Test web UI for OCurrent



---
* Homepage: https://github.com/ocurrent/ocurrent
* Source repo: git+https://github.com/ocurrent/ocurrent.git
* Bug tracker: https://github.com/ocurrent/ocurrent/issues

---
:camel: Pull-request generated by opam-publish v2.4.0