### PR TITLE
Cmdliner 2.0.0 incompatibilities

### DIFF
--- a/packages/bentov/bentov.1/opam
+++ b/packages/bentov/bentov.1/opam
@@ -10,7 +10,7 @@ doc: "https://barko.github.io/bentov/"
 bug-reports: "https://github.com/barko/bentov/issues"
 depends: [
   "dune" {>= "2.5"}
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "2.0.0"}
   "ocaml" {>= "4.08.0"}
 ]
 build: [

--- a/packages/bisect_ppx/bisect_ppx.2.0.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.0.0/opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune"
   "ocaml" {>= "4.02.0"}
   "ocaml" {with-test & < "4.12"}

--- a/packages/bisect_ppx/bisect_ppx.2.1.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.1.0/opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune"
   "ocaml" {>= "4.02.0"}
   "ocaml" {with-test & < "4.12"}

--- a/packages/bisect_ppx/bisect_ppx.2.2.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.2.0/opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune"
   "ocaml" {>= "4.02.0"}
   "ocaml" {with-test & < "4.12"}

--- a/packages/bisect_ppx/bisect_ppx.2.3.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.3.0/opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune"
   "ocaml" {>= "4.02.0"}
   "ocaml" {with-test & < "4.12"}

--- a/packages/bisect_ppx/bisect_ppx.2.4.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.4.0/opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune"
   "ocaml" {>= "4.02.0"}
   "ocaml" {with-test & < "4.12"}

--- a/packages/bisect_ppx/bisect_ppx.2.4.1/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.4.1/opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune"
   "ocaml" {>= "4.02.0"}
   "ocaml" {with-test & < "4.12"}

--- a/packages/bisect_ppx/bisect_ppx.2.5.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.5.0/opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.02.0"}
   "ocaml" {with-test & < "4.12"}

--- a/packages/bisect_ppx/bisect_ppx.2.6.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.6.0/opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.02.0" & < "5.0"}
   "ppxlib" {>= "0.21.0" & < "0.26.0"}

--- a/packages/bisect_ppx/bisect_ppx.2.7.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.7.0/opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.02.0" & < "5.0"}
   "ppxlib" {>= "0.21.0" & < "0.26.0"}

--- a/packages/bisect_ppx/bisect_ppx.2.7.1/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.7.1/opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.02.0" & < "5.0"}
   "ppxlib" {>= "0.21.0" & < "0.26.0"}

--- a/packages/bisect_ppx/bisect_ppx.2.8.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.8.0/opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.02.0" & < "5.0"}
   "ppxlib" {>= "0.21.0" & < "0.26.0"}

--- a/packages/bisect_ppx/bisect_ppx.2.8.1/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.8.1/opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.03.0"}
   "ppxlib" {>= "0.21.0" & < "0.26.0"}

--- a/packages/bisect_ppx/bisect_ppx.2.8.2/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.8.2/opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.03.0"}
   "ppxlib" {>= "0.26.0" & < "0.28.0"}

--- a/packages/bisect_ppx/bisect_ppx.2.8.3/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.8.3/opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.03.0"}
   "ppxlib" {>= "0.28.0" & < "0.36.0"}

--- a/packages/boltzgen/boltzgen.0.9.2/opam
+++ b/packages/boltzgen/boltzgen.0.9.2/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
   "ocaml-compiler-libs"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "base-unix"
   "odoc" {with-doc}
 ]

--- a/packages/boltzgen/boltzgen.0.9.3/opam
+++ b/packages/boltzgen/boltzgen.0.9.3/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
   "ocaml-compiler-libs"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "base-unix"
   "odoc" {with-doc}
 ]

--- a/packages/boltzgen/boltzgen.0.9/opam
+++ b/packages/boltzgen/boltzgen.0.9/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.6"}
   "ocaml" {>= "4.08.1"}
   "ocaml-compiler-libs"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cosovo/cosovo.3/opam
+++ b/packages/cosovo/cosovo.3/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/barko/cosovo/issues"
 depends: [
   "dune" {>= "2.5"}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "2.0.0"}
   "menhir" {>= "20200211"}
   "ocaml" {>= "4.08.0"}
 ]

--- a/packages/dkml-install-runner/dkml-install-runner.0.1.0/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_expect" {>= "v0.14.1"}
   "astring" {>= "0.8.5"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "2.0.0"}
   "fmt" {>= "0.8.9"}
   "logs" {>= "0.7.0"}
   "diskuvbox" {>= "0.1.0"}

--- a/packages/dkml-install-runner/dkml-install-runner.0.2.0/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ppx_expect" {>= "v0.14.1"}
   "astring" {>= "0.8.5"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "2.0.0"}
   "fmt" {>= "0.8.9"}
   "logs" {>= "0.7.0"}
   "diskuvbox" {>= "0.1.0"}

--- a/packages/dkml-install-runner/dkml-install-runner.0.3.0/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ppx_expect" {>= "v0.14.1"}
   "astring" {>= "0.8.5"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "2.0.0"}
   "fmt" {>= "0.8.9"}
   "logs" {>= "0.7.0"}
   "diskuvbox" {>= "0.1.0"}

--- a/packages/dkml-install-runner/dkml-install-runner.0.3.1/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.3.1/opam
@@ -21,7 +21,7 @@ depends: [
   "ppx_expect" {>= "v0.14.1"}
   "astring" {>= "0.8.5"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "2.0.0"}
   "fmt" {>= "0.8.9"}
   "logs" {>= "0.7.0"}
   "diskuvbox" {>= "0.1.1"}

--- a/packages/dkml-install-runner/dkml-install-runner.0.4.0/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.4.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_expect" {>= "v0.14.1"}
   "astring" {>= "0.8.5"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "fmt" {>= "0.8.9"}
   "logs" {>= "0.7.0"}
   "diskuvbox" {>= "0.1.1"}

--- a/packages/dkml-install-runner/dkml-install-runner.0.5.1/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.5.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_expect" {>= "v0.14.1"}
   "astring" {>= "0.8.5"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "fmt" {>= "0.8.9"}
   "logs" {>= "0.7.0"}
   "diskuvbox" {>= "0.1.1"}

--- a/packages/dkml-install-runner/dkml-install-runner.0.5.2/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.5.2/opam
@@ -14,7 +14,7 @@ depends: [
   "ppx_expect" {>= "v0.14.1"}
   "astring" {>= "0.8.5"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "fmt" {>= "0.8.9"}
   "logs" {>= "0.7.0"}
   "diskuvbox" {>= "0.1.1"}

--- a/packages/dkml-install-runner/dkml-install-runner.0.5.3/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.5.3/opam
@@ -14,7 +14,7 @@ depends: [
   "dkml-install" {= version}
   "astring" {>= "0.8.5"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "fmt" {>= "0.8.9"}
   "logs" {>= "0.7.0"}
   "diskuvbox" {>= "0.1.1"}

--- a/packages/dns-cli/dns-cli.10.0.0/opam
+++ b/packages/dns-cli/dns-cli.10.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "1.0.0"}
   "mirage-crypto" {>= "1.0.0"}

--- a/packages/dns-cli/dns-cli.4.0.0/opam
+++ b/packages/dns-cli/dns-cli.4.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-certify" {= version}
   "rresult" {>= "0.6.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.7.1" & < "0.8.0"}
   "nocrypto" {>= "0.5.4"}

--- a/packages/dns-cli/dns-cli.4.1.0/opam
+++ b/packages/dns-cli/dns-cli.4.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-certify" {= version}
   "rresult" {>= "0.6.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.8.0" & < "0.10.0"}
   "nocrypto" {>= "0.5.4"}

--- a/packages/dns-cli/dns-cli.4.2.0/opam
+++ b/packages/dns-cli/dns-cli.4.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-certify" {= version}
   "rresult" {>= "0.6.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.8.0" & < "0.10.0"}
   "nocrypto" {>= "0.5.4"}

--- a/packages/dns-cli/dns-cli.4.3.0/opam
+++ b/packages/dns-cli/dns-cli.4.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-certify" {= version}
   "rresult" {>= "0.6.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.8.0" & < "0.10.0"}
   "nocrypto" {>= "0.5.4"}

--- a/packages/dns-cli/dns-cli.4.3.1/opam
+++ b/packages/dns-cli/dns-cli.4.3.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-certify" {= version}
   "rresult" {>= "0.6.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.8.0" & < "0.10.0"}
   "nocrypto" {>= "0.5.4"}

--- a/packages/dns-cli/dns-cli.4.4.0/opam
+++ b/packages/dns-cli/dns-cli.4.4.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-certify" {= version}
   "rresult" {>= "0.6.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.10.0"}
   "mirage-crypto" {< "1.0.0"}

--- a/packages/dns-cli/dns-cli.4.4.1/opam
+++ b/packages/dns-cli/dns-cli.4.4.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-certify" {= version}
   "rresult" {>= "0.6.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.10.0"}
   "mirage-crypto" {< "1.0.0"}

--- a/packages/dns-cli/dns-cli.4.5.0/opam
+++ b/packages/dns-cli/dns-cli.4.5.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-certify" {= version}
   "rresult" {>= "0.6.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.10.0"}
   "mirage-crypto" {< "1.0.0"}

--- a/packages/dns-cli/dns-cli.4.6.1/opam
+++ b/packages/dns-cli/dns-cli.4.6.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-certify" {= version}
   "rresult" {>= "0.6.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.10.0"}
   "mirage-crypto" {< "1.0.0"}

--- a/packages/dns-cli/dns-cli.4.6.2/opam
+++ b/packages/dns-cli/dns-cli.4.6.2/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-certify" {= version}
   "rresult" {>= "0.6.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.10.0"}
   "mirage-crypto" {< "1.0.0"}

--- a/packages/dns-cli/dns-cli.4.6.3/opam
+++ b/packages/dns-cli/dns-cli.4.6.3/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-certify" {= version}
   "rresult" {>= "0.6.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.10.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.5.0.0/opam
+++ b/packages/dns-cli/dns-cli.5.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-certify" {= version}
   "rresult" {>= "0.6.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.10.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.5.0.1/opam
+++ b/packages/dns-cli/dns-cli.5.0.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-certify" {= version}
   "rresult" {>= "0.6.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.6.0.0/opam
+++ b/packages/dns-cli/dns-cli.6.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-certify" {= version}
   "rresult" {>= "0.6.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.6.0.1/opam
+++ b/packages/dns-cli/dns-cli.6.0.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.6.0.2/opam
+++ b/packages/dns-cli/dns-cli.6.0.2/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.6.1.0/opam
+++ b/packages/dns-cli/dns-cli.6.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.6.1.1/opam
+++ b/packages/dns-cli/dns-cli.6.1.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.6.1.2/opam
+++ b/packages/dns-cli/dns-cli.6.1.2/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.6.1.3/opam
+++ b/packages/dns-cli/dns-cli.6.1.3/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.6.1.4/opam
+++ b/packages/dns-cli/dns-cli.6.1.4/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.6.2.0/opam
+++ b/packages/dns-cli/dns-cli.6.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.6.2.1/opam
+++ b/packages/dns-cli/dns-cli.6.2.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.6.2.2/opam
+++ b/packages/dns-cli/dns-cli.6.2.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.6.3.0/opam
+++ b/packages/dns-cli/dns-cli.6.3.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.6.4.0/opam
+++ b/packages/dns-cli/dns-cli.6.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.6.4.1/opam
+++ b/packages/dns-cli/dns-cli.6.4.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.7.0.0/opam
+++ b/packages/dns-cli/dns-cli.7.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.7.0.1/opam
+++ b/packages/dns-cli/dns-cli.7.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.7.0.2/opam
+++ b/packages/dns-cli/dns-cli.7.0.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.7.0.3/opam
+++ b/packages/dns-cli/dns-cli.7.0.3/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.8.0.0/opam
+++ b/packages/dns-cli/dns-cli.8.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.13.0"}
   "mirage-crypto" {>= "0.8.0" & < "1.0.0"}

--- a/packages/dns-cli/dns-cli.9.0.0/opam
+++ b/packages/dns-cli/dns-cli.9.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "1.0.0"}
   "mirage-crypto" {>= "1.0.0"}

--- a/packages/dns-cli/dns-cli.9.1.0/opam
+++ b/packages/dns-cli/dns-cli.9.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dns-server" {= version}
   "dns-certify" {= version}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fpath" {>= "0.7.2"}
   "x509" {>= "1.0.0"}
   "mirage-crypto" {>= "1.0.0"}

--- a/packages/dolmen_bin/dolmen_bin.0.10/opam
+++ b/packages/dolmen_bin/dolmen_bin.0.10/opam
@@ -14,7 +14,7 @@ depends: [
   "dolmen_model" {= version }
   "dune" { >= "3.0" }
   "fmt"
-  "cmdliner" { >= "1.1.0" }
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "odoc" { with-doc }
 ]
 depopts: [

--- a/packages/dolmen_bin/dolmen_bin.0.5/opam
+++ b/packages/dolmen_bin/dolmen_bin.0.5/opam
@@ -13,7 +13,7 @@ depends: [
   "dolmen_loop" {= version }
   "dune" { >= "2.7" }
   "fmt"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "odoc" { with-doc }
 ]
 tags: [ "logic" "computation" "automated theorem prover" "logic" "smtlib" "tptp"]

--- a/packages/dolmen_bin/dolmen_bin.0.6/opam
+++ b/packages/dolmen_bin/dolmen_bin.0.6/opam
@@ -13,7 +13,7 @@ depends: [
   "dolmen_loop" {= version }
   "dune" { >= "2.7" }
   "fmt"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "odoc" { with-doc }
 ]
 tags: [ "logic" "computation" "automated theorem prover" "logic" "smtlib" "tptp"]

--- a/packages/dolmen_bin/dolmen_bin.0.7/opam
+++ b/packages/dolmen_bin/dolmen_bin.0.7/opam
@@ -13,7 +13,7 @@ depends: [
   "dolmen_loop" {= version }
   "dune" { >= "2.7" }
   "fmt"
-  "cmdliner" { >= "1.1.0" }
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "odoc" { with-doc }
 ]
 depopts: [

--- a/packages/dolmen_bin/dolmen_bin.0.8.1/opam
+++ b/packages/dolmen_bin/dolmen_bin.0.8.1/opam
@@ -14,7 +14,7 @@ depends: [
   "dolmen_model" {= version }
   "dune" { >= "3.0" }
   "fmt"
-  "cmdliner" { >= "1.1.0" }
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "odoc" { with-doc }
 ]
 depopts: [

--- a/packages/dolmen_bin/dolmen_bin.0.8/opam
+++ b/packages/dolmen_bin/dolmen_bin.0.8/opam
@@ -14,7 +14,7 @@ depends: [
   "dolmen_model" {= version }
   "dune" { >= "3.0" }
   "fmt"
-  "cmdliner" { >= "1.1.0" }
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "odoc" { with-doc }
 ]
 depopts: [

--- a/packages/dolmen_bin/dolmen_bin.0.9/opam
+++ b/packages/dolmen_bin/dolmen_bin.0.9/opam
@@ -14,7 +14,7 @@ depends: [
   "dolmen_model" {= version }
   "dune" { >= "3.0" }
   "fmt"
-  "cmdliner" { >= "1.1.0" }
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "odoc" { with-doc }
 ]
 depopts: [

--- a/packages/dune-release/dune-release.1.6.1/opam
+++ b/packages/dune-release/dune-release.1.6.1/opam
@@ -23,7 +23,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "fpath" {>= "0.7.3"}
   "bos"
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "astring"
   "opam-file-format" {>= "2.1.2"}

--- a/packages/dune-release/dune-release.1.6.2/opam
+++ b/packages/dune-release/dune-release.1.6.2/opam
@@ -23,7 +23,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "fpath" {>= "0.7.3"}
   "bos"
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "astring"
   "opam-file-format" {>= "2.1.2"}

--- a/packages/dune-release/dune-release.2.0.0/opam
+++ b/packages/dune-release/dune-release.2.0.0/opam
@@ -24,7 +24,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "fpath" {>= "0.7.3"}
   "bos" {>= "0.1.3"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "astring"
   "opam-file-format" {>= "2.1.2"}

--- a/packages/dune-release/dune-release.2.1.0/opam
+++ b/packages/dune-release/dune-release.2.1.0/opam
@@ -24,7 +24,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "fpath" {>= "0.7.3"}
   "bos" {>= "0.1.3"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "astring"
   "opam-file-format" {>= "2.1.2"}

--- a/packages/fsevents-lwt/fsevents-lwt.0.3.0/opam
+++ b/packages/fsevents-lwt/fsevents-lwt.0.3.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.8"}
   "fsevents" {= version}
   "cf-lwt"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "alcotest" {with-test}
   "lwt" {>= "5.0.0"}
   "odoc" {with-doc}

--- a/packages/functoria/functoria.3.1.2/opam
+++ b/packages/functoria/functoria.3.1.2/opam
@@ -21,7 +21,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.1.0"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "rresult"
   "astring"
   "fmt" {>= "0.8.7"}

--- a/packages/functoria/functoria.4.0.0/opam
+++ b/packages/functoria/functoria.4.0.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.9.0" | (with-test & >= "3.0.0")}
   "base-unix"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}

--- a/packages/functoria/functoria.4.1.0/opam
+++ b/packages/functoria/functoria.4.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.9.0" | (with-test & >= "3.0.0")}
   "base-unix"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}

--- a/packages/functoria/functoria.4.1.1/opam
+++ b/packages/functoria/functoria.4.1.1/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.9.0" | (with-test & >= "3.0.0")}
   "base-unix"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}

--- a/packages/functoria/functoria.4.2.0/opam
+++ b/packages/functoria/functoria.4.2.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.9.0" | (with-test & >= "3.0.0")}
   "base-unix"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}

--- a/packages/functoria/functoria.4.2.1/opam
+++ b/packages/functoria/functoria.4.2.1/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "2.9.0"}
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}

--- a/packages/functoria/functoria.4.3.0/opam
+++ b/packages/functoria/functoria.4.3.0/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "2.9.0"}
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}

--- a/packages/functoria/functoria.4.3.1/opam
+++ b/packages/functoria/functoria.4.3.1/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "2.9.0"}
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}

--- a/packages/functoria/functoria.4.3.2/opam
+++ b/packages/functoria/functoria.4.3.2/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "2.9.0"}
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}

--- a/packages/functoria/functoria.4.3.3/opam
+++ b/packages/functoria/functoria.4.3.3/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "2.9.0"}
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}

--- a/packages/functoria/functoria.4.3.4/opam
+++ b/packages/functoria/functoria.4.3.4/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "2.9.0"}
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}

--- a/packages/functoria/functoria.4.3.5/opam
+++ b/packages/functoria/functoria.4.3.5/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "2.9.0"}
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}

--- a/packages/functoria/functoria.4.3.6/opam
+++ b/packages/functoria/functoria.4.3.6/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "2.9.0"}
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}

--- a/packages/functoria/functoria.4.4.0/opam
+++ b/packages/functoria/functoria.4.4.0/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "2.9.0"}
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "cmdliner" {with-test & >= "1.2.0" & < "1.3.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}

--- a/packages/functoria/functoria.4.4.1/opam
+++ b/packages/functoria/functoria.4.4.1/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "2.9.0"}
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "cmdliner" {with-test & >= "1.2.0" & < "1.3.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}

--- a/packages/functoria/functoria.4.4.2/opam
+++ b/packages/functoria/functoria.4.4.2/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "2.9.0"}
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
   "cmdliner" {with-test & >= "1.2.0" & < "1.3.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}

--- a/packages/github-unix/github-unix.3.1.0/opam
+++ b/packages/github-unix/github-unix.3.1.0/opam
@@ -33,7 +33,7 @@ depends: [
   "cohttp-lwt-unix"
   "stringext"
   "lambda-term" {< "2.0"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "base-unix"
 ]
 synopsis: "GitHub APIv3 OCaml Library"

--- a/packages/github-unix/github-unix.4.0.0/opam
+++ b/packages/github-unix/github-unix.4.0.0/opam
@@ -27,7 +27,7 @@ depends: [
   "cohttp-lwt-unix"
   "stringext"
   "lambda-term" {< "2.0"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "base-unix"
 ]
 build: [

--- a/packages/github-unix/github-unix.4.1.0/opam
+++ b/packages/github-unix/github-unix.4.1.0/opam
@@ -27,7 +27,7 @@ depends: [
   "cohttp-lwt-unix"
   "stringext"
   "lambda-term" {>="2.0"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "base-unix"
 ]
 build: [

--- a/packages/github-unix/github-unix.4.2.0/opam
+++ b/packages/github-unix/github-unix.4.2.0/opam
@@ -34,7 +34,7 @@ depends: [
   "cohttp-lwt-unix" {>= "0.99.0"}
   "stringext"
   "lambda-term" {>= "2.0"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "base-unix"
 ]
 url {

--- a/packages/github-unix/github-unix.4.3.0/opam
+++ b/packages/github-unix/github-unix.4.3.0/opam
@@ -34,7 +34,7 @@ depends: [
   "cohttp-lwt-unix" {>= "0.99.0"}
   "stringext"
   "lambda-term" {>= "2.0"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "base-unix"
 ]
 url {

--- a/packages/github-unix/github-unix.4.3.1/opam
+++ b/packages/github-unix/github-unix.4.3.1/opam
@@ -34,7 +34,7 @@ depends: [
   "cohttp-lwt-unix" {>= "0.99.0"}
   "stringext"
   "lambda-term" {>= "2.0"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "base-unix"
 ]
 url {

--- a/packages/github-unix/github-unix.4.3.2/opam
+++ b/packages/github-unix/github-unix.4.3.2/opam
@@ -33,7 +33,7 @@ depends: [
   "cohttp" {>= "0.99.0"}
   "cohttp-lwt-unix" {>= "0.99.0"}
   "stringext"
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "base-unix"
 ]
 url {

--- a/packages/github-unix/github-unix.4.4.0/opam
+++ b/packages/github-unix/github-unix.4.4.0/opam
@@ -27,7 +27,7 @@ depends: [
   "cohttp" {>= "4.0.0"}
   "cohttp-lwt-unix" {>= "4.0.0"}
   "stringext"
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "base-unix"
   "lwt"
   "odoc" {with-doc}

--- a/packages/github-unix/github-unix.4.4.1/opam
+++ b/packages/github-unix/github-unix.4.4.1/opam
@@ -27,7 +27,7 @@ depends: [
   "cohttp" {>= "4.0.0"}
   "cohttp-lwt-unix" {>= "4.0.0"}
   "stringext"
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "base-unix"
   "lwt"
   "odoc" {with-doc}

--- a/packages/gospel/gospel.0.1.0/opam
+++ b/packages/gospel/gospel.0.1.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml" {>= "4.09"}
   "dune" {>= "2.4.0"}
   "menhir" {>= "20181006"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "fmt" {>= "0.8.7"}
   "ocaml-compiler-libs" {>= "v0.12.0"}
   "ppxlib" {>= "0.23.0" & < "0.26.0"}

--- a/packages/gospel/gospel.0.2.0/opam
+++ b/packages/gospel/gospel.0.2.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlfind"
   "dune" {>= "3.0.0"}
   "menhir" {>= "20181006"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fmt" {>= "0.8.7"}
   "ocaml-compiler-libs" {>= "v0.12.0"}
   "ppxlib" {>= "0.26.0" & < "0.36.0"}

--- a/packages/gospel/gospel.0.3.0/opam
+++ b/packages/gospel/gospel.0.3.0/opam
@@ -38,7 +38,7 @@ depends: [
   "dune" {>= "3.0.0"}
   "dune-build-info"
   "menhir" {>= "20181006"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "fmt" {>= "0.8.7"}
   "ocaml-compiler-libs" {>= "v0.12.0"}
   "ppxlib" {>= "0.26.0" & < "0.36.0"}

--- a/packages/hll/hll.2.7/opam
+++ b/packages/hll/hll.2.7/opam
@@ -14,7 +14,7 @@ remove: [
 
 depends: [
   "ocaml"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "containers"
   "ocamlfind"
   "pds" {build & (>= "5" & < "6")}

--- a/packages/hll/hll.3.16/opam
+++ b/packages/hll/hll.3.16/opam
@@ -8,7 +8,7 @@ install: [
   [make "PREFIX=%{prefix}%" "install"]
 ]
 depends: [
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "containers"
   "ocamlfind"
   "pds" { build & (>= "5" & < "6") }

--- a/packages/hll/hll.4.3/opam
+++ b/packages/hll/hll.4.3/opam
@@ -14,7 +14,7 @@ remove: [
 ]
 
 depends: [
-	"cmdliner" { >= "1.3.0" }
+	"cmdliner" {>= "1.3.0" & < "2.0.0"}
 	"containers" { >= "3.12.0" }
 	"ocaml" { >= "4.12.0" }
 	"ocamlfind"

--- a/packages/http-lwt-client/http-lwt-client.0.0.1/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.1/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "logs"
   "lwt"
   "rresult"

--- a/packages/http-lwt-client/http-lwt-client.0.0.2/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.2/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "logs"
   "lwt"
   "rresult"

--- a/packages/http-lwt-client/http-lwt-client.0.0.3/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.3/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "logs"
   "lwt"
   "rresult"

--- a/packages/http-lwt-client/http-lwt-client.0.0.4/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.4/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "logs"
   "lwt"
   "rresult"

--- a/packages/http-lwt-client/http-lwt-client.0.0.5/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.5/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "logs"
   "lwt"
   "base64" {>= "3.1.0"}

--- a/packages/http-lwt-client/http-lwt-client.0.0.6/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.6/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "logs"
   "lwt"
   "base64" {>= "3.1.0"}

--- a/packages/http-lwt-client/http-lwt-client.0.0.7/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.7/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "logs"
   "lwt"
   "base64" {>= "3.1.0"}

--- a/packages/http-lwt-client/http-lwt-client.0.0.8/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.8/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "logs"
   "lwt"
   "base64" {>= "3.1.0"}

--- a/packages/http-lwt-client/http-lwt-client.0.1.0/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.1.0/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "logs"
   "lwt"
   "base64" {>= "3.1.0"}

--- a/packages/http-lwt-client/http-lwt-client.0.2.0/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.2.0/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "logs"
   "lwt"
   "base64" {>= "3.1.0"}

--- a/packages/http-lwt-client/http-lwt-client.0.2.1/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.2.1/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "logs"
   "lwt"
   "base64" {>= "3.1.0"}

--- a/packages/http-lwt-client/http-lwt-client.0.2.2/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.2.2/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "logs"
   "lwt"
   "base64" {>= "3.1.0"}

--- a/packages/http-lwt-client/http-lwt-client.0.2.3/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.2.3/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "logs"
   "lwt"
   "base64" {>= "3.1.0"}

--- a/packages/http-lwt-client/http-lwt-client.0.2.4/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.2.4/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "logs"
   "lwt"
   "base64" {>= "3.1.0"}

--- a/packages/http-lwt-client/http-lwt-client.0.2.5/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.2.5/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "logs"
   "lwt"
   "base64" {>= "3.1.0"}

--- a/packages/http-lwt-client/http-lwt-client.0.2.6/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.2.6/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "logs"
   "lwt"
   "base64" {>= "3.1.0"}

--- a/packages/http-lwt-client/http-lwt-client.0.3.0/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.3.0/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "logs"
   "lwt"
   "base64" {>= "3.1.0"}

--- a/packages/http-lwt-client/http-lwt-client.0.3.1/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.3.1/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "logs"
   "lwt"
   "base64" {>= "3.1.0"}

--- a/packages/index/index.1.3.0/opam
+++ b/packages/index/index.1.3.0/opam
@@ -26,7 +26,7 @@ depends: [
   "fmt" {>= "0.8.5"}
   "logs" {>= "0.7.0"}
   "mtime"   {>= "1.1.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.1.0"}
   "progress" {>= "0.1.1" & < "0.2.0"}
   "semaphore-compat" {>= "1.0.1"}

--- a/packages/index/index.1.3.1/opam
+++ b/packages/index/index.1.3.1/opam
@@ -26,7 +26,7 @@ depends: [
   "fmt" {>= "0.8.5"}
   "logs" {>= "0.7.0"}
   "mtime"   {>= "1.1.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.1.0"}
   "progress" {>= "0.1.1" & < "0.2.0"}
   "semaphore-compat" {>= "1.0.1"}

--- a/packages/index/index.1.3.2/opam
+++ b/packages/index/index.1.3.2/opam
@@ -26,7 +26,7 @@ depends: [
   "fmt"
   "logs" {>= "0.7.0"}
   "mtime"   {>= "1.1.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.1.0"}
   "progress" {>= "0.1.1" & < "0.2.0"}
   "semaphore-compat"  {>= "1.0.1"}

--- a/packages/index/index.1.3.3/opam
+++ b/packages/index/index.1.3.3/opam
@@ -26,7 +26,7 @@ depends: [
   "fmt"
   "logs"    {>= "0.7.0"}
   "mtime"   {>= "1.1.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.1.0"}
   "progress" {>= "0.1.1" & < "0.2.0"}
   "semaphore-compat"  {>= "1.0.1"}

--- a/packages/index/index.1.4.0/opam
+++ b/packages/index/index.1.4.0/opam
@@ -27,7 +27,7 @@ depends: [
   "fmt"     {>= "0.8.5"}
   "logs"    {>= "0.7.0"}
   "mtime"   {>= "1.1.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.1.0"}
   "progress" {>= "0.1.1" & < "0.2.0"}
   "semaphore-compat" {>= "1.0.1"}

--- a/packages/index/index.1.4.1/opam
+++ b/packages/index/index.1.4.1/opam
@@ -27,7 +27,7 @@ depends: [
   "fmt"     {>= "0.8.5"}
   "logs"    {>= "0.7.0"}
   "mtime" {>= "1.1.0" & < "2.0.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.1.0"}
   "progress" {>= "0.2.1"}
   "semaphore-compat" {>= "1.0.1"}

--- a/packages/index/index.1.4.2/opam
+++ b/packages/index/index.1.4.2/opam
@@ -27,7 +27,7 @@ depends: [
   "fmt"     {>= "0.8.5"}
   "logs"    {>= "0.7.0"}
   "mtime" {>= "1.1.0" & < "2.0.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.1.0"}
   "progress" {>= "0.2.1"}
   "semaphore-compat" {>= "1.0.1"}

--- a/packages/index/index.1.5.0/opam
+++ b/packages/index/index.1.5.0/opam
@@ -27,7 +27,7 @@ depends: [
   "fmt"     {>= "0.8.5"}
   "logs"    {>= "0.7.0"}
   "mtime" {>= "1.1.0" & < "2.0.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.1.0"}
   "progress" {>= "0.2.1"}
   "semaphore-compat" {>= "1.0.1"}

--- a/packages/index/index.1.6.0/opam
+++ b/packages/index/index.1.6.0/opam
@@ -27,7 +27,7 @@ depends: [
   "fmt"     {>= "0.8.5"}
   "logs"    {>= "0.7.0"}
   "mtime" {>= "1.1.0" & < "2.0.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.1.0"}
   "progress" {>= "0.2.1"}
   "semaphore-compat" {>= "1.0.1"}

--- a/packages/index/index.1.6.1/opam
+++ b/packages/index/index.1.6.1/opam
@@ -27,7 +27,7 @@ depends: [
   "fmt"     {>= "0.8.5"}
   "logs"    {>= "0.7.0"}
   "mtime" {>= "1.1.0" & < "2.0.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "progress" {>= "0.2.1"}
   "semaphore-compat" {>= "1.0.1"}
   "jsonm"

--- a/packages/index/index.1.6.2/opam
+++ b/packages/index/index.1.6.2/opam
@@ -27,7 +27,7 @@ depends: [
   "fmt"     {>= "0.8.5"}
   "logs"    {>= "0.7.0"}
   "mtime"   {>= "2.0.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "progress" {>= "0.2.1"}
   "semaphore-compat" {>= "1.0.1"}
   "jsonm"

--- a/packages/irmin-test/irmin-test.2.10.0/opam
+++ b/packages/irmin-test/irmin-test.2.10.0/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.10.1/opam
+++ b/packages/irmin-test/irmin-test.2.10.1/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.10.2/opam
+++ b/packages/irmin-test/irmin-test.2.10.2/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.3.0/opam
+++ b/packages/irmin-test/irmin-test.2.3.0/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.4.0/opam
+++ b/packages/irmin-test/irmin-test.2.4.0/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.5.0/opam
+++ b/packages/irmin-test/irmin-test.2.5.0/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.5.1/opam
+++ b/packages/irmin-test/irmin-test.2.5.1/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.5.2/opam
+++ b/packages/irmin-test/irmin-test.2.5.2/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.5.3/opam
+++ b/packages/irmin-test/irmin-test.2.5.3/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.5.4/opam
+++ b/packages/irmin-test/irmin-test.2.5.4/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.6.0/opam
+++ b/packages/irmin-test/irmin-test.2.6.0/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.6.1/opam
+++ b/packages/irmin-test/irmin-test.2.6.1/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.7.0/opam
+++ b/packages/irmin-test/irmin-test.2.7.0/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.7.1/opam
+++ b/packages/irmin-test/irmin-test.2.7.1/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.7.2/opam
+++ b/packages/irmin-test/irmin-test.2.7.2/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.8.0/opam
+++ b/packages/irmin-test/irmin-test.2.8.0/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.9.0/opam
+++ b/packages/irmin-test/irmin-test.2.9.0/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.2.9.1/opam
+++ b/packages/irmin-test/irmin-test.2.9.1/opam
@@ -27,7 +27,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
 ]
 

--- a/packages/irmin-test/irmin-test.3.10.0/opam
+++ b/packages/irmin-test/irmin-test.3.10.0/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.2.1/opam
+++ b/packages/irmin-test/irmin-test.3.2.1/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.2.2/opam
+++ b/packages/irmin-test/irmin-test.3.2.2/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.3.0/opam
+++ b/packages/irmin-test/irmin-test.3.3.0/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.3.1/opam
+++ b/packages/irmin-test/irmin-test.3.3.1/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.3.2/opam
+++ b/packages/irmin-test/irmin-test.3.3.2/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.4.0/opam
+++ b/packages/irmin-test/irmin-test.3.4.0/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.4.1/opam
+++ b/packages/irmin-test/irmin-test.3.4.1/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.4.2/opam
+++ b/packages/irmin-test/irmin-test.3.4.2/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.4.3/opam
+++ b/packages/irmin-test/irmin-test.3.4.3/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.5.0/opam
+++ b/packages/irmin-test/irmin-test.3.5.0/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.5.1/opam
+++ b/packages/irmin-test/irmin-test.3.5.1/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.5.2/opam
+++ b/packages/irmin-test/irmin-test.3.5.2/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.6.0/opam
+++ b/packages/irmin-test/irmin-test.3.6.0/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.6.1/opam
+++ b/packages/irmin-test/irmin-test.3.6.1/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.7.0/opam
+++ b/packages/irmin-test/irmin-test.3.7.0/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.7.1/opam
+++ b/packages/irmin-test/irmin-test.3.7.1/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.7.2/opam
+++ b/packages/irmin-test/irmin-test.3.7.2/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.8.0/opam
+++ b/packages/irmin-test/irmin-test.3.8.0/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/irmin-test/irmin-test.3.9.0/opam
+++ b/packages/irmin-test/irmin-test.3.9.0/opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/packages/lilac/lilac.0.1.1/opam
+++ b/packages/lilac/lilac.0.1.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/shnewto/lilac/issues"
 tags: [ "library" "lib" "lilac" "yaml" ]
 license: "MIT"
 depends: [
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "2.0.0"}
   "stdio" {>= "v0.9.0"}
   "base" {>= "v0.9.0"}
   "yaml" {>= "2.1.0"}

--- a/packages/mdx/mdx.1.10.0/opam
+++ b/packages/mdx/mdx.1.10.0/opam
@@ -28,7 +28,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-version" {>= "2.3.0"}

--- a/packages/mdx/mdx.1.10.1/opam
+++ b/packages/mdx/mdx.1.10.1/opam
@@ -28,7 +28,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-version" {>= "2.3.0"}

--- a/packages/mdx/mdx.1.11.0/opam
+++ b/packages/mdx/mdx.1.11.0/opam
@@ -28,7 +28,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-version" {>= "2.3.0"}

--- a/packages/mdx/mdx.1.11.1/opam
+++ b/packages/mdx/mdx.1.11.1/opam
@@ -28,7 +28,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-version" {>= "2.3.0"}

--- a/packages/mdx/mdx.1.4.0/opam
+++ b/packages/mdx/mdx.1.4.0/opam
@@ -20,7 +20,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "astring"
   "logs"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocamlfind" {>= "1.7.2"}

--- a/packages/mdx/mdx.1.5.0/opam
+++ b/packages/mdx/mdx.1.5.0/opam
@@ -21,7 +21,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "astring"
   "logs"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-migrate-parsetree" {>= "1.0.6" & < "2.0.0"}

--- a/packages/mdx/mdx.1.6.0/opam
+++ b/packages/mdx/mdx.1.6.0/opam
@@ -21,7 +21,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "astring"
   "logs"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-migrate-parsetree" {>= "1.0.6" & < "2.0.0"}

--- a/packages/mdx/mdx.1.7.0/opam
+++ b/packages/mdx/mdx.1.7.0/opam
@@ -22,7 +22,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "astring"
   "logs"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-migrate-parsetree" {>= "1.0.6" & < "2.0.0"}

--- a/packages/mdx/mdx.1.8.0/opam
+++ b/packages/mdx/mdx.1.8.0/opam
@@ -27,7 +27,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "astring"
   "logs" {>= "0.5.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-migrate-parsetree" {>= "1.4.0" & < "2.0.0"}

--- a/packages/mdx/mdx.1.8.1/opam
+++ b/packages/mdx/mdx.1.8.1/opam
@@ -28,7 +28,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.5.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-version" {>= "2.3.0"}

--- a/packages/mdx/mdx.1.9.0/opam
+++ b/packages/mdx/mdx.1.9.0/opam
@@ -28,7 +28,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-version" {>= "2.3.0"}

--- a/packages/mdx/mdx.2.0.0/opam
+++ b/packages/mdx/mdx.2.0.0/opam
@@ -25,7 +25,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-version" {>= "2.3.0"}

--- a/packages/mdx/mdx.2.1.0/opam
+++ b/packages/mdx/mdx.2.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-version" {>= "2.3.0"}

--- a/packages/mdx/mdx.2.2.0/opam
+++ b/packages/mdx/mdx.2.2.0/opam
@@ -25,7 +25,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "ocaml-version" {>= "2.3.0"}
   "odoc-parser" {>= "1.0.0" & < "2.3.0"}

--- a/packages/mdx/mdx.2.2.1/opam
+++ b/packages/mdx/mdx.2.2.1/opam
@@ -25,7 +25,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "ocaml-version" {>= "2.3.0"}
   "odoc-parser" {>= "1.0.0" & < "2.3.0"}

--- a/packages/mdx/mdx.2.3.0/opam
+++ b/packages/mdx/mdx.2.3.0/opam
@@ -25,7 +25,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "ocaml-version" {>= "2.3.0"}
   "odoc-parser" {>= "1.0.0" & < "2.3.0"}

--- a/packages/mdx/mdx.2.3.1/opam
+++ b/packages/mdx/mdx.2.3.1/opam
@@ -25,7 +25,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "ocaml-version" {>= "2.3.0"}
   "lwt" {with-test}

--- a/packages/mdx/mdx.2.4.0/opam
+++ b/packages/mdx/mdx.2.4.0/opam
@@ -25,7 +25,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "ocaml-version" {>= "2.3.0"}
   "lwt" {with-test}

--- a/packages/mdx/mdx.2.4.1/opam
+++ b/packages/mdx/mdx.2.4.1/opam
@@ -25,7 +25,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "ocaml-version" {>= "2.3.0"}
   "lwt" {with-test}

--- a/packages/mdx/mdx.2.5.0/opam
+++ b/packages/mdx/mdx.2.5.0/opam
@@ -25,7 +25,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "ocaml-version" {>= "2.3.0"}
   "lwt" {with-test}

--- a/packages/minicaml/minicaml.0.2.2/opam
+++ b/packages/minicaml/minicaml.0.2.2/opam
@@ -17,7 +17,7 @@ depends: [
     "ANSITerminal"
     "menhir"
     "ppx_deriving"
-    "cmdliner"
+    "cmdliner" {< "2.0.0"}
 ]
 url {
   src:

--- a/packages/minicaml/minicaml.0.3.1/opam
+++ b/packages/minicaml/minicaml.0.3.1/opam
@@ -18,7 +18,7 @@ depends: [
     "ANSITerminal"
     "menhir"
     "ppx_deriving"
-    "cmdliner"
+    "cmdliner" {< "2.0.0"}
     "alcotest" {with-test & >= "0.8.5"}
     "bisect_ppx" {with-test & >= "1.5.0"}
 ]

--- a/packages/minicaml/minicaml.0.3.3/opam
+++ b/packages/minicaml/minicaml.0.3.3/opam
@@ -19,7 +19,7 @@ depends: [
     "ANSITerminal"
     "menhir" {>= "20180528"}
     "ppx_deriving"
-    "cmdliner" {>= "0.9.8"}
+    "cmdliner" {>= "0.9.8" & < "2.0.0"}
     "cmdliner" {with-test & < "1.1.0"}
     "alcotest" {with-test & >= "0.8.5" & < "1.0.0"}
     "bisect_ppx" {>= "1.4.1" & < "2.0.0"}

--- a/packages/minicaml/minicaml.0.4/opam
+++ b/packages/minicaml/minicaml.0.4/opam
@@ -20,7 +20,7 @@ depends: [
     "ocamline" {>= "1.0" & < "1.2"}
     "menhir" {>= "20180528"}
     "ppx_deriving"
-    "cmdliner" {>= "0.9.8"}
+    "cmdliner" {>= "0.9.8" & < "2.0.0"}
     "cmdliner" {with-test & < "1.1.0"}
     "alcotest" {with-test & >= "0.8.5"}
     "bisect_ppx" {>= "1.4.1" & < "2.0.0"}

--- a/packages/mirage/mirage.4.0.0/opam
+++ b/packages/mirage/mirage.4.0.0/opam
@@ -29,7 +29,7 @@ depends: [
   "opam-monorepo" {>= "0.2.6" & < "0.3.0"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"

--- a/packages/mirage/mirage.4.1.0/opam
+++ b/packages/mirage/mirage.4.1.0/opam
@@ -30,7 +30,7 @@ depends: [
   "opam-monorepo" {= "0.3.0" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"

--- a/packages/mirage/mirage.4.1.1/opam
+++ b/packages/mirage/mirage.4.1.1/opam
@@ -30,7 +30,7 @@ depends: [
   "opam-monorepo" {= "0.3.0" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"

--- a/packages/mirage/mirage.4.2.0/opam
+++ b/packages/mirage/mirage.4.2.0/opam
@@ -30,7 +30,7 @@ depends: [
   "opam-monorepo" {< "0.3.5" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"

--- a/packages/mirage/mirage.4.2.1/opam
+++ b/packages/mirage/mirage.4.2.1/opam
@@ -31,7 +31,7 @@ depends: [
   "opam-monorepo" {< "0.3.5" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"

--- a/packages/mirage/mirage.4.3.0/opam
+++ b/packages/mirage/mirage.4.3.0/opam
@@ -31,7 +31,7 @@ depends: [
   "opam-monorepo" {< "0.3.5" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"

--- a/packages/mirage/mirage.4.3.1/opam
+++ b/packages/mirage/mirage.4.3.1/opam
@@ -31,7 +31,7 @@ depends: [
   "opam-monorepo" {< "0.3.5" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"

--- a/packages/mirage/mirage.4.3.2/opam
+++ b/packages/mirage/mirage.4.3.2/opam
@@ -31,7 +31,7 @@ depends: [
   "opam-monorepo" {< "0.3.5" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"

--- a/packages/mirage/mirage.4.3.3/opam
+++ b/packages/mirage/mirage.4.3.3/opam
@@ -30,7 +30,7 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"

--- a/packages/mirage/mirage.4.3.4/opam
+++ b/packages/mirage/mirage.4.3.4/opam
@@ -30,7 +30,7 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"

--- a/packages/mirage/mirage.4.3.5/opam
+++ b/packages/mirage/mirage.4.3.5/opam
@@ -30,7 +30,7 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"

--- a/packages/mirage/mirage.4.3.6/opam
+++ b/packages/mirage/mirage.4.3.6/opam
@@ -30,7 +30,7 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"

--- a/packages/mirage/mirage.4.4.0/opam
+++ b/packages/mirage/mirage.4.4.0/opam
@@ -30,7 +30,7 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "cmdliner" {< "1.3.0" & with-test}
+  "cmdliner" {with-test & < "1.3.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.4.1/opam
+++ b/packages/mirage/mirage.4.4.1/opam
@@ -30,7 +30,7 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "cmdliner" {< "1.3.0" & with-test}
+  "cmdliner" {with-test & < "1.3.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.4.2/opam
+++ b/packages/mirage/mirage.4.4.2/opam
@@ -30,7 +30,7 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "cmdliner" {< "1.3.0" & with-test}
+  "cmdliner" {with-test & < "1.3.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.5.0/opam
+++ b/packages/mirage/mirage.4.5.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "emile" {>= "1.1"}
   "fmt" {>= "0.8.7"}
   "ipaddr" {>= "5.0.0"}
@@ -34,7 +34,7 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "mirage-runtime" {with-test & = version}
-  "cmdliner" {< "1.3.0" & with-test}
+  "cmdliner" {with-test & < "1.3.0"}
 ]
 
 conflicts: [ "jbuilder" {with-test} ]

--- a/packages/mirage/mirage.4.5.1/opam
+++ b/packages/mirage/mirage.4.5.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "emile" {>= "1.1"}
   "fmt" {>= "0.8.7"}
   "ipaddr" {>= "5.0.0"}
@@ -34,7 +34,7 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "mirage-runtime" {with-test & = version}
-  "cmdliner" {< "1.3.0" & with-test}
+  "cmdliner" {with-test & < "1.3.0"}
 ]
 
 conflicts: [ "jbuilder" {with-test} ]

--- a/packages/mirage/mirage.4.6.0/opam
+++ b/packages/mirage/mirage.4.6.0/opam
@@ -22,8 +22,8 @@ depends: [
   "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
-  "cmdliner" {>= "1.2.0"}
-  "cmdliner" {with-test & >= "1.3.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
+  "cmdliner" {with-test & >= "1.3.0" & < "2.0.0"}
   "emile" {>= "1.1"}
   "fmt" {>= "0.8.7"}
   "ipaddr" {>= "5.0.0"}

--- a/packages/mirage/mirage.4.6.1/opam
+++ b/packages/mirage/mirage.4.6.1/opam
@@ -22,8 +22,8 @@ depends: [
   "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
-  "cmdliner" {>= "1.2.0"}
-  "cmdliner" {with-test & >= "1.3.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
+  "cmdliner" {with-test & >= "1.3.0" & < "2.0.0"}
   "emile" {>= "1.1"}
   "fmt" {>= "0.8.7"}
   "ipaddr" {>= "5.0.0"}

--- a/packages/mirage/mirage.4.7.0/opam
+++ b/packages/mirage/mirage.4.7.0/opam
@@ -22,8 +22,8 @@ depends: [
   "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
-  "cmdliner" {>= "1.2.0"}
-  "cmdliner" {with-test & >= "1.3.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
+  "cmdliner" {with-test & >= "1.3.0" & < "2.0.0"}
   "emile" {>= "1.1"}
   "fmt" {>= "0.8.7"}
   "ipaddr" {>= "5.0.0"}

--- a/packages/mirage/mirage.4.8.0/opam
+++ b/packages/mirage/mirage.4.8.0/opam
@@ -22,8 +22,8 @@ depends: [
   "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
-  "cmdliner" {>= "1.2.0"}
-  "cmdliner" {with-test & >= "1.3.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
+  "cmdliner" {with-test & >= "1.3.0" & < "2.0.0"}
   "emile" {>= "1.1"}
   "fmt" {>= "0.8.7"}
   "ipaddr" {>= "5.0.0"}

--- a/packages/mirage/mirage.4.8.1/opam
+++ b/packages/mirage/mirage.4.8.1/opam
@@ -22,8 +22,8 @@ depends: [
   "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
-  "cmdliner" {>= "1.2.0"}
-  "cmdliner" {with-test & >= "1.3.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
+  "cmdliner" {with-test & >= "1.3.0" & < "2.0.0"}
   "emile" {>= "1.1"}
   "fmt" {>= "0.8.7"}
   "ipaddr" {>= "5.0.0"}

--- a/packages/mirage/mirage.4.8.2/opam
+++ b/packages/mirage/mirage.4.8.2/opam
@@ -22,8 +22,8 @@ depends: [
   "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
-  "cmdliner" {>= "1.2.0"}
-  "cmdliner" {with-test & >= "1.3.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
+  "cmdliner" {with-test & >= "1.3.0" & < "2.0.0"}
   "emile" {>= "1.1"}
   "fmt" {>= "0.8.7"}
   "ipaddr" {>= "5.0.0"}

--- a/packages/mirage/mirage.4.9.0/opam
+++ b/packages/mirage/mirage.4.9.0/opam
@@ -22,8 +22,8 @@ depends: [
   "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
-  "cmdliner" {>= "1.2.0"}
-  "cmdliner" {with-test & >= "1.3.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
+  "cmdliner" {with-test & >= "1.3.0" & < "2.0.0"}
   "emile" {>= "1.1"}
   "fmt" {>= "0.8.7"}
   "ipaddr" {>= "5.0.0"}

--- a/packages/mkaudio/mkaudio.1.0.0/opam
+++ b/packages/mkaudio/mkaudio.1.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "oasis" {build}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "mm" {< "0.6.0"}
   "result"
   "ounit" {with-test}

--- a/packages/mkaudio/mkaudio.1.0.1/opam
+++ b/packages/mkaudio/mkaudio.1.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "oasis" {build}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "mm" {< "0.6.0"}
   "result"
   "ounit" {with-test}

--- a/packages/mkaudio/mkaudio.1.1.0/opam
+++ b/packages/mkaudio/mkaudio.1.1.0/opam
@@ -10,7 +10,7 @@ build: [
 depends: [
   "ocaml"
   "dune" {>= "1.1"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "mm" {< "0.6.0"}
   "result"
   "ounit" {with-test}

--- a/packages/mkaudio/mkaudio.1.1.1/opam
+++ b/packages/mkaudio/mkaudio.1.1.1/opam
@@ -10,7 +10,7 @@ build: [
 depends: [
   "ocaml"
   "dune" {>= "2.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "mm" {>= "0.6.0" & < "0.7.0"}
   "result"
   "ounit" {with-test}

--- a/packages/mkaudio/mkaudio.1.1.2/opam
+++ b/packages/mkaudio/mkaudio.1.1.2/opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "mm" {>= "0.7.0" & < "0.8.0"}
   "result"
   "ounit" {with-test}

--- a/packages/mkaudio/mkaudio.1.1.3/opam
+++ b/packages/mkaudio/mkaudio.1.1.3/opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "mm" {>= "0.8.0"}
   "result"
   "ounit" {with-test}

--- a/packages/nbd-tool/nbd-tool.6.0.0/opam
+++ b/packages/nbd-tool/nbd-tool.6.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "2.7.0"}
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "lwt" {>= "2.7.0"}
   "lwt_log"
   "mirage-block" {< "3.0.0"}

--- a/packages/nbd-tool/nbd-tool.6.0.1/opam
+++ b/packages/nbd-tool/nbd-tool.6.0.1/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "2.7.0"}
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "lwt" {>= "2.7.0"}
   "lwt_log"
   "mirage-block-unix"

--- a/packages/ocal/ocal.0.1.1/opam
+++ b/packages/ocal/ocal.0.1.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {< "5.0.0"}
   "astring" {build}
   "calendar" {build & >= "2.00"}
-  "cmdliner" {build}
+  "cmdliner" {build & < "2.0.0"}
   "ocamlfind" {build}
 ]
 synopsis: "Unix `cal` replacement"

--- a/packages/ocal/ocal.0.1.2/opam
+++ b/packages/ocal/ocal.0.1.2/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {< "5.0.0"}
   "astring" {build}
   "calendar" {build & >= "2.00"}
-  "cmdliner" {build}
+  "cmdliner" {build & < "2.0.0"}
   "ocamlfind" {build}
 ]
 synopsis: "Unix `cal` replacement"

--- a/packages/ocal/ocal.0.1.3/opam
+++ b/packages/ocal/ocal.0.1.3/opam
@@ -19,7 +19,7 @@ depends: [
   "jbuilder" {>= "1.0+beta11"}
   "astring" {build}
   "calendar" {build & >= "2.00"}
-  "cmdliner" {build}
+  "cmdliner" {build & < "2.0.0"}
 ]
 synopsis: "An improved Unix `cal` utility"
 description: """

--- a/packages/ocal/ocal.0.2.1/opam
+++ b/packages/ocal/ocal.0.2.1/opam
@@ -19,7 +19,7 @@ depends: [
   "jbuilder" {>= "1.0+beta11"}
   "astring" {build}
   "calendar" {build & >= "2.00"}
-  "cmdliner" {build}
+  "cmdliner" {build & < "2.0.0"}
   "notty" {build & >= "0.2.0"}
 ]
 synopsis: "An improved Unix `cal` utility"

--- a/packages/ocal/ocal.0.2.2/opam
+++ b/packages/ocal/ocal.0.2.2/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "astring"   {build}
   "calendar"  {build}
-  "cmdliner"  {build}
+  "cmdliner" {build & < "2.0.0"}
   "dune"
   "notty"     {build & >="0.2.0"}
   "ocaml"     {>="4.02.3"}

--- a/packages/ocamlformat-lib/ocamlformat-lib.0.27.0/opam
+++ b/packages/ocamlformat-lib/ocamlformat-lib.0.27.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "alcotest" {with-test & >= "1.3.0"}
   "base" {>= "v0.12.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8"}
   "dune-build-info"
   "either"

--- a/packages/ocp-indent/ocp-indent.1.6.1/opam
+++ b/packages/ocp-indent/ocp-indent.1.6.1/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "ocaml"
   "ocp-build" {build & >= "1.99.6-beta"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "base-bytes"
 ]
 post-messages: [

--- a/packages/ocp-indent/ocp-indent.1.7.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.7.0/opam
@@ -32,7 +32,7 @@ run-test: [
 depends: [
   "ocaml"
   "dune"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "ocamlfind"
   "base-bytes"
 ]

--- a/packages/ocp-indent/ocp-indent.1.8.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.8.0/opam
@@ -32,7 +32,7 @@ run-test: [
 depends: [
   "ocaml"
   "dune" {>= "1.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "ocamlfind"
   "base-bytes"
 ]

--- a/packages/ocp-indent/ocp-indent.1.8.1/opam
+++ b/packages/ocp-indent/ocp-indent.1.8.1/opam
@@ -32,7 +32,7 @@ run-test: [
 depends: [
   "ocaml"
   "dune" {>= "1.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "ocamlfind"
   "base-bytes"
 ]

--- a/packages/ocp-index/ocp-index.1.1.7/opam
+++ b/packages/ocp-index/ocp-index.1.1.7/opam
@@ -26,7 +26,7 @@ depends: [
   "jbuilder" {>= "1.0+beta7"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.7.2"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
 ]
 conflicts: [
   "dune" {>= "1.7.0"}

--- a/packages/ocp-index/ocp-index.1.1.9/opam
+++ b/packages/ocp-index/ocp-index.1.1.9/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.7.2"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
 ]
 post-messages:
   "This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:

--- a/packages/ocp-index/ocp-index.1.2.1/opam
+++ b/packages/ocp-index/ocp-index.1.2.1/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.9.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
 ]
 post-messages:
   "This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:

--- a/packages/ocp-index/ocp-index.1.2.2/opam
+++ b/packages/ocp-index/ocp-index.1.2.2/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.9.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "odoc" {with-test}
 ]
 post-messages:

--- a/packages/ocp-index/ocp-index.1.2/opam
+++ b/packages/ocp-index/ocp-index.1.2/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.9.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
 ]
 post-messages:
   "This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:

--- a/packages/ocp-index/ocp-index.1.3.0/opam
+++ b/packages/ocp-index/ocp-index.1.3.0/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.9.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "odoc" {with-doc}
 ]
 post-messages:

--- a/packages/ocp-index/ocp-index.1.3.1/opam
+++ b/packages/ocp-index/ocp-index.1.3.1/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.9.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "odoc" {with-doc}
 ]
 post-messages:

--- a/packages/ocp-index/ocp-index.1.3.2/opam
+++ b/packages/ocp-index/ocp-index.1.3.2/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.9.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "odoc" {with-doc}
 ]
 post-messages:

--- a/packages/ocp-index/ocp-index.1.3.3/opam
+++ b/packages/ocp-index/ocp-index.1.3.3/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.9.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "odoc" {with-doc}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/ocp-index/ocp-index.1.3.4/opam
+++ b/packages/ocp-index/ocp-index.1.3.4/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "odoc" {with-doc}
 ]
 post-messages:

--- a/packages/ocp-index/ocp-index.1.3.5/opam
+++ b/packages/ocp-index/ocp-index.1.3.5/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "odoc" {with-doc}
 ]
 post-messages:

--- a/packages/ocp-index/ocp-index.1.3.6/opam
+++ b/packages/ocp-index/ocp-index.1.3.6/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "odoc" {with-doc}
 ]
 post-messages:

--- a/packages/ocp-index/ocp-index.1.3.7/opam
+++ b/packages/ocp-index/ocp-index.1.3.7/opam
@@ -27,7 +27,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "odoc" {with-doc}
 ]
 post-messages:

--- a/packages/ocp-reloc/ocp-reloc.0.1/opam
+++ b/packages/ocp-reloc/ocp-reloc.0.1/opam
@@ -23,7 +23,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
-  "cmdliner" {build}
+  "cmdliner" {build & < "2.0.0"}
 ]
 synopsis: "Relocation of OCaml bytecode executables"
 description: """

--- a/packages/odoc/odoc.1.4.0/opam
+++ b/packages/odoc/odoc.1.4.0/opam
@@ -17,7 +17,7 @@ synopsis: "OCaml documentation generator"
 
 depends: [
   "astring" {build}
-  "cmdliner" {build & >= "1.0.0"}
+  "cmdliner" {build & >= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune"
   "fpath" {build}

--- a/packages/odoc/odoc.1.4.1/opam
+++ b/packages/odoc/odoc.1.4.1/opam
@@ -17,7 +17,7 @@ synopsis: "OCaml documentation generator"
 
 depends: [
   "astring" {build}
-  "cmdliner" {build & >= "1.0.0"}
+  "cmdliner" {build & >= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune"
   "fpath" {build}

--- a/packages/odoc/odoc.1.4.2/opam
+++ b/packages/odoc/odoc.1.4.2/opam
@@ -17,7 +17,7 @@ synopsis: "OCaml documentation generator"
 
 depends: [
   "astring" {build}
-  "cmdliner" {build & >= "1.0.0"}
+  "cmdliner" {build & >= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune"
   "fpath" {build}

--- a/packages/odoc/odoc.1.5.0/opam
+++ b/packages/odoc/odoc.1.5.0/opam
@@ -23,7 +23,7 @@ delimited with `(** ... *)`, and outputs HTML.
 
 depends: [
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune"
   "fpath"

--- a/packages/odoc/odoc.1.5.1/opam
+++ b/packages/odoc/odoc.1.5.1/opam
@@ -23,7 +23,7 @@ delimited with `(** ... *)`, and outputs HTML.
 
 depends: [
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune"
   "fpath"

--- a/packages/odoc/odoc.1.5.2/opam
+++ b/packages/odoc/odoc.1.5.2/opam
@@ -23,7 +23,7 @@ delimited with `(** ... *)`, and outputs HTML.
 
 depends: [
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune"
   "fpath"

--- a/packages/odoc/odoc.1.5.3/opam
+++ b/packages/odoc/odoc.1.5.3/opam
@@ -23,7 +23,7 @@ delimited with `(** ... *)`, and outputs HTML.
 
 depends: [
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune"
   "fpath"

--- a/packages/odoc/odoc.2.0.0/opam
+++ b/packages/odoc/odoc.2.0.0/opam
@@ -25,7 +25,7 @@ delimited with `(** ... *)`, and outputs HTML.
 depends: [
   "odoc-parser" {>= "0.9.0" & < "2.0.0"}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "2.9.1"}
   "fpath"

--- a/packages/odoc/odoc.2.0.1/opam
+++ b/packages/odoc/odoc.2.0.1/opam
@@ -25,7 +25,7 @@ delimited with `(** ... *)`, and outputs HTML.
 depends: [
   "odoc-parser" {>= "0.9.0" & < "2.0.0"}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "2.9.1"}
   "fpath"

--- a/packages/odoc/odoc.2.0.2/opam
+++ b/packages/odoc/odoc.2.0.2/opam
@@ -25,7 +25,7 @@ delimited with `(** ... *)`, and outputs HTML.
 depends: [
   "odoc-parser" {>= "0.9.0" & < "2.0.0"}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "2.9.1"}
   "fpath"

--- a/packages/odoc/odoc.2.1.0/opam
+++ b/packages/odoc/odoc.2.1.0/opam
@@ -25,7 +25,7 @@ delimited with `(** ... *)`, and outputs HTML.
 depends: [
   "odoc-parser" {>= "0.9.0" & < "2.0.0"}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "2.9.1"}
   "fpath"

--- a/packages/odoc/odoc.2.1.1/opam
+++ b/packages/odoc/odoc.2.1.1/opam
@@ -25,7 +25,7 @@ delimited with `(** ... *)`, and outputs HTML.
 depends: [
   "odoc-parser" {>= "0.9.0" & < "2.0.0"}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "2.9.1"}
   "fpath"

--- a/packages/odoc/odoc.2.2.0/opam
+++ b/packages/odoc/odoc.2.2.0/opam
@@ -25,7 +25,7 @@ delimited with `(** ... *)`, and outputs HTML.
 depends: [
   "odoc-parser" {>= "2.0.0" & < "2.3.0"}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.0.2"}
   "fpath"

--- a/packages/odoc/odoc.2.2.1/opam
+++ b/packages/odoc/odoc.2.2.1/opam
@@ -25,7 +25,7 @@ delimited with `(** ... *)`, and outputs HTML.
 depends: [
   "odoc-parser" {>= "2.0.0" & < "2.3.0"}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.0.2"}
   "fpath"

--- a/packages/odoc/odoc.2.2.2/opam
+++ b/packages/odoc/odoc.2.2.2/opam
@@ -25,7 +25,7 @@ delimited with `(** ... *)`, and outputs HTML.
 depends: [
   "odoc-parser" {>= "2.0.0" & < "2.3.0"}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.0.2"}
   "fpath"

--- a/packages/odoc/odoc.2.3.0/opam
+++ b/packages/odoc/odoc.2.3.0/opam
@@ -39,7 +39,7 @@ odoc is part of the [OCaml Platform](https://ocaml.org/docs/platform), the recom
 depends: [
   "odoc-parser" {= version}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.7.0"}
   "fpath"

--- a/packages/odoc/odoc.2.3.1/opam
+++ b/packages/odoc/odoc.2.3.1/opam
@@ -39,7 +39,7 @@ odoc is part of the [OCaml Platform](https://ocaml.org/docs/platform), the recom
 depends: [
   "odoc-parser" {= version}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.7.0"}
   "fpath"

--- a/packages/odoc/odoc.2.4.0/opam
+++ b/packages/odoc/odoc.2.4.0/opam
@@ -39,7 +39,7 @@ odoc is part of the [OCaml Platform](https://ocaml.org/docs/platform), the recom
 depends: [
   "odoc-parser" {= version}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.7.0"}
   "fpath"

--- a/packages/odoc/odoc.2.4.1/opam
+++ b/packages/odoc/odoc.2.4.1/opam
@@ -39,7 +39,7 @@ odoc is part of the [OCaml Platform](https://ocaml.org/docs/platform), the recom
 depends: [
   "odoc-parser" {= version}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.7.0"}
   "fpath"

--- a/packages/odoc/odoc.2.4.2/opam
+++ b/packages/odoc/odoc.2.4.2/opam
@@ -39,7 +39,7 @@ odoc is part of the [OCaml Platform](https://ocaml.org/docs/platform), the recom
 depends: [
   "odoc-parser" {= version}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.7.0"}
   "fpath"

--- a/packages/odoc/odoc.2.4.3/opam
+++ b/packages/odoc/odoc.2.4.3/opam
@@ -39,7 +39,7 @@ odoc is part of the [OCaml Platform](https://ocaml.org/docs/platform), the recom
 depends: [
   "odoc-parser" {= version}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.7.0"}
   "fpath"

--- a/packages/odoc/odoc.2.4.4/opam
+++ b/packages/odoc/odoc.2.4.4/opam
@@ -39,7 +39,7 @@ odoc is part of the [OCaml Platform](https://ocaml.org/docs/platform), the recom
 depends: [
   "odoc-parser" {= version}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.7.0"}
   "fpath"

--- a/packages/odoc/odoc.3.0.0~beta1/opam
+++ b/packages/odoc/odoc.3.0.0~beta1/opam
@@ -40,7 +40,7 @@ odoc is part of the [OCaml Platform](https://ocaml.org/docs/platform), the recom
 depends: [
   "odoc-parser" {= version}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.7.0"}
   "fpath"

--- a/packages/ometrics/ometrics.0.1.1/opam
+++ b/packages/ometrics/ometrics.0.1.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dot-merlin-reader" {>= "4.1"}
   "csexp" {>= "1.5.1"}
   "result" {>= "1.5"}
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "2.0.0"}
   "qcheck-alcotest" {with-test & >= "0.18"}
   "bisect_ppx" {dev & >= "2.6.0"}
 ]

--- a/packages/ometrics/ometrics.0.1.2/opam
+++ b/packages/ometrics/ometrics.0.1.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dot-merlin-reader" {>= "4.1"}
   "csexp" {>= "1.5.1"}
   "result" {>= "1.5"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "digestif" {>= "0.7.2"}
   "qcheck-alcotest" {with-test & >= "0.18"}
   "bisect_ppx" {dev & >= "2.6.0"}

--- a/packages/ometrics/ometrics.0.1.3/opam
+++ b/packages/ometrics/ometrics.0.1.3/opam
@@ -15,7 +15,7 @@ depends: [
   "menhir"
   "csexp" {>= "1.5.1"}
   "result" {>= "1.5"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "digestif" {>= "0.7.2"}
   "qcheck-alcotest" {with-test & >= "0.18"}
   "bisect_ppx" {dev & >= "2.6.0"}

--- a/packages/ometrics/ometrics.0.2.0/opam
+++ b/packages/ometrics/ometrics.0.2.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.12.0"}
   "dune" {>= "2.9.1"}
   "ppxlib" {>= "0.26.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "digestif" {>= "0.7.2"}
   "qcheck-alcotest" {with-test & >= "0.18"}
   "bisect_ppx" {dev & >= "2.6.0"}

--- a/packages/ometrics/ometrics.0.2.1/opam
+++ b/packages/ometrics/ometrics.0.2.1/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.12.0"}
   "dune" {>= "2.9.1"}
   "ppxlib" {>= "0.24.0" & < "0.26.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "digestif" {>= "0.7.2"}
   "qcheck-alcotest" {with-test & >= "0.18"}
   "bisect_ppx" {dev & >= "2.6.0"}

--- a/packages/opam-0install/opam-0install.0.4.1/opam
+++ b/packages/opam-0install/opam-0install.0.4.1/opam
@@ -20,7 +20,7 @@ license: "ISC"
 depends: [
   "dune" {>= "2.0"}
   "fmt"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "opam-state" {< "2.1.0~rc"}
   "ocaml" {>= "4.08.0"}
   "0install-solver"

--- a/packages/opam-0install/opam-0install.0.4.2/opam
+++ b/packages/opam-0install/opam-0install.0.4.2/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/ocaml-opam/opam-0install-solver/issues"
 depends: [
   "dune" {>= "2.7"}
   "fmt"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "opam-state" {>= "2.1.0~rc" & (< "2.2.0~beta3" | >= "2.2.0")}
   "ocaml" {>= "4.08.0"}
   "0install-solver"

--- a/packages/opam-0install/opam-0install.0.4.3/opam
+++ b/packages/opam-0install/opam-0install.0.4.3/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/ocaml-opam/opam-0install-solver/issues"
 depends: [
   "dune" {>= "2.7"}
   "fmt" {>= "0.8.7"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "opam-state" {>= "2.1.0~rc" & (< "2.2.0~beta3" | >= "2.2.0")}
   "ocaml" {>= "4.08.0"}
   "0install-solver"

--- a/packages/opam-0install/opam-0install.0.4.4/opam
+++ b/packages/opam-0install/opam-0install.0.4.4/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/ocaml-opam/opam-0install-solver/issues"
 depends: [
   "dune" {>= "2.7"}
   "fmt" {>= "0.8.7"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "opam-state" {>= "2.1.0~rc"}
   "ocaml" {>= "4.10.0"}
   "0install-solver"

--- a/packages/opam-0install/opam-0install.0.5/opam
+++ b/packages/opam-0install/opam-0install.0.5/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/ocaml-opam/opam-0install-solver/issues"
 depends: [
   "dune" {>= "2.7"}
   "fmt" {>= "0.8.7"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "opam-state" {>= "2.2.1"}
   "opam-format" {>= "2.2.1"}
   "ocaml" {>= "4.10.0"}

--- a/packages/opam-client/opam-client.2.0.0/opam
+++ b/packages/opam-client/opam-client.2.0.0/opam
@@ -25,7 +25,7 @@ depends: [
   "opam-state" {= "2.0.0"}
   "opam-solver" {= "2.0.0"}
   "re" {>= "1.7.2"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "jbuilder" {>= "1.0+beta20"}
 ]
 synopsis: "Client library for opam 2.0"

--- a/packages/opam-client/opam-client.2.0.0~rc2/opam
+++ b/packages/opam-client/opam-client.2.0.0~rc2/opam
@@ -25,7 +25,7 @@ depends: [
   "opam-state" {= "2.0.0~rc2"}
   "opam-solver" {= "2.0.0~rc2"}
   "re" {>= "1.7.2"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "jbuilder" {>= "1.0+beta18"}
 ]
 synopsis: "Client library for opam 2.0"

--- a/packages/opam-client/opam-client.2.0.0~rc3/opam
+++ b/packages/opam-client/opam-client.2.0.0~rc3/opam
@@ -25,7 +25,7 @@ depends: [
   "opam-state" {= "2.0.0~rc3"}
   "opam-solver" {= "2.0.0~rc3"}
   "re" {>= "1.7.2"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "jbuilder" {>= "1.0+beta20"}
 ]
 synopsis: "Client library for opam 2.0"

--- a/packages/opam-client/opam-client.2.0.1/opam
+++ b/packages/opam-client/opam-client.2.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "opam-state" {= "2.0.1"}
   "opam-solver" {= "2.0.1"}
   "re" {>= "1.7.2"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "jbuilder" {>= "1.0+beta20"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.0.10/opam
+++ b/packages/opam-client/opam-client.2.0.10/opam
@@ -25,7 +25,7 @@ depends: [
   "extlib" {>= "1.7.3" & < "1.7.8"}
   "opam-repository" {= version}
   "re" {>= "1.7.2"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.0.2/opam
+++ b/packages/opam-client/opam-client.2.0.2/opam
@@ -20,7 +20,7 @@ depends: [
   "opam-state" {= "2.0.2"}
   "opam-solver" {= "2.0.2"}
   "re" {>= "1.7.2"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.0.3/opam
+++ b/packages/opam-client/opam-client.2.0.3/opam
@@ -20,7 +20,7 @@ depends: [
   "opam-state" {= "2.0.3"}
   "opam-solver" {= "2.0.3"}
   "re" {>= "1.7.2"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.0.4/opam
+++ b/packages/opam-client/opam-client.2.0.4/opam
@@ -20,7 +20,7 @@ depends: [
   "opam-state" {= "2.0.4"}
   "opam-solver" {= "2.0.4"}
   "re" {>= "1.7.2"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.0.5/opam
+++ b/packages/opam-client/opam-client.2.0.5/opam
@@ -20,7 +20,7 @@ depends: [
   "opam-state" {= "2.0.5"}
   "opam-solver" {= "2.0.5"}
   "re" {>= "1.7.2"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.0.6/opam
+++ b/packages/opam-client/opam-client.2.0.6/opam
@@ -20,7 +20,7 @@ depends: [
   "opam-state" {= "2.0.6"}
   "opam-solver" {= "2.0.6"}
   "re" {>= "1.7.2"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.0.7/opam
+++ b/packages/opam-client/opam-client.2.0.7/opam
@@ -20,7 +20,7 @@ depends: [
   "opam-state" {= version}
   "opam-solver" {= version}
   "re" {>= "1.7.2"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.0.8/opam
+++ b/packages/opam-client/opam-client.2.0.8/opam
@@ -25,7 +25,7 @@ depends: [
   "extlib" {>= "1.7.3" & < "1.7.8"}
   "opam-repository" {= version}
   "re" {>= "1.7.2"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.0.9/opam
+++ b/packages/opam-client/opam-client.2.0.9/opam
@@ -25,7 +25,7 @@ depends: [
   "extlib" {>= "1.7.3" & < "1.7.8"}
   "opam-repository" {= version}
   "re" {>= "1.7.2"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.1.0/opam
+++ b/packages/opam-client/opam-client.2.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "extlib" {>= "1.7.3" & < "1.7.8"}
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.1.0~beta2/opam
+++ b/packages/opam-client/opam-client.2.1.0~beta2/opam
@@ -31,7 +31,7 @@ depends: [
   "extlib" {>= "1.7.3"}
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.5.0"}
 ]
 url {

--- a/packages/opam-client/opam-client.2.1.0~beta4/opam
+++ b/packages/opam-client/opam-client.2.1.0~beta4/opam
@@ -31,7 +31,7 @@ depends: [
   "extlib" {>= "1.7.3"}
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.5.0"}
 ]
 url {

--- a/packages/opam-client/opam-client.2.1.0~rc/opam
+++ b/packages/opam-client/opam-client.2.1.0~rc/opam
@@ -31,7 +31,7 @@ depends: [
   "extlib" {>= "1.7.3" & < "1.7.8"}
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 url {

--- a/packages/opam-client/opam-client.2.1.0~rc2/opam
+++ b/packages/opam-client/opam-client.2.1.0~rc2/opam
@@ -25,7 +25,7 @@ depends: [
   "extlib" {>= "1.7.3" & < "1.7.8"}
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.1.1/opam
+++ b/packages/opam-client/opam-client.2.1.1/opam
@@ -25,7 +25,7 @@ depends: [
   "extlib" {>= "1.7.3" & < "1.7.8"}
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.1.2/opam
+++ b/packages/opam-client/opam-client.2.1.2/opam
@@ -31,7 +31,7 @@ depends: [
   "extlib" {>= "1.7.3" & < "1.7.8"}
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 url {

--- a/packages/opam-client/opam-client.2.1.3/opam
+++ b/packages/opam-client/opam-client.2.1.3/opam
@@ -25,7 +25,7 @@ depends: [
   "extlib" {>= "1.7.3" & < "1.7.8"}
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.1.4/opam
+++ b/packages/opam-client/opam-client.2.1.4/opam
@@ -25,7 +25,7 @@ depends: [
   ("base64" {>= "3.1.0"} | "base64" & "ocaml" {= "4.02.3"})
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.1.5/opam
+++ b/packages/opam-client/opam-client.2.1.5/opam
@@ -25,7 +25,7 @@ depends: [
   ("base64" {>= "3.1.0"} | "base64" & "ocaml" {= "4.02.3"})
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.1.6/opam
+++ b/packages/opam-client/opam-client.2.1.6/opam
@@ -25,7 +25,7 @@ depends: [
   ("base64" {>= "3.1.0"} | "base64" & "ocaml" {= "4.02.3"})
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 build: [

--- a/packages/opam-client/opam-client.2.2.0/opam
+++ b/packages/opam-client/opam-client.2.2.0/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.10.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.2.0~alpha/opam
+++ b/packages/opam-client/opam-client.2.2.0~alpha/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.2.0~alpha2/opam
+++ b/packages/opam-client/opam-client.2.2.0~alpha2/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.2.0~alpha3/opam
+++ b/packages/opam-client/opam-client.2.2.0~alpha3/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 flags: avoid-version

--- a/packages/opam-client/opam-client.2.2.0~beta1/opam
+++ b/packages/opam-client/opam-client.2.2.0~beta1/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.2.0~beta2/opam
+++ b/packages/opam-client/opam-client.2.2.0~beta2/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.2.0~beta3/opam
+++ b/packages/opam-client/opam-client.2.2.0~beta3/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.10.3"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.2.0~rc1/opam
+++ b/packages/opam-client/opam-client.2.2.0~rc1/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.10.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.2.1/opam
+++ b/packages/opam-client/opam-client.2.2.1/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.10.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.3.0/opam
+++ b/packages/opam-client/opam-client.2.3.0/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.10.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.3.0~alpha1/opam
+++ b/packages/opam-client/opam-client.2.3.0~alpha1/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.10.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.6.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.3.0~beta1/opam
+++ b/packages/opam-client/opam-client.2.3.0~beta1/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.10.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.3.0~beta2/opam
+++ b/packages/opam-client/opam-client.2.3.0~beta2/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.10.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.3.0~rc1/opam
+++ b/packages/opam-client/opam-client.2.3.0~rc1/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.10.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 conflicts: [

--- a/packages/opam-ed/opam-ed.0.1/opam
+++ b/packages/opam-ed/opam-ed.0.1/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "opam-file-format" {= "2.0.0~beta3"}
 ]
 synopsis: "Command-line edition tool for handling the opam file syntax"

--- a/packages/opam-ed/opam-ed.0.3/opam
+++ b/packages/opam-ed/opam-ed.0.3/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/AltGr/opam-ed/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "opam-file-format" {>= "2.0.0" & < "2.1"}
 ]
 build: [

--- a/packages/opam-ed/opam-ed.0.4/opam
+++ b/packages/opam-ed/opam-ed.0.4/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/AltGr/opam-ed/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "opam-file-format" {>= "2.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/opam-installer/opam-installer.2.0.0/opam
+++ b/packages/opam-installer/opam-installer.2.0.0/opam
@@ -25,7 +25,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= "2.0.0"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "jbuilder" {>= "1.0+beta17"}
 ]
 synopsis: "Installation of files to a prefix, following opam conventions"

--- a/packages/opam-installer/opam-installer.2.0.0~rc2/opam
+++ b/packages/opam-installer/opam-installer.2.0.0~rc2/opam
@@ -25,7 +25,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= "2.0.0~rc2"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "jbuilder" {>= "1.0+beta17"}
 ]
 synopsis: "Installation of files to a prefix, following opam conventions"

--- a/packages/opam-installer/opam-installer.2.0.0~rc3/opam
+++ b/packages/opam-installer/opam-installer.2.0.0~rc3/opam
@@ -25,7 +25,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= "2.0.0~rc3"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "jbuilder" {>= "1.0+beta17"}
 ]
 synopsis: "Installation of files to a prefix, following opam conventions"

--- a/packages/opam-installer/opam-installer.2.0.1/opam
+++ b/packages/opam-installer/opam-installer.2.0.1/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= "2.0.1"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "jbuilder" {>= "1.0+beta17"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.0.10/opam
+++ b/packages/opam-installer/opam-installer.2.0.10/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.0.2/opam
+++ b/packages/opam-installer/opam-installer.2.0.2/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= "2.0.2"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.0.3/opam
+++ b/packages/opam-installer/opam-installer.2.0.3/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= "2.0.3"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.0.4/opam
+++ b/packages/opam-installer/opam-installer.2.0.4/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= "2.0.4"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.0.5/opam
+++ b/packages/opam-installer/opam-installer.2.0.5/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= "2.0.5"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.0.6/opam
+++ b/packages/opam-installer/opam-installer.2.0.6/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= "2.0.6"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.0.7/opam
+++ b/packages/opam-installer/opam-installer.2.0.7/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.0.8/opam
+++ b/packages/opam-installer/opam-installer.2.0.8/opam
@@ -23,7 +23,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.0.9/opam
+++ b/packages/opam-installer/opam-installer.2.0.9/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.1.0/opam
+++ b/packages/opam-installer/opam-installer.2.1.0/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.1.0~beta4/opam
+++ b/packages/opam-installer/opam-installer.2.1.0~beta4/opam
@@ -29,7 +29,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.5.0"}
 ]
 url {

--- a/packages/opam-installer/opam-installer.2.1.0~rc/opam
+++ b/packages/opam-installer/opam-installer.2.1.0~rc/opam
@@ -29,7 +29,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 url {

--- a/packages/opam-installer/opam-installer.2.1.0~rc2/opam
+++ b/packages/opam-installer/opam-installer.2.1.0~rc2/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.1.1/opam
+++ b/packages/opam-installer/opam-installer.2.1.1/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.1.2/opam
+++ b/packages/opam-installer/opam-installer.2.1.2/opam
@@ -29,7 +29,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 url {

--- a/packages/opam-installer/opam-installer.2.1.3/opam
+++ b/packages/opam-installer/opam-installer.2.1.3/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.1.4/opam
+++ b/packages/opam-installer/opam-installer.2.1.4/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.1.5/opam
+++ b/packages/opam-installer/opam-installer.2.1.5/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.1.6/opam
+++ b/packages/opam-installer/opam-installer.2.1.6/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.11.0"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.2.0/opam
+++ b/packages/opam-installer/opam-installer.2.2.0/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.2.0~alpha/opam
+++ b/packages/opam-installer/opam-installer.2.2.0~alpha/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.2.0~alpha2/opam
+++ b/packages/opam-installer/opam-installer.2.2.0~alpha2/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.2.0~alpha3/opam
+++ b/packages/opam-installer/opam-installer.2.2.0~alpha3/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 flags: avoid-version

--- a/packages/opam-installer/opam-installer.2.2.0~beta1/opam
+++ b/packages/opam-installer/opam-installer.2.2.0~beta1/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.2.0~beta2/opam
+++ b/packages/opam-installer/opam-installer.2.2.0~beta2/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 flags: avoid-version

--- a/packages/opam-installer/opam-installer.2.2.0~beta3/opam
+++ b/packages/opam-installer/opam-installer.2.2.0~beta3/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 available: opam-version >= "2.1.0"

--- a/packages/opam-installer/opam-installer.2.2.0~rc1/opam
+++ b/packages/opam-installer/opam-installer.2.2.0~rc1/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 flags: avoid-version

--- a/packages/opam-installer/opam-installer.2.2.1/opam
+++ b/packages/opam-installer/opam-installer.2.2.1/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.0.0"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.3.0/opam
+++ b/packages/opam-installer/opam-installer.2.3.0/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.3.0~alpha1/opam
+++ b/packages/opam-installer/opam-installer.2.3.0~alpha1/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.6.0"}
 ]
 available: opam-version >= "2.1.0"

--- a/packages/opam-installer/opam-installer.2.3.0~beta1/opam
+++ b/packages/opam-installer/opam-installer.2.3.0~beta1/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 available: opam-version >= "2.1.0"

--- a/packages/opam-installer/opam-installer.2.3.0~beta2/opam
+++ b/packages/opam-installer/opam-installer.2.3.0~beta2/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 available: opam-version >= "2.1.0"

--- a/packages/opam-installer/opam-installer.2.3.0~rc1/opam
+++ b/packages/opam-installer/opam-installer.2.3.0~rc1/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 available: opam-version >= "2.1.0"

--- a/packages/opium/opium.0.17.0/opam
+++ b/packages/opium/opium.0.17.0/opam
@@ -29,7 +29,7 @@ depends: [
   "base-unix"
   "lwt"
   "logs"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "ppx_fields_conv" {>= "v0.9.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "re" {>= "1.3.0"}

--- a/packages/opium/opium.0.17.1/opam
+++ b/packages/opium/opium.0.17.1/opam
@@ -30,7 +30,7 @@ depends: [
   "base-unix"
   "lwt"
   "logs"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "ppx_fields_conv" {>= "v0.9.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "re" {>= "1.3.0"}

--- a/packages/opium/opium.0.18.0/opam
+++ b/packages/opium/opium.0.18.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ezjsonm"
   "lwt"
   "logs"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "ppx_fields_conv"
   "ppx_sexp_conv"
   "re"

--- a/packages/opium/opium.0.19.0/opam
+++ b/packages/opium/opium.0.19.0/opam
@@ -17,7 +17,7 @@ depends: [
   "logs"
   "fmt"
   "mtime" {>= "1.0.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "ptime"
   "magic-mime"
   "yojson" {>= "1.6.0"}

--- a/packages/opium/opium.0.20.0/opam
+++ b/packages/opium/opium.0.20.0/opam
@@ -18,7 +18,7 @@ depends: [
   "logs"
   "fmt"
   "mtime" {>= "1.0.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "ptime"
   "magic-mime"
   "yojson" {>= "1.6.0"}

--- a/packages/oskel/oskel.0.1.0/opam
+++ b/packages/oskel/oskel.0.1.0/opam
@@ -16,7 +16,7 @@ doc: "https://CraigFe.github.io/oskel"
 bug-reports: "https://github.com/CraigFe/oskel/issues"
 depends: [
   "dune" {>= "2.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.1.0"}
   "fmt" {>= "0.8.7"}
   "logs"

--- a/packages/oskel/oskel.0.2.0/opam
+++ b/packages/oskel/oskel.0.2.0/opam
@@ -16,7 +16,7 @@ doc: "https://CraigFe.github.io/oskel"
 bug-reports: "https://github.com/CraigFe/oskel/issues"
 depends: [
   "dune" {>= "2.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.1.0"}
   "fmt" {>= "0.8.7"}
   "logs"

--- a/packages/oskel/oskel.0.3.0/opam
+++ b/packages/oskel/oskel.0.3.0/opam
@@ -16,7 +16,7 @@ doc: "https://CraigFe.github.io/oskel"
 bug-reports: "https://github.com/CraigFe/oskel/issues"
 depends: [
   "dune" {>= "2.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cmdliner" {with-test & < "1.1.0"}
   "fmt" {>= "0.8.7"}
   "logs"

--- a/packages/owork/owork.0.1.0/opam
+++ b/packages/owork/owork.0.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "1.10"}
   "ocaml" {>= "4.04.0"}
   "astring" {>= "0.8"}
-  "cmdliner" {>= "1.0"}
+  "cmdliner" {>= "1.0" & < "2.0.0"}
   "duration" {>= "0.1"}
   "fmt" {>= "0.8"}
   "logs" {>= "0.6"}

--- a/packages/owork/owork.0.1.1/opam
+++ b/packages/owork/owork.0.1.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.10"}
   "ocaml" {>= "4.04.0"}
   "astring" {>= "0.8"}
-  "cmdliner" {>= "1.0"}
+  "cmdliner" {>= "1.0" & < "2.0.0"}
   "duration" {>= "0.1"}
   "fmt" {>= "0.8"}
   "logs" {>= "0.6"}

--- a/packages/smtml/smtml.0.1.0/opam
+++ b/packages/smtml/smtml.0.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml_intrinsics"
   "z3" {>= "4.12.2" & < "4.13"}
   "menhir" {build & >= "20220210"}
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "zarith" {>= "1.5"}
   "odoc" {with-doc}
   "hc" {>= "0.3"}

--- a/packages/smtml/smtml.0.1.1/opam
+++ b/packages/smtml/smtml.0.1.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml_intrinsics"
   "z3" {>= "4.12.2" & < "4.13"}
   "menhir" {build & >= "20220210"}
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "zarith" {>= "1.5"}
   "odoc" {with-doc}
   "hc" {>= "0.3"}

--- a/packages/smtml/smtml.0.1.2/opam
+++ b/packages/smtml/smtml.0.1.2/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.14"}
   "ocaml" {>= "4.14.0"}
   "ocaml_intrinsics"
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "zarith" {>= "1.5"}
   "hc" {>= "0.3"}
   "menhir" {build & >= "20220210"}

--- a/packages/smtml/smtml.0.2.0/opam
+++ b/packages/smtml/smtml.0.2.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.14"}
   "ocaml" {>= "4.14.0"}
   "ocaml_intrinsics"
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "zarith" {>= "1.5"}
   "hc" {>= "0.3"}
   "menhir" {build & >= "20220210"}

--- a/packages/smtml/smtml.0.2.1/opam
+++ b/packages/smtml/smtml.0.2.1/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.14"}
   "ocaml" {>= "4.14.0"}
   "ocaml_intrinsics"
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "zarith" {>= "1.5"}
   "hc" {>= "0.3"}
   "menhir" {build & >= "20220210"}

--- a/packages/smtml/smtml.0.2.2/opam
+++ b/packages/smtml/smtml.0.2.2/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.14"}
   "ocaml" {>= "4.14.0"}
   "ocaml_intrinsics"
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "zarith" {>= "1.5"}
   "hc" {>= "0.3"}
   "menhir" {build & >= "20220210"}

--- a/packages/smtml/smtml.0.2.3/opam
+++ b/packages/smtml/smtml.0.2.3/opam
@@ -14,7 +14,7 @@ depends: [
   "prelude" {>= "0.2" & < "0.3"}
   "ocaml_intrinsics"
   "fmt" {>= "0.8.7"}
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "zarith" {>= "1.5"}
   "hc" {>= "0.3"}
   "menhir" {build & >= "20220210"}

--- a/packages/smtml/smtml.0.2.4/opam
+++ b/packages/smtml/smtml.0.2.4/opam
@@ -14,7 +14,7 @@ depends: [
   "prelude" {= "0.3"}
   "ocaml_intrinsics"
   "fmt" {>= "0.8.7"}
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "zarith" {>= "1.5"}
   "hc" {>= "0.3"}
   "menhir" {build & >= "20220210"}

--- a/packages/smtml/smtml.0.2.5/opam
+++ b/packages/smtml/smtml.0.2.5/opam
@@ -13,7 +13,7 @@ depends: [
   "prelude" {= "0.3"}
   "ocaml_intrinsics"
   "fmt" {>= "0.8.7"}
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "zarith" {>= "1.5"}
   "hc" {>= "0.3"}
   "menhir" {build & >= "20220210"}

--- a/packages/smtml/smtml.0.3.1/opam
+++ b/packages/smtml/smtml.0.3.1/opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/formalsec/smtml"
 doc: "https://formalsec.github.io/smtml/smtml/index.html"
 bug-reports: "https://github.com/formalsec/smtml/issues"
 depends: [
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "dune" {>= "3.10"}
   "dolmen" {= "0.10"}
   "dolmen_type" {= "0.10"}

--- a/packages/smtml/smtml.0.4.0/opam
+++ b/packages/smtml/smtml.0.4.0/opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/formalsec/smtml"
 doc: "https://formalsec.github.io/smtml/smtml/index.html"
 bug-reports: "https://github.com/formalsec/smtml/issues"
 depends: [
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "dune" {>= "3.10"}
   "dune-glob" {with-test}
   "dolmen" {= "0.10"}

--- a/packages/smtml/smtml.0.4.1/opam
+++ b/packages/smtml/smtml.0.4.1/opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/formalsec/smtml"
 doc: "https://formalsec.github.io/smtml/smtml/index.html"
 bug-reports: "https://github.com/formalsec/smtml/issues"
 depends: [
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "dune" {>= "3.10"}
   "dune-glob" {with-test}
   "dolmen" {= "0.10"}

--- a/packages/smtml/smtml.0.5.0/opam
+++ b/packages/smtml/smtml.0.5.0/opam
@@ -18,7 +18,7 @@ doc: "https://formalsec.github.io/smtml/smtml/index.html"
 bug-reports: "https://github.com/formalsec/smtml/issues"
 depends: [
   "bos"
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "dune" {>= "3.10"}
   "dune-glob" {with-test}
   "dolmen" {= "0.10"}

--- a/packages/smtml/smtml.0.6.0/opam
+++ b/packages/smtml/smtml.0.6.0/opam
@@ -19,7 +19,7 @@ doc: "https://formalsec.github.io/smtml/smtml/index.html"
 bug-reports: "https://github.com/formalsec/smtml/issues"
 depends: [
   "bos"
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "dune" {>= "3.10"}
   "dolmen" {= "0.10"}
   "dolmen_type" {= "0.10"}

--- a/packages/smtml/smtml.0.6.1/opam
+++ b/packages/smtml/smtml.0.6.1/opam
@@ -19,7 +19,7 @@ doc: "https://formalsec.github.io/smtml/smtml/index.html"
 bug-reports: "https://github.com/formalsec/smtml/issues"
 depends: [
   "bos"
-  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
   "dune" {>= "3.10"}
   "dolmen" {= "0.10"}
   "dolmen_type" {= "0.10"}

--- a/packages/telltime/telltime.0.0.1/opam
+++ b/packages/telltime/telltime.0.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ptime"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "oseq"
   "daypack-lib" {= "0.0.4"}
 ]

--- a/packages/telltime/telltime.0.0.2/opam
+++ b/packages/telltime/telltime.0.0.2/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ptime"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "oseq"
   "daypack-lib" {= "0.0.5"}
 ]

--- a/packages/telltime/telltime.0.0.3/opam
+++ b/packages/telltime/telltime.0.0.3/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ptime"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "oseq"
   "daypack-lib" {= "0.0.6"}
 ]

--- a/packages/tldr/tldr.0.3.0/opam
+++ b/packages/tldr/tldr.0.3.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ANSITerminal"
   "angstrom" {>= "0.14.0"}
   "stdio" {< "v0.17"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
 ]
 conflicts: [
   "ssl" {= "0.5.6"}

--- a/packages/user-setup/user-setup.0.4/opam
+++ b/packages/user-setup/user-setup.0.4/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.02"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "re"
 ]
 depopts: ["tuareg" "merlin" "ocp-indent" "ocp-index"]

--- a/packages/user-setup/user-setup.0.5/opam
+++ b/packages/user-setup/user-setup.0.5/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.00.1"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "re"
 ]
 depopts: ["tuareg" "merlin" "ocp-indent" "ocp-index"]

--- a/packages/user-setup/user-setup.0.6/opam
+++ b/packages/user-setup/user-setup.0.6/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.00"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "re"
 ]
 depopts: ["tuareg" "merlin" "ocp-indent" "ocp-index"]

--- a/packages/user-setup/user-setup.0.7/opam
+++ b/packages/user-setup/user-setup.0.7/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "3.12.1"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "re"
 ]
 depopts: ["tuareg" "merlin" "ocp-indent" "ocp-index"]

--- a/packages/user-setup/user-setup.0.8/opam
+++ b/packages/user-setup/user-setup.0.8/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "3.12.1"}
   "ocamlfind" {build}
   "ocamlbuild"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "re" {>= "1.7.2"}
 ]
 depopts: ["tuareg" "merlin" "ocp-indent" "ocp-index"]


### PR DESCRIPTION
This constrains packages whose *latest* version is known for sure to be incompatible with [upcoming changes](https://github.com/dbuenzli/cmdliner/issues/206) in cmdliner 2.0.0. An issue will be reported on their issue tracker.

When `cmdliner.2.0.0` is released there will be more incompatibilites, as this did not test 1) packages that couldn't compiler on macos 2) packages that depended on the ones in this PR 3) packages whose *previous* versions were perhaps not compatible with cmdliner 2.0.0.



