### PR TITLE
[new release] archive (2 packages) (3.7.2+5)

### DIFF
--- a/packages/archive-lwt/archive-lwt.3.7.2+5/opam
+++ b/packages/archive-lwt/archive-lwt.3.7.2+5/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Binding to libarchive for LWT"
+description: """
+ libarchive is a C library for reading and writing tar, cpio, zip, ISO, and
+ other archive formats. This library is its OCaml bindings.
+
+ * Reads a variety of formats, including tar, pax, cpio, zip, xar, lha, ar,
+   cab, mtree, and ISO images.
+ * Writes tar, pax, cpio, zip, xar, ar, ISO, mtree, and shar archives.
+ * Full automatic format detection when reading archives, including
+   compressed archives.
+
+ [libarchive website](http://code.google.com/p/libarchive/)
+"""
+maintainer: ["Sylvain Le Gall <sylvain+ocaml@le-gall.net>"]
+authors: ["Sylvain Le Gall"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-archive"
+bug-reports: "https://github.com/gildor478/ocaml-archive/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14.1"}
+  "archive" {= version}
+  "lwt" {>= "2.3.2"}
+  "extlib" {>= "1.8.0" & with-test}
+  "ounit2" {>= "2.2.7" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/gildor478/ocaml-archive.git"
+url {
+  src:
+    "https://github.com/gildor478/ocaml-archive/releases/download/v3.7.2%2B5/archive-3.7.2.5.tbz"
+  checksum: [
+    "sha256=628004d93c1af1c732c4d44328f6ff6a695662f6fe7c1aa62c041612bbdea585"
+    "sha512=d62db7f8c6b9293cb27bb58c0fd828b9be0e803ab492b640b45dac11ff89321adb8fadd5ff9a8d429aca3b2563497247991ba2fbf2e073f567b985d229b42235"
+  ]
+}
+x-commit-hash: "5adae5c344722019412e538289e2e0e150d2e99b"

--- a/packages/archive/archive.3.7.2+5/opam
+++ b/packages/archive/archive.3.7.2+5/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "Binding to libarchive"
+description: """
+ libarchive is a C library for reading and writing tar, cpio, zip, ISO, and
+ other archive formats. This library is its OCaml bindings.
+
+ * Reads a variety of formats, including tar, pax, cpio, zip, xar, lha, ar,
+   cab, mtree, and ISO images.
+ * Writes tar, pax, cpio, zip, xar, ar, ISO, mtree, and shar archives.
+ * Full automatic format detection when reading archives, including
+   compressed archives.
+
+ [libarchive website](http://code.google.com/p/libarchive/)
+"""
+maintainer: ["Sylvain Le Gall <sylvain+ocaml@le-gall.net>"]
+authors: ["Sylvain Le Gall"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/gildor478/ocaml-archive"
+bug-reports: "https://github.com/gildor478/ocaml-archive/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14.1"}
+  "fileutils" {>= "0.6.6"}
+  "conf-pkg-config" {build}
+  "extlib" {>= "1.8.0" & with-test}
+  "ounit2" {>= "2.2.7" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/gildor478/ocaml-archive.git"
+depexts: [
+  ["libarchive"] {os = "macos" & os-distribution = "homebrew"}
+  ["libarchive"] {os = "macos" & os-distribution = "macports"}
+  ["libarchive-devel"] {os = "win32" & os-distribution = "cygwin"}
+  ["libarchive-dev" "openssl-dev"] {os-distribution = "alpine"}
+  ["libarchive-dev"] {os-family = "debian"}
+  ["libarchive-dev"] {os-family = "ubuntu"}
+  ["libarchive-devel"] {os-family = "fedora"}
+  ["libarchive-devel"] {os-family = "rhel"}
+  ["libarchive"] {os-family = "gentoo"}
+  ["libarchive"] {os-family = "bsd"}
+  ["libarchive-devel"] {os-family = "suse"}
+  ["libarchive-devel"] {os-family = "opensuse"}
+]
+url {
+  src:
+    "https://github.com/gildor478/ocaml-archive/releases/download/v3.7.2%2B5/archive-3.7.2.5.tbz"
+  checksum: [
+    "sha256=628004d93c1af1c732c4d44328f6ff6a695662f6fe7c1aa62c041612bbdea585"
+    "sha512=d62db7f8c6b9293cb27bb58c0fd828b9be0e803ab492b640b45dac11ff89321adb8fadd5ff9a8d429aca3b2563497247991ba2fbf2e073f567b985d229b42235"
+  ]
+}
+x-commit-hash: "5adae5c344722019412e538289e2e0e150d2e99b"
+


### PR DESCRIPTION
Binding to libarchive

- Project page: <a href="https://github.com/gildor478/ocaml-archive">https://github.com/gildor478/ocaml-archive</a>

##### CHANGES:

### Fixed
- Upgrade dune setup and prepare an opam release.
