### PR TITLE
Package core_unix.v0.17.1

### DIFF
--- a/packages/core_unix/core_unix.v0.17.1/opam
+++ b/packages/core_unix/core_unix.v0.17.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/core_unix"
+bug-reports: "https://github.com/janestreet/core_unix/issues"
+dev-repo: "git+https://github.com/janestreet/core_unix.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/core_unix/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"                    {>= "5.1.0"}
+  "core"                     {>= "v0.17" & < "v0.18"}
+  "core_kernel"              {>= "v0.17" & < "v0.18"}
+  "expect_test_helpers_core" {>= "v0.17" & < "v0.18"}
+  "jane-street-headers"      {>= "v0.17" & < "v0.18"}
+  "jst-config"               {>= "v0.17" & < "v0.18"}
+  "ppx_jane"                 {>= "v0.17" & < "v0.18"}
+  "ppx_optcomp"              {>= "v0.17" & < "v0.18"}
+  "sexplib"                  {>= "v0.17" & < "v0.18"}
+  "timezone"                 {>= "v0.17" & < "v0.18"}
+  "uopt"                     {>= "v0.17" & < "v0.18"}
+  "base-threads"
+  "dune"                     {>= "3.11.0"}
+  "spawn"                    {>= "v0.15"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Unix-specific portions of Core"
+description: "
+Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
+"
+depexts: ["linux-headers"] {os-family = "alpine"}
+url {
+  src:
+    "https://github.com/janestreet/core_unix/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=9370dca36f518fcea046d2752e3de22b"
+    "sha512=c4e8ce9d5885ac8fa8d554a97e1857f3a1c933e0eb5dfd4fe874412b9d09e6d0a2973b644733855553f33f5c859719228f0e6aaf3a2b7eb5befb46fc513750de"
+  ]
+}


### PR DESCRIPTION
### `core_unix.v0.17.1`
Unix-specific portions of Core
Unix-specific extensions to some of the modules defined in [core] and [core_kernel].



---
* Homepage: https://github.com/janestreet/core_unix
* Source repo: git+https://github.com/janestreet/core_unix.git
* Bug tracker: https://github.com/janestreet/core_unix/issues

---
:camel: Pull-request generated by opam-publish v2.4.0