### PR TITLE
[new release] encore (0.8.1)

### DIFF
--- a/packages/encore/encore.0.8.1/opam
+++ b/packages/encore/encore.0.8.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/encore"
+bug-reports:  "https://github.com/mirage/encore/issues"
+dev-repo:     "git+https://github.com/mirage/encore.git"
+doc:          "https://mirage.github.io/encore/"
+license:      "MIT"
+synopsis:     "Library to generate encoder/decoder which ensure isomorphism"
+description: """
+Encore is a little library to provide an interface to generate an angstrom decoder and
+an internal encoder from a shared description. The goal is to ensure a dual isomorphism
+between them.
+"""
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"  {>= "2.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "fmt"
+  "bigstringaf" {>= "0.5.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/encore/releases/download/v0.8.1/encore-0.8.1.tbz"
+  checksum: [
+    "sha256=aa0ea179205ce8e49f6fbbd9c448b8aeb2a1fa7c7e7df9ec09f56f855477c98d"
+    "sha512=1d45278af321026902554d929cf97820637bae9042bcea3dfb0b017993ca150685a1cc1c4febd10f83de214a382c50e398b365c35dce8e5add8e504f4a05dabb"
+  ]
+}
+x-commit-hash: "9743a598ff0b0e14221a379b157bcd3725df44d1"


### PR DESCRIPTION
Library to generate encoder/decoder which ensure isomorphism

- Project page: <a href="https://github.com/mirage/encore">https://github.com/mirage/encore</a>
- Documentation: <a href="https://mirage.github.io/encore/">https://mirage.github.io/encore/</a>

##### CHANGES:

- Correctly handle the `0xff` character on the encoder side (@yomimono, mirage/encore#33)
