### PR TITLE
Add `ocaml` dependency to `rust-staticlib-virtual`

### DIFF
--- a/packages/rust-staticlib-virtual/rust-staticlib-virtual.0.1.0/opam
+++ b/packages/rust-staticlib-virtual/rust-staticlib-virtual.0.1.0/opam
@@ -9,6 +9,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/Lupus/rust-staticlib-gen"
 bug-reports: "https://github.com/Lupus/rust-staticlib-gen/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.7"}
   "odoc" {with-doc}
 ]

--- a/packages/rust-staticlib-virtual/rust-staticlib-virtual.0.2.0/opam
+++ b/packages/rust-staticlib-virtual/rust-staticlib-virtual.0.2.0/opam
@@ -9,6 +9,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/Lupus/rust-staticlib-gen"
 bug-reports: "https://github.com/Lupus/rust-staticlib-gen/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.7"}
   "odoc" {with-doc}
 ]

--- a/packages/rust-staticlib-virtual/rust-staticlib-virtual.0.2.1/opam
+++ b/packages/rust-staticlib-virtual/rust-staticlib-virtual.0.2.1/opam
@@ -9,6 +9,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/Lupus/rust-staticlib-gen"
 bug-reports: "https://github.com/Lupus/rust-staticlib-gen/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.7"}
   "odoc" {with-doc}
 ]

--- a/packages/rust-staticlib-virtual/rust-staticlib-virtual.0.2.2/opam
+++ b/packages/rust-staticlib-virtual/rust-staticlib-virtual.0.2.2/opam
@@ -9,6 +9,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/Lupus/rust-staticlib-gen"
 bug-reports: "https://github.com/Lupus/rust-staticlib-gen/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.7"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Adds missing `ocaml` dependency. Upstream patch: https://github.com/Lupus/rust-staticlib-gen/pull/7