### PR TITLE
fix Base compilation on macOS 10.4 on arm64

### DIFF
--- a/packages/base/base.v0.17.1/opam
+++ b/packages/base/base.v0.17.1/opam
@@ -39,3 +39,11 @@ url {
     "sha512=ed5eb5e83d8085fc06f111862d609b393e394bbdcc6e25bab50030a250ffa2e540dbee02169b6f28ec220f10f61d189cd7b5646eece910c63620f5174fb5a655"
   ]
 }
+patches: ["fix-mpopcnt.patch" { arch="arm64" & os="macos"} ]
+extra-source "fix-mpopcnt.patch" {
+  src:
+    "https://patch-diff.githubusercontent.com/raw/janestreet/base/pull/180.diff"
+  checksum: [
+    "sha256=78fecf4719e82aec5fc17a1140df18b07c1a640d3336c39dcd5cd85206bcede3"
+  ]
+}


### PR DESCRIPTION
See https://github.com/janestreet/base/pull/180 for details