### PR TITLE
add a with-test dependency on irmin-cli to tls, with an upper bound of 2.0.0

### DIFF
--- a/packages/irmin-cli/irmin-cli.3.10.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.10.0/opam
@@ -50,6 +50,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {>= "2.0.0" & with-test}
+  "tls" {< "2.0.0" & with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.4.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.4.0/opam
@@ -48,6 +48,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
+  "tls" {< "2.0.0" & with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.4.1/opam
+++ b/packages/irmin-cli/irmin-cli.3.4.1/opam
@@ -48,6 +48,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
+  "tls" {< "2.0.0" & with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.4.2/opam
+++ b/packages/irmin-cli/irmin-cli.3.4.2/opam
@@ -48,6 +48,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
+  "tls" {< "2.0.0" & with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.4.3/opam
+++ b/packages/irmin-cli/irmin-cli.3.4.3/opam
@@ -48,6 +48,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
+  "tls" {< "2.0.0" & with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.5.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.5.0/opam
@@ -48,6 +48,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
+  "tls" {< "2.0.0" & with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.5.1/opam
+++ b/packages/irmin-cli/irmin-cli.3.5.1/opam
@@ -48,6 +48,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
+  "tls" {< "2.0.0" & with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.5.2/opam
+++ b/packages/irmin-cli/irmin-cli.3.5.2/opam
@@ -48,6 +48,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
+  "tls" {< "2.0.0" & with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.6.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.6.0/opam
@@ -48,6 +48,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
+  "tls" {< "2.0.0" & with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.6.1/opam
+++ b/packages/irmin-cli/irmin-cli.3.6.1/opam
@@ -48,6 +48,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
+  "tls" {< "2.0.0" & with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.7.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.7.0/opam
@@ -48,6 +48,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
+  "tls" {< "2.0.0" & with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.7.1/opam
+++ b/packages/irmin-cli/irmin-cli.3.7.1/opam
@@ -48,6 +48,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
+  "tls" {< "2.0.0" & with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.7.2/opam
+++ b/packages/irmin-cli/irmin-cli.3.7.2/opam
@@ -48,6 +48,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
+  "tls" {< "2.0.0" & with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.8.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.8.0/opam
@@ -48,6 +48,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {>= "2.0.0" & with-test}
+  "tls" {< "2.0.0" & with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.9.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.9.0/opam
@@ -50,6 +50,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {>= "2.0.0" & with-test}
+  "tls" {< "2.0.0" & with-test}
 ]
 
 synopsis: "CLI for Irmin"


### PR DESCRIPTION
The error:
```
== ERROR while compiling irmin-cli.3.9.0 ====================================#
context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
path                 ~/.opam/4.14/.opam-switch/build/irmin-cli.3.9.0
command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p irmin-cli -j 71
exit-code            1
env-file             ~/.opam/log/irmin-cli-8-b9ad78.env
output-file          ~/.opam/log/irmin-cli-8-b9ad78.out
= output ###
File "examples/merkle_proofs.md", line 1, characters 0-0:
/usr/bin/git --no-pager diff --no-index --color=always -u _build/default/examples/merkle_proofs.md _build/default/examples/.mdx/merkle_proofs.md.corrected
diff --git a/_build/default/examples/merkle_proofs.md b/_build/default/examples/.mdx/merkle_proofs.md.corrected
index 1fde16d..6ecce5b 100644
--- a/_build/default/examples/merkle_proofs.md
+++ b/_build/default/examples/.mdx/merkle_proofs.md.corrected
@@ -11,6 +11,168 @@ More specifically, for Irmin, a Merkle proof is the subset of a tree stored in a
 # #require "checkseum.ocaml";;
 # #require "irmin";;
 # #require "irmin-git.unix";;
+/home/opam/.opam/4.14/lib/sexplib0: added to search path
+/home/opam/.opam/4.14/lib/sexplib0/sexplib0.cma: loaded
+/home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib: added to search path
+/home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib/ppx_sexp_conv_lib.cma: loaded
+/home/opam/.opam/4.14/lib/seq: added to search path
+/home/opam/.opam/4.14/lib/re: added to search path
+/home/opam/.opam/4.14/lib/re/re.cma: loaded
+/home/opam/.opam/4.14/lib/uri-sexp: added to search path
+/home/opam/.opam/4.14/lib/uri-sexp/uri_sexp.cma: loaded
+/home/opam/.opam/4.14/lib/cohttp: added to search path
+/home/opam/.opam/4.14/lib/cohttp/cohttp.cma: loaded
+/home/opam/.opam/4.14/lib/logs/logs_lwt.cma: loaded
+/home/opam/.opam/4.14/lib/cohttp-lwt: added to search path
+/home/opam/.opam/4.14/lib/cohttp-lwt/cohttp_lwt.cma: loaded
+/home/opam/.opam/4.14/lib/domain-name: added to search path
+/home/opam/.opam/4.14/lib/domain-name/domain_name.cma: loaded
+/home/opam/.opam/4.14/lib/macaddr: added to search path
+/home/opam/.opam/4.14/lib/macaddr/macaddr.cma: loaded
+/home/opam/.opam/4.14/lib/ipaddr: added to search path
+/home/opam/.opam/4.14/lib/ipaddr/ipaddr.cma: loaded
+/home/opam/.opam/4.14/lib/ipaddr-sexp: added to search path
+/home/opam/.opam/4.14/lib/ipaddr-sexp/ipaddr_sexp.cma: loaded
+/home/opam/.opam/4.14/lib/conduit: added to search path
+/home/opam/.opam/4.14/lib/conduit/conduit.cma: loaded
+/home/opam/.opam/4.14/lib/conduit-lwt: added to search path
+/home/opam/.opam/4.14/lib/conduit-lwt/conduit_lwt.cma: loaded
+/home/opam/.opam/4.14/lib/rresult: added to search path
+/home/opam/.opam/4.14/lib/rresult/rresult.cma: loaded
+/home/opam/.opam/4.14/lib/fpath: added to search path
+/home/opam/.opam/4.14/lib/fpath/fpath.cma: loaded
+/home/opam/.opam/4.14/lib/bos: added to search path
+/home/opam/.opam/4.14/lib/bos/bos.cma: loaded
+/home/opam/.opam/4.14/lib/mirage-crypto: added to search path
+/home/opam/.opam/4.14/lib/mirage-crypto/mirage_crypto.cma: loaded
+/home/opam/.opam/4.14/lib/ohex: added to search path
+/home/opam/.opam/4.14/lib/ohex/ohex.cma: loaded
+/home/opam/.opam/4.14/lib/ptime: added to search path
+/home/opam/.opam/4.14/lib/ptime/ptime.cma: loaded
+/home/opam/.opam/4.14/lib/ptime/clock: added to search path
+/home/opam/.opam/4.14/lib/ptime/clock/ptime_clock.cma: loaded
+/home/opam/.opam/4.14/lib/asn1-combinators: added to search path
+/home/opam/.opam/4.14/lib/asn1-combinators/asn1_combinators.cma: loaded
+/home/opam/.opam/4.14/lib/gmap: added to search path
+/home/opam/.opam/4.14/lib/gmap/gmap.cma: loaded
+/home/opam/.opam/4.14/lib/kdf/pbkdf: added to search path
+/home/opam/.opam/4.14/lib/kdf/pbkdf/pbkdf.cma: loaded
+/home/opam/.opam/4.14/lib/mirage-crypto-rng: added to search path
+/home/opam/.opam/4.14/lib/mirage-crypto-rng/mirage_crypto_rng.cma: loaded
+/home/opam/.opam/4.14/lib/mirage-crypto-ec: added to search path
+/home/opam/.opam/4.14/lib/mirage-crypto-ec/mirage_crypto_ec.cma: loaded
+/home/opam/.opam/4.14/lib/zarith: added to search path
+/home/opam/.opam/4.14/lib/zarith/zarith.cma: loaded
+/home/opam/.opam/4.14/lib/mirage-crypto-pk: added to search path
+/home/opam/.opam/4.14/lib/mirage-crypto-pk/mirage_crypto_pk.cma: loaded
+/home/opam/.opam/4.14/lib/x509: added to search path
+/home/opam/.opam/4.14/lib/x509/x509.cma: loaded
+/home/opam/.opam/4.14/lib/ca-certs: added to search path
+/home/opam/.opam/4.14/lib/ca-certs/ca_certs.cma: loaded
+/home/opam/.opam/4.14/lib/ipaddr/unix: added to search path
+/home/opam/.opam/4.14/lib/ipaddr/unix/ipaddr_unix.cma: loaded
+/home/opam/.opam/4.14/lib/ocaml/threads: added to search path
+/home/opam/.opam/4.14/lib/mirage-crypto-rng/unix: added to search path
+/home/opam/.opam/4.14/lib/mirage-crypto-rng/unix/mirage_crypto_rng_unix.cma: loaded
+/home/opam/.opam/4.14/lib/kdf/hkdf: added to search path
+/home/opam/.opam/4.14/lib/kdf/hkdf/hkdf.cma: loaded
+/home/opam/.opam/4.14/lib/tls: added to search path
+/home/opam/.opam/4.14/lib/tls/tls.cma: loaded
+/home/opam/.opam/4.14/lib/tls-lwt: added to search path
+/home/opam/.opam/4.14/lib/tls-lwt/tls_lwt.cma: loaded
+/home/opam/.opam/4.14/lib/uri/services: added to search path
+/home/opam/.opam/4.14/lib/uri/services/uri_services.cma: loaded
+/home/opam/.opam/4.14/lib/conduit-lwt-unix: added to search path
+/home/opam/.opam/4.14/lib/conduit-lwt-unix/conduit_lwt_unix.cma: loaded
+/home/opam/.opam/4.14/lib/magic-mime: added to search path
+/home/opam/.opam/4.14/lib/magic-mime/magic_mime_library.cma: loaded
+/home/opam/.opam/4.14/lib/cohttp-lwt-unix: added to search path
+/home/opam/.opam/4.14/lib/cohttp-lwt-unix/cohttp_lwt_unix.cma: loaded
+/home/opam/.opam/4.14/lib/decompress/de: added to search path
+/home/opam/.opam/4.14/lib/decompress/de/de.cma: loaded
+/home/opam/.opam/4.14/lib/decompress/zl: added to search path
+/home/opam/.opam/4.14/lib/decompress/zl/zl.cma: loaded
+/home/opam/.opam/4.14/lib/duff: added to search path
+/home/opam/.opam/4.14/lib/duff/duff.cma: loaded
+/home/opam/.opam/4.14/lib/ke: added to search path
+/home/opam/.opam/4.14/lib/ke/ke.cma: loaded
+/home/opam/.opam/4.14/lib/psq: added to search path
+/home/opam/.opam/4.14/lib/psq/psq.cma: loaded
+/home/opam/.opam/4.14/lib/carton: added to search path
+/home/opam/.opam/4.14/lib/carton/carton.cma: loaded
+/home/opam/.opam/4.14/lib/cstruct: added to search path
+/home/opam/.opam/4.14/lib/cstruct/cstruct.cma: loaded
+/home/opam/.opam/4.14/lib/carton-git: added to search path
+/home/opam/.opam/4.14/lib/carton-git/carton_git.cma: loaded
+/home/opam/.opam/4.14/lib/carton/thin: added to search path
+/home/opam/.opam/4.14/lib/carton/thin/thin.cma: loaded
+/home/opam/.opam/4.14/lib/carton-lwt: added to search path
+/home/opam/.opam/4.14/lib/carton-lwt/carton_lwt.cma: loaded
+/home/opam/.opam/4.14/lib/encore: added to search path
+/home/opam/.opam/4.14/lib/encore/encore.cma: loaded
+/home/opam/.opam/4.14/lib/git/loose: added to search path
+/home/opam/.opam/4.14/lib/git/loose/loose.cma: loaded
+/home/opam/.opam/4.14/lib/git/loose-git: added to search path
+/home/opam/.opam/4.14/lib/git/loose-git/loose_git.cma: loaded
+/home/opam/.opam/4.14/lib/pecu: added to search path
+/home/opam/.opam/4.14/lib/pecu/pecu.cma: loaded
+/home/opam/.opam/4.14/lib/emile: added to search path
+/home/opam/.opam/4.14/lib/emile/emile.cma: loaded
+/home/opam/.opam/4.14/lib/git/nss/sigs: added to search path
+/home/opam/.opam/4.14/lib/git/nss/sigs/sigs.cma: loaded
+/home/opam/.opam/4.14/lib/git/nss/pkt-line: added to search path
+/home/opam/.opam/4.14/lib/git/nss/pkt-line/pkt_line.cma: loaded
+/home/opam/.opam/4.14/lib/git/nss/smart: added to search path
+/home/opam/.opam/4.14/lib/git/nss/smart/smart.cma: loaded
+/home/opam/.opam/4.14/lib/git/nss/smart-flow: added to search path
+/home/opam/.opam/4.14/lib/git/nss/smart-flow/smart_flow.cma: loaded
+/home/opam/.opam/4.14/lib/git/nss/neg: added to search path
+/home/opam/.opam/4.14/lib/git/nss/neg/neg.cma: loaded
+/home/opam/.opam/4.14/lib/git/nss/pck: added to search path
+/home/opam/.opam/4.14/lib/git/nss/pck/pck.cma: loaded
+/home/opam/.opam/4.14/lib/git/nss: added to search path
+/home/opam/.opam/4.14/lib/git/nss/nss.cma: loaded
+/home/opam/.opam/4.14/lib/mirage-flow: added to search path
+/home/opam/.opam/4.14/lib/mirage-flow/mirage_flow.cma: loaded
+/home/opam/.opam/4.14/lib/git/nss/unixiz: added to search path
+/home/opam/.opam/4.14/lib/git/nss/unixiz/unixiz.cma: loaded
+/home/opam/.opam/4.14/lib/mimic: added to search path
+/home/opam/.opam/4.14/lib/mimic/mimic.cma: loaded
+/home/opam/.opam/4.14/lib/git/nss/git: added to search path
+/home/opam/.opam/4.14/lib/git/nss/git/smart_git.cma: loaded
+/home/opam/.opam/4.14/lib/git/nss/hkt: added to search path
+/home/opam/.opam/4.14/lib/git/nss/hkt/hkt.cma: loaded
+/home/opam/.opam/4.14/lib/hxd/core: added to search path
+/home/opam/.opam/4.14/lib/hxd/core/hxd.cma: loaded
+/home/opam/.opam/4.14/lib/hxd/string: added to search path
+/home/opam/.opam/4.14/lib/hxd/string/hxd_string.cma: loaded
+/home/opam/.opam/4.14/lib/git: added to search path
+/home/opam/.opam/4.14/lib/git/git.cma: loaded
+/home/opam/.opam/4.14/lib/mirage-clock: added to search path
+/home/opam/.opam/4.14/lib/mirage-clock/mirage_clock.cma: loaded
+/home/opam/.opam/4.14/lib/ca-certs-nss: added to search path
+/home/opam/.opam/4.14/lib/ca-certs-nss/ca_certs_nss.cma: loaded
+/home/opam/.opam/4.14/lib/faraday: added to search path
+/home/opam/.opam/4.14/lib/faraday/faraday.cma: loaded
+/home/opam/.opam/4.14/lib/result: added to search path
+/home/opam/.opam/4.14/lib/result/result.cma: loaded
+/home/opam/.opam/4.14/lib/httpaf: added to search path
+/home/opam/.opam/4.14/lib/httpaf/httpaf.cma: loaded
+/home/opam/.opam/4.14/lib/mirage-time: added to search path
+/home/opam/.opam/4.14/lib/mirage-time/mirage_time.cma: loaded
+/home/opam/.opam/4.14/lib/paf: added to search path
+/home/opam/.opam/4.14/lib/paf/paf.cma: loaded
+/home/opam/.opam/4.14/lib/duration: added to search path
+/home/opam/.opam/4.14/lib/duration/duration.cma: loaded
+/home/opam/.opam/4.14/lib/tcpip: added to search path
+/home/opam/.opam/4.14/lib/tcpip/tcpip.cma: loaded
+/home/opam/.opam/4.14/lib/mirage-kv: added to search path
+/home/opam/.opam/4.14/lib/mirage-kv/mirage_kv.cma: loaded
+/home/opam/.opam/4.14/lib/mirage-ptime: added to search path
+/home/opam/.opam/4.14/lib/tls-mirage: added to search path
+/home/opam/.opam/4.14/lib/tls-mirage/tls_mirage.cma: loaded
+File "_none_", line 1:
+Error: Reference to undefined global `Mirage_ptime'
 # #require "ppx_irmin";;
```

for https://github.com/ocaml/opam-repository/pull/27389 //cc @mseri (I don't quite understand why mdx doesn't load the mirage-ptime (default variant)).