### PR TITLE
[new release] melange-json (2 packages) (2.0.0)

### DIFF
--- a/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.1.0.0/opam
+++ b/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "melange" {>= "2.0.0" & < "3.0.0"}
   "atd"
   "atdgen"
-  "melange-json"
+  "melange-json" {< "2.0.0"}
   "melange-jest" {with-test}
   "reason" {with-test}
   "opam-check-npm-deps" {with-test}

--- a/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.3.0.0/opam
+++ b/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.3.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "melange" {>= "3.0.0"}
   "atd"
   "atdgen"
-  "melange-json"
+  "melange-json" {< "2.0.0"}
   "melange-jest" {with-test}
   "reason" {with-test}
   "opam-check-npm-deps" {with-test}

--- a/packages/melange-json-native/melange-json-native.2.0.0/opam
+++ b/packages/melange-json-native/melange-json-native.2.0.0/opam
@@ -27,7 +27,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/melange-json-native/melange-json-native.2.0.0/opam
+++ b/packages/melange-json-native/melange-json-native.2.0.0/opam
@@ -11,7 +11,7 @@ license: ["LGPL-3.0-only" "MPL-2.0"]
 homepage: "https://github.com/melange-community/melange-json/"
 bug-reports: "https://github.com/melange-community/melange-json/issues"
 depends: [
-  "dune" {>= "3.9"}
+  "dune" {>= "3.16"}
   "ocaml" {>= "4.12"}
   "ppxlib" {>= "0.29.0"}
   "yojson" {>= "1.6.0"}

--- a/packages/melange-json-native/melange-json-native.2.0.0/opam
+++ b/packages/melange-json-native/melange-json-native.2.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Compositional JSON encode/decode PPX for OCaml"
+description:
+  "A PPX for OCaml that automates encoding and decoding JSON into typed values. It supports custom encoders and decoders, and integrates with Yojson"
+maintainer: [
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+  "Javier Chávarri <javier.chavarri@gmail.com>"
+]
+authors: ["Andrey Popp"]
+license: ["LGPL-3.0-only" "MPL-2.0"]
+homepage: "https://github.com/melange-community/melange-json/"
+bug-reports: "https://github.com/melange-community/melange-json/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "4.12"}
+  "ppxlib" {>= "0.29.0"}
+  "yojson" {>= "1.6.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-community/melange-json.git"
+url {
+  src:
+    "https://github.com/melange-community/melange-json/releases/download/2.0.0/melange-json-2.0.0.tbz"
+  checksum: [
+    "sha256=5049c1694ac30f7de3dbffc10e9a01b83c3302b4147902d97c31b7482fdb2ad8"
+    "sha512=bcad995988dd4f5bfba1824e9ae5d4e12c1ea20dba6a943db04a2a112428dd78d09fd4cc87b5ca2f4fb08b0b5d4165b249953325b210170687d1a0ae47dd18a1"
+  ]
+}
+x-commit-hash: "03479308a277671b7c933bcd9390adecfa058778"

--- a/packages/melange-json-native/melange-json-native.2.0.0/opam
+++ b/packages/melange-json-native/melange-json-native.2.0.0/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/melange-community/melange-json/issues"
 depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "4.12"}
-  "ppxlib" {>= "0.29.0"}
+  "ppxlib" {>= "0.32.0"}
   "yojson" {>= "1.6.0"}
   "odoc" {with-doc}
 ]

--- a/packages/melange-json/melange-json.2.0.0/opam
+++ b/packages/melange-json/melange-json.2.0.0/opam
@@ -32,7 +32,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/melange-json/melange-json.2.0.0/opam
+++ b/packages/melange-json/melange-json.2.0.0/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/melange-community/melange-json/issues"
 depends: [
   "dune" {>= "3.16"}
   "ocaml"
-  "melange" {>= "3.0.0"}
+  "melange" {>= "4.0.0"}
   "melange-jest" {with-test}
   "reason" {>= "3.10.0" & with-test}
   "ppxlib" {>= "0.32.0"}

--- a/packages/melange-json/melange-json.2.0.0/opam
+++ b/packages/melange-json/melange-json.2.0.0/opam
@@ -11,7 +11,7 @@ license: ["LGPL-3.0-only" "MPL-2.0"]
 homepage: "https://github.com/melange-community/melange-json/"
 bug-reports: "https://github.com/melange-community/melange-json/issues"
 depends: [
-  "dune" {>= "3.9"}
+  "dune" {>= "3.16"}
   "ocaml"
   "melange" {>= "3.0.0"}
   "melange-jest" {with-test}

--- a/packages/melange-json/melange-json.2.0.0/opam
+++ b/packages/melange-json/melange-json.2.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compositional JSON encode/decode library and PPX for Melange"
+description:
+  "Provides tools for converting JSON to typed OCaml values in Melange. It includes custom encoders, decoders, and a PPX for automating these conversions."
+maintainer: [
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+  "Javier Chávarri <javier.chavarri@gmail.com>"
+]
+authors: ["glennsl" "Andrey Popp"]
+license: ["LGPL-3.0-only" "MPL-2.0"]
+homepage: "https://github.com/melange-community/melange-json/"
+bug-reports: "https://github.com/melange-community/melange-json/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml"
+  "melange" {>= "3.0.0"}
+  "melange-jest" {with-test}
+  "reason" {>= "3.10.0" & with-test}
+  "ppxlib"
+  "opam-check-npm-deps" {with-test}
+  "ocaml-lsp-server" {with-test}
+  "ocamlformat" {>= "0.27.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-community/melange-json.git"
+url {
+  src:
+    "https://github.com/melange-community/melange-json/releases/download/2.0.0/melange-json-2.0.0.tbz"
+  checksum: [
+    "sha256=5049c1694ac30f7de3dbffc10e9a01b83c3302b4147902d97c31b7482fdb2ad8"
+    "sha512=bcad995988dd4f5bfba1824e9ae5d4e12c1ea20dba6a943db04a2a112428dd78d09fd4cc87b5ca2f4fb08b0b5d4165b249953325b210170687d1a0ae47dd18a1"
+  ]
+}
+x-commit-hash: "03479308a277671b7c933bcd9390adecfa058778"

--- a/packages/melange-json/melange-json.2.0.0/opam
+++ b/packages/melange-json/melange-json.2.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "melange" {>= "3.0.0"}
   "melange-jest" {with-test}
   "reason" {>= "3.10.0" & with-test}
-  "ppxlib"
+  "ppxlib" {>= "0.32.0"}
   "opam-check-npm-deps" {with-test}
   "ocaml-lsp-server" {with-test}
   "ocamlformat" {>= "0.27.0" & with-test}


### PR DESCRIPTION
Compositional JSON encode/decode library and PPX for Melange

- Project page: <a href="https://github.com/melange-community/melange-json/">https://github.com/melange-community/melange-json/</a>

##### CHANGES:

- **[breaking]** Library, PPX: Unify runtimes (`*.ppx-runtime` libraries are
  removed, can use `melange-json` and `melange-json-native` instead), replace
  `Json` module with `Melange_json`, deprecate `Decode` and `Encode` modules,
  introduce new decoding error type and helper function
  `of_json_error_to_string`.
  ([melange-community/melange-json#36](https://github.com/melange-community/melange-json/pull/36))
- **[breaking]** PPX: Code to decode polyvariants doesn't use an additional
  `_poly` function which was also generated by the PPX. Instead
  `Unexpected_variant` error is used to signal that next decoder should be
  tried. ([melange-community/melange-json#32](https://github.com/melange-community/melange-json/pull/32))
- **[breaking]** Json.Decode.DecodeError exception now contains a variant type
  as payload instead of a string.
  ([melange-community/melange-json#32](https://github.com/melange-community/melange-json/pull/32))
- **[breaking]** PPX: Rename `[@json.as]` to `[@json.name]`
  ([melange-community/melange-json#23](https://github.com/melange-community/melange-json/pull/23))
- **[breaking]** PPX: Drop special encoding for enumeration-like variants
  (variants with each constructor having no arguments).
  ([melange-community/melange-json#26](https://github.com/melange-community/melange-json/pull/26))
- **[breaking]** PPX: change JSON representation of polyvariants, make it
  compatible with ppx_deriving_yojson and ppx_yojson_conv
  ([melange-community/melange-json#27](https://github.com/melange-community/melange-json/pull/27))
- **[breaking]** PPX: Consistent use of exceptions in runtime.
  ([melange-community/melange-json#28](https://github.com/melange-community/melange-json/pull/28))
- PPX: `[@@deriving json]` now can be used within signatures (this includes
  `.mli` files).
  ([melange-community/melange-json#32](https://github.com/melange-community/melange-json/pull/32))
- PPX: Add runtime for `result`
  ([melange-community/melange-json#13](https://github.com/melange-community/melange-json/pull/13))
- PPX: Add `yojson` as runtime dep for the native version
  ([melange-community/melange-json#15](https://github.com/melange-community/melange-json/pull/15))
- PPX: add `[@@json_string]` for deriving converters to/from JSON strings
  directly ([melange-community/melange-json#30](https://github.com/melange-community/melange-json/pull/30))
- PPX: add support for `int64` in the runtime
  ([melange-community/melange-json#33](https://github.com/melange-community/melange-json/pull/33))
- PPX: remove `string_to_json` usage on js side
  ([melange-community/melange-json#35](https://github.com/melange-community/melange-json/pull/35))
- PPX: Add array functions to native runtime
  ([melange-community/melange-json#37](https://github.com/melange-community/melange-json/pull/37))
