### PR TITLE
Package libbinaryen.116.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.116.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.116.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "6.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v116.0.0/libbinaryen-v116.0.0.tar.gz"
+  checksum: [
+    "md5=a340333a30843a2e830b2ced5f17f5b2"
+    "sha512=cffbe444383f349232a77354b5da0d6d6b922c0e37a832e8ebb713e5b6b480b47dbaa762ab4b1b3d9f629792971583e017ebb44f6e7a86b92b7262076d5a1aa4"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.116.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [116.0.0](https://github.com/grain-lang/libbinaryen/compare/v115.0.0...v116.0.0) (2025-02-17)


### ⚠ BREAKING CHANGES

* Upgrade to Binaryen v116 ([#92](https://github.com/grain-lang/libbinaryen/issues/92))

### Features

* Upgrade to Binaryen v116 ([#92](https://github.com/grain-lang/libbinaryen/issues/92)) ([7f9308d](https://github.com/grain-lang/libbinaryen/commit/7f9308d15601ad989a89f619e5818056d0d872a0))


---
:camel: Pull-request generated by opam-publish v2.4.0