### PR TITLE
`conf-graphviz`: call `dot` directly instead of depending on `which`

### DIFF
--- a/packages/conf-graphviz/conf-graphviz.0.1/opam
+++ b/packages/conf-graphviz/conf-graphviz.0.1/opam
@@ -5,9 +5,8 @@ authors: "http://www.graphviz.org/Credits.php"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "EPL-1.0"
 build: [
-  ["which" "dot"]
+  ["command" "-v" "dot"]
 ]
-depends: ["conf-which" {build}]
 depexts: [
   ["graphviz"] {os-family = "debian"}
   ["graphviz"] {os-family = "ubuntu"}

--- a/packages/conf-graphviz/conf-graphviz.0.1/opam
+++ b/packages/conf-graphviz/conf-graphviz.0.1/opam
@@ -4,9 +4,7 @@ homepage: "http://www.graphviz.org/"
 authors: "http://www.graphviz.org/Credits.php"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "EPL-1.0"
-build: [
-  ["command" "-v" "dot"]
-]
+build: ["dot" "-V"]
 depexts: [
   ["graphviz"] {os-family = "debian"}
   ["graphviz"] {os-family = "ubuntu"}


### PR DESCRIPTION
This avoids a dependency on `which` and `dot -V` is compatible with Windows if it is installed.

Suggested by @MisterDA.