### PR TITLE
[new release] sail (13 packages) (0.19)

### DIFF
--- a/packages/libsail/libsail.0.19/opam
+++ b/packages/libsail/libsail.0.19/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis:
+  "Sail is a language for describing the instruction semantics of processors"
+description: """
+Sail is a language for describing the instruction-set
+architecture (ISA) semantics of processors. Sail aims to provide a
+engineer-friendly, vendor-pseudocode-like language for describing
+instruction semantics. It is essentially a first-order imperative
+language, but with lightweight dependent typing for numeric types and
+bitvector lengths, which are automatically checked using Z3. It has
+been used for several papers, available from
+http://www.cl.cam.ac.uk/~pes20/sail/.
+"""
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "dune-site" {>= "3.0.2"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "menhir" {>= "20240715" & build}
+  "ott" {>= "0.28" & build}
+  "lem" {>= "2018-12-14"}
+  "linksem" {>= "0.3"}
+  "conf-gmp"
+  "yojson" {>= "1.6.0"}
+  "pprint" {>= "20220103"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.19/sail-0.19.tbz"
+  checksum: [
+    "sha256=5458e69ac0a5d9f52738d1946509c501897f5487accb9610b1f20c30305d23e0"
+    "sha512=416e28b9a22784939d38fc23435f6df7a4d01660ba912994fd89adba908f95a325dd21c315ccac3e3b8c9172f0e9ce6ef87264d54ec04306c69f7c2f277452ee"
+  ]
+}
+x-commit-hash: "7ac8131a08d46be253625755d5a985be6920e876"

--- a/packages/sail/sail.0.19/opam
+++ b/packages/sail/sail.0.19/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis:
+  "Sail is a language for describing the instruction semantics of processors"
+description: """
+Sail is a language for describing the instruction-set
+architecture (ISA) semantics of processors. Sail aims to provide a
+engineer-friendly, vendor-pseudocode-like language for describing
+instruction semantics. It is essentially a first-order imperative
+language, but with lightweight dependent typing for numeric types and
+bitvector lengths, which are automatically checked using Z3. It has
+been used for several papers, available from
+http://www.cl.cam.ac.uk/~pes20/sail/.
+"""
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "sail_manifest" {= version & build}
+  "sail_ocaml_backend" {= version & post}
+  "sail_c_backend" {= version & post}
+  "sail_smt_backend" {= version & post}
+  "sail_sv_backend" {= version & post}
+  "sail_lem_backend" {= version & post}
+  "sail_coq_backend" {= version & post}
+  "sail_lean_backend" {= version & post}
+  "sail_latex_backend" {= version & post}
+  "sail_doc_backend" {= version & post}
+  "sail_output" {= version & post}
+  "linenoise" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+substs: [ "src/bin/manifest.ml" ]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.19/sail-0.19.tbz"
+  checksum: [
+    "sha256=5458e69ac0a5d9f52738d1946509c501897f5487accb9610b1f20c30305d23e0"
+    "sha512=416e28b9a22784939d38fc23435f6df7a4d01660ba912994fd89adba908f95a325dd21c315ccac3e3b8c9172f0e9ce6ef87264d54ec04306c69f7c2f277452ee"
+  ]
+}
+x-commit-hash: "7ac8131a08d46be253625755d5a985be6920e876"

--- a/packages/sail_c_backend/sail_c_backend.0.19/opam
+++ b/packages/sail_c_backend/sail_c_backend.0.19/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to C translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.19/sail-0.19.tbz"
+  checksum: [
+    "sha256=5458e69ac0a5d9f52738d1946509c501897f5487accb9610b1f20c30305d23e0"
+    "sha512=416e28b9a22784939d38fc23435f6df7a4d01660ba912994fd89adba908f95a325dd21c315ccac3e3b8c9172f0e9ce6ef87264d54ec04306c69f7c2f277452ee"
+  ]
+}
+x-commit-hash: "7ac8131a08d46be253625755d5a985be6920e876"

--- a/packages/sail_coq_backend/sail_coq_backend.0.19/opam
+++ b/packages/sail_coq_backend/sail_coq_backend.0.19/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Coq translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.19/sail-0.19.tbz"
+  checksum: [
+    "sha256=5458e69ac0a5d9f52738d1946509c501897f5487accb9610b1f20c30305d23e0"
+    "sha512=416e28b9a22784939d38fc23435f6df7a4d01660ba912994fd89adba908f95a325dd21c315ccac3e3b8c9172f0e9ce6ef87264d54ec04306c69f7c2f277452ee"
+  ]
+}
+x-commit-hash: "7ac8131a08d46be253625755d5a985be6920e876"

--- a/packages/sail_doc_backend/sail_doc_backend.0.19/opam
+++ b/packages/sail_doc_backend/sail_doc_backend.0.19/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Sail documentation generator"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "base64" {>= "3.1.0"}
+  "omd" {>= "1.3.1" & < "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.19/sail-0.19.tbz"
+  checksum: [
+    "sha256=5458e69ac0a5d9f52738d1946509c501897f5487accb9610b1f20c30305d23e0"
+    "sha512=416e28b9a22784939d38fc23435f6df7a4d01660ba912994fd89adba908f95a325dd21c315ccac3e3b8c9172f0e9ce6ef87264d54ec04306c69f7c2f277452ee"
+  ]
+}
+x-commit-hash: "7ac8131a08d46be253625755d5a985be6920e876"

--- a/packages/sail_latex_backend/sail_latex_backend.0.19/opam
+++ b/packages/sail_latex_backend/sail_latex_backend.0.19/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to LaTeX formatting"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "omd" {>= "1.3.1" & < "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.19/sail-0.19.tbz"
+  checksum: [
+    "sha256=5458e69ac0a5d9f52738d1946509c501897f5487accb9610b1f20c30305d23e0"
+    "sha512=416e28b9a22784939d38fc23435f6df7a4d01660ba912994fd89adba908f95a325dd21c315ccac3e3b8c9172f0e9ce6ef87264d54ec04306c69f7c2f277452ee"
+  ]
+}
+x-commit-hash: "7ac8131a08d46be253625755d5a985be6920e876"

--- a/packages/sail_lean_backend/sail_lean_backend.0.19/opam
+++ b/packages/sail_lean_backend/sail_lean_backend.0.19/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Lean translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.19/sail-0.19.tbz"
+  checksum: [
+    "sha256=5458e69ac0a5d9f52738d1946509c501897f5487accb9610b1f20c30305d23e0"
+    "sha512=416e28b9a22784939d38fc23435f6df7a4d01660ba912994fd89adba908f95a325dd21c315ccac3e3b8c9172f0e9ce6ef87264d54ec04306c69f7c2f277452ee"
+  ]
+}
+x-commit-hash: "7ac8131a08d46be253625755d5a985be6920e876"

--- a/packages/sail_lem_backend/sail_lem_backend.0.19/opam
+++ b/packages/sail_lem_backend/sail_lem_backend.0.19/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Lem translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.19/sail-0.19.tbz"
+  checksum: [
+    "sha256=5458e69ac0a5d9f52738d1946509c501897f5487accb9610b1f20c30305d23e0"
+    "sha512=416e28b9a22784939d38fc23435f6df7a4d01660ba912994fd89adba908f95a325dd21c315ccac3e3b8c9172f0e9ce6ef87264d54ec04306c69f7c2f277452ee"
+  ]
+}
+x-commit-hash: "7ac8131a08d46be253625755d5a985be6920e876"

--- a/packages/sail_manifest/sail_manifest.0.19/opam
+++ b/packages/sail_manifest/sail_manifest.0.19/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Helper tool for compiling Sail"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.19/sail-0.19.tbz"
+  checksum: [
+    "sha256=5458e69ac0a5d9f52738d1946509c501897f5487accb9610b1f20c30305d23e0"
+    "sha512=416e28b9a22784939d38fc23435f6df7a4d01660ba912994fd89adba908f95a325dd21c315ccac3e3b8c9172f0e9ce6ef87264d54ec04306c69f7c2f277452ee"
+  ]
+}
+x-commit-hash: "7ac8131a08d46be253625755d5a985be6920e876"

--- a/packages/sail_ocaml_backend/sail_ocaml_backend.0.19/opam
+++ b/packages/sail_ocaml_backend/sail_ocaml_backend.0.19/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to OCaml translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "base64" {>= "3.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.19/sail-0.19.tbz"
+  checksum: [
+    "sha256=5458e69ac0a5d9f52738d1946509c501897f5487accb9610b1f20c30305d23e0"
+    "sha512=416e28b9a22784939d38fc23435f6df7a4d01660ba912994fd89adba908f95a325dd21c315ccac3e3b8c9172f0e9ce6ef87264d54ec04306c69f7c2f277452ee"
+  ]
+}
+x-commit-hash: "7ac8131a08d46be253625755d5a985be6920e876"

--- a/packages/sail_output/sail_output.0.19/opam
+++ b/packages/sail_output/sail_output.0.19/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Example Sail output plugin"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.19/sail-0.19.tbz"
+  checksum: [
+    "sha256=5458e69ac0a5d9f52738d1946509c501897f5487accb9610b1f20c30305d23e0"
+    "sha512=416e28b9a22784939d38fc23435f6df7a4d01660ba912994fd89adba908f95a325dd21c315ccac3e3b8c9172f0e9ce6ef87264d54ec04306c69f7c2f277452ee"
+  ]
+}
+x-commit-hash: "7ac8131a08d46be253625755d5a985be6920e876"

--- a/packages/sail_smt_backend/sail_smt_backend.0.19/opam
+++ b/packages/sail_smt_backend/sail_smt_backend.0.19/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to SMT translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.19/sail-0.19.tbz"
+  checksum: [
+    "sha256=5458e69ac0a5d9f52738d1946509c501897f5487accb9610b1f20c30305d23e0"
+    "sha512=416e28b9a22784939d38fc23435f6df7a4d01660ba912994fd89adba908f95a325dd21c315ccac3e3b8c9172f0e9ce6ef87264d54ec04306c69f7c2f277452ee"
+  ]
+}
+x-commit-hash: "7ac8131a08d46be253625755d5a985be6920e876"

--- a/packages/sail_sv_backend/sail_sv_backend.0.19/opam
+++ b/packages/sail_sv_backend/sail_sv_backend.0.19/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Systemverilog translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.19/sail-0.19.tbz"
+  checksum: [
+    "sha256=5458e69ac0a5d9f52738d1946509c501897f5487accb9610b1f20c30305d23e0"
+    "sha512=416e28b9a22784939d38fc23435f6df7a4d01660ba912994fd89adba908f95a325dd21c315ccac3e3b8c9172f0e9ce6ef87264d54ec04306c69f7c2f277452ee"
+  ]
+}
+x-commit-hash: "7ac8131a08d46be253625755d5a985be6920e876"


### PR DESCRIPTION
Sail is a language for describing the instruction semantics of processors

- Project page: <a href="https://github.com/rems-project/sail">https://github.com/rems-project/sail</a>

##### CHANGES:

In addition to numerous bug-fixes and smaller improvements, the
following major changes and improvements have been made to the
language:

##### Model configuration system

Sail now supports writing configurable ISA models. There is a new
language construct:
```
config x.y : T
```
which will interpret a JSON value contained at `x.y` in a provided
configuration file as the Sail type T. Depending on the Sail backend,
the configuration can be provided statically at build time using the
`--config` flag, or at runtime for C generated from Sail.

Sail is able to generate a JSON schema which describes the set of
configuration parameters supported by a model, to enable static
checking of configurations.

See the corresponding section of the Sail manual for details.

##### Abstract types

Abstract types are no longer behind an experimental flag. One can write:
```
// Declare a top-level abstract numeric type
type xlen : Int

// And then write top-level constraints about it
constraint xlen in {32, 64, 128}
```

These abstract types are integrated with the configuration system so
the following is supported.
```
type xlen : Int = config <some key>
```

##### Stricter bitvector type indexing

Stricter indexing for bitvector types. Previous versions of Sail
treated `bitvector('n)` as uninhabited if `'n < 0`, but otherwise
permitted such bitvector types in signatures. Now the type
`bitvector('n)` is only well-formed if `'n >= 0`. This is a breaking
change, as some previously permitted definitions are now rejected
without additional constraints. However Sail has a new kind `Nat`
which allows it to infer these `>= 0` constraints when explicit type
variables are omitted, so in a function signature
```
val foo : forall 'n. bits('n) -> bool
```
the `'n` type variable will be inferred as:
```
val foo : forall ('n : Nat). bits('n) -> bool
```
This is enabled with the `--strict-bitvector` flag. We expect this
behaviour will be the default in future.

##### Removed support for compressed ELF binaries

As a convenience feature, the Sail C runtime allowed transparently
loading compressed ELF files directly by using `gzopen`. However, it
is easy to just manually decompress such files before passing them to
the runtime, so we have decided to remove this feature in favour
of fewer build-time dependencies for the Sail C runtime.

##### Lean backend (HIGHLY EXPERIMENTAL)

This release contains the first version of a new Sail to Lean backend.

It is currently highly experimental, and will likely not compile all
Sail programs.

##### Sail to SystemVerilog improvements

The Sail to SystemVerilog generation has been improved significantly,
to the point where it is possible (with some hackery) get a working
sail-riscv emulator running in Verilator. Note that we still consider
this backend a work in progress, so expect to run into issues for the
time being.

##### Sail to C improvements

Several new flags have been implemented:

* The `--c-no-mangle` flag disables name mangling (except where
  necessary for monomorphisation, or to avoid name-clashes), producing
  much more readable function names.

* The `--c-generate-header` will cause Sail to generate both a `.c`
  file and a corresponding `.h` file, rather than just a `.c` file.
  There is also a `--c-header-include` flag which mirrors the
  `--c-include` flag when this option is used.

Type synonyms are now preserved into C, which makes it possible to
write external bindings that refer to polymorphic types in Sail.

Code generation for the `newtype` construct has been improved.
