### PR TITLE
Release ppxlib and ppxlib-tools 0.35.0

### DIFF
--- a/packages/ppxlib-tools/ppxlib-tools.0.35.0/opam
+++ b/packages/ppxlib-tools/ppxlib-tools.0.35.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Tools for PPX users and authors"
+description: """
+Set of helper tools for PPX users and authors.
+
+ppxlib-pp-ast: Command line tool to pretty print OCaml ASTs in a human readable
+format."""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0"}
+  "ppxlib" {= version}
+  "cmdliner" {>= "1.3.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.35.0/ppxlib-0.35.0.tbz"
+  checksum: [
+    "sha256=d9d959fc9f84260487e45684dc741898a92fc5506b61a7f5cac65d21832db925"
+    "sha512=e428b1e3b89261c7efdaa18016264d1afbf067cb9b0d41124b04796c2487ac7ca8ee9a24a60d56f20d1774cb44aaa9ecf1512f17455812ba8d62d4ef93616ee7"
+  ]
+}
+x-commit-hash: "3a791083c612e91fa4e6a9660ef69776ea750324"

--- a/packages/ppxlib/ppxlib.0.35.0/opam
+++ b/packages/ppxlib/ppxlib.0.35.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "Standard infrastructure for ppx rewriters"
+description: """
+Ppxlib is the standard infrastructure for ppx rewriters
+and other programs that manipulate the in-memory representation of
+OCaml programs, a.k.a the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0" & < "5.4.0"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0" {>= "v0.12"}
+  "sexplib0" {with-test & >= "v0.15"}
+  "stdlib-shims"
+  "ocamlfind" {with-test}
+  "re" {with-test & >= "1.9.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "ocamlformat" {with-dev-setup & = "0.26.2"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-migrate-parsetree" {< "2.0.0"}
+  "ocaml-base-compiler" {= "5.1.0~alpha1"}
+  "ocaml-variants" {= "5.1.0~alpha1+options"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.35.0/ppxlib-0.35.0.tbz"
+  checksum: [
+    "sha256=d9d959fc9f84260487e45684dc741898a92fc5506b61a7f5cac65d21832db925"
+    "sha512=e428b1e3b89261c7efdaa18016264d1afbf067cb9b0d41124b04796c2487ac7ca8ee9a24a60d56f20d1774cb44aaa9ecf1512f17455812ba8d62d4ef93616ee7"
+  ]
+}
+x-commit-hash: "3a791083c612e91fa4e6a9660ef69776ea750324"


### PR DESCRIPTION
As usual, starting with a draft to see the revdeps builds.

**CHANGES:**

- Allow use of effect syntax in preprocessed files without causing migration failures. (ocaml-ppx/ppxlib#552, @hhugo, @NathanReb)

- Remove support for compilers older than 4.08 (ocaml-ppx/ppxlib#556, @NathanReb)

- Add a --use-compiler-pp flag to the standalone driver. This flag can be set when the driver outputs source code to make it use the compiler's Pprintast instead of ppxlib's. (ocaml-ppx/ppxlib#555, @NathanReb)