### PR TITLE
update devkit availability

### DIFF
--- a/packages/devkit/devkit.1.20240429/opam
+++ b/packages/devkit/devkit.1.20240429/opam
@@ -39,7 +39,7 @@ conflicts: [
   "jemalloc" {< "0.2"}
   "opentelemetry" {< "0.6"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "arm32" & arch != "x86_32" & os != "freebsd"
 url {
   src:
     "https://github.com/ahrefs/devkit/releases/download/1.20240429/devkit-1.20240429.tbz"


### PR DESCRIPTION
This package fails on freebsd architectures:
https://ocaml.ci.dev/github/ahrefs/monorobot/commit/671657f6f27ea6333c077a4a6387ec7ef181c61a/variant/freebsd-14.1-4.14_opam-2.3