### PR TITLE
[new release] tcpip (9.0.1)

### DIFF
--- a/packages/tcpip/tcpip.9.0.1/opam
+++ b/packages/tcpip/tcpip.9.0.1/opam
@@ -16,7 +16,7 @@ x-maintenance-intent: [ "(latest)" ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {os != "macos" & with-test}
 ]
 conflicts: [
   "mirage-xen" {< "6.0.0"}

--- a/packages/tcpip/tcpip.9.0.1/opam
+++ b/packages/tcpip/tcpip.9.0.1/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+x-maintenance-intent: [ "(latest)" ]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding"
+  "result" {< "1.5"}
+]
+depends: [
+  "dune" {>= "2.7.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.2.0"}
+  "cstruct-lwt"
+  "mirage-net" {>= "3.0.0"}
+  "mirage-mtime" {>= "4.0.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "mirage-sleep" {>= "4.0.0"}
+  "ipaddr" {>= "5.6.0"}
+  "macaddr" {>="4.0.0"}
+  "macaddr-cstruct"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv" {>= "0.2.0"}
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "4.0.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "mirage-vnetif" {with-test & >= "0.6.2"}
+  "alcotest" {with-test & >="1.5.0"}
+  "pcap-format" {with-test}
+  "ipaddr-cstruct"
+  "macaddr-cstruct"
+  "lru" {>= "0.3.0"}
+  "metrics"
+  "cmdliner" {>= "1.1.0"}
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v9.0.1/tcpip-9.0.1.tbz"
+  checksum: [
+    "sha256=fac07ce986811cf5e3d71373d92b631cc30fbef548d6da21b0917212dcf90b03"
+    "sha512=01de13f560d58b1524c39619e4e4cb6ebbf069155eb43d0f264aa12b00e0cc8c39792719e3ca46585dd596b692b8e1e3f8c132f005ed9e2d77747c0c158bf4d9"
+  ]
+}
+x-commit-hash: "ee22b76879cda4f00cd942664fb55904a9d63378"


### PR DESCRIPTION
OCaml TCP/IP networking stack, used in MirageOS

- Project page: <a href="https://github.com/mirage/mirage-tcpip">https://github.com/mirage/mirage-tcpip</a>
- Documentation: <a href="https://mirage.github.io/mirage-tcpip/">https://mirage.github.io/mirage-tcpip/</a>

##### CHANGES:

* Unix: avoid spurious warnings when the fd is scheduled to be closed (mirage/mirage-tcpip#527
  @hannesm, review by @djs55 @reynir)
* Unix: if recvfrom (UDP sockets) returns 0 (signalling EOF), do not try to read
  again (avoids busy loops) (mirage/mirage-tcpip#528 @hannesm, review by @reynir)
