### PR TITLE
Package libbinaryen.121.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.121.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.121.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "6.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v121.0.0/libbinaryen-v121.0.0.tar.gz"
+  checksum: [
+    "md5=23f94cff8a222499ab49d7540357d47e"
+    "sha512=f6444cabcf8961b95c01ef911a030c0bc03c22220f63aa38e727811167f51bd7cd5b5ed03360de3c88d35de435b2b759986fff723ac3ca22244961dec4ff6770"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.121.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [121.0.0](https://github.com/grain-lang/libbinaryen/compare/v120.0.0...v121.0.0) (2025-03-04)


### ⚠ BREAKING CHANGES

* Upgrade to Binaryen v121 ([#101](https://github.com/grain-lang/libbinaryen/issues/101))

### Features

* Upgrade to Binaryen v121 ([#101](https://github.com/grain-lang/libbinaryen/issues/101)) ([cc960c8](https://github.com/grain-lang/libbinaryen/commit/cc960c86c559ab6c86a5d9c529a0416c029d480e))

---
:camel: Pull-request generated by opam-publish v2.4.0