### PR TITLE
wyrd needs conf-autoconf

### DIFF
--- a/packages/wyrd/wyrd.1.4.6/opam
+++ b/packages/wyrd/wyrd.1.4.6/opam
@@ -18,7 +18,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.06"}
   "camlp4"
   "conf-autoconf"
   "conf-ncurses"

--- a/packages/wyrd/wyrd.1.4.6/opam
+++ b/packages/wyrd/wyrd.1.4.6/opam
@@ -20,6 +20,7 @@ build: [
 depends: [
   "ocaml"
   "camlp4"
+  "conf-autoconf"
   "conf-ncurses"
 ]
 x-ci-accept-failures: ["debian-unstable"]


### PR DESCRIPTION
Fails with
```
=== ERROR while compiling wyrd.1.4.6 =========================================#
 context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-base-compiler.5.3.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.3/.opam-switch/build/wyrd.1.4.6
 command              ~/.opam/opam-init/hooks/sandbox.sh build make
 exit-code            2
 env-file             ~/.opam/log/wyrd-9-01b87a.env
 output-file          ~/.opam/log/wyrd-9-01b87a.out
 autoconf
 make: autoconf: No such file or directory
 make: *** [Makefile:199: configure] Error 127
```

Seen on https://github.com/ocaml/opam-repository/pull/27455