### PR TITLE
Add license for ocaml-inifiles

### DIFF
--- a/packages/ocaml-inifiles/ocaml-inifiles.1.2/opam
+++ b/packages/ocaml-inifiles/ocaml-inifiles.1.2/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
+license: "LGPL-2.1-or-later"
 build: [
   [make "all"]
   [make "opt"]


### PR DESCRIPTION
It is based on the contents of the COPYING file from the source archive:

> Copyright (C) 2004 Eric Stokes, and The California
> State University at Northridge
> 
> This library is free software; you can redistribute it and/or               
> modify it under the terms of the GNU Lesser General Public                  
> License as published by the Free Software Foundation; either                
> version 2.1 of the License, or (at your option) any later version.          
>    
> This library is distributed in the hope that it will be useful,             
> but WITHOUT ANY WARRANTY; without even the implied warranty of              
> MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU           
> Lesser General Public License for more details.                             
>    
> You should have received a copy of the GNU Lesser General Public
> License along with this library; if not, write to the Free Software
> Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
> USA
> 