### PR TITLE
`opsian` unavailable on additional arches

### DIFF
--- a/packages/opsian/opsian.0.1/opam
+++ b/packages/opsian/opsian.0.1/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/Opsian/opsian-ocaml/issues"
 depends: [
   "dune" {>= "2.8"}
   ("ocaml" {>= "4.12.0" & < "5.0.0"} |
-   ("ocaml" {>= "5.0.0"} & "runtime_events_tools"))
+   ("ocaml" {>= "5.0.0" & < "5.1"} & "runtime_events_tools"))
   "conf-automake"
   "conf-perl"
   "conf-liblzma"

--- a/packages/opsian/opsian.0.1/opam
+++ b/packages/opsian/opsian.0.1/opam
@@ -19,7 +19,7 @@ conflicts: [
   "runtime_events_tools" {>= "0.5"}
 ]
 available:
-  arch != "arm32" & arch != "arm64" & arch != "x86_32" & arch != "s390x" &
+  arch != "arm32" & arch != "arm64" & arch != "x86_32" & arch != "s390x" & arch != "ppc64" &
   os-family != "arch" & os-family != "alpine" & os != "macos"
 build: ["dune" "build" "--release" "-j" jobs]
 dev-repo: "git+https://github.com/Opsian/opsian-ocaml.git"

--- a/packages/opsian/opsian.0.1/opam
+++ b/packages/opsian/opsian.0.1/opam
@@ -20,7 +20,7 @@ conflicts: [
 ]
 available:
   arch != "arm32" & arch != "arm64" & arch != "x86_32" & arch != "s390x" & arch != "ppc64" & arch != "riscv64" &
-  os-family != "arch" & os-family != "alpine" & os != "macos"
+  os-family != "arch" & os-family != "alpine" & os != "macos" & os != "freebsd"
 build: ["dune" "build" "--release" "-j" jobs]
 dev-repo: "git+https://github.com/Opsian/opsian-ocaml.git"
 url {

--- a/packages/opsian/opsian.0.1/opam
+++ b/packages/opsian/opsian.0.1/opam
@@ -19,8 +19,8 @@ conflicts: [
   "runtime_events_tools" {>= "0.5"}
 ]
 available:
-  arch != "arm32" & arch != "x86_32" & arch != "s390x" & os-family != "arch" &
-  os-family != "alpine" & os != "macos"
+  arch != "arm32" & arch != "arm64" & arch != "x86_32" & arch != "s390x" &
+  os-family != "arch" & os-family != "alpine" & os != "macos"
 build: ["dune" "build" "--release" "-j" jobs]
 dev-repo: "git+https://github.com/Opsian/opsian-ocaml.git"
 url {

--- a/packages/opsian/opsian.0.1/opam
+++ b/packages/opsian/opsian.0.1/opam
@@ -19,7 +19,7 @@ conflicts: [
   "runtime_events_tools" {>= "0.5"}
 ]
 available:
-  arch != "arm32" & arch != "arm64" & arch != "x86_32" & arch != "s390x" & arch != "ppc64" &
+  arch != "arm32" & arch != "arm64" & arch != "x86_32" & arch != "s390x" & arch != "ppc64" & arch != "riscv64" &
   os-family != "arch" & os-family != "alpine" & os != "macos"
 build: ["dune" "build" "--release" "-j" jobs]
 dev-repo: "git+https://github.com/Opsian/opsian-ocaml.git"


### PR DESCRIPTION
While working on #27607 I noticed that `opsian` doesn't build on even more platforms, thus I cherry-picked the fixes into this PR.