### PR TITLE
[new release] opam-monorepo (0.4.1)

### DIFF
--- a/packages/mirage/mirage.4.5.0/opam
+++ b/packages/mirage/mirage.4.5.0/opam
@@ -19,6 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
+  "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
   "cmdliner" {>= "1.2.0"}

--- a/packages/opam-monorepo/opam-monorepo.0.4.1/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.4.1/opam
@@ -16,6 +16,7 @@ depends: [
   "dune" {>= "3.6"}
   "ocaml" {>= "4.10.0"}
   "odoc" {with-doc}
+  "conf-pkg-config"
 ]
 conflicts: [
   "dune-build-info" {= "2.7.0" | = "2.7.1"}
@@ -24,26 +25,6 @@ conflicts: [
 dev-repo: "git+https://github.com/tarides/opam-monorepo.git"
 build: [ "dune" "build" "-p" name "-j" jobs "@install" "@test/lib/runtest" {with-test} ]
 flags: [ plugin ]
-depexts: [
-  ["devel/pkgconf"] {os = "openbsd"}
-  ["pkg-config"] {os-distribution = "nixos"}
-  ["pkg-config"] {os-family = "debian"}
-  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
-  ["pkgconf"] {os = "cygwin"}
-  ["pkgconf"] {os = "freebsd"}
-  ["pkgconf"] {os-distribution = "alpine"}
-  ["pkgconf"] {os-distribution = "arch"}
-  ["pkgconf-pkg-config"] {os-distribution = "fedora"}
-  ["pkgconf-pkg-config"] {os-distribution = "mageia"}
-  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
-  ["pkgconf-pkg-config"] {os-distribution = "ol" & os-version >= "8"}
-  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
-  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
-  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
-  ["pkgconfig"] {os-distribution = "ol" & os-version <= "7"}
-  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
-  ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
-]
 url {
   src:
     "https://github.com/tarides/opam-monorepo/releases/download/0.4.1/opam-monorepo-0.4.1.tbz"

--- a/packages/opam-monorepo/opam-monorepo.0.4.1/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.4.1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Assemble and manage fully vendored Dune repositories"
+description: """
+The opam monorepo plugin provides a convenient interface to bridge the
+opam package manager with having a local copy of all the source
+code required to build a project using the dune build tool."""
+maintainer: ["anil@recoil.org"]
+authors: [
+  "Anil Madhavapeddy" "Nathan Rebours" "Lucas Pluvinage" "Jules Aguillon"
+]
+license: "ISC"
+homepage: "https://github.com/tarides/opam-monorepo"
+doc: "https://tarides.github.io/opam-monorepo"
+bug-reports: "https://github.com/tarides/opam-monorepo/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.10.0"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "dune-build-info" {= "2.7.0" | = "2.7.1"}
+  "dune-configurator" {= "2.7.0" | = "2.7.1"}
+]
+dev-repo: "git+https://github.com/tarides/opam-monorepo.git"
+build: [ "dune" "build" "-p" name "-j" jobs "@install" "@test/lib/runtest" {with-test} ]
+flags: [ plugin ]
+depexts: [
+  ["devel/pkgconf"] {os = "openbsd"}
+  ["pkg-config"] {os-distribution = "nixos"}
+  ["pkg-config"] {os-family = "debian"}
+  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconf"] {os = "cygwin"}
+  ["pkgconf"] {os = "freebsd"}
+  ["pkgconf"] {os-distribution = "alpine"}
+  ["pkgconf"] {os-distribution = "arch"}
+  ["pkgconf-pkg-config"] {os-distribution = "fedora"}
+  ["pkgconf-pkg-config"] {os-distribution = "mageia"}
+  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "ol" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
+  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
+  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "ol" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
+  ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
+]
+url {
+  src:
+    "https://github.com/tarides/opam-monorepo/releases/download/0.4.1/opam-monorepo-0.4.1.tbz"
+  checksum: [
+    "sha256=9a1839629f6c00d60f7c71f68b72cc8191a70c363ffc0efa97e19ed241f8ae57"
+    "sha512=77b5047c83e921eaaada7ecb860d0181bdb0d3c5c501345cb2031f54120fe3c675228a715518510d91d8a0eaafb9c96dc2ca1f3e1a6007d439234b239b266b19"
+  ]
+}
+x-commit-hash: "f6c3411793b8e597955318c7cab43974de4d3708"


### PR DESCRIPTION
Assemble and manage fully vendored Dune repositories

- Project page: <a href="https://github.com/tarides/opam-monorepo">https://github.com/tarides/opam-monorepo</a>
- Documentation: <a href="https://tarides.github.io/opam-monorepo">https://tarides.github.io/opam-monorepo</a>

##### CHANGES:

### Added

### Changed

### Deprecated

### Fixed
- Fix support for pinned packages. In that case, it is not necessary to add
  dev-repo conflicts as `opam-monorepo` will always use the pinned repository.
  (tarides/opam-monorepo#398, tarides/opam-monorepo#353, @samoht, @reynir, reported by @emillon)
- Improve the speed of `opam monorepo pull`. Loading an switch state might take
  a few seconds -- replace it with a call to `ocamlc --version` to check if the
  lockfile is compatible with the currently available OCaml compiler
  (tarides/opam-monorepo#403, @samoht)
- Treat "ocaml-compiler" as a package to be ignored by the check whether it uses
  dune for building (tarides/opam-monorepo#407, @hannesm, review by @shym)
- Bump opam dependencies to 2.3.0, allowing newer variables like with-dev-setup
    (tarides/opam-monorepo#408, @palainp, @Firobe, tarides/opam-monorepo#380, @kit-ty-kate)

### Removed

### Security
