### PR TITLE
Vcaml does not build with OCaml 5.1

### DIFF
--- a/packages/vcaml/vcaml.v0.16.0/opam
+++ b/packages/vcaml/vcaml.v0.16.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"                      {>= "4.14.0"}
+  "ocaml"                      {>= "4.14.0" & < "5.1"}
   "async"                      {>= "v0.16" & < "v0.17"}
   "core"                       {>= "v0.16" & < "v0.17"}
   "core_kernel"                {>= "v0.16" & < "v0.17"}


### PR DESCRIPTION
While attempting to view the documentation of the latest released version of vcaml (v.016.0) I [noticed it didn't build](https://ocaml.org/p/vcaml/latest/doc/index.html). Turns out, when running it on 4.14.2 it works, same on 5.0.0 but on 5.1.1 it fails.

The build error looks like this

```
=== ERROR while compiling vcaml.v0.16.0 ======================================#
 context     2.2.1 | linux/x86_64 | ocaml-base-compiler.5.1.1 | https://opam.ocaml.org#4a9170ea6d035edaf46f2af0545ca66d06561668
 path        ~/place/vvvcaml/_opam/.opam-switch/build/vcaml.v0.16.0
 command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p vcaml -j 7
 exit-code   1
 env-file    ~/.opam/log/vcaml-794317-262fd9.env
 output-file ~/.opam/log/vcaml-794317-262fd9.out
 ## output ###
 [...]
 113 |     end)
 114 |     (Open_on_rhs_intf)
 115 |     ()
 Error: The functor application is ill-typed.
        These arguments:
          $S1 Open_on_rhs_intf ()
        do not match these parameters:
          functor (X : Base__Applicative_intf.For_let_syntax) (Intf : ...)
          (Impl : Intf.S) -> ...
        1. Module $S1 matches the expected module type Base__Applicative_intf.For_let_syntax
        2. Module Open_on_rhs_intf matches the expected module type
        3. The functor was expected to be applicative at this position
```

Thus I am suggesting this upper version constraint for vcaml.