### PR TITLE
[new release] mirage-mtime (5.0.0)

### DIFF
--- a/packages/mirage-mtime/mirage-mtime.5.0.0/opam
+++ b/packages/mirage-mtime/mirage-mtime.5.0.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "anil@recoil.org"
-authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+maintainer: "hannes@mehnert.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray" "Hannes Mehnert"]
 license: "ISC"
 tags: "org:mirage"
 homepage: "https://github.com/mirage/mirage-mtime"
@@ -25,6 +25,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/mirage-mtime.git"
+x-maintenance-intent: [ "(latest)" ]
 url {
   src:
     "https://github.com/mirage/mirage-mtime/releases/download/v5.0.0/mirage-mtime-5.0.0.tbz"

--- a/packages/mirage-mtime/mirage-mtime.5.0.0/opam
+++ b/packages/mirage-mtime/mirage-mtime.5.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-mtime"
+doc: "https://mirage.github.io/mirage-mtime/"
+bug-reports: "https://github.com/mirage/mirage-mtime/issues"
+synopsis: "Libraries and module types for a monotonic clock"
+description: """
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirageos.org) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements a monotonic timesource since an arbitrary point.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "mtime" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-mtime.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-mtime/releases/download/v5.0.0/mirage-mtime-5.0.0.tbz"
+  checksum: [
+    "sha256=23075a0326728fc81f44fc503fd48ec1bdbc01bb55cbd3d8eea72bd0f9ecf465"
+    "sha512=3a4fa1dd7affffbe77df6e90bb40d229eb36d259ad463a602385331fb6d9f099d6cc1536545b4288b4b6933765da1ffc8b67d5b2cccaaa3af639c960ef993616"
+  ]
+}
+x-commit-hash: "5659fca67bf06a44c56c3a17c059242749629902"


### PR DESCRIPTION
Libraries and module types for a monotonic clock

- Project page: <a href="https://github.com/mirage/mirage-mtime">https://github.com/mirage/mirage-mtime</a>
- Documentation: <a href="https://mirage.github.io/mirage-mtime/">https://mirage.github.io/mirage-mtime/</a>

##### CHANGES:

* Renamed to mirage-mtime (from mirage-clock), only the MCLOCK part
* use "dune variants" for the different implementations
