### PR TITLE
Fix libcurl detection on Windows

### DIFF
--- a/packages/conf-libcurl/conf-libcurl.3/opam
+++ b/packages/conf-libcurl/conf-libcurl.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "blue-prawn"
+authors: ["Daniel Stenberg"]
+homepage: "https://curl.haxx.se/"
+license: "BSD-like"
+build: [
+  ["sh" "--login" "-exc" "curl-config --libs"] {os = "win32" & os-distribution != "cygwinports"}
+  ["curl-config" "--libs"] {os != "win32" | os-distribution = "cygwinports"}
+]
+depexts: [
+  ["libcurl4-gnutls-dev"] {os-family = "debian"}
+  ["libcurl4-gnutls-dev"] {os-family = "ubuntu"}
+  ["libcurl-devel"] {os-distribution = "mageia"}
+  ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
+  ["curl"] {os-distribution = "nixos"}
+  ["curl"] {os-distribution = "arch"}
+  ["curl"] {os = "win32" & os-distribution = "cygwinports"}
+  ["curl-dev"] {os-distribution = "alpine"}
+  ["libcurl-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["libcurl-devel"] {os-distribution = "fedora"}
+  ["libcurl-devel"] {os-distribution = "ol"}
+  ["curl"] {os-distribution = "homebrew" & os = "macos"}
+  ["curl"] {os-distribution = "macports" & os = "macos"}
+  ["curl"] {os = "freebsd"}
+]
+depends: [
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-i686" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+]
+synopsis: "Virtual package relying on a libcurl system installation"
+description:
+  "This package can only install if the libcurl is installed on the system."
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf


### PR DESCRIPTION
curl-config will only be available if it's in the PATH, and that happens only if the shell is a login shell, as the entry is added in one of the shell configuration files.

I've added the `--login` flag. Not sure if submitting a `.3` is the right way.

Closes #27539.