### PR TITLE
update re2 availability

### DIFF
--- a/packages/re2/re2.v0.17.0/opam
+++ b/packages/re2/re2.v0.17.0/opam
@@ -18,7 +18,7 @@ depends: [
   "conf-g++"          {build}
   "dune"              {>= "3.11.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "arm32" & arch != "x86_32" & os != "freebsd"
 synopsis: "OCaml bindings for RE2, Google's regular expression library"
 description: "
 "


### PR DESCRIPTION
This package fails on freebsd architectures:
https://ocaml.ci.dev/github/ahrefs/monorobot/commit/671657f6f27ea6333c077a4a6387ec7ef181c61a/variant/freebsd-14.1-4.14_opam-2.3

