### PR TITLE
[new release] memtrace-mirage (0.2.1.2.3)

### DIFF
--- a/packages/memtrace-mirage/memtrace-mirage.0.2.1.2.3/opam
+++ b/packages/memtrace-mirage/memtrace-mirage.0.2.1.2.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Streaming client for Memprof using MirageOS API"
+description: "Generates compact traces of a program's memory use."
+maintainer: ["team@robur.coop"]
+authors: [
+  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Robur Team <team@robur.coop>"
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+license: "MIT"
+homepage: "https://github.com/robur-coop/memtrace-mirage"
+bug-reports: "https://github.com/robur-coop/memtrace-mirage/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.11.0" & < "5"}
+  "mirage-flow" {>= "3.0.0"}
+  "mirage-ptime" {>= "5.0.0"}
+  "ptime" {>= "1.0.0"}
+  "lwt" {>= "5.5.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/robur-coop/memtrace-mirage.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/memtrace-mirage/releases/download/v0.2.1.2.3/memtrace-mirage-0.2.1.2.3.tbz"
+  checksum: [
+    "sha256=6e3e2e255c5ff5c31bf97b62f3c09673cb28f00a3f89d1fa8ad96a9fa32d6780"
+    "sha512=6415aa2bdb02657705a95cf13f2f02278dbf8ef8938f7fc3820ced48c12b192f6041005dc2b61840f56a5294e2a9dadd26487b89022dd49a461d035845a37614"
+  ]
+}
+x-commit-hash: "b46cee77711b805f966469c914796a4b1cdabd94"


### PR DESCRIPTION
Streaming client for Memprof using MirageOS API

- Project page: <a href="https://github.com/robur-coop/memtrace-mirage">https://github.com/robur-coop/memtrace-mirage</a>

##### CHANGES:

Remove functor for PCLOCK, it is now a variant (robur-coop/memtrace-mirage#1)
