### PR TITLE
[new release] ocamlgraph (2 packages) (2.2.0)

### DIFF
--- a/packages/ocamlgraph/ocamlgraph.2.2.0/opam
+++ b/packages/ocamlgraph/ocamlgraph.2.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "A generic graph library for OCaml"
+description: "Provides both graph data structures and graph algorithms"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
+authors: ["Sylvain Conchon" "Jean-Christophe Filliâtre" "Julien Signoles"]
+license: "LGPL-2.1-only"
+tags: [
+  "graph"
+  "library"
+  "algorithms"
+  "directed graph"
+  "vertice"
+  "edge"
+  "persistent"
+  "imperative"
+]
+homepage: "https://github.com/backtracking/ocamlgraph/"
+doc: "https://backtracking.github.io/ocamlgraph"
+bug-reports: "https://github.com/backtracking/ocamlgraph/issues/new"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "graphics" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/backtracking/ocamlgraph.git"
+url {
+  src:
+    "https://github.com/backtracking/ocamlgraph/releases/download/2.2.0/ocamlgraph-2.2.0.tbz"
+  checksum: [
+    "sha256=b0956210863cc24f480203ba3c2ef06dfae5579536a05744364e7de58822b230"
+    "sha512=257cdd5fb90337b3e3682cade1269c1d181f3124e569a731909f49bbfbe581ab529ac401472fb9ef57166ac34d8ebadfa6a32c93665f38f5a335982d5e5dc0e1"
+  ]
+}
+x-commit-hash: "710007690fb2286f9f2ce10e19fa47a67b634670"

--- a/packages/ocamlgraph_gtk/ocamlgraph_gtk.2.2.0/opam
+++ b/packages/ocamlgraph_gtk/ocamlgraph_gtk.2.2.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Displaying graphs using OCamlGraph and GTK"
+description: "Displaying graphs using OCamlGraph and GTK"
+maintainer: ["jean-christophe.filliatre@cnrs.fr"]
+authors: ["Sylvain Conchon" "Jean-Christophe Filliâtre" "Julien Signoles"]
+license: "LGPL-2.1-only"
+tags: [
+  "graph"
+  "library"
+  "algorithms"
+  "directed graph"
+  "vertice"
+  "edge"
+  "persistent"
+  "imperative"
+]
+homepage: "https://github.com/backtracking/ocamlgraph/"
+doc: "https://backtracking.github.io/ocamlgraph"
+bug-reports: "https://github.com/backtracking/ocamlgraph/issues/new"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "lablgtk"
+  "conf-gnomecanvas"
+  "ocamlgraph" {>= "2.0.0"}
+  "dune" {>= "2.0"}
+  "graphics" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/backtracking/ocamlgraph.git"
+url {
+  src:
+    "https://github.com/backtracking/ocamlgraph/releases/download/2.2.0/ocamlgraph-2.2.0.tbz"
+  checksum: [
+    "sha256=b0956210863cc24f480203ba3c2ef06dfae5579536a05744364e7de58822b230"
+    "sha512=257cdd5fb90337b3e3682cade1269c1d181f3124e569a731909f49bbfbe581ab529ac401472fb9ef57166ac34d8ebadfa6a32c93665f38f5a335982d5e5dc0e1"
+  ]
+}
+x-commit-hash: "710007690fb2286f9f2ce10e19fa47a67b634670"


### PR DESCRIPTION
A generic graph library for OCaml

- Project page: <a href="https://github.com/backtracking/ocamlgraph/">https://github.com/backtracking/ocamlgraph/</a>
- Documentation: <a href="https://backtracking.github.io/ocamlgraph">https://backtracking.github.io/ocamlgraph</a>

##### CHANGES:

  - [Topological]: Fix topological stable sort (backtracking/ocamlgraph#149, Maxime Buyse)
  - [Path]: new module [Bfs01] to implement 0-1 BFS
  - [Classic] new functions [kneser] and [petersen] to build Kneser's
    graphs and the Petersen graph
  - [Oper] fixed transitive reduction (backtracking/ocamlgraph#145, reported by sim642)
    and tests for transitive reduction!
  - new example `depend2dot` to turn `make`-like dependencies
    into a DOT graph, with transitive reduction
  - [Graphviz]: added `PosPinned` to type `NeatoAttributes.vertex`
  - [Oper]: improved efficiency of `intersect`
    (backtracking/ocamlgraph#136, reported by Ion Chirica)
  - [Path.Check]: improved efficiency with a better use of the cache
    (backtracking/ocamlgraph#125 by Paul Patault)
  - [Cycles.Johnson]: Enumerate elementary cycles (Johnson, 1975)
    (contributed by Timothy Bourke)
  - [Traverse.Bfs]: new function `{fold,iter}_component_dist` to
    perform a breadth-first traversal with the distance from the source
