### PR TITLE
Add qcheck upper bounds to previous ppx_deriving_qcheck releases

### DIFF
--- a/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.3.0/opam
+++ b/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.3.0/opam
@@ -8,12 +8,12 @@ bug-reports: "https://github.com/c-cube/qcheck/-/issues"
 depends: [
   "dune" {>= "2.8.0"}
   "ocaml" {>= "4.08.0"}
-  "qcheck" {>= "0.19"}
+  "qcheck" {>= "0.19" & < "0.24"}
   "ppxlib" {>= "0.22.0"}
   "ppx_deriving" {>= "5.2.1"}
   "odoc" {with-doc}
   "alcotest" {with-test & >= "1.4.0"}
-  "qcheck-alcotest" {with-test & >= "0.17"}
+  "qcheck-alcotest" {with-test & >= "0.17" & < "0.24"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.4.0/opam
+++ b/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.4.0/opam
@@ -8,12 +8,12 @@ bug-reports: "https://github.com/c-cube/qcheck/-/issues"
 depends: [
   "dune" {>= "2.8.0"}
   "ocaml" {>= "4.08.0"}
-  "qcheck" {>= "0.19"}
+  "qcheck" {>= "0.19" & < "0.24"}
   "ppxlib" {>= "0.22.0"}
   "ppx_deriving" {>= "5.2.1"}
   "odoc" {with-doc}
   "alcotest" {with-test & >= "1.4.0"}
-  "qcheck-alcotest" {with-test & >= "0.17"}
+  "qcheck-alcotest" {with-test & >= "0.17" & < "0.24"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.4.1/opam
+++ b/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.4.1/opam
@@ -8,12 +8,12 @@ bug-reports: "https://github.com/c-cube/qcheck/-/issues"
 depends: [
   "dune" {>= "2.8.0"}
   "ocaml" {>= "4.08.0"}
-  "qcheck-core" {>= "0.19"}
+  "qcheck-core" {>= "0.19" & < "0.24"}
   "ppxlib" {>= "0.22.0"}
   "ppx_deriving" {>= "5.2.1"}
   "odoc" {with-doc}
   "alcotest" {with-test & >= "1.4.0"}
-  "qcheck-alcotest" {with-test & >= "0.17"}
+  "qcheck-alcotest" {with-test & >= "0.17" & < "0.24"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.5/opam
+++ b/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.5/opam
@@ -8,12 +8,12 @@ bug-reports: "https://github.com/c-cube/qcheck/-/issues"
 depends: [
   "dune" {>= "2.8.0"}
   "ocaml" {>= "4.08.0"}
-  "qcheck-core" {>= "0.19"}
+  "qcheck-core" {>= "0.19" & < "0.24"}
   "ppxlib" {>= "0.22.0"}
   "ppx_deriving" {>= "5.2.1"}
   "odoc" {with-doc}
   "alcotest" {with-test & >= "1.4.0"}
-  "qcheck-alcotest" {with-test & >= "0.17"}
+  "qcheck-alcotest" {with-test & >= "0.17" & < "0.24"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
`qcheck.0.24` in #27469 may change the output distribution of randomized property-based tests using the QCheck2 module, which may cause older `ppx_deriving_qcheck` releases to fail `dune runtest`.

This PR therefore adds qcheck upper bounds of 0.24 to them.