### PR TITLE
Package ocaml_intrinsics.v0.16.2

### DIFF
--- a/packages/ocaml_intrinsics/ocaml_intrinsics.v0.16.2/opam
+++ b/packages/ocaml_intrinsics/ocaml_intrinsics.v0.16.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ocaml_intrinsics"
+bug-reports: "https://github.com/janestreet/ocaml_intrinsics/issues"
+dev-repo: "git+https://github.com/janestreet/ocaml_intrinsics.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ocaml_intrinsics/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"             {>= "4.14.0"}
+  "dune"              {>= "2.0.0"}
+  "dune-configurator"
+]
+synopsis: "Intrinsics"
+description: "
+Provides functions to invoke amd64 instructions (such as clz,popcnt,rdtsc,rdpmc)
+     when available, or compatible software implementation on other targets.
+"
+available: (arch = "x86_64" | arch = "arm64") & os != "win32"
+url {
+  src:
+    "https://github.com/janestreet/ocaml_intrinsics/archive/refs/tags/v0.16.2.tar.gz"
+  checksum: [
+    "md5=30a6bf3dcbde30922a38c970a6898b4d"
+    "sha512=2d13598222764f79f610825a24e61ee5f5aab9689796189beba8d1f450d2428e9b557b6b9f6b0166db6f04e06796db0549825a42032fd8c7d79852581e407208"
+  ]
+}


### PR DESCRIPTION
### `ocaml_intrinsics.v0.16.2`
Intrinsics
Provides functions to invoke amd64 instructions (such as clz,popcnt,rdtsc,rdpmc)
     when available, or compatible software implementation on other targets.



---
* Homepage: https://github.com/janestreet/ocaml_intrinsics
* Source repo: git+https://github.com/janestreet/ocaml_intrinsics.git
* Bug tracker: https://github.com/janestreet/ocaml_intrinsics/issues

---
:camel: Pull-request generated by opam-publish v2.4.0