### PR TITLE
2 packages from kit-ty-kate/opam-build at 0.2.5

### DIFF
--- a/packages/opam-build/opam-build.0.2.5/opam
+++ b/packages/opam-build/opam-build.0.2.5/opam
@@ -1,6 +1,9 @@
 opam-version: "2.0"
 synopsis: "An opam plugin to build projects"
 maintainer: "Kate <kit-ty-kate@outlook.com>"
+description: """
+opam-build allows to build any project easily with just one command: opam build. This will setup a local switch and install all the required dependencies.
+"""
 authors: "Kate <kit-ty-kate@outlook.com>"
 license: "MIT"
 homepage: "https://github.com/kit-ty-kate/opam-build"

--- a/packages/opam-build/opam-build.0.2.5/opam
+++ b/packages/opam-build/opam-build.0.2.5/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to build projects"
+maintainer: "Kate <kit-ty-kate@outlook.com>"
+authors: "Kate <kit-ty-kate@outlook.com>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.3" & < "2.4"}
+  "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
+]
+available: opam-version >= "2.3" & opam-version < "2.4"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.2.5/opam-build-0.2.5.tar.gz"
+  checksum: [
+    "md5=7d68bc72a303aafa5d1546fa6bc55d7b"
+    "sha512=a07acfff1f566c9f4e50fba8b9dae9c25a09acd304e6a5c260602e31eb3932aef02795de16f2616ba78a93db2499114cc6a1371d65dd34c1a45418b16f75886a"
+  ]
+}

--- a/packages/opam-test/opam-test.0.2.5/opam
+++ b/packages/opam-test/opam-test.0.2.5/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to test projects"
+maintainer: "Kate <kit-ty-kate@outlook.com>"
+authors: "Kate <kit-ty-kate@outlook.com>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.3" & < "2.4"}
+  "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
+]
+available: opam-version >= "2.3" & opam-version < "2.4"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.2.5/opam-build-0.2.5.tar.gz"
+  checksum: [
+    "md5=7d68bc72a303aafa5d1546fa6bc55d7b"
+    "sha512=a07acfff1f566c9f4e50fba8b9dae9c25a09acd304e6a5c260602e31eb3932aef02795de16f2616ba78a93db2499114cc6a1371d65dd34c1a45418b16f75886a"
+  ]
+}

--- a/packages/opam-test/opam-test.0.2.5/opam
+++ b/packages/opam-test/opam-test.0.2.5/opam
@@ -1,6 +1,9 @@
 opam-version: "2.0"
 synopsis: "An opam plugin to test projects"
 maintainer: "Kate <kit-ty-kate@outlook.com>"
+description: """
+opam-test: similar to opam-build, this will setup a local switch and install all the required dependencies, but will also run the tests on top of it. It also circumvents issues with cyclic test dependencies in opam (where the tests require a package that needs the library it is trying to test). Such cyclic dependency is present in packages such as odoc or base. See https://github.com/ocaml/opam/issues/4594
+"""
 authors: "Kate <kit-ty-kate@outlook.com>"
 license: "MIT"
 homepage: "https://github.com/kit-ty-kate/opam-build"


### PR DESCRIPTION
This pull-request concerns:
- `opam-build.0.2.5`: An opam plugin to build projects
- `opam-test.0.2.5`: An opam plugin to test projects



---
* Homepage: https://github.com/kit-ty-kate/opam-build
* Source repo: git+https://github.com/kit-ty-kate/opam-build.git
* Bug tracker: https://github.com/kit-ty-kate/opam-build/issues

---
:camel: Pull-request generated by opam-publish v2.5.0