### PR TITLE
Fix bdd source url

### DIFF
--- a/packages/bdd/bdd.0.3/opam
+++ b/packages/bdd/bdd.0.3/opam
@@ -18,7 +18,7 @@ synopsis:
   "Quick implementation of a Binary Decision Diagrams (BDD) library for OCaml"
 flags: light-uninstall
 url {
-  src: "https://www.lri.fr/~filliatr/ftp/ocaml/bdd/bdd-0.3.tar.gz"
+  src: "https://usr.lmf.cnrs.fr/~jcf/ftp/ocaml/bdd/bdd-0.3.tar.gz"
   checksum: [
     "sha256=678e591c9b5ee7cd310589c433828c266204f7c260627aea5e5d12798ec9c3c0"
     "md5=56834a743f15b1569712125660aa4af4"


### PR DESCRIPTION
The previous url was being redirected to a webpage (https://usr.lmf.cnrs.fr/~jcf/).

CC @backtracking 