### PR TITLE
release ocamlbuild 0.16.1

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.16.1/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.16.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+authors: ["Nicolas Pouillard" "Berke Durak"]
+homepage: "https://github.com/ocaml/ocamlbuild/"
+bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+license: "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
+doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
+dev-repo: "git+https://github.com/ocaml/ocamlbuild.git"
+synopsis:
+  "OCamlbuild is a build system with builtin rules to easily build most OCaml projects"
+
+build: [
+  [
+    make
+    "-f"
+    "configure.make"
+    "all"
+    "OCAMLBUILD_PREFIX=%{prefix}%"
+    "OCAMLBUILD_BINDIR=%{bin}%"
+    "OCAMLBUILD_LIBDIR=%{lib}%"
+    "OCAMLBUILD_MANDIR=%{man}%"
+    "OCAML_NATIVE=%{ocaml:native}%"
+    "OCAML_NATIVE_TOOLS=%{ocaml:native}%"
+  ]
+  [make "check-if-preinstalled" "all" "opam-install"]
+]
+
+conflicts: [
+  "base-ocamlbuild"
+  "ocamlfind" {< "1.6.2"}
+]
+
+depends: [
+  "ocaml" {>= "4.08"}
+  "ocamlfind" {with-test}
+  "menhirLib" {with-test}
+]
+
+url {
+  src: "https://github.com/ocaml/ocamlbuild/archive/refs/tags/0.16.1.tar.gz"
+  checksum: [
+    "sha512=e918b9a0081f271e507c7a4f4d5d5a7cdf818ca51c52acec1bac85ddad5f6cad078cb3c568252fbcf5401c2d75323ed8f50fdd881bda1c9632840320408393ae"
+  ]
+}


### PR DESCRIPTION
The ocamlbuild 0.16.0 release was not pushed on opam as the opam-ci caught compatibility issues, see
  https://github.com/ocaml/opam-repository/pull/27442

The present bugfix release should fix the compatibility issue @mseri caught and improve the CI situation (before: 555 packages broken, with all tgls releases and kinetic-client.0.0.9 known to be affected by the compatibility issue)