### PR TITLE
[new release] melange (5.0.0)

### DIFF
--- a/packages/melange/melange.5.0.0-414/opam
+++ b/packages/melange/melange.5.0.0-414/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "4.14" & < "5.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {dev & with-test}
+  "ppxlib" {>= "0.30.0"}
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/5.0.0-414/melange-5.0.0-414.tbz"
+  checksum: [
+    "sha256=d3bfad131e9be5d518f78f551762b6d87a914a82a6bc1c27c68ec1fc6a9bfaba"
+    "sha512=d496721aba46a93df32858ecb35f4a3ec9d8511d6db0525cfaba0ebd5fd3911ec93e00a1cd2ecf5063fa38df61af544e22adc0a5170db43e76d995bfaf62a0fc"
+  ]
+}
+x-commit-hash: "212c9c51e9b3f81bec7fb4b612cba0a45739aae4"

--- a/packages/melange/melange.5.0.0-51/opam
+++ b/packages/melange/melange.5.0.0-51/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "5.3"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {dev & with-test}
+  "ppxlib" {>= "0.30.0"}
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/5.0.0-51/melange-5.0.0-51.tbz"
+  checksum: [
+    "sha256=55aacaadd212ed0063910a17e9f870367d31955314f1b3b78b93a380a69dba90"
+    "sha512=dd01e7dd2549af15f815f631929e6488e5eee619106de46d5ff179eb370afcbc9ce201ddf56eb4a416bffdb7ef562253518b0cc17e39ad5e72a1d699892c1c9c"
+  ]
+}
+x-commit-hash: "5f374a1048eade8a7be06a4bb1b932a053e4aa82"

--- a/packages/melange/melange.5.0.0-52/opam
+++ b/packages/melange/melange.5.0.0-52/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "5.2" & < "5.3"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {dev & with-test}
+  "ppxlib" {>= "0.30.0"}
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/5.0.0-52/melange-5.0.0-52.tbz"
+  checksum: [
+    "sha256=0f28c188cbe7087b9f15ea64f311cc326554fa3ff2102bd5ecccb859e016e164"
+    "sha512=9a1f163a31c5715f213240b21f904c7fcee521e8739a612645389a6aefc872f527c2498fc90a4b234dee38cc0cf09fc723a340690b0ae44de8a22d9bc51fee42"
+  ]
+}
+x-commit-hash: "e09eeff6112d8c5daf2d24f37be1f9ccb69e523e"

--- a/packages/melange/melange.5.0.0-53/opam
+++ b/packages/melange/melange.5.0.0-53/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "5.3"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {dev & with-test}
+  "ppxlib" {>= "0.30.0"}
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/5.0.0-53/melange-5.0.0-53.tbz"
+  checksum: [
+    "sha256=659dff4dd844250ef8437c09916aa888e3447d5eb1efbcf449bafc7008ab5db0"
+    "sha512=1051b793452b3a7e053aa3ca6d2e3742d75eb39da04bce8e53fc8753fa593391446342604a6740f9c346e81b2781a709648bf6a8a97a2342e2549c7401a1b0eb"
+  ]
+}
+x-commit-hash: "db197fbdbc5d65599925ca35b125385a1b8d80c0"


### PR DESCRIPTION
CHANGES:

- Make the `unprocessed` alert fatal by default ([melange-re/melange#1135](https://github.com/melange-re/melange/pull/1135))
- support `-H` for hidden include dirs in OCaml 5.2 ([melange-re/melange#1137](https://github.com/melange-re/melange/pull/1137))
- support `[@mel.*]` attributes in uncurried externals ([melange-re/melange#1140](https://github.com/melange-re/melange/pull/1140))
- add Worker types to `melange.dom` ([melange-re/melange#1147](https://github.com/melange-re/melange/pull/1147))
- Add support for dynamic `import()` ([melange-re/melange#1164](https://github.com/melange-re/melange/pull/1164))
- Fix code generation of custom `true` / `false` constructors ([melange-re/melange#1175](https://github.com/melange-re/melange/pull/1175))
- Fix code generation of OCaml objects that refers to an init variable in scope ([melange-re/melange#1183](https://github.com/melange-re/melange/pull/1183))
- Support `[@mel.as "string"]` in variant definitions ([melange-re/melange#884](https://github.com/melange-re/melange/pull/884))
- BREAKING: remove `[@@deriving jsConverter]` for variant definitions ([melange-re/melange#884](https://github.com/melange-re/melange/pull/884)). Use `[@mel.as "string here"]` instead.
- Support OCaml 5.3 ([melange-re/melange#1168](https://github.com/melange-re/melange/pull/1168))
- Upgrade Stdlib to the OCaml 5.3 Stdlib ([melange-re/melange#1182](https://github.com/melange-re/melange/pull/1182))
- Support `[@mel.tag "the_tag"]` in variant definitions ([melange-re/melange#1189](https://github.com/melange-re/melange/pull/1189))
  - combined with `[@mel.as ..]` in variant definitions and inline record payloads, Melange can now express types for discriminated union object shapes.
- melange-ppx: don't silence warning 20 (`ignored-extra-argument`) for `%mel.raw` application ([melange-re/melange#1166](https://github.com/melange-re/melange/pull/1166)).
  - This change reverts the behavior introduced in ([melange-re/melange#915](https://github.com/melange-re/melange/pull/915)).
  - The new recommendation is to annotate `%mel.raw` functions or disable warning 20 at the project level.
- ppx,core: propagate internal FFI information via attributes instead of adding marshalled data in the native primitive name ([melange-re/melange#1222](https://github.com/melange-re/melange/pull/1222))
- melange-ppx: allow `@mel.unwrap` polyvariants not to have a payload ([melange-re/melange#1239](https://github.com/melange-re/melange/pull/1239))
- `melange.node`: fix `Buffer.fromString` and add `Buffer.fromStringWithEncoding` ([melange-re/melange#1246](https://github.com/melange-re/melange/pull/1246))
- `melange.node`: bind to all supported Node.js `Buffer` encodings in `Node.Buffer` ([melange-re/melange#1246](https://github.com/melange-re/melange/pull/1246))
- `melange.js`: Add `Js.FormData` with bindings to the [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) API ([melange-re/melange#1153](https://github.com/melange-re/melange/pull/1153), [melange-re/melange#1270](https://github.com/melange-re/melange/pull/1270), [melange-re/melange#1281](https://github.com/melange-re/melange/pull/1281)
- `melange.js`: Add `Js.Blob` and `Js.File` with bindings to the [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) and [File](https://developer.mozilla.org/en-US/docs/Web/API/File) APIs ([melange-re/melange#1218](https://github.com/melange-re/melange/pull/1218))
- `melange.js`: add `TypedArray` types at the toplevel in the `Js` module ([melange-re/melange#1248](https://github.com/melange-re/melange/pull/1248))
- BREAKING: remove `--mel-g` ([melange-re/melange#1234](https://github.com/melange-re/melange/pull/1234))
- runtime(`melange.js`): port `[@mel.send.pipe]` functions to `[@mel.send]`, taking advantage of the `@mel.send` + labeled argument improvement (see above) ([melange-re/melange#1260](https://github.com/melange-re/melange/pull/1260), [melange-re/melange#1264](https://github.com/melange-re/melange/pull/1264), [melange-re/melange#1265](https://github.com/melange-re/melange/pull/1265), [melange-re/melange#1266](https://github.com/melange-re/melange/pull/1266), [melange-re/melange#1280](https://github.com/melange-re/melange/pull/1280), [melange-re/melange#1278](https://github.com/melange-re/melange/pull/1278))
- core: fix a crash related to finding constructor names in pattern matching triggered by dune's earlier implementation of `(implicit_transitive_deps false)` ([melange-re/melange#1238](https://github.com/melange-re/melange/pull/1238), [melange-re/melange#1262](https://github.com/melange-re/melange/pull/1262))
- core: pre-compute the closure param map for functions inlined with `--mel-cross-module-opt` ([melange-re/melange#1219](https://github.com/melange-re/melange/pull/1219))
- BREAKING: ppx: print the `deprecated` alert for `@@deriving abstract` at the declaration site rather than at (all) usages ([melange-re/melange#1269](https://github.com/melange-re/melange/pull/1269))
- JS generation: prettify `for` loops ([melange-re/melange#1275](https://github.com/melange-re/melange/pull/1275))
- JS generation: improve formatting for `throw` and `return` statements, JS objects ([melange-re/melange#1286](https://github.com/melange-re/melange/pull/1286), [melange-re/melange#1289](https://github.com/melange-re/melange/pull/1289))
- JS generation: improve formatting for empty return and continue statements ([melange-re/melange#1288](https://github.com/melange-re/melange/pull/1288))
- JS generation: remove trailing spaces before commas in `export` ([melange-re/melange#1287](https://github.com/melange-re/melange/pull/1287))
- JS generation: remove redundant switch cases branches ([melange-re/melange#1295](https://github.com/melange-re/melange/pull/1295))
- JS generation: move space before comma inside `for` definition ([melange-re/melange#1296](https://github.com/melange-re/melange/pull/1296))
- JS generation: add space before while loop condition ([melange-re/melange#1297](https://github.com/melange-re/melange/pull/1297))
- JS generation: improve indentation of parenthesized blocks ([melange-re/melange#1293](https://github.com/melange-re/melange/pull/1293))
- JS generation: add space after constructor comments ([melange-re/melange#1294](https://github.com/melange-re/melange/pull/1294))
- JS generation: improve identation of `switch` cases ([melange-re/melange#1299](https://github.com/melange-re/melange/pull/1299))
- JS generation: don't generate empty `default:` cases in `switch` ([melange-re/melange#1300](https://github.com/melange-re/melange/pull/1300))
- JS generation: emit `module.exports` in CommonJS instead of `exports.x` ([melange-re/melange#1314](https://github.com/melange-re/melange/pull/1314))
- JS generation: remove trailing newline after `switch` ([melange-re/melange#1313](https://github.com/melange-re/melange/pull/1313))
- ffi: allow annotating `@mel.send` FFI with `@mel.this` to specify which parameter should represent the "self" argument. ([melange-re/melange#1303](https://github.com/melange-re/melange/pull/1285), [melange-re/melange#1310](https://github.com/melange-re/melange/pull/1310))
  - This improvement to the FFI allows expressing more FFI constructs via labeled and optionally labeled arguments, e.g. `external foo: value:string -> (t [@mel.this]) -> unit = "foo" [@@mel.send]` will now produce `t.foo(value)` instead of `value.foo(t)`.
  - It also allows removing usages of `[@mel.send.pipe: t]` in favor of `[@mel.send]` with `[@mel.this]`, including when used with `@mel.variadic`.
- ppx: deprecate `[@mel.send.pipe]` ([melange-re/melange#1321](https://github.com/melange-re/melange/pull/1321))
- core: fix missed optimization on OCaml versions 5.2 and above, caused by [ocaml/ocaml#12236](https://github.com/ocaml/ocaml/pull/12236) generating multiple function nodes for `fun a -> fun b -> ...` in the Lambda IR.