### PR TITLE
Package visitors.20250207

### DIFF
--- a/packages/visitors/visitors.20250207/opam
+++ b/packages/visitors/visitors.20250207/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/visitors"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/visitors.git"
+bug-reports: "francois.pottier@inria.fr"
+license: "LGPL-2.1-only"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ppxlib" {>= "0.22.0"}
+  "ppx_deriving" {>= "5.0"}
+  "result"
+  "dune" {>= "2.0"}
+]
+synopsis: "An OCaml syntax extension for generating visitor classes"
+description: """
+Annotating an algebraic data type definition with [@@deriving visitors { ... }]
+causes visitor classes to be automatically generated. A visitor is an object
+that knows how to traverse and transform a data structure."""
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/visitors/-/archive/20250207/archive.tar.gz"
+  checksum: [
+    "md5=a7859dc1761bf68271a0125ef8671c4b"
+    "sha512=6c3a5926e8a783dd2cde706455eeea1497432e9221b4494c95001213c8336d01f6d0234bb140e7e8a0a086e3bc81df49577cc1523c09b4e7d3e4e58d7ca4f9a9"
+  ]
+}


### PR DESCRIPTION
### `visitors.20250207`
An OCaml syntax extension for generating visitor classes
Annotating an algebraic data type definition with [@@deriving visitors { ... }]
causes visitor classes to be automatically generated. A visitor is an object
that knows how to traverse and transform a data structure.



---
* Homepage: https://gitlab.inria.fr/fpottier/visitors
* Source repo: git+https://gitlab.inria.fr/fpottier/visitors.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.5.0