### PR TITLE
[new release] solo5-elftool (0.4.0)

### DIFF
--- a/packages/albatross/albatross.1.4.0/opam
+++ b/packages/albatross/albatross.1.4.0/opam
@@ -36,7 +36,7 @@ depends: [
   "hex"
   "http-lwt-client" {>= "0.0.4" & < "0.1.0"}
   "happy-eyeballs-lwt"
-  "solo5-elftool" {>= "0.3"}
+  "solo5-elftool" {>= "0.3" & < "0.4.0"}
   "owee" {>= "0.4"}
 ]
 build: [

--- a/packages/albatross/albatross.1.4.1/opam
+++ b/packages/albatross/albatross.1.4.1/opam
@@ -36,7 +36,7 @@ depends: [
   "hex"
   "http-lwt-client" {>= "0.0.4" & < "0.1.0"}
   "happy-eyeballs-lwt"
-  "solo5-elftool" {>= "0.3"}
+  "solo5-elftool" {>= "0.3" & < "0.4.0"}
   "owee" {>= "0.4"}
 ]
 build: [

--- a/packages/albatross/albatross.1.4.2/opam
+++ b/packages/albatross/albatross.1.4.2/opam
@@ -36,7 +36,7 @@ depends: [
   "hex"
   "http-lwt-client" {>= "0.0.4" & < "0.1.0"}
   "happy-eyeballs-lwt"
-  "solo5-elftool" {>= "0.3"}
+  "solo5-elftool" {>= "0.3" & < "0.4.0"}
   "owee" {>= "0.4"}
 ]
 build: [

--- a/packages/albatross/albatross.1.4.3/opam
+++ b/packages/albatross/albatross.1.4.3/opam
@@ -36,7 +36,7 @@ depends: [
   "hex"
   "http-lwt-client" {>= "0.0.4" & < "0.1.0"}
   "happy-eyeballs-lwt"
-  "solo5-elftool" {>= "0.3"}
+  "solo5-elftool" {>= "0.3" & < "0.4.0"}
   "owee" {>= "0.4"}
 ]
 build: [

--- a/packages/albatross/albatross.1.5.0/opam
+++ b/packages/albatross/albatross.1.5.0/opam
@@ -36,7 +36,7 @@ depends: [
   "hex"
   "http-lwt-client" {>= "0.0.4" & < "0.1.0"}
   "happy-eyeballs-lwt"
-  "solo5-elftool" {>= "0.3"}
+  "solo5-elftool" {>= "0.3" & < "0.4.0"}
   "owee" {>= "0.4"}
   "alcotest" {with-test}
 ]

--- a/packages/albatross/albatross.1.5.1/opam
+++ b/packages/albatross/albatross.1.5.1/opam
@@ -36,7 +36,7 @@ depends: [
   "hex"
   "http-lwt-client" {>= "0.0.4" & < "0.1.0"}
   "happy-eyeballs-lwt"
-  "solo5-elftool" {>= "0.3"}
+  "solo5-elftool" {>= "0.3" & < "0.4.0"}
   "owee" {>= "0.4"}
   "alcotest" {with-test}
 ]

--- a/packages/albatross/albatross.1.5.2/opam
+++ b/packages/albatross/albatross.1.5.2/opam
@@ -36,7 +36,7 @@ depends: [
   "hex"
   "http-lwt-client" {>= "0.0.4" & < "0.1.0"}
   "happy-eyeballs-lwt"
-  "solo5-elftool" {>= "0.3"}
+  "solo5-elftool" {>= "0.3" & < "0.4.0"}
   "owee" {>= "0.4"}
   "alcotest" {with-test}
 ]

--- a/packages/albatross/albatross.1.5.3/opam
+++ b/packages/albatross/albatross.1.5.3/opam
@@ -36,7 +36,7 @@ depends: [
   "hex"
   "http-lwt-client" {>= "0.2.0"}
   "happy-eyeballs-lwt"
-  "solo5-elftool" {>= "0.3"}
+  "solo5-elftool" {>= "0.3" & < "0.4.0"}
   "owee" {>= "0.4"}
   "alcotest" {with-test}
 ]

--- a/packages/albatross/albatross.1.5.4/opam
+++ b/packages/albatross/albatross.1.5.4/opam
@@ -36,7 +36,7 @@ depends: [
   "hex"
   "http-lwt-client" {>= "0.2.0"}
   "happy-eyeballs-lwt"
-  "solo5-elftool" {>= "0.3"}
+  "solo5-elftool" {>= "0.3" & < "0.4.0"}
   "owee" {>= "0.4"}
   "alcotest" {with-test}
 ]

--- a/packages/albatross/albatross.1.5.5/opam
+++ b/packages/albatross/albatross.1.5.5/opam
@@ -36,7 +36,7 @@ depends: [
   "hex"
   "http-lwt-client" {>= "0.2.0"}
   "happy-eyeballs-lwt"
-  "solo5-elftool" {>= "0.3"}
+  "solo5-elftool" {>= "0.3" & < "0.4.0"}
   "owee" {>= "0.4"}
   "alcotest" {with-test}
 ]

--- a/packages/albatross/albatross.1.5.6/opam
+++ b/packages/albatross/albatross.1.5.6/opam
@@ -37,7 +37,7 @@ depends: [
   "hex"
   "http-lwt-client" {>= "0.2.0"}
   "happy-eyeballs-lwt"
-  "solo5-elftool" {>= "0.3"}
+  "solo5-elftool" {>= "0.3" & < "0.4.0"}
   "owee" {>= "0.4"}
   "alcotest" {with-test}
 ]

--- a/packages/albatross/albatross.2.0.0/opam
+++ b/packages/albatross/albatross.2.0.0/opam
@@ -37,7 +37,7 @@ depends: [
   "hex"
   "http-lwt-client" {>= "0.2.0"}
   "happy-eyeballs-lwt"
-  "solo5-elftool" {>= "0.3"}
+  "solo5-elftool" {>= "0.3" & < "0.4.0"}
   "owee" {>= "0.4"}
   "alcotest" {with-test}
 ]

--- a/packages/albatross/albatross.2.1.0/opam
+++ b/packages/albatross/albatross.2.1.0/opam
@@ -37,7 +37,7 @@ depends: [
   "ohex" {>= "0.2.0"}
   "http-lwt-client" {>= "0.2.0"}
   "happy-eyeballs-lwt"
-  "solo5-elftool" {>= "0.3"}
+  "solo5-elftool" {>= "0.3" & < "0.4.0"}
   "owee" {>= "0.4"}
   "fpath" {>= "0.7.3"}
   "logs-syslog" {>= "0.4.0"}

--- a/packages/albatross/albatross.2.2.0/opam
+++ b/packages/albatross/albatross.2.2.0/opam
@@ -33,7 +33,7 @@ depends: [
   "ohex" {>= "0.2.0"}
   "http-lwt-client" {>= "0.3.0"}
   "happy-eyeballs-lwt"
-  "solo5-elftool" {>= "0.3"}
+  "solo5-elftool" {>= "0.3" & < "0.4.0"}
   "fpath" {>= "0.7.3"}
   "logs-syslog" {>= "0.4.1"}
   "digestif" {>= "1.2.0"}

--- a/packages/albatross/albatross.2.3.0/opam
+++ b/packages/albatross/albatross.2.3.0/opam
@@ -33,7 +33,7 @@ depends: [
   "ohex" {>= "0.2.0"}
   "http-lwt-client" {>= "0.3.0"}
   "happy-eyeballs-lwt"
-  "solo5-elftool" {>= "0.3"}
+  "solo5-elftool" {>= "0.3" & < "0.4.0"}
   "fpath" {>= "0.7.3"}
   "logs-syslog" {>= "0.4.1"}
   "digestif" {>= "1.2.0"}

--- a/packages/builder-web/builder-web.0.2.0/opam
+++ b/packages/builder-web/builder-web.0.2.0/opam
@@ -46,7 +46,7 @@ depends: [
   "tar" {>= "3.0.0"}
   "tar-unix" {>= "3.0.0"}
   "owee"
-  "solo5-elftool" {>= "0.3.0"}
+  "solo5-elftool" {>= "0.3.0" & < "0.4.0"}
   "decompress" {>= "1.5.0"}
   "digestif" {>= "1.2.0"}
   "alcotest" {>= "1.2.0" & with-test}

--- a/packages/metrics-rusage/metrics-rusage.0.3.0/opam
+++ b/packages/metrics-rusage/metrics-rusage.0.3.0/opam
@@ -13,6 +13,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
+available: os != "win32"
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.4"}

--- a/packages/metrics-rusage/metrics-rusage.0.4.0/opam
+++ b/packages/metrics-rusage/metrics-rusage.0.4.0/opam
@@ -13,6 +13,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
+available: os != "win32"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.4"}

--- a/packages/metrics-rusage/metrics-rusage.0.4.1/opam
+++ b/packages/metrics-rusage/metrics-rusage.0.4.1/opam
@@ -13,6 +13,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
+available: os != "win32"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.4"}

--- a/packages/owee/owee.0.7/opam
+++ b/packages/owee/owee.0.7/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.06"}
   "dune" {>= "2.0"}
 ]
-available: arch != "x86_32" & arch != "arm32"
+available: arch != "x86_32" & arch != "arm32" & os != "win32"
 synopsis: "OCaml library to work with DWARF format"
 description: """
 Owee is an experimental library to work with DWARF format.

--- a/packages/solo5-elftool/solo5-elftool.0.4.0/opam
+++ b/packages/solo5-elftool/solo5-elftool.0.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage: "https://git.robur.coop/robur/ocaml-solo5-elftool"
+dev-repo: "git+https://git.robur.coop/robur/ocaml-solo5-elftool.git"
+bug-reports: "https://github.com/robur-coop/ocaml-solo5-elftool/issues"
+doc: "https://robur-coop.github.io/ocaml-solo5-elftool/doc"
+maintainer: [ "team@robur.coop" ]
+authors: [ "Reynir Björnsson <reynir@reynir.dk>" ]
+license: "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.9"}
+  "cachet"
+  "fmt" {>= "0.8.7"}
+  "cmdliner" {>= "1.1.0"}
+]
+
+available: arch != "arm32" & arch != "x86_32"
+conflicts: [
+  "result" {< "1.5"}
+]
+
+synopsis: "OCaml Solo5 elftool for querying solo5 manifests"
+description: """
+OCaml Solo5 elftool is a library and executable for reading solo5 device
+manifests from solo5 ELF executables.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-solo5-elftool/releases/download/v0.4.0/solo5-elftool-0.4.0.tbz"
+  checksum: [
+    "sha256=677925871c794478bb4f6c15c0f8b7b3a905cc30c8455806a84b24cf76f2ed12"
+    "sha512=2f981b6d52724744f876f72a8d6eee256241184add4af5febe83a6ba037da1cebbf7c54ab17fd464875fddb179ab66c713411f537d2caa41e6074dcf0a4340ad"
+  ]
+}
+x-commit-hash: "6c03f5b8ed5228c83fdf6b551eb8257a8cf6a5b6"


### PR DESCRIPTION
OCaml Solo5 elftool for querying solo5 manifests

- Project page: <a href="https://git.robur.coop/robur/ocaml-solo5-elftool">https://git.robur.coop/robur/ocaml-solo5-elftool</a>
- Documentation: <a href="https://robur-coop.github.io/ocaml-solo5-elftool/doc">https://robur-coop.github.io/ocaml-solo5-elftool/doc</a>

##### CHANGES:

* Reimplement the necessary ELF parsing and drop the owee dependency. This makes it possible to use this library in Mirage.
* **BREAKING**: Switch to cachet instead of requiring the whole binary in memory.
