### PR TITLE
Add: uuidm.0.9.10

### DIFF
--- a/packages/uuidm/uuidm.0.9.10/opam
+++ b/packages/uuidm/uuidm.0.9.10/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Universally unique identifiers (UUIDs) for OCaml"
+description: """\
+Uuidm is an OCaml library implementing 128 bits universally unique
+identifiers version 3, 5 (named based with MD5, SHA-1 hashing), 4
+(random based), 7 (time and random based) and 8 (custom) according to
+[RFC 9562].
+
+Uuidm has no dependency. It is distributed under the ISC license.
+
+[RFC 9562]: https://www.rfc-editor.org/rfc/rfc9562
+
+Homepage: <https://erratique.ch/software/uuidm>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uuidm programmers"
+license: "ISC"
+tags: ["uuid" "codec" "org:erratique"]
+homepage: "https://erratique.ch/software/uuidm"
+doc: "https://erratique.ch/software/uuidm/doc/"
+bug-reports: "https://github.com/dbuenzli/uuidm/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+]
+depopts: ["cmdliner"]
+conflicts: [
+  "cmdliner" {< "1.3.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/uuidm.git"
+url {
+  src: "https://erratique.ch/software/uuidm/releases/uuidm-0.9.10.tbz"
+  checksum:
+    "sha512=22cbc872a0be910ebd5cda67bb471b5ab93cd1edfa535a86169a9d0f7a5cce85824b9e8a43d16d7587e1968b37a70fac1b75af075700117089a28879297dda07"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `uuidm.0.9.10` [home](https://erratique.ch/software/uuidm), [doc](https://erratique.ch/software/uuidm/doc/), [issues](https://github.com/dbuenzli/uuidm/issues)  
  *Universally unique identifiers (UUIDs) for OCaml*


---

#### `uuidm` v0.9.10 2025-03-10 La Forclaz (VS)

- Install forgotten `index.mld` file.
- `uuidtrip`: handle `cmdliner` deprecations.

---

Use `b0 -- .opam publish uuidm.0.9.10` to update the pull request.