### PR TITLE
Patch conf-diffutils's build check on OpenBSD

### DIFF
--- a/packages/conf-diffutils/conf-diffutils.2/opam
+++ b/packages/conf-diffutils/conf-diffutils.2/opam
@@ -5,7 +5,7 @@ maintainer: "chetsky@gmail.com"
 authors: "GNU Project"
 license: "GPL-3.0-or-later"
 build: [
-  ["diff" "--help"] { os != "freebsd" }
+  ["diff" "--help"] { os != "freebsd" & os != "openbsd" }
   ["gdiff" "--help"] { os = "freebsd" | os = "openbsd" }
 ]
 depexts: [


### PR DESCRIPTION
#27554 added `conf-diffutils` support for OpenBSD.

This works well and installs the `"textproc/gdiff"` package as expected:
https://ocaml.ci.dev/github/jmid/mutaml/commit/c508493571338bfb064c5a81209a0cdb52352fb8/variant/openbsd-76-amd64-5.3_opam-2.3

The `build` check however still runs `diff --help` because of an unfortunate oversight:
```
#=== ERROR while compiling conf-diffutils.2 ===================================#
# context     2.3.0 | openbsd/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path        ~/.opam/4.14.2/.opam-switch/build/conf-diffutils.2
# command     /usr/bin/diff --help
# exit-code   2
# env-file    ~/.opam/log/conf-diffutils-64278-7c7160.env
# output-file ~/.opam/log/conf-diffutils-64278-7c7160.out
### output ###
# diff: unknown option -- help
# usage: diff [-abdipTtw] [-c | -e | -f | -n | -q | -u] [-I pattern] [-L label]
#             file1 file2
#        diff [-abdipTtw] [-I pattern] [-L label] -C number file1 file2
#        diff [-abditw] [-I pattern] -D string file1 file2
#        diff [-abdipTtw] [-I pattern] [-L label] -U number file1 file2
#        diff [-abdiNPprsTtw] [-c | -e | -f | -n | -q | -u] [-I pattern]
#             [-L label] [-S name] [-X file] [-x pattern] dir1 dir2
```

This PR thus patches the `build` check accordingly.

In fairness, `opam-ci` does not include the experimental openbsd runner yet, meaning the original PR was not checked:

> Note: ocaml-ci has added an openbsd target, but the opam-ci hasn't yet, so the CI hasn't tested this much

I thus discovered this oversight on `ocaml-ci` 2 weeks after the above was merged... :shrug: 