### PR TITLE
irmin: extend the x-maintenance-intent

### DIFF
--- a/packages/irmin-http/irmin-http.3.8.0/opam
+++ b/packages/irmin-http/irmin-http.3.8.0/opam
@@ -46,3 +46,4 @@ url {
   ]
 }
 x-commit-hash: "c3daafbc68a39f21c7d777dfd33632c3ac60cedf"
+x-maintenance-intent: [ "(none)" ]

--- a/packages/irmin-layers/irmin-layers.2.10.2/opam
+++ b/packages/irmin-layers/irmin-layers.2.10.2/opam
@@ -32,3 +32,4 @@ url {
   ]
 }
 x-commit-hash: "9a2731c84eb8a9cef3a53b041d068b493979d14b"
+x-maintenance-intent: [ "(none)" ]

--- a/packages/irmin-mirage-git/irmin-mirage-git.3.10.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.3.10.0/opam
@@ -34,3 +34,4 @@ url {
   ]
 }
 x-commit-hash: "7fa4b043a97944635cc100ae2e7dd85f73d8a4ce"
+x-maintenance-intent: [ "(latest)" ]

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.3.10.0/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.3.10.0/opam
@@ -33,3 +33,4 @@ url {
   ]
 }
 x-commit-hash: "7fa4b043a97944635cc100ae2e7dd85f73d8a4ce"
+x-maintenance-intent: [ "(latest)" ]

--- a/packages/libirmin/libirmin.3.10.0/opam
+++ b/packages/libirmin/libirmin.3.10.0/opam
@@ -32,3 +32,4 @@ url {
   ]
 }
 x-commit-hash: "7fa4b043a97944635cc100ae2e7dd85f73d8a4ce"
+x-maintenance-intent: [ "(latest)" ]


### PR DESCRIPTION
- irmin-mirage-git/irmin-mirage-graphql/libirmin: set to latest
- irmin-layers/irmin-http: since the latest release doesn't carry these anymore, set to none

//cc @art-w @samoht please have a look whether this is sensible to you (I'm not sure why irmin-http 3.1.0 got a x-maintenance-intent).