### PR TITLE
[new release] mirage-logs (3.0.0)

### DIFF
--- a/packages/mirage-logs/mirage-logs.3.0.0/opam
+++ b/packages/mirage-logs/mirage-logs.3.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "talex5@gmail.com"
+authors: [ "Thomas Leonard" ]
+license: "ISC"
+homepage: "https://github.com/mirage/mirage-logs"
+dev-repo: "git+https://github.com/mirage/mirage-logs.git"
+bug-reports: "https://github.com/mirage/mirage-logs/issues"
+doc: "https://mirage.github.io/mirage-logs/"
+tags: ["org:mirage"]
+depends: [
+  "ocaml" { >= "4.08.0" }
+  "dune" {>= "3.0"}
+  "logs" { >= "0.5.0" }
+  "fmt" { >= "0.9.0" }
+  "ptime" { >= "0.8.1" }
+  "mirage-ptime" { >= "4.0.0" }
+  "cmdliner" { >= "1.1.0" }
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+synopsis: "A reporter for the Logs library that writes log messages to stderr, using a Mirage `CLOCK` to add timestamps"
+description: """
+The Logs reporter prefixes each entry with a timestamp, and writes it to stderr.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-logs/releases/download/v3.0.0/mirage-logs-3.0.0.tbz"
+  checksum: [
+    "sha256=a6db7dfc3afd87e5b78fff52007a56bca6672207ae067e68c63ef69318926750"
+    "sha512=dd97fcb18913e80cc7acd2a54968a9fe863dccae80dd42ad8e232924371c4e22c7dcbdbc92c33107ebfa12ba1d83caefb08a4ccfff49e082b0b25c94d58adb8d"
+  ]
+}
+x-commit-hash: "08e4de445cfb9894b7086975ab51725ff9bbd700"


### PR DESCRIPTION
A reporter for the Logs library that writes log messages to stderr, using a Mirage `CLOCK` to add timestamps

- Project page: <a href="https://github.com/mirage/mirage-logs">https://github.com/mirage/mirage-logs</a>
- Documentation: <a href="https://mirage.github.io/mirage-logs/">https://mirage.github.io/mirage-logs/</a>

##### CHANGES:

- Use mirage-ptime (a dune variant) instead of mirage-clock (mirage/mirage-logs#29 @hannesm)
