### PR TITLE
More constraints for failing packages for #27602

### DIFF
--- a/packages/acgtk/acgtk.1.5.0/opam
+++ b/packages/acgtk/acgtk.1.5.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "1.1"}
   "menhir"
   "ANSITerminal"
-  "fmt"
+  "fmt" {< "0.10.0"}
   "logs"
   "mtime" {>= "1.0.0" & < "2.0.0"}
   "cairo2"

--- a/packages/acgtk/acgtk.2.0.0/opam
+++ b/packages/acgtk/acgtk.2.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "menhir" { >= "20211230"}
   "ocamlgraph"
   "ANSITerminal" { >= "0.8" }
-  "fmt"
+  "fmt" {< "0.10.0"}
   "logs"
   "mtime" { >= "2.0.0"}
   "cmdliner" { >= "1.1.0"}

--- a/packages/current/current.0.2/opam
+++ b/packages/current/current.0.2/opam
@@ -31,6 +31,7 @@ depends: [
   "cmdliner"
   "sqlite3"
   "duration"
+  "logs" {< "0.8.0"}
   "prometheus"
   "dune" {>= "1.9"}
   "re" {>= "1.9.0"}

--- a/packages/current/current.0.3/opam
+++ b/packages/current/current.0.3/opam
@@ -32,6 +32,7 @@ depends: [
   "sqlite3"
   "duration"
   "prometheus"
+  "logs" {< "0.8.0"}
   "dune" {>= "2.0"}
   "re" {>= "1.9.0"}
   "lwt-dllist"

--- a/packages/ocluster/ocluster.0.1/opam
+++ b/packages/ocluster/ocluster.0.1/opam
@@ -25,7 +25,7 @@ depends: [
   "capnp-rpc-net" {< "2.0"}
   "capnp-rpc-unix" {>= "0.9.0" & < "2.0"}
   "logs"
-  "fmt"
+  "fmt" {< "0.10.0"}
   "conf-libev" {os != "win32"}
   "digestif" {>= "0.8"}
   "fpath"


### PR DESCRIPTION
This adds a few more constraints due to recent `logs` and `fmt` releases for errors spotted in the last #27602 CI run.