### PR TITLE
[new release] mirage-kv-mem (4.0.0)

### DIFF
--- a/packages/caldav/caldav.0.1.0/opam
+++ b/packages/caldav/caldav.0.1.0/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-random-test" {with-test}
   "tcpip" {with-test & >= "3.7.0"}
   "mirage-clock-unix" {with-test & >= "2.0.0"}
-  "mirage-kv-mem" {with-test & >= "2.0.0"}
+  "mirage-kv-mem" {with-test & >= "2.0.0" & < "4.0.0"}
   "mirage-kv" {>= "3.0.0" & < "6.0.0"}
   "mirage-clock" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0" & < "4.0.0"}

--- a/packages/caldav/caldav.0.1.1/opam
+++ b/packages/caldav/caldav.0.1.1/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-random-test" {with-test}
   "tcpip" {with-test & >= "3.7.0"}
   "mirage-clock-unix" {with-test & >= "2.0.0"}
-  "mirage-kv-mem" {with-test & >= "2.0.0"}
+  "mirage-kv-mem" {with-test & >= "2.0.0" & < "4.0.0"}
   "fmt" {>= "0.8.7"}
   "mirage-kv" {>= "3.0.0" & < "6.0.0"}
   "mirage-clock" {>= "2.0.0"}

--- a/packages/caldav/caldav.0.2.0/opam
+++ b/packages/caldav/caldav.0.2.0/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-random-test" {with-test}
   "tcpip" {with-test & >= "3.7.0"}
   "mirage-clock-unix" {with-test & >= "2.0.0"}
-  "mirage-kv-mem" {with-test & >= "2.0.0"}
+  "mirage-kv-mem" {with-test & >= "2.0.0" & < "4.0.0"}
   "fmt" {>= "0.8.7"}
   "mirage-kv" {>= "3.0.0" & < "6.0.0"}
   "mirage-clock" {>= "2.0.0"}

--- a/packages/caldav/caldav.0.2.1/opam
+++ b/packages/caldav/caldav.0.2.1/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-random-test" {with-test}
   "tcpip" {with-test & >= "3.7.0"}
   "mirage-clock-unix" {with-test & >= "2.0.0"}
-  "mirage-kv-mem" {with-test & >= "2.0.0"}
+  "mirage-kv-mem" {with-test & >= "2.0.0" & < "4.0.0"}
   "fmt" {>= "0.8.7"}
   "mirage-kv" {>= "6.0.0"}
   "mirage-clock" {>= "2.0.0"}

--- a/packages/caldav/caldav.0.2.2/opam
+++ b/packages/caldav/caldav.0.2.2/opam
@@ -27,7 +27,7 @@ depends: [
   "ounit" {with-test & >= "2.0.0"}
   "tcpip" {with-test & >= "3.7.0"}
   "mirage-clock-unix" {with-test & >= "2.0.0"}
-  "mirage-kv-mem" {with-test & >= "2.0.0"}
+  "mirage-kv-mem" {with-test & >= "2.0.0" & < "4.0.0"}
   "fmt" {>= "0.8.7"}
   "mirage-kv" {>= "6.0.0"}
   "mirage-clock" {>= "2.0.0"}

--- a/packages/caldav/caldav.0.2.3/opam
+++ b/packages/caldav/caldav.0.2.3/opam
@@ -27,7 +27,7 @@ depends: [
   "ounit2" {with-test & >= "2.0.0"}
   "tcpip" {with-test & >= "3.7.0"}
   "mirage-clock-unix" {with-test & >= "2.0.0"}
-  "mirage-kv-mem" {with-test & >= "2.0.0"}
+  "mirage-kv-mem" {with-test & >= "2.0.0" & < "4.0.0"}
   "fmt" {>= "0.8.7"}
   "mirage-kv" {>= "6.0.0"}
   "mirage-clock" {>= "2.0.0"}

--- a/packages/crunch/crunch.3.0.0/opam
+++ b/packages/crunch/crunch.3.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "1.0"}
   "lwt" {with-test}
   "mirage-kv-lwt" {with-test & >= "2.0.0"}
-  "mirage-kv-mem" {with-test}
+  "mirage-kv-mem" {with-test & < "4.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/crunch/crunch.3.1.0/opam
+++ b/packages/crunch/crunch.3.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "1.0"}
   "lwt" {with-test}
   "mirage-kv" {with-test & >= "3.0.0"}
-  "mirage-kv-mem" {with-test & >= "3.0.0"}
+  "mirage-kv-mem" {with-test & >= "3.0.0" & < "4.0.0"}
 ]
 conflicts: [
   "mirage-kv" {< "3.0.0"}

--- a/packages/crunch/crunch.3.2.0/opam
+++ b/packages/crunch/crunch.3.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "1.0"}
   "lwt" {with-test}
   "mirage-kv" {with-test & >= "3.0.0"}
-  "mirage-kv-mem" {with-test & >= "3.0.0"}
+  "mirage-kv-mem" {with-test & >= "3.0.0" & < "4.0.0"}
 ]
 conflicts: [
   "mirage-kv" {< "3.0.0"}

--- a/packages/crunch/crunch.3.3.1/opam
+++ b/packages/crunch/crunch.3.3.1/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "2.5"}
   "lwt" {with-test}
   "mirage-kv" {with-test & >= "3.0.0"}
-  "mirage-kv-mem" {with-test & >= "3.0.0"}
+  "mirage-kv-mem" {with-test & >= "3.0.0" & < "4.0.0"}
   "fmt" {with-test}
 ]
 conflicts: [

--- a/packages/mirage-kv-mem/mirage-kv-mem.2.0.0/opam
+++ b/packages/mirage-kv-mem/mirage-kv-mem.2.0.0/opam
@@ -45,3 +45,4 @@ url {
     "md5=ae88011c01c5eb24520eaf44cbe0fb07"
   ]
 }
+x-maintenance-intent: [ "(latest)" ]

--- a/packages/mirage-kv-mem/mirage-kv-mem.4.0.0/opam
+++ b/packages/mirage-kv-mem/mirage-kv-mem.4.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/mirage/mirage-kv-mem"
+doc: "https://mirage.github.io/mirage-kv-mem/"
+bug-reports: "https://github.com/mirage/mirage-kv-mem/issues"
+dev-repo: "git+https://github.com/mirage/mirage-kv-mem.git"
+tags: [ "org:mirage" "org:robur" ]
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.3.0"}
+  "alcotest" {with-test}
+  "mirage-ptime" {>= "5.0.0"}
+  "mirage-kv" {>= "6.0.0"}
+  "fmt" {>= "0.9.0"}
+  "ptime" {>= "1.1.0"}
+  "optint" {>= "0.3.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+
+synopsis: "In-memory key value store for MirageOS"
+description: """
+Implements the mirage-kv interface, but does not provide a persistent data storage.
+Use for testing or amnesia.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv-mem/releases/download/v4.0.0/mirage-kv-mem-4.0.0.tbz"
+  checksum: [
+    "sha256=fabae062fceea192683143abb8334c5b3afefa13cfcaa18c42078e3e6a34a9e0"
+    "sha512=62f8b0c37c2a83a50bdebabbc21f473b0d6b4c591d19846f59b025b6038330c96c761ded17efde1732d4ba5957ab2eed3c360350896f08616d624e57d3127c8b"
+  ]
+}
+x-commit-hash: "df75cb046d665933caa32ffe3cf5dfc58ab89c1c"


### PR DESCRIPTION
In-memory key value store for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-kv-mem">https://github.com/mirage/mirage-kv-mem</a>
- Documentation: <a href="https://mirage.github.io/mirage-kv-mem/">https://mirage.github.io/mirage-kv-mem/</a>

##### CHANGES:

* Use dune variants and mirage-ptime instead of functorising over PCLOCK
  (mirage/mirage-kv-mem#6 @hannesm)
