### PR TITLE
[new release] icalendar (0.1.10)

### DIFF
--- a/packages/icalendar/icalendar.0.1.10/opam
+++ b/packages/icalendar/icalendar.0.1.10/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/robur-coop/icalendar"
+bug-reports: "https://github.com/robur-coop/icalendar/issues"
+dev-repo: "git+https://github.com/robur-coop/icalendar.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://robur-coop.github.io/icalendar/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "1.3"}
+  "alcotest" {with-test}
+  "fmt"
+  "angstrom" {>= "0.14.0"}
+  "re" {>= "1.7.2"}
+  "uri"
+  "ptime"
+  "ppx_deriving"
+  "gmap" {>= "0.3.0"}
+]
+
+synopsis: "A library to parse and print the iCalendar (RFC 5545) format"
+description: """
+Parse and print .ics files as specified in RFC 5545.
+Supports recurrent events, but only to the day level of detail.
+Does not support vJournal components.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/icalendar/releases/download/v0.1.10/icalendar-0.1.10.tbz"
+  checksum: [
+    "sha256=b889abf1a4ee5ed4d6bc2c4a444149aa290887a99e38e912820bc6a8a199527f"
+    "sha512=02ae2532e37df6bd0b0a73575ef45195b07339478975d2031d72baaec2fa6698d72abe6fd566929cc4859627bdc56982e8934e15c96435c2e4ba9e28a97e2bc1"
+  ]
+}
+x-commit-hash: "5157f6c873d1b93c8fa38011e576aeff96a9061a"


### PR DESCRIPTION
A library to parse and print the iCalendar (RFC 5545) format

- Project page: <a href="https://github.com/robur-coop/icalendar">https://github.com/robur-coop/icalendar</a>
- Documentation: <a href="https://robur-coop.github.io/icalendar/">https://robur-coop.github.io/icalendar/</a>

##### CHANGES:

* handle EXDATE in recur_event (robur-coop/icalendar#12 @EmileTrotignon)
