### PR TITLE
Add: uutf.1.0.4

### DIFF
--- a/packages/uutf/uutf.1.0.4/opam
+++ b/packages/uutf/uutf.1.0.4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Non-blocking streaming Unicode codec for OCaml"
+description: """\
+**Warning.** You are encouraged not to use this library.
+
+- As of OCaml 4.14, both UTF encoding and decoding are available
+  in the standard library, see the `String` and `Buffer` modules.
+- If you are looking for a stream abstraction compatible with
+  effect based concurrency look into [`bytesrw`] package."""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uutf programmers"
+license: "ISC"
+tags: ["unicode" "text" "utf-8" "utf-16" "codec" "org:erratique"]
+homepage: "https://erratique.ch/software/uutf"
+doc: "https://erratique.ch/software/uutf/doc/"
+bug-reports: "https://github.com/dbuenzli/uutf/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+]
+depopts: ["cmdliner"]
+conflicts: [
+  "cmdliner" {< "1.3.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/uutf.git"
+url {
+  src: "https://erratique.ch/software/uutf/releases/uutf-1.0.4.tbz"
+  checksum:
+    "sha512=e35f408bc971cd8da3077e6c3321e0d8f4eb569898e0e219fde62dae78fbd0a0095cb7f036287656f6a1b346584f7b9f0c6dec0a5a092180da36e43247027598"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `uutf.1.0.4` [home](https://erratique.ch/software/uutf), [doc](https://erratique.ch/software/uutf/doc/), [issues](https://github.com/dbuenzli/uutf/issues)  
  *Non-blocking streaming Unicode codec for OCaml*


---

#### `uutf` v1.0.4 2025-03-10 La Forclaz (VS)

- Implement `Uutf.Buffer.*` with `Stdlib.Buffer.*`, no need to bloat
  these executables with dozens of different UTF encoders.
- Require OCaml >= 4.08.
- `uutftrip`, handle `cmdliner` deprecations.

---

Use `b0 -- .opam publish uutf.1.0.4` to update the pull request.