### PR TITLE
Update Mazeppa `opam` files

### DIFF
--- a/packages/mazeppa/mazeppa.0.3.3/opam
+++ b/packages/mazeppa/mazeppa.0.3.3/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "5.1"}
   "dune" {>= "3.15"}
   "pprint"
-  "checked_oint" {>= "0.2.0"}
+  "checked_oint" {= "0.2.0"}
   "ppx_deriving"
   "ppx_string_interpolation"
   "ppx_yojson_conv"

--- a/packages/mazeppa/mazeppa.0.3.4/opam
+++ b/packages/mazeppa/mazeppa.0.3.4/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "5.1"}
   "dune" {>= "3.15"}
   "pprint"
-  "checked_oint" {>= "0.2.0"}
+  "checked_oint" {= "0.2.0"}
   "ppx_deriving"
   "ppx_string_interpolation"
   "ppx_yojson_conv"

--- a/packages/mazeppa/mazeppa.0.4.1/opam
+++ b/packages/mazeppa/mazeppa.0.4.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.14"}
   "pprint"
-  "checked_oint" {>= "0.2.1"}
+  "checked_oint" {= "0.2.1"}
   "ppx_deriving"
   "ppx_string_interpolation"
   "ppx_yojson_conv"

--- a/packages/mazeppa/mazeppa.0.4.2/opam
+++ b/packages/mazeppa/mazeppa.0.4.2/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.14"}
   "pprint"
-  "checked_oint" {>= "0.2.1"}
+  "checked_oint" {= "0.2.1"}
   "ppx_deriving"
   "ppx_string_interpolation"
   "ppx_yojson_conv"

--- a/packages/mazeppa/mazeppa.0.4.3/opam
+++ b/packages/mazeppa/mazeppa.0.4.3/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.14"}
   "pprint"
-  "checked_oint" {>= "0.3.0"}
+  "checked_oint" {= "0.3.0"}
   "ppx_deriving"
   "ppx_string_interpolation"
   "ppx_yojson_conv"

--- a/packages/mazeppa/mazeppa.0.5.0/opam
+++ b/packages/mazeppa/mazeppa.0.5.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.14"}
   "pprint"
-  "checked_oint" {>= "0.4.1"}
+  "checked_oint" {= "0.4.1"}
   "ppx_deriving"
   "ppx_string_interpolation"
   "ppx_yojson_conv"

--- a/packages/mazeppa/mazeppa.0.5.1/opam
+++ b/packages/mazeppa/mazeppa.0.5.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.14"}
   "pprint"
-  "checked_oint" {>= "0.4.1"}
+  "checked_oint" {= "0.4.1"}
   "ppx_deriving"
   "ppx_string_interpolation"
   "ppx_yojson_conv"


### PR DESCRIPTION
Related to https://github.com/ocaml/opam-repository/pull/27746.
