### PR TITLE
[new release] patricia-tree (0.11.0)

### DIFF
--- a/packages/patricia-tree/patricia-tree.0.11.0/opam
+++ b/packages/patricia-tree/patricia-tree.0.11.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Patricia Tree data structure in OCaml for maps and sets. Supports generic key-value pairs"
+maintainer: ["Dorian Lesbre <dorian.lesbre@cea.fr>"]
+authors: [
+  "Matthieu Lemerre <matthieu.lemerre@cea.fr>"
+  "Dorian Lesbre <dorian.lesbre@cea.fr>"
+]
+license: "LGPL-2.1-only"
+homepage: "https://codex.top/api/patricia-tree/"
+doc: "https://codex.top/api/patricia-tree/"
+bug-reports:
+  "https://github.com/codex-semantics-library/patricia-tree/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0"}
+  "qcheck-core" {>= "0.21.2" & with-test}
+  "ppx_inline_test" {>= "v0.16.0" & with-test}
+  "mdx" {>= "2.4.1" & with-test}
+  "odoc" {>= "2.4.0" & with-doc}
+  "sherlodoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/codex-semantics-library/patricia-tree.git"
+url {
+  src:
+    "https://github.com/codex-semantics-library/patricia-tree/releases/download/v0.11.0/patricia-tree-0.11.0.tbz"
+  checksum: [
+    "sha256=18fcde5d35d65c9bb2f9ec4ff732ecdd8969ba6fc2cf51d29ecb3be66e2fe664"
+    "sha512=da038d5096deb4bf3c02efd694e962ecf9b2571d140fa1fef17cce474f628ec070b93a44fd742748b9d3ba0e51041f864623d83e9cb0c72214abb0fb4a043625"
+  ]
+}
+x-commit-hash: "8c964963985ae2cf5292146102316520f31e8fda"


### PR DESCRIPTION
Patricia Tree data structure in OCaml for maps and sets. Supports generic key-value pairs

- Project page: <a href="https://codex.top/api/patricia-tree/">https://codex.top/api/patricia-tree/</a>
- Documentation: <a href="https://codex.top/api/patricia-tree/">https://codex.top/api/patricia-tree/</a>

##### CHANGES:

- Add some `reflexive_equal` and `reflexive_compare` functions
- Add `min_binding_inter` for maps, `min_elt_inter` for sets and their max counterparts
- Add `difference` and `symmetric_difference` function to maps (and add `difference` to `WithForeign`)
- Add `diff` functions to sets
- Internal refactor.
