### PR TITLE
[new release] http-lwt-client (0.3.2)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.3.2/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.3.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/http-lwt-client"
+dev-repo: "git+https://github.com/robur-coop/http-lwt-client.git"
+bug-reports: "https://github.com/robur-coop/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "lwt"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "1.0.0"}
+  "tls-lwt" {>= "1.0.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.10.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/http-lwt-client/releases/download/v0.3.2/http-lwt-client-0.3.2.tbz"
+  checksum: [
+    "sha256=488bc9d06135d404126a6090d8d58811bf3d7f0d119277d511e0a205cf6db5a5"
+    "sha512=86c2bfc74a9b3736e1f9a9edddbacb0b0969f379d9cb47336afd307523b6647b1bdaaaf98ca3a5c2716e9a32b5b022a5cbd47373078653d2278a86b0f7a761df"
+  ]
+}
+x-commit-hash: "f0245150db0c37752a36bc75b92217b9601c251b"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/robur-coop/http-lwt-client">https://github.com/robur-coop/http-lwt-client</a>

##### CHANGES:

* Handle cmdliner deprecations (reported in robur-coop/http-lwt-client#27, fixed in robur-coop/http-lwt-client#28)
