### PR TITLE
[new release] awa (2 packages) (0.5.0)

### DIFF
--- a/packages/awa-mirage/awa-mirage.0.5.0/opam
+++ b/packages/awa-mirage/awa-mirage.0.5.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime" {>= "1.0.0"}
+  "lwt" {>= "5.3.0"}
+  "mirage-sleep" {>= "4.0.0"}
+  "duration" {>= "0.2.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "mirage-mtime" {>= "4.0.0"}
+  "logs"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.5.0/awa-0.5.0.tbz"
+  checksum: [
+    "sha256=4984a4841e372a661a084606c058a130f2ef87566bf71796162a396ad635f40f"
+    "sha512=39f06cf2807b82c24dd3874d92804df4c449e503e83bb9cd56169c3de64782060af8f9f817008ec10ad3e8c4d04ce6aecc3360c2fc5e26a900c1fae5d9bf6c92"
+  ]
+}
+x-commit-hash: "ffc4362477d435cba654397a4497304a17a41eb4"

--- a/packages/awa/awa.0.5.0/opam
+++ b/packages/awa/awa.0.5.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.7"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "1.0.0"}
+  "x509" {>= "1.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-unix"
+  "mtime" {>= "1.0.0"}
+  "logs"
+  "fmt"
+  "cmdliner" {>= "1.1.0"}
+  "base64" {>= "3.0.0"}
+  "zarith"
+  "eqaf" {>= "0.8"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.5.0/awa-0.5.0.tbz"
+  checksum: [
+    "sha256=4984a4841e372a661a084606c058a130f2ef87566bf71796162a396ad635f40f"
+    "sha512=39f06cf2807b82c24dd3874d92804df4c449e503e83bb9cd56169c3de64782060af8f9f817008ec10ad3e8c4d04ce6aecc3360c2fc5e26a900c1fae5d9bf6c92"
+  ]
+}
+x-commit-hash: "ffc4362477d435cba654397a4497304a17a41eb4"

--- a/packages/git-mirage/git-mirage.3.17.0/opam
+++ b/packages/git-mirage/git-mirage.3.17.0/opam
@@ -15,7 +15,7 @@ depends: [
   "git" {= version}
   "git-paf" {= version}
   "awa" {>= "0.2.0"}
-  "awa-mirage" {>= "0.2.0"}
+  "awa-mirage" {>= "0.2.0" & < "0.5.0"}
   "dns" {>= "6.1.3"}
   "dns-client" {>= "6.1.3"}
   "tls" {>= "1.0.0"}


### PR DESCRIPTION
SSH implementation in OCaml

- Project page: <a href="https://github.com/mirage/awa-ssh">https://github.com/mirage/awa-ssh</a>
- Documentation: <a href="https://mirage.github.io/awa-ssh/api">https://mirage.github.io/awa-ssh/api</a>

##### CHANGES:

* Fix regression from 6379b473 (server-sig-algs should be Hostkey.preferred_algs)
  (mirage/awa-ssh#75, @reynir)
* Avoid functors over Mirage_time.S and Mirage_clock.MCLOCK (mirage/awa-ssh#76 @hannesm)
* Adapt to mirage-crypto-rng 1.2.0 (mirage/awa-ssh#76 @hannesm)
