### PR TITLE
Add missing ppxlib.0.36.0 upper bounds

### DIFF
--- a/packages/flow_parser/flow_parser.0.229.1/opam
+++ b/packages/flow_parser/flow_parser.0.229.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.14.0" & < "5.2"}
   "dune" {>= "3.2"}
   "base" {>= "v0.14.1"}
-  "ppxlib" {>= "0.26.0"}
+  "ppxlib" {>= "0.26.0" & < "0.36.0"}
   "ppx_deriving" {build}
   "ppx_gen_rec" {build}
   "wtf8"

--- a/packages/flow_parser/flow_parser.0.246.0/opam
+++ b/packages/flow_parser/flow_parser.0.246.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "5.2.0" & < "5.3"}
   "dune" {>= "3.2"}
   "base" {>= "v0.16.3"}
-  "ppxlib" {>= "0.32.1"}
+  "ppxlib" {>= "0.32.1" & < "0.36.0"}
   "ppx_deriving" {build}
   "ppx_gen_rec" {build}
   "wtf8"

--- a/packages/validate/validate.0.1.0/opam
+++ b/packages/validate/validate.0.1.0/opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "5.0.0"}
   "dune" {>= "3.12"}
   "alcotest" {with-test}
+  "ppxlib" {< "0.36.0"}
   "ppx_deriving"
   "re"
   "uri"

--- a/packages/validate/validate.0.2.0/opam
+++ b/packages/validate/validate.0.2.0/opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "5.0.0"}
   "dune" {>= "3.12"}
   "alcotest" {with-test}
+  "ppxlib" {< "0.36.0"}
   "ppx_deriving"
   "re"
   "uri"

--- a/packages/validate/validate.1.0.0/opam
+++ b/packages/validate/validate.1.0.0/opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "5.0.0"}
   "dune" {>= "3.12"}
   "alcotest" {with-test}
+  "ppxlib" {< "0.36.0"}
   "ppx_deriving"
   "re"
   "uri"

--- a/packages/validate/validate.1.1.0/opam
+++ b/packages/validate/validate.1.1.0/opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "5.0.0"}
   "dune" {>= "3.12"}
   "alcotest" {with-test}
+  "ppxlib" {< "0.36.0"}
   "ppx_deriving"
   "re"
   "uri"


### PR DESCRIPTION
Some more missing upper bounds that were hidden behind a `ppx_deriving` dependency, uncovered by #27621 rev deps build.

`validate` was not declaring the dependency it had on `ppxlib` so I took the liberty to add it, with the proper upper bound.