### PR TITLE
Add `ocaml` dependency for `roman` packages

### DIFF
--- a/packages/roman/roman.0.1/opam
+++ b/packages/roman/roman.0.1/opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/johnwhitington/roman"
 bug-reports: "https://github.com/johnwhitington/roman/issues"
 depends: [
   "dune" {>= "2.8"}
+  "ocaml"
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/roman/roman.0.2/opam
+++ b/packages/roman/roman.0.2/opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/johnwhitington/roman"
 bug-reports: "https://github.com/johnwhitington/roman/issues"
 depends: [
   "dune" {>= "2.8"}
+  "ocaml"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Adds the fact that `roman` requires some kind of OCaml compiler to build.

PR submitted upstream: https://github.com/johnwhitington/roman/pull/1