### PR TITLE
Topiary v0.6.0

### DIFF
--- a/packages/topiary/topiary.0.6.0/opam
+++ b/packages/topiary/topiary.0.6.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+
+maintainer: "hello@tweag.io"
+authors: [ "Tweag" ]
+
+homepage: "https://topiary.tweag.io/"
+bug-reports: "https://github.com/tweag/topiary/issues"
+dev-repo: "git+https://github.com/tweag/topiary.git"
+
+license: "MIT"
+depends: ["conf-rust-2021"]
+
+build:[
+  [ "cargo" "build"
+      "--release"
+      "--package" "topiary-cli" ]
+  [ "sh" "make-topiary-wrapper.sh"
+      "--queries-dir" "%{share}%/topiary/queries"
+      "--topiary-wrapped" "%{bin}%/.topiary-wrapped/topiary"
+      "--output-file" "topiary-wrapper" ]
+]
+
+install: [
+  [ "mkdir" "%{bin}%/.topiary-wrapped" ]
+  [ "cp" "target/release/topiary" "%{bin}%/.topiary-wrapped/topiary" ]
+  [ "cp" "topiary-wrapper" "%{bin}%/topiary" ]
+  [ "mkdir" "%{share}%/topiary" ]
+  [ "cp" "-R" "topiary/topiary-queries/queries" "%{share}%/topiary/queries" ]
+]
+
+synopsis: "A formatter for OCaml based on the Topiary universal formatting engine"
+description: """
+Topiary is a tool in the Tree-sitter ecosystem, designed for formatter authors
+and formatter users. Authors can create a formatter without having to write
+their own engine or even their own parser. Users benefit from uniform code style
+and the convenience of using a single formatter tool across multiple languages.
+
+Topiary is written in Rust and developed by Tweag.
+"""
+
+url {
+  src: "https://github.com/tweag/topiary-opam/releases/download/v0.6.0/source-code-with-submodules.tar.xz"
+  checksum: [
+    "md5=6e9771b047d5ca821fde4545f862e557"
+    "sha512=589ae0ba7ed3146f8f71ba0a55723fe79a4c0a1e876ddc1b004766482dd7f60b17bb62a94bf9f952c3a2535cf832f53ceef71066df0945244bab94ea3751e2e1"
+  ]
+}

--- a/packages/topiary/topiary.0.6.0/opam
+++ b/packages/topiary/topiary.0.6.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/tweag/topiary/issues"
 dev-repo: "git+https://github.com/tweag/topiary.git"
 
 license: "MIT"
-depends: ["conf-rust-2021"]
+depends: ["conf-rust-2024"]
 
 build:[
   [ "cargo" "build"

--- a/packages/topiary/topiary.0.6.0/opam
+++ b/packages/topiary/topiary.0.6.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/tweag/topiary/issues"
 dev-repo: "git+https://github.com/tweag/topiary.git"
 
 license: "MIT"
-depends: ["conf-rust-2024"]
+depends: ["conf-rust-2021"]
 
 build:[
   [ "cargo" "build"


### PR DESCRIPTION
Website: https://topiary.tweag.io/
Repository: https://github.com/tweag/topiary
Release: https://github.com/tweag/topiary/releases/tag/v0.6.0
Change log: https://github.com/tweag/topiary/blob/v0.6.0/CHANGELOG.md