### PR TITLE
Add: webbrowser.0.6.2

### DIFF
--- a/packages/webbrowser/webbrowser.0.6.2/opam
+++ b/packages/webbrowser/webbrowser.0.6.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Open and reload URIs in browsers from OCaml"
+description: """\
+*Warning* This library is maintained but no longer developed.  Similar
+functionality can be found in the libraries of [`b0`] (and its
+`show-url` tool).
+
+Webbrowser is a library to open and reload URIs in web browsers from
+OCaml.
+
+Webbrowser depends on [bos][bos]. The command line support provided by
+the Webbrowser_cli library depends on [cmdliner][cmdliner].
+
+Webbrowser is distributed under the ISC license. 
+
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[b0]: http://erratique.ch/software/b0
+
+Homepage: <http://erratique.ch/software/webbrowser>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The webbrowser programmers"
+license: "ISC"
+tags: ["web" "http" "url" "browser" "cli" "org:erratique"]
+homepage: "https://erratique.ch/software/webbrowser"
+doc: "https://erratique.ch/software/webbrowser/doc/"
+bug-reports: "https://github.com/dbuenzli/webbrowser/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "bos" {>= "0.2.1"}
+  "rresult" {>= "0.7.0"}
+  "cmdliner" {>= "1.3.0"}
+  "topkg" {build & >= "1.0.3"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/webbrowser.git"
+url {
+  src:
+    "https://erratique.ch/software/webbrowser/releases/webbrowser-0.6.2.tbz"
+  checksum:
+    "sha512=37b7f883d2426613933332ee186d306b8959e67d631b761fa239e292d2c24c4a867177938ee8e675910879386d3404781b30224d53dbf18ac4376c89411a2059"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `webbrowser.0.6.2` [home](https://erratique.ch/software/webbrowser), [doc](https://erratique.ch/software/webbrowser/doc/), [issues](https://github.com/dbuenzli/webbrowser/issues)  
  *Open and reload URIs in browsers from OCaml*


---

#### `webbrowser` v0.6.2 2025-03-10

*Warning* This library is maintained but no longer developed.  Similar
functionality can be found in the libraries of [`b0`] (and its
`show-url` tool).

- Require OCaml >= 4.08.
- Install libraries in their own directories.
- Handle `cmdliner` deprecations.
- Drop direct dependency on `astring`
- `cmdliner` is no longer a depopt. This ensure that depending on
  `webbrowser` installs the `browse(1)` tool. You can still use the
  library without depending on it.

---

Use `b0 -- .opam publish webbrowser.0.6.2` to update the pull request.