### PR TITLE
[new release] camldiets (0.3)

### DIFF
--- a/packages/camldiets/camldiets.0.3/opam
+++ b/packages/camldiets/camldiets.0.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "A highly efficient OCaml set implementation for fat sets, i.e. densely populated sets over a discrete linear order"
+description:
+  "A highly efficient OCaml set implementation for fat sets, i.e. densely populated sets over a discrete linear order."
+maintainer: ["Oliver Friedmann" "Martin Lange"]
+authors: ["Oliver Friedmann" "Martin Lange"]
+license: "BSD-3-clause"
+homepage: "https://github.com/tcsprojects/camldiets"
+bug-reports: "https://github.com/tcsprojects/camldiets/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.10"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tcsprojects/camldiets.git"
+url {
+  src:
+    "https://github.com/tcsprojects/camldiets/releases/download/v0.3/camldiets-0.3.tbz"
+  checksum: [
+    "sha256=53835314f6a6a15ef01790a5a1aa1e2097566de9b4bc0c424e9a694fcaa90c7f"
+    "sha512=0de67240cdb1fa582e43c7580875cdcdcb18cc4a1bacf46b395c26608009319c3d1474d1463ad5c552b367f3b3110ef50de8abeb058184f66b5dd1d70abea810"
+  ]
+}
+x-commit-hash: "7583e1147b9e42066bc59c486b83c40dc1a3295c"


### PR DESCRIPTION
A highly efficient OCaml set implementation for fat sets, i.e. densely populated sets over a discrete linear order

- Project page: <a href="https://github.com/tcsprojects/camldiets">https://github.com/tcsprojects/camldiets</a>

##### CHANGES:

- Change from OASIS to DUNE
- Change from OCAML 4 to OCAML 5
