### PR TITLE
[new release] http-mirage-client (0.0.9)

### DIFF
--- a/packages/http-mirage-client/http-mirage-client.0.0.9/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.9/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "HTTP client for MirageOS"
+maintainer: ["team@robur.coop"]
+authors: [
+  "Robur Team <team@robur.coop>"
+]
+license: "MIT"
+homepage: "https://github.com/robur-coop/http-mirage-client"
+bug-reports: "https://github.com/robur-coop/http-mirage-client/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.11.0"}
+  "paf" {>= "0.2.0"}
+  "tcpip" {>= "7.0.0"}
+  "lwt" {>= "5.5.0"}
+  "mimic-happy-eyeballs" {>= "0.0.9"}
+  "httpaf"
+  "alcotest-lwt" {with-test & >= "1.0.0"}
+  "mirage-crypto-rng" {with-test}
+  "dns-client-mirage" {with-test & >= "10.0.0"}
+  "happy-eyeballs-mirage" {with-test & >= "2.0.0"}
+  "h2" {>= "0.10.0"}
+  "tls" {>= "1.0.0"}
+  "x509" {>= "1.0.0"}
+  "ca-certs-nss" {>= "3.108-1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"} # macOS is disabled due to restrictions in sandbox-exec
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/robur-coop/http-mirage-client.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/http-mirage-client/releases/download/v0.0.9/http-mirage-client-0.0.9.tbz"
+  checksum: [
+    "sha256=2251ed31730b4b6f97658a5ef89676fd0b027dad62a3a9595aa6ec5e46bc3457"
+    "sha512=572014fba97ca07912ec83a57a16511debaec284dadf1d68c7c320cb5656bf7f3d0d3731eae6c6e250f091da253584f111807b9e9995e9735ec773da447d0e44"
+  ]
+}
+x-commit-hash: "a6ce9ccec344ba20128fae15750ebb2224c37067"

--- a/packages/http-mirage-client/http-mirage-client.0.0.9/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.9/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/robur-coop/http-mirage-client/issues"
 depends: [
   "dune" {>= "2.3"}
   "ocaml" {>= "4.11.0"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "tcpip" {>= "7.0.0"}
   "lwt" {>= "5.5.0"}
   "mimic-happy-eyeballs" {>= "0.0.9"}

--- a/packages/letsencrypt-mirage/letsencrypt-mirage.1.0.0/opam
+++ b/packages/letsencrypt-mirage/letsencrypt-mirage.1.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.13.0"}
   "dune" {>= "1.2.0"}
   "letsencrypt" {= version}
-  "http-mirage-client"
+  "http-mirage-client" {< "0.0.9"}
   "tcpip" {>= "7.0.0"}
   "mirage-time" {>= "3.0.0"}
   "duration"


### PR DESCRIPTION
HTTP client for MirageOS

- Project page: <a href="https://github.com/robur-coop/http-mirage-client">https://github.com/robur-coop/http-mirage-client</a>

##### CHANGES:

- Remove unnecessary functors (@hannesm)
