### PR TITLE
[new release] albatross (2.4.1)

### DIFF
--- a/packages/albatross/albatross.2.4.1/opam
+++ b/packages/albatross/albatross.2.4.1/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/robur-coop/albatross"
+dev-repo: "git+https://github.com/robur-coop/albatross.git"
+bug-reports: "https://github.com/robur-coop/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "2.7.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "5.3.0"}
+  "logs"
+  "bos" {>= "0.2.0"}
+  "ptime" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "1.0.0"}
+  "tls" {>= "1.0.2"}
+  "tls-lwt" {>= "1.0.2"}
+  "asn1-combinators" {>= "0.3.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "ohex" {>= "0.2.0"}
+  "http-lwt-client" {>= "0.3.0"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.4.0"}
+  "cachet" {>= "0.0.2"}
+  "fpath" {>= "0.7.3"}
+  "logs-syslog" {>= "0.4.1"}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/albatross/releases/download/v2.4.1/albatross-2.4.1.tbz"
+  checksum: [
+    "sha256=fca03a99220d743386ed97900271e2fb1e38c48c56f10faa2a47757fc931db8e"
+    "sha512=ee608bcd42047f702bfe6007f664dc10d71faa4f2aeaedf278802c58f6b3bcfe35d53ebcb73f5e3ce59bbc9e6bfa8f27e81051d10a690876fa035b0279e950da"
+  ]
+}
+x-commit-hash: "79b3b9a180ffd566e869db27ee7c70d185e2f8bd"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/robur-coop/albatross">https://github.com/robur-coop/albatross</a>

##### CHANGES:

* Re-add ptime 1.1.0 compatibility (dune-universe/opam-overlays only ships 1.1.0)
