### PR TITLE
Add a qcheck upper bound for preface.1.0.0

### DIFF
--- a/packages/preface/preface.1.0.0/opam
+++ b/packages/preface/preface.1.0.0/opam
@@ -25,8 +25,8 @@ depends: [
   "dune" { >= "2.8.0" }
   "either"
   "alcotest" {with-test}
-  "qcheck-core" {with-test & >= "0.18"}
-  "qcheck-alcotest" {with-test}
+  "qcheck-core" {with-test & >= "0.18" & < "0.24"}
+  "qcheck-alcotest" {with-test & < "0.24"}
   "mdx" {with-test}
   "odoc"{with-doc}
 ]


### PR DESCRIPTION
`preface.1.0.0` is incompatible with `qcheck.0.24` as observed in #27468. This PR therefore adds an upper bound.

In more detail: `qcheck.0.24` adding missing `result` combinators in c-cube/qcheck#308 which cause a signature clash with the handwritten `result` combinator already present in `preface.1.0.0`
https://github.com/xvw/preface/blob/b7f5210830b7916033c56ede6108c2c439c31cdf/test/preface_qcheck/gen.ml#L66-L68 and thus resulting in the error message:
```
# Error: The implementation test/preface_qcheck/gen.ml
#        does not match the interface test/preface_qcheck/.preface_qcheck.objs/byte/preface_qcheck__Gen.cmi:
#         Values do not match:
#           val result :
#             ?distribution:float ->
#             (Random.State.t -> 'a) ->
#             (Random.State.t -> 'b) -> Random.State.t -> ('a, 'b) result
#         is not included in
#           val result : ?ratio:float -> 'a t -> 'e t -> ('a, 'e) result t
#         The type
#           ?distribution:float ->
#           (Random.State.t -> 'a) ->
#           (Random.State.t -> 'b) -> Random.State.t -> ('a, 'b) result
#         is not compatible with the type
#           ?ratio:float -> 'c t -> 'd t -> ('c, 'd) result t
#         File "test/preface_qcheck/gen.mli", line 61, characters 8-56:
#           Expected declaration
#         File "test/preface_qcheck/gen.ml", line 66, characters 4-10:
#           Actual declaration
```

To confirm that this PR indeed fixes the above, I'll be happy to wait and rebase it on `master` once #27468 is merged.