### PR TITLE
Add `ocaml` dependency to `make-random`

### DIFF
--- a/packages/make-random/make-random.0.1/opam
+++ b/packages/make-random/make-random.0.1/opam
@@ -14,6 +14,7 @@ homepage: "https://github.com/LesBoloss-es/xoshiro"
 doc: "https://lesboloss-es.github.io/xoshiro/"
 bug-reports: "https://github.com/LesBoloss-es/xoshiro/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.8"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Adds missing ocaml dependency. Upstream patch: https://github.com/LesBoloss-es/xoshiro/pull/3.