### PR TITLE
[new release] slipshow (0.1.1)

### DIFF
--- a/packages/slipshow/slipshow.0.1.1/opam
+++ b/packages/slipshow/slipshow.0.1.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.6"}
   "crunch" {with-dev-setup}
-  "cmdliner"
+  "cmdliner" {>= "1.3.0"}
   "base64"
   "bos"
   "lwt"
@@ -39,7 +39,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & os = "linux"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/slipshow/slipshow.0.1.1/opam
+++ b/packages/slipshow/slipshow.0.1.1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "A compiler from markdown to slipshow"
+description:
+  "Slipshow is an engine to write slips, a concept evolved from slides."
+maintainer: ["Paul-Elliot"]
+authors: ["Paul-Elliot"]
+license: "GPL-3.0-or-later"
+tags: ["slipshow" "presentation" "slideshow" "beamer"]
+homepage: "https://github.com/panglesd/slipshow"
+doc: "https://slipshow.readthedocs.io"
+bug-reports: "https://github.com/panglesd/slipshow/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.6"}
+  "crunch" {with-dev-setup}
+  "cmdliner"
+  "base64"
+  "bos"
+  "lwt"
+  "irmin-watcher"
+  "js_of_ocaml-compiler"
+  "js_of_ocaml-lwt"
+  "magic-mime"
+  "dream" {>= "1.0.0~alpha5"}
+  "fpath"
+  "ppx_blob" {>= "0.8.0"}
+  "sexplib"
+  "ppx_sexp_conv"
+  "odoc" {with-doc}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/panglesd/slipshow.git"
+url {
+  src:
+    "https://github.com/panglesd/slipshow/releases/download/v0.1.1/slipshow-0.1.1.tbz"
+  checksum: [
+    "sha256=252cfc464cba5b86565d8fe1090f77807c89cbb551034538faa2a122a1d9ffcf"
+    "sha512=b5feeeaaffb1263e9f126513f87a3925a5e6f9cc77148a40da54e22d06aa19b53b21703b6998dc2743a71bd839346e620bf2543c08149a1caecfb1aaca576d9f"
+  ]
+}
+x-commit-hash: "8127fab3c4a2563792f1eb109ad04d15796dc29f"


### PR DESCRIPTION
## 0.1.1

Quick release mostly to allow publishing on opam!

- Vendor modified Brr, instead of pinning.
- Build released binaries in release mode, without QEMU.
- Fix `-dirty` suffix on `slipshow --version`.

## 0.1.0

(Only available through `0.1.1`, see #27584)

> [!NOTE]
> TLDR:
> - Engine rewritten in OCaml
>   - Fewer bugs when navigating back
>   - Stronger foundation (eg, for subslips)
>   - Custom scripts requires minor adjustments
>   - Breaking change in subslip HTML
> - Drawing now in SVG
>   - No more zoom issues
>   - Erasing works "per-stroke"
> - Revamped table of content
>   - Now based on title structure rather than subslips
> - New `--markdown-output` flag for converting to GFM
> - Parser bugfixes
> - License change: Now GPLv3 (previously MIT)
> - npm distribution discontinued.
> - Special thanks to NLNet for their [sponsorship](https://nlnet.nl/project/Slipshow/)!

See the full announcement on the [release page](https://github.com/panglesd/slipshow/releases/tag/v0.1.0)!