### PR TITLE
[new release] mirage-flow (3 packages) (5.0.0)

### DIFF
--- a/packages/mirage-flow-combinators/mirage-flow-combinators.5.0.0/opam
+++ b/packages/mirage-flow-combinators/mirage-flow-combinators.5.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "logs"
+  "cstruct" {>= "6.0.0"}
+  "mirage-mtime" {>= "4.0.0"}
+  "mirage-flow" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS specialized to lwt"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v5.0.0/mirage-flow-5.0.0.tbz"
+  checksum: [
+    "sha256=37ca79cae0ed9b270b87712edcb397a5dec4ab39357b28107e00daa6c8553323"
+    "sha512=3cf9ebd09ce6e29f9f99a00bf47d2962ccd0e6627b0cdb407538c491480102211bde863d342624cdd4bdb2e1b198b8bf5b2109f881e8113210468ad5b5aa8632"
+  ]
+}
+x-commit-hash: "22c4d50031f24d3ef86700cfc988db62a89a7a6b"

--- a/packages/mirage-flow-unix/mirage-flow-unix.5.0.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.5.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "mirage-flow" {= version}
+  "lwt" {>= "4.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "alcotest" {with-test}
+  "mirage-flow-combinators" {with-test & = version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS on Unix"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v5.0.0/mirage-flow-5.0.0.tbz"
+  checksum: [
+    "sha256=37ca79cae0ed9b270b87712edcb397a5dec4ab39357b28107e00daa6c8553323"
+    "sha512=3cf9ebd09ce6e29f9f99a00bf47d2962ccd0e6627b0cdb407538c491480102211bde863d342624cdd4bdb2e1b198b8bf5b2109f881e8113210468ad5b5aa8632"
+  ]
+}
+x-commit-hash: "22c4d50031f24d3ef86700cfc988db62a89a7a6b"

--- a/packages/mirage-flow/mirage-flow.5.0.0/opam
+++ b/packages/mirage-flow/mirage-flow.5.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "4.0.0"}
+  "fmt"
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v5.0.0/mirage-flow-5.0.0.tbz"
+  checksum: [
+    "sha256=37ca79cae0ed9b270b87712edcb397a5dec4ab39357b28107e00daa6c8553323"
+    "sha512=3cf9ebd09ce6e29f9f99a00bf47d2962ccd0e6627b0cdb407538c491480102211bde863d342624cdd4bdb2e1b198b8bf5b2109f881e8113210468ad5b5aa8632"
+  ]
+}
+x-commit-hash: "22c4d50031f24d3ef86700cfc988db62a89a7a6b"


### PR DESCRIPTION
Flow implementations and combinators for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-flow">https://github.com/mirage/mirage-flow</a>
- Documentation: <a href="https://mirage.github.io/mirage-flow/">https://mirage.github.io/mirage-flow/</a>

##### CHANGES:

- Remove functor over Mirage_clock.MCLOCK, use mirage-mtime instead
  (mirage/mirage-flow#53 @hannesm)
