### PR TITLE
[new release] dune (15 packages) (3.18.0~alpha0)

### DIFF
--- a/packages/chrome-trace/chrome-trace.3.18.0~alpha0/opam
+++ b/packages/chrome-trace/chrome-trace.3.18.0~alpha0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Chrome trace event generation library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.18.0_alpha0/dune-3.18.0.alpha0.tbz"
+  checksum: [
+    "sha256=16c655c8d488f2d1f9f21c7e6128d15a7b88a03af7e93df13ba7adfbf6434f40"
+    "sha512=780502a365e27d354bb14fa0576796dc82332da101344c14354cdf76a5d42be3c3ce5cbac9fd7c7dcf1a00fb933c37985a7750b0f974b530be79a1e869f5554b"
+  ]
+}
+x-commit-hash: "f6c8a1bb92fa564e19acac26c6760317525b50de"

--- a/packages/dune-action-plugin/dune-action-plugin.3.18.0~alpha0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.18.0~alpha0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "dune-glob" {= version}
+  "csexp" {>= "1.5.0"}
+  "ppx_expect" {with-test}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "dune-rpc" {= version}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.18.0_alpha0/dune-3.18.0.alpha0.tbz"
+  checksum: [
+    "sha256=16c655c8d488f2d1f9f21c7e6128d15a7b88a03af7e93df13ba7adfbf6434f40"
+    "sha512=780502a365e27d354bb14fa0576796dc82332da101344c14354cdf76a5d42be3c3ce5cbac9fd7c7dcf1a00fb933c37985a7750b0f974b530be79a1e869f5554b"
+  ]
+}
+x-commit-hash: "f6c8a1bb92fa564e19acac26c6760317525b50de"

--- a/packages/dune-build-info/dune-build-info.3.18.0~alpha0/opam
+++ b/packages/dune-build-info/dune-build-info.3.18.0~alpha0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Embed build information inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.18.0_alpha0/dune-3.18.0.alpha0.tbz"
+  checksum: [
+    "sha256=16c655c8d488f2d1f9f21c7e6128d15a7b88a03af7e93df13ba7adfbf6434f40"
+    "sha512=780502a365e27d354bb14fa0576796dc82332da101344c14354cdf76a5d42be3c3ce5cbac9fd7c7dcf1a00fb933c37985a7750b0f974b530be79a1e869f5554b"
+  ]
+}
+x-commit-hash: "f6c8a1bb92fa564e19acac26c6760317525b50de"

--- a/packages/dune-configurator/dune-configurator.3.18.0~alpha0/opam
+++ b/packages/dune-configurator/dune-configurator.3.18.0~alpha0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.18.0_alpha0/dune-3.18.0.alpha0.tbz"
+  checksum: [
+    "sha256=16c655c8d488f2d1f9f21c7e6128d15a7b88a03af7e93df13ba7adfbf6434f40"
+    "sha512=780502a365e27d354bb14fa0576796dc82332da101344c14354cdf76a5d42be3c3ce5cbac9fd7c7dcf1a00fb933c37985a7750b0f974b530be79a1e869f5554b"
+  ]
+}
+x-commit-hash: "f6c8a1bb92fa564e19acac26c6760317525b50de"

--- a/packages/dune-glob/dune-glob.3.18.0~alpha0/opam
+++ b/packages/dune-glob/dune-glob.3.18.0~alpha0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "stdune" {= version}
+  "dyn"
+  "ordering"
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.18.0_alpha0/dune-3.18.0.alpha0.tbz"
+  checksum: [
+    "sha256=16c655c8d488f2d1f9f21c7e6128d15a7b88a03af7e93df13ba7adfbf6434f40"
+    "sha512=780502a365e27d354bb14fa0576796dc82332da101344c14354cdf76a5d42be3c3ce5cbac9fd7c7dcf1a00fb933c37985a7750b0f974b530be79a1e869f5554b"
+  ]
+}
+x-commit-hash: "f6c8a1bb92fa564e19acac26c6760317525b50de"

--- a/packages/dune-private-libs/dune-private-libs.3.18.0~alpha0/opam
+++ b/packages/dune-private-libs/dune-private-libs.3.18.0~alpha0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "csexp" {>= "1.5.0"}
+  "pp" {>= "1.1.0"}
+  "dyn" {= version}
+  "stdune" {= version}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.18.0_alpha0/dune-3.18.0.alpha0.tbz"
+  checksum: [
+    "sha256=16c655c8d488f2d1f9f21c7e6128d15a7b88a03af7e93df13ba7adfbf6434f40"
+    "sha512=780502a365e27d354bb14fa0576796dc82332da101344c14354cdf76a5d42be3c3ce5cbac9fd7c7dcf1a00fb933c37985a7750b0f974b530be79a1e869f5554b"
+  ]
+}
+x-commit-hash: "f6c8a1bb92fa564e19acac26c6760317525b50de"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.18.0~alpha0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.18.0~alpha0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc and Lwt"
+description: "Specialization of dune-rpc to Lwt"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "dune-rpc" {= version}
+  "csexp" {>= "1.5.0"}
+  "lwt" {>= "5.6.0"}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.18.0_alpha0/dune-3.18.0.alpha0.tbz"
+  checksum: [
+    "sha256=16c655c8d488f2d1f9f21c7e6128d15a7b88a03af7e93df13ba7adfbf6434f40"
+    "sha512=780502a365e27d354bb14fa0576796dc82332da101344c14354cdf76a5d42be3c3ce5cbac9fd7c7dcf1a00fb933c37985a7750b0f974b530be79a1e869f5554b"
+  ]
+}
+x-commit-hash: "f6c8a1bb92fa564e19acac26c6760317525b50de"

--- a/packages/dune-rpc/dune-rpc.3.18.0~alpha0/opam
+++ b/packages/dune-rpc/dune-rpc.3.18.0~alpha0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.18.0_alpha0/dune-3.18.0.alpha0.tbz"
+  checksum: [
+    "sha256=16c655c8d488f2d1f9f21c7e6128d15a7b88a03af7e93df13ba7adfbf6434f40"
+    "sha512=780502a365e27d354bb14fa0576796dc82332da101344c14354cdf76a5d42be3c3ce5cbac9fd7c7dcf1a00fb933c37985a7750b0f974b530be79a1e869f5554b"
+  ]
+}
+x-commit-hash: "f6c8a1bb92fa564e19acac26c6760317525b50de"

--- a/packages/dune-site/dune-site.3.18.0~alpha0/opam
+++ b/packages/dune-site/dune-site.3.18.0~alpha0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Embed locations information inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.18.0_alpha0/dune-3.18.0.alpha0.tbz"
+  checksum: [
+    "sha256=16c655c8d488f2d1f9f21c7e6128d15a7b88a03af7e93df13ba7adfbf6434f40"
+    "sha512=780502a365e27d354bb14fa0576796dc82332da101344c14354cdf76a5d42be3c3ce5cbac9fd7c7dcf1a00fb933c37985a7750b0f974b530be79a1e869f5554b"
+  ]
+}
+x-commit-hash: "f6c8a1bb92fa564e19acac26c6760317525b50de"

--- a/packages/dune/dune.3.18.0~alpha0/opam
+++ b/packages/dune/dune.3.18.0~alpha0/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+Dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+Dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+Dune is composable; supporting multi-package development by simply
+dropping multiple repositories into the same directory.
+
+Dune also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  "ocaml" {>= "4.08"}
+  "base-unix"
+  "base-threads"
+  "lwt" { with-dev-setup & os != "win32" }
+  "cinaps" { with-dev-setup }
+  "csexp" { with-dev-setup & >= "1.3.0" }
+  "js_of_ocaml" { with-dev-setup & >= "6.0.1" & os != "win32" }
+  "js_of_ocaml-compiler" { with-dev-setup & >= "6.0.1" & os != "win32" }
+  "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
+  "menhir" { with-dev-setup & os != "win32" }
+  "ocamlfind" { with-dev-setup & os != "win32" }
+  "odoc" { with-dev-setup & >= "2.4.0" & os != "win32" }
+  "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
+  "ppx_inline_test" { with-dev-setup & os != "win32" }
+  "ppxlib" { with-dev-setup & >= "0.35.0" & os != "win32" }
+  "ctypes" { with-dev-setup & os != "win32" }
+  "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
+  "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.18.0_alpha0/dune-3.18.0.alpha0.tbz"
+  checksum: [
+    "sha256=16c655c8d488f2d1f9f21c7e6128d15a7b88a03af7e93df13ba7adfbf6434f40"
+    "sha512=780502a365e27d354bb14fa0576796dc82332da101344c14354cdf76a5d42be3c3ce5cbac9fd7c7dcf1a00fb933c37985a7750b0f974b530be79a1e869f5554b"
+  ]
+}
+x-commit-hash: "f6c8a1bb92fa564e19acac26c6760317525b50de"

--- a/packages/dyn/dyn.3.18.0~alpha0/opam
+++ b/packages/dyn/dyn.3.18.0~alpha0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.18.0_alpha0/dune-3.18.0.alpha0.tbz"
+  checksum: [
+    "sha256=16c655c8d488f2d1f9f21c7e6128d15a7b88a03af7e93df13ba7adfbf6434f40"
+    "sha512=780502a365e27d354bb14fa0576796dc82332da101344c14354cdf76a5d42be3c3ce5cbac9fd7c7dcf1a00fb933c37985a7750b0f974b530be79a1e869f5554b"
+  ]
+}
+x-commit-hash: "f6c8a1bb92fa564e19acac26c6760317525b50de"

--- a/packages/ocamlc-loc/ocamlc-loc.3.18.0~alpha0/opam
+++ b/packages/ocamlc-loc/ocamlc-loc.3.18.0~alpha0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Parse ocaml compiler output into structured form"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-lsp-server" {< "1.15.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.18.0_alpha0/dune-3.18.0.alpha0.tbz"
+  checksum: [
+    "sha256=16c655c8d488f2d1f9f21c7e6128d15a7b88a03af7e93df13ba7adfbf6434f40"
+    "sha512=780502a365e27d354bb14fa0576796dc82332da101344c14354cdf76a5d42be3c3ce5cbac9fd7c7dcf1a00fb933c37985a7750b0f974b530be79a1e869f5554b"
+  ]
+}
+x-commit-hash: "f6c8a1bb92fa564e19acac26c6760317525b50de"

--- a/packages/ordering/ordering.3.18.0~alpha0/opam
+++ b/packages/ordering/ordering.3.18.0~alpha0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.18.0_alpha0/dune-3.18.0.alpha0.tbz"
+  checksum: [
+    "sha256=16c655c8d488f2d1f9f21c7e6128d15a7b88a03af7e93df13ba7adfbf6434f40"
+    "sha512=780502a365e27d354bb14fa0576796dc82332da101344c14354cdf76a5d42be3c3ce5cbac9fd7c7dcf1a00fb933c37985a7750b0f974b530be79a1e869f5554b"
+  ]
+}
+x-commit-hash: "f6c8a1bb92fa564e19acac26c6760317525b50de"

--- a/packages/stdune/stdune.3.18.0~alpha0/opam
+++ b/packages/stdune/stdune.3.18.0~alpha0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "dyn" {= version}
+  "ordering" {= version}
+  "pp" {>= "2.0.0"}
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.18.0_alpha0/dune-3.18.0.alpha0.tbz"
+  checksum: [
+    "sha256=16c655c8d488f2d1f9f21c7e6128d15a7b88a03af7e93df13ba7adfbf6434f40"
+    "sha512=780502a365e27d354bb14fa0576796dc82332da101344c14354cdf76a5d42be3c3ce5cbac9fd7c7dcf1a00fb933c37985a7750b0f974b530be79a1e869f5554b"
+  ]
+}
+x-commit-hash: "f6c8a1bb92fa564e19acac26c6760317525b50de"

--- a/packages/xdg/xdg.3.18.0~alpha0/opam
+++ b/packages/xdg/xdg.3.18.0~alpha0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.18.0_alpha0/dune-3.18.0.alpha0.tbz"
+  checksum: [
+    "sha256=16c655c8d488f2d1f9f21c7e6128d15a7b88a03af7e93df13ba7adfbf6434f40"
+    "sha512=780502a365e27d354bb14fa0576796dc82332da101344c14354cdf76a5d42be3c3ce5cbac9fd7c7dcf1a00fb933c37985a7750b0f974b530be79a1e869f5554b"
+  ]
+}
+x-commit-hash: "f6c8a1bb92fa564e19acac26c6760317525b50de"


### PR DESCRIPTION
Fast, portable, and opinionated build system

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

### Fixed

- Support HaikuOS: don't call `execve` since it's not allowed if other pthreads
  have been created. The fact that Haiku can't call `execve` from other threads
  than the principal thread of a process (a team in haiku jargon), is a
  discrepancy to POSIX and hence there is a [bug about
  it](https://dev.haiku-os.org/ticket/18665). (@Sylvain78, ocaml/dune#10953)
- Fix flag ordering in generated Merlin configurations (ocaml/dune#11503, @voodoos, fixes
  ocaml/merlin#1900, reported by @vouillon)

### Added

- Add `(format-dune-file <src> <dst>)` action. It provides a replacement to
  `dune format-dune-file` command.  (ocaml/dune#11166, @nojb)
- Allow the `--prefix` flag when configuring dune with `ocaml configure.ml`.
  This allows to set the prefix just like `$ dune install --prefix`. (ocaml/dune#11172,
  @rgrinberg)
- Allow arguments starting with `+` in preprocessing definitions (starting with
  `(lang dune 3.18)`). (@amonteiro, ocaml/dune#11234)
- Support for opam `(maintenance_intent ...)` in dune-project (ocaml/dune#11274, @art-w)
- Validate opam `maintenance_intent` (ocaml/dune#11308, @art-w)
- Support `not` in package dependencies constraints (ocaml/dune#11404, @art-w, reported
  by @hannesm)

### Changed

- Warn when failing to discover root due to reads failing. The previous
  behavior was to abort. (@KoviRobi, ocaml/dune#11173)
- Use shorter path for inline-tests artifacts. (@hhugo, ocaml/dune#11307)
- Allow dash in `dune init` project name (ocaml/dune#11402, @art-w, reported by @saroupille)
- On Windows, under heavy load, file delete operations can sometimes fail due to
  AV programs, etc. Guard against it by retrying the operation up to 30x with a
  1s waiting gap (ocaml/dune#11437, fixes ocaml/dune#11425, @MSoegtropIMC)
- Cache: we now only store the executable permission bit for files (ocaml/dune#11541,
  fixes ocaml/dune#11533, @ElectreAAS)
- Display negative error codes on Windows in hex which is the more customary
  way to display `NTSTATUS` codes (ocaml/dune#11504, @MisterDA)
