### PR TITLE
2 conf-files, one for the magick-core lib, one for the major version 6 and a second one for 7

### DIFF
--- a/packages/conf-magick-core6/conf-magick-core6.1/opam
+++ b/packages/conf-magick-core6/conf-magick-core6.1/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "https://github.com/fccm2"
+homepage: "https://imagemagick.org/script/magick-core.php"
+license: "https://imagemagick.org/script/license.php"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: ["John Cristy"]
+synopsis: "Virtual package relying on the magick-core-6"
+description: """
+This package checks if the magick-core-6 library from image-magick-6 is installed on the system.
+"""
+depends: [ "conf-pkg-config" {build} ]
+build: [
+  [ "sh" "-c"
+    "pkg-config --exists MagickCore && \
+     pkg-config --modversion MagickCore | awk -F. '{ if ($1 == 6) exit 0; else exit 1; }'"
+  ]
+]
+depexts: [
+]
+flags: conf

--- a/packages/conf-magick-core7/conf-magick-core7.1/opam
+++ b/packages/conf-magick-core7/conf-magick-core7.1/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "https://github.com/fccm2"
+homepage: "https://imagemagick.org/script/magick-core.php"
+license: "https://imagemagick.org/script/license.php"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: ["John Cristy"]
+synopsis: "Virtual package relying on the magick-core-7"
+description: """
+This package checks if the magick-core-7 library from image-magick-7 is installed on the system.
+"""
+depends: [ "conf-pkg-config" {build} ]
+build: [
+  [ "sh" "-c"
+    "pkg-config --exists MagickCore && \
+     pkg-config --modversion MagickCore | awk -F. '{ if ($1 == 7) exit 0; else exit 1; }'"
+  ]
+]
+depexts: [
+]
+flags: conf


### PR DESCRIPTION
Provides 2 different conf-files, because the magick-core library version 6 is still the one that seems to be provided in Debian 12.