### PR TITLE
update availability for libevent.0.9.0

### DIFF
--- a/packages/libevent/libevent.0.9.0/opam
+++ b/packages/libevent/libevent.0.9.0/opam
@@ -26,6 +26,7 @@ depends: [
   "ounit" {with-test}
   "conf-libevent" {build}
 ]
+available: !(os = "macos" & os-distribution = "homebrew" & arch = "arm64")
 conflicts: [ "ocaml-option-bytecode-only" ]
 synopsis: "OCaml wrapper for the libevent API"
 description: """


### PR DESCRIPTION
This package fails on macos homebrew arm64 architectures:
failing builds:
https://ocaml.ci.dev/github/ahrefs/monorobot/commit/671657f6f27ea6333c077a4a6387ec7ef181c61a/variant/macos-homebrew-5.3_arm64_opam-2.3
https://ocaml.ci.dev/github/ahrefs/monorobot/commit/671657f6f27ea6333c077a4a6387ec7ef181c61a/variant/macos-homebrew-4.14_arm64_opam-2.3

It passes on non-arm64 architectures:
https://ocaml.ci.dev/github/ahrefs/monorobot/commit/671657f6f27ea6333c077a4a6387ec7ef181c61a/variant/macos-homebrew-4.14_opam-2.3
https://ocaml.ci.dev/github/ahrefs/monorobot/commit/671657f6f27ea6333c077a4a6387ec7ef181c61a/variant/macos-homebrew-5.3_opam-2.3