### PR TITLE
[new release] ppx_deriving_hash (0.1.3)

### DIFF
--- a/packages/ppx_deriving_hash/ppx_deriving_hash.0.1.3/opam
+++ b/packages/ppx_deriving_hash/ppx_deriving_hash.0.1.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "[@@deriving hash]"
+description:
+  "Deriver for standard hash functions without extra dependencies."
+maintainer: ["Simmo Saan <simmo.saan@gmail.com>"]
+authors: ["Simmo Saan <simmo.saan@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/sim642/ppx_deriving_hash"
+bug-reports: "https://github.com/sim642/ppx_deriving_hash/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppxlib" {>= "0.36.0"}
+  "ppx_deriving" {>= "5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sim642/ppx_deriving_hash.git"
+url {
+  src:
+    "https://github.com/sim642/ppx_deriving_hash/releases/download/0.1.3/ppx_deriving_hash-0.1.3.tbz"
+  checksum: [
+    "sha256=19bf51f397f255ab32a1aa44bbb6ca49e29b7cf46e4e8a9cc756ad90aee8bd09"
+    "sha512=9879a5cfc5dacd71e88a832eb96c6d8127f46f1d5619f149fd2d882a23e27170a0e4bca4f50132bcc48f53435168919377a8b66590465b0411a4e6c4c5e85eea"
+  ]
+}
+x-commit-hash: "09fe8b1d95675006e0a889aa033a370f31000ac1"


### PR DESCRIPTION
[@@deriving hash]

- Project page: <a href="https://github.com/sim642/ppx_deriving_hash">https://github.com/sim642/ppx_deriving_hash</a>

##### CHANGES:

* Add `lazy` support (sim642/ppx_deriving_hash#5).
* Migrate to OCaml 5.2 AST for ppxlib 0.36.0 (sim642/ppx_deriving_hash#6).
