### PR TITLE
[new release] pcre (8.0.3)

### DIFF
--- a/packages/pcre/pcre.8.0.3/opam
+++ b/packages/pcre/pcre.8.0.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Bindings to the Perl Compatibility Regular Expressions library"
+description: """
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: ["Markus Mottl <markus.mottl@gmail.com>"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "dune-configurator"
+  "conf-libpcre" {build}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/pcre-ocaml/releases/download/8.0.3/pcre-8.0.3.tbz"
+  checksum: [
+    "sha256=1488027811001cacfbffa6cdb14a2a6c7d9cdde32aeb68298557446be90d7f79"
+    "sha512=be82954c474461323cef1582140d7d064a8fbcd2ff8be7e6219158efdd4d102c9b3906323e34d607400c2bcc9f4c15b64c3770a8af75ff40b0fd198ae32f2330"
+  ]
+}
+x-commit-hash: "863ae9c4348144cf2b81bbe3e2b6ec125992e19a"


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library

- Project page: <a href="https://mmottl.github.io/pcre-ocaml">https://mmottl.github.io/pcre-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/pcre-ocaml/api">https://mmottl.github.io/pcre-ocaml/api</a>

##### CHANGES:

- Removed export on `caml_alloc_some` to prevent linking issues.
- Added OUnit2-based test suite.

Thanks to Chet Murthy for these contribution.
