### PR TITLE
[new release] gettext (3 packages) (0.5.0)

### DIFF
--- a/packages/gettext-camomile/gettext-camomile.0.5.0/opam
+++ b/packages/gettext-camomile/gettext-camomile.0.5.0/opam
@@ -8,6 +8,7 @@ homepage: "https://github.com/gildor478/ocaml-gettext"
 doc: "https://gildor478.github.io/ocaml-gettext/"
 bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
 depends: [
+  "ocaml" {>= "4.14"}
   "dune" {>= "3.17"}
   "gettext" {= version}
   "camomile" {>= "2.0.0"}

--- a/packages/gettext-camomile/gettext-camomile.0.5.0/opam
+++ b/packages/gettext-camomile/gettext-camomile.0.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Internationalization library using camomile (i18n)"
+description: "See gettext package description."
+maintainer: ["Sylvain Le Gall <sylvain+ocaml@le-gall.net>"]
+authors: ["Sylvain Le Gall"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-gettext"
+doc: "https://gildor478.github.io/ocaml-gettext/"
+bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "gettext" {= version}
+  "camomile" {>= "2.0.0"}
+  "ounit2" {>= "2.2.7" & with-test}
+  "fileutils" {>= "0.6.6" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/gildor478/ocaml-gettext.git"
+url {
+  src:
+    "https://github.com/gildor478/ocaml-gettext/releases/download/v0.5.0/gettext-0.5.0.tbz"
+  checksum: [
+    "sha256=08dd9df55b2af1838e2312be4be942b4375dbc18c2aed0ca1924488750e34f5d"
+    "sha512=4a09eab6d6f0d6ec435ca3d70305e2f97cbcc04bea72f85efcf649a0ead2faa322a0b054eb953b719f6dea98fb08de32fc80b4cf967681465c5a51e335aaf8d4"
+  ]
+}
+x-commit-hash: "999e85cadbe675f8e60083241b403438f8d2c869"

--- a/packages/gettext-stub/gettext-stub.0.5.0/opam
+++ b/packages/gettext-stub/gettext-stub.0.5.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Internationalization using C gettext library (i18n)"
+description: "See gettext package description."
+maintainer: ["Sylvain Le Gall <sylvain+ocaml@le-gall.net>"]
+authors: ["Sylvain Le Gall"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-gettext"
+doc: "https://gildor478.github.io/ocaml-gettext/"
+bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "gettext" {= version}
+  "dune-configurator" {>= "3.17.0"}
+  "ounit2" {>= "2.2.7" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/gildor478/ocaml-gettext.git"
+depexts: [
+  ["gettext"] {os = "macos" & os-distribution = "homebrew"}
+  ["gettext"] {os = "macos" & os-distribution = "macports"}
+  ["gettext-devel"] {os = "win32" & os-distribution = "cygwinports"}
+  ["gettext-devel"] {os = "win32" & os-distribution = "cygwin"}
+  ["gettext-dev"] {os-distribution = "alpine"}
+  ["libc6-dev"] {os-family = "debian"}
+]
+url {
+  src:
+    "https://github.com/gildor478/ocaml-gettext/releases/download/v0.5.0/gettext-0.5.0.tbz"
+  checksum: [
+    "sha256=08dd9df55b2af1838e2312be4be942b4375dbc18c2aed0ca1924488750e34f5d"
+    "sha512=4a09eab6d6f0d6ec435ca3d70305e2f97cbcc04bea72f85efcf649a0ead2faa322a0b054eb953b719f6dea98fb08de32fc80b4cf967681465c5a51e335aaf8d4"
+  ]
+}
+x-commit-hash: "999e85cadbe675f8e60083241b403438f8d2c869"

--- a/packages/gettext-stub/gettext-stub.0.5.0/opam
+++ b/packages/gettext-stub/gettext-stub.0.5.0/opam
@@ -8,6 +8,7 @@ homepage: "https://github.com/gildor478/ocaml-gettext"
 doc: "https://gildor478.github.io/ocaml-gettext/"
 bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
 depends: [
+  "ocaml" {>= "4.14"}
   "dune" {>= "3.17"}
   "gettext" {= version}
   "dune-configurator" {>= "3.17.0"}

--- a/packages/gettext/gettext.0.5.0/opam
+++ b/packages/gettext/gettext.0.5.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Internationalization library (i18n)"
+description: """
+This library enables string translation in OCaml. The API is based on GNU
+gettext. It comes with a tool to extract strings which need to be translated
+from OCaml source files.
+
+This enables OCaml program to output string in the native language of
+the user, if a corresponding translation file of the English strings is
+provided.
+
+"""
+maintainer: ["Sylvain Le Gall <sylvain+ocaml@le-gall.net>"]
+authors: ["Sylvain Le Gall"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-gettext"
+doc: "https://gildor478.github.io/ocaml-gettext/"
+bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "dune-site"
+  "ocaml" {>= "4.14.0"}
+  "cppo" {>= "1.8.0" & build}
+  "seq" {>= "base" & with-test}
+  "ounit2" {>= "2.2.7" & with-test}
+  "fileutils" {>= "0.6.6"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/gildor478/ocaml-gettext.git"
+url {
+  src:
+    "https://github.com/gildor478/ocaml-gettext/releases/download/v0.5.0/gettext-0.5.0.tbz"
+  checksum: [
+    "sha256=08dd9df55b2af1838e2312be4be942b4375dbc18c2aed0ca1924488750e34f5d"
+    "sha512=4a09eab6d6f0d6ec435ca3d70305e2f97cbcc04bea72f85efcf649a0ead2faa322a0b054eb953b719f6dea98fb08de32fc80b4cf967681465c5a51e335aaf8d4"
+  ]
+}
+x-commit-hash: "999e85cadbe675f8e60083241b403438f8d2c869"


### PR DESCRIPTION
Internationalization library (i18n)

- Project page: <a href="https://github.com/gildor478/ocaml-gettext">https://github.com/gildor478/ocaml-gettext</a>
- Documentation: <a href="https://gildor478.github.io/ocaml-gettext/">https://gildor478.github.io/ocaml-gettext/</a>

##### CHANGES:

### Changed
- Use dune 3.17 and most recent features (
- Use camomile 2.X.X
- Upgrade all dependencies (ounit, fileutils, seq)

### Fixed
- Support for ocaml up to 5.3.
- Add documentation to describe examples and how to use gettext with them.
- Apply all patches from Debian.

Thanks to Chet Murty, Stephane Glondu, Daniil Baturin, Marek Kubica, Marcelo
Seri for their help with this release.
