### PR TITLE
[new release] mirage-qubes (2 packages) (2.0.0)

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.2.0.0/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.2.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "mirage-qubes" {= version}
+  "tcpip" { >= "9.0.0" }
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "ipaddr" { >= "3.0.0" }
+  "lwt" { >= "5.7.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v2.0.0/mirage-qubes-2.0.0.tbz"
+  checksum: [
+    "sha256=708b9bbb7faea04b05bf694c253b440b638a83852420ee2b22604cd2bfe1849f"
+    "sha512=02e439a531ecd2cdaab1683378021d7e0773c6743bb46d282f1eb43c67e304085e8fe42def717f86285e09f0893a5a0b78cf76a7622010d3767331d83bd33e3b"
+  ]
+}
+x-commit-hash: "ff58fca6f334cad15076cd42ab173c84dd6a6ff3"

--- a/packages/mirage-qubes/mirage-qubes.2.0.0/opam
+++ b/packages/mirage-qubes/mirage-qubes.2.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "cstruct" { >= "6.0.0" }
+  "vchan-xen" { >= "6.0.0" }
+  "mirage-xen" { >= "8.0.0" }
+  "lwt" { >= "5.7.0" }
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.08.0" }
+  "ohex" { >= "0.2.0" }
+  "fmt" {>= "0.8.5"}
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+description: """
+Implementations of various Qubes protocols:
+
+- Qubes.RExec: provide services to other VMs
+- Qubes.GUI: just enough of the GUI protocol so that Qubes accepts the AppVM
+- Qubes.DB: read and write the VM's QubesDB database"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v2.0.0/mirage-qubes-2.0.0.tbz"
+  checksum: [
+    "sha256=708b9bbb7faea04b05bf694c253b440b638a83852420ee2b22604cd2bfe1849f"
+    "sha512=02e439a531ecd2cdaab1683378021d7e0773c6743bb46d282f1eb43c67e304085e8fe42def717f86285e09f0893a5a0b78cf76a7622010d3767331d83bd33e3b"
+  ]
+}
+x-commit-hash: "ff58fca6f334cad15076cd42ab173c84dd6a6ff3"


### PR DESCRIPTION
Implementations of various Qubes protocols for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-qubes">https://github.com/mirage/mirage-qubes</a>
- Documentation: <a href="https://mirage.github.io/mirage-qubes">https://mirage.github.io/mirage-qubes</a>

##### CHANGES:

- Adapt to tcpip 9.0.0 API changes (mirage/mirage-qubes#75, @hannesm)
