### PR TITLE
not-ocamlfind 0.14: windows bugfixes

### DIFF
--- a/packages/frama-clang/frama-clang.0.0.14/opam
+++ b/packages/frama-clang/frama-clang.0.0.14/opam
@@ -70,3 +70,4 @@ extra-source "CMakeLists.txt.patch" {
   checksum:
     "sha256=6b69ba205c2277b921546322f0997fb6765c7fb553410a3e5b579230aa9f3202"
 }
+available: false

--- a/packages/not-ocamlfind/not-ocamlfind.0.14/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.14/opam
@@ -37,6 +37,6 @@ dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
 url {
   src: "https://github.com/chetmurthy/not-ocamlfind/archive/refs/tags/0.14.tar.gz"
   checksum: [
-    "sha512=6f2bb0db885d06bff510d9576afe7838e0cd50e672326c1427979c8fee6f515ee870103bf0747ef20f5b6ea15396ae4d5297e6f5f9f3dc18dc91640734af224c"
+    "sha512=98fda1ff916ebdc9ad960faea2c0f69955d443a2ad18ac79d0d3dffa843210a4c18a997df317c42aa6c92f8f6dc20a432b8b4f6b2abe76237f53d27459f348a2"
   ]
 }

--- a/packages/not-ocamlfind/not-ocamlfind.0.14/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.14/opam
@@ -1,4 +1,3 @@
-
 opam-version: "2.0"
 synopsis: "A small frontend for ocamlfind that adds a few useful commands"
 license: "MIT"

--- a/packages/not-ocamlfind/not-ocamlfind.0.14/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.14/opam
@@ -29,9 +29,6 @@ build: [
   [make "all"]
 ]
 install: [make "install"]
-conflicts: [
-   "frama-clang" { = "0.0.14" }
-]
 dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
 url {
   src: "https://github.com/chetmurthy/not-ocamlfind/archive/refs/tags/0.14.tar.gz"

--- a/packages/not-ocamlfind/not-ocamlfind.0.14/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.14/opam
@@ -1,0 +1,39 @@
+
+opam-version: "2.0"
+synopsis: "A small frontend for ocamlfind that adds a few useful commands"
+license: "MIT"
+x-maintenance-intent: [ "(latest)" ]
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+
+(* Gerd wrote most of this code; I just modified it (and probably
+introduced bugs.  This is to silence opam *)
+
+authors: "Chet Murthy <chetsky@gmail.com>"
+homepage: "https://github.com/chetmurthy/not-ocamlfind"
+bug-reports: "Chet Murthy <chetsky@gmail.com>"
+depends: [
+  "ocamlfind" {>= "1.8.0"}
+  "camlp-streams"
+  "conf-m4" {build}
+  "fmt" {>= "0.8.8"}
+  "rresult" {>= "0.6.0"}
+  "ocamlgraph" {>= "2.0.0"}
+  "conf-which"
+]
+depexts: [
+  [
+    "xdot"
+  ] {os-family = "debian"}
+]
+build: [
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-custom" "-no-topfind" {preinstalled}]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
+url {
+  src: "https://github.com/chetmurthy/not-ocamlfind/archive/refs/tags/0.14.tar.gz"
+  checksum: [
+    "sha512=703f4bfc35837ab722118e33a68b4aabf69d15572b784196386487622eba0f462b9507d9e52538de9c598cc63e687641928da3ecf8b330daff8aaed03c897455"
+  ]
+}

--- a/packages/not-ocamlfind/not-ocamlfind.0.14/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.14/opam
@@ -30,10 +30,13 @@ build: [
   [make "all"]
 ]
 install: [make "install"]
+conflicts: [
+   "frama-clang" { = "0.0.14" }
+]
 dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
 url {
   src: "https://github.com/chetmurthy/not-ocamlfind/archive/refs/tags/0.14.tar.gz"
   checksum: [
-    "sha512=703f4bfc35837ab722118e33a68b4aabf69d15572b784196386487622eba0f462b9507d9e52538de9c598cc63e687641928da3ecf8b330daff8aaed03c897455"
+    "sha512=6f2bb0db885d06bff510d9576afe7838e0cd50e672326c1427979c8fee6f515ee870103bf0747ef20f5b6ea15396ae4d5297e6f5f9f3dc18dc91640734af224c"
   ]
 }


### PR DESCRIPTION
executable name needs .EXE suffix.  Also updated cached copy of ocamlfind to latest (1.9.8)