### PR TITLE
libsail, yocaml: add some upper bounds to ocaml 5.3

### DIFF
--- a/packages/libsail/libsail.0.15/opam
+++ b/packages/libsail/libsail.0.15/opam
@@ -28,6 +28,7 @@ license: "BSD-2-Clause"
 homepage: "https://github.com/rems-project/sail"
 bug-reports: "https://github.com/rems-project/sail/issues"
 depends: [
+  "ocaml" {< "5.3"}
   "dune" {>= "3.0"}
   "dune-site" {>= "3.0.2"}
   "menhir" {build & >= "20180523"}

--- a/packages/libsail/libsail.0.16/opam
+++ b/packages/libsail/libsail.0.16/opam
@@ -28,6 +28,7 @@ license: "BSD-2-Clause"
 homepage: "https://github.com/rems-project/sail"
 bug-reports: "https://github.com/rems-project/sail/issues"
 depends: [
+  "ocaml" {< "5.3"}
   "dune" {>= "3.0"}
   "dune-site" {>= "3.0.2"}
   "bisect_ppx" {dev & >= "2.5.0"}

--- a/packages/libsail/libsail.0.17.1/opam
+++ b/packages/libsail/libsail.0.17.1/opam
@@ -28,6 +28,7 @@ license: "BSD-2-Clause"
 homepage: "https://github.com/rems-project/sail"
 bug-reports: "https://github.com/rems-project/sail/issues"
 depends: [
+  "ocaml" {< "5.3"}
   "dune" {>= "3.0"}
   "dune-site" {>= "3.0.2"}
   "bisect_ppx" {dev & >= "2.5.0"}

--- a/packages/libsail/libsail.0.18/opam
+++ b/packages/libsail/libsail.0.18/opam
@@ -28,6 +28,7 @@ license: "BSD-2-Clause"
 homepage: "https://github.com/rems-project/sail"
 bug-reports: "https://github.com/rems-project/sail/issues"
 depends: [
+  "ocaml"
   "dune" {>= "3.0"}
   "dune-site" {>= "3.0.2"}
   "bisect_ppx" {dev & >= "2.5.0"}
@@ -41,6 +42,7 @@ depends: [
   "pprint" {>= "20220103"}
   "odoc" {with-doc}
 ]
+build-env: OCAMLPARAM = "_,w=-46,keywords=5.2" # uses the effect keyword
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/yocaml_yaml/yocaml_yaml.1.0.0/opam
+++ b/packages/yocaml_yaml/yocaml_yaml.1.0.0/opam
@@ -20,7 +20,7 @@ dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
 bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
 
 depends: [
-  "ocaml" { >= "4.11.1" }
+  "ocaml" { >= "4.11.1" & < "5.3"}
   "dune" { >= "2.8" }
   "odoc" {with-doc}
   "preface" { >= "1.0.0" }


### PR DESCRIPTION
related to the use of the effect keyword. For the latest libsail we use a specific build-env flag for ocamlfind to keep compatibility since there is not a new release. Seen on #27253