### PR TITLE
[new release] domainslib (0.5.2)

### DIFF
--- a/packages/domainslib/domainslib.0.5.2/opam
+++ b/packages/domainslib/domainslib.0.5.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Parallel Structures over Domains for Multicore OCaml"
+maintainer: ["KC Sivaramakrishnan <kc@kcsrk.info>" "Sudha Parimala"]
+authors: ["KC Sivaramakrishnan <kc@kcsrk.info>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/domainslib"
+doc: "https://ocaml-multicore.github.io/domainslib/doc"
+bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "5.0"}
+  "saturn" {>= "1.0.0"}
+  "domain-local-await" {>= "0.1.0"}
+  "kcas" {>= "0.3.0" & with-test}
+  "mirage-clock-unix" {with-test & >= "4.2.0"}
+  "qcheck-core" {with-test & >= "0.20"}
+  "qcheck-multicoretests-util" {with-test & >= "0.1"}
+  "qcheck-stm" {with-test & >= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/domainslib/releases/download/0.5.2/domainslib-0.5.2.tbz"
+  checksum: [
+    "sha256=a720ece2cb41b2a591ad1a44a2db9ecd5573e8b7b5112e8d46d0f275f9af1caf"
+    "sha512=08300d827a7aadd164929177ee15ef45a729a10b961efbb1df7051b1ddf9f869a3c77b58aa277e17ad2002f292b4970af1d8d6b9576f448e769996a36e64ed56"
+  ]
+}
+x-commit-hash: "2a884868ff69c13ecef8efecca9ba1102ff11a7f"


### PR DESCRIPTION
Parallel Structures over Domains for Multicore OCaml

- Project page: <a href="https://github.com/ocaml-multicore/domainslib">https://github.com/ocaml-multicore/domainslib</a>
- Documentation: <a href="https://ocaml-multicore.github.io/domainslib/doc">https://ocaml-multicore.github.io/domainslib/doc</a>

##### CHANGES:

* Upgrade to Saturn 1.0 (ocaml-multicore/domainslib#129, @Sudha247)
* Update README.md instruction to use OCaml 5.1.0 (ocaml-multicore/domainslib#123, @punchagan)
* Fix Saturn.Queue function (ocaml-multicore/domainslib#121, @Sudha247)
* Make parallel_scan work on noncommutative functions (ocaml-multicore/domainslib#118, @aytao)
* Test condition tweaks (ocaml-multicore/domainslib#113, @jmid)
* Adjust PBTs based on recommended_domain_count (ocaml-multicore/domainslib#112, @jmid)
