### PR TITLE
ocaml-variants 4.00.1 +mirage+: mark as not maintained

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-unix/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-unix/opam
@@ -57,3 +57,4 @@ extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch?full_index=1"
   checksum: "sha256=bb0e0e736ecc55c9f8cd8f74ca00a920bfe46e4200b82c5a45da952053b374da"
 }
+x-maintained: false

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-xen/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-xen/opam
@@ -57,3 +57,4 @@ extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch?full_index=1"
   checksum: "sha256=bb0e0e736ecc55c9f8cd8f74ca00a920bfe46e4200b82c5a45da952053b374da"
 }
+x-maintained: false


### PR DESCRIPTION
these are two very old variants for arcane versions of mirage/mirari. I'd be keen to mark them as unmaintained so they can move on to the opam-repository-archive.

waiting for an ok from @samoht or @avsm