### PR TITLE
[new release] mirage-ptime (5.0.0)

### DIFF
--- a/packages/mirage-ptime/mirage-ptime.5.0.0/opam
+++ b/packages/mirage-ptime/mirage-ptime.5.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-ptime"
+doc: "https://mirage.github.io/mirage-ptime/"
+bug-reports: "https://github.com/mirage/mirage-ptime/issues"
+synopsis: "Libraries and module types for portable clocks"
+description: """
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirageos.org) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements a POSIX clock which counts time since the Unix epoch.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "ptime" {>= "1.1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-ptime.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-ptime/releases/download/v5.0.0/mirage-ptime-5.0.0.tbz"
+  checksum: [
+    "sha256=d553560468d5b94db25b05738c2499f290ee66b14ac22b4302e667f1fa443471"
+    "sha512=b7de3bf598e3ec36b3646633a0244589b75ab12e4ddcf5f964e98e639933ba815ea813a6a3eb6bfc849af7a346f2be3dbd3b0047d825f9dfe0a4c6ffed8e8fce"
+  ]
+}
+x-commit-hash: "48b9d1e2928688e1dbe1dc52a04322bcb3c2dd17"

--- a/packages/mirage-ptime/mirage-ptime.5.0.0/opam
+++ b/packages/mirage-ptime/mirage-ptime.5.0.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "anil@recoil.org"
-authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+maintainer: "hannes@mehnert.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray" "Hannes Mehnert"]
 license: "ISC"
 tags: "org:mirage"
 homepage: "https://github.com/mirage/mirage-ptime"
@@ -25,6 +25,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/mirage-ptime.git"
+x-maintenance-intent: [ "(latest)" ]
 url {
   src:
     "https://github.com/mirage/mirage-ptime/releases/download/v5.0.0/mirage-ptime-5.0.0.tbz"


### PR DESCRIPTION
Libraries and module types for portable clocks

- Project page: <a href="https://github.com/mirage/mirage-ptime">https://github.com/mirage/mirage-ptime</a>
- Documentation: <a href="https://mirage.github.io/mirage-ptime/">https://mirage.github.io/mirage-ptime/</a>

##### CHANGES:

* Renamed to mirage-ptime (from mirage-clock), only the PCLOCK part
* Use Ptime.t directly in the interface
* use "dune variants" for the different implementations
