### PR TITLE
Package coq-waterproof.2.2.0+8.20

### DIFF
--- a/packages/coq-waterproof/coq-waterproof.2.2.0+8.20/opam
+++ b/packages/coq-waterproof/coq-waterproof.2.2.0+8.20/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Jim Portegies <j.w.portegies@tue.nl>"
+authors: [
+  "Jelle Wemmenhove"
+  "Pim Otte"
+  "Balthazar Pathiachvili"
+  "Cosmin Manea"
+  "Lulof Pirée"
+  "Adrian Vrămuleţ"
+  "Tudor Voicu"
+  "Jim Portegies <j.w.portegies@tue.nl>"
+]
+
+synopsis: "Coq proofs in a style that resembles non-mechanized mathematical proofs"
+description: """
+The Waterproof plugin for the Coq proof assistant allows you to write Coq proofs in a style that resembles handwritten mathematical proofs, designed to help university students with learning how to prove mathematical statements.
+"""
+
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/impermeable/coq-waterproof"
+dev-repo: "git+https://github.com/impermeable/coq-waterproof.git"
+bug-reports: "https://github.com/impermeable/coq-waterproof/issues"
+
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "coq" {>= "8.20" & < "8.21" | = "dev"}
+  "dune" {>= "3.6"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install"]
+]
+
+available: (arch != "s390x") & (arch != "ppc64") & (os != "win32")
+
+tags: [
+  "keyword:mathematics education"
+  "category:Mathematics/Education"
+  "date:2023-11-04"
+  "logpath:Waterproof"
+]
+url {
+  src:
+    "https://github.com/impermeable/coq-waterproof/archive/refs/tags/2.2.0+8.20.tar.gz"
+  checksum: [
+    "md5=18c6dafc6fb018f167f89fb236ff494b"
+    "sha512=096ebe52912ebe3fb063a5ce88bee1dfc8f63226f7f1284a4304a079751b98c617a4fcafa9781c3e54e024e631c87248885b56efc20086c98ae0e525cfe08efb"
+  ]
+}


### PR DESCRIPTION
### `coq-waterproof.2.2.0+8.20`
Coq proofs in a style that resembles non-mechanized mathematical proofs
The Waterproof plugin for the Coq proof assistant allows you to write Coq proofs in a style that resembles handwritten mathematical proofs, designed to help university students with learning how to prove mathematical statements.



---
* Homepage: https://github.com/impermeable/coq-waterproof
* Source repo: git+https://github.com/impermeable/coq-waterproof.git
* Bug tracker: https://github.com/impermeable/coq-waterproof/issues

---
:camel: Pull-request generated by opam-publish v2.2.0