### PR TITLE
[new release] obelisk (0.8.0)

### DIFF
--- a/packages/obelisk/obelisk.0.8.0/opam
+++ b/packages/obelisk/obelisk.0.8.0/opam
@@ -13,10 +13,10 @@ depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.2.0"}
   "menhir" {>= "20190613"}
-  "re"
+  "re" {>= "1.7.2"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/obelisk/obelisk.0.8.0/opam
+++ b/packages/obelisk/obelisk.0.8.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Pretty-printing for Menhir files"
+description: """
+Obelisk is a simple tool which produces pretty-printed output from a Menhir parser file (.mly).
+It is inspired from yacc2latex and is also written in OCaml, but is aimed at supporting features from Menhir instead of only those of ocamlyacc."""
+maintainer: ["Lélio Brun <lb@leliobrun.net>"]
+authors: ["Lélio Brun"]
+license: "MIT"
+homepage: "https://github.com/Lelio-Brun/Obelisk"
+doc: "https://github.com/Lelio-Brun/Obelisk/blob/master/README.md"
+bug-reports: "https://github.com/Lelio-Brun/obelisk/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.2.0"}
+  "menhir" {>= "20190613"}
+  "re"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Lelio-Brun/obelisk.git"
+url {
+  src:
+    "https://github.com/Lelio-Brun/Obelisk/releases/download/v0.8.0/obelisk-0.8.0.tbz"
+  checksum: [
+    "sha256=89e86dd6484679765deed8028932c2826aa106a794b7ee64cb38c8fc89491aa8"
+    "sha512=59e03ea49715a8cc0ecf5db0686dfc316270ff56dc515b46a13e440fd5d44fe103c121ce73d181d83588d8e305b536cee965a1055359185aa8e3dffccb131c76"
+  ]
+}
+x-commit-hash: "7365c912d4b7987568a70ada47d9a4966e8a221a"


### PR DESCRIPTION
Pretty-printing for Menhir files

- Project page: <a href="https://github.com/Lelio-Brun/Obelisk">https://github.com/Lelio-Brun/Obelisk</a>
- Documentation: <a href="https://github.com/Lelio-Brun/Obelisk/blob/master/README.md">https://github.com/Lelio-Brun/Obelisk/blob/master/README.md</a>

##### CHANGES:

- add lower bound for Menhir version
- update LaTeX backends
- add a new LaTeX mode using `simplebnf`
- remove `suffix` dependency in favor of `xparse`
