### PR TITLE
Package rocq-pil.1.0.1

### DIFF
--- a/packages/rocq-pil/rocq-pil.1.0.1/opam
+++ b/packages/rocq-pil/rocq-pil.1.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Rocq library for Propositional Intuitionistic Logic & Pitts Interpolation Library"
+
+homepage: "https://github.com/hferee/rocq-pil"
+dev-repo: "git+https://github.com/hferee/rocq-pil.git"
+bug-reports: "https://github.com/hferee/rocq-pil/issues"
+doc: "https://hferee.github.io/UIML"
+maintainer: "feree@irif.fr"
+authors: [
+  "Hugo Férée"
+  "Sam van Gool"
+  "Yago Iglesias Vasquez"
+]
+license: "CECILL-2.1"
+
+depends: [
+  "dune" {>= "3.8"}
+  "coq" {>= "8.20.1"}
+  "coq-stdpp" {>= "1.11.0"}
+  "coq-equations" {}
+]
+
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+url {
+  src: "https://github.com/hferee/rocq-pil/archive/1.0.0.tar.gz"
+  checksum: "sha256=45f516160f30506e2605fba55ff94c1d5dd53e43815b29b8d04b53119d0b43b2"
+}
+
+tags: [
+  "date:2025-02-14"
+  "keyword:intuitionistic logic"
+  "keyword:proof theory"
+  "keyword:propositional quantifiers"
+  "category:CS/Algo/Decision procedures"
+  "category:Math/Logic/Foundations"
+  "category:Math/Logic/Modal Logic"
+  "logpath:ISL"
+]


### PR DESCRIPTION
### `rocq-pil.1.0.1`
Rocq library for Propositional Intuitionistic Logic & Pitts Interpolation Library



---
* Homepage: https://github.com/hferee/rocq-pil
* Source repo: git+https://github.com/hferee/rocq-pil.git
* Bug tracker: https://github.com/hferee/rocq-pil/issues

---
:camel: Pull-request generated by opam-publish v2.5.0