### PR TITLE
Update package name for SUSE

### DIFF
--- a/packages/conf-sdl2-ttf/conf-sdl2-ttf.1/opam
+++ b/packages/conf-sdl2-ttf/conf-sdl2-ttf.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["libsdl2-ttf-dev"] {os-family = "debian"}
   ["libsdl2-ttf-dev"] {os-family = "ubuntu"}
   ["libsdl2_ttf-devel"] {os-family = "mageia"}
-  ["libSDL2_ttf-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["SDL2_ttf-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["SDL2_ttf-devel"] {os-distribution = "fedora"}
   # oraclelinux does not seem to have sdl2-ttf
   ["epel-release" "SDL2_ttf-devel"] {os-distribution = "centos"}


### PR DESCRIPTION
The devel package has this name in Tumbleweed as well as in the "games" extra repository in Leap

see the list of built packages near the bottom of this build log: https://build.opensuse.org/package/live_build_log/openSUSE:Factory/SDL2_ttf/standard/x86_64