### PR TITLE
[WIP] [new release] js_of_ocaml (8 packages) (6.0.0)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.0.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.0.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.08" & < "5.4"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.16.1" & with-test}
+  "ppxlib" {>= "0.15.0"}
+  "re" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "sedlex" {>= "3.3"}
+  "qcheck" {with-test}
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson" {>= "1.6"}
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.0.0/js_of_ocaml-6.0.0.tbz"
+  checksum: [
+    "sha256=32741ec7cba1d4c6d6fc98039017941ff8576e46e44d2dfcf915fae05740c9de"
+    "sha512=35b5787773d89bccf26d3c2fafe7ee365d2c41c39a97bc338fe668b34b2e3c7194b01b95ccf2193199d3ebc95ad6c0d1ca98d87fe9eb9497eb1b0587d07007f2"
+  ]
+}
+x-commit-hash: "7c6c20949ebff14ba0d069ba1b5ff99a0f3be434"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.0.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "menhir"
   "menhirLib"
   "menhirSdk"
-  "yojson" {>= "1.6"}
+  "yojson" {>= "2.1"}
   "odoc" {with-doc}
 ]
 depopts: ["ocamlfind"]

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.6.0.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.6.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "lwt" {>= "2.4.4"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["graphics" "lwt_log"]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.0.0/js_of_ocaml-6.0.0.tbz"
+  checksum: [
+    "sha256=32741ec7cba1d4c6d6fc98039017941ff8576e46e44d2dfcf915fae05740c9de"
+    "sha512=35b5787773d89bccf26d3c2fafe7ee365d2c41c39a97bc338fe668b34b2e3c7194b01b95ccf2193199d3ebc95ad6c0d1ca98d87fe9eb9497eb1b0587d07007f2"
+  ]
+}
+x-commit-hash: "7c6c20949ebff14ba0d069ba1b5ff99a0f3be434"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.6.0.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.6.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15.0"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.0.0/js_of_ocaml-6.0.0.tbz"
+  checksum: [
+    "sha256=32741ec7cba1d4c6d6fc98039017941ff8576e46e44d2dfcf915fae05740c9de"
+    "sha512=35b5787773d89bccf26d3c2fafe7ee365d2c41c39a97bc338fe668b34b2e3c7194b01b95ccf2193199d3ebc95ad6c0d1ca98d87fe9eb9497eb1b0587d07007f2"
+  ]
+}
+x-commit-hash: "7c6c20949ebff14ba0d069ba1b5ff99a0f3be434"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.6.0.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.6.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.0.0/js_of_ocaml-6.0.0.tbz"
+  checksum: [
+    "sha256=32741ec7cba1d4c6d6fc98039017941ff8576e46e44d2dfcf915fae05740c9de"
+    "sha512=35b5787773d89bccf26d3c2fafe7ee365d2c41c39a97bc338fe668b34b2e3c7194b01b95ccf2193199d3ebc95ad6c0d1ca98d87fe9eb9497eb1b0587d07007f2"
+  ]
+}
+x-commit-hash: "7c6c20949ebff14ba0d069ba1b5ff99a0f3be434"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.6.0.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.6.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml-compiler" {= version}
+  "ocamlfind" {>= "1.5.1"}
+  "cohttp-lwt-unix" {>= "6.0.0" & with-test}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15"}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.0.0/js_of_ocaml-6.0.0.tbz"
+  checksum: [
+    "sha256=32741ec7cba1d4c6d6fc98039017941ff8576e46e44d2dfcf915fae05740c9de"
+    "sha512=35b5787773d89bccf26d3c2fafe7ee365d2c41c39a97bc338fe668b34b2e3c7194b01b95ccf2193199d3ebc95ad6c0d1ca98d87fe9eb9497eb1b0587d07007f2"
+  ]
+}
+x-commit-hash: "7c6c20949ebff14ba0d069ba1b5ff99a0f3be434"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.6.0.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.6.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "react" {>= "1.2.2"}
+  "reactiveData" {>= "0.2"}
+  "tyxml" {>= "4.6"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.0.0/js_of_ocaml-6.0.0.tbz"
+  checksum: [
+    "sha256=32741ec7cba1d4c6d6fc98039017941ff8576e46e44d2dfcf915fae05740c9de"
+    "sha512=35b5787773d89bccf26d3c2fafe7ee365d2c41c39a97bc338fe668b34b2e3c7194b01b95ccf2193199d3ebc95ad6c0d1ca98d87fe9eb9497eb1b0587d07007f2"
+  ]
+}
+x-commit-hash: "7c6c20949ebff14ba0d069ba1b5ff99a0f3be434"

--- a/packages/js_of_ocaml/js_of_ocaml.6.0.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.6.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml-compiler" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.0.0/js_of_ocaml-6.0.0.tbz"
+  checksum: [
+    "sha256=32741ec7cba1d4c6d6fc98039017941ff8576e46e44d2dfcf915fae05740c9de"
+    "sha512=35b5787773d89bccf26d3c2fafe7ee365d2c41c39a97bc338fe668b34b2e3c7194b01b95ccf2193199d3ebc95ad6c0d1ca98d87fe9eb9497eb1b0587d07007f2"
+  ]
+}
+x-commit-hash: "7c6c20949ebff14ba0d069ba1b5ff99a0f3be434"

--- a/packages/ojs-base/ojs-base.0.6.0/opam
+++ b/packages/ojs-base/ojs-base.0.6.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://framagit.org/zoggy/ojs-base/-/issues"
 depends: [
   "ocaml" {>= "4.12.0"}
   "ocamlfind" {build}
-  "js_of_ocaml" {>= "3.9.0"}
+  "js_of_ocaml" {>= "3.9.0" & < "6.0.0"}
   "websocket" {>= "2.14"}
   "websocket-lwt-unix" {>= "2.14"}
   "lwt" {>= "5.4.0" & < "5.8.0"}

--- a/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.0.0/opam
+++ b/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.0.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to WebAssembly"
+description:
+  "Wasm_of_ocaml is a compiler from OCaml bytecode to WebAssembly. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "js_of_ocaml" {= version}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15.0"}
+  "re" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "opam-format" {with-test}
+  "sedlex" {>= "2.3"}
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson" {>= "2.1"}
+  "binaryen-bin"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.0.0/js_of_ocaml-6.0.0.tbz"
+  checksum: [
+    "sha256=32741ec7cba1d4c6d6fc98039017941ff8576e46e44d2dfcf915fae05740c9de"
+    "sha512=35b5787773d89bccf26d3c2fafe7ee365d2c41c39a97bc338fe668b34b2e3c7194b01b95ccf2193199d3ebc95ad6c0d1ca98d87fe9eb9497eb1b0587d07007f2"
+  ]
+}
+x-commit-hash: "7c6c20949ebff14ba0d069ba1b5ff99a0f3be434"

--- a/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.0.0/opam
+++ b/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.0.0/opam
@@ -33,6 +33,7 @@ conflicts: [
   "ocamlfind" {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
 ]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 build: [
   ["dune" "subst"] {dev}
   [
@@ -43,11 +44,9 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 url {
   src:
     "https://github.com/ocsigen/js_of_ocaml/releases/download/6.0.0/js_of_ocaml-6.0.0.tbz"


### PR DESCRIPTION
Compiler from OCaml bytecode to JavaScript

- Project page: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>
- Documentation: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>

##### CHANGES:

## Features/Changes
* Compiler/Runtime: Make resuming a continuation more efficient in js (ocsigen/js_of_ocaml#1765)
* Compiler/Runtime: Effects: add an optional feature of "dynamic switching" between CPS
  and direct style, resulting in better performance when
  no effect handler is installed
* Compiler: Merged Wasm_of_ocaml (ocsigen/js_of_ocaml#1724)
* Lib: fix the type of some DOM properties and methods (ocsigen/js_of_ocaml#1747)
* Lib: removed no longer relevant Js.optdef type annotations (ocsigen/js_of_ocaml#1769)
* Lib: Add other textMetrics property (ocsigen/js_of_ocaml#1784)
* Lib: rename Firebug to Console (ocsigen/js_of_ocaml#1802)
* Test: use dune test stanzas (ocsigen/js_of_ocaml#1631)
* Test: run wasm tests on windows
* Misc: drop support for IE
* Misc: move tests to OCaml 5.3
* Misc: import many test from the OCaml codebase
* Runtime: support for float16 bigarrays
* Runtime: support more Unix functions (ocsigen/js_of_ocaml#1823)
* Runtime: various filesystem fixes (ocsigen/js_of_ocaml#1825)

## Bug fixes
* Compiler: Fix small bug in global data flow analysis (ocsigen/js_of_ocaml#1768)
* Runtime: no longer leak channels
* Runtime: Fix Marshal.to_buffer (ocsigen/js_of_ocaml#1798)
* Runtime: unmarshalling objects should refresh its id
* Runtime: check size upper bound during array creation
* Runtime: return sys_error when reading from a closed channels
* Runtime: fix parsing of hex-float with very large exponent
* Runtime: make sure [n / 0L] is not optimized away by DCE
* Runtime: fix Unix.LargeFile.stat/lstat
* Runtime: fix stat/lstat times
* Runtime: fix reading from stdin in an interactive nodejs
