### PR TITLE
Package coq-AttestationProtocolOrdering.dev

### DIFF
--- a/packages/coq-AttestationProtocolOrdering/coq-AttestationProtocolOrdering.dev/opam
+++ b/packages/coq-AttestationProtocolOrdering/coq-AttestationProtocolOrdering.dev/opam
@@ -1,0 +1,40 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "sarahjohnson@ku.edu"
+
+homepage: "https://github.com/I2S/AttestationProtocolOrdering"
+dev-repo: "git+https://github.com/I2S/AttestationProtocolOrdering.git"
+bug-reports: "https://github.com/I2S/AttestationProtocolOrdering/issues"
+
+
+synopsis: "Coq library for ordering attestation protocols by their difficulty to attack"
+description: """
+AttestationProtocolOrdering is a Coq library for ordering attestation
+protocols by their difficulty to attack. Relies on the Chase model finder
+to enumerate possible attacks on attestation protocols specified in the
+Copland domain-specific language."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.20"}
+]
+
+tags: [
+  "logpath:AttestationProtocolOrdering"
+]
+authors: [
+  "Sarah Johnson"
+  "Anna Fritz"
+  "Perry Alexander"
+]
+url {
+  src:
+    "https://github.com/Sarah-Scott/AttestationProtocolOrdering/archive/refs/tags/v0.0.tar.gz"
+  checksum: [
+    "md5=9d94fe503c210c4b1595c4bab5d3e332"
+    "sha512=7bba2a015090e8f4921d13be9fe874fbf3a0fecfd00a43449e4cc16eb7e40a2b1c7665daa100caa2f95741786b77dcd44432704a29e1bfa5a6345d9e963a9d52"
+  ]
+}


### PR DESCRIPTION
### `coq-AttestationProtocolOrdering.dev`
Coq library for ordering attestation protocols by their difficulty to attack
AttestationProtocolOrdering is a Coq library for ordering attestation
protocols by their difficulty to attack. Relies on the Chase model finder
to enumerate possible attacks on attestation protocols specified in the
Copland domain-specific language.



---
* Homepage: https://github.com/I2S/AttestationProtocolOrdering
* Source repo: git+https://github.com/I2S/AttestationProtocolOrdering.git
* Bug tracker: https://github.com/I2S/AttestationProtocolOrdering/issues

---
:camel: Pull-request generated by opam-publish v2.5.0