### PR TITLE
Add `ocaml` dependency to `pure-splitmix`

### DIFF
--- a/packages/pure-splitmix/pure-splitmix.0.3/opam
+++ b/packages/pure-splitmix/pure-splitmix.0.3/opam
@@ -7,6 +7,7 @@ license: "MIT"
 dev-repo: "git+https://github.com/Lysxia/pure-splitmix.git"
 build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
+  "ocaml"
   "dune" {>= "1.6"}
 ]
 synopsis: "Purely functional splittable PRNG"


### PR DESCRIPTION
Added OCaml dependency to the latest version which is missing it. Upstream patch for the fix: https://github.com/Lysxia/pure-splitmix/pull/1