### PR TITLE
[new release] icalendar (0.1.11)

### DIFF
--- a/packages/icalendar/icalendar.0.1.11/opam
+++ b/packages/icalendar/icalendar.0.1.11/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/robur-coop/icalendar"
+bug-reports: "https://github.com/robur-coop/icalendar/issues"
+dev-repo: "git+https://github.com/robur-coop/icalendar.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://robur-coop.github.io/icalendar/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "1.3"}
+  "alcotest" {with-test}
+  "fmt"
+  "angstrom" {>= "0.14.0"}
+  "re" {>= "1.7.2"}
+  "uri"
+  "ptime"
+  "ppx_deriving"
+  "gmap" {>= "0.3.0"}
+]
+
+synopsis: "A library to parse and print the iCalendar (RFC 5545) format"
+description: """
+Parse and print .ics files as specified in RFC 5545.
+Supports recurrent events, but only to the day level of detail.
+Does not support vJournal components.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/icalendar/releases/download/v0.1.11/icalendar-0.1.11.tbz"
+  checksum: [
+    "sha256=be425cf4f272d08d4102207f637169750fb0845ab2f6fc109dd242e95552c346"
+    "sha512=791b747e463edd27823905625352e476931710fde2ea6248e94334a994ec4a08fb86c2c03bac0e359b7a17529d5b479b65d0111c9677e06769c01bb904a268dc"
+  ]
+}
+x-commit-hash: "5462bc2a0780f2b879c75a62aec91305ed1f5825"


### PR DESCRIPTION
A library to parse and print the iCalendar (RFC 5545) format

- Project page: <a href="https://github.com/robur-coop/icalendar">https://github.com/robur-coop/icalendar</a>
- Documentation: <a href="https://robur-coop.github.io/icalendar/">https://robur-coop.github.io/icalendar/</a>

##### CHANGES:

* handle recurrence ids (robur-coop/icalendar#13 @Khady @hannesm, tested by @RyanGibb)
* recurrence: handle until with local date
  (reported by @RyanGibb in robur-coop/icalendar#15, fixed robur-coop/icalendar#17 @hannesm)
* relax todo and event parsers to allow properties after alarms
  (reported by @RyanGibb in robur-coop/icalendar#14, fixed robur-coop/icalendar#16 @hannesm)
* relax display alarm parser to allow an alarm without description
  (reported by @RyanGibb in robur-coop/icalendar#14, fixed robur-coop/icalendar#16 @hannesm)
* fix registration of exdate test (robur-coop/icalendar#13 @Khady)
