### PR TITLE
Add `ocaml` dependency to `zlist`

### DIFF
--- a/packages/zlist/zlist.0.4.0/opam
+++ b/packages/zlist/zlist.0.4.0/opam
@@ -8,6 +8,7 @@ license: "Apache-2.0"
 homepage: "https://gitlab.com/jhaberku/Zlist"
 bug-reports: "https://gitlab.com/jhaberku/Zlist/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.7"}
   "odoc" {with-doc}
 ]

--- a/packages/zlist/zlist.0.5.0/opam
+++ b/packages/zlist/zlist.0.5.0/opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/hakuch/zlist"
 doc: "https://hakuch.github.io/zlist"
 bug-reports: "https://github.com/hakuch/zlist/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.7"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
The packages need OCaml to build but the newer versions don't declare that dependency.

Upstream PR with near-identical fix: https://github.com/hakuch/zlist/pull/1