### PR TITLE
[new release] codept and codept-lib  (0.12.1)

### DIFF
--- a/packages/codept-lib/codept-lib.0.12.1/opam
+++ b/packages/codept-lib/codept-lib.0.12.1/opam
@@ -13,6 +13,7 @@ bug-reports: "https://github.com/Octachron/codept/issues"
 depends: [
   "dune" {>= "2.8"}
   "menhir" {>= "20180523"}
+  "ocaml" {>= "4.03" & < "5.4~"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/codept-lib/codept-lib.0.12.1/opam
+++ b/packages/codept-lib/codept-lib.0.12.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Alternative ocaml dependency  analyzer"
+description: """
+Codept intends to be a dependency solver for OCaml project and an
+  alternative to ocamldep. This package provides the core library used to build
+  the codept executable under a more permissive license in order to be easier to
+  reuse in other projects"""
+maintainer: ["Florian Angeletti <octa@polychoron.fr>"]
+authors: ["Florian Angeletti <octa@polychoron.fr>"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/Octachron/codept"
+bug-reports: "https://github.com/Octachron/codept/issues"
+depends: [
+  "dune"
+  "menhir" {>= "20180523"}
+  "ocaml" {>= "4.03" & < "5.4~"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Octachron/codept.git"
+x-maintenance-intent: "latest"
+url {
+  src:
+    "https://github.com/Octachron/codept/releases/download/0.12.1/codept-0.12.1.tbz"
+  checksum: [
+    "sha256=381d300bad1d526d241414d74c670853896547c10efe69f56a1838f00264f69b"
+    "sha512=1517e482a60ed9c76cceff0f64ef73b28a667800fb5bd0a0f142487bbd9c36aadc9534b70de1d261027bd7164dc80ac620d8c04cc94990f627db49e96f786ae5"
+  ]
+}
+x-commit-hash: "d9902f2a11217122a04edb39b5c5d4d540ad18fd"

--- a/packages/codept-lib/codept-lib.0.12.1/opam
+++ b/packages/codept-lib/codept-lib.0.12.1/opam
@@ -11,12 +11,12 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/Octachron/codept"
 bug-reports: "https://github.com/Octachron/codept/issues"
 depends: [
-  "dune"
+  "dune" {>= "2.7"}
   "menhir" {>= "20180523"}
-  "ocaml" {>= "4.03" & < "5.4~"}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"
@@ -25,7 +25,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/codept-lib/codept-lib.0.12.1/opam
+++ b/packages/codept-lib/codept-lib.0.12.1/opam
@@ -11,7 +11,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/Octachron/codept"
 bug-reports: "https://github.com/Octachron/codept/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "2.8"}
   "menhir" {>= "20180523"}
   "odoc" {with-doc}
 ]

--- a/packages/codept/codept.0.12.1/opam
+++ b/packages/codept/codept.0.12.1/opam
@@ -17,11 +17,12 @@ license: "GPL-3.0-or-later"
 homepage: "https://github.com/Octachron/codept"
 bug-reports: "https://github.com/Octachron/codept/issues"
 depends: [
-  "dune"
+  "dune" {>= "2.7"}
   "codept-lib" {= version}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/codept/codept.0.12.1/opam
+++ b/packages/codept/codept.0.12.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Alternative ocaml dependency analyzer"
+description: """
+Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep. Compared to ocamldep, codept major features are:
+
+ * whole project analysis
+ * exhaustive warning and error messages
+ * structured format (s-expression or json) for dependencies
+ * uniform handling of delayed alias dependencies
+ * (experimental) full dependencies,
+   when dependencies up to transitive closure are not enough
+
+Both ocamldep and codept computes an over-approximation of the dependencies graph of OCaml project. However, codept uses whole project analysis to reduce the number of fictitious dependencies inferred at the project scale, whereas ocamldep is, by design, limited to local file analysis."""
+maintainer: ["Florian Angeletti <octa@polychoron.fr>"]
+authors: ["Florian Angeletti <octa@polychoron.fr>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/Octachron/codept"
+bug-reports: "https://github.com/Octachron/codept/issues"
+depends: [
+  "dune"
+  "codept-lib" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Octachron/codept.git"
+x-maintenance-intent: "latest"
+url {
+  src:
+    "https://github.com/Octachron/codept/releases/download/0.12.1/codept-0.12.1.tbz"
+  checksum: [
+    "sha256=381d300bad1d526d241414d74c670853896547c10efe69f56a1838f00264f69b"
+    "sha512=1517e482a60ed9c76cceff0f64ef73b28a667800fb5bd0a0f142487bbd9c36aadc9534b70de1d261027bd7164dc80ac620d8c04cc94990f627db49e96f786ae5"
+  ]
+}
+x-commit-hash: "d9902f2a11217122a04edb39b5c5d4d540ad18fd"

--- a/packages/codept/codept.0.12.1/opam
+++ b/packages/codept/codept.0.12.1/opam
@@ -17,7 +17,7 @@ license: "GPL-3.0-or-later"
 homepage: "https://github.com/Octachron/codept"
 bug-reports: "https://github.com/Octachron/codept/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "2.8"}
   "codept-lib" {= version}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
This is a new release of [codept](https://github.com/Octachron/codept) an alternative dependency analyzers for OCaml project. This new version splits the core analysis library package from the executable package. The new `codept-lib` version also updates the support for OCaml 5.2 and 5.3, and fixes the handling of `open F(X).Y`. 

CHANGES:
---------------
   * Support OCaml 5.2
   * Support OCaml 5.3

## packaging changes

   * Expose LGPL library
   * maintenance intents field

## Library changes

   * Make the error formatter a parameter
   * Better inequality explanation for modules

## Bug fixes

   * fix `-export` bugs
   * handle open `F(X).Y`

## Internal

* Improve test stability on Windows