### PR TITLE
[new release] obelisk (0.8.0)

### DIFF
--- a/packages/obelisk/obelisk.0.8.0/opam
+++ b/packages/obelisk/obelisk.0.8.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Pretty-printing for Menhir files"
+description: """
+Obelisk is a simple tool which produces pretty-printed output from a Menhir parser file (.mly).
+It is inspired from yacc2latex and is also written in OCaml, but is aimed at supporting features from Menhir instead of only those of ocamlyacc."""
+maintainer: ["Lélio Brun <lb@leliobrun.net>"]
+authors: ["Lélio Brun"]
+license: "MIT"
+homepage: "https://github.com/Lelio-Brun/Obelisk"
+doc: "https://github.com/Lelio-Brun/Obelisk/blob/master/README.md"
+bug-reports: "https://github.com/Lelio-Brun/obelisk/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.2.0"}
+  "menhir" {>= "20190613"}
+  "re"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Lelio-Brun/obelisk.git"
+url {
+  src:
+    "https://github.com/Lelio-Brun/Obelisk/releases/download/v0.8.0/obelisk-0.8.0.tbz"
+  checksum: [
+    "sha256=b1fdf63a4c88fe6f19456ea45255b284ec96c032f1580bfad43794a05beefaf8"
+    "sha512=387c57ec8a7ebad265fded1ab9076c99b7aeebfd17e0540cad00da32cb859af889d8257af9e416033d442c20e5bfa3c0f8576042987d6ee0181b131b7fec9b54"
+  ]
+}
+x-commit-hash: "dfb42547a4a8781fbadab4b1c54792c114cd6a35"


### PR DESCRIPTION
Pretty-printing for Menhir files

- Project page: <a href="https://github.com/Lelio-Brun/Obelisk">https://github.com/Lelio-Brun/Obelisk</a>
- Documentation: <a href="https://github.com/Lelio-Brun/Obelisk/blob/master/README.md">https://github.com/Lelio-Brun/Obelisk/blob/master/README.md</a>

##### CHANGES:

- add lower bound for Menhir version
- update LaTeX backends
- add a new LaTeX mode using `simplebnf`
- remove `suffix` dependency in favor of `xparse`
