### PR TITLE
Add missing ppxlib.0.36.0 upper bounds

### DIFF
--- a/packages/ppx_deriving_ezjsonm/ppx_deriving_ezjsonm.0.4.0/opam
+++ b/packages/ppx_deriving_ezjsonm/ppx_deriving_ezjsonm.0.4.0/opam
@@ -15,7 +15,7 @@ depends: [
   "mdx" {with-test & >= "2.4.1"}
   "ppx_deriving" {with-test}
   "ocaml" {>= "4.08.1"}
-  "ppxlib" {>= "0.25.0"}
+  "ppxlib" {>= "0.25.0" & < "0.36.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.1.0/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "mdx" {with-test}
   "ezjsonm" {with-test}
   "ocaml" {>= "4.08.1"}
-  "ppxlib" {>= "0.14.0"}
+  "ppxlib" {>= "0.14.0" & < "0.36.0"}
   "yaml" {< "3.0.1"}
   "yaml" {with-test & >= "2.0.0" & < "3.0.1"}
   "rresult" {< "0.7.0"}

--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.1.1/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.1.1/opam
@@ -13,7 +13,7 @@ depends: [
   "mdx" {with-test}
   "ezjsonm" {with-test}
   "ocaml" {>= "4.08.1"}
-  "ppxlib" {>= "0.14.0"}
+  "ppxlib" {>= "0.14.0" & < "0.36.0"}
   "yaml"
 ]
 build: [

--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.0/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "mdx" {with-test}
   "ezjsonm" {with-test}
   "ocaml" {>= "4.08.1"}
-  "ppxlib" {>= "0.14.0"}
+  "ppxlib" {>= "0.14.0" & < "0.36.0"}
   "ppx_deriving"
   "yaml"
   "odoc" {with-doc}

--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.1/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.1/opam
@@ -14,7 +14,7 @@ depends: [
   "mdx" {with-test}
   "ezjsonm" {with-test}
   "ocaml" {>= "4.08.1"}
-  "ppxlib" {>= "0.14.0"}
+  "ppxlib" {>= "0.14.0" & < "0.36.0"}
   "ppx_deriving"
   "yaml"
   "odoc" {with-doc}

--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.2/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.2/opam
@@ -14,7 +14,7 @@ depends: [
   "alcotest" {with-test}
   "mdx" {with-test & >= "2.0.0"}
   "ocaml" {>= "4.08.1"}
-  "ppxlib" {>= "0.25.0"}
+  "ppxlib" {>= "0.25.0" & < "0.36.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.3/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.3/opam
@@ -14,7 +14,7 @@ depends: [
   "alcotest" {with-test}
   "mdx" {with-test & >= "2.0.0"}
   "ocaml" {>= "4.08.1"}
-  "ppxlib" {>= "0.25.0"}
+  "ppxlib" {>= "0.25.0" & < "0.36.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.3.0/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.3.0/opam
@@ -14,7 +14,7 @@ depends: [
   "alcotest" {with-test}
   "mdx" {with-test & >= "2.0.0"}
   "ocaml" {>= "4.08.1"}
-  "ppxlib" {>= "0.25.0"}
+  "ppxlib" {>= "0.25.0" & < "0.36.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.4.0/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.4.0/opam
@@ -15,7 +15,7 @@ depends: [
   "mdx" {with-test & >= "2.4.1"}
   "ppx_deriving" {with-test}
   "ocaml" {>= "4.08.1"}
-  "ppxlib" {>= "0.25.0"}
+  "ppxlib" {>= "0.25.0" & < "0.36.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Adds another set of ppxlib.0.36.0 upper bounds. The failures were detected by the rev deps build from #27621.