### PR TITLE
[new release] slipshow (0.1.0)

### DIFF
--- a/packages/slipshow/slipshow.0.1.0/opam
+++ b/packages/slipshow/slipshow.0.1.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "A compiler from markdown to slipshow"
+description:
+  "Slipshow is an engine to write slips, a concept evolved from slides."
+maintainer: ["Paul-Elliot"]
+authors: ["Paul-Elliot"]
+license: "GPL-3.0-or-later"
+tags: ["slipshow" "presentation" "slideshow" "beamer"]
+homepage: "https://github.com/panglesd/slipshow"
+doc: "https://slipshow.readthedocs.io"
+bug-reports: "https://github.com/panglesd/slipshow/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.6"}
+  "crunch" {with-dev-setup}
+  "cmdliner"
+  "base64"
+  "bos"
+  "lwt"
+  "irmin-watcher"
+  "js_of_ocaml-compiler"
+  "js_of_ocaml-lwt"
+  "magic-mime"
+  "dream" {>= "1.0.0~alpha5"}
+  "fpath"
+  "brr" {>= "0.0.6"}
+  "ppx_blob" {>= "0.8.0"}
+  "sexplib"
+  "ppx_sexp_conv"
+  "odoc" {with-doc}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/panglesd/slipshow.git"
+pin-depends: [
+  "brr.dev" "git+https://github.com/panglesd/brr.git#bindings-window-inner-size"
+]
+url {
+  src:
+    "https://github.com/panglesd/slipshow/releases/download/v0.1.0/slipshow-0.1.0.tbz"
+  checksum: [
+    "sha256=9cb83e11c5a26116d2207928473a6bc27a367091a9568ec616acc94f4d8f0166"
+    "sha512=d5b214c83ff85bd4aaedd6553cbdb5a5450dcea55276fe524443c7cad45052e56579fdbcd6015e28902465da72c7a8a282533395dc5685c80b72f2725cd9af1f"
+  ]
+}
+x-commit-hash: "34caccc2e1b8b879fca824efe4eab992119d3886"


### PR DESCRIPTION
CHANGES:

> [!NOTE]
> TLDR:
> - Engine rewritten in OCaml
>   - Fewer bugs when navigating back
>   - Stronger foundation (eg, for subslips)
>   - Custom scripts requires minor adjustments
>   - Breaking change in subslip HTML
> - Drawing now in SVG
>   - No more zoom issues
>   - Erasing works "per-stroke"
> - Revamped table of content
>   - Now based on title structure rather than subslips
> - New `--markdown-output` flag for converting to GFM
> - Parser bugfixes
> - License change: Now GPLv3 (previously MIT)
> - npm distribution discontinued.
> - Special thanks to NLNet for their [sponsorship](https://nlnet.nl/project/Slipshow/)!

See the [release notes](https://github.com/panglesd/slipshow/releases/download/v0.1.0/slipshow-0.1.0.tbz)!