### PR TITLE
[new release] pplumbing (0.0.10)

### DIFF
--- a/packages/pplumbing/pplumbing.0.0.10/opam
+++ b/packages/pplumbing/pplumbing.0.0.10/opam
@@ -1,0 +1,85 @@
+opam-version: "2.0"
+synopsis: "Utility libraries to use with [pp]"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/pplumbing"
+doc: "https://mbarbin.github.io/pplumbing/"
+bug-reports: "https://github.com/mbarbin/pplumbing/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "cmdlang" {>= "0.0.9"}
+  "cmdlang-to-cmdliner" {>= "0.0.9"}
+  "cmdliner" {>= "1.3.0"}
+  "dyn" {>= "3.17"}
+  "fmt" {>= "0.9.0"}
+  "loc" {>= "0.2.0"}
+  "logs" {>= "0.7.0"}
+  "ordering" {>= "3.17"}
+  "pp" {>= "2.0.0"}
+  "sexplib0" {>= "v0.17"}
+  "stdune" {>= "3.17"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/pplumbing.git"
+description: """\
+
+[pplumbing] defines a set of utility libraries to use with [pp]. It
+is compatible with [logs] and inspired by design choices used by
+[dune] for user messages:
+
+- [Pp_tty] extends [pp] to build colored documents in the user's
+  terminal using ansi escape codes.
+
+- [Err] is an abstraction to report located errors and warnings to
+  the user.
+
+- [Log] is an interface to [logs] using [Pp_tty] rather than [Format].
+
+- [Log_cli] contains functions to work with [Err] on the side of end
+  programs (such as a command line tool). It defines command line
+  helpers to configure the [Err] library, while taking care of setting
+  the [logs] and [fmt] style rendering.
+
+- [Cmdlang_cmdliner_runner] is a library for running command line
+  programs specified with [cmdlang] with [cmdliner] as a backend and
+  making opinionated choices, assuming your dependencies are using
+  [Err].
+
+These libraries are meant to combine nicely into a small ecosystem of
+useful helpers to build CLIs in OCaml.
+
+[cmdlang]: https://github.com/mbarbin/cmdlang
+[cmdliner]: https://github.com/dbuenzli/cmdliner
+[dune]: https://github.com/ocaml/dune
+[fmt]: https://github.com/dbuenzli/fmt
+[logs]: https://github.com/dbuenzli/logs
+[pp]: https://github.com/ocaml-dune/pp
+
+"""
+tags: [ "cli" "cmdlang" "logs" "pp" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/pplumbing/releases/download/0.0.10/pplumbing-0.0.10.tbz"
+  checksum: [
+    "sha256=17725f5fc34bab17168bb8dadca78b07e76aada6736617782af34d34ef0e7cc1"
+    "sha512=6b538f79a41dc43f6b8adca455972a0755ddbeb348f17442cb47a0eb3d72ef9bf630ffbe2e3634d66d1b44972ade7bf95e6b495c54bb219841cf8024b16b196d"
+  ]
+}
+x-commit-hash: "48fa979cbfad07d1111a09c01999560f20fd7f5c"


### PR DESCRIPTION
Utility libraries to use with `pp` with helpers to build CLIs in OCaml.

- Project page: https://github.com/mbarbin/pplumbing

This is an initial release so I can take the ownership of the opam name, and allowing to publish a first version of `dunolint` which depends on this package.