### PR TITLE
[new release] preface (1.1.0)

### DIFF
--- a/packages/preface/preface.1.1.0/opam
+++ b/packages/preface/preface.1.1.0/opam
@@ -16,7 +16,7 @@ bug-reports: "https://github.com/xvw/preface/issues"
 build: [
   [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
-  [ "dune" "runtest" "-p" name ] {with-test}
+  [ "dune" "runtest" "-p" name ] {with-test & ocaml:version >= "5.1.0"}
   [ "dune" "build" "@doc" "-p" name ] {with-doc}
 ]
 

--- a/packages/preface/preface.1.1.0/opam
+++ b/packages/preface/preface.1.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+
+maintainer: "xaviervdw@gmail.com"
+authors: [
+  "Didier Plaindoux <d.plaindoux@free.fr>"
+  "Pierre Ruyter <grimfw@gmail.com>"
+  "Xavier Van de Woestyne <xaviervdw@gmail.com>"
+]
+
+license: "MIT"
+tags: ["library" "standard" "monad"]
+homepage: "https://github.com/xvw/preface"
+dev-repo: "git+https://github.com/xvw/preface.git"
+bug-reports: "https://github.com/xvw/preface/issues"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name ] {with-test}
+  [ "dune" "build" "@doc" "-p" name ] {with-doc}
+]
+
+depends: [
+  "ocaml" { >= "4.12.0" }
+  "dune" { >= "2.8.0" }
+  "alcotest" {with-test}
+  "qcheck-core" { >= "0.19"}
+  "qcheck-alcotest" {with-test}
+  "mdx" {with-test}
+  "odoc"{with-doc}
+]
+
+synopsis: "An opinionated library for function programming (à La Haskell)"
+description:"""
+Preface is an opinionated library designed to facilitate the
+handling of recurring functional programming idioms in OCaml.
+"""
+url {
+  src:
+    "https://github.com/xvw/preface/releases/download/v1.1.0/preface-1.1.0.tbz"
+  checksum: [
+    "sha256=82d8cebf4fa7aac522835e84e735ddfd24de5b9f6d816fb8134ce1f460e4494f"
+    "sha512=22c84b1870311c52f245d4703ffa6adcbc33ed7d152ddbc17978c35c56a9c71b4231158ed25a6fd53ee80a2913d52a81247529afddb0e0639c63174717500daf"
+  ]
+}
+x-commit-hash: "904d5db8b71eade4d51dd7ab76e1736f75436b82"

--- a/packages/yocaml/yocaml.1.0.0/opam
+++ b/packages/yocaml/yocaml.1.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" { >= "2.8" }
   "odoc" {with-doc}
   "alcotest" {with-test}
-  "preface" { >= "1.0.0"}
+  "preface" { = "1.0.0"}
 ]
 conflicts: [
   "ocaml-variants" {= "4.12.0+domains+effects" | = "5.1.1+effect-syntax"}

--- a/packages/yocaml_cmark/yocaml_cmark.1.0.0/opam
+++ b/packages/yocaml_cmark/yocaml_cmark.1.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" { >= "4.14.0" }
   "dune" { >= "2.8" }
   "odoc" {with-doc}
-  "preface" { >= "1.0.0" }
+  "preface" { = "1.0.0" }
   "cmarkit"
   "yocaml" {= version}
 ]

--- a/packages/yocaml_git/yocaml_git.1.0.0/opam
+++ b/packages/yocaml_git/yocaml_git.1.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" { >= "4.11.1" }
   "dune" { >= "2.8" }
   "odoc" {with-doc}
-  "preface" { >= "1.0.0" }
+  "preface" { = "1.0.0" }
   "lwt" { >= "5.4.2" }
   "git-kv" { >= "0.0.3" }
   "git-unix"

--- a/packages/yocaml_jingoo/yocaml_jingoo.1.0.0/opam
+++ b/packages/yocaml_jingoo/yocaml_jingoo.1.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" { >= "4.11.1" }
   "dune" { >= "2.8" }
   "odoc" {with-doc}
-  "preface" { >= "1.0.0"}
+  "preface" { = "1.0.0"}
   "jingoo" { >= "1.4.3" }
   "yocaml" {= version}
 ]

--- a/packages/yocaml_markdown/yocaml_markdown.1.0.0/opam
+++ b/packages/yocaml_markdown/yocaml_markdown.1.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" { >= "4.11.1" }
   "dune" { >= "2.8" }
   "odoc" {with-doc}
-  "preface" { >= "1.0.0" }
+  "preface" { = "1.0.0" }
   "omd" { >= "1.3.1" }
   "yocaml" {= version}
 ]

--- a/packages/yocaml_mustache/yocaml_mustache.1.0.0/opam
+++ b/packages/yocaml_mustache/yocaml_mustache.1.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" { >= "4.11.1" }
   "dune" { >= "2.8" }
   "odoc" {with-doc}
-  "preface" { >= "1.0.0" }
+  "preface" { = "1.0.0" }
   "mustache" { >= "3.1.0" }
   "yocaml" {= version}
 ]

--- a/packages/yocaml_unix/yocaml_unix.1.0.0/opam
+++ b/packages/yocaml_unix/yocaml_unix.1.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" { >= "4.11.1" }
   "dune" { >= "2.8" }
   "odoc" {with-doc}
-  "preface" { >= "1.0.0" }
+  "preface" { = "1.0.0" }
   "cryptokit" { >= "1.16.1" }
   "logs" {>= "0.7.0" }
   "conduit-lwt" { >= "4.0.0" }

--- a/packages/yocaml_yaml/yocaml_yaml.1.0.0/opam
+++ b/packages/yocaml_yaml/yocaml_yaml.1.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" { >= "4.11.1" & < "5.3"}
   "dune" { >= "2.8" }
   "odoc" {with-doc}
-  "preface" { >= "1.0.0" }
+  "preface" { = "1.0.0" }
   "yaml" { >= "2.1.0" }
   "yocaml" {= version}
   "alcotest" {with-test}


### PR DESCRIPTION
An opinionated library for function programming (à La Haskell)

- Project page: <a href="https://github.com/xvw/preface">https://github.com/xvw/preface</a>

##### CHANGES:

- Some fixture for `5.3.0` [**@xvw**](https://github.com/xvw)
- Add `Lattice` [**@hakimba**](https://github.com/hakimba)
- Add `Bounded_lattice` [**@hakimba**](https://github.com/hakimba)
- **Breaking change** Move Monomorphized version of `Result` abstraction under the module `Result.Mono` and provide Indexed abstraction [**@mspwn**](https://github.com/mspwn)
- **Breaking change** Remove manifest types in submodules (`Infix` and `Syntax`) [**@mspwn**](https://github.com/mspwn)
- Add `Indexed_functor`, `Indexed_alt`, `Indexed_apply`, `Indexed_applicative`, `Indexed_alternative`, `Indexed_selective`, `Indexed_bind`, `Indexed_monad`, `Indexed_monad_plus`, `Indexed_comonad`, `Indexed_foldable` [**@mspwn**](https://github.com/mspwn), [**@gr-im**](https://github.com/gr-im), [**@xvw**](https://github.com/xvw)
- Add `Bounded_join_semilattice` [**@hakimba**](https://github.com/hakimba)
- Add `Bounded_meet_semilattice` [**@hakimba**](https://github.com/hakimba)
- Add `Join_semilattice` [**@hakimba**](https://github.com/hakimba)
- Add `Meet_semilattice` [**@xvw**](https://github.com/xvw) and [**@hakimba**](https://github.com/hakimba)
- Add `Equivalence` in `Preface.Stdlib` [**@gr-im**](https://github.com/gr-im), [**@xvw**](https://github.com/xvw)
- Add `Preface.Laws` and `Preface.Qcheck` to allow external users to build their own test suites for implementations outside Preface [**@gr-im**](https://github.com/gr-im), [**@xvw**](https://github.com/xvw)
- **Breaking change** change minimal version of OCaml to `>= 4.12.0` [**@gr-im**](https://github.com/gr-im)
- Exposition of `Apply` and `Make` in `Preface.Make` [**@gr-im**](https://github.com/gr-im)
