### PR TITLE
[new release] Melange 5.1.0

### DIFF
--- a/packages/melange/melange.5.1.0-414/opam
+++ b/packages/melange/melange.5.1.0-414/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "4.14" & < "5.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {dev & with-test}
+  "ppxlib" {>= "0.30.0" & < "0.36.0"}
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/5.1.0-414/melange-5.1.0-414.tbz"
+  checksum: [
+    "sha256=4afd57c8ea823612024ec5f37ad5e1ff3a97fed753ba9619d10d676512dfa5ed"
+    "sha512=711fc4046b08ef602aefce6e11e5e039933ff7eafe326fcdfc4e5e9ae08d6e7b6a2dd3dc8c1bf1bbcb545b8be4772e6c4313f10ca65a332530a399be11058ef0"
+  ]
+}
+x-commit-hash: "018b44a0d511e48bde78f0b1f7ac5750423bdd9f"

--- a/packages/melange/melange.5.1.0-51/opam
+++ b/packages/melange/melange.5.1.0-51/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "5.1.1" & < "5.2"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {dev & with-test}
+  "ppxlib" {>= "0.30.0" & < "0.36.0"}
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/5.1.0-51/melange-5.1.0-51.tbz"
+  checksum: [
+    "sha256=0c817cbd92c42ac15fea6e6d975fd3eb3aa31f22b10cca22b3687ffed0e1b092"
+    "sha512=a0b85e22b106df7e9448d12977b740f735445640d4a9368591bdf5e67a95b93d5aacf957086c524549e3402faf0916c3f501ba43a631c74d8af4a7c986842c09"
+  ]
+}
+x-commit-hash: "168ea5c56d5f2b16cdf8070f44919d7e41a62e2d"

--- a/packages/melange/melange.5.1.0-52/opam
+++ b/packages/melange/melange.5.1.0-52/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "5.2" & < "5.3"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {dev & with-test}
+  "ppxlib" {>= "0.30.0" & < "0.36.0"}
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/5.1.0-52/melange-5.1.0-52.tbz"
+  checksum: [
+    "sha256=1062089c60a8dc900363213898bc39173926e0e07e57dca2d9ac95d2556adefd"
+    "sha512=6581a4a2f6f50783324967362acf4d5404b735e3c02f0d1659d58cb9b5a2a37b6f03c2346f652a2f77a042b84cfb27a0139d7674f81f0edb7a6b7b558c8c4235"
+  ]
+}
+x-commit-hash: "7fef609b2770933f1d99ebfb05fe693e79880bb6"

--- a/packages/melange/melange.5.1.0-53/opam
+++ b/packages/melange/melange.5.1.0-53/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "5.3"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {dev & with-test}
+  "ppxlib" {>= "0.30.0" & < "0.36.0"}
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/5.1.0-53/melange-5.1.0-53.tbz"
+  checksum: [
+    "sha256=f7aac30f3ba5feff8373e2164cdb5b38a59457cadfec74b564c2b62d035ca4a9"
+    "sha512=39a0b7430035b5355bad4f42fb07d719da56e457d78399fc34c38e5eeb6e5e5259f06a1209dc00325818e3dc1dd9a5988f6a25c106d2ee0ee2033ab9074791cd"
+  ]
+}
+x-commit-hash: "2432b02d9c1990ae62fd44fad8bb53ea35b1e6b0"


### PR DESCRIPTION
- Update JS reserved keywords ([#1338](https://github.com/melange-re/melange/pull/1338))
- Remove errors for `bs.*` and non-namespaced attributes ([#1348](https://github.com/melange-re/melange/pull/1348))
    - These attributes haven't been supported since Melange v4, and deprecated
      before that
    - erroring on e.g. attributes like `@as` prevents e.g. universal libraries
      that want to use PPXes supporting `@as` with native semantics.
- remove `@mel.splice` error ([#1350](https://github.com/melange-re/melange/pull/1350))
    - `@mel.splice` has been removed in earlier Melange versions and it has
      been producing errors for the last 2 versions. Since ecosystem libraries
      have been keeping up to date with Melange versions, after this change, it
      will be silently ignored.
- allow `@mel.as "constant"` and `@mel.this` to coexist -- marking the constant argument as the instance / self argument
  ([#1353](https://github.com/melange-re/melange/pull/1353))
- JS generation: improve indentation of `new` blocks ([#1360](https://github.com/melange-re/melange/pull/1360))
- JS generation: improve indentation of blocks with array/string/char accesses ([#1361](https://github.com/melange-re/melange/pull/1361))
- runtime: improve the runtime for exceptions / extensible variants to account
  for sharing extensions across contexts ([#1326](https://github.com/melange-re/melange/pull/1326))
    - This change moves the exception runtime from a global counter to a
      counter _per module_. This impacts calls to `Printexc.exn_slot_id` and
      `Printexc.exn_slot_name`, which would previously return the global
      identifier at exception creation, and will now return the module-local
      runtime identifier.
- build: fix Melange build on dune profiles other than `dev` / `release` ([#1365](https://github.com/melange-re/melange/pull/1365))
- core, runtime: optimize throwing errors in Melange, fix re-throwing regression and throwing JS values ([#1362](https://github.com/melange-re/melange/pull/1362))
- runtime: add `Js.Fetch` module with types for `fetch` in JS ([#1343](https://github.com/melange-re/melange/pull/1343))
- runtime: add `Js.ReadableStream` module to unify around its type in community libraries ([#1344](https://github.com/melange-re/melange/pull/1344))
- runtime: add `Js.WritableStream` ([#1367](https://github.com/melange-re/melange/pull/1367))

