### PR TITLE
dkim-mirage: add upper bound for dns-client release

### DIFF
--- a/packages/dkim-mirage/dkim-mirage.0.7.0/opam
+++ b/packages/dkim-mirage/dkim-mirage.0.7.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml"             {>= "4.08.0"}
   "dune"              {>= "2.0.0"}
   "dkim"              {= version}
-  "dns-client-mirage" {>= "8.0.0"}
+  "dns-client-mirage" {>= "8.0.0" & < "10.0.0"}
   "mirage-clock"
   "tcpip"             {>= "7.0.0"}
   "lwt"


### PR DESCRIPTION
observed in https://github.com/ocaml/opam-repository/pull/27408

the error is "Library "mirage-time" not found." - a dependency of dns-client-mirage < 10.0.0. the dkim package will need to be adjusted and a new release is needed to conform with the new ecosystem (fewer functors)