### PR TITLE
[new release] domain-name (0.4.1)

### DIFF
--- a/packages/domain-name/domain-name.0.4.1/opam
+++ b/packages/domain-name/domain-name.0.4.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/hannesm/domain-name"
+doc: "https://hannesm.github.io/domain-name/doc"
+bug-reports: "https://github.com/hannesm/domain-name/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/domain-name.git"
+synopsis: "RFC 1035 Internet domain names"
+description: """
+A domain name is a sequence of labels separated by dots, such as `foo.example`.
+Each label may contain any bytes. The length of each label may not exceed 63
+charactes.  The total length of a domain name is limited to 253 (byte
+representation is 255), but other protocols (such as SMTP) may apply even
+smaller limits.  A domain name label is case preserving, comparison is done in a
+case insensitive manner.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/hannesm/domain-name/releases/download/v0.4.1/domain-name-0.4.1.tbz"
+  checksum: [
+    "sha256=1dba32f35a7cd5cc8187d21e2cc21a0b667a645447a0eefe57afe3ca25bc4566"
+    "sha512=6846998704d11a63756035ad6226cc4708c7c29b2327ca7ca279a174b8c1c403962801019cc5a0ce27474bb3c382ce878c19fd85f694fab4360f4969341f0656"
+  ]
+}
+x-commit-hash: "26c8a60f57d73e5f767ca8049dba29ca0a214d55"


### PR DESCRIPTION
RFC 1035 Internet domain names

- Project page: <a href="https://github.com/hannesm/domain-name">https://github.com/hannesm/domain-name</a>
- Documentation: <a href="https://hannesm.github.io/domain-name/doc">https://hannesm.github.io/domain-name/doc</a>

##### CHANGES:

* handle root specially for encoding and decoding (hannesm/domain-name#12 @reynir, fixes hannesm/domain-name#10)
