### PR TITLE
[new release] capnp-rpc (3 packages) (2.1)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.2.0/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.2.0/opam
@@ -29,3 +29,4 @@ url {
   ]
 }
 x-commit-hash: "252fd9b064367270a48d6bc73cbcd8f188f353d9"
+x-maintenance-intent: ["(latest)"]

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2.3/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2.3/opam
@@ -43,3 +43,4 @@ url {
   ]
 }
 x-commit-hash: "86427f68fa9a851fad6317cfda5e8b596add7fe9"
+x-maintenance-intent: ["(none)"]

--- a/packages/capnp-rpc-net/capnp-rpc-net.2.1/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.2.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides support for using Cap'n Proto services over a network,
+optionally using TLS."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "5.2"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.6.0"}
+  "capnp-rpc" {= version}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "cstruct" {>= "6.0.0"}
+  "tls-eio" {>= "1.0.2"}
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "prometheus" {>= "0.5"}
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "1.0.3"}
+  "dune" {>= "3.16"}
+  "mirage-crypto" {>= "1.2.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v2.1/capnp-rpc-2.1.tbz"
+  checksum: [
+    "sha256=4b59a4147cf6e49c650dbfa4cdb918aec3be69cffd1ef6b5c818584464feb987"
+    "sha512=69114597e9cd8ad42c72c1751796b216f98f2a9f09f50a0628b4a3259c2f9b169fd47a73be7b76cfda298a6c202bc79762116865272e35ca0d0914242ace34d7"
+  ]
+}
+x-commit-hash: "dd17b1469e542ee0269481750e994592758ccaaa"

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.2.1/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.2.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+doc: "https://mirage.github.io/capnp-rpc/"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+depends: [
+  "ocaml" {>= "5.2"}
+  "capnp-rpc-net" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "cstruct" {>= "6.2.0"}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "extunix"
+  "base64" {>= "3.0.0"}
+  "dune" {>= "3.16"}
+  "ipaddr" {>= "5.3.0" }
+  "alcotest" {>= "1.6.0" & with-test}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "mdx" {>= "2.4.1" & with-test}
+  "eio_main" {with-test}
+  "eio" {>= "1.2"}
+]
+conflicts: [
+  "jbuilder"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v2.1/capnp-rpc-2.1.tbz"
+  checksum: [
+    "sha256=4b59a4147cf6e49c650dbfa4cdb918aec3be69cffd1ef6b5c818584464feb987"
+    "sha512=69114597e9cd8ad42c72c1751796b216f98f2a9f09f50a0628b4a3259c2f9b169fd47a73be7b76cfda298a6c202bc79762116865272e35ca0d0914242ace34d7"
+  ]
+}
+x-commit-hash: "dd17b1469e542ee0269481750e994592758ccaaa"

--- a/packages/capnp-rpc/capnp-rpc.2.1/opam
+++ b/packages/capnp-rpc/capnp-rpc.2.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Eio for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "5.2"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.6.0"}
+  "stdint" {>= "0.6.0"}
+  "eio" {>= "1.2"}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "uri" {>= "1.6.0"}
+  "dune" {>= "3.16"}
+  "alcotest" {>= "1.6.0" & with-test}
+  "afl-persistent" {with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v2.1/capnp-rpc-2.1.tbz"
+  checksum: [
+    "sha256=4b59a4147cf6e49c650dbfa4cdb918aec3be69cffd1ef6b5c818584464feb987"
+    "sha512=69114597e9cd8ad42c72c1751796b216f98f2a9f09f50a0628b4a3259c2f9b169fd47a73be7b76cfda298a6c202bc79762116865272e35ca0d0914242ace34d7"
+  ]
+}
+x-commit-hash: "dd17b1469e542ee0269481750e994592758ccaaa"


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

- Update to mirage-crypto-rng 1.2.0 (@talex5 mirage/capnp-rpc#313).
  There is no need to do `Mirage_crypto_rng_eio.run` now.

- `Restorer.Table.create` now takes a switch (@talex5 mirage/capnp-rpc#306).
  The table is now cleared when the switch finishes. Avoids having to remember to set this up manually.

- Update README now that 2.0 is released (@talex5 mirage/capnp-rpc#307 mirage/capnp-rpc#308).

Build and opam metadata:

- OCaml 5.2 is the minimum version (@talex5 mirage/capnp-rpc#305).

- Update Windows CI (@smorimoto mirage/capnp-rpc#310 mirage/capnp-rpc#311).

- Add `x-maintenance-intent` to opam files (@talex5 mirage/capnp-rpc#315, requested by @hannesm).

- Remove capnp-rpc-lwt compatibility package (@talex5 mirage/capnp-rpc#314).
  The existing release should continue working; no point releasing an unchanged version every time there's a capnp-rpc release.
