### PR TITLE
Package catala-format.0.2.0

### DIFF
--- a/packages/catala-format/catala-format.0.2.0/opam
+++ b/packages/catala-format/catala-format.0.2.0/opam
@@ -10,6 +10,8 @@ license: "Apache-2.0"
 depends: [
   "ocaml"
   "dune"
+  "cmdliner"
+  "lwt" {with-test}
   "topiary" {= "0.5.1"}
 ]
 

--- a/packages/catala-format/catala-format.0.2.0/opam
+++ b/packages/catala-format/catala-format.0.2.0/opam
@@ -8,6 +8,8 @@ dev-repo: "git+https://github.com/CatalaLang/catala-format.git"
 
 license: "Apache-2.0"
 depends: [
+  "ocaml"
+  "dune"
   "topiary" {= "0.5.1"}
 ]
 

--- a/packages/catala-format/catala-format.0.2.0/opam
+++ b/packages/catala-format/catala-format.0.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "vincent.botbol@inria.fr"
+authors: [ "Vincent Botbol" ]
+
+homepage: "https://github.com/CatalaLang/catala-format"
+bug-reports: "https://github.com/CatalaLang/catala-format"
+dev-repo: "git+https://github.com/CatalaLang/catala-format.git"
+
+license: "Apache-2.0"
+depends: [
+  "topiary" {= "0.5.1"}
+]
+
+build:[
+  "dune" "build"
+  "-p" name
+  "-j" jobs
+  "@catala-format"
+]
+
+install: [
+  [ "cp" "_build/default/src/main.exe" "%{bin}%/catala-format" ]
+  [ "mkdir" "-p" "%{topiary:share}%/queries" ]
+  [ "cp" "catala.scm" "%{topiary:share}%/queries/" ]
+  [ "mkdir" "-p" "%{topiary:share}%/configs" ]
+  [ "cp" "catala.ncl" "%{topiary:share}%/configs/" ]
+]
+
+synopsis: "A formatter for Catala based on the Topiary universal formatting engine"
+description: """
+A formatter for Catala based on the Topiary universal formatting engine.
+
+Topiary repository: https://github.com/tweag/topiary
+"""
+url {
+  src:
+    "https://github.com/CatalaLang/catala-format/archive/refs/tags/catala-format.0.2.0.tar.gz"
+  checksum: [
+    "md5=b52ef11c369657d2424ad5b5f99d7ff9"
+    "sha512=f3bd400db9d3352bc4307729906f793604e67d65fc00d99c6ad61384b7dad301fb0b57619ae5a1b14eb2ef2d1aa52761796492300ae82c8ede4a74d237a5284e"
+  ]
+}


### PR DESCRIPTION
### `catala-format.0.2.0`
A formatter for Catala based on the Topiary universal formatting engine
A formatter for Catala based on the Topiary universal formatting engine.

Topiary repository: https://github.com/tweag/topiary



---
* Homepage: https://github.com/CatalaLang/catala-format
* Source repo: git+https://github.com/CatalaLang/catala-format.git
* Bug tracker: https://github.com/CatalaLang/catala-format

---
:camel: Pull-request generated by opam-publish v2.3.0