### PR TITLE
[new release] mirage-solo5 (0.10.0)

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.10.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.10.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-solo5"
+bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-solo5.git"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {>= "2.7.0"}
+  "bheap" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "2.4.3"}
+  "metrics"
+  "metrics-lwt" {>= "0.2.0"}
+  "mirage-runtime" {>= "4.6.0"}
+  "mirage-sleep" {>= "4.0.0"}
+  "duration"
+]
+conflicts: [
+  "io-page" {< "2.4.0"}
+  "tcpip" {< "6.1.0"}
+]
+synopsis: "Solo5 core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+[Solo5](https://github.com/Solo5/solo5) targets, which handles the main loop
+and timers. It also provides the low level C startup code and C stubs required
+by the OCaml code.
+
+Currently this package also includes the C stubs used by the Solo5 `console`,
+`block` and `net` implementations.
+
+The OCaml runtime and C runtime required to support it are provided separately
+by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-solo5/releases/download/v0.10.0/mirage-solo5-0.10.0.tbz"
+  checksum: [
+    "sha256=885ceb22ce5c7d1176dabded6690279abefd2e89429383eac6ee57a73d975480"
+    "sha512=75dfdb6f90f0f2b10e2c2581f4d4f57794dd0bf5fe09e929714977c803ddb6450d6ddbfb58d88a0dfd8c87ce4a3bc84bee764e1b8a0c3c3b6539b3e5f934eb39"
+  ]
+}
+x-commit-hash: "be95f5a5b1af6d19ce60c1ab2475d27c007f824a"


### PR DESCRIPTION
Solo5 core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-solo5">https://github.com/mirage/mirage-solo5</a>

##### CHANGES:

* Use dune-variants, sleeper storage is now in mirage-sleep (mirage/mirage-solo5#96 @hannesm)
