### PR TITLE
Release ppx_deriving_yojson.3.10.0

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.10.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.10.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving_yojson"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving_yojson/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving_yojson.git"
+tags: [ "syntax" "json" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.0"}
+  "yojson" {>= "1.6.0"}
+  "ppx_deriving" {>= "6.1"}
+  "ppxlib" {>= "0.36.0"}
+  "ounit2" {with-test}
+]
+synopsis:
+  "JSON codec generator for OCaml"
+description: """
+ppx_deriving_yojson is a ppx_deriving plugin that provides
+a JSON codec generator.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_deriving_yojson/releases/download/v3.10.0/ppx_deriving_yojson-3.10.0.tbz"
+  checksum: [
+    "sha256=ced3d265e4287f1f18b09df6446a24444fad52b2a3054cbcbe0c9494d0e89b3f"
+    "sha512=038752a73690dc1b55031c119f57ee27fbee0d51a4a541d2f31ad1baf8b05637396c0b97a7dbfd77db600b689e90a62bfff7ca3fcf74545bd5b32dc3dabff511"
+  ]
+}
+x-commit-hash: "89f6c1deb9e2daa4370e70bae11ba76b9ca19e98"


### PR DESCRIPTION
**CHANGES:**
- Bump to ppxlib.0.36.0, 5.2 AST (ocaml-ppx/ppx_deriving_yojson#160, @patricoferris)
- Fix more `Poly_typ ([], ...)` nodes generation (ocaml-ppx/ppx_deriving_yojson#160, @NathanReb)
