### PR TITLE
Disable runtest for bytestring on 5.2.0+

### DIFF
--- a/packages/bytestring/bytestring.0.0.8/opam
+++ b/packages/bytestring/bytestring.0.0.8/opam
@@ -41,7 +41,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version < "5.2.0"}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
This PR disables runtest for bytestring on 5.2.0+ where slightly different ppx output cause cram tests to fail.

I most recently got a red light for this on #27468 but has previously observed and noted it in #27086 #27038 #26196.

For my own part this adds needless CI noise when rolling QCheck release.

https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/7e0e9d80efed5e4890f2c637e95806ade415b5a2
```
/home/opam: (run (network host)
                 (shell "(opam reinstall --with-test bytestring.0.0.8) || true"))
The following actions will be performed:
=== recompile 1 package
  - recompile bytestring 0.0.8

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-> retrieved bytestring.0.0.8  (https://github.com/riot-ml/riot/releases/download/0.0.8/riot-0.0.8.tbz)
[ERROR] The compilation of bytestring.0.0.8 failed at "dune build -p bytestring -j 31 @install @runtest".

#=== ERROR while compiling bytestring.0.0.8 ===================================#
# context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-base-compiler.5.3.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/bytestring.0.0.8
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p bytestring -j 31 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/bytestring-7-b9339d.env
# output-file          ~/.opam/log/bytestring-7-b9339d.out
### output ###
# (cd _build/default/bytestring && ./bytestring_transient_test.exe)
# test "add_literal_utf trns \"\\xc3\\x28\" raises" OK
# prop "add literal utf8 string" OK
# prop "add literal string" OK
# prop "add to empty string" OK
# prop "duplicate" OK
# (cd _build/default/bytestring && ./bytestring_test.exe)
# test "naughty_string" = "" OK
# test "naughty_string" = "undefined" OK
# test "naughty_string" = "undef" OK
# test "naughty_string" = "null" OK

[...]

# index 622c64d..38d1bdb 100644
# --- a/_build/.sandbox/50f2e4ce2223bfcd5eb007a766149a0b/default/bytestring/ppx.t/run.t
# +++ b/_build/.sandbox/50f2e4ce2223bfcd5eb007a766149a0b/default/bytestring/ppx.t/run.t.corrected
# @@ -118,7 +118,8 @@
#      {
#        tool_name = "ppx_driver";
#        include_dirs = [];
# -      load_path = [];
# +      hidden_include_dirs = [];
# +      load_path = ([], []);
#        open_modules = [];
#        for_package = None;
#        debug = false;

[...]
```