### PR TITLE
[new release] bitwuzla-cxx (0.7.0)

### DIFF
--- a/packages/bitwuzla-cxx/bitwuzla-cxx.0.7.0/opam
+++ b/packages/bitwuzla-cxx/bitwuzla-cxx.0.7.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "SMT solver for AUFBVFP (C++ API)"
+description: """
+
+OCaml binding for the SMT solver Bitwuzla C++ API.
+
+Bitwuzla is a Satisfiability Modulo Theories (SMT) solver for the theories of fixed-size bit-vectors, arrays and uninterpreted functions and their combinations. Its name is derived from an Austrian dialect expression that can be translated as “someone who tinkers with bits”."""
+maintainer: ["Frédéric Recoules <frederic.recoules@cea.fr>"]
+authors: ["Frédéric Recoules"]
+license: "MIT"
+tags: ["SMT solver" "AUFBVFP"]
+homepage: "https://bitwuzla.github.io"
+doc: "https://bitwuzla.github.io/docs/ocaml/"
+bug-reports: "https://github.com/bitwuzla/ocaml-bitwuzla/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.12"}
+  "conf-git" {build}
+  "conf-gcc" {build}
+  "conf-g++" {build}
+  "zarith"
+  "ppx_inline_test" {with-test & >= "v0.13"}
+  "ppx_expect" {with-test & >= "v0.13"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
+available: [ arch != "arm32" & (os = "linux" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) | os = "macos" & os-distribution = "homebrew") ]
+url {
+  src:
+    "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/0.7.0/bitwuzla-cxx-0.7.0.tbz"
+  checksum: [
+    "sha256=ab98f9f9b5486f45b780d14e9684e3452efaaa8e3642071a1d93ebb506ea971f"
+    "sha512=4a6e37b5ce8ea8fdb827b0a7171bf8b3ecf3952309580142ab45ddfed83ca3a07c817675a6cee081536a3ac88625aacace5966ef09169cc9b83d42cf041ce101"
+  ]
+}
+x-commit-hash: "4e496f036a0b5d87ff3f25d761931f680017feb4"

--- a/packages/bitwuzla-cxx/bitwuzla-cxx.0.7.0/opam
+++ b/packages/bitwuzla-cxx/bitwuzla-cxx.0.7.0/opam
@@ -38,7 +38,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
-available: [ arch != "arm32" & (os = "linux" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) | os = "macos" & os-distribution = "homebrew") ]
+available: [ arch != "arm32" & (os = "linux" & os-distribution != "arch" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) | os = "macos" & os-distribution = "homebrew") ]
 url {
   src:
     "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/0.7.0/bitwuzla-cxx-0.7.0.tbz"

--- a/packages/bitwuzla-cxx/bitwuzla-cxx.0.7.0/opam
+++ b/packages/bitwuzla-cxx/bitwuzla-cxx.0.7.0/opam
@@ -43,8 +43,8 @@ url {
   src:
     "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/0.7.0/bitwuzla-cxx-0.7.0.tbz"
   checksum: [
-    "sha256=ab98f9f9b5486f45b780d14e9684e3452efaaa8e3642071a1d93ebb506ea971f"
-    "sha512=4a6e37b5ce8ea8fdb827b0a7171bf8b3ecf3952309580142ab45ddfed83ca3a07c817675a6cee081536a3ac88625aacace5966ef09169cc9b83d42cf041ce101"
+    "sha256=496fb480731b9a12db47a212d0c752b749c33f811ae684260c9643f69f257abb"
+    "sha512=f092f868a053526efdcb5b2a5a83e3672f64a12de9dff4fa13f174afc5b4ec8b083c70a12581cad52cb3889ce000d88080c8752242bc7e992c11357d848f4b23"
   ]
 }
-x-commit-hash: "4e496f036a0b5d87ff3f25d761931f680017feb4"
+x-commit-hash: "9d2894f3d37c2267d6036e5f92acb5a855a75f25"


### PR DESCRIPTION
SMT solver for AUFBVFP (C++ API)

- Project page: <a href="https://bitwuzla.github.io">https://bitwuzla.github.io</a>
- Documentation: <a href="https://bitwuzla.github.io/docs/ocaml/">https://bitwuzla.github.io/docs/ocaml/</a>

##### CHANGES:

Update [Bitwuzla](https://github.com/bitwuzla/bitwuzla/releases/tag/0.7.0) sources.

Vendor submodules:
- [Bitwuzla](https://github.com/bitwuzla/bitwuzla) tag:0.7.0
