### PR TITLE
Add `ocaml` as a dependency of `globlon.1.0`

### DIFF
--- a/packages/globlon/globlon.1.0/opam
+++ b/packages/globlon/globlon.1.0/opam
@@ -10,6 +10,7 @@ homepage: "https://github.com/bleepbloopsify/globlon"
 bug-reports: "https://github.com/bleepbloopsify/globlon/issues"
 depends: [
   "dune" {>= "2.8"}
+  "ocaml"
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/globlon/globlon.1.0/opam
+++ b/packages/globlon/globlon.1.0/opam
@@ -27,6 +27,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: os != "win32"
 dev-repo: "git+https://github.com/bleepbloopsify/globlon.git"
 url {
   src: "https://github.com/bleepbloopsify/globlon/archive/1.0.tar.gz"


### PR DESCRIPTION
Upstream PR: https://github.com/bleepbloopsify/globlon/pull/1