### PR TITLE
[new release] opam-check-npm-deps (4.0.0)

### DIFF
--- a/packages/opam-check-npm-deps/opam-check-npm-deps.4.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.4.0.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis:
+  "An opam plugin to check for npm depexts inside the node_modules folder"
+description:
+  "Provides the `opam check-npm-deps` command, which given an opam switch, gathers all the depexts belonging to the npm platform and their version constraints, and checks the `node_modules` folder to see if the constraints are satisfied."
+maintainer: ["Javier Chávarri <javier.chavarri@ahrefs.com>"]
+authors: ["Javier Chávarri <javier.chavarri@ahrefs.com>"]
+tags: ["melange" "org:ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/opam-check-npm-deps"
+bug-reports: "https://github.com/ahrefs/opam-check-npm-deps/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "reason" {>= "3.8.1"}
+  "dune" {>= "3.8"}
+  "opam-client" {>= "2.4" & < "2.5"}
+  "mccs" {>= "1.1+14"}
+  "angstrom" {>= "0.15.0"}
+  "fmt" {>= "0.9.0"}
+  "bos"
+  "lwt_ppx"
+  "ppx_deriving_yojson"
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_let"
+  "ppx_sexp_conv"
+  "odoc" {with-doc}
+]
+available: opam-version >= "2.4" & opam-version < "2.5"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/opam-check-npm-deps.git"
+flags: plugin
+url {
+  src:
+    "https://github.com/ahrefs/opam-check-npm-deps/releases/download/4.0.0/opam-check-npm-deps-4.0.0.tbz"
+  checksum: [
+    "sha256=b92a94220116315c3c27273903d8e5e5813d8b78b8192b11a8388176d55cc084"
+    "sha512=213bb4a77968b468ec578782c8e29732c820d3dc3092ac732dba4bdd6663bb5ab6ee0e8a75c86436a8f3e32b066599a79a9cc0bae24aac7f1508478b1bcba945"
+  ]
+}
+x-commit-hash: "96f9bcfcf42bf6e3da045425cbf718c240f6ef33"


### PR DESCRIPTION
An opam plugin to check for npm depexts inside the node_modules folder

- Project page: <a href="https://github.com/ahrefs/opam-check-npm-deps">https://github.com/ahrefs/opam-check-npm-deps</a>

##### CHANGES:

- Support opam 2.4
