### PR TITLE
LablTk 8.06.15 and OCamlBrowser 5.3.0

### DIFF
--- a/packages/labltk/labltk.8.06.15/opam
+++ b/packages/labltk/labltk.8.06.15/opam
@@ -31,7 +31,7 @@ description: "ocamlbrowser is now a separate package.\n\
 url {
   src: "https://github.com/garrigue/labltk/archive/refs/tags/8.06.15.tar.gz"
   checksum: [
-    "sha256=789c89a82c256e46855da5b1cfab733d02ad884f4538e6837d528d6e6cc74b27"
-    "md5=e694853ffb488a65395d533144ac51f8"
+    "sha256=fe0e11bacdb537ce9027aec072262405f01fe4017d19213d5a82ef053e50594d"
+    "md5=c5f70ac8a2d36e083a51603f8d3a0901"
   ]
 }

--- a/packages/labltk/labltk.8.06.15/opam
+++ b/packages/labltk/labltk.8.06.15/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://garrigue.github.io/labltk/"
+bug-reports: "https://github.com/garrigue/labltk/issues"
+dev-repo: "git+https://github.com/garrigue/labltk.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+build: [
+  ["./configure" "-use-findlib" "-verbose" "-installbindir" bin]
+  [
+    make
+    "library"
+    "opt" {!ocaml-option-bytecode-only:installed}
+  ]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "ocamlfind" {build}
+  "conf-tcl"
+  "conf-tk"
+]
+post-messages: [
+  "This package requires Tcl/Tk with its development packages installed on your system" {failure}
+]
+synopsis: "OCaml interface to Tcl/Tk"
+description: "ocamlbrowser is now a separate package.\n\
+             For details, see https://garrigue.github.io/labltk/"
+url {
+  src: "https://github.com/garrigue/labltk/archive/refs/tags/8.06.15.tar.gz"
+  checksum: [
+    "sha256=789c89a82c256e46855da5b1cfab733d02ad884f4538e6837d528d6e6cc74b27"
+    "md5=e694853ffb488a65395d533144ac51f8"
+  ]
+}

--- a/packages/ocamlbrowser/ocamlbrowser.5.3.0/opam
+++ b/packages/ocamlbrowser/ocamlbrowser.5.3.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://garrigue.github.io/labltk/"
+bug-reports: "https://github.com/garrigue/labltk/issues"
+dev-repo: "git+https://github.com/garrigue/labltk.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+build: [
+  ["./configure" "-use-findlib" "-installbindir" bin]
+  [make "all"]
+]
+install: [
+  [make "install-browser"]
+]
+depends: [
+  "ocaml" {>= "5.3" & < "5.4"}
+  "labltk" {>= "8.06.15"}
+  "ocamlfind" {build}
+  "conf-tcl"
+  "conf-tk"
+]
+post-messages: [
+  "This package requires Tcl/Tk with its development packages installed on your system" {failure}
+]
+synopsis: "OCamlBrowser Library Explorer"
+description: "Requires LablTk. For details, see https://garrigue.github.io/labltk/"
+url {
+  src: "https://github.com/garrigue/labltk/archive/refs/tags/8.06.15.tar.gz"
+  checksum: [
+    "sha256=789c89a82c256e46855da5b1cfab733d02ad884f4538e6837d528d6e6cc74b27"
+    "md5=e694853ffb488a65395d533144ac51f8"
+  ]
+}

--- a/packages/ocamlbrowser/ocamlbrowser.5.3.0/opam
+++ b/packages/ocamlbrowser/ocamlbrowser.5.3.0/opam
@@ -27,7 +27,8 @@ description: "Requires LablTk. For details, see https://garrigue.github.io/lablt
 url {
   src: "https://github.com/garrigue/labltk/archive/refs/tags/8.06.15.tar.gz"
   checksum: [
-    "sha256=789c89a82c256e46855da5b1cfab733d02ad884f4538e6837d528d6e6cc74b27"
-    "md5=e694853ffb488a65395d533144ac51f8"
+    "sha256=fe0e11bacdb537ce9027aec072262405f01fe4017d19213d5a82ef053e50594d"
+    "md5=c5f70ac8a2d36e083a51603f8d3a0901"
   ]
 }
+


### PR DESCRIPTION
This is a new release of LablTk and OCamlBrowser.

* Update OCamlBrowser for OCaml 5.3
* Add support for Tcl/Tk 9.0 (PR#28) [Richard WM Jones]
* Honor LABLTK_{DEFS,LIBS} environment variables (PR#23) [Eckhard Lehmann]