### PR TITLE
enable build on SUSE Linux

### DIFF
--- a/packages/bin_prot/bin_prot.v0.17.0/opam
+++ b/packages/bin_prot/bin_prot.v0.17.0/opam
@@ -24,7 +24,7 @@ depends: [
 depopts: [
   "mirage-xen-ocaml"
 ]
-available: arch != "arm32" & arch != "x86_32" & os != "freebsd" & os-family != "opensuse" & os-family != "suse"
+available: arch != "arm32" & arch != "x86_32" & os != "freebsd"
 synopsis: "A binary protocol generator"
 description: "
 Part of Jane Street's Core library


### PR DESCRIPTION
It installs just fine in an ordinary SUSE Linux installation.

Fixes commit 848c1de0f0 ("`os-family` might be `"suse"`")
Fixes commit ae5be4ec64 ("`bin_prot` FTBFS on OpenSUSE")