### PR TITLE
[new release] dream-html (2 packages) (3.10.0)

### DIFF
--- a/packages/dream-html/dream-html.3.10.0/opam
+++ b/packages/dream-html/dream-html.3.10.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.14.0"}
+  "ppxlib" {>= "0.33.0" & < "1.0.0"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.10.0/dream-html-3.10.0.tbz"
+  checksum: [
+    "sha256=64c4eefc0ff2a7a8d6f7de5a0242e2d0a5044e50ce0bc292b7c356509cb28346"
+    "sha512=0528e6fe044626c5f663f4d0fddf79a2b497b69c90d7aa656e9b8c789b1a68a5464a7a0f8f6a81001d3429e6906a6f7e33cd2a9fb6f5f3f1564bfa45ae4e9d57"
+  ]
+}
+x-commit-hash: "ed9a3dd73b2e5360ab0abb50ec3ed909755c2113"

--- a/packages/pure-html/pure-html.3.10.0/opam
+++ b/packages/pure-html/pure-html.3.10.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.10.0/dream-html-3.10.0.tbz"
+  checksum: [
+    "sha256=64c4eefc0ff2a7a8d6f7de5a0242e2d0a5044e50ce0bc292b7c356509cb28346"
+    "sha512=0528e6fe044626c5f663f4d0fddf79a2b497b69c90d7aa656e9b8c789b1a68a5464a7a0f8f6a81001d3429e6906a6f7e33cd2a9fb6f5f3f1564bfa45ae4e9d57"
+  ]
+}
+x-commit-hash: "ed9a3dd73b2e5360ab0abb50ec3ed909755c2113"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

See https://github.com/yawaramin/dream-html/tags
