### PR TITLE
tls-eio: restrict to mirage-crypto-rng-eio < 1.2.0

### DIFF
--- a/packages/tls-eio/tls-eio.1.0.0/opam
+++ b/packages/tls-eio/tls-eio.1.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "3.0"}
   "tls" {= version}
   "mirage-crypto-rng" {>= "1.0.0"}
-  "mirage-crypto-rng-eio" {with-test & >= "1.0.0"}
+  "mirage-crypto-rng-eio" {with-test & >= "1.0.0" & < "1.2.0"}
   "eio" {>= "0.12"}
   "eio_main" {>= "0.12" & with-test}
   "mdx" {with-test}

--- a/packages/tls-eio/tls-eio.1.0.2/opam
+++ b/packages/tls-eio/tls-eio.1.0.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "3.0"}
   "tls" {= version}
   "mirage-crypto-rng" {>= "1.0.0"}
-  "mirage-crypto-rng-eio" {with-test & >= "1.0.0"}
+  "mirage-crypto-rng-eio" {with-test & >= "1.0.0" & < "1.2.0"}
   "eio" {>= "0.12"}
   "eio_main" {>= "0.12" & with-test}
   "mdx" {with-test}

--- a/packages/tls-eio/tls-eio.1.0.4/opam
+++ b/packages/tls-eio/tls-eio.1.0.4/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "3.0"}
   "tls" {= version}
   "mirage-crypto-rng" {>= "1.0.0"}
-  "mirage-crypto-rng-eio" {with-test & >= "1.0.0"}
+  "mirage-crypto-rng-eio" {with-test & >= "1.0.0" & < "1.2.0"}
   "eio" {>= "0.12"}
   "eio_main" {>= "0.12" & with-test}
   "mdx" {with-test}


### PR DESCRIPTION
observed in https://github.com/ocaml/opam-repository/pull/27551

the error:

```
=== ERROR while compiling tls-eio.1.0.0 ======================================#
 context              2.4.0~alpha1~dev | linux/x86_64 | ocaml-base-compiler.5.3.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.3/.opam-switch/build/tls-eio.1.0.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p tls-eio -j 31
 exit-code            1
 env-file             ~/.opam/log/tls-eio-7-d67be9.env
 output-file          ~/.opam/log/tls-eio-7-d67be9.out
output ###
 (cd _build/default/eio/tests && ./fuzz.exe --repeat 200)
 random ops: PASS

 File "eio/tests/tls_eio.md", line 1, characters 0-0:
 /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/eio/tests/tls_eio.md _build/default/eio/tests/.mdx/tls_eio.md.corrected
 diff --git a/_build/default/eio/tests/tls_eio.md b/_build/default/eio/tests/.mdx/tls_eio.md.corrected
 index 0bc529e..01e78c1 100644
 --- a/_build/default/eio/tests/tls_eio.md
 +++ b/_build/default/eio/tests/.mdx/tls_eio.md.corrected
 @@ -104,11 +104,15 @@ let serve_ssl ~config server_s callback =
         test_client ~net ("127.0.0.1", "4433")
      )
    ;;
 +Line 4, characters 3-28:
 +Alert deprecated: Mirage_crypto_rng_eio.run
 +Use 'Mirage_crypto_rng_unix.use_default ()' instead.
  +server -> start @ tcp:127.0.0.1:4433
  +server -> connect
  +handler accepted
  +handler + GET / HTTP/1.1
  +client <- GET
  +client done.
 +
  - : unit = ()
  ```
```