### PR TITLE
[new release] benchmark (1.7)

### DIFF
--- a/packages/benchmark/benchmark.1.7/opam
+++ b/packages/benchmark/benchmark.1.7/opam
@@ -10,7 +10,7 @@ authors: [
   "Doug Bagley"
   "c-cube"
 ]
-license: "LGPL-3.0 with OCaml linking exception"
+license: "LGPL-3.0 WITH OCaml linking exception"
 homepage: "https://github.com/Chris00/ocaml-benchmark"
 bug-reports: "https://github.com/Chris00/ocaml-benchmark/issues"
 depends: [
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "2.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/benchmark/benchmark.1.7/opam
+++ b/packages/benchmark/benchmark.1.7/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Benchmark running times of code"
+description: """
+This module provides a set of tools to measure the running times of
+your functions and to easily compare the results.  A statistical test
+is used to determine whether the results truly differ."""
+maintainer: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+authors: [
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Doug Bagley"
+  "c-cube"
+]
+license: "LGPL-3.0 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-benchmark"
+bug-reports: "https://github.com/Chris00/ocaml-benchmark/issues"
+depends: [
+  "ocaml" {>= "4.03"}
+  "base-unix"
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Chris00/ocaml-benchmark.git"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-benchmark/releases/download/v1.7/benchmark-1.7.tbz"
+  checksum: [
+    "sha256=0228fbbc9cda98d5907e32de1a010d948a7a225f3e59cf61b1a86be1e0c6b3af"
+    "sha512=9ca163fb3ae6c5e5239d0198cc9ec9b0811a48cf160f6e0fff635b0afdda99ae4503d0e4341b95bcb1e15bc1fcb60238761e49d4004c506fb2c53174c9890de2"
+  ]
+}
+x-commit-hash: "d299f7101aab4e08e0a37518262583af51db0d83"


### PR DESCRIPTION
Benchmark running times of code

- Project page: <a href="https://github.com/Chris00/ocaml-benchmark">https://github.com/Chris00/ocaml-benchmark</a>

##### CHANGES:

- move to dune 2.0
- collect and display GC statistics
- use Re.Pcre instead of pcre in example
