### PR TITLE
[new release] opam-monorepo (0.4.2)

### DIFF
--- a/packages/opam-monorepo/opam-monorepo.0.4.2/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.4.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Assemble and manage fully vendored Dune repositories"
+description: """
+The opam monorepo plugin provides a convenient interface to bridge the
+opam package manager with having a local copy of all the source
+code required to build a project using the dune build tool."""
+maintainer: ["anil@recoil.org"]
+authors: [
+  "Anil Madhavapeddy" "Nathan Rebours" "Lucas Pluvinage" "Jules Aguillon"
+]
+license: "ISC"
+homepage: "https://github.com/tarides/opam-monorepo"
+doc: "https://tarides.github.io/opam-monorepo"
+bug-reports: "https://github.com/tarides/opam-monorepo/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.10.0"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "dune-build-info" {= "2.7.0" | = "2.7.1"}
+  "dune-configurator" {= "2.7.0" | = "2.7.1"}
+]
+dev-repo: "git+https://github.com/tarides/opam-monorepo.git"
+build: [ "dune" "build" "-p" name "-j" jobs "@install" "@test/lib/runtest" {with-test} ]
+flags: [ plugin ]
+url {
+  src:
+    "https://github.com/tarides/opam-monorepo/releases/download/0.4.2/opam-monorepo-0.4.2.tbz"
+  checksum: [
+    "sha256=51741adc1992f3ed415dd15ecb1aebe61784b28fa27dade0392a7a39d04e74fe"
+    "sha512=40e6ac5f66fabdf7f1dd997dcdc7b25c188274e8d51b8fea5631c19252bcd742ab64e554b10e9631ba1ff49961f59bb76c8d67cba0e03d6ec5ada5b9fefa3be9"
+  ]
+}
+x-commit-hash: "71984beaa656d2dd5ade17d6f55fe9dca21130a9"

--- a/packages/opam-monorepo/opam-monorepo.0.4.2/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.4.2/opam
@@ -14,7 +14,7 @@ doc: "https://tarides.github.io/opam-monorepo"
 bug-reports: "https://github.com/tarides/opam-monorepo/issues"
 depends: [
   "dune" {>= "3.6"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.13.0"}
   "odoc" {with-doc}
   "conf-pkg-config"
 ]

--- a/packages/opam-monorepo/opam-monorepo.0.4.2/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.4.2/opam
@@ -16,6 +16,7 @@ depends: [
   "dune" {>= "3.6"}
   "ocaml" {>= "4.10.0"}
   "odoc" {with-doc}
+  "conf-pkg-config"
 ]
 conflicts: [
   "dune-build-info" {= "2.7.0" | = "2.7.1"}


### PR DESCRIPTION
Assemble and manage fully vendored Dune repositories

- Project page: <a href="https://github.com/tarides/opam-monorepo">https://github.com/tarides/opam-monorepo</a>
- Documentation: <a href="https://tarides.github.io/opam-monorepo">https://tarides.github.io/opam-monorepo</a>

##### CHANGES:

### Added

### Changed

### Deprecated

### Fixed

- Drop `base` as a dependency to fix build on macos-arm (tarides/opam-monorepo#411, @reynir, reported by @gm0stache)

### Removed

### Security
