### PR TITLE
[new release] arg-complete (0.2.0)

### DIFF
--- a/packages/arg-complete/arg-complete.0.2.0/opam
+++ b/packages/arg-complete/arg-complete.0.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Bash completion support for Stdlib.Arg"
+maintainer: ["Simmo Saan <simmo.saan@gmail.com>"]
+authors: ["Simmo Saan <simmo.saan@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/sim642/ocaml-arg-complete"
+doc: "https://sim642.github.io/ocaml-arg-complete"
+bug-reports: "https://github.com/sim642/ocaml-arg-complete/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "cppo" {>= "1.1.0"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sim642/ocaml-arg-complete.git"
+url {
+  src:
+    "https://github.com/sim642/ocaml-arg-complete/releases/download/0.2.0/arg-complete-0.2.0.tbz"
+  checksum: [
+    "sha256=91f8f188efa9a4e59f218e3e6134aa638a1a755ecd6f415975738e4592d4dc51"
+    "sha512=e04e0564790abfef9f2b296edbf682cfb5199d7d432c1e386cc46ba34ff1231bf8312cf866cd26332d592ceb498948e5235ab5aec34b1cc061fb840fe94592d5"
+  ]
+}
+x-commit-hash: "a36cec1a60e7db9eb67bafd1b7bfa13bc943976f"


### PR DESCRIPTION
Bash completion support for Stdlib.Arg

- Project page: <a href="https://github.com/sim642/ocaml-arg-complete">https://github.com/sim642/ocaml-arg-complete</a>
- Documentation: <a href="https://sim642.github.io/ocaml-arg-complete">https://sim642.github.io/ocaml-arg-complete</a>

##### CHANGES:

* Add support for `getopt_long` style arguments with `=` (sim642/ocaml-arg-complete#2).
