### PR TITLE
Adding conf-sndfile virtual package for libsndfile

### DIFF
--- a/packages/conf-sndfile/conf-sndfile.1/opam
+++ b/packages/conf-sndfile/conf-sndfile.1/opam
@@ -4,14 +4,19 @@ homepage: "https://github.com/libsndfile/libsndfile"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "libsndfile developers"
 license: "LGPL-2.1-or-later"
-build: ["pkg-config" "--exists" "sndfile"]
+build: [
+  ["pkg-config" "--exists" "sndfile"] {os != "openbsd" & os != "win32" & !(os = "macos" & os-distribution = "homebrew")}
+  ["pkgconf" "--exists" "sndfile"] {(os = "win32" & os-distribution != "msys2") | (os = "macos" & os-distribution = "homebrew")}
+]
 depends: [
   "conf-pkg-config" {build}
+  ("host-arch-x86_64" {os = "win32" & os-distribution = "msys2"} & "conf-mingw-w64-pkgconf-x86_64" {os = "win32" & os-distribution = "msys2"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution = "msys2"} & "conf-mingw-w64-pkgconf-i686" {os = "win32" & os-distribution = "msys2"})
 ]
 depexts: [
   ["libsndfile-dev"] {os-family = "debian" | os-family = "ubuntu" | os-distribution = "alpine"}
-  ["libsndfile"] {os-family = "arch" | os = "freebsd" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
-  ["libsndfile-devel"] {os = "win32" & os-distribution = "cygwinports" | os-family = "suse" | os-family = "opensuse" | os-distribution = "centos" | os-distribution = "fedora"}
+  ["libsndfile"] {os = "win32" & os-distribution = "msys2" | os-family = "arch" | os = "freebsd" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
+  ["libsndfile-devel"] {os-family = "suse" | os-family = "opensuse" | os-distribution = "centos" | os-distribution = "fedora"}
 ]
 synopsis: "Virtual package relying on sndfile"
 description:

--- a/packages/conf-sndfile/conf-sndfile.1/opam
+++ b/packages/conf-sndfile/conf-sndfile.1/opam
@@ -13,8 +13,8 @@ depends: [
 ]
 depexts: [
   ["libsndfile-dev"] {os-family = "debian" | os-family = "ubuntu" | os-distribution = "alpine"}
-  ["libsndfile"] {os = "win32" & os-distribution = "cygwin" | os-family = "arch" | os = "freebsd" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
-  ["libsndfile-devel"] {os-family = "suse" | os-family = "opensuse" | os-distribution = "centos" | os-distribution = "fedora"}
+  ["libsndfile"] {os-family = "arch" | os = "freebsd" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
+  ["libsndfile-devel"] {os = "win32" & os-distribution = "cygwin" | os-family = "suse" | os-family = "opensuse" | os-distribution = "centos" | os-distribution = "fedora"}
   ["mingw-w64-x86_64-libsndfile"] {os = "win32" & os-distribution = "msys2" & arch = "x86_64"}
   ["mingw-w64-i686-libsndfile"] {os = "win32" & os-distribution = "msys2" & arch = "x86_32"}
 ]

--- a/packages/conf-sndfile/conf-sndfile.1/opam
+++ b/packages/conf-sndfile/conf-sndfile.1/opam
@@ -10,13 +10,13 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_64" {os = "win32" & os-distribution = "msys2"} & "conf-mingw-w64-pkgconf-x86_64" {os = "win32" & os-distribution = "msys2"} |
-   "host-arch-x86_32" {os = "win32" & os-distribution = "msys2"} & "conf-mingw-w64-pkgconf-i686" {os = "win32" & os-distribution = "msys2"})
 ]
 depexts: [
   ["libsndfile-dev"] {os-family = "debian" | os-family = "ubuntu" | os-distribution = "alpine"}
-  ["libsndfile"] {os = "win32" & os-distribution = "msys2" | os-family = "arch" | os = "freebsd" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
+  ["libsndfile"] {os = "win32" & os-distribution = "cygwin" | os-family = "arch" | os = "freebsd" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
   ["libsndfile-devel"] {os-family = "suse" | os-family = "opensuse" | os-distribution = "centos" | os-distribution = "fedora"}
+  ["mingw-w64-x86_64-libsndfile"] {os = "win32" & os-distribution = "msys2" & arch = "x86_64"}
+  ["mingw-w64-i686-libsndfile"] {os = "win32" & os-distribution = "msys2" & arch = "x86_32"}
 ]
 synopsis: "Virtual package relying on sndfile"
 description:

--- a/packages/conf-sndfile/conf-sndfile.1/opam
+++ b/packages/conf-sndfile/conf-sndfile.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://github.com/libsndfile/libsndfile"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "libsndfile developers"
+license: "LGPL-2.1-or-later"
+build: ["pkg-config" "--exists" "sndfile"]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  ["libsndfile-dev"] {os-family = "debian" | os-family = "ubuntu" | os-distribution = "alpine"}
+  ["libsndfile"] {os-family = "arch" | os = "freebsd" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
+  ["libsndfile-devel"] {os = "win32" & os-distribution = "cygwinports" | os-family = "suse" | os-family = "opensuse" | os-distribution = "centos" | os-distribution = "fedora"}
+]
+synopsis: "Virtual package relying on sndfile"
+description:
+  "This package can only install if the sndfile library is installed on the system."
+flags: conf


### PR DESCRIPTION
Adding the libsndfile (https://libsndfile.github.io/libsndfile/) virtual package for opam packages relying on the library.