### PR TITLE
[new release] mirage-xen (9.0.0)

### DIFF
--- a/packages/mirage-xen/mirage-xen.9.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.9.0.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "lwt-dllist"
+  "io-page" {>= "2.4.0"}
+  "mirage-runtime" {>= "4.6.0"}
+  "logs"
+  "fmt" {>= "0.8.5"}
+  "bheap" {>= "2.0.0"}
+  "duration"
+  "metrics"
+  "metrics-lwt" {>= "0.2.0"}
+  "mirage-sleep" {>= "4.0.0"}
+]
+available: [
+  (arch = "x86_64" ) &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-xen/releases/download/v9.0.0/mirage-xen-9.0.0.tbz"
+  checksum: [
+    "sha256=95d15ff80782fbc013c2a57f496815da56a3859bc1eb86947fe07149afc8fa43"
+    "sha512=99ef971baa1630cf7cb43d08fa125b8c26a58b61be6b3b4f8561d18614d5f86e969ef220a45282a93be9a8864bf0e12660ed323d161b8a88d398126598ed5614"
+  ]
+}
+x-commit-hash: "91a845a95277c299d57347db71171aa1ee4b7de5"


### PR DESCRIPTION
Xen core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-xen">https://github.com/mirage/mirage-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-xen/">https://mirage.github.io/mirage-xen/</a>

##### CHANGES:

* Use dune-variants, sleeper storage is now in mirage-sleep (mirage/mirage-xen#54 @hannesm)
