### PR TITLE
core_unix: Disable the package on OCaml >= 5.3 on non-x86_64 platforms

### DIFF
--- a/packages/core_unix/core_unix.v0.17.0/opam
+++ b/packages/core_unix/core_unix.v0.17.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"                    {>= "5.1.0"}
+  "ocaml"                    {>= "5.1.0" & (< "5.3" | arch = "x86_64")}
   "core"                     {>= "v0.17" & < "v0.18"}
   "core_kernel"              {>= "v0.17" & < "v0.18"}
   "expect_test_helpers_core" {>= "v0.17" & < "v0.18"}


### PR DESCRIPTION
see janestreet/core_unix#14