### PR TITLE
[new release] fswatch

### DIFF
--- a/packages/fswatch/fswatch.11-0.1.5/opam
+++ b/packages/fswatch/fswatch.11-0.1.5/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://github.com/kandu/ocaml-fswatch/"
+bug-reports: "https://github.com/kandu/ocaml-fswatch/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/kandu/ocaml-fswatch"
+build: [
+  ["sh" "-exec" "echo \\(-I/usr/local/include/libfswatch/c -I/usr/include/libfswatch/c\\) > fswatch/src/inc_cflags"] { !(os-distribution = "homebrew" & arch = "arm64") & os-family != "bsd" }
+  ["sh" "-exec" "echo -lfswatch > fswatch/src/inc_libs"] { !(os-distribution = "homebrew" & arch = "arm64") & os-family != "bsd" }
+
+  ["sh" "-exec" "echo -I$(brew --prefix)/include/libfswatch/c > fswatch/src/inc_cflags"] { os-distribution = "homebrew" & arch = "arm64" }
+  ["sh" "-exec" "echo \\(-L$(brew --prefix)/lib -lfswatch\\) > fswatch/src/inc_libs"] { os-distribution = "homebrew" & arch = "arm64" }
+
+  ["sh" "-exec" "echo -I/usr/local/include/libfswatch/c > fswatch/src/inc_cflags"] { os-family = "bsd" }
+  ["sh" "-exec" "echo \\(-L/usr/local/lib -lfswatch\\) > fswatch/src/inc_libs"] { os-family = "bsd" }
+
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-fswatch"
+  "dune" {>= "1.4"}
+]
+
+synopsis: "Bindings for libfswatch -- file change monitor"
+description: """fswatch is a file change monitor that receives notifications when the contents of the specified files or directories are modified."""
+
+url {
+  src: "https://github.com/kandu/ocaml-fswatch/archive/11-0.1.5.tar.gz"
+  checksum: [
+    "sha256=b8b694abf73ca633eafa5f611b7140adacd5102bdded99453cd2da4d58c8bd58"
+    "md5=bea57e7942c8230c4b329e48417609f2"
+  ]
+}

--- a/packages/fswatch/fswatch.11-0.1.6/opam
+++ b/packages/fswatch/fswatch.11-0.1.6/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://github.com/kandu/ocaml-fswatch/"
+bug-reports: "https://github.com/kandu/ocaml-fswatch/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/kandu/ocaml-fswatch"
+build: [
+  ["sh" "-exec" "echo \\(-I/usr/local/include/libfswatch/c -I/usr/include/libfswatch/c\\) > fswatch/src/inc_cflags"] { !(os-distribution = "homebrew" & arch = "arm64") & os-family != "bsd" }
+  ["sh" "-exec" "echo -lfswatch > fswatch/src/inc_libs"] { !(os-distribution = "homebrew" & arch = "arm64") & os-family != "bsd" }
+
+  ["sh" "-exec" "echo -I$(brew --prefix)/include/libfswatch/c > fswatch/src/inc_cflags"] { os-distribution = "homebrew" & arch = "arm64" }
+  ["sh" "-exec" "echo \\(-L$(brew --prefix)/lib -lfswatch\\) > fswatch/src/inc_libs"] { os-distribution = "homebrew" & arch = "arm64" }
+
+  ["sh" "-exec" "echo -I/usr/local/include/libfswatch/c > fswatch/src/inc_cflags"] { os-family = "bsd" }
+  ["sh" "-exec" "echo \\(-L/usr/local/lib -lfswatch\\) > fswatch/src/inc_libs"] { os-family = "bsd" }
+
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "conf-fswatch"
+  "dune" {>= "1.4"}
+]
+
+synopsis: "Bindings for libfswatch -- file change monitor"
+description: """fswatch is a file change monitor that receives notifications when the contents of the specified files or directories are modified."""
+
+url {
+  src: "https://github.com/kandu/ocaml-fswatch/archive/11-0.1.6.tar.gz"
+  checksum: [
+    "sha256=b70b4ac61b3fc36b2dcde9e87dcec410531f6addf21d6e437d75fd5eeb2efb73"
+    "md5=f7dc5c7ce67bd09e5ff09603a9cedbd2"
+  ]
+}


### PR DESCRIPTION
11-0.1.6 (2025-03-21)
----------------------

compatible with fswatch 1.18

11-0.1.5 (2025-03-21)
----------------------

drop the workaround for the extra-thread malbehavior of fswatch