### PR TITLE
Add rust 2024 edition

### DIFF
--- a/packages/conf-rust-2024/conf-rust-2024.1/opam
+++ b/packages/conf-rust-2024/conf-rust-2024.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "contact@trili.tech"
+authors: [
+  "TriliTech"
+  "Simon Cruanes"
+]
+homepage: "https://github.com/ocaml/opam-repository"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "MIT"
+build: [
+  ["cargo" "--version"]
+  ["rustc" "--edition" "2024" "test.rs"]
+]
+depexts: [
+  ["cargo"] {os-distribution = "centos" & os-version >= "8"}
+  ["cargo"] {os-distribution = "ol" & os-version >= "8"}
+  ["cargo"] {os-distribution = "fedora"}
+  ["cargo"] {os-family = "suse" | os-family = "opensuse"}
+  ["cargo"] {os-family = "debian"}
+  ["cargo"] {os-family = "ubuntu"}
+  ["cargo" "rustc"] {os-distribution = "nixos"}
+  ["cargo"] {os-family = "alpine"}
+  ["rust"] {os-family = "arch"}
+  ["rust"] {os = "macos" & os-distribution = "homebrew"}
+  ["rust"] {os = "freebsd"}
+]
+x-ci-accept-failures: [
+  "centos-7" # does not have cargo by default
+  "oraclelinux-7" # does not have cargo by default
+  "debian-10" # rust 2021 is not in the default repository (version is too old)
+  "debian-11" # rust 2021 is not in the default repository (version is too old)
+  "alpine-3.14" # ships with version where rust 2021 is not stable
+]
+synopsis: "Virtual package relying on cargo (rust build system)"
+description:
+  "This package can only install if cargo (edition=2021) is installed on the system."
+flags: conf
+extra-source "test.rs" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-rust-2021/test.rs"
+  checksum:
+    "sha256=536e506bb90914c243a12b397b9a998f85ae2cbd9ba02dfd03a9e155ca5ca0f4"
+}


### PR DESCRIPTION
It is now being stabilized (see https://github.com/rust-lang/rust/pull/133349)

May need an update to the test.rs and distributions once it is out, but will help with packages that need recent rust