### PR TITLE
Package opam-publish.2.5.1

### DIFF
--- a/packages/opam-publish/opam-publish.2.5.1/opam
+++ b/packages/opam-publish/opam-publish.2.5.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A tool to ease contributions to opam repositories"
+description: """\
+opam-publish automates publishing packages to package repositories: it checks that the
+opam file is complete using `opam lint`, verifies and adds the archive URL and its
+checksum and files a GitHub pull request for merging it."""
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+depends: [
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "1.0"}
+  "lwt_ssl"
+  "ocaml" {>= "4.08.0"}
+  "opam-core" {>= "2.2.0"}
+  "opam-format" {>= "2.2.0"}
+  "opam-state" {>= "2.2.0"}
+  "github" {>= "4.3.2"}
+  "github-unix" {>= "4.3.2"}
+]
+conflicts: [
+  "ssl" {= "0.5.6"}
+]
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+url {
+  src:
+    "https://github.com/ocaml/opam-publish/releases/download/2.5.1/opam-publish-2.5.1.tar.gz"
+  checksum: [
+    "md5=faaca05485e10574959125f6ab2039ba"
+    "sha512=591c6372cb54833c2797575587503d912ba9710981d054aa48961267d5fd6dbad79581bc1fa860e3d9000ba687b4e5d7dd4aa737cf2d475bfcc574abd667ac33"
+  ]
+}


### PR DESCRIPTION
### `opam-publish.2.5.1`
A tool to ease contributions to opam repositories
opam-publish automates publishing packages to package repositories: it checks that the
opam file is complete using `opam lint`, verifies and adds the archive URL and its
checksum and files a GitHub pull request for merging it.



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v2.5.0