### PR TITLE
revise irmin-cli struggle with mirage-ptime and mirage-mtime within mdx:

### DIFF
--- a/packages/irmin-cli/irmin-cli.3.10.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.10.0/opam
@@ -53,8 +53,8 @@ depends: [
 ]
 
 conflicts: [
-  "mirage-ptime" {with-test}
-  "mirage-mtime" {with-test}
+  "mirage-ptime"
+  "mirage-mtime"
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.10.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.10.0/opam
@@ -50,7 +50,11 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {>= "2.0.0" & with-test}
-  "tls" {< "2.0.0" & with-test}
+]
+
+conflicts: [
+  "mirage-ptime" {with-test}
+  "mirage-mtime" {with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.4.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.4.0/opam
@@ -51,8 +51,8 @@ depends: [
 ]
 
 conflicts: [
-  "mirage-ptime" {with-test}
-  "mirage-mtime" {with-test}
+  "mirage-ptime"
+  "mirage-mtime"
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.4.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.4.0/opam
@@ -48,7 +48,11 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
-  "tls" {< "2.0.0" & with-test}
+]
+
+conflicts: [
+  "mirage-ptime" {with-test}
+  "mirage-mtime" {with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.4.1/opam
+++ b/packages/irmin-cli/irmin-cli.3.4.1/opam
@@ -51,8 +51,8 @@ depends: [
 ]
 
 conflicts: [
-  "mirage-ptime" {with-test}
-  "mirage-mtime" {with-test}
+  "mirage-ptime"
+  "mirage-mtime"
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.4.1/opam
+++ b/packages/irmin-cli/irmin-cli.3.4.1/opam
@@ -48,7 +48,11 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
-  "tls" {< "2.0.0" & with-test}
+]
+
+conflicts: [
+  "mirage-ptime" {with-test}
+  "mirage-mtime" {with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.4.2/opam
+++ b/packages/irmin-cli/irmin-cli.3.4.2/opam
@@ -51,8 +51,8 @@ depends: [
 ]
 
 conflicts: [
-  "mirage-ptime" {with-test}
-  "mirage-mtime" {with-test}
+  "mirage-ptime"
+  "mirage-mtime"
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.4.2/opam
+++ b/packages/irmin-cli/irmin-cli.3.4.2/opam
@@ -48,7 +48,11 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
-  "tls" {< "2.0.0" & with-test}
+]
+
+conflicts: [
+  "mirage-ptime" {with-test}
+  "mirage-mtime" {with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.4.3/opam
+++ b/packages/irmin-cli/irmin-cli.3.4.3/opam
@@ -51,8 +51,8 @@ depends: [
 ]
 
 conflicts: [
-  "mirage-ptime" {with-test}
-  "mirage-mtime" {with-test}
+  "mirage-ptime"
+  "mirage-mtime"
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.4.3/opam
+++ b/packages/irmin-cli/irmin-cli.3.4.3/opam
@@ -48,7 +48,11 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
-  "tls" {< "2.0.0" & with-test}
+]
+
+conflicts: [
+  "mirage-ptime" {with-test}
+  "mirage-mtime" {with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.5.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.5.0/opam
@@ -51,8 +51,8 @@ depends: [
 ]
 
 conflicts: [
-  "mirage-ptime" {with-test}
-  "mirage-mtime" {with-test}
+  "mirage-ptime"
+  "mirage-mtime"
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.5.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.5.0/opam
@@ -48,7 +48,11 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
-  "tls" {< "2.0.0" & with-test}
+]
+
+conflicts: [
+  "mirage-ptime" {with-test}
+  "mirage-mtime" {with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.5.1/opam
+++ b/packages/irmin-cli/irmin-cli.3.5.1/opam
@@ -51,8 +51,8 @@ depends: [
 ]
 
 conflicts: [
-  "mirage-ptime" {with-test}
-  "mirage-mtime" {with-test}
+  "mirage-ptime"
+  "mirage-mtime"
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.5.1/opam
+++ b/packages/irmin-cli/irmin-cli.3.5.1/opam
@@ -48,7 +48,11 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
-  "tls" {< "2.0.0" & with-test}
+]
+
+conflicts: [
+  "mirage-ptime" {with-test}
+  "mirage-mtime" {with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.5.2/opam
+++ b/packages/irmin-cli/irmin-cli.3.5.2/opam
@@ -51,8 +51,8 @@ depends: [
 ]
 
 conflicts: [
-  "mirage-ptime" {with-test}
-  "mirage-mtime" {with-test}
+  "mirage-ptime"
+  "mirage-mtime"
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.5.2/opam
+++ b/packages/irmin-cli/irmin-cli.3.5.2/opam
@@ -48,7 +48,11 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
-  "tls" {< "2.0.0" & with-test}
+]
+
+conflicts: [
+  "mirage-ptime" {with-test}
+  "mirage-mtime" {with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.6.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.6.0/opam
@@ -51,8 +51,8 @@ depends: [
 ]
 
 conflicts: [
-  "mirage-ptime" {with-test}
-  "mirage-mtime" {with-test}
+  "mirage-ptime"
+  "mirage-mtime"
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.6.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.6.0/opam
@@ -48,7 +48,11 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
-  "tls" {< "2.0.0" & with-test}
+]
+
+conflicts: [
+  "mirage-ptime" {with-test}
+  "mirage-mtime" {with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.6.1/opam
+++ b/packages/irmin-cli/irmin-cli.3.6.1/opam
@@ -51,8 +51,8 @@ depends: [
 ]
 
 conflicts: [
-  "mirage-ptime" {with-test}
-  "mirage-mtime" {with-test}
+  "mirage-ptime"
+  "mirage-mtime"
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.6.1/opam
+++ b/packages/irmin-cli/irmin-cli.3.6.1/opam
@@ -48,7 +48,11 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
-  "tls" {< "2.0.0" & with-test}
+]
+
+conflicts: [
+  "mirage-ptime" {with-test}
+  "mirage-mtime" {with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.7.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.7.0/opam
@@ -51,8 +51,8 @@ depends: [
 ]
 
 conflicts: [
-  "mirage-ptime" {with-test}
-  "mirage-mtime" {with-test}
+  "mirage-ptime"
+  "mirage-mtime"
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.7.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.7.0/opam
@@ -48,7 +48,11 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
-  "tls" {< "2.0.0" & with-test}
+]
+
+conflicts: [
+  "mirage-ptime" {with-test}
+  "mirage-mtime" {with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.7.1/opam
+++ b/packages/irmin-cli/irmin-cli.3.7.1/opam
@@ -51,8 +51,8 @@ depends: [
 ]
 
 conflicts: [
-  "mirage-ptime" {with-test}
-  "mirage-mtime" {with-test}
+  "mirage-ptime"
+  "mirage-mtime"
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.7.1/opam
+++ b/packages/irmin-cli/irmin-cli.3.7.1/opam
@@ -48,7 +48,11 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
-  "tls" {< "2.0.0" & with-test}
+]
+
+conflicts: [
+  "mirage-ptime" {with-test}
+  "mirage-mtime" {with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.7.2/opam
+++ b/packages/irmin-cli/irmin-cli.3.7.2/opam
@@ -51,8 +51,8 @@ depends: [
 ]
 
 conflicts: [
-  "mirage-ptime" {with-test}
-  "mirage-mtime" {with-test}
+  "mirage-ptime"
+  "mirage-mtime"
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.7.2/opam
+++ b/packages/irmin-cli/irmin-cli.3.7.2/opam
@@ -48,7 +48,11 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {with-test & >= "2.0.0" & < "2.4"}
-  "tls" {< "2.0.0" & with-test}
+]
+
+conflicts: [
+  "mirage-ptime" {with-test}
+  "mirage-mtime" {with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.8.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.8.0/opam
@@ -48,7 +48,11 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {>= "2.0.0" & with-test}
-  "tls" {< "2.0.0" & with-test}
+]
+
+conflicts: [
+  "mirage-ptime" {with-test}
+  "mirage-mtime" {with-test}
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.8.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.8.0/opam
@@ -51,8 +51,8 @@ depends: [
 ]
 
 conflicts: [
-  "mirage-ptime" {with-test}
-  "mirage-mtime" {with-test}
+  "mirage-ptime"
+  "mirage-mtime"
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.9.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.9.0/opam
@@ -53,8 +53,8 @@ depends: [
 ]
 
 conflicts: [
-  "mirage-ptime" {with-test}
-  "mirage-mtime" {with-test}
+  "mirage-ptime"
+  "mirage-mtime"
 ]
 
 synopsis: "CLI for Irmin"

--- a/packages/irmin-cli/irmin-cli.3.9.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.9.0/opam
@@ -50,7 +50,11 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {>= "2.0.0" & with-test}
-  "tls" {< "2.0.0" & with-test}
+]
+
+conflicts: [
+  "mirage-ptime" {with-test}
+  "mirage-mtime" {with-test}
 ]
 
 synopsis: "CLI for Irmin"


### PR DESCRIPTION
The issue is:
+File "_none_", line 1:
+Error: Reference to undefined global `Mirage_mtime'

While it does some toplevel stuff. Now, it seems that these dune variants need to be manually loaded (as is digestif.ocaml in the same mdx). So, my suspicion is we need this conflict.

revises https://github.com/ocaml/opam-repository/pull/27398