### PR TITLE
Add `ocaml` dependency to `xmelly.1.0.0`

### DIFF
--- a/packages/xmelly/xmelly.1.0.0/opam
+++ b/packages/xmelly/xmelly.1.0.0/opam
@@ -12,6 +12,7 @@ homepage: "https://github.com/m4c0/xmelly"
 bug-reports: "https://github.com/m4c0/xmelly/issues"
 depends: [
   "dune" {>= "2.9"}
+  "ocaml" {>= "4.07.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Upstream already has this dependency: https://github.com/m4c0/xmelly/commit/d8283a949b8662be034754a72fa76defe853750a