### PR TITLE
[new release] ca-certs-nss (3.108-1)

### DIFF
--- a/packages/ca-certs-nss/ca-certs-nss.3.108-1/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.108-1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "X.509 trust anchors extracted from Mozilla's NSS"
+description: """
+Trust anchors extracted from Mozilla's NSS certdata.txt package,
+to be used in MirageOS unikernels.
+"""
+maintainer: ["Hannes Mehnert <hannes@mehnert.org>"]
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+license: "ISC"
+homepage: "https://github.com/mirage/ca-certs-nss"
+doc: "https://mirage.github.io/ca-certs-nss/doc"
+bug-reports: "https://github.com/mirage/ca-certs-nss/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "mirage-ptime" {>= "4.0.0"}
+  "x509" {>= "1.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "digestif" {>= "1.2.0"}
+  "logs" {build}
+  "fmt" {build & >= "0.8.7"}
+  "bos" {build}
+  "cmdliner" {build & >= "1.1.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ca-certs-nss.git"
+tags: ["org:mirage"]
+url {
+  src:
+    "https://github.com/mirage/ca-certs-nss/releases/download/v3.108-1/ca-certs-nss-3.108-1.tbz"
+  checksum: [
+    "sha256=b28622f2c5b53ab7f39e28c2198805598ea06b282e42cdff15c057942d857e56"
+    "sha512=45f4feda68751b64865b423e1589b3c99be6c1e16a6d4ad8def01817474f3be882b6b8a8b0df9cae77ce3856fedaea1dc487ba893615be82033c790fd4c65f84"
+  ]
+}
+x-commit-hash: "1b597c31b79134babeb220718166e0b6f10d8c60"

--- a/packages/dns-client-mirage/dns-client-mirage.9.0.0/opam
+++ b/packages/dns-client-mirage/dns-client-mirage.9.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "happy-eyeballs" {>= "1.0.0"}
   "tls-mirage" {>= "1.0.0"}
   "x509" {>= "1.0.0"}
-  "ca-certs-nss" {>= "3.101-1"}
+  "ca-certs-nss" {>= "3.101-1" & <= "3.108"}
   "mirage-crypto-rng-mirage" {>= "1.0.0"}
 ]
 synopsis: "DNS client API for MirageOS"

--- a/packages/dns-client-mirage/dns-client-mirage.9.1.0/opam
+++ b/packages/dns-client-mirage/dns-client-mirage.9.1.0/opam
@@ -26,7 +26,7 @@ depends: [
   "happy-eyeballs" {>= "1.0.0"}
   "tls-mirage" {>= "1.0.0"}
   "x509" {>= "1.0.0"}
-  "ca-certs-nss" {>= "3.101-1"}
+  "ca-certs-nss" {>= "3.101-1" & <= "3.108"}
   "mirage-crypto-rng-mirage" {>= "1.0.0"}
 ]
 synopsis: "DNS client API for MirageOS"

--- a/packages/git-mirage/git-mirage.3.17.0/opam
+++ b/packages/git-mirage/git-mirage.3.17.0/opam
@@ -23,7 +23,7 @@ depends: [
   "uri"
   "happy-eyeballs-mirage" {>= "0.1.2"}
   "happy-eyeballs" {>= "0.1.2"}
-  "ca-certs-nss"
+  "ca-certs-nss" {<= "3.108"}
   "mirage-crypto" {>= "1.0.0"}
   "ptime"
   "x509" {>= "1.0.0"}

--- a/packages/sendmail-mirage/sendmail-mirage.0.10.0/opam
+++ b/packages/sendmail-mirage/sendmail-mirage.0.10.0/opam
@@ -21,7 +21,7 @@ depends: [
   "domain-name"
   "happy-eyeballs-mirage"
   "mirage-flow"
-  "ca-certs-nss"
+  "ca-certs-nss" {<= "3.108"}
   "lwt"
   "tls" {>= "0.13.0"}
   "tls-mirage" {>= "0.16.0"}

--- a/packages/sendmail-mirage/sendmail-mirage.0.11.0/opam
+++ b/packages/sendmail-mirage/sendmail-mirage.0.11.0/opam
@@ -21,7 +21,7 @@ depends: [
   "domain-name"
   "happy-eyeballs-mirage"
   "mirage-flow"
-  "ca-certs-nss"
+  "ca-certs-nss" {<= "3.108"}
   "lwt"
   "tls" {>= "0.13.0"}
   "tls-mirage" {>= "0.16.0"}


### PR DESCRIPTION
X.509 trust anchors extracted from Mozilla's NSS

- Project page: <a href="https://github.com/mirage/ca-certs-nss">https://github.com/mirage/ca-certs-nss</a>
- Documentation: <a href="https://mirage.github.io/ca-certs-nss/doc">https://mirage.github.io/ca-certs-nss/doc</a>

##### CHANGES:

* Use mirage-ptime instead of functorising over PCLOCK (mirage/ca-certs-nss#11 @hannesm)
