### PR TITLE
Mark `guile.1.0` as unavailable on systems shipping with new GCC

### DIFF
--- a/packages/conf-guile/conf-guile.1/opam
+++ b/packages/conf-guile/conf-guile.1/opam
@@ -27,6 +27,7 @@ depexts: [
   ["guile"] {os = "macos" & os-distribution = "macports"}
   ["guile"] {os = "win32" & os-distribution = "cygwinports"}
 ]
+available: !(os-distribution = "opensuse-leap" & os-version < "16")
 synopsis: "Virtual package relying on an GNU Guile system installation"
 description:
   "This package can only install if GNU Guile is installed on the system."

--- a/packages/guile/guile.1.0/opam
+++ b/packages/guile/guile.1.0/opam
@@ -42,7 +42,8 @@ available: os-distribution != "opensuse-tumbleweed" &
   !(os-family = "debian" & os-version >= "13") &
   !(os-family = "ubuntu" & os-version >= "24.04") &
   !(os-distribution = "fedora" & os-version >= "40") &
-  !(os-distribution = "alpine" & os-version >= "3.20")
+  !(os-distribution = "alpine" & os-version >= "3.20") &
+  !(os = "freebsd" & os-version >= "14")
 url {
   src: "https://github.com/gopiandcode/guile-ocaml/archive/1.0.tar.gz"
   checksum: [

--- a/packages/guile/guile.1.0/opam
+++ b/packages/guile/guile.1.0/opam
@@ -37,6 +37,7 @@ build: [
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/gopiandcode/guile-ocaml.git"
+available: !(os-distribution = "debian" & os-version >= "13")
 url {
   src: "https://github.com/gopiandcode/guile-ocaml/archive/1.0.tar.gz"
   checksum: [

--- a/packages/guile/guile.1.0/opam
+++ b/packages/guile/guile.1.0/opam
@@ -43,7 +43,8 @@ available: os-distribution != "opensuse-tumbleweed" &
   !(os-family = "ubuntu" & os-version >= "24.04") &
   !(os-distribution = "fedora" & os-version >= "40") &
   !(os-distribution = "alpine" & os-version >= "3.20") &
-  !(os = "freebsd" & os-version >= "14")
+  !(os = "freebsd" & os-version >= "14") &
+  !(os = "macos" & os-distribution = "homebrew")
 url {
   src: "https://github.com/gopiandcode/guile-ocaml/archive/1.0.tar.gz"
   checksum: [

--- a/packages/guile/guile.1.0/opam
+++ b/packages/guile/guile.1.0/opam
@@ -37,7 +37,12 @@ build: [
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/gopiandcode/guile-ocaml.git"
-available: !(os-distribution = "debian" & os-version >= "13")
+available: os-distribution != "opensuse-tumbleweed" &
+  os-distribution != "arch" &
+  !(os-family = "debian" & os-version >= "13") &
+  !(os-family = "ubuntu" & os-version >= "24.04") &
+  !(os-distribution = "fedora" & os-version >= "40") &
+  !(os-distribution = "alpine" & os-version >= "3.20")
 url {
   src: "https://github.com/gopiandcode/guile-ocaml/archive/1.0.tar.gz"
   checksum: [


### PR DESCRIPTION
Related to #27771, `guile.1.0` seems to also have an issue building on systems that ship with GCC 14.

FTBFS with a failure like this:

```
File "stubgen/dune", lines 12-16, characters 0-263: 12 | (rule (targets bindings_stubs_gen.exe)
13 |  (deps bindings_stubs_gen.c c_flags c_library_flags) 14 |  (action
15 |   (bash
16 |     "%{cc} bindings_stubs_gen.c -I `dirname %{lib:ctypes:ctypes_cstubs_internals.h}` -I %{ocaml_where} $(< c_flags) $(< c_library_flags) -o %{targets}")))
(cd _build/default/stubgen && /usr/bin/bash -e -u -o pipefail -c 'gcc -O2 -fno-strict-aliasing -fwrapv -fPIC -pthread -D_FILE_OFFSET_BITS=64 -Wall -fdiagnostics-color=always bindings_stubs_gen.c -I `dirname ../../_private/default/.pkg/ctypes/target/lib/ctypes/ctypes_cstubs_internals.h` -I /home/opam/.cache/dune/toolchains/ocaml-compiler.5.3.0-128080a60f158774bfad0f37dcf62390/target/lib/ocaml $(< c_flags) $(< c_library_flags) -o bindings_stubs_gen.exe')
bindings_stubs_gen.c: In function 'main':
bindings_stubs_gen.c:35:41: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
   35 |      enum { check_SCM_UNDEFINED_const = (int)SCM_UNDEFINED };
      |                                         ^
bindings_stubs_gen.c:36:19: error: initialization of 'intptr_t' {aka 'long int'} from 'struct scm_unused_struct *' makes integer from pointer without a cast [-Wint-conversion]
   36 |      intptr_t v = (SCM_UNDEFINED);
      |                   ^
bindings_stubs_gen.c:42:35: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
   42 |      enum { check_SCM_EOL_const = (int)SCM_EOL };
      |                                   ^
bindings_stubs_gen.c:43:19: error: initialization of 'intptr_t' {aka 'long int'} from 'struct scm_unused_struct *' makes integer from pointer without a cast [-Wint-conversion]
   43 |      intptr_t v = (SCM_EOL);
      |                   ^
bindings_stubs_gen.c:49:38: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
   49 |      enum { check_SCM_BOOL_T_const = (int)SCM_BOOL_T };
      |                                      ^
bindings_stubs_gen.c:50:19: error: initialization of 'intptr_t' {aka 'long int'} from 'struct scm_unused_struct *' makes integer from pointer without a cast [-Wint-conversion]
   50 |      intptr_t v = (SCM_BOOL_T);
      |                   ^
bindings_stubs_gen.c:56:38: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
   56 |      enum { check_SCM_BOOL_F_const = (int)SCM_BOOL_F };
      |                                      ^
bindings_stubs_gen.c:57:19: error: initialization of 'intptr_t' {aka 'long int'} from 'struct scm_unused_struct *' makes integer from pointer without a cast [-Wint-conversion]
   57 |      intptr_t v = (SCM_BOOL_F);
      |                   ^
```