### PR TITLE
update conf-g++ availability

### DIFF
--- a/packages/conf-g++/conf-g++.1.0/opam
+++ b/packages/conf-g++/conf-g++.1.0/opam
@@ -23,6 +23,7 @@ depexts: [
   ["gcc-g++"] {os = "win32" & os-distribution = "cygwinports"}
   ["gcc"] {os = "freebsd"}
 ]
+available: os != "openbsd"
 depends:
   ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-i686" {os = "win32" & os-distribution != "cygwinports"}) |
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-x86_64" {os = "win32" & os-distribution != "cygwinports"})


### PR DESCRIPTION
This package fails on openbsd:
https://ocaml.ci.dev/github/ahrefs/monorobot/commit/671657f6f27ea6333c077a4a6387ec7ef181c61a/variant/openbsd-76-amd64-4.14_opam-2.3
https://ocaml.ci.dev/github/ahrefs/monorobot/commit/671657f6f27ea6333c077a4a6387ec7ef181c61a/variant/openbsd-76-amd64-5.3_opam-2.3