### PR TITLE
release pa_ppx_regexp 0.05 that withdraws support for pcre

### DIFF
--- a/packages/pa_ppx_regexp/pa_ppx_regexp.0.05/opam
+++ b/packages/pa_ppx_regexp/pa_ppx_regexp.0.05/opam
@@ -1,0 +1,42 @@
+
+synopsis: "A Camlp5 PPX Rewriter for Perl Regexp Workalikes "
+description:
+"""
+This is a PPX Rewriter for some workalikes to perl regexp operations,
+based on Camlp5 (so it's compatible with all the other Camlp5-based PPX rewriters).
+"""
+opam-version: "2.0"
+x-maintenance-intent: [ "(latest)" ]
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_regexp"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_regexp/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_regexp.git"
+doc: "https://github.com/camlp5/pa_ppx_regexp/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.01.00" }
+  "pa_ppx"      { >= "0.17" }
+  "pa_ppx_migrate"      { >= "0.10" }
+  "pa_ppx_static" { >= "0.01" }
+  "not-ocamlfind" { >= "0.10" }
+  "ounit" { >= "2.2.7" }
+  "mdx" {>= "2.3.0" & with-test}
+  "fmt"
+  "pcre2" { >= "8.0.3" }
+  "re" { >= "1.12.0" }
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_regexp/archive/refs/tags/0.05.tar.gz"
+  checksum: [
+    "sha512=8c8701247e2a11dc1fbc6c94418529bed103935d6dcde58bf354f69c67c6cb8c5c2a9a354768904233b7b15b060b3425af522e1bc72a4805300676d3c86ae57d"
+  ]
+}


### PR DESCRIPTION
b/c Debian testing has stopped supporting pcre