### PR TITLE
fstar.2025.03.25

### DIFF
--- a/packages/fstar/fstar.2025.03.25/opam
+++ b/packages/fstar/fstar.2025.03.25/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "taramana@microsoft.com"
+authors: [
+  "Nik Swamy <nswamy@microsoft.com>"
+  "Jonathan Protzenko <protz@microsoft.com>"
+  "Tahina Ramananandro <taramana@microsoft.com>"
+]
+homepage: "http://fstar-lang.org"
+license: "Apache-2.0"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "batteries"
+  "zarith" {>= "1.14"}
+  "stdint"
+  "yojson"
+  "dune" { >= "3.8.0"}
+  "memtrace" {>= "0.2.3"}
+  "menhirLib"
+  "menhir" {build & >= "20230415"}
+  "mtime" {>= "2.1.0"}
+  "pprint"
+  "sedlex"
+  "ppxlib" {>= "0.27.0"}
+  "process"
+  "ppx_deriving" {build}
+  "ppx_deriving_yojson" {build}
+]
+depexts: ["coreutils"] {os = "macos" & os-distribution = "homebrew"}
+build: [
+  [make "-j" jobs "ADMIT=1"]
+]
+install: [
+  [make "PREFIX=%{prefix}%" "install"]
+]
+post-messages: [
+  """
+F* requires specific versions of Z3 to work correctly, and will refuse to run
+if the version string does not match. You should have z3-4.8.5 and z3-4.13.3
+in your $PATH. For details, see
+https://github.com/FStarLang/FStar/blob/master/INSTALL.md#runtime-dependency-particular-version-of-z3.
+""" {success}
+]
+dev-repo: "git+https://github.com/FStarLang/FStar"
+bug-reports: "https://github.com/FStarLang/FStar/issues"
+synopsis: "Verification system for effectful programs"
+url {
+  src: "https://github.com/FStarLang/FStar/archive/refs/tags/v2025.03.25.tar.gz"
+  checksum: [
+    "md5=2d7f02d2931ddc9c74abdac9eb165ed0"
+    "sha512=0131974e624146bc05cbdf668b961ef46a3a2edef3f29638b28e38c74bbb4254f9e9039341198c8d8be40eb05dd440bd6ac799b7d1d39c483103395863b8e1ab"
+  ]
+}


### PR DESCRIPTION
Hi, this adds F* release v2025.03.25 into OPAM. It's just an update of the tarball URL and hashes wrt to previous one (thanks to @chandradeepdey). It's my first time posting a PR here so not sure if I'm missing any other step.

I'm also considering having a PR into here opened automatically after every F* release, wondering if that would be acceptable and if other projects do it.

Thank you!

