### PR TITLE
Avoid runtest on saturn.0.4.1 with OCaml 4

### DIFF
--- a/packages/saturn/saturn.0.4.1/opam
+++ b/packages/saturn/saturn.0.4.1/opam
@@ -29,7 +29,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version >= "5.0.0"}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
A runtest of saturn.0.4.1 triggers a deadlock, and eventually a timeout.

This happened most recently twice on #27468, adding needless CI noise:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/7e0e9d80efed5e4890f2c637e95806ade415b5a2
```
/home/opam: (run (network host)
                 (shell "(opam reinstall --with-test saturn.0.4.1) || true"))
The following actions will be performed:
=== recompile 1 package
  - recompile saturn                     0.4.1
=== install 13 packages
  - install   containers                 3.15   [required by dscheck]
  - install   csexp                      1.5.2  [required by dune-configurator]
  - install   dscheck                    0.5.0  [required by saturn]
  - install   dune-configurator          3.17.2 [required by containers]
  - install   either                     1.0.0  [required by containers]
  - install   oseq                       0.5.1  [required by dscheck]
  - install   ounit2                     2.2.7  [required by qcheck-ounit]
  - install   qcheck                     0.24   [required by saturn]
  - install   qcheck-multicoretests-util 0.7    [required by qcheck-stm]
  - install   qcheck-ounit               0.24   [required by qcheck]
  - install   qcheck-stm                 0.7    [required by saturn]
  - install   tsort                      2.1.0  [required by dscheck]
  - install   yojson                     2.2.2  [required by saturn]

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-> retrieved containers.3.15  (https://github.com/c-cube/ocaml-containers/releases/download/v3.15/containers-3.15.tbz)
-> retrieved csexp.1.5.2  (https://github.com/ocaml-dune/csexp/releases/download/1.5.2/csexp-1.5.2.tbz)
-> installed csexp.1.5.2
-> retrieved dscheck.0.5.0  (https://github.com/ocaml-multicore/dscheck/releases/download/0.5.0/dscheck-0.5.0.tbz)
-> retrieved dune-configurator.3.17.2  (https://github.com/ocaml/dune/releases/download/3.17.2/dune-3.17.2.tbz)
-> retrieved either.1.0.0  (https://github.com/mirage/either/releases/download/1.0.0/either-1.0.0.tbz)
-> installed either.1.0.0
-> retrieved oseq.0.5.1  (https://github.com/c-cube/oseq/releases/download/v0.5.1/oseq-0.5.1.tbz)
-> retrieved ounit2.2.2.7  (https://github.com/gildor478/ounit/releases/download/v2.2.7/ounit-2.2.7.tbz)
-> installed oseq.0.5.1
-> retrieved qcheck.0.24, qcheck-ounit.0.24  (https://github.com/c-cube/qcheck/archive/v0.24.tar.gz)
-> retrieved qcheck-multicoretests-util.0.7, qcheck-stm.0.7  (https://github.com/ocaml-multicore/multicoretests/archive/refs/tags/0.7.tar.gz)
-> installed dune-configurator.3.17.2
-> installed ounit2.2.2.7
-> retrieved saturn.0.4.1  (https://github.com/ocaml-multicore/saturn/releases/download/0.4.1/saturn-0.4.1.tbz)
-> installed qcheck-ounit.0.24
-> installed qcheck-multicoretests-util.0.7
-> retrieved tsort.2.1.0  (https://github.com/dmbaturin/ocaml-tsort/archive/refs/tags/2.1.0.tar.gz)
-> installed qcheck.0.24
-> installed tsort.2.1.0
-> retrieved yojson.2.2.2  (https://github.com/ocaml-community/yojson/releases/download/2.2.2/yojson-2.2.2.tbz)
-> installed qcheck-stm.0.7
-> installed containers.3.15
-> installed dscheck.0.5.0
-> removed   saturn.0.4.1
-> installed yojson.2.2.2
2025-02-18 17:30.58: Cancelling: Timeout (120.0 minutes)
Job cancelled
2025-02-18 17:31.04: Timeout (120.0 minutes)
```

This is not a new thing. Previously I've observed it on, e.g., #27086 #27038 #26574 #26196.
In addition to adding noise, it ends up delaying PRs compared to "all green ones".

As this only seems to trigger on OCaml 4, the PR requires OCaml 5 to trigger `runtest`. 
Finally, there's both saturn 0.5.0 and 1.0.0 releases available, neither of which time out.