### PR TITLE
Add `ocaml` dependency on `vpt.5.0.0`

### DIFF
--- a/packages/vpt/vpt.5.0.0/opam
+++ b/packages/vpt/vpt.5.0.0/opam
@@ -11,6 +11,7 @@ build: [
 ]
 depends: [
   "dune" {>= "2.8"}
+  "ocaml"
 ]
 synopsis: "Vantage point tree implementation in OCaml"
 description: """


### PR DESCRIPTION
Upstream PR here: https://github.com/UnixJunkie/vp-tree/pull/22

Older versions already all have an `ocaml` dependency, so seems only fitting to add.