### PR TITLE
Package dbase4.0.1.5

### DIFF
--- a/packages/dbase4/dbase4.0.1.5/opam
+++ b/packages/dbase4/dbase4.0.1.5/opam
@@ -12,10 +12,10 @@ bug-reports: "https://github.com/hothing/ocaml-libdbf/issues"
 depends: [
   "dune" {>= "3.17"}
   "ocaml" {>= "5.2"}
-  "cstruct"
-  "ppx_cstruct"
-  "bitstring"
-  "ppx_bitstring"
+  "cstruct" {>= "6.2"}
+  "ppx_cstruct" {>= "6.2"}
+  "bitstring" {>= "4.1"}
+  "ppx_bitstring" {>= "4.1"}
   "odoc" {with-doc}
   "alcotest" {with-test}
 ]
@@ -36,9 +36,9 @@ build: [
 dev-repo: "git+https://github.com/hothing/ocaml-libdbf.git"
 url {
   src:
-    "https://github.com/hothing/ocaml-libdbf/archive/refs/tags/0.1.5b.tar.gz"
+    "https://github.com/hothing/ocaml-libdbf/archive/refs/tags/0.1.5c.tar.gz"
   checksum: [
-    "md5=020f2d2c1353b0d2f299267af9f55e3a"
-    "sha512=4c47a5ac41b69a1c36441316417a9a20a5f3c1e1c49e6f06c20e31357c2a004c4b4c860c803c4ce1201c5b7ffaa439cb756fe7020fe943114d94f77b58513a8b"
+    "md5=52a463a2aeaa7752233bbad897ac9332"
+    "sha512=ea9d9dbecdabd15d7c46fb54ad73da957219c56bb574d5cb4f2f2be2b5b3abd3a604919ec76e059b6a36c9e1c0d59bebe4b990387cd930b3c18c4723b71587b9"
   ]
 }


### PR DESCRIPTION
### `dbase4.0.1.5`
A DBF/DBT files reader library
A DBF reader library with MEMO support and sequental record access



---
* Homepage: https://github.com/hothing/ocaml-libdbf
* Source repo: git+https://github.com/hothing/ocaml-libdbf.git
* Bug tracker: https://github.com/hothing/ocaml-libdbf/issues

---
:camel: Pull-request generated by opam-publish v2.5.0