### PR TITLE
Package libbinaryen.117.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.117.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.117.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "6.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v117.0.0/libbinaryen-v117.0.0.tar.gz"
+  checksum: [
+    "md5=c9c924f956db977e06488bd53a8e7ac0"
+    "sha512=dd34e3e4f02a9138f6b8abc4581ebc9d9706ee30a399e6b539bae766ae01574141a6067dda9bbdaef0639378bf932e95a88bc80006e0b987c704b2d08e59973e"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.117.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [117.0.0](https://github.com/grain-lang/libbinaryen/compare/v116.0.0...v117.0.0) (2025-03-02)


### ⚠ BREAKING CHANGES

* Upgrade to Binaryen v117 ([#93](https://github.com/grain-lang/libbinaryen/issues/93))

### Features

* Upgrade to Binaryen v117 ([#93](https://github.com/grain-lang/libbinaryen/issues/93)) ([ea58318](https://github.com/grain-lang/libbinaryen/commit/ea58318ef23a7d59b61d149f387286fcedd92d86))

---
:camel: Pull-request generated by opam-publish v2.4.0