### PR TITLE
[new release] ansifmt (0.3.0)

### DIFF
--- a/packages/ansifmt/ansifmt.0.3.0/opam
+++ b/packages/ansifmt/ansifmt.0.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A simple, lightweight library for ANSI formatting"
+description:
+  "A simple, lightweight library for ANSI formatting with powerful features such as a element-based system for pretty-printing code in the terminal."
+maintainer: ["Qexat <contact@qexat.com>"]
+authors: ["Qexat <contact@qexat.com>"]
+license: "MIT"
+tags: ["ansi" "formatting" "pretty-printing" "terminal"]
+homepage: "https://github.com/qexat/ansifmt"
+bug-reports: "https://github.com/qexat/ansifmt/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/qexat/ansifmt.git"
+url {
+  src:
+    "https://github.com/qexat/ansifmt/releases/download/0.3.0/ansifmt-0.3.0.tbz"
+  checksum: [
+    "sha256=2aafe8c72c1112b95b4b13be7f070d8fa0618a9414a85c3fb395a0ea3b5ace29"
+    "sha512=394320608cd6ffffb68c1b20d593d42929e155678be2adc3f43e86900adcadab50758ff53d91aa770259c302784064782c89b8d623016e370421a702755350ee"
+  ]
+}
+x-commit-hash: "c5cdc2d376af59bc3e42ebfb3874fbca5c3a36b3"


### PR DESCRIPTION
A simple, lightweight library for ANSI formatting

- Project page: <a href="https://github.com/qexat/ansifmt">https://github.com/qexat/ansifmt</a>

##### CHANGES:

## Features

- Add `Custom` token type variant which takes a styling, for tokens without particular semantics.
- Add `Formatting.Element` that supersedes `Formatting.Tree`.
- Add `Formatting.Interfaces.TO_ELEMENT` interface which establishes the contract to convert to a formatting element that is used by formatting and printing utilitary functions such as `format` and `IO.print_formatted`.
- Expose the `Int8` module that is used by `Color`.
- Add `Token.number` to easily construct a number literal token.

## Removed

- Remove `Formatting.Tree`, `Formatting.TOKENIZABLE` and its associated functions. Use `Formatting.Element` instead.
- Remove the `Prelude` module. It has merged with the core `Ansifmt` module.
- Remove `print_formatted` alias from the prelude. The function can still be found as `IO.print_formatted`.
- Remove `make_styling` alias from the prelude. The function can still be found as `Styling.create`.

## Internal

- Renamed `Utils` to `Internal`.
- `Formatting` is now a directory instead of a file containing all its submodules.
- Added `List.intersperse` and `List.singleton` (used in `Formatting.Element`).
- Added `Bool.tautology` (used in `Formatting.Element`).
