### PR TITLE
Set upper bound on OCaml compiler version in flow_parser 0.246.0

### DIFF
--- a/packages/flow_parser/flow_parser.0.246.0/opam
+++ b/packages/flow_parser/flow_parser.0.246.0/opam
@@ -7,7 +7,7 @@ license: "MIT"
 
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "ocaml" {>= "5.2.0"}
+  "ocaml" {>= "5.2.0" & < "5.3"}
   "dune" {>= "3.2"}
   "base" {>= "v0.16.3"}
   "ppxlib" {>= "0.32.1"}


### PR DESCRIPTION
Not supported