### PR TITLE
Avoid referring to ez-conf-lib:exe

### DIFF
--- a/packages/conf-gmp-paths/conf-gmp-paths.1/opam
+++ b/packages/conf-gmp-paths/conf-gmp-paths.1/opam
@@ -8,7 +8,7 @@ homepage: "http://gmplib.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-1.0-or-later"
 build: [
-  [ "sh" ez-conf-lib:exe "gmp" "gmp.h" "test-gmp.c"
+  [ "sh" "%{ez-conf-lib:lib}%/ez-conf-lib" "gmp" "gmp.h" "test-gmp.c"
          "--package-name" "conf-gmp-paths"
          "--"
          "/usr/local" {os != "macos" & os != "win32"}

--- a/packages/conf-mpfr-paths/conf-mpfr-paths.1/opam
+++ b/packages/conf-mpfr-paths/conf-mpfr-paths.1/opam
@@ -8,7 +8,7 @@ homepage: "http://gmplib.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-1.0-or-later"
 build: [
-  [ "sh" ez-conf-lib:exe "mpfr" "mpfr.h" "test-mpfr.c"
+  [ "sh" "%{ez-conf-lib:lib}%/ez-conf-lib" "mpfr" "mpfr.h" "test-mpfr.c"
          "CPPFLAGS+=-I%{conf-gmp-paths:incdir}%"
          "LDFLAGS+=-L%{conf-gmp-paths:libdir}%"
          "LIBS+=-lgmp"


### PR DESCRIPTION
The `ez-conf-lib:exe` variable is set in `ez-conf-lib.config` generated while building the `ez-conf-lib` package, and is set to the absolute path to the `ez-conf-lib` script. This causes a problem if the opam switch where `ez-conf-lib` is installed to is ever moved, as the absolute path will no longer refer to the correct place. This also creates problems for dune package management which moves all installed artifacts of a package after running its install command.

The fix is to refer to the `ez-conf-lib` script directly by specifying its path relative to the `lib` directory where it is installed.

This is intended to fix https://github.com/ocaml/dune/issues/11598 (that issue is closed because we implemented a hacky workaround in dune's overlay repo).

CC @nberth who authored these packgaes.