### PR TITLE
[new release] crunch (4.0.0)

### DIFF
--- a/packages/crunch/crunch.4.0.0/opam
+++ b/packages/crunch/crunch.4.0.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer:   "MirageOS team"
+authors:      ["Anil Madhavapeddy" "Thomas Gazagnaire" "Stefanie Schirmer" "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/ocaml-crunch"
+bug-reports:  "https://github.com/mirage/ocaml-crunch/issues"
+doc:          "https://mirage.github.io/ocaml-crunch/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/ocaml-crunch.git"
+tags:         ["org:mirage" "org:xapi-project"]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "cmdliner" {>= "1.1"}
+  "ptime"
+  "dune" {>= "2.5"}
+  "lwt" {with-test}
+  "mirage-kv" {with-test & >= "3.0.0"}
+  "mirage-kv-mem" {with-test & >= "4.0.0"}
+  "fmt" {with-test}
+]
+conflicts: [
+  "mirage-kv" {< "3.0.0"}
+  "mirage-kv-mem" {< "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+     name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+synopsis: "Convert a filesystem into a static OCaml module"
+description: """
+`ocaml-crunch` takes a directory of files and compiles them into a standalone
+OCaml module which serves the contents directly from memory.  This can be
+convenient for libraries that need a few embedded files (such as a web server)
+and do not want to deal with all the trouble of file configuration.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-crunch/releases/download/v4.0.0/crunch-4.0.0.tbz"
+  checksum: [
+    "sha256=939b8d1129ed6c634cb0f9ccc6f6d44aa1703cd05ce6091f2ee2a0162944b89b"
+    "sha512=4753307f6d7d6e6a5abf39b437efc40ab9b2c517c8cf5e9bff05a8eab91f01545a7f6ae979303adde94ff23fa14a6466ce831dc39cfc50ad04548f3cbb7a857b"
+  ]
+}
+x-commit-hash: "dfeeafba20f5c5825c2518707aaa3251a804df9f"


### PR DESCRIPTION
Convert a filesystem into a static OCaml module

- Project page: <a href="https://github.com/mirage/ocaml-crunch">https://github.com/mirage/ocaml-crunch</a>
- Documentation: <a href="https://mirage.github.io/ocaml-crunch/">https://mirage.github.io/ocaml-crunch/</a>

##### CHANGES:

* Update to mirage-kv-mem 4.0.0 API changes (fewer functors) (mirage/ocaml-crunch#68 @hannesm)
