### PR TITLE
[new release] paf (2 packages) (0.8.0)

### DIFF
--- a/packages/git-paf/git-paf.3.10.0/opam
+++ b/packages/git-paf/git-paf.3.10.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.10.1/opam
+++ b/packages/git-paf/git-paf.3.10.1/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.11.0/opam
+++ b/packages/git-paf/git-paf.3.11.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.12.0/opam
+++ b/packages/git-paf/git-paf.3.12.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.13.0/opam
+++ b/packages/git-paf/git-paf.3.13.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.14.0/opam
+++ b/packages/git-paf/git-paf.3.14.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.15.0/opam
+++ b/packages/git-paf/git-paf.3.15.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.16.0/opam
+++ b/packages/git-paf/git-paf.3.16.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.16.1/opam
+++ b/packages/git-paf/git-paf.3.16.1/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.17.0/opam
+++ b/packages/git-paf/git-paf.3.17.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.7.0"}
+  "paf" {>= "0.7.0" & < "0.8.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.5.0/opam
+++ b/packages/git-paf/git-paf.3.5.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.3" & < "0.0.4"}
-  "paf" {>= "0.0.2"}
+  "paf" {>= "0.0.2" & < "0.8.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.6.0/opam
+++ b/packages/git-paf/git-paf.3.6.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.3" & < "0.0.4"}
-  "paf" {>= "0.0.2"}
+  "paf" {>= "0.0.2" & < "0.8.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/http-mirage-client/http-mirage-client.0.0.1/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/robur-coop/http-mirage-client/issues"
 depends: [
   "dune" {>= "2.3"}
   "ocaml" {>= "4.11.0"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "mirage-clock" {>= "4.0.0"}
   "mirage-time" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}

--- a/packages/http-mirage-client/http-mirage-client.0.0.2/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.2/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/robur-coop/http-mirage-client/issues"
 depends: [
   "dune" {>= "2.3"}
   "ocaml" {>= "4.11.0"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "mirage-clock" {>= "4.0.0"}
   "mirage-time" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}

--- a/packages/http-mirage-client/http-mirage-client.0.0.3/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.3/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/robur-coop/http-mirage-client/issues"
 depends: [
   "dune" {>= "2.3"}
   "ocaml" {>= "4.11.0"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "mirage-clock" {>= "4.0.0"}
   "mirage-time" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}

--- a/packages/http-mirage-client/http-mirage-client.0.0.4/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.4/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/robur-coop/http-mirage-client/issues"
 depends: [
   "dune" {>= "2.3"}
   "ocaml" {>= "4.11.0"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "mirage-clock" {>= "4.0.0"}
   "mirage-time" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}

--- a/packages/http-mirage-client/http-mirage-client.0.0.5/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.5/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/robur-coop/http-mirage-client/issues"
 depends: [
   "dune" {>= "2.3"}
   "ocaml" {>= "4.11.0"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "mirage-clock" {>= "4.0.0"}
   "mirage-time" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}

--- a/packages/http-mirage-client/http-mirage-client.0.0.7/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.7/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/robur-coop/http-mirage-client/issues"
 depends: [
   "dune" {>= "2.3"}
   "ocaml" {>= "4.11.0"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "mirage-clock" {>= "4.0.0"}
   "mirage-time" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}

--- a/packages/http-mirage-client/http-mirage-client.0.0.8/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.8/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/robur-coop/http-mirage-client/issues"
 depends: [
   "dune" {>= "2.3"}
   "ocaml" {>= "4.11.0"}
-  "paf" {>= "0.2.0"}
+  "paf" {>= "0.2.0" & < "0.8.0"}
   "mirage-clock" {>= "4.0.0"}
   "mirage-time" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}

--- a/packages/letsencrypt-mirage/letsencrypt-mirage.0.5.0/opam
+++ b/packages/letsencrypt-mirage/letsencrypt-mirage.0.5.0/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-time" {>= "3.0.0"}
   "duration"
   "emile" {>= "1.1"}
-  "paf" {>= "0.4.0"}
+  "paf" {>= "0.4.0" & < "0.8.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/letsencrypt-mirage/letsencrypt-mirage.0.5.1/opam
+++ b/packages/letsencrypt-mirage/letsencrypt-mirage.0.5.1/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-time" {>= "3.0.0"}
   "duration"
   "emile" {>= "1.1"}
-  "paf" {>= "0.4.0"}
+  "paf" {>= "0.4.0" & < "0.8.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/letsencrypt-mirage/letsencrypt-mirage.1.0.0/opam
+++ b/packages/letsencrypt-mirage/letsencrypt-mirage.1.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-time" {>= "3.0.0"}
   "duration"
   "emile" {>= "1.1"}
-  "paf" {>= "0.4.0"}
+  "paf" {>= "0.4.0" & < "0.8.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/paf-cohttp/paf-cohttp.0.8.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.8.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "cohttp-lwt" {< "6.0.0~"}
+  "domain-name"
+  "h1"
+  "ipaddr"
+  "alcotest-lwt"      {with-test & >= "1.1.0"}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "tcpip"             {with-test & >= "6.0.0"}
+  "uri"               {with-test}
+  "lwt"               {with-test}
+  "astring"           {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {os != "macos"}
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.8.0/paf-0.8.0.tbz"
+  checksum: [
+    "sha256=d2ad3b819a735320e85a50389bf3fe1064afbd528067b470564a4ece2ab31b63"
+    "sha512=e6bf4640a1411ab15fcec1fda9c494bfa895bd1d5c2f40542a9680252dd2cabf2f3da7f17849489e5ddfef2c003b35a9945a2f8aae432d3d1608745f02767612"
+  ]
+}
+x-commit-hash: "219037330a04f82e3d6121eaa32542a45673f03d"

--- a/packages/paf-cohttp/paf-cohttp.0.8.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.8.0/opam
@@ -18,7 +18,7 @@ depends: [
   "alcotest-lwt"      {with-test & >= "1.1.0"}
   "fmt"               {with-test}
   "logs"              {with-test}
-  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
   "tcpip"             {with-test & >= "6.0.0"}
   "uri"               {with-test}
   "lwt"               {with-test}

--- a/packages/paf/paf.0.8.0/opam
+++ b/packages/paf/paf.0.8.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "tcpip" {>= "8.0.1"}
+  "tls-mirage" {>= "0.17.4"}
+  "mimic" {>= "0.0.7"}
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "x509" {with-test & > "1.0.0"}
+  "bigstringaf" {>= "0.7.0"}
+  "h1"
+  "h2" {>= "0.10.0"}
+  "faraday" {>= "0.7.2"}
+  "tls" {>= "1.0.0"}
+  "cstruct" {>= "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {os != "macos"}
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.8.0/paf-0.8.0.tbz"
+  checksum: [
+    "sha256=d2ad3b819a735320e85a50389bf3fe1064afbd528067b470564a4ece2ab31b63"
+    "sha512=e6bf4640a1411ab15fcec1fda9c494bfa895bd1d5c2f40542a9680252dd2cabf2f3da7f17849489e5ddfef2c003b35a9945a2f8aae432d3d1608745f02767612"
+  ]
+}
+x-commit-hash: "219037330a04f82e3d6121eaa32542a45673f03d"


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Add `x-maintenance-intent` (@hannesm, dinosaure/paf-le-chien#100)
- Remove `mirage-time` dependency and upgrade to mirage-crypto.1.2.0 (@hannesm, dinosaure/paf-le-chien#101)
