### PR TITLE
remove duplicate `x-ci-accept-failures` in `pa_ppx_q_ast.0.12`

### DIFF
--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.12/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.12/opam
@@ -39,7 +39,6 @@ depends: [
 conflicts: [
    "pa_ppx_parsetree" { <= "0.02" }
 ]
-x-ci-accept-failures: [ "opensuse-tumbleweed" ]
 build: [
   [make "sys"]
   [make "test"] {with-test}


### PR DESCRIPTION
I noticed this when running opam2json over opam-repository due to https://github.com/tweag/opam2json/issues/2

It looks like the duplicate field was introduced here https://github.com/ocaml/opam-repository/pull/27092/files#diff-8121447724b4236b184edeb9b12f666c5674051a89ac01748bf97a286d3b0d1cR17

CC @chetmurthy @mseri

Thanks!