### PR TITLE
Add Alt Linux support to conf-autoconf, conf-automake, conf-dpkg, conf-gmp and conf-which

### DIFF
--- a/packages/conf-autoconf/conf-autoconf.0.2/opam
+++ b/packages/conf-autoconf/conf-autoconf.0.2/opam
@@ -26,6 +26,7 @@ depexts: [
   ["system:autoconf"] {os = "win32" & os-distribution = "cygwinports"}
   ["autoconf"] {os-distribution = "cygwin"}
   ["autoconf"] {os-family = "suse" | os-family = "opensuse"}
+  ["autoconf"] {os-family = "altlinux"}
 ]
 synopsis: "Virtual package relying on autoconf installation"
 description: """

--- a/packages/conf-automake/conf-automake.1/opam
+++ b/packages/conf-automake/conf-automake.1/opam
@@ -34,6 +34,7 @@ depexts: [
   [ "automake" ] {os-family = "nixos"}
   [ "system:automake" ] {os = "win32" & os-distribution = "cygwinports"}
   [ "automake" ] {os-distribution = "cygwin"}
+  [ "automake" ] {os-family = "altlinux"}
 ]
 synopsis: "Virtual package relying on GNU automake"
 description: "This package can only install if GNU automake is installed on the system."

--- a/packages/conf-dpkg/conf-dpkg.1/opam
+++ b/packages/conf-dpkg/conf-dpkg.1/opam
@@ -20,6 +20,7 @@ depexts: [
   ["dpkg"] {os = "openbsd"}
   ["dpkg"] {os = "netbsd"}
   ["dpkg"] {os-family = "nixos"}
+  ["dpkg"] {os-family = "altlinux"}
 ]
 x-ci-accept-failures: [
   "oraclelinux-7" # Does not have the package by default

--- a/packages/conf-gmp/conf-gmp.5/opam
+++ b/packages/conf-gmp/conf-gmp.5/opam
@@ -35,6 +35,7 @@ depexts: [
   ["gmp-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gmp"] {os = "win32" & os-distribution = "cygwinports"}
   ["gmp"] {os-distribution = "nixos"}
+  ["libgmp-devel"] {os-family = "altlinux"}
 ]
 synopsis: "Virtual package relying on a GMP lib system installation"
 description:

--- a/packages/conf-which/conf-which.1/opam
+++ b/packages/conf-which/conf-which.1/opam
@@ -14,6 +14,7 @@ depexts: [
   ["debianutils"] {os-family = "ubuntu"}
   ["which"] {os-distribution = "nixos"}
   ["which"] {os-family = "arch"}
+  ["which"] {os-family = "altlinux"}
 ]
 synopsis: "Virtual package relying on which"
 description:


### PR DESCRIPTION
Required for the testsuite of opam 2.4: https://github.com/ocaml/opam/pull/6277