### PR TITLE
Update coccinelle 1.2.0

### DIFF
--- a/packages/coccinelle/coccinelle.1.2/opam
+++ b/packages/coccinelle/coccinelle.1.2/opam
@@ -35,7 +35,7 @@ description: """
 Coccinelle provides the language SmPL (Semantic Patch Language) for specifying
 desired matches and transformations in C code."""
 url {
-  src: "https://github.com/user-attachments/files/19763988/1.2.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/refs/heads/main/coccinelle-1.2.0.tar.gz"
   checksum: [
     "md5=2fb149bc3c196d6d8f2170d3d4cf2ae4"
     "sha512=a3a3d5021fbbfe5c5173f39e9fb4162427ff8adff66ae62c4d59ff15f75a3f25fa844fa5133e8ae18574d4dc26a68ffa949a1d34aa69dfdfd56af5a8c13ea227"

--- a/packages/coccinelle/coccinelle.1.2/opam
+++ b/packages/coccinelle/coccinelle.1.2/opam
@@ -35,7 +35,7 @@ description: """
 Coccinelle provides the language SmPL (Semantic Patch Language) for specifying
 desired matches and transformations in C code."""
 url {
-  src: "https://github.com/coccinelle/coccinelle/archive/refs/tags/1.2.tar.gz"
+  src: "https://github.com/user-attachments/files/19763988/1.2.tar.gz"
   checksum: [
     "md5=2fb149bc3c196d6d8f2170d3d4cf2ae4"
     "sha512=a3a3d5021fbbfe5c5173f39e9fb4162427ff8adff66ae62c4d59ff15f75a3f25fa844fa5133e8ae18574d4dc26a68ffa949a1d34aa69dfdfd56af5a8c13ea227"


### PR DESCRIPTION
Initially, coccinelle was released as 1.2 version. Later, it was renamed to 1.2.0 for consistency with other releases. 1.2.tar.gz package is no longer available on the releases page, now it's 1.2.0.tar.gz

I renamed the package. However, it may be better just to update the link.z