### PR TITLE
Package strymonas-pure.2.1.1

### DIFF
--- a/packages/strymonas-pure/strymonas-pure.2.1.1/opam
+++ b/packages/strymonas-pure/strymonas-pure.2.1.1/opam
@@ -20,8 +20,8 @@ depends: [
 build: [
   [make "-C" "lib/" "pure"]
 ]
-install:[make "install-pure"]
-remove:[make "uninstall-pure"]
+install:[make "-C" "lib/" "install-pure"]
+remove:[make "-C" "lib/" "uninstall-pure"]
 url {
   src:
     "https://github.com/strymonas/strymonas-ocaml/archive/refs/tags/v2.1.1.tar.gz"

--- a/packages/strymonas-pure/strymonas-pure.2.1.1/opam
+++ b/packages/strymonas-pure/strymonas-pure.2.1.1/opam
@@ -18,6 +18,7 @@ depends: [
   "ocamlfind" {build}
 ]
 build: [
+  [make "-C" "lib/" "depend-pure"]
   [make "-C" "lib/" "pure"]
 ]
 install:[make "-C" "lib/" "install-pure"]
@@ -26,7 +27,7 @@ url {
   src:
     "https://github.com/strymonas/strymonas-ocaml/archive/refs/tags/v2.1.1.tar.gz"
   checksum: [
-    "md5=60eed1419d5c1194ffcbc8cf912e129b"
-    "sha512=76fa0171b7a55e3836b74913df9e144ca1eef7363ac71871699b10ca654eb874f032efef33acec234cacee1e7a930b95947b8e18a8c914780260f5987469c827"
+    "md5=30f9ea3a42485f778c500c7affaf0363"
+    "sha512=4b4d3d9357929d6688d70018b016115a26965238b72bcb892b8d3df23a811271726d395318869c1409ed15fed803febfdd4e688bb4b766a6b7dff7e14ce3ad59"
   ]
 }

--- a/packages/strymonas-pure/strymonas-pure.2.1.1/opam
+++ b/packages/strymonas-pure/strymonas-pure.2.1.1/opam
@@ -1,0 +1,32 @@
+
+opam-version: "2.0"
+synopsis: "Stream fusion, to completeness"
+maintainer: "tomoaki.kobayashi.t3@alumni.tohoku.ac.jp"
+authors: [
+  "Oleg Kiselyov"
+  "Tomoaki Kobayashi"
+  "Aggelos Biboudis"
+  "Nick Palladinos"
+  "Yannis Smaragdakis"
+]
+license: "MIT"
+homepage: "https://strymonas.github.io/"
+bug-reports: "https://github.com/strymonas/strymonas-ocaml/issues"
+dev-repo: "git+https://github.com/strymonas/strymonas-ocaml.git"
+depends: [
+  "ocaml" {>= "4.14.1"}
+  "ocamlfind" {build}
+]
+build: [
+  [make "pure"]
+]
+install:[make "install-pure"]
+remove:[make "uninstall-pure"]
+url {
+  src:
+    "https://github.com/strymonas/strymonas-ocaml/archive/refs/tags/v2.1.1.tar.gz"
+  checksum: [
+    "md5=60eed1419d5c1194ffcbc8cf912e129b"
+    "sha512=76fa0171b7a55e3836b74913df9e144ca1eef7363ac71871699b10ca654eb874f032efef33acec234cacee1e7a930b95947b8e18a8c914780260f5987469c827"
+  ]
+}

--- a/packages/strymonas-pure/strymonas-pure.2.1.1/opam
+++ b/packages/strymonas-pure/strymonas-pure.2.1.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlfind" {build}
 ]
 build: [
-  [make "pure"]
+  [make "-C" "lib/" "pure"]
 ]
 install:[make "install-pure"]
 remove:[make "uninstall-pure"]

--- a/packages/strymonas-pure/strymonas-pure.2.1.1/opam
+++ b/packages/strymonas-pure/strymonas-pure.2.1.1/opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml" {>= "4.14.1"}
   "ocamlfind" {build}
 ]
+available: [sys-ocaml-version = "4.14.1" | (arch != "arm32" & arch != "x86_32")]
 build: [
   [make "-C" "lib/" "depend-pure"]
   [make "-C" "lib/" "pure"]


### PR DESCRIPTION
### `strymonas-pure.2.1.1`
Stream fusion, to completeness



---
* Homepage: https://strymonas.github.io/
* Source repo: git+https://github.com/strymonas/strymonas-ocaml.git
* Bug tracker: https://github.com/strymonas/strymonas-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.4.0