### PR TITLE
ocaml-solo5 (2 packages) (1.1.0)

### DIFF
--- a/packages/ocaml-solo5-cross-aarch64/ocaml-solo5-cross-aarch64.1.1.0/opam
+++ b/packages/ocaml-solo5-cross-aarch64/ocaml-solo5-cross-aarch64.1.1.0/opam
@@ -54,7 +54,7 @@ description:
   "This package provides a OCaml cross-compiler for ARM64, suitable for linking with a Solo5 unikernel."
 url {
   src:
-    "https://github.com/mirage/ocaml-solo5/archive/refs/tags/v1.0.1.tar.gz"
+    "https://github.com/mirage/ocaml-solo5/archive/refs/tags/v1.1.0.tar.gz"
   checksum: [
     "md5=00e5f51d0ce72f7517f3b2a7f910c572"
     "sha512=91f349384a8864076c3d1b0ce3f4e94aa54900cf51e2471d21427bb25cbffac606bcd754fa545f4b2c4516ea2b0731cb580ab30bdf1911c9e47ee24d7c88c863"

--- a/packages/ocaml-solo5-cross-aarch64/ocaml-solo5-cross-aarch64.1.1.0/opam
+++ b/packages/ocaml-solo5-cross-aarch64/ocaml-solo5-cross-aarch64.1.1.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-solo5"
+bug-reports: "https://github.com/mirage/ocaml-solo5/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
+build: [
+  ["./configure.sh"
+   "--prefix=%{prefix}%"
+   "--sysroot=%{_:lib}%"
+   "--target=aarch64-solo5-none-static"
+   "--ocaml-configure-option=--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+   "--ocaml-configure-option=--enable-flambda" {ocaml-option-flambda:installed}
+  ]
+  [make "-j%{jobs}%"]
+  [make "%{name}%.install"]
+]
+install: [
+  [make "install-ocaml"]
+]
+depopts: [
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+]
+run-test: [
+  [make "test"]
+]
+depends: [
+  "conf-git" {build} # to patch the compiler sources
+  "conf-pkg-config" {build} # to detect how to link with zstd
+  "ocamlfind" {build} # needed by dune context (for tests)
+  "ocaml-src" {build}
+  "ocaml" {= "5.3.0"}
+  "solo5" {>= "0.9.1"}
+  "solo5-cross-aarch64" {>= "0.9.1" }
+]
+conflicts: [
+  "ocaml-solo5"
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available: [
+  ((os = "linux" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "freebsd" & arch = "x86_64")
+  | (os = "openbsd" & arch = "x86_64"))
+]
+x-maintenance-intent: [ "(latest)" ]
+synopsis: "OCaml cross-compiler to the freestanding 64-bit ARM Solo5 backend"
+description:
+  "This package provides a OCaml cross-compiler for ARM64, suitable for linking with a Solo5 unikernel."
+url {
+  src:
+    "https://github.com/mirage/ocaml-solo5/archive/refs/tags/v1.0.1.tar.gz"
+  checksum: [
+    "md5=00e5f51d0ce72f7517f3b2a7f910c572"
+    "sha512=91f349384a8864076c3d1b0ce3f4e94aa54900cf51e2471d21427bb25cbffac606bcd754fa545f4b2c4516ea2b0731cb580ab30bdf1911c9e47ee24d7c88c863"
+  ]
+}

--- a/packages/ocaml-solo5/ocaml-solo5.1.1.0/opam
+++ b/packages/ocaml-solo5/ocaml-solo5.1.1.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-solo5"
+bug-reports: "https://github.com/mirage/ocaml-solo5/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
+build: [
+  ["./configure.sh"
+   "--prefix=%{prefix}%"
+   "--target=x86_64-solo5-none-static" { arch = "x86_64" }
+   "--target=aarch64-solo5-none-static" { arch = "arm64" }
+   "--ocaml-configure-option=--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+   "--ocaml-configure-option=--enable-flambda" {ocaml-option-flambda:installed}
+  ]
+  [make "-j%{jobs}%"]
+  [make "%{name}%.install"]
+]
+install: [
+  [make "install-ocaml"]
+]
+depopts: [
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+]
+run-test: [
+  [make "test"]
+]
+depends: [
+  "conf-git" {build} # to patch the compiler sources
+  "conf-pkg-config" {build} # to detect how to link with zstd
+  "ocamlfind" {build} # needed by dune context (for tests)
+  "ocaml-src" {build}
+  "ocaml" {= "5.3.0"}
+  "solo5" {>= "0.9.1"}
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available: [
+  ((os = "linux" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "freebsd" & arch = "x86_64")
+  | (os = "openbsd" & arch = "x86_64"))
+]
+x-maintenance-intent: [ "(latest)" ]
+synopsis: "OCaml cross-compiler to the freestanding Solo5 backend"
+description:
+  "This package provides a OCaml cross-compiler, suitable for linking with a Solo5 unikernel."
+url {
+  src:
+    "https://github.com/mirage/ocaml-solo5/archive/refs/tags/v1.1.0.tar.gz"
+  checksum: [
+    "md5=00e5f51d0ce72f7517f3b2a7f910c572"
+    "sha512=91f349384a8864076c3d1b0ce3f4e94aa54900cf51e2471d21427bb25cbffac606bcd754fa545f4b2c4516ea2b0731cb580ab30bdf1911c9e47ee24d7c88c863"
+  ]
+}


### PR DESCRIPTION
This PR updates the available version of ocaml-solo5 for Ocaml 5.3.