### PR TITLE
Point coq/coqide/coq-stdlib release tarballs to checksum-stable released tarballs

### DIFF
--- a/packages/coq-core/coq-core.8.17.0/opam
+++ b/packages/coq-core/coq-core.8.17.0/opam
@@ -61,6 +61,6 @@ dev-repo: "git+https://github.com/coq/coq.git"
 depopts: ["coq-native"]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.17.0/coq-8.17.0.tar.gz"
   checksum: "sha512=2f77bcb5211018b5d46320fd39fd34450eeb654aca44551b28bb50a2364398c4b34587630b6558db867ecfb63b246fd3e29dc2375f99967ff62bc002db9c3250"
 }

--- a/packages/coq-core/coq-core.8.17.1/opam
+++ b/packages/coq-core/coq-core.8.17.1/opam
@@ -60,6 +60,6 @@ dev-repo: "git+https://github.com/coq/coq.git"
 depopts: ["coq-native"]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.17.1/coq-8.17.1.tar.gz"
   checksum: "sha512=9a35311acec2a806730b94ac7dceabc88837f235c52a14c026827d9b89433bd7fa9555a9fc6829aa49edfedb24c8bbaf1411ebf463b74a50aeb17cba47745b6b"
 }

--- a/packages/coq-stdlib/coq-stdlib.8.17.0/opam
+++ b/packages/coq-stdlib/coq-stdlib.8.17.0/opam
@@ -48,6 +48,6 @@ dev-repo: "git+https://github.com/coq/coq.git"
 depopts: ["coq-native"]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.17.0/coq-8.17.0.tar.gz"
   checksum: "sha512=2f77bcb5211018b5d46320fd39fd34450eeb654aca44551b28bb50a2364398c4b34587630b6558db867ecfb63b246fd3e29dc2375f99967ff62bc002db9c3250"
 }

--- a/packages/coq-stdlib/coq-stdlib.8.17.1/opam
+++ b/packages/coq-stdlib/coq-stdlib.8.17.1/opam
@@ -48,6 +48,6 @@ dev-repo: "git+https://github.com/coq/coq.git"
 depopts: ["coq-native"]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.17.1/coq-8.17.1.tar.gz"
   checksum: "sha512=9a35311acec2a806730b94ac7dceabc88837f235c52a14c026827d9b89433bd7fa9555a9fc6829aa49edfedb24c8bbaf1411ebf463b74a50aeb17cba47745b6b"
 }

--- a/packages/coq/coq.8.10.0/opam
+++ b/packages/coq/coq.8.10.0/opam
@@ -40,7 +40,7 @@ patches: ["fix-parallel-make.patch"
          ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.10.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.10.0/coq-8.10.0.tar.gz"
   checksum: "sha512=f3da7f77f5ec760d6339233f5fcb3d743092d05baa33f3f0781e6729bcb996b14c2cfc45f5000a6fc4cee10b9e7532682bddda25c5dc2616d9e7ca70306b4724"
 }
 extra-source "fix-parallel-make.patch" {

--- a/packages/coq/coq.8.10.1/opam
+++ b/packages/coq/coq.8.10.1/opam
@@ -47,7 +47,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.10.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.10.1/coq-8.10.1.tar.gz"
   checksum: "sha512=5c6a20e283c351a4b0ecdb393fb77cfc9b72b474453c99c95f52a70da47dd72fff7229c2ef92d61aadade8f2ed6e03c1a7740d0fa2fcc87ea72659f95eceb2dc"
 }
 extra-source "coq.install" {

--- a/packages/coq/coq.8.10.2/opam
+++ b/packages/coq/coq.8.10.2/opam
@@ -47,7 +47,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.10.2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.10.2/coq-8.10.2.tar.gz"
   checksum: "sha512=80df91b64efc9907480388ec479362ee21067c64436da720989d6d1645ffc2f2230ae5c13069c55842da3baa7facbd143c2190d1d64d8c87935802000a02156f"
 }
 extra-source "coq.install" {

--- a/packages/coq/coq.8.11.0/opam
+++ b/packages/coq/coq.8.11.0/opam
@@ -47,7 +47,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.11.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.11.0/coq-8.11.0.tar.gz"
   checksum: "sha512=db7c3da4bab268cb729bcf9f03f5cd3bbb7a3b5b7094fe2b110189e54e436f9883640db88643d09cec5dc169c209a51661238e41b8de3035ff7ea8561c794c89"
 }
 extra-source "coq.install" {

--- a/packages/coq/coq.8.11.1/opam
+++ b/packages/coq/coq.8.11.1/opam
@@ -47,7 +47,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.11.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.11.1/coq-8.11.1.tar.gz"
   checksum: "sha512=974f09268ca729b525884e02e3179837e31f8001a2c244f138a36a7984329324083e66d07526bba89acaed656eb7711e2c5b257517309d0479839c5d1ac96aa5"
 }
 extra-source "coq.install" {

--- a/packages/coq/coq.8.11.2/opam
+++ b/packages/coq/coq.8.11.2/opam
@@ -47,7 +47,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.11.2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.11.2/coq-8.11.2.tar.gz"
   checksum: "sha512=f8ab307b8e39ffda5f6984e187c1f8de1cb6dec5c322726dbbe535ee611683cfeeb9cee3e11ad83f5e44e843fc51e7e2d50b4ea69ab42fde38aaf3d0cf2dea3c"
 }
 extra-source "coq.install" {

--- a/packages/coq/coq.8.12.0/opam
+++ b/packages/coq/coq.8.12.0/opam
@@ -47,7 +47,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.12.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.12.0/coq-8.12.0.tar.gz"
   checksum: "sha512=8a64624c578ce0ab781fb3b1f162bd8b095735ad891fdad2fb7c40849afbdc7c1360187c6b62a5ef2982566f4c6c78029240c611ae769943a5250af300eb1240"
 }
 extra-source "coq.install" {

--- a/packages/coq/coq.8.12.1/opam
+++ b/packages/coq/coq.8.12.1/opam
@@ -47,7 +47,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.12.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.12.1/coq-8.12.1.tar.gz"
   checksum: "sha512=39452c86a35403b4ca7427c1973b93bc4d1e0052f12a53608ca94bbd2a4f902b9fc0f58b550b7eba03c2d346e06989104e92eee0d842ec267ce69200b8aa37a6"
 }
 extra-source "coq.install" {

--- a/packages/coq/coq.8.12.2/opam
+++ b/packages/coq/coq.8.12.2/opam
@@ -47,7 +47,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.12.2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.12.2/coq-8.12.2.tar.gz"
   checksum: "sha512=6b524edbceb5795f04bbd2b52f191bfcf10b611f7a2fa0450c30b72c944f88418d261729476b64603faacfe2be5f7992a2997541e54e6f8691d4dc8b4969198d"
 }
 extra-source "coq.install" {

--- a/packages/coq/coq.8.13.0/opam
+++ b/packages/coq/coq.8.13.0/opam
@@ -54,7 +54,7 @@ install: [
 patches: [ "disable_warn_70.patch" ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.13.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.13.0/coq-8.13.0.tar.gz"
   checksum: "sha256=06445dbd6cb3c8a2e4e957dbd12e094d609a62fcb0c8c3cad0cd1fdedda25c9b"
 }
 extra-source "disable_warn_70.patch" {

--- a/packages/coq/coq.8.13.1/opam
+++ b/packages/coq/coq.8.13.1/opam
@@ -54,7 +54,7 @@ install: [
 patches: [ "disable_warn_70.patch" ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.13.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.13.1/coq-8.13.1.tar.gz"
   checksum: "sha256=95e71b16e6f3592e53d8bb679f051b062afbd12069a4105ffc9ee50e421d4685"
 }
 extra-source "disable_warn_70.patch" {

--- a/packages/coq/coq.8.13.2/opam
+++ b/packages/coq/coq.8.13.2/opam
@@ -54,7 +54,7 @@ install: [
 patches: [ "disable_warn_70.patch" ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.13.2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.13.2/coq-8.13.2.tar.gz"
   checksum: "sha256=1e7793d8483f1e939f62df6749f843df967a15d843a4a5acb024904b76e25a14"
 }
 extra-source "disable_warn_70.patch" {

--- a/packages/coq/coq.8.14.0/opam
+++ b/packages/coq/coq.8.14.0/opam
@@ -52,7 +52,7 @@ install: [
 patches: [ "dune-install-set-root.patch" "ld_stricter.patch" "disable_warn_70.patch" ]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.14.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.14.0/coq-8.14.0.tar.gz"
   checksum: "sha256=b1501d686c21836302191ae30f610cca57fb309214c126518ca009363ad2cd3c"
 }
 extra-source "ld_stricter.patch" {

--- a/packages/coq/coq.8.14.1/opam
+++ b/packages/coq/coq.8.14.1/opam
@@ -52,7 +52,7 @@ install: [
 patches: [ "ld_stricter.patch" ]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.14.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.14.1/coq-8.14.1.tar.gz"
   checksum: "sha256=3cbfc1e1a72b16d4744f5b64ede59586071e31d9c11c811a0372060727bfd9c3"
 }
 extra-source "ld_stricter.patch" {

--- a/packages/coq/coq.8.15.0/opam
+++ b/packages/coq/coq.8.15.0/opam
@@ -50,6 +50,6 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.15.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.15.0/coq-8.15.0.tar.gz"
   checksum: "sha256=73466e61f229b23b4daffdd964be72bd7a110963b9d84bd4a86bb05c5dc19ef3"
 }

--- a/packages/coq/coq.8.15.1/opam
+++ b/packages/coq/coq.8.15.1/opam
@@ -50,6 +50,6 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.15.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.15.1/coq-8.15.1.tar.gz"
   checksum: "sha256=513e953b7183d478acb75fd6e80e4dc32ac1a918cf4343ac31a859cfb4e9aad2"
 }

--- a/packages/coq/coq.8.15.2/opam
+++ b/packages/coq/coq.8.15.2/opam
@@ -50,6 +50,6 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.15.2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.15.2/coq-8.15.2.tar.gz"
   checksum: "sha256=13a67c0a4559ae22e9765c8fdb88957b16c2b335a2d5f47e4d6d9b4b8b299926"
 }

--- a/packages/coq/coq.8.16.0/opam
+++ b/packages/coq/coq.8.16.0/opam
@@ -50,6 +50,6 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.16.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.16.0/coq-8.16.0.tar.gz"
   checksum: "sha256=36577b55f4a4b1c64682c387de7abea932d0fd42fc0cd5406927dca344f53587"
 }

--- a/packages/coq/coq.8.16.1/opam
+++ b/packages/coq/coq.8.16.1/opam
@@ -50,6 +50,6 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.16.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.16.1/coq-8.16.1.tar.gz"
   checksum: "sha256=583471c8ed4f227cb374ee8a13a769c46579313d407db67a82d202ee48300e4b"
 }

--- a/packages/coq/coq.8.17.0/opam
+++ b/packages/coq/coq.8.17.0/opam
@@ -40,6 +40,6 @@ build: [
 dev-repo: "git+https://github.com/coq/coq.git"
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.17.0/coq-8.17.0.tar.gz"
   checksum: "sha512=2f77bcb5211018b5d46320fd39fd34450eeb654aca44551b28bb50a2364398c4b34587630b6558db867ecfb63b246fd3e29dc2375f99967ff62bc002db9c3250"
 }

--- a/packages/coq/coq.8.17.1/opam
+++ b/packages/coq/coq.8.17.1/opam
@@ -40,6 +40,6 @@ build: [
 dev-repo: "git+https://github.com/coq/coq.git"
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.17.1/coq-8.17.1.tar.gz"
   checksum: "sha512=9a35311acec2a806730b94ac7dceabc88837f235c52a14c026827d9b89433bd7fa9555a9fc6829aa49edfedb24c8bbaf1411ebf463b74a50aeb17cba47745b6b"
 }

--- a/packages/coq/coq.8.7.0/opam
+++ b/packages/coq/coq.8.7.0/opam
@@ -63,7 +63,7 @@ depends: [
 synopsis: "Formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.7.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.7.0/coq-8.7.0.tar.gz"
   checksum: [
     "sha256=f376207ed051b3fd27c519f44b25eb25f8dddbce22715f68c3cedfd2e4b39297"
     "md5=4d79181b17c63fe5287aeaf6263077e7"

--- a/packages/coq/coq.8.7.1+1/opam
+++ b/packages/coq/coq.8.7.1+1/opam
@@ -65,7 +65,7 @@ depends: [
 synopsis: "Formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.7.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.7.1/coq-8.7.1.tar.gz"
   checksum: [
     "sha256=d381b38522cee0e73804ee3a763648f602eda942312c18d333f9567c56dbfd03"
     "md5=15347f45471e2d5277c60585297cd3e0"

--- a/packages/coq/coq.8.7.1+2/opam
+++ b/packages/coq/coq.8.7.1+2/opam
@@ -67,7 +67,7 @@ depends: [
 synopsis: "Formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.7.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.7.1/coq-8.7.1.tar.gz"
   checksum: [
     "sha256=d381b38522cee0e73804ee3a763648f602eda942312c18d333f9567c56dbfd03"
     "md5=15347f45471e2d5277c60585297cd3e0"

--- a/packages/coq/coq.8.7.1/opam
+++ b/packages/coq/coq.8.7.1/opam
@@ -62,7 +62,7 @@ depends: [
 synopsis: "Formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.7.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.7.1/coq-8.7.1.tar.gz"
   checksum: [
     "sha256=d381b38522cee0e73804ee3a763648f602eda942312c18d333f9567c56dbfd03"
     "md5=15347f45471e2d5277c60585297cd3e0"

--- a/packages/coq/coq.8.7.2/opam
+++ b/packages/coq/coq.8.7.2/opam
@@ -63,7 +63,7 @@ remove: [
 synopsis: "Formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.7.2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.7.2/coq-8.7.2.tar.gz"
   checksum: [
     "sha256=ef25c3979f69b891d40a8776b96059229b06de3d037923de9c657faf8ede78d2"
     "md5=470c8f2bd74a085e1f71d5e4770e64e7"

--- a/packages/coq/coq.8.8.0/opam
+++ b/packages/coq/coq.8.8.0/opam
@@ -63,7 +63,7 @@ remove: [
 synopsis: "Formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.8.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.8.0/coq-8.8.0.tar.gz"
   checksum: [
     "sha256=caf7c1d39e68e0e41ed92be1d57c88983fb12edb9fa95667a5ad2d6aba98263d"
     "md5=9c97bb78eb051178d8b3731ae042c73f"

--- a/packages/coq/coq.8.8.1/opam
+++ b/packages/coq/coq.8.8.1/opam
@@ -63,7 +63,7 @@ remove: [
 synopsis: "Formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.8.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.8.1/coq-8.8.1.tar.gz"
   checksum: [
     "sha256=c852fef30f511135993bc9dbed299849663d0096a72bf0797a133f86deda9e8d"
     "md5=2dc320d35d4b1ffce5db1dc92c3aeb24"

--- a/packages/coq/coq.8.8.2/opam
+++ b/packages/coq/coq.8.8.2/opam
@@ -63,7 +63,7 @@ remove: [
 synopsis: "Formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.8.2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.8.2/coq-8.8.2.tar.gz"
   checksum: [
     "sha256=f9f843b21fda18195fbf80c706bce8ac70ccb43cbd82f6916747dc6c22d05044"
     "md5=5d693cd1953a0dd74920b43d183bc26c"

--- a/packages/coq/coq.8.9.0/opam
+++ b/packages/coq/coq.8.9.0/opam
@@ -58,7 +58,7 @@ remove: [
 synopsis: "Formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.9.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.9.0/coq-8.9.0.tar.gz"
   checksum: [
     "sha256=8bd6e2bc8d79f96df19b8888ebfbdfdbe50fa9cd3fb969c13b610f7d05070ff0"
     "md5=490c89609c1271fe7f20e6ea1bd107b5"

--- a/packages/coq/coq.8.9.1/opam
+++ b/packages/coq/coq.8.9.1/opam
@@ -40,7 +40,7 @@ install: [
 patches: ["ocaml408_compat.patch"]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.9.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.9.1/coq-8.9.1.tar.gz"
   checksum: [
     "sha256=87251327e8a1e25c6b08b5c0ae8e7cdf3a91a5f30832bbe74ccc4f0bde9618ea"
     "md5=b0e47c588ca498073ad35eb5627a8852"

--- a/packages/coqide-server/coqide-server.8.17.0/opam
+++ b/packages/coqide-server/coqide-server.8.17.0/opam
@@ -35,6 +35,6 @@ build: [
 dev-repo: "git+https://github.com/coq/coq.git"
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.17.0/coq-8.17.0.tar.gz"
   checksum: "sha512=2f77bcb5211018b5d46320fd39fd34450eeb654aca44551b28bb50a2364398c4b34587630b6558db867ecfb63b246fd3e29dc2375f99967ff62bc002db9c3250"
 }

--- a/packages/coqide-server/coqide-server.8.17.1/opam
+++ b/packages/coqide-server/coqide-server.8.17.1/opam
@@ -35,6 +35,6 @@ build: [
 dev-repo: "git+https://github.com/coq/coq.git"
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.17.1/coq-8.17.1.tar.gz"
   checksum: "sha512=9a35311acec2a806730b94ac7dceabc88837f235c52a14c026827d9b89433bd7fa9555a9fc6829aa49edfedb24c8bbaf1411ebf463b74a50aeb17cba47745b6b"
 }

--- a/packages/coqide/coqide.8.10.0/opam
+++ b/packages/coqide/coqide.8.10.0/opam
@@ -36,7 +36,7 @@ install: [
 patches: ["fix-parallel-make.patch"]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.10.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.10.0/coq-8.10.0.tar.gz"
   checksum: "sha512=f3da7f77f5ec760d6339233f5fcb3d743092d05baa33f3f0781e6729bcb996b14c2cfc45f5000a6fc4cee10b9e7532682bddda25c5dc2616d9e7ca70306b4724"
 }
 extra-source "fix-parallel-make.patch" {

--- a/packages/coqide/coqide.8.10.1/opam
+++ b/packages/coqide/coqide.8.10.1/opam
@@ -40,7 +40,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.10.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.10.1/coq-8.10.1.tar.gz"
   checksum: "sha512=5c6a20e283c351a4b0ecdb393fb77cfc9b72b474453c99c95f52a70da47dd72fff7229c2ef92d61aadade8f2ed6e03c1a7740d0fa2fcc87ea72659f95eceb2dc"
 }
 extra-source "coqide.install" {

--- a/packages/coqide/coqide.8.10.2/opam
+++ b/packages/coqide/coqide.8.10.2/opam
@@ -40,7 +40,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.10.2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.10.2/coq-8.10.2.tar.gz"
   checksum: "sha512=80df91b64efc9907480388ec479362ee21067c64436da720989d6d1645ffc2f2230ae5c13069c55842da3baa7facbd143c2190d1d64d8c87935802000a02156f"
 }
 extra-source "coqide.install" {

--- a/packages/coqide/coqide.8.11.0/opam
+++ b/packages/coqide/coqide.8.11.0/opam
@@ -40,7 +40,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.11.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.11.0/coq-8.11.0.tar.gz"
   checksum: "sha512=db7c3da4bab268cb729bcf9f03f5cd3bbb7a3b5b7094fe2b110189e54e436f9883640db88643d09cec5dc169c209a51661238e41b8de3035ff7ea8561c794c89"
 }
 extra-source "coqide.install" {

--- a/packages/coqide/coqide.8.11.1/opam
+++ b/packages/coqide/coqide.8.11.1/opam
@@ -41,7 +41,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.11.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.11.1/coq-8.11.1.tar.gz"
   checksum: "sha512=974f09268ca729b525884e02e3179837e31f8001a2c244f138a36a7984329324083e66d07526bba89acaed656eb7711e2c5b257517309d0479839c5d1ac96aa5"
 }
 extra-source "coqide.install" {

--- a/packages/coqide/coqide.8.11.2/opam
+++ b/packages/coqide/coqide.8.11.2/opam
@@ -42,7 +42,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.11.2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.11.2/coq-8.11.2.tar.gz"
   checksum: "sha512=f8ab307b8e39ffda5f6984e187c1f8de1cb6dec5c322726dbbe535ee611683cfeeb9cee3e11ad83f5e44e843fc51e7e2d50b4ea69ab42fde38aaf3d0cf2dea3c"
 }
 extra-source "coqide.install" {

--- a/packages/coqide/coqide.8.12.0/opam
+++ b/packages/coqide/coqide.8.12.0/opam
@@ -42,7 +42,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.12.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.12.0/coq-8.12.0.tar.gz"
   checksum: "sha512=8a64624c578ce0ab781fb3b1f162bd8b095735ad891fdad2fb7c40849afbdc7c1360187c6b62a5ef2982566f4c6c78029240c611ae769943a5250af300eb1240"
 }
 extra-source "coqide.install" {

--- a/packages/coqide/coqide.8.12.1/opam
+++ b/packages/coqide/coqide.8.12.1/opam
@@ -42,7 +42,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.12.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.12.1/coq-8.12.1.tar.gz"
   checksum: "sha512=39452c86a35403b4ca7427c1973b93bc4d1e0052f12a53608ca94bbd2a4f902b9fc0f58b550b7eba03c2d346e06989104e92eee0d842ec267ce69200b8aa37a6"
 }
 extra-source "coqide.install" {

--- a/packages/coqide/coqide.8.12.2/opam
+++ b/packages/coqide/coqide.8.12.2/opam
@@ -42,7 +42,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.12.2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.12.2/coq-8.12.2.tar.gz"
   checksum: "sha512=6b524edbceb5795f04bbd2b52f191bfcf10b611f7a2fa0450c30b72c944f88418d261729476b64603faacfe2be5f7992a2997541e54e6f8691d4dc8b4969198d"
 }
 extra-source "coqide.install" {

--- a/packages/coqide/coqide.8.13.0/opam
+++ b/packages/coqide/coqide.8.13.0/opam
@@ -42,7 +42,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.13.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.13.0/coq-8.13.0.tar.gz"
   checksum: "sha256=06445dbd6cb3c8a2e4e957dbd12e094d609a62fcb0c8c3cad0cd1fdedda25c9b"
 }
 extra-source "coqide.install" {

--- a/packages/coqide/coqide.8.13.1/opam
+++ b/packages/coqide/coqide.8.13.1/opam
@@ -42,7 +42,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.13.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.13.1/coq-8.13.1.tar.gz"
   checksum: "sha256=95e71b16e6f3592e53d8bb679f051b062afbd12069a4105ffc9ee50e421d4685"
 }
 extra-source "coqide.install" {

--- a/packages/coqide/coqide.8.13.2/opam
+++ b/packages/coqide/coqide.8.13.2/opam
@@ -42,7 +42,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.13.2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.13.2/coq-8.13.2.tar.gz"
   checksum: "sha256=1e7793d8483f1e939f62df6749f843df967a15d843a4a5acb024904b76e25a14"
 }
 extra-source "coqide.install" {

--- a/packages/coqide/coqide.8.14.0/opam
+++ b/packages/coqide/coqide.8.14.0/opam
@@ -35,6 +35,6 @@ build: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.14.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.14.0/coq-8.14.0.tar.gz"
   checksum: "sha256=b1501d686c21836302191ae30f610cca57fb309214c126518ca009363ad2cd3c"
 }

--- a/packages/coqide/coqide.8.14.1/opam
+++ b/packages/coqide/coqide.8.14.1/opam
@@ -35,6 +35,6 @@ build: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.14.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.14.1/coq-8.14.1.tar.gz"
   checksum: "sha256=3cbfc1e1a72b16d4744f5b64ede59586071e31d9c11c811a0372060727bfd9c3"
 }

--- a/packages/coqide/coqide.8.15.0/opam
+++ b/packages/coqide/coqide.8.15.0/opam
@@ -35,6 +35,6 @@ build: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.15.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.15.0/coq-8.15.0.tar.gz"
   checksum: "sha256=73466e61f229b23b4daffdd964be72bd7a110963b9d84bd4a86bb05c5dc19ef3"
 }

--- a/packages/coqide/coqide.8.15.1/opam
+++ b/packages/coqide/coqide.8.15.1/opam
@@ -35,6 +35,6 @@ build: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.15.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.15.1/coq-8.15.1.tar.gz"
   checksum: "sha256=513e953b7183d478acb75fd6e80e4dc32ac1a918cf4343ac31a859cfb4e9aad2"
 }

--- a/packages/coqide/coqide.8.15.2/opam
+++ b/packages/coqide/coqide.8.15.2/opam
@@ -35,6 +35,6 @@ build: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.15.2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.15.2/coq-8.15.2.tar.gz"
   checksum: "sha256=13a67c0a4559ae22e9765c8fdb88957b16c2b335a2d5f47e4d6d9b4b8b299926"
 }

--- a/packages/coqide/coqide.8.16.0/opam
+++ b/packages/coqide/coqide.8.16.0/opam
@@ -35,6 +35,6 @@ build: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.16.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.16.0/coq-8.16.0.tar.gz"
   checksum: "sha256=36577b55f4a4b1c64682c387de7abea932d0fd42fc0cd5406927dca344f53587"
 }

--- a/packages/coqide/coqide.8.16.1/opam
+++ b/packages/coqide/coqide.8.16.1/opam
@@ -35,6 +35,6 @@ build: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.16.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.16.1/coq-8.16.1.tar.gz"
   checksum: "sha256=583471c8ed4f227cb374ee8a13a769c46579313d407db67a82d202ee48300e4b"
 }

--- a/packages/coqide/coqide.8.17.0/opam
+++ b/packages/coqide/coqide.8.17.0/opam
@@ -39,6 +39,6 @@ build: [
 dev-repo: "git+https://github.com/coq/coq.git"
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.17.0/coq-8.17.0.tar.gz"
   checksum: "sha512=2f77bcb5211018b5d46320fd39fd34450eeb654aca44551b28bb50a2364398c4b34587630b6558db867ecfb63b246fd3e29dc2375f99967ff62bc002db9c3250"
 }

--- a/packages/coqide/coqide.8.17.1/opam
+++ b/packages/coqide/coqide.8.17.1/opam
@@ -39,6 +39,6 @@ build: [
 dev-repo: "git+https://github.com/coq/coq.git"
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.17.1/coq-8.17.1.tar.gz"
   checksum: "sha512=9a35311acec2a806730b94ac7dceabc88837f235c52a14c026827d9b89433bd7fa9555a9fc6829aa49edfedb24c8bbaf1411ebf463b74a50aeb17cba47745b6b"
 }

--- a/packages/coqide/coqide.8.7.1/opam
+++ b/packages/coqide/coqide.8.7.1/opam
@@ -37,7 +37,7 @@ install: [
 synopsis: "IDE of the Coq formal proof management system."
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.7.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.7.1/coq-8.7.1.tar.gz"
   checksum: [
     "sha256=d381b38522cee0e73804ee3a763648f602eda942312c18d333f9567c56dbfd03"
     "md5=15347f45471e2d5277c60585297cd3e0"

--- a/packages/coqide/coqide.8.7.2/opam
+++ b/packages/coqide/coqide.8.7.2/opam
@@ -38,7 +38,7 @@ remove: ["rm" "-rf" "%{lib}%/coq/ide" "%{doc}%/FAQ-CoqIde"]
 synopsis: "IDE of the Coq formal proof management system."
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.7.2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.7.2/coq-8.7.2.tar.gz"
   checksum: [
     "sha256=ef25c3979f69b891d40a8776b96059229b06de3d037923de9c657faf8ede78d2"
     "md5=470c8f2bd74a085e1f71d5e4770e64e7"

--- a/packages/coqide/coqide.8.8.0/opam
+++ b/packages/coqide/coqide.8.8.0/opam
@@ -38,7 +38,7 @@ remove: ["rm" "-rf" "%{lib}%/coq/ide" "%{doc}%/FAQ-CoqIde"]
 synopsis: "IDE of the Coq formal proof management system."
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.8.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.8.0/coq-8.8.0.tar.gz"
   checksum: [
     "sha256=caf7c1d39e68e0e41ed92be1d57c88983fb12edb9fa95667a5ad2d6aba98263d"
     "md5=9c97bb78eb051178d8b3731ae042c73f"

--- a/packages/coqide/coqide.8.8.1/opam
+++ b/packages/coqide/coqide.8.8.1/opam
@@ -38,7 +38,7 @@ remove: ["rm" "-rf" "%{lib}%/coq/ide" "%{doc}%/FAQ-CoqIde"]
 synopsis: "IDE of the Coq formal proof management system."
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.8.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.8.1/coq-8.8.1.tar.gz"
   checksum: [
     "sha256=c852fef30f511135993bc9dbed299849663d0096a72bf0797a133f86deda9e8d"
     "md5=2dc320d35d4b1ffce5db1dc92c3aeb24"

--- a/packages/coqide/coqide.8.8.2/opam
+++ b/packages/coqide/coqide.8.8.2/opam
@@ -38,7 +38,7 @@ remove: ["rm" "-rf" "%{lib}%/coq/ide" "%{doc}%/FAQ-CoqIde"]
 synopsis: "IDE of the Coq formal proof management system."
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.8.2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.8.2/coq-8.8.2.tar.gz"
   checksum: [
     "sha256=f9f843b21fda18195fbf80c706bce8ac70ccb43cbd82f6916747dc6c22d05044"
     "md5=5d693cd1953a0dd74920b43d183bc26c"

--- a/packages/coqide/coqide.8.9.0/opam
+++ b/packages/coqide/coqide.8.9.0/opam
@@ -38,7 +38,7 @@ remove: ["rm" "-rf" "%{lib}%/coq/ide" "%{doc}%/FAQ-CoqIde"]
 synopsis: "IDE of the Coq formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.9.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.9.0/coq-8.9.0.tar.gz"
   checksum: [
     "sha256=8bd6e2bc8d79f96df19b8888ebfbdfdbe50fa9cd3fb969c13b610f7d05070ff0"
     "md5=490c89609c1271fe7f20e6ea1bd107b5"

--- a/packages/coqide/coqide.8.9.1/opam
+++ b/packages/coqide/coqide.8.9.1/opam
@@ -37,7 +37,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/coq/coq/archive/V8.9.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.9.1/coq-8.9.1.tar.gz"
   checksum: [
     "sha256=87251327e8a1e25c6b08b5c0ae8e7cdf3a91a5f30832bbe74ccc4f0bde9618ea"
     "md5=b0e47c588ca498073ad35eb5627a8852"


### PR DESCRIPTION
This should in particular avoid breakage when we rename the repository to rocq-prover.