### PR TITLE
Package libbinaryen.118.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.118.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.118.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "6.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v118.0.0/libbinaryen-v118.0.0.tar.gz"
+  checksum: [
+    "md5=d0701aa3bc8a038f4915816d2f4b6aea"
+    "sha512=b6b892d8c072481c90a6af593223ee1107bcfc878ab951cc5e2823f227e1093d3ead2bdcdecba19df3653428b3883ec39540af8fc5ec485a3c962c75e1f75a8b"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.118.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [118.0.0](https://github.com/grain-lang/libbinaryen/compare/v117.0.0...v118.0.0) (2025-03-02)


### ⚠ BREAKING CHANGES

* Upgrade to Binaryen v118

### Features

* Upgrade to Binaryen v118 ([bf51e2c](https://github.com/grain-lang/libbinaryen/commit/bf51e2ca7e117822db160878fc73d238beb9adb9))

---
:camel: Pull-request generated by opam-publish v2.4.0