### PR TITLE
5 packages from c-cube/qcheck

### DIFF
--- a/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.7/opam
+++ b/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.7/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "PPX Deriver for QCheck"
+maintainer: "valentin.chb@gmail.com"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/-/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "ocaml" {>= "4.08.0"}
+  "qcheck-core" {>= "0.24"}
+  "ppxlib" {>= "0.36.0"}
+  "ppx_deriving" {>= "6.1.0"}
+  "odoc" {with-doc}
+  "alcotest" {with-test & >= "1.4.0"}
+  "qcheck-alcotest" {with-test & >= "0.24"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.25.tar.gz"
+  checksum: [
+    "md5=e1e928bf792c27de5c072f9123eeaec9"
+    "sha512=a0b5791cea09f98f1f17221e6289b87a7a1c16ae1c9af0c2e5bd6a170f2cf8727dba0759a7fd932d5d617e8c242562d69187c7e74eefd5262bc5fd75a322699e"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck-alcotest/qcheck-alcotest.0.25/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.25/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Alcotest backend for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "quickcheck" "qcheck" "alcotest"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "qcheck-core" {= version}
+  "alcotest" {>= "1.2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.25.tar.gz"
+  checksum: [
+    "md5=e1e928bf792c27de5c072f9123eeaec9"
+    "sha512=a0b5791cea09f98f1f17221e6289b87a7a1c16ae1c9af0c2e5bd6a170f2cf8727dba0759a7fd932d5d617e8c242562d69187c7e74eefd5262bc5fd75a322699e"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck-core/qcheck-core.0.25/opam
+++ b/packages/qcheck-core/qcheck-core.0.25/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Core qcheck library"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "alcotest" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.25.tar.gz"
+  checksum: [
+    "md5=e1e928bf792c27de5c072f9123eeaec9"
+    "sha512=a0b5791cea09f98f1f17221e6289b87a7a1c16ae1c9af0c2e5bd6a170f2cf8727dba0759a7fd932d5d617e8c242562d69187c7e74eefd5262bc5fd75a322699e"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck-ounit/qcheck-ounit.0.25/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.25/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "OUnit backend for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["qcheck" "quickcheck" "ounit"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "qcheck-core" {= version}
+  "ounit2"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.25.tar.gz"
+  checksum: [
+    "md5=e1e928bf792c27de5c072f9123eeaec9"
+    "sha512=a0b5791cea09f98f1f17221e6289b87a7a1c16ae1c9af0c2e5bd6a170f2cf8727dba0759a7fd932d5d617e8c242562d69187c7e74eefd5262bc5fd75a322699e"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck/qcheck.0.25/opam
+++ b/packages/qcheck/qcheck.0.25/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Compatibility package for qcheck"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "qcheck-core" {= version}
+  "qcheck-ounit" {= version}
+  "alcotest" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.25.tar.gz"
+  checksum: [
+    "md5=e1e928bf792c27de5c072f9123eeaec9"
+    "sha512=a0b5791cea09f98f1f17221e6289b87a7a1c16ae1c9af0c2e5bd6a170f2cf8727dba0759a7fd932d5d617e8c242562d69187c7e74eefd5262bc5fd75a322699e"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `ppx_deriving_qcheck.0.7`: PPX Deriver for QCheck
- `qcheck.0.25`: Compatibility package for qcheck
- `qcheck-alcotest.0.25`: Alcotest backend for qcheck
- `qcheck-core.0.25`: Core qcheck library
- `qcheck-ounit.0.25`: OUnit backend for qcheck



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: git+https://github.com/c-cube/qcheck.git

---
:camel: Pull-request generated by opam-publish v2.5.0