### PR TITLE
Add `x-maintenance-intent` to encoding and smtml

### DIFF
--- a/packages/encoding/encoding.0.0.4/opam
+++ b/packages/encoding/encoding.0.0.4/opam
@@ -46,3 +46,4 @@ url {
 }
 messages: [ "encoding is Deprecated. You should consider using 'smtml' instead" ]
 flags: deprecated
+x-maintenance-intent: [ "(none)" ]

--- a/packages/smtml/smtml.0.6.1/opam
+++ b/packages/smtml/smtml.0.6.1/opam
@@ -77,3 +77,4 @@ url {
     "sha512=f2e1b073ed59a6bb8aa7739d0293ea14b748b6bd32604104de552c6dfedb8777ce6319420b2ce42139611102b6cde167c4441ad74e4ea35ec9a8a2f34ba301ca"
   ]
 }
+x-maintenance-intent: [ "(latest)" ]


### PR DESCRIPTION
I don't know if I need to add this to every opam file in the packages or if adding it to the latest version is enough. As a follow-up question, for future releases of smtml, I should continue to include `x-maintenance-intent: [ "(latest)" ]`, right?