### PR TITLE
`core_unix.v0.17.0` does not build on OCaml 5.3

### DIFF
--- a/packages/core_unix/core_unix.v0.17.0/opam
+++ b/packages/core_unix/core_unix.v0.17.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"                    {>= "5.1.0"}
+  "ocaml"                    {>= "5.1.0" & < "5.3"}
   "core"                     {>= "v0.17" & < "v0.18"}
   "core_kernel"              {>= "v0.17" & < "v0.18"}
   "expect_test_helpers_core" {>= "v0.17" & < "v0.18"}


### PR DESCRIPTION
This is similar to #27304. A change that was released in 5.3 makes compiling `core_unix` on every platform with OCaml 5.3 fail.

Failing build: https://ocaml.ci.dev/github/ocaml-community/yojson/commit/aa1a43fbb946203852d4dcdcceaf4d60442752a0/variant/fedora-41-5.3_opam-2.3

```
=== ERROR while compiling core_unix.v0.17.0 ==================================#
 context     2.3.0 | linux/x86_64 | ocaml-base-compiler.5.3.0 | file:///home/opam/opam-repository
 path        ~/.opam/5.3/.opam-switch/build/core_unix.v0.17.0
 command     ~/.opam/5.3/bin/dune build -p core_unix -j 255
 exit-code   1
 env-file    ~/.opam/log/core_unix-1-b83684.env
 output-file ~/.opam/log/core_unix-1-b83684.out
 File "bigstring_unix/src/dune", line 4, characters 9-29:
 4 |   (names bigstring_unix_stubs recvmmsg))
              ^^^^^^^^^^^^^^^^^^^^
 (cd _build/default/bigstring_unix/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -fPIC -pthread -D_FILE_OFFSET_BITS=64 -fdiagnostics-color=always -g -I /home/opam/.opam/5.3/lib/ocaml -I /home/opam/.opam/5.3/lib/base -I /home/opam/.opam/5.3/lib/base/base_internalhash_types -I /home/opam/.opam/5.3/lib/base/md5 -I /home/opam/.opam/5.3/lib/base/shadow_stdlib -I /home/opam/.opam/5.3/lib/base_bigstring -I /home/opam/.opam/5.3/lib/base_quickcheck -I /home/opam/.opam/5.3/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.3/lib/bin_prot -I /home/opam/.opam/5.3/lib/bin_prot/shape -I /home/opam/.opam/5.3/lib/core -I /home/opam/.opam/5.3/lib/core/base_for_tests -I /home/opam/.opam/5.3/lib/core/command -I /home/opam/.opam/5.3/lib/core/filename_base -I /home/opam/.opam/5.3/lib/core/heap_block -I /home/opam/.opam/5.3/lib/core/univ_map -I /home/opam/.opam/5.3/lib/core/validate -I /home/opam/.opam/5.3/lib/core_kernel/caml_threads -I /home/opam/.opam/5.3/lib/core_kernel/caml_unix -I /home/opam/.opam/5.3/lib/core_kernel/flags -I /home/opam/.opam/5.3/lib/fieldslib -I /home/opam/.opam/5.3/lib/gel -I /home/opam/.opam/5.3/lib/int_repr -I /home/opam/.opam/5.3/lib/jane-street-headers -I /home/opam/.opam/5.3/lib/ocaml/threads -I /home/opam/.opam/5.3/lib/ocaml/unix -I /home/opam/.opam/5.3/lib/ocaml_intrinsics_kernel -I /home/opam/.opam/5.3/lib/parsexp -I /home/opam/.opam/5.3/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_diff/diffable -I /home/opam/.opam/5.3/lib/ppx_diff/diffable_cinaps -I /home/opam/.opam/5.3/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_expect/config -I /home/opam/.opam/5.3/lib/ppx_expect/config_types -I /home/opam/.opam/5.3/lib/ppx_expect/make_corrected_file -I /home/opam/.opam/5.3/lib/ppx_expect/runtime -I /home/opam/.opam/5.3/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_inline_test/config -I /home/opam/.opam/5.3/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_log/syntax -I /home/opam/.opam/5.3/lib/ppx_log/types -I /home/opam/.opam/5.3/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.3/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_stable_witness/runtime -I /home/opam/.opam/5.3/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/5.3/lib/ppx_string/runtime -I /home/opam/.opam/5.3/lib/ppxlib/print_diff -I /home/opam/.opam/5.3/lib/sexplib -I /home/opam/.opam/5.3/lib/sexplib/unix -I /home/opam/.opam/5.3/lib/sexplib0 -I /home/opam/.opam/5.3/lib/spawn -I /home/opam/.opam/5.3/lib/splittable_random -I /home/opam/.opam/5.3/lib/stdio -I /home/opam/.opam/5.3/lib/time_now -I /home/opam/.opam/5.3/lib/typerep -I /home/opam/.opam/5.3/lib/variantslib -I ../../core_unix/src -I ../../error_checking_mutex/src -I ../../ocaml_c_utils/src -I ../../signal_unix/src -o bigstring_unix_stubs.o -c bigstring_unix_stubs.c)
 In file included from /home/opam/.opam/5.3/lib/ocaml/caml/io.h:28,
                  from bigstring_unix_stubs.c:316:
 /home/opam/.opam/5.3/lib/ocaml/caml/platform.h: In function 'caml_plat_latch_is_released':
 /home/opam/.opam/5.3/lib/ocaml/caml/platform.h:222:10: error: implicit declaration of function 'atomic_load_acquire' [-Wimplicit-function-declaration]
   222 |   return atomic_load_acquire(&latch->value) == Latch_released;
       |          ^~~~~~~~~~~~~~~~~~~
 /home/opam/.opam/5.3/lib/ocaml/caml/platform.h: In function 'caml_plat_latch_set':
 /home/opam/.opam/5.3/lib/ocaml/caml/platform.h:230:3: error: implicit declaration of function 'atomic_store_release'; did you mean 'atomic_store_explicit'? [-Wimplicit-function-declaration]
   230 |   atomic_store_release(&latch->value, Latch_unreleased);
       |   ^~~~~~~~~~~~~~~~~~~~
       |   atomic_store_explicit
 (cd _build/default && /home/opam/.opam/5.3/bin/ocamlopt.opt -w -40 -g -I time_float_unix/time_unix/.time_unix.objs/byte -I time_float_unix/time_unix/.time_unix.objs/native -I /home/opam/.opam/5.3/lib/base -I /home/opam/.opam/5.3/lib/base/base_internalhash_types -I /home/opam/.opam/5.3/lib/base/md5 -I /home/opam/.opam/5.3/lib/base/shadow_stdlib -I /home/opam/.opam/5.3/lib/base_bigstring -I /home/opam/.opam/5.3/lib/base_quickcheck -I /home/opam/.opam/5.3/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.3/lib/bin_prot -I /home/opam/.opam/5.3/lib/bin_prot/shape -I /home/opam/.opam/5.3/lib/core -I /home/opam/.opam/5.3/lib/core/base_for_tests -I /home/opam/.opam/5.3/lib/core/command -I /home/opam/.opam/5.3/lib/core/filename_base -I /home/opam/.opam/5.3/lib/core/heap_block -I /home/opam/.opam/5.3/lib/core/univ_map -I /home/opam/.opam/5.3/lib/core/validate -I /home/opam/.opam/5.3/lib/core_kernel/caml_threads -I /home/opam/.opam/5.3/lib/core_kernel/caml_unix -I /home/opam/.opam/5.3/lib/core_kernel/flags -I /home/opam/.opam/5.3/lib/fieldslib -I /home/opam/.opam/5.3/lib/gel -I /home/opam/.opam/5.3/lib/int_repr -I /home/opam/.opam/5.3/lib/jane-street-headers -I /home/opam/.opam/5.3/lib/ocaml/threads -I /home/opam/.opam/5.3/lib/ocaml/unix -I /home/opam/.opam/5.3/lib/ocaml_intrinsics_kernel -I /home/opam/.opam/5.3/lib/parsexp -I /home/opam/.opam/5.3/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_diff/diffable -I /home/opam/.opam/5.3/lib/ppx_diff/diffable_cinaps -I /home/opam/.opam/5.3/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_expect/config -I /home/opam/.opam/5.3/lib/ppx_expect/config_types -I /home/opam/.opam/5.3/lib/ppx_expect/make_corrected_file -I /home/opam/.opam/5.3/lib/ppx_expect/runtime -I /home/opam/.opam/5.3/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_inline_test/config -I /home/opam/.opam/5.3/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_log/syntax -I /home/opam/.opam/5.3/lib/ppx_log/types -I /home/opam/.opam/5.3/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.3/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_stable_witness/runtime -I /home/opam/.opam/5.3/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/5.3/lib/ppx_string/runtime -I /home/opam/.opam/5.3/lib/ppxlib/print_diff -I /home/opam/.opam/5.3/lib/sexplib -I /home/opam/.opam/5.3/lib/sexplib/unix -I /home/opam/.opam/5.3/lib/sexplib0 -I /home/opam/.opam/5.3/lib/spawn -I /home/opam/.opam/5.3/lib/splittable_random -I /home/opam/.opam/5.3/lib/stdio -I /home/opam/.opam/5.3/lib/time_now -I /home/opam/.opam/5.3/lib/timezone -I /home/opam/.opam/5.3/lib/typerep -I /home/opam/.opam/5.3/lib/variantslib -I core_unix/src/.core_unix.objs/byte -I core_unix/src/.core_unix.objs/native -I error_checking_mutex/src/.error_checking_mutex.objs/byte -I error_checking_mutex/src/.error_checking_mutex.objs/native -I signal_unix/src/.signal_unix.objs/byte -I signal_unix/src/.signal_unix.objs/native -I time_float_unix/src/.time_float_unix.objs/byte -I time_float_unix/src/.time_float_unix.objs/native -intf-suffix .ml -no-alias-deps -o time_float_unix/time_unix/.time_unix.objs/native/time_unix.cmx -c -impl time_float_unix/time_unix/time_unix.pp.ml)
 File "time_float_unix/time_unix/time_unix.ml", line 1, characters 4-14:
 1 | [@@@deprecated "[since 2022-04] Use [Time_float_unix] instead"]
         ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
```