### PR TITLE
smtmt < 0.6.1 is not compatible with alt-ergo-lib 2.6.1

### DIFF
--- a/packages/smtml/smtml.0.3.1/opam
+++ b/packages/smtml/smtml.0.3.1/opam
@@ -48,6 +48,7 @@ depopts: ["alt-ergo-lib" "bitwuzla-cxx" "colibri2" "cvc5" "z3"]
 conflicts: [
   "bitwuzla-cxx" {< "0.6.0"}
   "z3" {< "4.12.2" | >= "4.14"}
+  "alt-ergo-lib" {>= "2.6.1"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/smtml/smtml.0.4.0/opam
+++ b/packages/smtml/smtml.0.4.0/opam
@@ -49,6 +49,7 @@ depopts: ["alt-ergo-lib" "bitwuzla-cxx" "colibri2" "cvc5" "z3"]
 conflicts: [
   "bitwuzla-cxx" {< "0.6.0"}
   "z3" {< "4.12.2" | >= "4.14"}
+  "alt-ergo-lib" {>= "2.6.1"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 build: [

--- a/packages/smtml/smtml.0.4.1/opam
+++ b/packages/smtml/smtml.0.4.1/opam
@@ -49,6 +49,7 @@ depopts: ["alt-ergo-lib" "bitwuzla-cxx" "colibri2" "cvc5" "z3"]
 conflicts: [
   "bitwuzla-cxx" {< "0.6.0"}
   "z3" {< "4.12.2" | >= "4.14"}
+  "alt-ergo-lib" {>= "2.6.1"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 build: [

--- a/packages/smtml/smtml.0.5.0/opam
+++ b/packages/smtml/smtml.0.5.0/opam
@@ -52,6 +52,7 @@ depopts: ["alt-ergo-lib" "bitwuzla-cxx" "colibri2" "cvc5" "z3"]
 conflicts: [
   "bitwuzla-cxx" {< "0.6.0"}
   "z3" {< "4.12.2" | >= "4.14"}
+  "alt-ergo-lib" {>= "2.6.1"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/smtml/smtml.0.6.0/opam
+++ b/packages/smtml/smtml.0.6.0/opam
@@ -53,6 +53,7 @@ depopts: ["alt-ergo-lib" "bitwuzla-cxx" "colibri2" "cvc5" "z3"]
 conflicts: [
   "bitwuzla-cxx" {< "0.6.0"}
   "z3" {< "4.12.2" | >= "4.14"}
+  "alt-ergo-lib" {>= "2.6.1"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/27765

```
#=== ERROR while compiling smtml.0.6.0 ========================================#
# context              2.3.0 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/smtml.0.6.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p smtml -j 39 @install
# exit-code            1
# env-file             ~/.opam/log/smtml-7-081655.env
# output-file          ~/.opam/log/smtml-7-081655.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -open Smtml_prelude -g -bin-annot -I src/smtml/.smtml.objs/byte -I src/smtml/.smtml.objs/public_cmi -I /home/opam/.opam/4.14/lib/alt-ergo-lib -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/bos -I /home/opam/.opam/4.14/lib/camlzip -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/dolmen -I /home/opam/.opam/4.14/lib/dolmen/ae -I /home/opam/.opam/4.14/lib/dolmen/class -I /home/opam/.opam/4.14/lib/dolmen/dimacs -I /home/opam/.opam/4.14/lib/dolmen/icnf -I /home/opam/.opam/4.14/lib/dolmen/intf -I /home/opam/.opam/4.14/lib/dolmen/line -I /home/opam/.opam/4.14/lib/dolmen/smtlib2 -I /home/opam/.opam/4.14/lib/dolmen/smtlib2/poly -I /home/opam/.opam/4.14/lib/dolmen/smtlib2/v6 -I /home/opam/.opam/4.14/lib/dolmen/smtlib2/v6_response -I /home/opam/.opam/4.14/lib/dolmen/smtlib2/v6_script -I /home/opam/.opam/4.14/lib/dolmen/std -I /home/opam/.opam/4.14/lib/dolmen/tptp -I /home/opam/.opam/4.14/lib/dolmen/tptp/v6_3_0 -I /home/opam/.opam/4.14/lib/dolmen/zf -I /home/opam/.opam/4.14/lib/dolmen_loop -I /home/opam/.opam/4.14/lib/dolmen_model -I /home/opam/.opam/4.14/lib/dolmen_type -I /home/opam/.opam/4.14/lib/dune-build-info -I /home/opam/.opam/4.14/lib/farith -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/fpath -I /home/opam/.opam/4.14/lib/gen -I /home/opam/.opam/4.14/lib/hc -I /home/opam/.opam/4.14/lib/hmap -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/logs/fmt -I /home/opam/.opam/4.14/lib/menhirLib -I /home/opam/.opam/4.14/lib/ocaml_intrinsics -I /home/opam/.opam/4.14/lib/ocplib-simplex -I /home/opam/.opam/4.14/lib/patricia-tree -I /home/opam/.opam/4.14/lib/pp_loc -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/prelude -I /home/opam/.opam/4.14/lib/rresult -I /home/opam/.opam/4.14/lib/scfg -I /home/opam/.opam/4.14/lib/sedlex -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/spelll -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/yojson -I /home/opam/.opam/4.14/lib/zarith -I /home/opam/.opam/4.14/lib/zip -I src/smtml_prelude/.smtml_prelude.objs/byte -no-alias-deps -open Smtml -o src/smtml/.smtml.objs/byte/smtml__Altergo_mappings.cmo -c -impl src/smtml/altergo_mappings.ml)
# File "src/smtml/altergo_mappings.default.ml", line 104, characters 16-34:
# Error: Unbound module AEL.Translate
```