### PR TITLE
conf-diffutils: add support for OpenBSD

### DIFF
--- a/packages/conf-diffutils/conf-diffutils.2/opam
+++ b/packages/conf-diffutils/conf-diffutils.2/opam
@@ -6,7 +6,7 @@ authors: "GNU Project"
 license: "GPL-3.0-or-later"
 build: [
   ["diff" "--help"] { os != "freebsd" }
-  ["gdiff" "--help"] { os = "freebsd" }
+  ["gdiff" "--help"] { os = "freebsd" | os = "openbsd" }
 ]
 depexts: [
   ["diffutils"] {os-family = "debian"}
@@ -21,6 +21,7 @@ depexts: [
   ["diffutils"] {os-distribution = "arch"}
   ["diffutils"] {os = "macos" & os-distribution = "homebrew"}
   ["diffutils"] {os = "freebsd"}
+  ["textproc/gdiff"] {os = "openbsd"}
 ]
 
 synopsis: "Virtual package relying on diffutils"


### PR DESCRIPTION
This PR adds `conf-diffutils` support for OpenBSD

Source: http://ports.su/textproc/gdiff