### PR TITLE
ocamlfind 1.9.5 is not compatible with ocaml 5 (while 1.9.8 is fine)

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.9.5/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.5/opam
@@ -13,7 +13,7 @@ authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 homepage: "http://projects.camlcity.org/projects/findlib.html"
 bug-reports: "https://github.com/ocaml/ocamlfind/issues"
 depends: [
-  "ocaml" {>= "4.02.0" & < "5~" }
+  "ocaml" {>= "4.02.0" & < "5.0"}
 ]
 depopts: ["graphics"]
 build: [

--- a/packages/ocamlfind/ocamlfind.1.9.5/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.5/opam
@@ -13,7 +13,7 @@ authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 homepage: "http://projects.camlcity.org/projects/findlib.html"
 bug-reports: "https://github.com/ocaml/ocamlfind/issues"
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5~" }
 ]
 depopts: ["graphics"]
 build: [


### PR DESCRIPTION
As found out while downgrading from 1.9.8 to 1.9.5 in Rocq 9.0 builds (PR #27613)

https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/ab2f39d6673b097a056f3e1bd489d6f4714b1cbe/variant/compilers,5.0,coq-stdlib.9.0.0,lower-bounds