### PR TITLE
[new release] ppx_viewpattern (0.1.1)

### DIFF
--- a/packages/ppx_viewpattern/ppx_viewpattern.0.1.1/opam
+++ b/packages/ppx_viewpattern/ppx_viewpattern.0.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "View patterns in OCaml"
+description:
+  "Transformation for view patterns in OCaml. Attempts to imitate Haskell view patterns."
+maintainer: ["Simmo Saan <simmo.saan@gmail.com>"]
+authors: ["Simmo Saan <simmo.saan@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/sim642/ppx_viewpattern"
+bug-reports: "https://github.com/sim642/ppx_viewpattern/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppxlib" {>= "0.36.0"}
+  "ounit2" {with-test}
+  "qcheck-ounit" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sim642/ppx_viewpattern.git"
+url {
+  src:
+    "https://github.com/sim642/ppx_viewpattern/releases/download/0.1.1/ppx_viewpattern-0.1.1.tbz"
+  checksum: [
+    "sha256=7edc8a6c112fd430efa62d77c3eb8c1e1320fa5fff9e86e67cced0918b5371bf"
+    "sha512=3f41006389d724198a94bdf1282d38509a6d0a7bef9c28d501f96904f35cd6f8835c2e3b1b2269dd573a18b5fc3489731d2250717daa304e9640170e0af858ca"
+  ]
+}
+x-commit-hash: "d889e0061ae2ca60b04254c09b1de68ae0732972"


### PR DESCRIPTION
View patterns in OCaml

- Project page: <a href="https://github.com/sim642/ppx_viewpattern">https://github.com/sim642/ppx_viewpattern</a>

##### CHANGES:

* Migrate to OCaml 5.2 AST for ppxlib 0.36.0 (sim642/ppx_viewpattern#2).
