### PR TITLE
carton-git: add maintenance-intent of none (this package was dropped upstream)

### DIFF
--- a/packages/carton-git/carton-git.0.7.2/opam
+++ b/packages/carton-git/carton-git.0.7.2/opam
@@ -45,3 +45,4 @@ url {
   ]
 }
 x-commit-hash: "25bf9b68ee8cf7804dbd80f93499fd2ca5811fe5"
+x-maintenance-intent: [ "(none)" ]


### PR DESCRIPTION
awaiting an ok from @dinosaure -- please note this PR won't make any reverse dependencies (such as git) uninstallable / archivable / ...