### PR TITLE
6 packages from gitlab.com/api/v4/projects/60486861/packages/generic/src/2.3.0-5/MlFront.tar.gz

### DIFF
--- a/packages/MlFront_Cache/MlFront_Cache.2.3.0/opam
+++ b/packages/MlFront_Cache/MlFront_Cache.2.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Caching for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "bos" {>= "0.2.1"}
+  "fmt" {>= "0.9.0"}
+  "fpath" {>= "0.7.3"}
+  "mirage-crypto-rng" {>= "2.0.0"}
+  "sqlite3" {>= "5.2.0"}
+  "uuidm" {>= "0.9.8"}
+  "MlFront_Core" {= version}
+  "MlFront_Errors" {= version}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.3.0-5/MlFront.tar.gz"
+  checksum: [
+    "md5=ab44f53bf2de58dd79e705341b14efe7"
+    "sha512=1f38ce5fbc5a4d4656c0c1ce89356e155387b2421adff8f99e0596f5d7746bcb0a2a4b2c3efada51ab9cebd61210e475c135c78d0f15c4384f73bb81b190b3f0"
+  ]
+}

--- a/packages/MlFront_Cli/MlFront_Cli.2.3.0/opam
+++ b/packages/MlFront_Cli/MlFront_Cli.2.3.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Command line interfaces for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14.0"}
+  "bos" {>= "0.2.1"}
+  "cmdliner" {>= "1.2.0"}
+  "crunch" {>= "3.3.1"}
+  "fmt" {>= "0.9.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "stringext" {>= "1.6.0"}
+  "diskuvbox" {with-test & >= "0.2.0"}
+  "ezjsonm" {>= "1.3.0"}
+  "menhir" {>= "20180523"}
+  "containers-data" {with-test & >= "3.13.1"}
+  "digestif" {>= "1.1.4"}
+  "crowbar" {with-test & >= "0.2.1"}
+  "re" {with-test & >= "1.11.0"}
+  "stringext" {with-test & >= "1.6.0"}
+  "tezt" {with-test & >= "4.1.0"}
+  "ppxlib" {with-test & >= "0.30.0"}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "sh"
+    "ci/build-cli.sh"
+    "-t" {with-test}
+    "-d" {with-doc}
+    "-a"
+    "windows_unknown" {os = "win32"}
+    "unix_unknown" {!(os = "win32")}
+  ]
+  ["install" "MlFront_Cli.install.win32" "MlFront_Cli.install"]
+    {os = "win32"}
+  ["install" "MlFront_Cli.install.unix" "MlFront_Cli.install"]
+    {!(os = "win32")}
+]
+build-env: DISABLE_PPXLIB_TESTS = "1"
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.3.0-5/MlFront.tar.gz"
+  checksum: [
+    "md5=ab44f53bf2de58dd79e705341b14efe7"
+    "sha512=1f38ce5fbc5a4d4656c0c1ce89356e155387b2421adff8f99e0596f5d7746bcb0a2a4b2c3efada51ab9cebd61210e475c135c78d0f15c4384f73bb81b190b3f0"
+  ]
+}

--- a/packages/MlFront_Core/MlFront_Core.2.3.0/opam
+++ b/packages/MlFront_Core/MlFront_Core.2.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Module and library identification for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "digestif" {>= "1.1.4"}
+  "stringext" {>= "1.6.0"}
+  "crowbar" {with-test & >= "0.2.1"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.3.0-5/MlFront.tar.gz"
+  checksum: [
+    "md5=ab44f53bf2de58dd79e705341b14efe7"
+    "sha512=1f38ce5fbc5a4d4656c0c1ce89356e155387b2421adff8f99e0596f5d7746bcb0a2a4b2c3efada51ab9cebd61210e475c135c78d0f15c4384f73bb81b190b3f0"
+  ]
+}

--- a/packages/MlFront_Errors/MlFront_Errors.2.3.0/opam
+++ b/packages/MlFront_Errors/MlFront_Errors.2.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Error handling for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "fmt" {>= "0.9.0"}
+  "logs" {>= "0.7.0"}
+  "stringext" {>= "1.6.0"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.3.0-5/MlFront.tar.gz"
+  checksum: [
+    "md5=ab44f53bf2de58dd79e705341b14efe7"
+    "sha512=1f38ce5fbc5a4d4656c0c1ce89356e155387b2421adff8f99e0596f5d7746bcb0a2a4b2c3efada51ab9cebd61210e475c135c78d0f15c4384f73bb81b190b3f0"
+  ]
+}

--- a/packages/MlFront_Manip/MlFront_Manip.2.3.0/opam
+++ b/packages/MlFront_Manip/MlFront_Manip.2.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Binary manipulation tools for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "tezt" {with-test & >= "4.1.0"}
+  "ppxlib" {with-test & >= "0.30.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.3.0-5/MlFront.tar.gz"
+  checksum: [
+    "md5=ab44f53bf2de58dd79e705341b14efe7"
+    "sha512=1f38ce5fbc5a4d4656c0c1ce89356e155387b2421adff8f99e0596f5d7746bcb0a2a4b2c3efada51ab9cebd61210e475c135c78d0f15c4384f73bb81b190b3f0"
+  ]
+}

--- a/packages/MlFront_ZipFile/MlFront_ZipFile.2.3.0/opam
+++ b/packages/MlFront_ZipFile/MlFront_ZipFile.2.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Zip files for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "re" {>= "1.11.0"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.3.0-5/MlFront.tar.gz"
+  checksum: [
+    "md5=ab44f53bf2de58dd79e705341b14efe7"
+    "sha512=1f38ce5fbc5a4d4656c0c1ce89356e155387b2421adff8f99e0596f5d7746bcb0a2a4b2c3efada51ab9cebd61210e475c135c78d0f15c4384f73bb81b190b3f0"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `MlFront_Cache.2.3.0`: Caching for MlFront
- `MlFront_Cli.2.3.0`: Command line interfaces for MlFront
- `MlFront_Core.2.3.0`: Module and library identification for MlFront
- `MlFront_Errors.2.3.0`: Error handling for MlFront
- `MlFront_Manip.2.3.0`: Binary manipulation tools for MlFront
- `MlFront_ZipFile.2.3.0`: Zip files for MlFront



---
* Homepage: https://diskuv.com/mlfront/overview-1/
* Source repo: git+https://gitlab.com/dkml/build-tools/MlFront.git
* Bug tracker: https://gitlab.com/dkml/build-tools/MlFront/-/issues

---
:camel: Pull-request generated by opam-publish v2.5.0