### PR TITLE
[new release] opentelemetry (5 packages) (0.11)

### DIFF
--- a/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.11/opam
+++ b/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.11/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Collector client for opentelemetry, using cohttp + lwt"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team and contributors"]
+license: "MIT"
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "mtime" {>= "1.4"}
+  "opentelemetry" {= version}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "lwt_ppx" {>= "2.0"}
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.11/opentelemetry-0.11.tbz"
+  checksum: [
+    "sha256=7c674ecf1851d23cc520dad81ac1135ad4ac2460e54985dfe655fcfda265a713"
+    "sha512=34f585d9961d0c9ad908f479b3cf93cadc9602ffc39ec37396c8613cc76ae3e2fbaf5446a51c4820cc02b16e01d6df74cb607e3fa1b291d1847f2d76b31f5f0e"
+  ]
+}
+x-commit-hash: "c3c5761b06a2fcf8246679d08e582249706aa73a"

--- a/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.11/opam
+++ b/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.11/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Collector client for opentelemetry, using http + ezcurl"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team and contributors"]
+license: "MIT"
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "mtime" {>= "1.4"}
+  "opentelemetry" {= version}
+  "odoc" {with-doc}
+  "ezcurl" {>= "0.2.3"}
+  "ocurl"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.11/opentelemetry-0.11.tbz"
+  checksum: [
+    "sha256=7c674ecf1851d23cc520dad81ac1135ad4ac2460e54985dfe655fcfda265a713"
+    "sha512=34f585d9961d0c9ad908f479b3cf93cadc9602ffc39ec37396c8613cc76ae3e2fbaf5446a51c4820cc02b16e01d6df74cb607e3fa1b291d1847f2d76b31f5f0e"
+  ]
+}
+x-commit-hash: "c3c5761b06a2fcf8246679d08e582249706aa73a"

--- a/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.11/opam
+++ b/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.11/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Opentelemetry tracing for Cohttp HTTP servers"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team and contributors"]
+license: "MIT"
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "opentelemetry" {= version}
+  "opentelemetry-lwt" {= version}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "cohttp-lwt" {>= "4.0.0" & < "6"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.11/opentelemetry-0.11.tbz"
+  checksum: [
+    "sha256=7c674ecf1851d23cc520dad81ac1135ad4ac2460e54985dfe655fcfda265a713"
+    "sha512=34f585d9961d0c9ad908f479b3cf93cadc9602ffc39ec37396c8613cc76ae3e2fbaf5446a51c4820cc02b16e01d6df74cb607e3fa1b291d1847f2d76b31f5f0e"
+  ]
+}
+x-commit-hash: "c3c5761b06a2fcf8246679d08e582249706aa73a"

--- a/packages/opentelemetry-lwt/opentelemetry-lwt.0.11/opam
+++ b/packages/opentelemetry-lwt/opentelemetry-lwt.0.11/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Lwt-compatible instrumentation for https://opentelemetry.io"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team and contributors"]
+license: "MIT"
+tags: ["instrumentation" "tracing" "opentelemetry" "datadog" "lwt"]
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "opentelemetry" {= version}
+  "cohttp-lwt-unix" {with-test}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "lwt_ppx" {>= "2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.11/opentelemetry-0.11.tbz"
+  checksum: [
+    "sha256=7c674ecf1851d23cc520dad81ac1135ad4ac2460e54985dfe655fcfda265a713"
+    "sha512=34f585d9961d0c9ad908f479b3cf93cadc9602ffc39ec37396c8613cc76ae3e2fbaf5446a51c4820cc02b16e01d6df74cb607e3fa1b291d1847f2d76b31f5f0e"
+  ]
+}
+x-commit-hash: "c3c5761b06a2fcf8246679d08e582249706aa73a"

--- a/packages/opentelemetry/opentelemetry.0.11/opam
+++ b/packages/opentelemetry/opentelemetry.0.11/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Instrumentation for https://opentelemetry.io"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team and contributors"]
+license: "MIT"
+tags: ["instrumentation" "tracing" "opentelemetry" "datadog" "jaeger"]
+homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
+bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "ptime"
+  "hmap"
+  "atomic"
+  "thread-local-storage" {>= "0.2" & < "0.3"}
+  "odoc" {with-doc}
+  "alcotest" {with-test}
+  "pbrt" {>= "3.0" & < "4.0"}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup & >= "0.24" & < "0.25"}
+]
+depopts: ["trace" "lwt" "eio"]
+conflicts: [
+  "trace" {< "0.9"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.11/opentelemetry-0.11.tbz"
+  checksum: [
+    "sha256=7c674ecf1851d23cc520dad81ac1135ad4ac2460e54985dfe655fcfda265a713"
+    "sha512=34f585d9961d0c9ad908f479b3cf93cadc9602ffc39ec37396c8613cc76ae3e2fbaf5446a51c4820cc02b16e01d6df74cb607e3fa1b291d1847f2d76b31f5f0e"
+  ]
+}
+x-commit-hash: "c3c5761b06a2fcf8246679d08e582249706aa73a"


### PR DESCRIPTION
Instrumentation for https://opentelemetry.io

- Project page: <a href="https://github.com/imandra-ai/ocaml-opentelemetry">https://github.com/imandra-ai/ocaml-opentelemetry</a>

##### CHANGES:

- add `Span_kind.t`, add {kind,set_kind} to `Scope`
- expose `Span_status` types
- add `Scope.set_span_status`
- add `record_exception`
- otel.trace: extension points for links, record_exn, kind
- otel.trace: set status of a span based on `exception.message`

- add cohttp upper bound version constraint
- in backends, call `tick()` before cleaning up
- reduce memory usage of `Scope.t` (@tatchi)

- remove dependency on ambient-context, vendor/inline/specialize it
