### PR TITLE
release pa_ppx.0.17: major upgrade for sexp deriver

### DIFF
--- a/packages/pa_ppx/pa_ppx.0.17/opam
+++ b/packages/pa_ppx/pa_ppx.0.17/opam
@@ -37,7 +37,7 @@ doc: "https://github.com/camlp5/pa_ppx/doc"
 x-ci-accept-failures: [ "opensuse-tumbleweed" ]
 
 depends: [
-  "ocaml"       { >= "4.10.0" & < "5.04.0" }
+  "ocaml"       { >= "4.10.0" & < "5.4.0" }
   "conf-perl"
   "camlp5-buildscripts" { >= "0.03" }
   "camlp5"      { >= "8.03.01" }

--- a/packages/pa_ppx/pa_ppx.0.17/opam
+++ b/packages/pa_ppx/pa_ppx.0.17/opam
@@ -71,6 +71,6 @@ install: [make "install"]
 url {
   src: "https://github.com/camlp5/pa_ppx/archive/refs/tags/0.17.tar.gz"
   checksum: [
-    "sha512=5b6361d4115c511bc844d89ac8ebed2b4fd2cf3aadcf036b1738e2ad15469775375fc56f2b8ae128ef21198a202378006db9858618e73ff24b9ba04767668f2e"
+    "sha512=2cf78681f647bfca058fe0fa82ff91078c7aaee82e2a44f7988d3a0d858bdefc1e8b51c04e4904eb2d1a9f1867688eb55334a32d62120f1a9d3f514ff17e97b0"
   ]
 }

--- a/packages/pa_ppx/pa_ppx.0.17/opam
+++ b/packages/pa_ppx/pa_ppx.0.17/opam
@@ -1,0 +1,76 @@
+
+synopsis: "PPX Rewriters for Ocaml, written using Camlp5"
+description:
+"""
+This is a collection of PPX rewriters, re-implementing those based on ppxlib
+and other libraries, but instead based on Camlp5.  Included is also a collection
+of support libraries for writing new PPX rewriters.  Included are:
+
+pa_assert: ppx_assert
+pa_ppx.deriving, pa_ppx.deriving_plugins (enum, eq, fold, iter, make, map, ord, sexp, show, yojson):
+  ppx_deriving, plugins, ppx_sexp_conv, ppx_deriving_yojson
+pa_ppx.expect_test: ppx_expect_test
+pa_ppx.here: ppx_here
+pa_ppx.import: ppx_import
+pa_ppx.inline_test: ppx_inline_test
+
+pa_ppx.undo_deriving: pa_ppx.deriving expands [@@deriving ...] into code; this rewriter undoes that.
+pa_ppx.unmatched_vala: expands to match-cases (support library for camlp5-based PPX rewriters)
+pa_ppx.hashrecons: support for writing AST rewriters that automatically fills in hash-consing boilerplate
+pa_dock: implements doc-comment extraction for camlp5 preprocessors
+
+Many of the reimplementations in fact offer significant enhanced
+function, described in the pa_ppx documentation.  In addition, there
+is an extensive test-suite, much of it slightly modified versions of
+the tests for the respective PPX rewriters.
+
+"""
+opam-version: "2.0"
+x-maintenance-intent: [ "(latest)" ]
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx.git"
+doc: "https://github.com/camlp5/pa_ppx/doc"
+x-ci-accept-failures: [ "opensuse-tumbleweed" ]
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "5.04.0" }
+  "conf-perl"
+  "camlp5-buildscripts" { >= "0.03" }
+  "camlp5"      { >= "8.03.01" }
+  "not-ocamlfind" { >= "0.10" }
+  "pcre2"
+  "result" { >= "1.5" }
+  "yojson" { >= "1.7.0" }
+  "sexplib0"
+  "bos" { >= "0.2.0" }
+  "fmt"
+  "uint" { >= "2.0.1" }
+  "ounit"
+  "cppo"
+  "sexplib" { with-test & >= "v0.14.0" }
+  "ppx_import" { with-test & >= "1.7.1"  & <= "1.11.0" }
+  "ppx_deriving" { with-test & >= "6.0.2" }
+  "ppx_deriving_yojson" { with-test & >= "3.5.2" & >= "3.8.0" }
+  "ppx_here" { with-test & >= "v0.13.0" }
+  "ppx_sexp_conv" { with-test & >= "v0.13.0" }
+#  "expect_test_helpers" { with-test & >= "v0.13.0" }
+]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
+build: [
+  [make "get-generated"]
+  [make "-j%{jobs}%" "DEBUG=-g" "sys"]
+  [make "DEBUG=-g" "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx/archive/refs/tags/0.17.tar.gz"
+  checksum: [
+    "sha512=5b6361d4115c511bc844d89ac8ebed2b4fd2cf3aadcf036b1738e2ad15469775375fc56f2b8ae128ef21198a202378006db9858618e73ff24b9ba04767668f2e"
+  ]
+}


### PR DESCRIPTION
brought over ppx_sexp_conv unit-test and updated pa_ppx.deriving_plugins.sexp to pass everything that made sense.