### PR TITLE
core_unix does not build on non-glibc Linux

### DIFF
--- a/packages/core_unix/core_unix.v0.16.0/opam
+++ b/packages/core_unix/core_unix.v0.16.0/opam
@@ -29,8 +29,7 @@ synopsis: "Unix-specific portions of Core"
 description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
 "
-depexts: ["linux-headers"] {os-family = "alpine"}
-available: [ !(os = "freebsd" & os-version >= "14") ]
+available: [ !(os = "freebsd" & os-version >= "14") & os != "alpine" ]
 url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/core_unix-v0.16.0.tar.gz"
 checksum: "sha256=4f70a9d3a761799d00c0a207942b4abd9f1a144bbcb19df98021d9fb7bfa9e5f"


### PR DESCRIPTION
The relevant error message is

```
getconf: GNU_LIBC_VERSION: unknown variable
```

which comes from
https://github.com/janestreet/core_unix/blob/v0.16.0/unix_pseudo_terminal/src/discover.sh#L13 and getconf will return 2 if it doesn't know the variable, thus will fail the build.

Example of failing build: https://ocaml.ci.dev/github/ocaml-community/yojson/commit/aa1a43fbb946203852d4dcdcceaf4d60442752a0/variant/alpine-3.21-4.14_opam-2.3

```
=== ERROR while compiling core_unix.v0.16.0 ==================================#
 context     2.3.0 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
 path        ~/.opam/4.14/.opam-switch/build/core_unix.v0.16.0
 command     ~/.opam/4.14/bin/dune build -p core_unix -j 71
 exit-code   1
 env-file    ~/.opam/log/core_unix-1-783890.env
 output-file ~/.opam/log/core_unix-1-783890.out
 File "bigstring_unix/src/dune", line 3, characters 10-30:
 3 |  (c_names bigstring_unix_stubs recvmmsg) (preprocessor_deps config.h)
               ^^^^^^^^^^^^^^^^^^^^
 (cd _build/default/bigstring_unix/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -I /home/opam/.opam/4.14/lib/ocaml -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/command -I /home/opam/.opam/4.14/lib/core/filename_base -I /home/opam/.opam/4.14/lib/core/heap_block -I /home/opam/.opam/4.14/lib/core/univ_map -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/caml_threads -I /home/opam/.opam/4.14/lib/core_kernel/caml_unix -I /home/opam/.opam/4.14/lib/core_kernel/flags -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_stable_witness/runtime -I /home/opam/.opam/4.14/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib/unix -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/spawn -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/variantslib -I ../../core_unix/src -I ../../error_checking_mutex/src -I ../../ocaml_c_utils/src -I ../../signal_unix/src -o bigstring_unix_stubs.o -c bigstring_unix_stubs.c)
 bigstring_unix_stubs.c:39:9: warning: "__BYTE_ORDER" redefined
    39 | #define __BYTE_ORDER _BYTE_ORDER
       |         ^~~~~~~~~~~~
 In file included from /usr/include/sys/select.h:16,
                  from /usr/include/fortify/sys/select.h:23,
                  from /usr/include/sys/types.h:71,
                  from bigstring_unix_stubs.c:33:
 /usr/include/bits/alltypes.h:5:9: note: this is the location of the previous definition
     5 | #define __BYTE_ORDER 1234
       |         ^~~~~~~~~~~~
 bigstring_unix_stubs.c:40:9: warning: "__LITTLE_ENDIAN" redefined
    40 | #define __LITTLE_ENDIAN _LITTLE_ENDIAN
       |         ^~~~~~~~~~~~~~~
 /usr/include/bits/alltypes.h:45:9: note: this is the location of the previous definition
    45 | #define __LITTLE_ENDIAN 1234
       |         ^~~~~~~~~~~~~~~
 bigstring_unix_stubs.c:41:9: warning: "__BIG_ENDIAN" redefined
    41 | #define __BIG_ENDIAN _BIG_ENDIAN
       |         ^~~~~~~~~~~~
 /usr/include/bits/alltypes.h:46:9: note: this is the location of the previous definition
    46 | #define __BIG_ENDIAN 4321
       |         ^~~~~~~~~~~~
 bigstring_unix_stubs.c: In function 'bigstring_sendmsg_nonblocking_no_sigpipe_stub':
 bigstring_unix_stubs.c:746:45: error: initialization of 'int' from 'void *' makes integer from pointer without a cast [-Wint-conversion]
   746 |   struct msghdr msghdr = {NULL, 0, NULL, 0, NULL, 0, 0};
       |                                             ^~~~
 bigstring_unix_stubs.c:746:45: note: (near initialization for 'msghdr.__pad1')
 (cd _build/default/filename_unix/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_LARGEFILE64_SOURCE -g -I /home/opam/.opam/4.14/lib/ocaml -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/command -I /home/opam/.opam/4.14/lib/core/filename_base -I /home/opam/.opam/4.14/lib/core/heap_block -I /home/opam/.opam/4.14/lib/core/univ_map -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/caml_unix -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_stable_witness/runtime -I /home/opam/.opam/4.14/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/variantslib -I ../../sys_unix/src -o filename_unix_stubs.o -c filename_unix_stubs.c)
 In file included from /home/opam/.opam/4.14/lib/jane-street-headers/ocaml_utils.h:6,
                  from filename_unix_stubs.c:5:
 filename_unix_stubs.c: In function 'core_unix_realpath':
 /home/opam/.opam/4.14/lib/ocaml/caml/mlvalues.h:290:23: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
   290 | #define String_val(x) ((const char *) Bp_val(x))
       |                       ^
 filename_unix_stubs.c:32:16: note: in expansion of macro 'String_val'
    32 |   char *path = String_val(v_path);
       |                ^~~~~~~~~~
 File "linux_ext/src/dune", line 4, characters 10-25:
 4 |  (c_names linux_ext_stubs) (preprocessor_deps config.h)
               ^^^^^^^^^^^^^^^
 (cd _build/default/linux_ext/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -I /home/opam/.opam/4.14/lib/ocaml -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/command -I /home/opam/.opam/4.14/lib/core/filename_base -I /home/opam/.opam/4.14/lib/core/heap_block -I /home/opam/.opam/4.14/lib/core/univ_map -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/bounded_int_table -I /home/opam/.opam/4.14/lib/core_kernel/caml_threads -I /home/opam/.opam/4.14/lib/core_kernel/caml_unix -I /home/opam/.opam/4.14/lib/core_kernel/flags -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_stable_witness/runtime -I /home/opam/.opam/4.14/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib/unix -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/spawn -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/timezone -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/variantslib -I ../../core_thread/src -I ../../core_unix/src -I ../../error_checking_mutex/src -I ../../filename_unix/src -I ../../signal_unix/src -I ../../sys_unix/src -I ../../time_float_unix/src -I ../../time_ns_unix/src -o linux_ext_stubs.o -c linux_ext_stubs.c)
 linux_ext_stubs.c: In function 'core_linux_sendmsg_nonblocking_no_sigpipe_stub':
 linux_ext_stubs.c:246:46: error: initialization of 'int' from 'void *' makes integer from pointer without a cast [-Wint-conversion]
   246 |   struct msghdr msghdr = { NULL, 0, NULL, 0, NULL, 0, 0 };
       |                                              ^~~~
 linux_ext_stubs.c:246:46: note: (near initialization for 'msghdr.__pad1')
 (cd _build/default/unix_pseudo_terminal/src && /bin/bash -e -u -o pipefail -c './discover.sh config_ext.h /home/opam/.opam/4.14/lib/jst-config/config.h')
 getconf: GNU_LIBC_VERSION: unknown variable
 (cd _build/default/core_unix/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_LARGEFILE64_SOURCE -g -I /home/opam/.opam/4.14/lib/ocaml -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/command -I /home/opam/.opam/4.14/lib/core/filename_base -I /home/opam/.opam/4.14/lib/core/heap_block -I /home/opam/.opam/4.14/lib/core/univ_map -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/caml_threads -I /home/opam/.opam/4.14/lib/core_kernel/caml_unix -I /home/opam/.opam/4.14/lib/core_kernel/flags -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_stable_witness/runtime -I /home/opam/.opam/4.14/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib/unix -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/spawn -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/variantslib -I ../../error_checking_mutex/src -I ../../signal_unix/src -o core_unix_stubs.o -c core_unix_stubs.c)
 core_unix_stubs.c:349:2: warning: #warning "_POSIX_SYNCHRONIZED_IO undefined or <= 0; aliasing unix_fdatasync to unix_fsync" [-Wcpp]
   349 | #warning "_POSIX_SYNCHRONIZED_IO undefined or <= 0; aliasing unix_fdatasync to unix_fsync"
       |  ^~~~~~~
 core_unix_stubs.c:1299:2: warning: #warning "_POSIX_PRIORITY_SCHEDULING not present; sched_setscheduler undefined" [-Wcpp]
  1299 | #warning "_POSIX_PRIORITY_SCHEDULING not present; sched_setscheduler undefined"
       |  ^~~~~~~
```