### PR TITLE
[new release] git-kv (0.1.3)

### DIFF
--- a/packages/git-kv/git-kv.0.1.3/opam
+++ b/packages/git-kv/git-kv.0.1.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Robur Team <team@robur.coop>"
+authors: [ "Robur Team <team@robur.coop>" ]
+license: "MIT"
+homepage: "https://github.com/robur-coop/git-kv"
+dev-repo: "git+https://github.com/robur-coop/git-kv.git"
+bug-reports: "https://github.com/robur-coop/git-kv/issues"
+synopsis: "A Mirage_kv implementation using git"
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.9.0"}
+  "git"               {>= "3.10.0"}
+  "mirage-kv"         {>= "6.0.0"}
+  "carton"            {>= "0.7.0"}
+  "carton-lwt"        {>= "0.7.0"}
+  "fmt"               {>= "0.8.7"}
+  "mirage-ptime"      {>= "5.0.0"}
+  "ptime"
+  "hxd"               {with-test}
+  "conf-git"          {with-test}
+  "mirage-crypto-rng" {>= "1.2.0" & with-test}
+  "git-unix"          {>= "3.10.0" & with-test}
+  "alcotest"          {>= "1.8.0" & with-test}
+  "bos"               {>= "0.2.1" & with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/git-kv/releases/download/v0.1.3/git-kv-0.1.3.tbz"
+  checksum: [
+    "sha256=85f8809ce899ceda1f1096ad0b75b42790791f03de43fb2ec5e3e011ced19e1f"
+    "sha512=fa1703db48271141fa9d123269690cc5a52faf91be09ffef7b76e5b3b28158d03fa7b8c5ebc0a26e9bc0c473ea5c2f4c0dc0f7c5d5031afb47da996be70058c6"
+  ]
+}
+x-commit-hash: "4fa5a541bdbb52cd0cfb1c9b257a878fe5276b66"

--- a/packages/git-kv/git-kv.0.1.3/opam
+++ b/packages/git-kv/git-kv.0.1.3/opam
@@ -17,18 +17,18 @@ depends: [
   "fmt"               {>= "0.8.7"}
   "mirage-ptime"      {>= "5.0.0"}
   "ptime"
-  "hxd"               {with-test}
-  "conf-git"          {with-test}
-  "mirage-crypto-rng" {>= "1.2.0" & with-test}
-  "git-unix"          {>= "3.10.0" & with-test}
-  "alcotest"          {>= "1.8.0" & with-test}
-  "bos"               {>= "0.2.1" & with-test}
+#  "hxd"               {with-test}
+#  "conf-git"          {with-test}
+#  "mirage-crypto-rng" {>= "1.2.0" & with-test}
+#  "git-unix"          {>= "3.10.0" & with-test}
+#  "alcotest"          {>= "1.8.0" & with-test}
+#  "bos"               {>= "0.2.1" & with-test}
 ]
 
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test} # disabled due to sandbox issues (opens a TCP socket)
 ]
 x-maintenance-intent: [ "(latest)" ]
 url {

--- a/packages/yocaml_git/yocaml_git.1.0.0/opam
+++ b/packages/yocaml_git/yocaml_git.1.0.0/opam
@@ -25,7 +25,7 @@ depends: [
   "odoc" {with-doc}
   "preface" { = "1.0.0" }
   "lwt" { >= "5.4.2" }
-  "git-kv" { >= "0.0.3" }
+  "git-kv" { >= "0.0.3" & < "0.1.3"}
   "git-unix"
   "mirage-clock"
   "yocaml" {= version}

--- a/packages/yocaml_git/yocaml_git.2.1.0/opam
+++ b/packages/yocaml_git/yocaml_git.2.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "lwt" {>= "5.7.0"}
   "mimic" {>= "0.0.9"}
   "cstruct" {>= "6.2.0"}
-  "git-kv" {>= "0.0.5"}
+  "git-kv" {>= "0.0.5" & < "0.1.3"}
   "git-unix" {>= "3.16.1"}
   "mirage-clock" {>= "4.2.0"}
   "yocaml" {= version}


### PR DESCRIPTION
A Mirage_kv implementation using git

- Project page: <a href="https://github.com/robur-coop/git-kv">https://github.com/robur-coop/git-kv</a>

##### CHANGES:

- Defunctorise: remove functor over PCLOCK, use mirage-ptime instead of mirage-clock (!12 @hannesm, review by @reynir)
