### PR TITLE
[new release] dunolint (2 packages) (0.0.20250310)

### DIFF
--- a/packages/dunolint-lib/dunolint-lib.0.0.20250310/opam
+++ b/packages/dunolint-lib/dunolint-lib.0.0.20250310/opam
@@ -1,0 +1,75 @@
+opam-version: "2.0"
+synopsis: "A library to create dunolint configs"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/dunolint"
+doc: "https://mbarbin.github.io/dunolint/"
+bug-reports: "https://github.com/mbarbin/dunolint/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.3"}
+  "base" {>= "v0.17"}
+  "dune-glob" {>= "3.17"}
+  "fpath-base" {>= "0.2.2"}
+  "ppx_compare" {>= "v0.17"}
+  "ppx_enumerate" {>= "v0.17"}
+  "ppx_hash" {>= "v0.17"}
+  "ppx_here" {>= "v0.17"}
+  "ppx_let" {>= "v0.17"}
+  "ppx_sexp_conv" {>= "v0.17"}
+  "ppx_sexp_value" {>= "v0.17"}
+  "ppxlib" {>= "0.35.0"}
+  "re" {>= "1.8.0"}
+  "sexplib0" {>= "v0.17"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/dunolint.git"
+description: """\
+
+[dunolint] is a set of OCaml libraries and a cli tool to lint and help
+manage files in (large) dune projects.
+
+[dunolint-lib] is the package you need as a user to define a dunolint
+config, without pulling all the dependencies required by the linter
+engine and command line.
+
+It defines a configuration language in which you can express linting
+invariants for your projects. The tool will enforce these invariants,
+applying global and systematic changes automatically when able, and
+help with general ergonomics questions.
+
+For example: "I want for all libs in this subdirectory to enable
+`bisect_ppx`, please go patch my dune files". Or, "I would like all
+libraries that verify this particular predicate to supply the ppx flag
+`-unused-code-warnings=force`", and more.
+
+You can setup [dunolint] as part of your CI checks to help enforcing
+properties and linting checks going forward.
+
+"""
+tags: [ "dune" "linter" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/dunolint/releases/download/0.0.20250310/dunolint-0.0.20250310.tbz"
+  checksum: [
+    "sha256=b44119c96aeabb960e852711c2f20ae43f0011e796f05e012141ba980a5b58f6"
+    "sha512=5bf76732adc940db6cac0875e94c3eaff436288faba95388b9675c68b3f30f5362e01f289fc8a096325f7db812ace273773a1e051ab7d7ace3b8db4a57a0e070"
+  ]
+}
+x-commit-hash: "8c0c34d8f7c250aff52881a2fe25569488c8dbf5"

--- a/packages/dunolint/dunolint.0.0.20250310/opam
+++ b/packages/dunolint/dunolint.0.0.20250310/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+synopsis: "A linter for build files in dune projects"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/dunolint"
+doc: "https://mbarbin.github.io/dunolint/"
+bug-reports: "https://github.com/mbarbin/dunolint/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.3"}
+  "base" {>= "v0.17"}
+  "cmdlang" {>= "0.0.9"}
+  "dunolint-lib" {= version}
+  "file-rewriter" {>= "0.0.3"}
+  "fmt" {>= "0.9.0"}
+  "fpath" {>= "0.7.3"}
+  "fpath-base" {>= "0.2.2"}
+  "fpath-sexp0" {>= "0.2.2"}
+  "loc" {>= "0.2.2"}
+  "logs" {>= "0.7.0"}
+  "parsexp" {>= "v0.17"}
+  "patdiff" {>= "v0.17"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.10"}
+  "ppx_compare" {>= "v0.17"}
+  "ppx_enumerate" {>= "v0.17"}
+  "ppx_hash" {>= "v0.17"}
+  "ppx_here" {>= "v0.17"}
+  "ppx_let" {>= "v0.17"}
+  "ppx_sexp_conv" {>= "v0.17"}
+  "ppx_sexp_value" {>= "v0.17"}
+  "ppxlib" {>= "0.35.0"}
+  "sexplib0" {>= "v0.17"}
+  "sexps-rewriter" {>= "0.0.3"}
+  "stdio" {>= "v0.17"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/dunolint.git"
+description: """\
+
+[dunolint] is a set of OCaml libraries and a cli tool to lint and help
+manage files in (large) dune projects.
+
+[dunolint] is the package that implements the linter engine for
+dunolint configs as well as the [dunolint] command line tool.
+
+You may install it to get the [dunolint] cli, and/or if you want to
+use the linting libraries to write custom rewriters and linters.
+
+"""
+tags: [ "dune" "linter" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/dunolint/releases/download/0.0.20250310/dunolint-0.0.20250310.tbz"
+  checksum: [
+    "sha256=b44119c96aeabb960e852711c2f20ae43f0011e796f05e012141ba980a5b58f6"
+    "sha512=5bf76732adc940db6cac0875e94c3eaff436288faba95388b9675c68b3f30f5362e01f289fc8a096325f7db812ace273773a1e051ab7d7ace3b8db4a57a0e070"
+  ]
+}
+x-commit-hash: "8c0c34d8f7c250aff52881a2fe25569488c8dbf5"

--- a/packages/pplumbing/pplumbing.0.0.10/opam
+++ b/packages/pplumbing/pplumbing.0.0.10/opam
@@ -1,0 +1,85 @@
+opam-version: "2.0"
+synopsis: "Utility libraries to use with [pp]"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/pplumbing"
+doc: "https://mbarbin.github.io/pplumbing/"
+bug-reports: "https://github.com/mbarbin/pplumbing/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "cmdlang" {>= "0.0.9"}
+  "cmdlang-to-cmdliner" {>= "0.0.9"}
+  "cmdliner" {>= "1.3.0"}
+  "dyn" {>= "3.17"}
+  "fmt" {>= "0.9.0"}
+  "loc" {>= "0.2.2"}
+  "logs" {>= "0.7.0"}
+  "ordering" {>= "3.17"}
+  "pp" {>= "2.0.0"}
+  "sexplib0" {>= "v0.17"}
+  "stdune" {>= "3.17"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/pplumbing.git"
+description: """\
+
+[pplumbing] defines a set of utility libraries to use with [pp]. It
+is compatible with [logs] and inspired by design choices used by
+[dune] for user messages:
+
+- [Pp_tty] extends [pp] to build colored documents in the user's
+  terminal using ansi escape codes.
+
+- [Err] is an abstraction to report located errors and warnings to
+  the user.
+
+- [Log] is an interface to [logs] using [Pp_tty] rather than [Format].
+
+- [Log_cli] contains functions to work with [Err] on the side of end
+  programs (such as a command line tool). It defines command line
+  helpers to configure the [Err] library, while taking care of setting
+  the [logs] and [fmt] style rendering.
+
+- [Cmdlang_cmdliner_runner] is a library for running command line
+  programs specified with [cmdlang] with [cmdliner] as a backend and
+  making opinionated choices, assuming your dependencies are using
+  [Err].
+
+These libraries are meant to combine nicely into a small ecosystem of
+useful helpers to build CLIs in OCaml.
+
+[cmdlang]: https://github.com/mbarbin/cmdlang
+[cmdliner]: https://github.com/dbuenzli/cmdliner
+[dune]: https://github.com/ocaml/dune
+[fmt]: https://github.com/dbuenzli/fmt
+[logs]: https://github.com/dbuenzli/logs
+[pp]: https://github.com/ocaml-dune/pp
+
+"""
+tags: [ "cli" "cmdlang" "logs" "pp" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/pplumbing/releases/download/0.0.10/pplumbing-0.0.10.tbz"
+  checksum: [
+    "sha256=17725f5fc34bab17168bb8dadca78b07e76aada6736617782af34d34ef0e7cc1"
+    "sha512=6b538f79a41dc43f6b8adca455972a0755ddbeb348f17442cb47a0eb3d72ef9bf630ffbe2e3634d66d1b44972ade7bf95e6b495c54bb219841cf8024b16b196d"
+  ]
+}
+x-commit-hash: "48fa979cbfad07d1111a09c01999560f20fd7f5c"


### PR DESCRIPTION
A linter for build files in dune projects

- Project page: https://github.com/mbarbin/dunolint

This is an initial release so I can take ownership of the package namespace on opam, and allow early trials for interested parties.