### PR TITLE
Package libbinaryen.119.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.119.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.119.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "6.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v119.0.0/libbinaryen-v119.0.0.tar.gz"
+  checksum: [
+    "md5=2453618b0327349777a8bfd1bf7e5088"
+    "sha512=06de202624a46ea0aea4572b270c5ff6adce054d69339b6fc3ba3dcad3449d02d56b76b1c1035bb273d1cd9fa8ad4219e7b3a8d564508d0152d8bb27a6b7f737"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.119.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [119.0.0](https://github.com/grain-lang/libbinaryen/compare/v118.0.0...v119.0.0) (2025-03-02)


### ⚠ BREAKING CHANGES

* Upgrade to Binaryen v119 ([#95](https://github.com/grain-lang/libbinaryen/issues/95))

### Features

* Upgrade to Binaryen v119 ([#95](https://github.com/grain-lang/libbinaryen/issues/95)) ([5cd6dc5](https://github.com/grain-lang/libbinaryen/commit/5cd6dc54817122ded9f22209c81294611544628d))

---
:camel: Pull-request generated by opam-publish v2.4.0