### PR TITLE
[new release] melange (5.0.1)

### DIFF
--- a/packages/melange/melange.5.0.1-414/opam
+++ b/packages/melange/melange.5.0.1-414/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "4.14" & < "5.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {dev & with-test}
+  "ppxlib" {>= "0.30.0"}
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/5.0.1-414/melange-5.0.1-414.tbz"
+  checksum: [
+    "sha256=f06d711405ef0b0dbedf68b4b9e857b45b99ba731adcaf183b58aab48c6ec282"
+    "sha512=49c974fcac26d57d89b9549788c5ef3b59afeb760ce455895e623ec8f47b77da83c6bc84997c09d5cc7c56f13bb90debc7627679d957b41f0c148600d7b03fb3"
+  ]
+}
+x-commit-hash: "41b35e289eb04ee5ed19fcc606567f6f35914870"

--- a/packages/melange/melange.5.0.1-51/opam
+++ b/packages/melange/melange.5.0.1-51/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "5.1.1" & < "5.2"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {dev & with-test}
+  "ppxlib" {>= "0.30.0"}
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/5.0.1-51/melange-5.0.1-51.tbz"
+  checksum: [
+    "sha256=7753da6c74f2dc6ac610ec71c96ba7c7230dfec1af3fd60c587767643112fc6e"
+    "sha512=5be34a60d44ae5423bd3552d967db2cab462aeb17a2a28050a87b2a714e74b944f532763b804e5472b2cef37eeabf99885a66eddfb030e6e21826d2214880768"
+  ]
+}
+x-commit-hash: "dad03760eb3bd50b4d5b151028fce7f8a0c077f0"

--- a/packages/melange/melange.5.0.1-52/opam
+++ b/packages/melange/melange.5.0.1-52/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "5.2" & < "5.3"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {dev & with-test}
+  "ppxlib" {>= "0.30.0"}
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/5.0.1-52/melange-5.0.1-52.tbz"
+  checksum: [
+    "sha256=6662a248daefc50a5b1586ea9c2337d70d3dfdb55c690619b179041f8ab9b613"
+    "sha512=e767493ed6e50cfc604d1c1a16145dafcad710b3ade407b5ea87bb596439025185f076a5c1236f9c9794b58bf74dde7d32ed9b97ccdc1083078c5b380aa86503"
+  ]
+}
+x-commit-hash: "bb1040ee03e4176250186440b7e80b9489777d49"

--- a/packages/melange/melange.5.0.1-53/opam
+++ b/packages/melange/melange.5.0.1-53/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "5.3" & < "5.4"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {dev & with-test}
+  "ppxlib" {>= "0.30.0"}
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/5.0.1-53/melange-5.0.1-53.tbz"
+  checksum: [
+    "sha256=abb26e01e5439cb0c7c41f62411441816af7c7c18a9e0800063c3d4df4da8fec"
+    "sha512=9d6f7d80f48fe773f6a427d199c1fc5ea095231fc09a4b7a35d4604abcacd5e11dfdd68d017862eb783882b887e536a06c8b9ead22e8ee7ffe23c1d164cee31a"
+  ]
+}
+x-commit-hash: "6d368bf8de3e4a2e4cc131364d1731488b0f9ed7"


### PR DESCRIPTION
## Changes

- Fix `[@mel.send]` and `[@mel.this]` interaction in the presence of constant `[@mel.as ".."]` arguments ([#1328](https://github.com/melange-re/melange/pull/1328))
- Allow skipping over `[@mel.as ".."]` constant arguments in `[@mel.send]` in the absence of `@mel.this` ([#1328](https://github.com/melange-re/melange/pull/1328))
- core: fix missed function argument fusion optimization on OCaml versions 5.2 and above, caused by [ocaml/ocaml#12236](https://github.com/ocaml/ocaml/pull/12236) generating multiple function nodes for `fun a -> fun b -> ...` in the Lambda IR. This issue, while partially fixed in Melange 5.0.0, didn't account for default arguments ([#1253](https://github.com/melange-re/melange/issues/1253), [#1334](https://github.com/melange-re/melange/issues/1334)).

