### PR TITLE
Package libbinaryen.120.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.120.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.120.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "6.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v120.0.0/libbinaryen-v120.0.0.tar.gz"
+  checksum: [
+    "md5=c9ee9e71d441c21f9a29d548ba0fe758"
+    "sha512=d49c2b7759b5e9096db3641dc24c4f029fa0b7a03a14e8383c8d2c1750c6a0d30bcb55c4cf63aeb53ee83fa7dd6abab9b6f15888aeeafa699668c094eb9afacf"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.120.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [120.0.0](https://github.com/grain-lang/libbinaryen/compare/v119.0.0...v120.0.0) (2025-03-02)


### ⚠ BREAKING CHANGES

* Upgrade to Binaryen v120 ([#100](https://github.com/grain-lang/libbinaryen/issues/100))

### Features

* Upgrade to Binaryen v120 ([#100](https://github.com/grain-lang/libbinaryen/issues/100)) ([93c0281](https://github.com/grain-lang/libbinaryen/commit/93c0281a38b196b14a3e2a6148b0ae335388c077))

---
:camel: Pull-request generated by opam-publish v2.4.0