### PR TITLE
[new release] linol (3 packages) (0.10)

### DIFF
--- a/packages/linol-eio/linol-eio.0.10/opam
+++ b/packages/linol-eio/linol-eio.0.10/opam
@@ -15,7 +15,7 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/linol-eio/linol-eio.0.10/opam
+++ b/packages/linol-eio/linol-eio.0.10/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "LSP server library (with Eio for concurrency)"
+maintainer: ["Simon Cruanes"]
+authors: ["Nick Hu"]
+license: "MIT"
+homepage: "https://github.com/c-cube/linol"
+bug-reports: "https://github.com/c-cube/linol/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "yojson" {>= "1.6"}
+  "linol" {= version}
+  "base-unix"
+  "eio" {>= "1.0" & < "2.0"}
+  "eio_main" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/linol.git"
+url {
+  src:
+    "https://github.com/c-cube/linol/releases/download/v0.10/linol-0.10.tbz"
+  checksum: [
+    "sha256=174bb8cad5b8b0c260d62b0a85da13c4f5caba4fcee042ee58284b09de7896ea"
+    "sha512=77460788407c72a33fbe289ec9c78421117543594b3524a5c8fe836f0e272c5ceb1e1074b91c1d1f476f89b75b6f63847a8021675a782ff36457c9626121a7f4"
+  ]
+}
+x-commit-hash: "1b4c56b134753b1dde46d63e9ed838a15d029595"

--- a/packages/linol-lwt/linol-lwt.0.10/opam
+++ b/packages/linol-lwt/linol-lwt.0.10/opam
@@ -14,7 +14,7 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/linol-lwt/linol-lwt.0.10/opam
+++ b/packages/linol-lwt/linol-lwt.0.10/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "LSP server library (with Lwt for concurrency)"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+homepage: "https://github.com/c-cube/linol"
+bug-reports: "https://github.com/c-cube/linol/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "yojson" {>= "1.6"}
+  "linol" {= version}
+  "base-unix"
+  "lwt" {>= "5.1" & < "6.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/linol.git"
+url {
+  src:
+    "https://github.com/c-cube/linol/releases/download/v0.10/linol-0.10.tbz"
+  checksum: [
+    "sha256=174bb8cad5b8b0c260d62b0a85da13c4f5caba4fcee042ee58284b09de7896ea"
+    "sha512=77460788407c72a33fbe289ec9c78421117543594b3524a5c8fe836f0e272c5ceb1e1074b91c1d1f476f89b75b6f63847a8021675a782ff36457c9626121a7f4"
+  ]
+}
+x-commit-hash: "1b4c56b134753b1dde46d63e9ed838a15d029595"

--- a/packages/linol/linol.0.10/opam
+++ b/packages/linol/linol.0.10/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "LSP server library"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+homepage: "https://github.com/c-cube/linol"
+bug-reports: "https://github.com/c-cube/linol/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "yojson" {>= "1.6"}
+  "logs"
+  "trace" {>= "0.4"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+  "uutf" {>= "1.0.2"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/linol.git"
+url {
+  src:
+    "https://github.com/c-cube/linol/releases/download/v0.10/linol-0.10.tbz"
+  checksum: [
+    "sha256=174bb8cad5b8b0c260d62b0a85da13c4f5caba4fcee042ee58284b09de7896ea"
+    "sha512=77460788407c72a33fbe289ec9c78421117543594b3524a5c8fe836f0e272c5ceb1e1074b91c1d1f476f89b75b6f63847a8021675a782ff36457c9626121a7f4"
+  ]
+}
+x-commit-hash: "1b4c56b134753b1dde46d63e9ed838a15d029595"

--- a/packages/linol/linol.0.10/opam
+++ b/packages/linol/linol.0.10/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_yojson_conv_lib" {>= "v0.14"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
LSP server library

- Project page: <a href="https://github.com/c-cube/linol">https://github.com/c-cube/linol</a>

##### CHANGES:

- use `git subtree` to vendor lsp+jsonrpc, so that they
    are not dependencies anymore and do not conflict with
    other users
- Add `filter_text_document` to ignore some documents
