### PR TITLE
smtml 0.4.1 is not compatible with bitwuzla-cxx 0.7.0

### DIFF
--- a/packages/smtml/smtml.0.4.1/opam
+++ b/packages/smtml/smtml.0.4.1/opam
@@ -47,7 +47,7 @@ depends: [
 ]
 depopts: ["alt-ergo-lib" "bitwuzla-cxx" "colibri2" "cvc5" "z3"]
 conflicts: [
-  "bitwuzla-cxx" {< "0.6.0"}
+  "bitwuzla-cxx" {< "0.6.0" | >= "0.7.0"}
   "z3" {< "4.12.2" | >= "4.14"}
   "alt-ergo-lib" {>= "2.6.1"}
 ]


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/27768