### PR TITLE
Package cpdf.2.8.1

### DIFF
--- a/packages/cpdf/cpdf.2.8.1/opam
+++ b/packages/cpdf/cpdf.2.8.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "contact@coherentgraphics.co.uk"
+license: "AGPL-3.0-or-later"
+build: [[make]]
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "ocamlfind" {build}
+  "camlpdf" {= version}
+]
+homepage: "http://github.com/johnwhitington/cpdf-source"
+authors: ["John Whitington"]
+bug-reports: "http://github.com/johnwhitington/cpdf-source/issues"
+dev-repo: "git+https://github.com/johnwhitington/cpdf-source"
+install: [[make "install"]]
+synopsis: "PDF command line tools"
+url {
+  src:
+    "https://github.com/johnwhitington/cpdf-source/archive/refs/tags/v2.8.1.tar.gz"
+  checksum: [
+    "md5=45ba51aae6b5d3ea6cb421037f8f73bb"
+    "sha512=f325c703835a82be462cafa5fb9548329ef648e3aa66bca73c2ae1d9e99813b3008915018bf5090e0c0dd6e31509e97895b01c64a9b4484c4993be59e85995e8"
+  ]
+}


### PR DESCRIPTION
### `cpdf.2.8.1`
PDF command line tools



---
* Homepage: http://github.com/johnwhitington/cpdf-source
* Source repo: git+https://github.com/johnwhitington/cpdf-source
* Bug tracker: http://github.com/johnwhitington/cpdf-source/issues

---
:camel: Pull-request generated by opam-publish v2.4.0