### PR TITLE
[new release] cohttp (14 packages) (6.1.0)

### DIFF
--- a/packages/cohttp-async/cohttp-async.6.1.0/opam
+++ b/packages/cohttp-async/cohttp-async.6.1.0/opam
@@ -29,7 +29,7 @@ depends: [
   "cohttp" {= version}
   "async_kernel" {>= "v0.16.0"}
   "async_unix" {>= "v0.16.0"}
-  "async" {>= "v0.16.0"}
+  "async" {>= "v0.17.0"}
   "base" {>= "v0.16.0"}
   "core" {with-test}
   "core_unix" {>= "v0.14.0"}

--- a/packages/cohttp-async/cohttp-async.6.1.0/opam
+++ b/packages/cohttp-async/cohttp-async.6.1.0/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation for the Async concurrency library"
+description: """
+An implementation of an HTTP client and server using the Async
+concurrency library. See the `Cohttp_async` module for information
+on how to use this.  The package also installs `cohttp-curl-async`
+and a `cohttp-server-async` binaries for quick uses of a HTTP(S)
+client and server respectively.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.14" & < "5.3.0"}
+  "http" {= version}
+  "cohttp" {= version}
+  "async_kernel" {>= "v0.16.0"}
+  "async_unix" {>= "v0.16.0"}
+  "async" {>= "v0.16.0"}
+  "base" {>= "v0.16.0"}
+  "core" {with-test}
+  "core_unix" {>= "v0.14.0"}
+  "conduit-async" {>= "1.2.0"}
+  "magic-mime"
+  "digestif" {with-test}
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "ounit2" {with-test}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+  "ipaddr"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-async/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "s390x"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.1.0/cohttp-6.1.0.tbz"
+  checksum: [
+    "sha256=a81ac49699ec45f58b3d85cc4e2274120d28449d7c2075adb3234f0583d76c33"
+    "sha512=55b75c6afea58fa97a702712c5ecfb67bcfb8de32345ca0e40c16561aaf6f001daaf05781484a1df5caab85353f931b841169f3229563c655c463b7f7b44cd54"
+  ]
+}
+x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"

--- a/packages/cohttp-bench/cohttp-bench.6.1.0/opam
+++ b/packages/cohttp-bench/cohttp-bench.6.1.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Benchmarks binaries for Cohttp"
+description: """
+This package contains some benchmarks for http and cohttp.
+The benchmarks for the server latency will require wrk2
+(https://github.com/giltene/wrk2) to run. The latency graphs
+can then be generated with HdrHistogram plotter, also available
+online at https://hdrhistogram.github.io/HdrHistogram/plotFiles.html."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "core" {>= "v0.13.0"}
+  "core_bench"
+  "eio" {>= "0.12"}
+  "eio_main"
+  "http" {= version}
+  "cohttp" {= version}
+  "cohttp-eio" {= version}
+  "cohttp-lwt-unix" {= version}
+  "cohttp-server-lwt-unix" {= version}
+  "cohttp-async" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-bench/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.1.0/cohttp-6.1.0.tbz"
+  checksum: [
+    "sha256=a81ac49699ec45f58b3d85cc4e2274120d28449d7c2075adb3234f0583d76c33"
+    "sha512=55b75c6afea58fa97a702712c5ecfb67bcfb8de32345ca0e40c16561aaf6f001daaf05781484a1df5caab85353f931b841169f3229563c655c463b7f7b44cd54"
+  ]
+}
+x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"

--- a/packages/cohttp-curl-async/cohttp-curl-async.6.1.0/opam
+++ b/packages/cohttp-curl-async/cohttp-curl-async.6.1.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Cohttp client using Curl & Async as the backend"
+description: """
+An HTTP client that relies on Curl + Async for the backend. Does not require
+conduit for SSL."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocurl" {>= "0.9.2"}
+  "http" {= version}
+  "stringext"
+  "cohttp-curl" {= version}
+  "core" {>= "v0.16.0"}
+  "core_unix" {>= "v0.14.0"}
+  "core_kernel" {with-test}
+  "async_kernel" {with-test & >= "v0.17.0"}
+  "async_unix" {with-test}
+  "cohttp-async" {with-test & = version}
+  "uri" {with-test & >= "4.2.0"}
+  "fmt" {with-test}
+  "ounit2" {with-test}
+  "alcotest" {with-test & >= "1.7.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-curl-async/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.1.0/cohttp-6.1.0.tbz"
+  checksum: [
+    "sha256=a81ac49699ec45f58b3d85cc4e2274120d28449d7c2075adb3234f0583d76c33"
+    "sha512=55b75c6afea58fa97a702712c5ecfb67bcfb8de32345ca0e40c16561aaf6f001daaf05781484a1df5caab85353f931b841169f3229563c655c463b7f7b44cd54"
+  ]
+}
+x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"

--- a/packages/cohttp-curl-lwt/cohttp-curl-lwt.6.1.0/opam
+++ b/packages/cohttp-curl-lwt/cohttp-curl-lwt.6.1.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Cohttp client using Curl & Lwt as the backend"
+description: """
+An HTTP client that relies on Curl + Lwt for the backend. Does not require
+conduit for SSL."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08"}
+  "ocurl" {>= "0.9.2"}
+  "http" {= version}
+  "cohttp-curl" {= version}
+  "stringext"
+  "lwt" {>= "5.3.0"}
+  "uri" {with-test & >= "4.2.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "cohttp-lwt-unix" {with-test & = version}
+  "cohttp" {with-test & = version}
+  "cohttp-lwt" {with-test & = version}
+  "conduit-lwt" {with-test}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-curl-lwt/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.1.0/cohttp-6.1.0.tbz"
+  checksum: [
+    "sha256=a81ac49699ec45f58b3d85cc4e2274120d28449d7c2075adb3234f0583d76c33"
+    "sha512=55b75c6afea58fa97a702712c5ecfb67bcfb8de32345ca0e40c16561aaf6f001daaf05781484a1df5caab85353f931b841169f3229563c655c463b7f7b44cd54"
+  ]
+}
+x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"

--- a/packages/cohttp-curl/cohttp-curl.6.1.0/opam
+++ b/packages/cohttp-curl/cohttp-curl.6.1.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Shared code between the individual cohttp-curl clients"
+description: "Use cohttp-curl-lwt or cohttp-curl-async"
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08"}
+  "ocurl" {>= "0.9.2"}
+  "http" {= version}
+  "stringext"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-curl/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.1.0/cohttp-6.1.0.tbz"
+  checksum: [
+    "sha256=a81ac49699ec45f58b3d85cc4e2274120d28449d7c2075adb3234f0583d76c33"
+    "sha512=55b75c6afea58fa97a702712c5ecfb67bcfb8de32345ca0e40c16561aaf6f001daaf05781484a1df5caab85353f931b841169f3229563c655c463b7f7b44cd54"
+  ]
+}
+x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"

--- a/packages/cohttp-eio/cohttp-eio.6.1.0/opam
+++ b/packages/cohttp-eio/cohttp-eio.6.1.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation with eio backend"
+description:
+  "A CoHTTP server and client implementation based on `eio` library. `cohttp-eio`features a multicore capable HTTP 1.1 server. The library promotes and is built with direct style of coding as opposed to a monadic."
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "base-domains"
+  "cohttp" {= version}
+  "eio" {>= "0.12"}
+  "eio_main" {with-test}
+  "mdx" {with-test}
+  "logs"
+  "uri"
+  "tls-eio" {with-test & >= "1.0.0"}
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
+  "ca-certs" {with-test & >= "1.0.0"}
+  "fmt"
+  "ptime"
+  "http" {= version}
+  "ppx_here" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-eio/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.1.0/cohttp-6.1.0.tbz"
+  checksum: [
+    "sha256=a81ac49699ec45f58b3d85cc4e2274120d28449d7c2075adb3234f0583d76c33"
+    "sha512=55b75c6afea58fa97a702712c5ecfb67bcfb8de32345ca0e40c16561aaf6f001daaf05781484a1df5caab85353f931b841169f3229563c655c463b7f7b44cd54"
+  ]
+}
+x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.6.1.0/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.6.1.0/opam
@@ -28,7 +28,7 @@ depends: [
   "cohttp" {= version}
   "cohttp-lwt" {= version}
   "logs"
-  "lwt" {>= "3.0.0"}
+  "lwt" {>= "5.7.0"}
   "lwt_ppx" {with-test}
   "conf-npm" {with-test}
   "js_of_ocaml" {>= "3.3.0"}

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.6.1.0/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.6.1.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation for the Js_of_ocaml JavaScript compiler"
+description: """
+An implementation of an HTTP client for JavaScript, but using the
+CoHTTP types.  This lets you build HTTP clients that can compile
+natively (using one of the other Cohttp backends such as `cohttp-lwt-unix`)
+and also to native JavaScript via js_of_ocaml.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08"}
+  "http" {= version}
+  "cohttp" {= version}
+  "cohttp-lwt" {= version}
+  "logs"
+  "lwt" {>= "3.0.0"}
+  "lwt_ppx" {with-test}
+  "conf-npm" {with-test}
+  "js_of_ocaml" {>= "3.3.0"}
+  "js_of_ocaml-ppx" {>= "3.3.0"}
+  "js_of_ocaml-lwt" {>= "3.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-lwt-jsoo/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.1.0/cohttp-6.1.0.tbz"
+  checksum: [
+    "sha256=a81ac49699ec45f58b3d85cc4e2274120d28449d7c2075adb3234f0583d76c33"
+    "sha512=55b75c6afea58fa97a702712c5ecfb67bcfb8de32345ca0e40c16561aaf6f001daaf05781484a1df5caab85353f931b841169f3229563c655c463b7f7b44cd54"
+  ]
+}
+x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.1.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.1.0/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation for Unix and Windows using Lwt"
+description: """
+An implementation of an HTTP client and server using the Lwt
+concurrency library. See the `Cohttp_lwt_unix` module for information
+on how to use this.  The package also installs `cohttp-curl-lwt`
+and a `cohttp-server-lwt` binaries for quick uses of a HTTP(S)
+client and server respectively.
+
+Although the name implies that this only works under Unix, it
+should also be fine under Windows too.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08"}
+  "http" {= version}
+  "cohttp" {= version}
+  "cohttp-lwt" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "lwt" {>= "3.0.0"}
+  "conduit-lwt" {>= "7.1.0"}
+  "conduit-lwt-unix" {>= "7.1.0"}
+  "fmt" {>= "0.8.2"}
+  "base-unix"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "magic-mime"
+  "logs"
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-lwt-unix/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.1.0/cohttp-6.1.0.tbz"
+  checksum: [
+    "sha256=a81ac49699ec45f58b3d85cc4e2274120d28449d7c2075adb3234f0583d76c33"
+    "sha512=55b75c6afea58fa97a702712c5ecfb67bcfb8de32345ca0e40c16561aaf6f001daaf05781484a1df5caab85353f931b841169f3229563c655c463b7f7b44cd54"
+  ]
+}
+x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"

--- a/packages/cohttp-lwt/cohttp-lwt.6.1.0/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.6.1.0/opam
@@ -28,7 +28,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "http" {= version}
   "cohttp" {= version}
-  "lwt" {>= "5.4.0"}
+  "lwt" {>= "5.7.0"}
   "sexplib0"
   "ipaddr" {>= "5.6.0"}
   "ppx_sexp_conv" {>= "v0.13.0"}

--- a/packages/cohttp-lwt/cohttp-lwt.6.1.0/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.6.1.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation using the Lwt concurrency library"
+description: """
+This is a portable implementation of HTTP that uses the Lwt concurrency library
+to multiplex IO.  It implements as much of the logic in an OS-independent way
+as possible, so that more specialised modules can be tailored for different
+targets.  For example, you can install `cohttp-lwt-unix` or `cohttp-lwt-jsoo`
+for a Unix or JavaScript backend, or `cohttp-mirage` for the MirageOS unikernel
+version of the library. All of these implementations share the same IO logic
+from this module."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08"}
+  "http" {= version}
+  "cohttp" {= version}
+  "lwt" {>= "5.4.0"}
+  "sexplib0"
+  "ipaddr" {>= "5.6.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "logs"
+  "uri" {>= "2.0.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-lwt/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.1.0/cohttp-6.1.0.tbz"
+  checksum: [
+    "sha256=a81ac49699ec45f58b3d85cc4e2274120d28449d7c2075adb3234f0583d76c33"
+    "sha512=55b75c6afea58fa97a702712c5ecfb67bcfb8de32345ca0e40c16561aaf6f001daaf05781484a1df5caab85353f931b841169f3229563c655c463b7f7b44cd54"
+  ]
+}
+x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"

--- a/packages/cohttp-mirage/cohttp-mirage.6.1.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.6.1.0/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation for the MirageOS unikernel"
+description: """
+This HTTP implementation uses the Cohttp portable implementation
+along with the Lwt threading library in order to provide a
+`Cohttp_mirage` functor that can be used in MirageOS unikernels
+to build very small and efficient HTTP clients and servers
+without having a hard dependency on an underlying operating
+system.
+
+Please see <https://mirage.io> for a self-hosted explanation
+and instructions on how to use this library."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-channel" {>= "4.0.0"}
+  "conduit" {>= "8.0.0"}
+  "conduit-mirage" {>= "8.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "cohttp-lwt" {= version}
+  "cstruct" {>= "6.0.0"}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "magic-mime"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "cohttp" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-mirage/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.1.0/cohttp-6.1.0.tbz"
+  checksum: [
+    "sha256=a81ac49699ec45f58b3d85cc4e2274120d28449d7c2075adb3234f0583d76c33"
+    "sha512=55b75c6afea58fa97a702712c5ecfb67bcfb8de32345ca0e40c16561aaf6f001daaf05781484a1df5caab85353f931b841169f3229563c655c463b7f7b44cd54"
+  ]
+}
+x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"

--- a/packages/cohttp-server-lwt-unix/cohttp-server-lwt-unix.6.1.0/opam
+++ b/packages/cohttp-server-lwt-unix/cohttp-server-lwt-unix.6.1.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Lightweight Cohttp + Lwt based HTTP server"
+description: """
+This server implementation is faster than cohttp-lwt-unix and is independent of
+conduit.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08"}
+  "http" {= version}
+  "lwt" {>= "5.5.0"}
+  "conduit-lwt-unix" {with-test}
+  "cohttp-lwt-unix" {with-test & = version}
+  "cohttp-lwt" {with-test & = version}
+  "lwt"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-server-lwt-unix/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.1.0/cohttp-6.1.0.tbz"
+  checksum: [
+    "sha256=a81ac49699ec45f58b3d85cc4e2274120d28449d7c2075adb3234f0583d76c33"
+    "sha512=55b75c6afea58fa97a702712c5ecfb67bcfb8de32345ca0e40c16561aaf6f001daaf05781484a1df5caab85353f931b841169f3229563c655c463b7f7b44cd54"
+  ]
+}
+x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"

--- a/packages/cohttp-top/cohttp-top.6.1.0/opam
+++ b/packages/cohttp-top/cohttp-top.6.1.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "CoHTTP toplevel pretty printers for HTTP types"
+description: """
+This library installs toplevel prettyprinters for CoHTTP
+types such as the `Request`, `Response` and `Types` modules.
+Once this library has been loaded, you can directly see the
+values of those types in toplevels such as `utop` or `ocaml`.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08"}
+  "cohttp" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-top/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.1.0/cohttp-6.1.0.tbz"
+  checksum: [
+    "sha256=a81ac49699ec45f58b3d85cc4e2274120d28449d7c2075adb3234f0583d76c33"
+    "sha512=55b75c6afea58fa97a702712c5ecfb67bcfb8de32345ca0e40c16561aaf6f001daaf05781484a1df5caab85353f931b841169f3229563c655c463b7f7b44cd54"
+  ]
+}
+x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"

--- a/packages/cohttp/cohttp.6.1.0/opam
+++ b/packages/cohttp/cohttp.6.1.0/opam
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries.
+
+See the cohttp-async, cohttp-lwt, cohttp-lwt-unix, cohttp-lwt-jsoo and
+cohttp-mirage libraries for concrete implementations for particular
+targets.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "http" {= version}
+  "ocaml" {>= "4.08"}
+  "re" {>= "1.9.0"}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+  "logs"
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "stringext"
+  "base64" {>= "3.1.0"}
+  "fmt" {with-test}
+  "alcotest" {with-test & >= "1.7.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.1.0/cohttp-6.1.0.tbz"
+  checksum: [
+    "sha256=a81ac49699ec45f58b3d85cc4e2274120d28449d7c2075adb3234f0583d76c33"
+    "sha512=55b75c6afea58fa97a702712c5ecfb67bcfb8de32345ca0e40c16561aaf6f001daaf05781484a1df5caab85353f931b841169f3229563c655c463b7f7b44cd54"
+  ]
+}
+x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"

--- a/packages/http/http.6.1.0/opam
+++ b/packages/http/http.6.1.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Type definitions of HTTP essentials"
+description: """
+This package contains essential type definitions used in Cohttp. It is designed
+to have no dependencies and make it easy for other packages to easily
+interoperate with Cohttp."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08"}
+  "ppx_expect" {with-test & >= "v0.17.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "base_quickcheck" {with-test}
+  "ppx_assert" {with-test}
+  "ppx_sexp_conv" {with-test}
+  "ppx_compare" {with-test}
+  "ppx_here" {with-test}
+  "crowbar" {with-test & >= "0.2"}
+  "sexplib0" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@http/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.1.0/cohttp-6.1.0.tbz"
+  checksum: [
+    "sha256=a81ac49699ec45f58b3d85cc4e2274120d28449d7c2075adb3234f0583d76c33"
+    "sha512=55b75c6afea58fa97a702712c5ecfb67bcfb8de32345ca0e40c16561aaf6f001daaf05781484a1df5caab85353f931b841169f3229563c655c463b7f7b44cd54"
+  ]
+}
+x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"


### PR DESCRIPTION
An OCaml library for HTTP clients and servers

- Project page: <a href="https://github.com/mirage/ocaml-cohttp">https://github.com/mirage/ocaml-cohttp</a>
- Documentation: <a href="https://mirage.github.io/ocaml-cohttp/">https://mirage.github.io/ocaml-cohttp/</a>

##### CHANGES:

- cohttp-lwt-unix: Add http/https proxy support for client requests (@art-w @MisterDA, mirage/ocaml-cohttp#1080)
- cohttp-mirage: Support conduit 8.0.0 (@hannesm, mirage/ocaml-cohttp#1104)

