### PR TITLE
4 packages from c-cube/qcheck at 0.24

### DIFF
--- a/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.6/opam
+++ b/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.6/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "PPX Deriver for QCheck"
+maintainer: "valentin.chb@gmail.com"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/-/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "ocaml" {>= "4.08.0"}
+  "qcheck-core" {>= "0.24"}
+  "ppxlib" {>= "0.22.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "odoc" {with-doc}
+  "alcotest" {with-test & >= "1.4.0"}
+  "qcheck-alcotest" {with-test & >= "0.24"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.24.tar.gz"
+  checksum: [
+    "md5=cd03561cfc31e08e3a2f1115ee3f89fe"
+    "sha512=c7c1f437da940ba4bcf226e77d157633d25c0aa2567d3630be66c177bdd6bc920c406c0f810e0bf0e585c7a141c49507a2902331452a0b4651a5bac0660f2b49"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.6/opam
+++ b/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.6/opam
@@ -24,8 +24,8 @@ dev-repo: "git+https://github.com/c-cube/qcheck.git"
 url {
   src: "https://github.com/c-cube/qcheck/archive/v0.24.tar.gz"
   checksum: [
-    "md5=cd03561cfc31e08e3a2f1115ee3f89fe"
-    "sha512=c7c1f437da940ba4bcf226e77d157633d25c0aa2567d3630be66c177bdd6bc920c406c0f810e0bf0e585c7a141c49507a2902331452a0b4651a5bac0660f2b49"
+    "md5=4eecb056dba04a9b68786135dd2e66bc"
+    "sha512=b7a0dcf6c46e297f8e44f0c66d4b671f285c87fe4052f5e990f02012a5386b8052a5f1e79fc92093e7ef20c6d69155d63e40fc7e30cdc4d34b2d1c8654568958"
   ]
 }
 x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck-alcotest/qcheck-alcotest.0.24/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.24/opam
@@ -24,8 +24,8 @@ dev-repo: "git+https://github.com/c-cube/qcheck.git"
 url {
   src: "https://github.com/c-cube/qcheck/archive/v0.24.tar.gz"
   checksum: [
-    "md5=cd03561cfc31e08e3a2f1115ee3f89fe"
-    "sha512=c7c1f437da940ba4bcf226e77d157633d25c0aa2567d3630be66c177bdd6bc920c406c0f810e0bf0e585c7a141c49507a2902331452a0b4651a5bac0660f2b49"
+    "md5=4eecb056dba04a9b68786135dd2e66bc"
+    "sha512=b7a0dcf6c46e297f8e44f0c66d4b671f285c87fe4052f5e990f02012a5386b8052a5f1e79fc92093e7ef20c6d69155d63e40fc7e30cdc4d34b2d1c8654568958"
   ]
 }
 x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck-alcotest/qcheck-alcotest.0.24/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.24/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Alcotest backend for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "quickcheck" "qcheck" "alcotest"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "qcheck-core" {= version}
+  "alcotest" {>= "1.2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.24.tar.gz"
+  checksum: [
+    "md5=cd03561cfc31e08e3a2f1115ee3f89fe"
+    "sha512=c7c1f437da940ba4bcf226e77d157633d25c0aa2567d3630be66c177bdd6bc920c406c0f810e0bf0e585c7a141c49507a2902331452a0b4651a5bac0660f2b49"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck-core/qcheck-core.0.24/opam
+++ b/packages/qcheck-core/qcheck-core.0.24/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Core qcheck library"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "alcotest" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.24.tar.gz"
+  checksum: [
+    "md5=cd03561cfc31e08e3a2f1115ee3f89fe"
+    "sha512=c7c1f437da940ba4bcf226e77d157633d25c0aa2567d3630be66c177bdd6bc920c406c0f810e0bf0e585c7a141c49507a2902331452a0b4651a5bac0660f2b49"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck-core/qcheck-core.0.24/opam
+++ b/packages/qcheck-core/qcheck-core.0.24/opam
@@ -26,8 +26,8 @@ dev-repo: "git+https://github.com/c-cube/qcheck.git"
 url {
   src: "https://github.com/c-cube/qcheck/archive/v0.24.tar.gz"
   checksum: [
-    "md5=cd03561cfc31e08e3a2f1115ee3f89fe"
-    "sha512=c7c1f437da940ba4bcf226e77d157633d25c0aa2567d3630be66c177bdd6bc920c406c0f810e0bf0e585c7a141c49507a2902331452a0b4651a5bac0660f2b49"
+    "md5=4eecb056dba04a9b68786135dd2e66bc"
+    "sha512=b7a0dcf6c46e297f8e44f0c66d4b671f285c87fe4052f5e990f02012a5386b8052a5f1e79fc92093e7ef20c6d69155d63e40fc7e30cdc4d34b2d1c8654568958"
   ]
 }
 x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck-ounit/qcheck-ounit.0.24/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.24/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "OUnit backend for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["qcheck" "quickcheck" "ounit"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "qcheck-core" {= version}
+  "ounit2"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.24.tar.gz"
+  checksum: [
+    "md5=cd03561cfc31e08e3a2f1115ee3f89fe"
+    "sha512=c7c1f437da940ba4bcf226e77d157633d25c0aa2567d3630be66c177bdd6bc920c406c0f810e0bf0e585c7a141c49507a2902331452a0b4651a5bac0660f2b49"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck-ounit/qcheck-ounit.0.24/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.24/opam
@@ -24,8 +24,8 @@ dev-repo: "git+https://github.com/c-cube/qcheck.git"
 url {
   src: "https://github.com/c-cube/qcheck/archive/v0.24.tar.gz"
   checksum: [
-    "md5=cd03561cfc31e08e3a2f1115ee3f89fe"
-    "sha512=c7c1f437da940ba4bcf226e77d157633d25c0aa2567d3630be66c177bdd6bc920c406c0f810e0bf0e585c7a141c49507a2902331452a0b4651a5bac0660f2b49"
+    "md5=4eecb056dba04a9b68786135dd2e66bc"
+    "sha512=b7a0dcf6c46e297f8e44f0c66d4b671f285c87fe4052f5e990f02012a5386b8052a5f1e79fc92093e7ef20c6d69155d63e40fc7e30cdc4d34b2d1c8654568958"
   ]
 }
 x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck/qcheck.0.24/opam
+++ b/packages/qcheck/qcheck.0.24/opam
@@ -28,8 +28,8 @@ dev-repo: "git+https://github.com/c-cube/qcheck.git"
 url {
   src: "https://github.com/c-cube/qcheck/archive/v0.24.tar.gz"
   checksum: [
-    "md5=cd03561cfc31e08e3a2f1115ee3f89fe"
-    "sha512=c7c1f437da940ba4bcf226e77d157633d25c0aa2567d3630be66c177bdd6bc920c406c0f810e0bf0e585c7a141c49507a2902331452a0b4651a5bac0660f2b49"
+    "md5=4eecb056dba04a9b68786135dd2e66bc"
+    "sha512=b7a0dcf6c46e297f8e44f0c66d4b671f285c87fe4052f5e990f02012a5386b8052a5f1e79fc92093e7ef20c6d69155d63e40fc7e30cdc4d34b2d1c8654568958"
   ]
 }
 x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck/qcheck.0.24/opam
+++ b/packages/qcheck/qcheck.0.24/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Compatibility package for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "qcheck-core" {= version}
+  "qcheck-ounit" {= version}
+  "alcotest" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.24.tar.gz"
+  checksum: [
+    "md5=cd03561cfc31e08e3a2f1115ee3f89fe"
+    "sha512=c7c1f437da940ba4bcf226e77d157633d25c0aa2567d3630be66c177bdd6bc920c406c0f810e0bf0e585c7a141c49507a2902331452a0b4651a5bac0660f2b49"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `qcheck.0.24`: Compatibility package for qcheck
- `qcheck-alcotest.0.24`: Alcotest backend for qcheck
- `qcheck-core.0.24`: Core qcheck library
- `qcheck-ounit.0.24`: OUnit backend for qcheck



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: git+https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---
:camel: Pull-request generated by opam-publish v2.5.0