### PR TITLE
Package vscoq-language-server.2.2.5

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.2.5/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.2.5/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/coq-community/vscoq"
+bug-reports: "https://github.com/coq-community/vscoq/issues"
+dev-repo: "git+https://github.com/coq-community/vscoq"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { >= "4.14" }
+  "dune" { >= "3.5" }
+  "coq-core" { ((>= "8.18" < "8.21") | (= "dev")) }
+  "coq-stdlib" { ((>= "8.18" < "8.21") | (= "dev")) }
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "ppx_optcomp"
+  "result" { >= "1.5" }
+  "lsp" { >= "1.15"}
+  "sel" {>= "0.6.0"}
+]
+synopsis: "VSCoq language server"
+available: arch != "arm32" & arch != "x86_32"
+description: """
+LSP based language server for Coq and its VSCoq user interface
+"""
+url {
+  src:
+    "https://github.com/coq/vscoq/releases/download/v2.2.5/vscoq-language-server-2.2.5.tar.gz"
+  checksum: [
+    "md5=8bc848aaf2ad0fe41a02741e633ad7e3"
+    "sha512=eb6c80a3290b1d688ea3b94a3087f204c9f9f03bddd95b21952b02af1dc4de073c1b99baed5a5f6a395e69a27c0d45f6ec181488da62e9f5c6a77d91d752dd5c"
+  ]
+}


### PR DESCRIPTION
### `vscoq-language-server.2.2.5`
VSCoq language server
LSP based language server for Coq and its VSCoq user interface



---
* Homepage: https://github.com/coq-community/vscoq
* Source repo: git+https://github.com/coq-community/vscoq
* Bug tracker: https://github.com/coq-community/vscoq/issues

---
:camel: Pull-request generated by opam-publish v2.5.0