### PR TITLE
Release ppxlib and ppxlib-tools 0.36.0

### DIFF
--- a/packages/metapp/metapp.0.4.4/opam
+++ b/packages/metapp/metapp.0.4.4/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
   "stdcompat" {>= "12"}
-  "ppxlib" {>= "0.22.0"}
+  "ppxlib" {>= "0.22.0" & < "0.36.0"}
   "ocamlfind" {>= "1.8.1"}
   "odoc" {with-doc & >= "1.5.1"}
 ]

--- a/packages/ppxlib-tools/ppxlib-tools.0.36.0/opam
+++ b/packages/ppxlib-tools/ppxlib-tools.0.36.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Tools for PPX users and authors"
+description: """
+Set of helper tools for PPX users and authors.
+
+ppxlib-pp-ast: Command line tool to pretty print OCaml ASTs in a human readable
+format."""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0"}
+  "ppxlib" {= version}
+  "cmdliner" {>= "1.3.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.36.0/ppxlib-0.36.0.tbz"
+  checksum: [
+    "sha256=5aba1bce14c53108614130110c843d004bf93bd2cf3a0778fd7086b85390a434"
+    "sha512=1e3e8fee42fe74bffc178dbcbb2db8ec38dd23e71f6fed3c4c92618cf93892f5847787e6e9abb322f5c85d29a76afde28ce840b42e10fedc14cd82ba578ad06a"
+  ]
+}
+x-commit-hash: "f1667f502e197275b873175406f181c86954795e"

--- a/packages/ppxlib/ppxlib.0.36.0/opam
+++ b/packages/ppxlib/ppxlib.0.36.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "Standard infrastructure for ppx rewriters"
+description: """
+Ppxlib is the standard infrastructure for ppx rewriters
+and other programs that manipulate the in-memory representation of
+OCaml programs, a.k.a the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0" & < "5.4.0"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0" {>= "v0.12"}
+  "sexplib0" {with-test & >= "v0.15"}
+  "stdlib-shims"
+  "ocamlfind" {with-test}
+  "re" {with-test & >= "1.9.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "ocamlformat" {with-dev-setup & = "0.26.2"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-migrate-parsetree" {< "2.0.0"}
+  "ocaml-base-compiler" {= "5.1.0~alpha1"}
+  "ocaml-variants" {= "5.1.0~alpha1+options"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.36.0/ppxlib-0.36.0.tbz"
+  checksum: [
+    "sha256=5aba1bce14c53108614130110c843d004bf93bd2cf3a0778fd7086b85390a434"
+    "sha512=1e3e8fee42fe74bffc178dbcbb2db8ec38dd23e71f6fed3c4c92618cf93892f5847787e6e9abb322f5c85d29a76afde28ce840b42e10fedc14cd82ba578ad06a"
+  ]
+}
+x-commit-hash: "f1667f502e197275b873175406f181c86954795e"


### PR DESCRIPTION
As usual, starting with a draft PR.

We're bumping the internal AST to 5.2 in this version. As a reminder, this is the version where the function arity representation changed in the AST so this is going to cause complete and utter chaos in the rev deps build: this is expected.

@patricoferris worked on sending PRs to our breaking rev deps so the ecosystem should update relatively quickly.

I'll add upper bounds to breaking rev deps as part of this PR.