### PR TITLE
[new release] caisar (3.0)

### DIFF
--- a/packages/caisar/caisar.3.0/opam
+++ b/packages/caisar/caisar.3.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis:
+  "A platform for characterizing the safety and robustness of artificial intelligence based software"
+maintainer: ["AISER team, Software Safety and Security Laboratory, CEA-List"]
+authors: ["AISER team, Software Safety and Security Laboratory, CEA-List"]
+license: "LGPL-2.1-only"
+homepage: "https://git.frama-c.com/pub/caisar"
+doc: "https://git.frama-c.com/pub/caisar"
+bug-reports: "https://git.frama-c.com/pub/caisar/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "dune-site" {>= "2.9.0"}
+  "zarith" {>= "1.7"}
+  "ocplib-endian" {>= "1.0"}
+  "base" {>= "v0.16.0"}
+  "stdio" {>= "v0.14.0"}
+  "cmdliner" {>= "1.1.1"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "yojson" {>= "1.7.0"}
+  "menhirLib" {>= "20210310"}
+  "csv" {>= "2.4"}
+  "why3" {>= "1.7.0" & < "1.8.0"}
+  "re" {>= "1.12.0"}
+  "fpath" {>= "0.7.3"}
+  "yaml" {>= "3.1.0"}
+  "ocaml-protoc-plugin" {>= "4.2.0"}
+  "stdio" {>= "v0.14.0"}
+  "ocamlgraph" {>= "1.8.8"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_inline_test" {>= "0.12.0"}
+  "conf-texlive" {>= "1" & with-test}
+  "conf-python-3" {>= "9.0.0" & with-test}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "ppx_deriving_yaml" {>= "0.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/caisar.git"
+url {
+  src:
+    "https://git.frama-c.com/api/v4/projects/1082/packages/generic/caisar/3.0/caisar-3.0.tbz"
+  checksum: [
+    "sha256=de36deb42f1525672a8551c1055056bb864c496ef822eb4e26cbddee75c176bb"
+    "sha512=c8081b63fff1e092fed80f527ff5e85fc9e447a77dc180ddfca34386606b9239d9e0d2dfd9dce064cf5cc47d246f2be070092be1523457e5bf856223cf445136"
+  ]
+}
+x-commit-hash: "bd863ad1a0054d339cee18e764dcda35795825da"


### PR DESCRIPTION
CHANGES:

- [prover] Add support for operators `Transpose`, `Flatten`, `Reshape`, and `Gemm` in the transformation from ONNX to SMTLIB.

- [packaging] Add a [Nix](https://nix.dev/) environment for CAISAR. Nix is a package manager aiming for reproduceability. It is now possible to install CAISAR with a single command. The installation process through Nix is detailed in the documentation.

- [docker] convert the docker image to use the Nix environment.

- [prover] refine the integration of AIMOS