### PR TITLE
Add `ocaml` dependency to `ockt.0.0.1`

### DIFF
--- a/packages/ockt/ockt.0.0.1/opam
+++ b/packages/ockt/ockt.0.0.1/opam
@@ -7,6 +7,7 @@ homepage: "https://sr.ht/~cricket/ckt"
 bug-reports: "https://lists.sr.ht/~cricket/ockt-devel"
 depends: [
   "dune" {>= "2.9"}
+  "ocaml"
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://git.sr.ht/~cricket/ockt"


### PR DESCRIPTION
The code is written in OCaml, but it does not define a dependency on `ocaml`. This PR adds it.

I would submit a PR upstream, but I have no idea how to do that on `sr.ht`.