### PR TITLE
[new release] albatross (2.4.0)

### DIFF
--- a/packages/albatross/albatross.2.4.0/opam
+++ b/packages/albatross/albatross.2.4.0/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/robur-coop/albatross"
+dev-repo: "git+https://github.com/robur-coop/albatross.git"
+bug-reports: "https://github.com/robur-coop/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "2.7.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "5.3.0"}
+  "logs"
+  "bos" {>= "0.2.0"}
+  "ptime" {>= "1.2.0"}
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "1.0.0"}
+  "tls" {>= "1.0.2"}
+  "tls-lwt" {>= "1.0.2"}
+  "asn1-combinators" {>= "0.3.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "ohex" {>= "0.2.0"}
+  "http-lwt-client" {>= "0.3.0"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.4.0"}
+  "cachet" {>= "0.0.2"}
+  "fpath" {>= "0.7.3"}
+  "logs-syslog" {>= "0.4.1"}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/albatross/releases/download/v2.4.0/albatross-2.4.0.tbz"
+  checksum: [
+    "sha256=76663077b3090f1681868558c7dabf4236d3762e4263609f1ca7685ce0d61fb6"
+    "sha512=d9c6f2355229a98bbd135e72f00bf058e6fab86e4faea20b0ef05976ac59e1d95e083eedd2186534ee9ef38728ed17df475ac9575aa6ed9a459c9ec1f10e0e89"
+  ]
+}
+x-commit-hash: "23905e9d651c45f228fb19e9e5d9d4b7d5222d7b"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/robur-coop/albatross">https://github.com/robur-coop/albatross</a>

##### CHANGES:

* albatross-daemon: on startup backup the state file (robur-coop/albatross#206 @hannesm, fixes robur-coop/albatross#203)
* Add block size to info command, adapt types slightly (robur-coop/albatross#195 @hannesm)
* Allow the arguments in restart to be changed (robur-coop/albatross#195 @hannesm)
* Update to ocaml-solo5-elftool 0.4.0 - bump OCaml lower bound to 4.14
  (robur-coop/albatross#207 @reynir, robur-coop/albatross#208)
* BUGFIX: restart command kills the unikernel first (robur-coop/albatross#205 @reynir)
* Print manifest on mismatch (robur-coop/albatross#196 @reynir)
* Albatross-console: use physical equality for file descriptors (robur-coop/albatross#200 @reynir)
* Albatross-console: allow multiple subscribers (robur-coop/albatross#194 @reynir)
