### PR TITLE
OCaml compiler: redirect ocaml-variants.5.4.0+trunk to the 5.4 branch

### DIFF
--- a/packages/ocaml-compiler/ocaml-compiler.5.4/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4/opam
@@ -1,0 +1,133 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "Latest 5.4 development"
+maintainer: [
+  "David Allsopp <david@tarides.com>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.4"
+depends: [
+  # This is OCaml 5.4.0
+  "ocaml" {= "5.4.0" & post}
+
+  # General base- packages
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "base-effects" {post}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Architecture (non-Windows)
+  # opam-repository at present requires that ocaml-base-compiler is installed
+  # using an architecture which matches the machine's, since arch is used in
+  # available fields. Cross-compilation at this stage is an unstable accident.
+  "host-arch-arm32" {arch = "arm32" & post}
+  "host-arch-arm64" {arch = "arm64" & post}
+  "host-arch-ppc64" {arch = "ppc64" & post}
+  "host-arch-riscv64" {arch = "riscv64" & post}
+  "host-arch-s390x" {arch = "s390x" & post}
+  # The Windows ports explicitly select the architecture (see below) this
+  # facility is not yet available for other platforms.
+  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
+  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
+   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
+  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
+  # i686 mingw-w64 / MSVC
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
+  # Non-Windows systems
+   "host-system-other" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.42" & os = "win32"}
+]
+flags: [ avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
+build-env: [
+  [MSYS2_ARG_CONV_EXCL = "*"]
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
+    "--with-winpthreads-msvc=%{winpthreads:share}%" {system-msvc:installed}
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--without-zstd" {ocaml-option-no-compression:installed}
+    "--enable-tsan" {ocaml-option-tsan:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
+    "CFLAGS=-Os -mno-outline-atomics" {ocaml-option-musl:installed & arch = "arm64"}
+    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.4.tar.gz"
+}
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-no-compression"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+  "ocaml-option-tsan"
+]

--- a/packages/ocaml-variants/ocaml-variants.5.4.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.4.0+trunk/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
-synopsis: "Current trunk"
+synopsis: "Latest 5.4 development"
 maintainer: [
   "David Allsopp <david@tarides.com>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
@@ -11,122 +11,16 @@ authors: [
   "Alain Frisch"
   "Jacques Garrigue"
   "Didier Rémy"
+  "KC Sivaramakrishnan"
   "Jérôme Vouillon"
 ]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.4"
 depends: [
-  # This is OCaml 5.4.0
-  "ocaml" {= "5.4.0" & post}
-
-  # General base- packages
-  "base-unix" {post}
-  "base-bigarray" {post}
-  "base-threads" {post}
-  "base-domains" {post}
-  "base-nnp" {post}
-  "base-effects" {post}
+  "ocaml-compiler" {= "5.4"}
 
   "ocaml-beta" {opam-version < "2.1.0"}
-
-  # Architecture (non-Windows)
-  # opam-repository at present requires that ocaml-base-compiler is installed
-  # using an architecture which matches the machine's, since arch is used in
-  # available fields. Cross-compilation at this stage is an unstable accident.
-  "host-arch-arm32" {arch = "arm32" & post}
-  "host-arch-arm64" {arch = "arm64" & post}
-  "host-arch-ppc64" {arch = "ppc64" & post}
-  "host-arch-riscv64" {arch = "riscv64" & post}
-  "host-arch-s390x" {arch = "s390x" & post}
-  # The Windows ports explicitly select the architecture (see below) this
-  # facility is not yet available for other platforms.
-  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
-   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
-  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
-
-  # Port selection (Windows)
-  # amd64 mingw-w64 / MSVC
-  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
-      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
-  # i686 mingw-w64 / MSVC
-   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
-      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
-  # Non-Windows systems
-   "host-system-other" {os != "win32" & post})
-
-  # All the 32-bit architectures are bytecode-only
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
-
-  # Support Packages
-  "flexdll" {>= "0.42" & os = "win32"}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
-setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
-x-env-path-rewrite: [
-  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
-]
-build-env: [
-  [MSYS2_ARG_CONV_EXCL = "*"]
-  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
-  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
-]
-build: [
-  [
-    "./configure"
-    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
-    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
-    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
-    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
-    "--prefix=%{prefix}%"
-    "--docdir=%{doc}%/ocaml"
-    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
-    "--with-winpthreads-msvc=%{winpthreads:share}%" {system-msvc:installed}
-    "-C"
-    "--with-afl" {ocaml-option-afl:installed}
-    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
-    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
-    "--enable-flambda" {ocaml-option-flambda:installed}
-    "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--without-zstd" {ocaml-option-no-compression:installed}
-    "--enable-tsan" {ocaml-option-tsan:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
-    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
-    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
-    "CFLAGS=-Os" {ocaml-option-musl:installed}
-    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
-    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
-    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
-    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
-    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
-    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
-    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
-    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
-    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
-    "LIBS=-static" {ocaml-option-static:installed}
-    "--disable-warn-error"
-  ]
-  [make "-j%{jobs}%"]
-]
-install: [make "install"]
-url {
-  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
-}
-depopts: [
-  "ocaml-option-32bit"
-  "ocaml-option-afl"
-  "ocaml-option-bytecode-only"
-  "ocaml-option-no-flat-float-array"
-  "ocaml-option-flambda"
-  "ocaml-option-fp"
-  "ocaml-option-no-compression"
-  "ocaml-option-musl"
-  "ocaml-option-leak-sanitizer"
-  "ocaml-option-address-sanitizer"
-  "ocaml-option-static"
-  "ocaml-option-tsan"
-]


### PR DESCRIPTION
This PR redirects the 5.4.0+trunk branch package to the newly created 5.4 branch.
For this release, I am proposing to experimenting a stabler branching process where the 5.4.0+trunk package is redirected to the correct branch before we update the version number and magic numbers on the ocaml trunk branch.