### PR TITLE
[new release] letsencrypt (4 packages) (1.1.0)

### DIFF
--- a/packages/letsencrypt-app/letsencrypt-app.1.1.0/opam
+++ b/packages/letsencrypt-app/letsencrypt-app.1.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An ACME client implementation of the ACME protocol (RFC 8555) for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/robur-coop/ocaml-letsencrypt"
+bug-reports: "https://github.com/robur-coop/ocaml-letsencrypt/issues"
+doc: "https://robur-coop.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "letsencrypt-dns" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "logs"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "2.6.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "ptime"
+  "bos"
+  "fpath"
+  "randomconv" {>= "0.2.0"}
+  "ipaddr" {>= "5.6.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/ocaml-letsencrypt.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-letsencrypt/releases/download/v1.1.0/letsencrypt-1.1.0.tbz"
+  checksum: [
+    "sha256=230e7919f7f21b9b56038f616a8d73f415faa78376f842ae84b2283b01bc10a3"
+    "sha512=a30efac9a4d479d3519e99e8f81c2d824b55552d2a04b89caafe27836a326da1406be0be827619fd60526f65471ee7f0589ee348676e017cf1c857c1f803fafe"
+  ]
+}
+x-commit-hash: "cb7570b637dfefb5b254c4e592be1cb8ac1a0d95"

--- a/packages/letsencrypt-dns/letsencrypt-dns.1.1.0/opam
+++ b/packages/letsencrypt-dns/letsencrypt-dns.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "DNS solver for ACME implementation in OCaml"
+description: "A DNS solver for the ACME implementation in OCaml."
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/robur-coop/ocaml-letsencrypt"
+bug-reports: "https://github.com/robur-coop/ocaml-letsencrypt/issues"
+doc: "https://robur-coop.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "logs"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "2.6.0"}
+  "dns" {>= "9.0.0"}
+  "dns-tsig" {>= "9.0.0"}
+  "domain-name" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/ocaml-letsencrypt.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-letsencrypt/releases/download/v1.1.0/letsencrypt-1.1.0.tbz"
+  checksum: [
+    "sha256=230e7919f7f21b9b56038f616a8d73f415faa78376f842ae84b2283b01bc10a3"
+    "sha512=a30efac9a4d479d3519e99e8f81c2d824b55552d2a04b89caafe27836a326da1406be0be827619fd60526f65471ee7f0589ee348676e017cf1c857c1f803fafe"
+  ]
+}
+x-commit-hash: "cb7570b637dfefb5b254c4e592be1cb8ac1a0d95"

--- a/packages/letsencrypt-mirage/letsencrypt-mirage.1.1.0/opam
+++ b/packages/letsencrypt-mirage/letsencrypt-mirage.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml for MirageOS"
+description: "An ACME client implementation of the ACME protocol (RFC 8555) for OCaml & MirageOS"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/robur-coop/ocaml-letsencrypt"
+bug-reports: "https://github.com/robur-coop/ocaml-letsencrypt/issues"
+doc: "https://robur-coop.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "http-mirage-client" {>= "0.0.10"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-sleep" {>= "4.0.0"}
+  "duration"
+  "emile" {>= "1.1"}
+  "paf" {>= "0.8.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/ocaml-letsencrypt.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-letsencrypt/releases/download/v1.1.0/letsencrypt-1.1.0.tbz"
+  checksum: [
+    "sha256=230e7919f7f21b9b56038f616a8d73f415faa78376f842ae84b2283b01bc10a3"
+    "sha512=a30efac9a4d479d3519e99e8f81c2d824b55552d2a04b89caafe27836a326da1406be0be827619fd60526f65471ee7f0589ee348676e017cf1c857c1f803fafe"
+  ]
+}
+x-commit-hash: "cb7570b637dfefb5b254c4e592be1cb8ac1a0d95"

--- a/packages/letsencrypt/letsencrypt.1.1.0/opam
+++ b/packages/letsencrypt/letsencrypt.1.1.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An implementation of the ACME protocol (RFC 8555) for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/robur-coop/ocaml-letsencrypt"
+bug-reports: "https://github.com/robur-coop/ocaml-letsencrypt/issues"
+doc: "https://robur-coop.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.2.0"}
+  "base64" {>= "3.3.0"}
+  "logs"
+  "fmt" {>= "0.8.7"}
+  "uri"
+  "lwt" {>= "2.6.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-ec" {>= "1.0.0"}
+  "mirage-crypto-pk" {>= "1.0.0"}
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
+  "digestif" {>= "1.2.0"}
+  "x509" {>= "1.0.0"}
+  "yojson" {>= "1.6.0"}
+  "ounit2" {with-test}
+  "ptime"
+  "domain-name" {>= "0.2.0"}
+  "asn1-combinators" {>= "0.3.2"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/ocaml-letsencrypt.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-letsencrypt/releases/download/v1.1.0/letsencrypt-1.1.0.tbz"
+  checksum: [
+    "sha256=230e7919f7f21b9b56038f616a8d73f415faa78376f842ae84b2283b01bc10a3"
+    "sha512=a30efac9a4d479d3519e99e8f81c2d824b55552d2a04b89caafe27836a326da1406be0be827619fd60526f65471ee7f0589ee348676e017cf1c857c1f803fafe"
+  ]
+}
+x-commit-hash: "cb7570b637dfefb5b254c4e592be1cb8ac1a0d95"


### PR DESCRIPTION
ACME implementation in OCaml

- Project page: <a href="https://github.com/robur-coop/ocaml-letsencrypt">https://github.com/robur-coop/ocaml-letsencrypt</a>
- Documentation: <a href="https://robur-coop.github.io/ocaml-letsencrypt">https://robur-coop.github.io/ocaml-letsencrypt</a>

##### CHANGES:

* Defunctorise, update to paf 0.8.0 (robur-coop/ocaml-letsencrypt#35 @hannesm)
