### PR TITLE
[new release] plist-xml (0.5.1)

### DIFF
--- a/packages/plist-xml/plist-xml.0.5.1/opam
+++ b/packages/plist-xml/plist-xml.0.5.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis:
+  "Reading and writing of plist files in the XML format in pure OCaml"
+description: """
+Reading and writing of plist files in the XML format in pure OCaml.
+
+Implementation of https://www.apple.com/DTDs/PropertyList-1.0.dtd."""
+maintainer: ["Alan Hu <alanh@ccs.neu.edu>"]
+authors: ["Alan Hu <alanh@ccs.neu.edu>"]
+license: "MIT"
+homepage: "https://github.com/alan-j-hu/ocaml-plist-xml"
+doc: "https://alan-j-hu.github.io/ocaml-plist-xml/"
+bug-reports: "https://github.com/alan-j-hu/ocaml-plist-xml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "base64" {>= "3.4"}
+  "ISO8601" {>= "0.2.6"}
+  "menhir" {>= "20220210"}
+  "ocaml" {>= "4.13"}
+  "xmlm" {>= "1.4"}
+  "eio" {>= "0.7" & with-test}
+  "eio_main" {>= "0.7" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/alan-j-hu/ocaml-plist-xml.git"
+url {
+  src:
+    "https://github.com/alan-j-hu/ocaml-plist-xml/releases/download/0.5.1/plist-xml-0.5.1.tbz"
+  checksum: [
+    "sha256=3c40af8ede1c1e0b2893e44f5caecac7f1017271e820a9a57124ac736a49a678"
+    "sha512=bfdf0e6134a0369ffd0266db75f218037619fd0709d5812aa12aea6c4f4b996bd97264e8cbbb90817347d52bb380659c50f87b23b828b44cdd1a3d1d34818226"
+  ]
+}
+x-commit-hash: "66cd5f23fb0b884e0564741f667861c16a873328"

--- a/packages/plist-xml/plist-xml.0.5.1/opam
+++ b/packages/plist-xml/plist-xml.0.5.1/opam
@@ -5,8 +5,8 @@ description: """
 Reading and writing of plist files in the XML format in pure OCaml.
 
 Implementation of https://www.apple.com/DTDs/PropertyList-1.0.dtd."""
-maintainer: ["Alan Hu <alanh@ccs.neu.edu>"]
-authors: ["Alan Hu <alanh@ccs.neu.edu>"]
+maintainer: ["Alan Hu <ahulambda@gmail.com>"]
+authors: ["Alan Hu <ahulambda@gmail.com>"]
 license: "MIT"
 homepage: "https://github.com/alan-j-hu/ocaml-plist-xml"
 doc: "https://alan-j-hu.github.io/ocaml-plist-xml/"


### PR DESCRIPTION
Reading and writing of plist files in the XML format in pure OCaml

- Project page: <a href="https://github.com/alan-j-hu/ocaml-plist-xml">https://github.com/alan-j-hu/ocaml-plist-xml</a>
- Documentation: <a href="https://alan-j-hu.github.io/ocaml-plist-xml/">https://alan-j-hu.github.io/ocaml-plist-xml/</a>

##### CHANGES:

- Remove unused dependency on `cstruct`.
