### PR TITLE
Update Mazeppa v0.5.2 `opam` file

### DIFF
--- a/packages/mazeppa/mazeppa.0.5.2/opam
+++ b/packages/mazeppa/mazeppa.0.5.2/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.14"}
   "pprint"
-  "checked_oint" {>= "0.5.0"}
+  "checked_oint" {= "0.5.0"}
   "ppx_deriving"
   "ppx_string_interpolation"
   "ppx_yojson_conv"


### PR DESCRIPTION
This should fix https://github.com/ocaml/opam-repository/pull/27746.
