### PR TITLE
Update of the opam file for ACGtk 2.1.0.

### DIFF
--- a/packages/acgtk/acgtk.2.1.0/opam
+++ b/packages/acgtk/acgtk.2.1.0/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "sylvain.pogodalla@inria.fr"
+x-maintenance-intent: ["(latest)"]
 
 build: [
   ["dune" "subst"] {dev}
@@ -14,7 +15,7 @@ depends: [
   "menhir" { >= "20211230"}
   "ocamlgraph"
   "ANSITerminal" { >= "0.8" }
-  "fmt"
+  "fmt" { <= "0.9.0" }
   "logs"
   "mtime" { >= "2.0.0"}
   "cmdliner" { >= "1.1.0"}


### PR DESCRIPTION
This update:
+ sets an upper bound for `fmt` in the current `ACGtk` release (it seems the dependency to `fmt` is now explicitly required in dune files, dependency on `fmt.tty` alone does not seem to be enough for `fmt.0.10.0`);
+ sets the `x-maintenance-intent` status to "(latest)"