### PR TITLE
[new release] orthologic-coq (0.9.1)

### DIFF
--- a/packages/orthologic-coq/orthologic-coq.0.9.1/opam
+++ b/packages/orthologic-coq/orthologic-coq.0.9.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Simon Guilloud"
+
+homepage: "https://github.com/SimonGuilloud/orthologic-coq"
+dev-repo: "git+https://github.com/SimonGuilloud/orthologic-coq.git"
+bug-reports: "https://github.com/SimonGuilloud/orthologic-coq/issues"
+license: "CC-BY-4.0"
+
+synopsis: "A plugin to add orthologic-based tactics to Coq"
+description: """
+Orthologic-based reasoning is super great. 
+This plugin proposes a verified and optimized implementation of orthologic proof search, with memoization and pointer equality.
+It also provides an ocaml-based tactic that computes orthologic normal form, and a boolean tautology solver
+based on it."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "5.3.0"}
+  "dune" {>= "3.8"}
+  "coq" {= "8.18.0"}
+]
+
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:orthologic"
+  "logpath:OLCoq"
+]
+
+authors: [
+  "Simon Guilloud"
+  "Clément Pit-Claudel"
+]
+url {
+  src:
+    "https://github.com/SimonGuilloud/orthologic-coq/releases/download/v0.9.1/orthologic-coq-0.9.1.tbz"
+  checksum: [
+    "sha256=60a9eeb27b6ad0a6fadb4127f5a7fdc194133dc55fa627e5eaedbee58a58651e"
+    "sha512=bab767857cecbb1529e599785f2485e62171a55b7ec34483976a9a15e8223167c52a2977f88752e64f17fd1b4e6fde682b608bd046b2a7867da2eca10844cf57"
+  ]
+}
+x-commit-hash: "f546dffab29a715c4c542116991f7edb3ef26af6"

--- a/packages/orthologic-coq/orthologic-coq.0.9.1/opam
+++ b/packages/orthologic-coq/orthologic-coq.0.9.1/opam
@@ -30,6 +30,7 @@ authors: [
   "Simon Guilloud"
   "Clément Pit-Claudel"
 ]
+conflicts: arch != "arm32" & arch != "x86_32"
 url {
   src:
     "https://github.com/SimonGuilloud/orthologic-coq/releases/download/v0.9.1/orthologic-coq-0.9.1.tbz"

--- a/packages/orthologic-coq/orthologic-coq.0.9.1/opam
+++ b/packages/orthologic-coq/orthologic-coq.0.9.1/opam
@@ -30,7 +30,7 @@ authors: [
   "Simon Guilloud"
   "Clément Pit-Claudel"
 ]
-conflicts: arch != "arm32" & arch != "x86_32"
+available: arch != "arm32" & arch != "x86_32"
 url {
   src:
     "https://github.com/SimonGuilloud/orthologic-coq/releases/download/v0.9.1/orthologic-coq-0.9.1.tbz"


### PR DESCRIPTION
A plugin to add orthologic-based tactics to Coq

- Project page: <a href="https://github.com/SimonGuilloud/orthologic-coq">https://github.com/SimonGuilloud/orthologic-coq</a>

##### CHANGES:

Initial Release.
