### PR TITLE
[new release] mirage-crypto (9 packages) (1.2.0)

### DIFF
--- a/packages/mirage-crypto-ec/mirage-crypto-ec.1.2.0/opam
+++ b/packages/mirage-crypto-ec/mirage-crypto-ec.1.2.0/opam
@@ -55,8 +55,8 @@ url {
   src:
     "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
   checksum: [
-    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
-    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+    "sha256=09542bcd96c1d368ff9ba8853105f4c1781d8c94c2400df9f3ac0610ee07e67e"
+    "sha512=1b31c9df0ce774c87a36f714db4ea1f295bc1e2e317d30497523ec03564cace0f64ac4c535aa83c82792aa3331a92efe774e4c3300a6ffe09110ce0efc2ce24b"
   ]
 }
-x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"
+x-commit-hash: "fe7bad77d4d73c355f9a84c097ed5d15548207f5"

--- a/packages/mirage-crypto-ec/mirage-crypto-ec.1.2.0/opam
+++ b/packages/mirage-crypto-ec/mirage-crypto-ec.1.2.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Elliptic Curve Cryptography with primitives taken from Fiat"
+description: """
+An implementation of key exchange (ECDH) and digital signature (ECDSA/EdDSA)
+algorithms using code from Fiat (<https://github.com/mit-plv/fiat-crypto>).
+
+The curves P256 (SECP256R1), P384 (SECP384R1),
+P521 (SECP521R1), and 25519 (X25519, Ed25519) are implemented by this package.
+"""
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "Nathan Rebours <nathan.p.rebours@gmail.com>"
+  "Clément Pascutto <clement@tarides.com>"
+  "Etienne Millon <me@emillon.org>"
+  "Virgile Robles <virgile.robles@protonmail.ch>"
+# and from the fiat-crypto AUTHORS file
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+  "Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mirage/mirage-crypto"
+doc: "https://mirage.github.io/mirage-crypto/doc"
+bug-reports: "https://github.com/mirage/mirage-crypto/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.13.0"}
+  "dune-configurator"
+  "eqaf" {>= "0.7"}
+  "mirage-crypto-rng" {=version}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "ppx_deriving_yojson" {with-test}
+  "ppx_deriving" {with-test}
+  "yojson" {with-test & >= "1.6.0"}
+  "asn1-combinators" {with-test & >= "0.3.1"}
+  "ohex" {with-test & >= "0.2.0"}
+  "ounit2" {with-test}
+]
+conflicts: [
+  "ocaml-freestanding"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
+tags: ["org:mirage"]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
+  checksum: [
+    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
+    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+  ]
+}
+x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.1.2.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.1.2.0/opam
@@ -36,8 +36,8 @@ url {
   src:
     "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
   checksum: [
-    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
-    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+    "sha256=09542bcd96c1d368ff9ba8853105f4c1781d8c94c2400df9f3ac0610ee07e67e"
+    "sha512=1b31c9df0ce774c87a36f714db4ea1f295bc1e2e317d30497523ec03564cace0f64ac4c535aa83c82792aa3331a92efe774e4c3300a6ffe09110ce0efc2ce24b"
   ]
 }
-x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"
+x-commit-hash: "fe7bad77d4d73c355f9a84c097ed5d15548207f5"

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.1.2.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.1.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "ounit2" {with-test}
+  "randomconv" {with-test & >= "0.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "digestif" {>= "1.2.0"}
+  "zarith" {>= "1.13"}
+  "eqaf" {>= "0.8"}
+]
+conflicts: [
+  "ocaml-freestanding"
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
+  checksum: [
+    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
+    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+  ]
+}
+x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"

--- a/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.1.2.0/opam
+++ b/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.1.2.0/opam
@@ -33,8 +33,8 @@ url {
   src:
     "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
   checksum: [
-    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
-    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+    "sha256=09542bcd96c1d368ff9ba8853105f4c1781d8c94c2400df9f3ac0610ee07e67e"
+    "sha512=1b31c9df0ce774c87a36f714db4ea1f295bc1e2e317d30497523ec03564cace0f64ac4c535aa83c82792aa3331a92efe774e4c3300a6ffe09110ce0efc2ce24b"
   ]
 }
-x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"
+x-commit-hash: "fe7bad77d4d73c355f9a84c097ed5d15548207f5"

--- a/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.1.2.0/opam
+++ b/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.1.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an Async-friendly way"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "async" {>= "v0.14"}
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "ohex" {with-test & >= "0.2.0"}
+]
+available: os != "win32"
+description: """
+
+Mirage-crypto-rng-async feeds the entropy source for Mirage_crypto_rng-based
+random number generator implementations, in an Async-friendly way.
+"""
+
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
+  checksum: [
+    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
+    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+  ]
+}
+x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"

--- a/packages/mirage-crypto-rng-eio/mirage-crypto-rng-eio.1.2.0/opam
+++ b/packages/mirage-crypto-rng-eio/mirage-crypto-rng-eio.1.2.0/opam
@@ -33,8 +33,8 @@ url {
   src:
     "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
   checksum: [
-    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
-    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+    "sha256=09542bcd96c1d368ff9ba8853105f4c1781d8c94c2400df9f3ac0610ee07e67e"
+    "sha512=1b31c9df0ce774c87a36f714db4ea1f295bc1e2e317d30497523ec03564cace0f64ac4c535aa83c82792aa3331a92efe774e4c3300a6ffe09110ce0efc2ce24b"
   ]
 }
-x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"
+x-commit-hash: "fe7bad77d4d73c355f9a84c097ed5d15548207f5"

--- a/packages/mirage-crypto-rng-eio/mirage-crypto-rng-eio.1.2.0/opam
+++ b/packages/mirage-crypto-rng-eio/mirage-crypto-rng-eio.1.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["Bikal Gurung <gbikal@gmail.com>" ]
+maintainer:   "Bikal Gurung <gbikal@gmail.com>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an eio-friendly way"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7"}
+  "eio" {>= "0.12"}
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "mtime"
+  "cstruct" {>= "6.1.0"}
+  "eio_main" {with-test}
+  "ohex" {with-test & >= "0.2.0"}
+]
+description: """
+Mirage-crypto-rng-eio feeds the entropy source for Mirage_crypto_rng-based
+random number generator implementations, in an eio-friendly way.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
+  checksum: [
+    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
+    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+  ]
+}
+x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"

--- a/packages/mirage-crypto-rng-lwt/mirage-crypto-rng-lwt.1.2.0/opam
+++ b/packages/mirage-crypto-rng-lwt/mirage-crypto-rng-lwt.1.2.0/opam
@@ -29,8 +29,8 @@ url {
   src:
     "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
   checksum: [
-    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
-    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+    "sha256=09542bcd96c1d368ff9ba8853105f4c1781d8c94c2400df9f3ac0610ee07e67e"
+    "sha512=1b31c9df0ce774c87a36f714db4ea1f295bc1e2e317d30497523ec03564cace0f64ac4c535aa83c82792aa3331a92efe774e4c3300a6ffe09110ce0efc2ce24b"
   ]
 }
-x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"
+x-commit-hash: "fe7bad77d4d73c355f9a84c097ed5d15548207f5"

--- a/packages/mirage-crypto-rng-lwt/mirage-crypto-rng-lwt.1.2.0/opam
+++ b/packages/mirage-crypto-rng-lwt/mirage-crypto-rng-lwt.1.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "duration"
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "mtime" {>= "1.0.0"}
+  "lwt" {>= "4.0.0"}
+]
+description: """
+Mirage-crypto-rng-lwt provides entropy collection code for the RNG using Lwt.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
+  checksum: [
+    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
+    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+  ]
+}
+x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"

--- a/packages/mirage-crypto-rng-miou-unix/mirage-crypto-rng-miou-unix.1.2.0/opam
+++ b/packages/mirage-crypto-rng-miou-unix/mirage-crypto-rng-miou-unix.1.2.0/opam
@@ -32,8 +32,8 @@ url {
   src:
     "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
   checksum: [
-    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
-    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+    "sha256=09542bcd96c1d368ff9ba8853105f4c1781d8c94c2400df9f3ac0610ee07e67e"
+    "sha512=1b31c9df0ce774c87a36f714db4ea1f295bc1e2e317d30497523ec03564cace0f64ac4c535aa83c82792aa3331a92efe774e4c3300a6ffe09110ce0efc2ce24b"
   ]
 }
-x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"
+x-commit-hash: "fe7bad77d4d73c355f9a84c097ed5d15548207f5"

--- a/packages/mirage-crypto-rng-miou-unix/mirage-crypto-rng-miou-unix.1.2.0/opam
+++ b/packages/mirage-crypto-rng-miou-unix/mirage-crypto-rng-miou-unix.1.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an miou.unix-friendly way"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7"}
+  "miou" {>= "0.2.0"}
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "mtime" {>= "1.0.0"}
+  "digestif" {>= "1.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+description: """
+Mirage-crypto-rng-miou-unix feeds the entropy source for Mirage_crypto_rng-based
+random number generator implementations, in an miou.unix-friendly way.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
+  checksum: [
+    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
+    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+  ]
+}
+x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.1.2.0/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.1.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "BSD-2-Clause"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "logs"
+  "lwt" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.8.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-unix" {with-test & >= "5.0.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
+  checksum: [
+    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
+    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+  ]
+}
+x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.1.2.0/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.1.2.0/opam
@@ -35,8 +35,8 @@ url {
   src:
     "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
   checksum: [
-    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
-    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+    "sha256=09542bcd96c1d368ff9ba8853105f4c1781d8c94c2400df9f3ac0610ee07e67e"
+    "sha512=1b31c9df0ce774c87a36f714db4ea1f295bc1e2e317d30497523ec03564cace0f64ac4c535aa83c82792aa3331a92efe774e4c3300a6ffe09110ce0efc2ce24b"
   ]
 }
-x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"
+x-commit-hash: "fe7bad77d4d73c355f9a84c097ed5d15548207f5"

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.1.2.0/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.1.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "duration"
+  "logs"
+  "mirage-crypto" {=version}
+  "digestif" {>= "1.1.4"}
+  "ounit2" {with-test}
+  "randomconv" {with-test & >= "0.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
+  checksum: [
+    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
+    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+  ]
+}
+x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.1.2.0/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.1.2.0/opam
@@ -35,8 +35,8 @@ url {
   src:
     "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
   checksum: [
-    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
-    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+    "sha256=09542bcd96c1d368ff9ba8853105f4c1781d8c94c2400df9f3ac0610ee07e67e"
+    "sha512=1b31c9df0ce774c87a36f714db4ea1f295bc1e2e317d30497523ec03564cace0f64ac4c535aa83c82792aa3331a92efe774e4c3300a6ffe09110ce0efc2ce24b"
   ]
 }
-x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"
+x-commit-hash: "fe7bad77d4d73c355f9a84c097ed5d15548207f5"

--- a/packages/mirage-crypto/mirage-crypto.1.2.0/opam
+++ b/packages/mirage-crypto/mirage-crypto.1.2.0/opam
@@ -32,8 +32,8 @@ url {
   src:
     "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
   checksum: [
-    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
-    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+    "sha256=09542bcd96c1d368ff9ba8853105f4c1781d8c94c2400df9f3ac0610ee07e67e"
+    "sha512=1b31c9df0ce774c87a36f714db4ea1f295bc1e2e317d30497523ec03564cace0f64ac4c535aa83c82792aa3331a92efe774e4c3300a6ffe09110ce0efc2ce24b"
   ]
 }
-x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"
+x-commit-hash: "fe7bad77d4d73c355f9a84c097ed5d15548207f5"

--- a/packages/mirage-crypto/mirage-crypto.1.2.0/opam
+++ b/packages/mirage-crypto/mirage-crypto.1.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit2" {with-test}
+  "ohex" {with-test & >= "0.2.0"}
+  "eqaf" {>= "0.8"}
+]
+conflicts: [
+  "ocaml-freestanding"
+  "result" {< "1.5"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305).
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz"
+  checksum: [
+    "sha256=0fec11ff82d8c5b36cc930db91310711c6593a3975ba2f2e59836249e4754e40"
+    "sha512=1770344c7cdce45e40568b1e1730bf2fed5d30600aa9fdb50230953494d1a2c43e5affcdad4cf14b7163358425e3bb04c3a24f0dfe63020abb8b0891d5be4716"
+  ]
+}
+x-commit-hash: "1f334ef97e042b3367d54fbe8fbcf03b84841a38"


### PR DESCRIPTION
Simple symmetric cryptography for the modern age

- Project page: <a href="https://github.com/mirage/mirage-crypto">https://github.com/mirage/mirage-crypto</a>
- Documentation: <a href="https://mirage.github.io/mirage-crypto/doc">https://mirage.github.io/mirage-crypto/doc</a>

##### CHANGES:

Provide thread safety (Unix.fork and multi-domain safe) RNG generators by using
getrandom/getentropy on UNIX (or /dev/urandom). In your UNIX applications,
please use the "mirage-crypto-rng.unix" dependency and call
"Mirage_crypto_rng_unix.use_default ()" (instead of depending on
mirage-crypto-rng-{lwt,eio,async} and calling
"Mirage_crypto_rng_{eio,lwt,async}.initialize".

* mirage-crypto-rng: handle CPU_RNG failures (mirage/mirage-crypto#255 @hannesm, addresses mirage/mirage-crypto#251 mirage/mirage-crypto#252
  mirage/mirage-crypto#253)
* mirage-crypto-rng.unix: provide two generators: Urandom and Getentropy
  (mirage/mirage-crypto#250 @hannesm @reynir @edwintorok, addresses mirage/mirage-crypto#249)
* mirage-crypto-rng: deprecate the initialize for lwt, async, eio (and
  advertise `Mirage_crypto_rng_unix.use_default ()` (mirage/mirage-crypto#254 @hannesm)
* mirage-crypto-rng-eio: declare the cstruct dependency (mirage/mirage-crypto#247 @hannesm)
* include "windows.h" (all lowercase) (mirage/mirage-crypto#248 @mefyl)
