### PR TITLE
[new release] arg-complete (0.2.1)

### DIFF
--- a/packages/arg-complete/arg-complete.0.2.1/opam
+++ b/packages/arg-complete/arg-complete.0.2.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Bash completion support for Stdlib.Arg"
+maintainer: ["Simmo Saan <simmo.saan@gmail.com>"]
+authors: ["Simmo Saan <simmo.saan@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/sim642/ocaml-arg-complete"
+doc: "https://sim642.github.io/ocaml-arg-complete"
+bug-reports: "https://github.com/sim642/ocaml-arg-complete/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "cppo" {>= "1.1.0"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sim642/ocaml-arg-complete.git"
+url {
+  src:
+    "https://github.com/sim642/ocaml-arg-complete/releases/download/0.2.1/arg-complete-0.2.1.tbz"
+  checksum: [
+    "sha256=499bcb69e7aa6378f62d4beac46b34570e7b2679e976f024d639c4de9936ed05"
+    "sha512=7cbac1bec7bcd14fe3685e68028c9c49f2672809f4402e95f79f292977191dcc9ce9d340e570e8041c74870ce359f7563a0f258db723a533947100105dee814b"
+  ]
+}
+x-commit-hash: "70b2d862772c8c474ff5646ae6e5f3056044b90a"

--- a/packages/arg-complete/arg-complete.0.2.1/opam
+++ b/packages/arg-complete/arg-complete.0.2.1/opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/sim642/ocaml-arg-complete"
 doc: "https://sim642.github.io/ocaml-arg-complete"
 bug-reports: "https://github.com/sim642/ocaml-arg-complete/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.8"}
   "cppo" {>= "1.1.0"}
   "ounit2" {with-test}


### PR DESCRIPTION
Bash completion support for Stdlib.Arg

- Project page: <a href="https://github.com/sim642/ocaml-arg-complete">https://github.com/sim642/ocaml-arg-complete</a>
- Documentation: <a href="https://sim642.github.io/ocaml-arg-complete">https://sim642.github.io/ocaml-arg-complete</a>

##### CHANGES:

* Fix `Arg.Expand` tests on OCaml < 4.05.
