### PR TITLE
[new release] reason (2 packages) (3.15.0)

### DIFF
--- a/packages/reason/reason.3.15.0/opam
+++ b/packages/reason/reason.3.15.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Reason: Syntax & Toolchain for OCaml"
+description: """
+Reason gives OCaml a new syntax that is remniscient of languages like
+JavaScript. It's also the umbrella project for a set of tools for the OCaml &
+JavaScript ecosystem."""
+maintainer: [
+  "Jordan Walke <jordojw@gmail.com>"
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+]
+authors: ["Jordan Walke <jordojw@gmail.com>"]
+license: "MIT"
+homepage: "https://reasonml.github.io/"
+bug-reports: "https://github.com/reasonml/reason/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.06" & < "5.4"}
+  "ocamlfind" {build}
+  "dune-build-info" {>= "2.9.3"}
+  "menhir" {>= "20180523"}
+  "merlin-extend" {>= "0.6.2"}
+  "fix"
+  "ppx_derivers"
+  "cppo"
+  "ppxlib" {>= "0.28.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reasonml/reason.git"
+url {
+  src:
+    "https://github.com/reasonml/reason/releases/download/3.15.0/reason-3.15.0.tbz"
+  checksum: [
+    "sha256=2dc61c0ad42c0c334ec918c997d087c7e7ac8748622188359808025f4214b15f"
+    "sha512=adcb2bafbeccc1d1b515dfea1a7dbb57c01baf3d2ae95f728bcb11b02f09efda6d11ba3705f89c1d6750b2f624f201039d5a2fc3339a929ba5520a5a3e539eee"
+  ]
+}
+x-commit-hash: "2db8f7a4d2703b5c7e656f9f8b507215461b67a8"

--- a/packages/reason/reason.3.15.0/opam
+++ b/packages/reason/reason.3.15.0/opam
@@ -35,7 +35,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]
@@ -44,8 +43,8 @@ url {
   src:
     "https://github.com/reasonml/reason/releases/download/3.15.0/reason-3.15.0.tbz"
   checksum: [
-    "sha256=2dc61c0ad42c0c334ec918c997d087c7e7ac8748622188359808025f4214b15f"
-    "sha512=adcb2bafbeccc1d1b515dfea1a7dbb57c01baf3d2ae95f728bcb11b02f09efda6d11ba3705f89c1d6750b2f624f201039d5a2fc3339a929ba5520a5a3e539eee"
+    "sha256=ec3d2025f4391f0d2b88d2053e627a85aa1addd9c51320e9e72c690e05fb66a6"
+    "sha512=2bc7681a0e7649f619a8e93e961690531f697fadb1ae5d3f2c5913b0fce6995780394f2ce5b3e1920902ca7a2f4e188f62696f58f20ae3dd81c3658528bd0a33"
   ]
 }
-x-commit-hash: "2db8f7a4d2703b5c7e656f9f8b507215461b67a8"
+x-commit-hash: "71797e1529a7d08312e4741ba64562f362878047"

--- a/packages/rtop/rtop.3.15.0/opam
+++ b/packages/rtop/rtop.3.15.0/opam
@@ -28,7 +28,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]
@@ -37,8 +36,8 @@ url {
   src:
     "https://github.com/reasonml/reason/releases/download/3.15.0/reason-3.15.0.tbz"
   checksum: [
-    "sha256=2dc61c0ad42c0c334ec918c997d087c7e7ac8748622188359808025f4214b15f"
-    "sha512=adcb2bafbeccc1d1b515dfea1a7dbb57c01baf3d2ae95f728bcb11b02f09efda6d11ba3705f89c1d6750b2f624f201039d5a2fc3339a929ba5520a5a3e539eee"
+    "sha256=ec3d2025f4391f0d2b88d2053e627a85aa1addd9c51320e9e72c690e05fb66a6"
+    "sha512=2bc7681a0e7649f619a8e93e961690531f697fadb1ae5d3f2c5913b0fce6995780394f2ce5b3e1920902ca7a2f4e188f62696f58f20ae3dd81c3658528bd0a33"
   ]
 }
-x-commit-hash: "2db8f7a4d2703b5c7e656f9f8b507215461b67a8"
+x-commit-hash: "71797e1529a7d08312e4741ba64562f362878047"

--- a/packages/rtop/rtop.3.15.0/opam
+++ b/packages/rtop/rtop.3.15.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Reason toplevel"
+description:
+  "rtop is the toplevel (or REPL) for Reason, based on utop (https://github.com/ocaml-community/utop)."
+maintainer: [
+  "Jordan Walke <jordojw@gmail.com>"
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+]
+authors: ["Jordan Walke <jordojw@gmail.com>"]
+license: "MIT"
+homepage: "https://reasonml.github.io/"
+bug-reports: "https://github.com/reasonml/reason/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.06" & < "5.4"}
+  "reason" {= version}
+  "utop" {>= "2.0"}
+  "cppo"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reasonml/reason.git"
+url {
+  src:
+    "https://github.com/reasonml/reason/releases/download/3.15.0/reason-3.15.0.tbz"
+  checksum: [
+    "sha256=2dc61c0ad42c0c334ec918c997d087c7e7ac8748622188359808025f4214b15f"
+    "sha512=adcb2bafbeccc1d1b515dfea1a7dbb57c01baf3d2ae95f728bcb11b02f09efda6d11ba3705f89c1d6750b2f624f201039d5a2fc3339a929ba5520a5a3e539eee"
+  ]
+}
+x-commit-hash: "2db8f7a4d2703b5c7e656f9f8b507215461b67a8"


### PR DESCRIPTION
Reason: Syntax & Toolchain for OCaml

- Project page: <a href="https://reasonml.github.io/">https://reasonml.github.io/</a>

##### CHANGES:

- rtop: read `~/.config/rtop/init.re` configuration file (@anmonteiro,
  [reasonml/reason#2813](https://github.com/reasonml/reason/pull/2813))
    - the `-init FILE` flag works as before
- rtop: ignore `~/.ocamlinit.ml` or `~/.config/utop/init.ml` config files
  (@anmonteiro, [reasonml/reason#2813](https://github.com/reasonml/reason/pull/2813))
- Add support for raw identifier syntax (@anmonteiro,
  [reasonml/reason#2796](https://github.com/reasonml/reason/pull/2796))
- Fix: display attributes in record field and JSX props under punning
  (@pedrobslisboa, [reasonml/reason#2824](https://github.com/reasonml/reason/pull/2824))
- Support modest Unicode letters in identifiers
  (@anmonteiro, [reasonml/reason#2828](https://github.com/reasonml/reason/pull/2828))
- refmt: fix file descriptor leak
  (@anmonteiro, [reasonml/reason#2830](https://github.com/reasonml/reason/pull/2830))
