### PR TITLE
Package bnfgen.4.0.0

### DIFF
--- a/packages/bnfgen/bnfgen.4.0.0/opam
+++ b/packages/bnfgen/bnfgen.4.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Random text generator that takes context-free grammars from BNF files"
+description: """\
+BNFGen generates random texts based on user-defined context-free grammars
+specified in a BNF-like syntax. There are descriptive syntax error messages
+and tracing options.
+
+You can specify "weight" for rules with alternation to influence their probabilities.
+For example, in `<foo> ::= 10 <foo> "foo" | "foo";` the first (recursive) option will be
+taken ten times more often.
+
+You can also specify deterministic repetition ranges, like `<foo>{4}` (exactly four of `<foo>`)
+or `<foo>{1,5}` (from one to five of `<foo>`).
+
+This package includes both a library and a CLI tool based on it."""
+maintainer: "Daniil Baturin <daniil@baturin.org>"
+authors: "Daniil Baturin <daniil@baturin.org>"
+license: "MIT"
+homepage: "https://baturin.org/tools/bnfgen"
+bug-reports: "https://github.com/dmbaturin/bnfgen/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "menhir" {>= "20211128"}
+  "dune" {>= "1.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/dmbaturin/bnfgen"
+url {
+  src: "https://github.com/dmbaturin/bnfgen/archive/refs/tags/4.0.0.tar.gz"
+  checksum: [
+    "md5=0caf99c1e3293bb7c3e72a7fb3f78fd7"
+    "sha512=4e8e4f87531b0e295e4f8c095745d4395a9ed487fff3133d4d493f9d8b8ea7e470dde44639b0891c5e1fca71cde4585500db57cbb710d5d5220e1ef7a7f98b74"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `bnfgen.4.0.0`
Random text generator that takes context-free grammars from BNF files
BNFGen generates random texts based on user-defined context-free grammars
specified in a BNF-like syntax. There are descriptive syntax error messages
and tracing options.

You can specify "weight" for rules with alternation to influence their probabilities.
For example, in `<foo> ::= 10 <foo> "foo" | "foo";` the first (recursive) option will be
taken ten times more often.

You can also specify deterministic repetition ranges, like `<foo>{4}` (exactly four of `<foo>`)
or `<foo>{1,5}` (from one to five of `<foo>`).

This package includes both a library and a CLI tool based on it.



---
* Homepage: https://baturin.org/tools/bnfgen
* Source repo: git+https://github.com/dmbaturin/bnfgen
* Bug tracker: https://github.com/dmbaturin/bnfgen/issues

---
:camel: Pull-request generated by opam-publish v2.4.0