### PR TITLE
[new release] alcotest (5 packages) (1.9.0)

### DIFF
--- a/packages/alcotest-async/alcotest-async.1.9.0/opam
+++ b/packages/alcotest-async/alcotest-async.1.9.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Async-based helpers for Alcotest"
+description: "Async-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "re" {with-test}
+  "fmt" {with-test}
+  "cmdliner" {with-test & >= "1.2.0"}
+  "core" {>= "v0.16.0"}
+  "core_unix" {>= "v0.16.0"}
+  "base"
+  "async_kernel"
+  "ocaml" {>= "4.14.0"}
+  "alcotest" {= version}
+  "async" {>= "v0.16.0"}
+  "async_unix" {>= "v0.16.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.9.0/alcotest-1.9.0.tbz"
+  checksum: [
+    "sha256=e2387136ca854df2b4152139dd4d4b3953a646e804948073dedfe0a232f08a15"
+    "sha512=ba38fe4a9061b001d274e5d41fb06c10c84120570fc00dc57dc5a06ba05176c2413295680d839f465ba91469ea99d7e172a324e26f005d6e8c4d98fca7657241"
+  ]
+}
+x-commit-hash: "263a4245071f6dad243a3d72d9dd875b2bd267a0"

--- a/packages/alcotest-js/alcotest-js.1.9.0/opam
+++ b/packages/alcotest-js/alcotest-js.1.9.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Virtual package containing optional JavaScript dependencies for Alcotest"
+description:
+  "Virtual package containing optional JavaScript dependencies for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "alcotest" {= version}
+  "js_of_ocaml-compiler" {>= "3.11.0"}
+  "fmt" {with-test & >= "0.8.7"}
+  "cmdliner" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@runtest-js" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.9.0/alcotest-1.9.0.tbz"
+  checksum: [
+    "sha256=e2387136ca854df2b4152139dd4d4b3953a646e804948073dedfe0a232f08a15"
+    "sha512=ba38fe4a9061b001d274e5d41fb06c10c84120570fc00dc57dc5a06ba05176c2413295680d839f465ba91469ea99d7e172a324e26f005d6e8c4d98fca7657241"
+  ]
+}
+x-commit-hash: "263a4245071f6dad243a3d72d9dd875b2bd267a0"

--- a/packages/alcotest-js/alcotest-js.1.9.0/opam
+++ b/packages/alcotest-js/alcotest-js.1.9.0/opam
@@ -15,6 +15,7 @@ depends: [
   "js_of_ocaml-compiler" {>= "3.11.0"}
   "fmt" {with-test & >= "0.8.7"}
   "cmdliner" {with-test & >= "1.2.0"}
+  "conf-npm" {with-test}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/mirage/alcotest.git"

--- a/packages/alcotest-lwt/alcotest-lwt.1.9.0/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.1.9.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Lwt-based helpers for Alcotest"
+description: "Lwt-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "re" {with-test}
+  "cmdliner" {with-test & >= "1.2.0"}
+  "fmt"
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {= version}
+  "lwt"
+  "logs"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.9.0/alcotest-1.9.0.tbz"
+  checksum: [
+    "sha256=e2387136ca854df2b4152139dd4d4b3953a646e804948073dedfe0a232f08a15"
+    "sha512=ba38fe4a9061b001d274e5d41fb06c10c84120570fc00dc57dc5a06ba05176c2413295680d839f465ba91469ea99d7e172a324e26f005d6e8c4d98fca7657241"
+  ]
+}
+x-commit-hash: "263a4245071f6dad243a3d72d9dd875b2bd267a0"

--- a/packages/alcotest-mirage/alcotest-mirage.1.9.0/opam
+++ b/packages/alcotest-mirage/alcotest-mirage.1.9.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Mirage implementation for Alcotest"
+description: "Mirage implementation for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "re" {with-test}
+  "cmdliner" {with-test & >= "1.2.0"}
+  "fmt"
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {= version}
+  "mirage-clock" {>= "2.0.0"}
+  "duration"
+  "lwt"
+  "logs"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.9.0/alcotest-1.9.0.tbz"
+  checksum: [
+    "sha256=e2387136ca854df2b4152139dd4d4b3953a646e804948073dedfe0a232f08a15"
+    "sha512=ba38fe4a9061b001d274e5d41fb06c10c84120570fc00dc57dc5a06ba05176c2413295680d839f465ba91469ea99d7e172a324e26f005d6e8c4d98fca7657241"
+  ]
+}
+x-commit-hash: "263a4245071f6dad243a3d72d9dd875b2bd267a0"

--- a/packages/alcotest/alcotest.1.9.0/opam
+++ b/packages/alcotest/alcotest.1.9.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "Alcotest is a lightweight and colourful test framework"
+description: """
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "cmdliner" {>= "1.2.0"}
+  "re" {>= "1.7.2"}
+  "stdlib-shims"
+  "uutf" {>= "1.0.1"}
+  "ocaml-syntax-shims"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "js_of_ocaml-compiler" {< "5.8"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.9.0/alcotest-1.9.0.tbz"
+  checksum: [
+    "sha256=e2387136ca854df2b4152139dd4d4b3953a646e804948073dedfe0a232f08a15"
+    "sha512=ba38fe4a9061b001d274e5d41fb06c10c84120570fc00dc57dc5a06ba05176c2413295680d839f465ba91469ea99d7e172a324e26f005d6e8c4d98fca7657241"
+  ]
+}
+x-commit-hash: "263a4245071f6dad243a3d72d9dd875b2bd267a0"


### PR DESCRIPTION
Alcotest is a lightweight and colourful test framework

- Project page: <a href="https://github.com/mirage/alcotest">https://github.com/mirage/alcotest</a>
- Documentation: <a href="https://mirage.github.io/alcotest">https://mirage.github.io/alcotest</a>

##### CHANGES:

- Add `seq`, a testable for `Seq.t` and `contramap` (mirage/alcotest#412 @xvw)
- Expose the `V1.Skip` exception (mirage/alcotest#415, mirage/alcotest#416, @Khady)
- BREAKING FIX: `match_raises` now expects the user-defined function to return
  true for expected exceptions. Previously false was interpreted as an
  expected exception. (mirage/alcotest#418, mirage/alcotest#419, @psafont)
