### PR TITLE
[new release] mirage-monitoring (0.0.6)

### DIFF
--- a/packages/mirage-monitoring/mirage-monitoring.0.0.6/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.6/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mirage-monitoring"
+doc: "https://robur-coop.github.io/mirage-monitoring"
+dev-repo: "git+https://github.com/robur-coop/mirage-monitoring.git"
+bug-reports: "https://github.com/robur-coop/mirage-monitoring/issues"
+license: "AGPL-3.0-only"
+
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune"
+  "logs" {>= "0.6.3"}
+  "metrics" {>= "0.4.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "mirage-sleep" {>= "4.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-runtime" {>= "4.5.0"}
+  "memtrace-mirage" {>= "0.2.1.2.3"}
+]
+conflicts: [
+  "mirage-solo5" {< "0.9.2"}
+  "mirage-xen" {< "8.0.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Monitoring of MirageOS unikernels"
+description: """
+Reporting metrics to Influx, Telegraf. Dynamic adjusting log level and metrics
+sources, memprof profiling.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/mirage-monitoring/releases/download/v0.0.6/mirage-monitoring-0.0.6.tbz"
+  checksum: [
+    "sha256=0e574eb8ff65c3dddc38d0ec8c89e1be73d2e2bb62869a62da0a559578ec7537"
+    "sha512=7b3b065ec04981b6c9ece925ab43ea9a95baabb6174492eb11a67c7678ee1a9ec90662001ae157bc2565230b0df1a45dda2e61883267392883c521805e5a5492"
+  ]
+}
+x-commit-hash: "e80806501e12957d5e92a1042c4e14fe50e93261"


### PR DESCRIPTION
Monitoring of MirageOS unikernels

- Project page: <a href="https://github.com/robur-coop/mirage-monitoring">https://github.com/robur-coop/mirage-monitoring</a>
- Documentation: <a href="https://robur-coop.github.io/mirage-monitoring">https://robur-coop.github.io/mirage-monitoring</a>

##### CHANGES:

* Remove functors for PCLOCK and TIME, use "dune variants" packages instead
* Update to memtrace-mirage 0.2.1.2.3
