### PR TITLE
[new release] mirage-sleep (4.0.0)

### DIFF
--- a/packages/mirage-sleep/mirage-sleep.4.0.0/opam
+++ b/packages/mirage-sleep/mirage-sleep.4.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-sleep"
+doc: "https://mirage.github.io/mirage-sleep/"
+bug-reports: "https://github.com/mirage/mirage-sleep/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "lwt" {>= "4.0.0"}
+  "duration"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-sleep.git"
+synopsis: "Sleep operation for MirageOS"
+description: """
+Mirage_sleep defines the single function `ns`.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-sleep/releases/download/v4.0.0/mirage-sleep-4.0.0.tbz"
+  checksum: [
+    "sha256=27b730eec137104dc122149dc03d4a57755e5e312abe2566cacdcb80684413f0"
+    "sha512=72847ce2a105ea619ffc2a0b60c6443249caadaee9435ab48e71e7ee19f15376217514cc8c13850964ed80cf518b0449d5da663217633d4bf4185cd0f04c3521"
+  ]
+}
+x-commit-hash: "b1d897b32fe70c01dd60865bd7791aea6109a5a8"

--- a/packages/mirage-sleep/mirage-sleep.4.0.0/opam
+++ b/packages/mirage-sleep/mirage-sleep.4.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "thomas@gazagnaire.org"
+maintainer: "hannes@mehnert.org"
 authors: [
   "Thomas Gazagnaire"
   "Anil Madhavapeddy"
@@ -32,6 +32,7 @@ synopsis: "Sleep operation for MirageOS"
 description: """
 Mirage_sleep defines the single function `ns`.
 """
+x-maintenance-intent: [ "(latest)" ]
 url {
   src:
     "https://github.com/mirage/mirage-sleep/releases/download/v4.0.0/mirage-sleep-4.0.0.tbz"


### PR DESCRIPTION
Sleep operation for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-sleep">https://github.com/mirage/mirage-sleep</a>
- Documentation: <a href="https://mirage.github.io/mirage-sleep/">https://mirage.github.io/mirage-sleep/</a>

##### CHANGES:

* Renamed to mirage-sleep, use dune variants
