### PR TITLE
[new release] melange-atdgen-codec-runtime (3.0.1)

### DIFF
--- a/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.3.0.1/opam
+++ b/packages/melange-atdgen-codec-runtime/melange-atdgen-codec-runtime.3.0.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "A Melange runtime for atdgen"
+description: """A Melange runtime for atdgen, based on the Js.Json.t type
+provided by Melange and the combinators from melange-json
+"""
+maintainer: "Ahrefs"
+authors: "Ahrefs"
+license: "MIT"
+homepage: "https://github.com/ahrefs/melange-atdgen-codec-runtime"
+bug-reports: "https://github.com/ahrefs/melange-atdgen-codec-runtime/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml"
+  "melange" {>= "3.0.0"}
+  "atd"
+  "atdgen" {>= "2.16.0"}
+  "melange-json" {>= "2.0.0"}
+  "melange-jest" {with-test}
+  "reason" {with-test}
+  "opam-check-npm-deps" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/melange-atdgen-codec-runtime.git"
+url {
+  src:
+    "https://github.com/ahrefs/melange-atdgen-codec-runtime/releases/download/3.0.1/melange-atdgen-codec-runtime-3.0.1.tbz"
+  checksum: [
+    "sha256=cadf9c13ddcffe11dd0c6712925d49bbef61c9bc4d5b4bfce4d0628628ecaabc"
+    "sha512=88e16fc3271cc2605b0023912685814fc5050dd2cdd67436329c89b60001ef2153d6eab7496a96a2e4fc187b66cde9c790a47afb5d0daacd16fa75780db2b73f"
+  ]
+}
+x-commit-hash: "efc87b7a6da268b0a8912b17430c1d17a276eba4"


### PR DESCRIPTION
A Melange runtime for atdgen

- Project page: <a href="https://github.com/ahrefs/melange-atdgen-codec-runtime">https://github.com/ahrefs/melange-atdgen-codec-runtime</a>

##### CHANGES:

- Update to latest `melange-json` with unified runtime, [ahrefs/melange-atdgen-codec-runtime#53](https://github.com/ahrefs/melange-atdgen-codec-runtime/pull/53)
- Add `2.16.0` as lower bound version of `atdgen`, [ahrefs/melange-atdgen-codec-runtime#54](https://github.com/ahrefs/melange-atdgen-codec-runtime/pull/54)
