### PR TITLE
[new release] salto-analyzer (0.1)

### DIFF
--- a/packages/salto-analyzer/salto-analyzer.0.1/opam
+++ b/packages/salto-analyzer/salto-analyzer.0.1/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Salto static analyzer for OCaml programs"
+description: """
+Static analyzer for OCaml programs, that infers possible
+   output values for every part of a program, as well as exceptions that
+   might be raised. It is based on the theory of abstract interpretation."""
+maintainer: [
+  "Pierre Lermusiaux <pierre.lermusiaux@inria.fr>"
+  "Benoît Montagu <benoit.montagu@inria.fr>"
+]
+authors: [
+  "Pierre Lermusiaux <pierre.lermusiaux@inria.fr>"
+  "Benoît Montagu <benoit.montagu@inria.fr>"
+]
+license: "LGPL-3.0-or-later"
+homepage: "https://salto.gitlabpages.inria.fr/"
+bug-reports: "https://gitlab.inria.fr/salto/salto-analyzer/-/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "saltoIL" {>= "0.1.11"}
+  "base" {>= "v0.16.3"}
+  "cmdliner" {>= "1.2.0"}
+  "dmap" {>= "0.5"}
+  "hashcons" {>= "1.3"}
+  "hashset" {>= "1.0.0"}
+  "ppx_import" {build & >= "1.9.0"}
+  "ppx_deriving" {build & >= "5.2.1"}
+  "ppx_expect" {>= "v0.16.0"}
+  "ptset" {>= "1.0.1"}
+  "zarith" {>= "1.13"}
+  "ezjs_ace" {>= "0.1.1"}
+  "js_of_ocaml" {>= "5.4.0" & <= "5.9.1"}
+  "js_of_ocaml-ppx" {build & >= "5.4.0"}
+  "js_of_ocaml-tyxml" {>= "5.4.0"}
+  "zarith_stubs_js" {>= "0.16.1"}
+  "csexp" {>= "1.5.2"}
+  "ez_dune_describe" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.inria.fr/salto/salto-analyzer"
+url {
+  src:
+    "https://salto.gitlabpages.inria.fr/salto-analyzer/releases/salto-analyzer-0.1.tbz"
+  checksum: [
+    "sha256=dec936314e9d44dffdf10d9654bf37e631cdf32fa03052c9f4d4aa992c10b247"
+    "sha512=6efc54d9ff97fc5654c28a6c8f96d814be44cf53e03d301c907b5b2178813a0f7837e341272891b92417cc98529acc8a66062002e16e705c781a3ec2a3db5f16"
+  ]
+}
+x-commit-hash: "052c78a048375988dc8649cbeb45d156f031a732"


### PR DESCRIPTION
Salto static analyzer for OCaml programs

- Project page: <a href="https://salto.gitlabpages.inria.fr/">https://salto.gitlabpages.inria.fr/</a>

##### CHANGES:

- first public release
