### PR TITLE
add upper bounds for dns-client and mirage-crypto-rng-mirage

### DIFF
--- a/packages/caqti-mirage/caqti-mirage.2.1.2/opam
+++ b/packages/caqti-mirage/caqti-mirage.2.1.2/opam
@@ -10,7 +10,7 @@ depends: [
   "caqti-lwt" {>= "2.1.0" & < "2.2.0~"}
   "caqti-tls" {>= "2.1.0" & < "2.2.0~"}
   "dns-client" {>= "7.0.0"}
-  "dns-client-mirage" {>= "7.0.0"}
+  "dns-client-mirage" {>= "7.0.0" & < "10.0.0"}
   "domain-name"
   "dune" {>= "3.9"}
   "ipaddr"
@@ -18,7 +18,7 @@ depends: [
   "lwt" {>= "5.3.0"}
   "mirage-channel"
   "mirage-clock"
-  "mirage-crypto-rng-mirage" {>= "1.0.0"}
+  "mirage-crypto-rng-mirage" {>= "1.0.0" & < "2.0.0"}
   "mirage-time"
   "ocaml"
   "odoc" {with-doc}


### PR DESCRIPTION
observed in https://github.com/ocaml/opam-repository/pull/27408

the error is "Unbound module type Mirage_crypto_rng_mirage.S"