### PR TITLE
Package vscoq-language-server.2.2.4

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.2.4/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.2.4/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/coq-community/vscoq"
+bug-reports: "https://github.com/coq-community/vscoq/issues"
+dev-repo: "git+https://github.com/coq-community/vscoq"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { >= "4.14" }
+  "dune" { >= "3.5" }
+  "coq-core" { ((>= "8.18" < "8.21") | (= "dev")) }
+  "coq-stdlib" { ((>= "8.18" < "8.21") | (= "dev")) }
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "ppx_optcomp"
+  "result" { >= "1.5" }
+  "lsp" { >= "1.15"}
+  "sel" {>= "0.4.0"}
+]
+synopsis: "VSCoq language server"
+available: arch != "arm32" & arch != "x86_32"
+description: """
+LSP based language server for Coq and its VSCoq user interface
+"""
+url {
+  src:
+    "https://github.com/coq/vscoq/releases/download/v2.2.4/vscoq-language-server-2.2.4.tar.gz"
+  checksum: [
+    "md5=44ada383e4a3cb23d883eb720391e9db"
+    "sha512=e55ddda2beb5abbe5eb63c7ba6761b1f958dc4674178c4b5741082665d8ad15d481c978685dcf648afebb9b07abd95069347b8651f078d87820399f459e16f17"
+  ]
+}


### PR DESCRIPTION
### `vscoq-language-server.2.2.4`
VSCoq language server
LSP based language server for Coq and its VSCoq user interface



---
* Homepage: https://github.com/coq-community/vscoq
* Source repo: git+https://github.com/coq-community/vscoq
* Bug tracker: https://github.com/coq-community/vscoq/issues

---
:camel: Pull-request generated by opam-publish v2.5.0