### PR TITLE
[new release] slipshow (0.2.0)

### DIFF
--- a/packages/slipshow/slipshow.0.2.0/opam
+++ b/packages/slipshow/slipshow.0.2.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "A compiler from markdown to slipshow"
+description:
+  "Slipshow is an engine to write slips, a concept evolved from slides."
+maintainer: ["Paul-Elliot"]
+authors: ["Paul-Elliot"]
+license: "GPL-3.0-or-later"
+tags: ["slipshow" "presentation" "slideshow" "beamer"]
+homepage: "https://github.com/panglesd/slipshow"
+doc: "https://slipshow.readthedocs.io"
+bug-reports: "https://github.com/panglesd/slipshow/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.6"}
+  "crunch" {with-dev-setup}
+  "cmdliner" {>= "1.3.0"}
+  "base64"
+  "bos"
+  "lwt"
+  "irmin-watcher"
+  "js_of_ocaml-compiler"
+  "js_of_ocaml-lwt"
+  "magic-mime"
+  "dream" {>= "1.0.0~alpha5"}
+  "fpath"
+  "ppx_blob" {>= "0.8.0"}
+  "sexplib"
+  "ppx_sexp_conv"
+  "odoc" {with-doc}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/panglesd/slipshow.git"
+url {
+  src:
+    "https://github.com/panglesd/slipshow/releases/download/v0.2.0/slipshow-0.2.0.tbz"
+  checksum: [
+    "sha256=4e2c374f77a2293a7c07ee2bcd83754b8e6ad3d51dd708e63ba76456f8e36680"
+    "sha512=3e52d91dd7f16314d4a38d61774d450b7cf336090a0c3846b2a4ee1a0f3b791c1cdfbbda2ba6eabe0818678ba6b0849c67b5c284e8cac5203b32ae1c5680f1b9"
+  ]
+}
+x-commit-hash: "8f7436f72a10472227464a821f8462d52175a9d6"


### PR DESCRIPTION
CHANGES:

- Split commands in groups (panglesd/slipshow#112). Examples:
  - `slipshow file.md` becomes `slipshow compile file.md`
  - `slipshow --serve file.md` becomes `slipshow serve file.md`
  - `slipshow --markdown-output file.md` becomes `slipshow markdown file.md`
- Add a `--theme` argument and a command to list the themes: `slipshow themes list` (panglesd/slipshow#109)

- Allow to focus on multiple elements. Zooms as much as possible so everything is visible, and center. Backward compatible, focusing on a single element. (panglesd/slipshow#103)
- Pass all actions to slip-scripts, accesible via the `slip` object. (panglesd/slipshow#104)
- Introduce `slip.onUndo`, `slip.setProp` and `slip.state`. (panglesd/slipshow#97)
- Improve mobile support, with buttons to navigate and open the table of content (panglesd/slipshow#106)
- Add `scroll` action to scroll up or down, if needed (panglesd/slipshow#107)

- Add the "vanier" theme from the pre-OCaml era (panglesd/slipshow#109)