### PR TITLE
Add missing ocaml dependency to unisim_archisec

### DIFF
--- a/packages/unisim_archisec/unisim_archisec.0.0.10/opam
+++ b/packages/unisim_archisec/unisim_archisec.0.0.10/opam
@@ -12,6 +12,7 @@ license: "BSD-3-Clause"
 homepage: "https://binsec.github.io"
 bug-reports: "mailto:binsec@saxifrage.saclay.cea.fr"
 depends: [
+  "ocaml" {>= "4.08"}
   "dune" {>= "3.0"}
   "conf-gcc" {build}
   "conf-g++" {build}


### PR DESCRIPTION
Followup to https://github.com/ocaml/opam-repository/pull/27456 as per https://github.com/ocaml/opam-repository/pull/27456#pullrequestreview-2630084857