### PR TITLE
remove rust-llvm depext for conf-rust-llvm in ubuntu, rust-lld is

### DIFF
--- a/packages/conf-rust-llvm/conf-rust-llvm.1/opam
+++ b/packages/conf-rust-llvm/conf-rust-llvm.1/opam
@@ -17,7 +17,7 @@ depexts: [
   ["rust-llvm"] { os-family = "alpine" }
   ["rust-llvm"] { os-family = "arch" }
   ["rust-llvm"] { os-family = "debian" }
-  ["rust-llvm"] { os-family = "ubuntu" }
+  [] { os-family = "ubuntu" }
   ["rust-llvm"] { os-family = "opensuse" }
   ["rust-llvm"] { os-family = "suse" }
   ["rust-llvm"] { os-distribution = "centos" }


### PR DESCRIPTION
provided by the rustc package which should provided by the dependency on conf-rust which depends on cargo