### PR TITLE
update availability for conf-libevent.1

### DIFF
--- a/packages/conf-libevent/conf-libevent.1/opam
+++ b/packages/conf-libevent/conf-libevent.1/opam
@@ -27,6 +27,7 @@ depexts: [
   ["libevent"] {os = "macos" & os-distribution = "homebrew"}
   ["libevent"] {os = "macos" & os-distribution = "macports"}
 ]
+available: [ os-family != "windows" ]
 x-ci-accept-failures: [
   "oraclelinux-7"
 ]


### PR DESCRIPTION
This package fails on windows. I'm not sure if this is the right constraint, but searching through the repo I couldn't find anything specific for windows-server.

Failing builds:
https://ocaml.ci.dev/github/ahrefs/monorobot/commit/671657f6f27ea6333c077a4a6387ec7ef181c61a/variant/windows-server-2022-amd64-4.14_opam-2.3
https://ocaml.ci.dev/github/ahrefs/monorobot/commit/671657f6f27ea6333c077a4a6387ec7ef181c61a/variant/windows-server-2022-amd64-5.3_opam-2.3