### PR TITLE
[new release] dream-html (2 packages) (3.10.1)

### DIFF
--- a/packages/dream-html/dream-html.3.10.1/opam
+++ b/packages/dream-html/dream-html.3.10.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.14.0"}
+  "ppxlib" {>= "0.33.0" & < "1.0.0"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.10.1/dream-html-3.10.1.tbz"
+  checksum: [
+    "sha256=d9310e8c27e273392ae40eb1af572bd96eb410f37e6a6868808cdb9a7d3a7719"
+    "sha512=e1891a82657c9f994350e00ab2b6b86ec0904bef0fa1a17d93def089b62fd443a414a07c92b0d0adbde204b13d18fb4dea9fc6581ee02294c123bba6e1f7c816"
+  ]
+}
+x-commit-hash: "2abcd8d9854120a5d2f9db22fc2cbabce00e0345"

--- a/packages/pure-html/pure-html.3.10.1/opam
+++ b/packages/pure-html/pure-html.3.10.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.10.1/dream-html-3.10.1.tbz"
+  checksum: [
+    "sha256=d9310e8c27e273392ae40eb1af572bd96eb410f37e6a6868808cdb9a7d3a7719"
+    "sha512=e1891a82657c9f994350e00ab2b6b86ec0904bef0fa1a17d93def089b62fd443a414a07c92b0d0adbde204b13d18fb4dea9fc6581ee02294c123bba6e1f7c816"
+  ]
+}
+x-commit-hash: "2abcd8d9854120a5d2f9db22fc2cbabce00e0345"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

See https://github.com/yawaramin/dream-html/tags
