### PR TITLE
Release Caqti 2.2.4

### DIFF
--- a/packages/caqti-async/caqti-async.2.2.4/opam
+++ b/packages/caqti-async/caqti-async.2.2.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "async_kernel" {>= "v0.17.0"}
+  "async_unix" {>= "v0.11.0"}
+  "caqti" {>= "2.2.3" & < "2.3.0~"}
+  "core" {>= "v0.16.1"}
+  "core_unix"
+  "domain-name"
+  "dune" {>= "3.9"}
+  "ipaddr"
+  "logs"
+  "ocaml"
+  "alcotest" {with-test & >= "1.5.0"}
+  "alcotest-async" {with-test}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "caqti-driver-sqlite3" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Async support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.2.4/caqti-v2.2.4.tbz"
+  checksum: [
+    "sha256=b8ea432820154ec095132c4f7b244b06cd8553e0b2035185b844d9c4f30af8bb"
+    "sha512=b7e3ad8e6a9b587db2d517e15cd42df2945148f9223b2fa6f4bc2bcdd2709d53549cca4b65e54511d22466e4c9aa7f0b9c17305a07505519d8bf81d95de629b8"
+  ]
+}
+x-commit-hash: "b1faede963098ac99546e8c2fe794ae34b2d2437"

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.2.2.4/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.2.2.4/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocaml"
+  "caqti" {>= "2.2.0" & < "2.3.0~"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "3.9"}
+  "mariadb" {>= "1.1.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MariaDB driver for Caqti using C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.2.4/caqti-v2.2.4.tbz"
+  checksum: [
+    "sha256=b8ea432820154ec095132c4f7b244b06cd8553e0b2035185b844d9c4f30af8bb"
+    "sha512=b7e3ad8e6a9b587db2d517e15cd42df2945148f9223b2fa6f4bc2bcdd2709d53549cca4b65e54511d22466e4c9aa7f0b9c17305a07505519d8bf81d95de629b8"
+  ]
+}
+x-commit-hash: "b1faede963098ac99546e8c2fe794ae34b2d2437"

--- a/packages/caqti-driver-pgx/caqti-driver-pgx.2.2.4/opam
+++ b/packages/caqti-driver-pgx/caqti-driver-pgx.2.2.4/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "caqti" {>= "2.2.0" & < "2.3.0~"}
+  "domain-name"
+  "dune" {>= "3.9"}
+  "ipaddr"
+  "pgx" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on the pure-OCaml PGX library"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.2.4/caqti-v2.2.4.tbz"
+  checksum: [
+    "sha256=b8ea432820154ec095132c4f7b244b06cd8553e0b2035185b844d9c4f30af8bb"
+    "sha512=b7e3ad8e6a9b587db2d517e15cd42df2945148f9223b2fa6f4bc2bcdd2709d53549cca4b65e54511d22466e4c9aa7f0b9c17305a07505519d8bf81d95de629b8"
+  ]
+}
+x-commit-hash: "b1faede963098ac99546e8c2fe794ae34b2d2437"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.2.2.4/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.2.2.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "James Owen <james@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocaml"
+  "caqti" {>= "2.2.0" & < "2.3.0~"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "3.9"}
+  "odoc" {with-doc}
+  "postgresql" {>= "5.0.0"}
+  "uri" {>= "4.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.2.4/caqti-v2.2.4.tbz"
+  checksum: [
+    "sha256=b8ea432820154ec095132c4f7b244b06cd8553e0b2035185b844d9c4f30af8bb"
+    "sha512=b7e3ad8e6a9b587db2d517e15cd42df2945148f9223b2fa6f4bc2bcdd2709d53549cca4b65e54511d22466e4c9aa7f0b9c17305a07505519d8bf81d95de629b8"
+  ]
+}
+x-commit-hash: "b1faede963098ac99546e8c2fe794ae34b2d2437"

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.2.2.4/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.2.2.4/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocaml"
+  "caqti" {>= "2.2.0" & < "2.3.0~"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "3.9"}
+  "odoc" {with-doc}
+  "sqlite3" {>= "5.2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Sqlite3 driver for Caqti using C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.2.4/caqti-v2.2.4.tbz"
+  checksum: [
+    "sha256=b8ea432820154ec095132c4f7b244b06cd8553e0b2035185b844d9c4f30af8bb"
+    "sha512=b7e3ad8e6a9b587db2d517e15cd42df2945148f9223b2fa6f4bc2bcdd2709d53549cca4b65e54511d22466e4c9aa7f0b9c17305a07505519d8bf81d95de629b8"
+  ]
+}
+x-commit-hash: "b1faede963098ac99546e8c2fe794ae34b2d2437"

--- a/packages/caqti-eio/caqti-eio.2.2.4/opam
+++ b/packages/caqti-eio/caqti-eio.2.2.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "2.2.3" & < "2.3.0~"}
+  "dune" {>= "3.9"}
+  "eio" {>= "0.12"}
+  "logs"
+  "ocaml" {>= "5.0.0~"}
+  "alcotest" {with-test & >= "1.5.0"}
+  "caqti-driver-sqlite3" {with-test}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "eio_main" {with-test}
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Eio support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.2.4/caqti-v2.2.4.tbz"
+  checksum: [
+    "sha256=b8ea432820154ec095132c4f7b244b06cd8553e0b2035185b844d9c4f30af8bb"
+    "sha512=b7e3ad8e6a9b587db2d517e15cd42df2945148f9223b2fa6f4bc2bcdd2709d53549cca4b65e54511d22466e4c9aa7f0b9c17305a07505519d8bf81d95de629b8"
+  ]
+}
+x-commit-hash: "b1faede963098ac99546e8c2fe794ae34b2d2437"

--- a/packages/caqti-lwt/caqti-lwt.2.2.4/opam
+++ b/packages/caqti-lwt/caqti-lwt.2.2.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "2.2.3" & < "2.3.0~"}
+  "dune" {>= "3.9"}
+  "domain-name"
+  "ipaddr"
+  "logs"
+  "mtime" {>= "2.0.0"}
+  "lwt" {>= "5.3.0"}
+  "ocaml"
+  "alcotest" {with-test & >= "1.5.0"}
+  "alcotest-lwt" {with-test & >= "1.5.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "caqti-driver-sqlite3" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Lwt support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.2.4/caqti-v2.2.4.tbz"
+  checksum: [
+    "sha256=b8ea432820154ec095132c4f7b244b06cd8553e0b2035185b844d9c4f30af8bb"
+    "sha512=b7e3ad8e6a9b587db2d517e15cd42df2945148f9223b2fa6f4bc2bcdd2709d53549cca4b65e54511d22466e4c9aa7f0b9c17305a07505519d8bf81d95de629b8"
+  ]
+}
+x-commit-hash: "b1faede963098ac99546e8c2fe794ae34b2d2437"

--- a/packages/caqti-miou/caqti-miou.2.2.4/opam
+++ b/packages/caqti-miou/caqti-miou.2.2.4/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "2.2.3" & < "2.3.0~"}
+  "dune" {>= "3.9"}
+  "miou" {>= "0.3.0"}
+  "logs"
+  "ocaml" {>= "5.0.0~"}
+  "alcotest" {with-test & >= "1.5.0"}
+  "caqti-driver-sqlite3" {with-test}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "mirage-crypto-rng-miou-unix" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Miou support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.2.4/caqti-v2.2.4.tbz"
+  checksum: [
+    "sha256=b8ea432820154ec095132c4f7b244b06cd8553e0b2035185b844d9c4f30af8bb"
+    "sha512=b7e3ad8e6a9b587db2d517e15cd42df2945148f9223b2fa6f4bc2bcdd2709d53549cca4b65e54511d22466e4c9aa7f0b9c17305a07505519d8bf81d95de629b8"
+  ]
+}
+x-commit-hash: "b1faede963098ac99546e8c2fe794ae34b2d2437"

--- a/packages/caqti-mirage/caqti-mirage.2.2.4/opam
+++ b/packages/caqti-mirage/caqti-mirage.2.2.4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "2.2.0" & < "2.3.0~"}
+  "caqti-lwt" {>= "2.1.0" & < "2.3.0~"}
+  "caqti-tls" {>= "2.1.0" & < "2.3.0~"}
+  "dns-client" {>= "7.0.0"}
+  "dns-client-mirage" {>= "7.0.0"}
+  "domain-name"
+  "dune" {>= "3.9"}
+  "ipaddr"
+  "logs"
+  "lwt" {>= "5.3.0"}
+  "mirage-channel"
+  "mirage-sleep"
+  "ocaml"
+  "odoc" {with-doc}
+  "tls"
+  "tls-mirage" {>= "1.0.0"}
+  "tcpip" {>= "8.1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MirageOS support for Caqti including TLS"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.2.4/caqti-v2.2.4.tbz"
+  checksum: [
+    "sha256=b8ea432820154ec095132c4f7b244b06cd8553e0b2035185b844d9c4f30af8bb"
+    "sha512=b7e3ad8e6a9b587db2d517e15cd42df2945148f9223b2fa6f4bc2bcdd2709d53549cca4b65e54511d22466e4c9aa7f0b9c17305a07505519d8bf81d95de629b8"
+  ]
+}
+x-commit-hash: "b1faede963098ac99546e8c2fe794ae34b2d2437"

--- a/packages/caqti-tls/caqti-tls.2.1.2/opam
+++ b/packages/caqti-tls/caqti-tls.2.1.2/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/paurkedal/ocaml-caqti/"
 doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
-  "caqti" {>= "2.1.0" & < "2.2.0~"}
+  "caqti" {>= "2.1.0" & < "2.3.0~"}
   "dune" {>= "3.9"}
   "ocaml"
   "odoc" {with-doc}

--- a/packages/caqti/caqti.2.2.4/opam
+++ b/packages/caqti/caqti.2.2.4/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "Nathan Rebours <nathan@cryptosense.com>"
+  "Basile Clément"
+]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "angstrom" {>= "0.14.0"}
+  "bigstringaf"
+  "cmdliner" {with-test & >= "1.1.0"}
+  "domain-name" {>= "0.2.0"}
+  "dune" {>= "3.9"}
+  "dune-site"
+  "ipaddr" {>= "3.0.0"}
+  "logs"
+  "lru" {>= "0.3.1"}
+  "lwt-dllist"
+  "mdx" {with-test & >= "2.3.0"}
+  "mtime" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+  "ptime"
+  "re" {with-test}
+  "tls"
+  "uri" {>= "2.2.0"}
+  "x509"
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install"]
+  ["dune" "install" "-p" name "--create-install-file" name]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Unified interface to relational database libraries"
+description: """
+Caqti provides a monadic cooperative-threaded OCaml connector API for
+relational databases.
+
+The purpose of Caqti is further to help make applications independent of a
+particular database system. This is achieved by defining a common signature,
+which is implemented by the database drivers. Connection parameters are
+specified as an URI, which is typically provided at run-time. Caqti then
+loads a driver which can handle the URI, and provides a first-class module
+which implements the driver API and additional convenience functionality.
+
+Caqti does not make assumptions about the structure of the query language,
+and only provides the type information needed at the edges of communication
+between the OCaml code and the database; i.e. for encoding parameters and
+decoding returned tuples. It is hoped that this agnostic choice makes it a
+suitable target for higher level interfaces and code generators."""
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.2.4/caqti-v2.2.4.tbz"
+  checksum: [
+    "sha256=b8ea432820154ec095132c4f7b244b06cd8553e0b2035185b844d9c4f30af8bb"
+    "sha512=b7e3ad8e6a9b587db2d517e15cd42df2945148f9223b2fa6f4bc2bcdd2709d53549cca4b65e54511d22466e4c9aa7f0b9c17305a07505519d8bf81d95de629b8"
+  ]
+}
+x-commit-hash: "b1faede963098ac99546e8c2fe794ae34b2d2437"


### PR DESCRIPTION
The full release notes can be found here: https://github.com/paurkedal/ocaml-caqti/releases/tag/v2.2.0
