### PR TITLE
[new release] ca-certs (1.0.1)

### DIFF
--- a/packages/ca-certs/ca-certs.1.0.1/opam
+++ b/packages/ca-certs/ca-certs.1.0.1/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Detect root CA certificates from the operating system"
+description: """
+TLS requires a set of root anchors (Certificate Authorities) to
+authenticate servers. This library exposes this list so that it can be
+registered with ocaml-tls.
+"""
+maintainer: ["Etienne Millon <me@emillon.org>"]
+authors: [
+  "Etienne Millon <me@emillon.org>, Hannes Mehnert <hannes@mehnert.org>"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ca-certs"
+doc: "https://mirage.github.io/ca-certs/doc"
+bug-reports: "https://github.com/mirage/ca-certs/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "bos"
+  "fpath"
+  "ptime"
+  "logs"
+  "digestif" {>= "1.2.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "x509" {>= "1.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "ohex" {>= "0.2.0"}
+  "alcotest" {with-test}
+  "fmt" {with-test & >= "0.8.7"}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+dev-repo: "git+https://github.com/mirage/ca-certs.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"} # the opam sandbox on macos leads to test failures (ocaml/opam#4389)
+    "@doc" {with-doc}
+  ]
+]
+tags: ["org:mirage"]
+depexts: [
+  ["ca_root_nss"] {os = "freebsd"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ca-certs/releases/download/v1.0.1/ca-certs-1.0.1.tbz"
+  checksum: [
+    "sha256=d3cd7c8f548baecef208d425877a811d898ec7d1d9c4bdea6f78652c7c8361cc"
+    "sha512=cb2e2c509531a4824b035762e57217143d7eec7bc57434845b65850144051344b4ed27d61972b6580b83d2d012766919c101a0274fb6218c4e4f65b45d3c79fa"
+  ]
+}
+x-commit-hash: "319c8a6e7c06da6a4fc3dab5db41cdd28be2e9cf"


### PR DESCRIPTION
Detect root CA certificates from the operating system

- Project page: <a href="https://github.com/mirage/ca-certs">https://github.com/mirage/ca-certs</a>
- Documentation: <a href="https://mirage.github.io/ca-certs/doc">https://mirage.github.io/ca-certs/doc</a>

##### CHANGES:

* Add OCAML_EXTRA_CA_CERTS env variable (mirage/ca-certs#30 @art-w)
* macOS: add additional keychain path `/Library/Keychains/System.keychain`
  (mirage/ca-certs#28 @ajbt200128)
* Demote log levels of trust anchor parsing failures (now on the debug level),
  log a single warning message how many failures occured (mirage/ca-certs#36 @Julow)
