### PR TITLE
[new release] conduit (5 packages) (8.0.0)

### DIFF
--- a/packages/cohttp-mirage/cohttp-mirage.4.0.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.4.0.0/opam
@@ -22,8 +22,8 @@ depends: [
   "dune" {>= "1.1.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2"}
-  "conduit-mirage" {>= "2.3.0"}
+  "conduit" {>= "2.0.2" & < "8.0.0"}
+  "conduit-mirage" {>= "2.3.0" & < "8.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {=version}

--- a/packages/cohttp-mirage/cohttp-mirage.4.1.1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.4.1.1/opam
@@ -22,8 +22,8 @@ depends: [
   "dune" {>= "2.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2"}
-  "conduit-mirage" {>= "2.3.0"}
+  "conduit" {>= "2.0.2" & < "8.0.0"}
+  "conduit-mirage" {>= "2.3.0" & < "8.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {= version}

--- a/packages/cohttp-mirage/cohttp-mirage.4.1.2/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.4.1.2/opam
@@ -22,8 +22,8 @@ depends: [
   "dune" {>= "2.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2"}
-  "conduit-mirage" {>= "4.0.0"}
+  "conduit" {>= "2.0.2" & < "8.0.0"}
+  "conduit-mirage" {>= "4.0.0" & < "8.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {= version}

--- a/packages/cohttp-mirage/cohttp-mirage.5.0.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.5.0.0/opam
@@ -22,8 +22,8 @@ depends: [
   "dune" {>= "2.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2"}
-  "conduit-mirage" {>= "2.3.0"}
+  "conduit" {>= "2.0.2" & < "8.0.0"}
+  "conduit-mirage" {>= "2.3.0" & < "8.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {= version}

--- a/packages/cohttp-mirage/cohttp-mirage.5.1.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.5.1.0/opam
@@ -22,8 +22,8 @@ depends: [
   "dune" {>= "2.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2"}
-  "conduit-mirage" {>= "2.3.0"}
+  "conduit" {>= "2.0.2" & < "8.0.0"}
+  "conduit-mirage" {>= "2.3.0" & < "8.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {= version}

--- a/packages/cohttp-mirage/cohttp-mirage.5.2.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.5.2.0/opam
@@ -22,8 +22,8 @@ depends: [
   "dune" {>= "2.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2"}
-  "conduit-mirage" {>= "2.3.0"}
+  "conduit" {>= "2.0.2" & < "8.0.0"}
+  "conduit-mirage" {>= "2.3.0" & < "8.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {= version}

--- a/packages/cohttp-mirage/cohttp-mirage.5.3.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.5.3.0/opam
@@ -22,8 +22,8 @@ depends: [
   "dune" {>= "2.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2"}
-  "conduit-mirage" {>= "2.3.0"}
+  "conduit" {>= "2.0.2" & < "8.0.0"}
+  "conduit-mirage" {>= "2.3.0" & < "8.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {>= "5.3.0" & <= "5.3.1"}

--- a/packages/cohttp-mirage/cohttp-mirage.6.0.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.6.0.0/opam
@@ -30,8 +30,8 @@ depends: [
   "ocaml" {>= "4.08"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2"}
-  "conduit-mirage" {>= "2.3.0"}
+  "conduit" {>= "2.0.2" & < "8.0.0"}
+  "conduit-mirage" {>= "2.3.0" & < "8.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp-lwt" {= version}

--- a/packages/cohttp-mirage/cohttp-mirage.6.0.0~alpha0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.6.0.0~alpha0/opam
@@ -30,8 +30,8 @@ depends: [
   "ocaml" {>= "4.08"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2"}
-  "conduit-mirage" {>= "2.3.0"}
+  "conduit" {>= "2.0.2" & < "8.0.0"}
+  "conduit-mirage" {>= "2.3.0" & < "8.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp-lwt" {= version}

--- a/packages/cohttp-mirage/cohttp-mirage.6.0.0~alpha1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.6.0.0~alpha1/opam
@@ -30,8 +30,8 @@ depends: [
   "ocaml" {>= "4.08"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2"}
-  "conduit-mirage" {>= "2.3.0"}
+  "conduit" {>= "2.0.2" & < "8.0.0"}
+  "conduit-mirage" {>= "2.3.0" & < "8.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp-lwt" {= version}

--- a/packages/cohttp-mirage/cohttp-mirage.6.0.0~alpha2/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.6.0.0~alpha2/opam
@@ -30,8 +30,8 @@ depends: [
   "ocaml" {>= "4.08"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2"}
-  "conduit-mirage" {>= "2.3.0"}
+  "conduit" {>= "2.0.2" & < "8.0.0"}
+  "conduit-mirage" {>= "2.3.0" & < "8.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp-lwt" {= version}

--- a/packages/cohttp-mirage/cohttp-mirage.6.0.0~beta2/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.6.0.0~beta2/opam
@@ -30,8 +30,8 @@ depends: [
   "ocaml" {>= "4.08"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-channel" {>= "4.0.0"}
-  "conduit" {>= "2.0.2"}
-  "conduit-mirage" {>= "2.3.0"}
+  "conduit" {>= "2.0.2" & < "8.0.0"}
+  "conduit-mirage" {>= "2.3.0" & < "8.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "lwt" {>= "2.4.3"}
   "cohttp-lwt" {= version}

--- a/packages/conduit-async/conduit-async.8.0.0/opam
+++ b/packages/conduit-async/conduit-async.8.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "core" {>= "v0.15.0"}
+  "uri" {>= "4.0.0"}
+  "ppx_here" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib0"
+  "conduit" {=version}
+  "async" {>= "v0.15.0"}
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp" {>= "4.0.0"}
+]
+depopts: ["async_ssl"]
+conflicts: [
+  "async_ssl" {< "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Async"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v8.0.0/conduit-8.0.0.tbz"
+  checksum: [
+    "sha256=0a63d910865b5473893a170cda51f61388f488ecf4c4b2ed7fe9ec4e2cf66f61"
+    "sha512=63c73616c5a4a6436aa9a1c8d2771d70e15789c639aaec6b9a95622aee0b364f18278e88ed769fbae84fefb817bef1c9c81fe41e969f03db99612295a159b536"
+  ]
+}
+x-commit-hash: "cb1e6cfed4a24bf3fa49627424fb9d43bdc20d0f"

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.8.0.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.8.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "base-unix"
+  "logs"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "conduit-lwt" {=version}
+  "lwt" {>= "5.7.0"}
+  "uri" {>= "1.9.4"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+  "ca-certs"
+  "lwt_log" {with-test}
+  "ssl" {with-test}
+  "lwt_ssl" {with-test}
+]
+depopts: ["tls-lwt" "lwt_ssl" "launchd"]
+conflicts: [
+  "tls-lwt" {< "1.0.0"}
+  "ssl" {< "0.5.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Lwt_unix"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v8.0.0/conduit-8.0.0.tbz"
+  checksum: [
+    "sha256=0a63d910865b5473893a170cda51f61388f488ecf4c4b2ed7fe9ec4e2cf66f61"
+    "sha512=63c73616c5a4a6436aa9a1c8d2771d70e15789c639aaec6b9a95622aee0b364f18278e88ed769fbae84fefb817bef1c9c81fe41e969f03db99612295a159b536"
+  ]
+}
+x-commit-hash: "cb1e6cfed4a24bf3fa49627424fb9d43bdc20d0f"

--- a/packages/conduit-lwt/conduit-lwt.8.0.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.8.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib0"
+  "conduit" {=version}
+  "lwt" {>= "5.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v8.0.0/conduit-8.0.0.tbz"
+  checksum: [
+    "sha256=0a63d910865b5473893a170cda51f61388f488ecf4c4b2ed7fe9ec4e2cf66f61"
+    "sha512=63c73616c5a4a6436aa9a1c8d2771d70e15789c639aaec6b9a95622aee0b364f18278e88ed769fbae84fefb817bef1c9c81fe41e969f03db99612295a159b536"
+  ]
+}
+x-commit-hash: "cb1e6cfed4a24bf3fa49627424fb9d43bdc20d0f"

--- a/packages/conduit-mirage/conduit-mirage.8.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.8.0.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib0"
+  "uri" {>= "4.0.0"}
+  "cstruct" {>= "3.0.0"}
+  "mirage-ptime" {>= "5.0.0"}
+  "mirage-mtime" {>= "5.0.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "mirage-flow-combinators" {>= "2.0.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "mirage-sleep" {>= "4.0.0"}
+  "dns-client-mirage" {>= "10.0.0"}
+  "conduit-lwt" {=version}
+  "vchan" {>= "5.0.0"}
+  "xenstore"
+  "tls" {>= "2.0.0"}
+  "tls-mirage" {>= "2.0.0"}
+  "ca-certs-nss" {>= "3.108-1"}
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp"
+  "tcpip" {>= "7.0.0"}
+  "fmt" {>= "0.8.7"}
+]
+conflicts: [
+  "mirage-conduit"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for MirageOS"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v8.0.0/conduit-8.0.0.tbz"
+  checksum: [
+    "sha256=0a63d910865b5473893a170cda51f61388f488ecf4c4b2ed7fe9ec4e2cf66f61"
+    "sha512=63c73616c5a4a6436aa9a1c8d2771d70e15789c639aaec6b9a95622aee0b364f18278e88ed769fbae84fefb817bef1c9c81fe41e969f03db99612295a159b536"
+  ]
+}
+x-commit-hash: "cb1e6cfed4a24bf3fa49627424fb9d43bdc20d0f"

--- a/packages/conduit/conduit.8.0.0/opam
+++ b/packages/conduit/conduit.8.0.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib0"
+  "astring"
+  "uri"
+  "logs" {>= "0.5.0"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library"
+description: """
+The `conduit` library takes care of establishing and listening for
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The useful opam packages available that extend this library are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `conduit-mirage`: the MirageOS compatible implementation
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v8.0.0/conduit-8.0.0.tbz"
+  checksum: [
+    "sha256=0a63d910865b5473893a170cda51f61388f488ecf4c4b2ed7fe9ec4e2cf66f61"
+    "sha512=63c73616c5a4a6436aa9a1c8d2771d70e15789c639aaec6b9a95622aee0b364f18278e88ed769fbae84fefb817bef1c9c81fe41e969f03db99612295a159b536"
+  ]
+}
+x-commit-hash: "cb1e6cfed4a24bf3fa49627424fb9d43bdc20d0f"


### PR DESCRIPTION
A network connection establishment library

- Project page: <a href="https://github.com/mirage/ocaml-conduit">https://github.com/mirage/ocaml-conduit</a>
- Documentation: <a href="https://mirage.github.io/ocaml-conduit/">https://mirage.github.io/ocaml-conduit/</a>

##### CHANGES:

* Use the defunctorized dns-client-mirage, ca-certs-nss, happy-eyeballs
  (mirage/ocaml-conduit#436 @hannesm)
