### PR TITLE
Core_unix: `rdtsc` unavailable on `ppc64` & `s390x`

### DIFF
--- a/packages/core_unix/core_unix.v0.17.1/opam
+++ b/packages/core_unix/core_unix.v0.17.1/opam
@@ -25,7 +25,7 @@ depends: [
   "dune"                     {>= "3.11.0"}
   "spawn"                    {>= "v0.15"}
 ]
-available: arch != "arm32" & arch != "x86_32" & os-distribution != "alpine"
+available: arch != "arm32" & arch != "x86_32" & arch != "ppc64" & arch != "s390x" & os-distribution != "alpine"
 synopsis: "Unix-specific portions of Core"
 description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].


### PR DESCRIPTION
When attempting to link `core_bench` executables it fails with:

```
File "bench/dune", line 2, characters 8-13:
2 |  (names bench conversions)
^^^^^
(cd _build/default && /home/opam/.opam/5.3/bin/ocamlopt.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -o bench/bench.exe lib/yojson.cmxa /home/opam/.opam/5.3/lib/base/base_internalhash_types/base_internalhash_types.cmxa -I /home/opam/.opam/5.3/lib/base/base_internalhash_types /home/opam/.opam/5.3/lib/sexplib0/sexplib0.cmxa /home/opam/.opam/5.3/lib/base/shadow_stdlib/shadow_stdlib.cmxa /home/opam/.opam/5.3/lib/ocaml_intrinsics_kernel/ocaml_intrinsics_kernel.cmxa -I /home/opam/.opam/5.3/lib/ocaml_intrinsics_kernel /home/opam/.opam/5.3/lib/base/base.cmxa -I /home/opam/.opam/5.3/lib/base /home/opam/.opam/5.3/lib/ppx_sexp_conv/runtime-lib/ppx_sexp_conv_lib.cmxa /home/opam/.opam/5.3/lib/ppx_compare/runtime-lib/ppx_compare_lib.cmxa /home/opam/.opam/5.3/lib/ppx_enumerate/runtime-lib/ppx_enumerate_lib.cmxa /home/opam/.opam/5.3/lib/ppx_hash/runtime-lib/ppx_hash_lib.cmxa /home/opam/.opam/5.3/lib/ppx_here/runtime-lib/ppx_here_lib.cmxa /home/opam/.opam/5.3/lib/ppx_assert/runtime-lib/ppx_assert_lib.cmxa /home/opam/.opam/5.3/lib/ppx_bench/runtime-lib/ppx_bench_lib.cmxa /home/opam/.opam/5.3/lib/base/md5/md5_lib.cmxa /home/opam/.opam/5.3/lib/fieldslib/fieldslib.cmxa /home/opam/.opam/5.3/lib/variantslib/variantslib.cmxa /home/opam/.opam/5.3/lib/bin_prot/shape/bin_shape.cmxa /home/opam/.opam/5.3/lib/ppx_stable_witness/stable_witness/stable_witness.cmxa /home/opam/.opam/5.3/lib/bin_prot/bin_prot.cmxa -I /home/opam/.opam/5.3/lib/bin_prot /home/opam/.opam/5.3/lib/ppx_inline_test/config/inline_test_config.cmxa /home/opam/.opam/5.3/lib/jane-street-headers/jane_street_headers.cmxa /home/opam/.opam/5.3/lib/time_now/time_now.cmxa -I /home/opam/.opam/5.3/lib/time_now /home/opam/.opam/5.3/lib/ppx_inline_test/runtime-lib/ppx_inline_test_lib.cmxa /home/opam/.opam/5.3/lib/stdio/stdio.cmxa /home/opam/.opam/5.3/lib/ppx_module_timer/runtime/ppx_module_timer_runtime.cmxa /home/opam/.opam/5.3/lib/ppx_stable_witness/runtime/ppx_stable_witness_runtime.cmxa /home/opam/.opam/5.3/lib/ppx_string/runtime/ppx_string_runtime.cmxa /home/opam/.opam/5.3/lib/typerep/typerep_lib.cmxa /home/opam/.opam/5.3/lib/ppxlib/print_diff/ppxlib_print_diff.cmxa /home/opam/.opam/5.3/lib/ppx_expect/make_corrected_file/make_corrected_file.cmxa /home/opam/.opam/5.3/lib/ppx_expect/config_types/expect_test_config_types.cmxa /home/opam/.opam/5.3/lib/ppx_expect/config/expect_test_config.cmxa /home/opam/.opam/5.3/lib/ppx_expect/runtime/ppx_expect_runtime.cmxa -I /home/opam/.opam/5.3/lib/ppx_expect/runtime /home/opam/.opam/5.3/lib/parsexp/parsexp.cmxa /home/opam/.opam/5.3/lib/sexplib/sexplib.cmxa /home/opam/.opam/5.3/lib/ppx_log/types/ppx_log_types.cmxa /home/opam/.opam/5.3/lib/ppx_log/syntax/ppx_log_syntax.cmxa /home/opam/.opam/5.3/lib/splittable_random/splittable_random.cmxa /home/opam/.opam/5.3/lib/base_quickcheck/base_quickcheck.cmxa /home/opam/.opam/5.3/lib/base_quickcheck/ppx_quickcheck/runtime/ppx_quickcheck_runtime.cmxa /home/opam/.opam/5.3/lib/int_repr/int_repr.cmxa /home/opam/.opam/5.3/lib/base_bigstring/base_bigstring.cmxa -I /home/opam/.opam/5.3/lib/base_bigstring /home/opam/.opam/5.3/lib/core/base_for_tests/base_for_tests.cmxa /home/opam/.opam/5.3/lib/core/filename_base/filename_base.cmxa /home/opam/.opam/5.3/lib/core/univ_map/univ_map.cmxa /home/opam/.opam/5.3/lib/core/command/command.cmxa /home/opam/.opam/5.3/lib/core/heap_block/heap_block.cmxa -I /home/opam/.opam/5.3/lib/core/heap_block /home/opam/.opam/5.3/lib/gel/gel.cmxa /home/opam/.opam/5.3/lib/ppx_diff/diffable_cinaps/diffable_cinaps.cmxa /home/opam/.opam/5.3/lib/ppx_diff/diffable/diffable.cmxa /home/opam/.opam/5.3/lib/core/validate/validate.cmxa /home/opam/.opam/5.3/lib/core/core.cmxa -I /home/opam/.opam/5.3/lib/core /home/opam/.opam/5.3/lib/core_kernel/ansi_kernel/ansi_kernel.cmxa /home/opam/.opam/5.3/lib/core_kernel/bounded_int_table/bounded_int_table.cmxa /home/opam/.opam/5.3/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.3/lib/ocaml/threads/threads.cmxa /home/opam/.opam/5.3/lib/core_kernel/caml_threads/caml_threads.cmxa /home/opam/.opam/5.3/lib/core_kernel/caml_unix/caml_unix.cmxa /home/opam/.opam/5.3/lib/core_unix/signal_unix/signal_unix.cmxa -I /home/opam/.opam/5.3/lib/core_unix/signal_unix /home/opam/.opam/5.3/lib/core_unix/core_thread/core_thread.cmxa -I /home/opam/.opam/5.3/lib/core_unix/core_thread /home/opam/.opam/5.3/lib/core_unix/sys_unix/sys_unix.cmxa -I /home/opam/.opam/5.3/lib/core_unix/sys_unix /home/opam/.opam/5.3/lib/core_unix/filename_unix/filename_unix.cmxa -I /home/opam/.opam/5.3/lib/core_unix/filename_unix /home/opam/.opam/5.3/lib/core_unix/error_checking_mutex/error_checking_mutex.cmxa -I /home/opam/.opam/5.3/lib/core_unix/error_checking_mutex /home/opam/.opam/5.3/lib/core_kernel/flags/flags.cmxa /home/opam/.opam/5.3/lib/sexplib/unix/sexplib_unix.cmxa /home/opam/.opam/5.3/lib/spawn/spawn.cmxa -I /home/opam/.opam/5.3/lib/spawn /home/opam/.opam/5.3/lib/core_unix/core_unix.cmxa -I /home/opam/.opam/5.3/lib/core_unix /home/opam/.opam/5.3/lib/timezone/timezone.cmxa /home/opam/.opam/5.3/lib/core_unix/time_float_unix/time_float_unix.cmxa /home/opam/.opam/5.3/lib/core_unix/time_ns_unix/time_ns_unix.cmxa /home/opam/.opam/5.3/lib/core_unix/linux_ext/linux_ext.cmxa -I /home/opam/.opam/5.3/lib/core_unix/linux_ext /home/opam/.opam/5.3/lib/textutils/console/console.cmxa /home/opam/.opam/5.3/lib/uutf/uutf.cmxa /home/opam/.opam/5.3/lib/textutils/ascii_table_kernel/ascii_table_kernel.cmxa /home/opam/.opam/5.3/lib/textutils/ascii_table/ascii_table.cmxa /home/opam/.opam/5.3/lib/record_builder/record_builder.cmxa /home/opam/.opam/5.3/lib/core_extended/delimited_kernel/delimited_kernel.cmxa /home/opam/.opam/5.3/lib/core_kernel/version_util/version_util.cmxa -I /home/opam/.opam/5.3/lib/core_kernel/version_util /home/opam/.opam/5.3/lib/core_bench/internals/core_bench_internals.cmxa /home/opam/.opam/5.3/lib/core_kernel/thread_pool_cpu_affinity/thread_pool_cpu_affinity.cmxa /home/opam/.opam/5.3/lib/core_kernel/tuple_pool/tuple_pool.cmxa /home/opam/.opam/5.3/lib/core_kernel/timing_wheel/timing_wheel.cmxa /home/opam/.opam/5.3/lib/async_kernel/config/async_kernel_config.cmxa /home/opam/.opam/5.3/lib/core_kernel/moption/moption.cmxa /home/opam/.opam/5.3/lib/core_kernel/pairing_heap/pairing_heap.cmxa /home/opam/.opam/5.3/lib/core_kernel/sexp_hidden_in_test/sexp_hidden_in_test.cmxa /home/opam/.opam/5.3/lib/uopt/uopt.cmxa /home/opam/.opam/5.3/lib/core_kernel/thread_safe_queue/thread_safe_queue.cmxa /home/opam/.opam/5.3/lib/async_kernel/async_kernel.cmxa /home/opam/.opam/5.3/lib/core_unix/ocaml_c_utils/ocaml_c_utils.cmxa -I /home/opam/.opam/5.3/lib/core_unix/ocaml_c_utils /home/opam/.opam/5.3/lib/core_unix/bigstring_unix/bigstring_unix.cmxa -I /home/opam/.opam/5.3/lib/core_unix/bigstring_unix /home/opam/.opam/5.3/lib/cstruct/cstruct.cmxa -I /home/opam/.opam/5.3/lib/cstruct /home/opam/.opam/5.3/lib/async_kernel/eager_deferred/eager_deferred.cmxa /home/opam/.opam/5.3/lib/core_kernel/iobuf/iobuf.cmxa /home/opam/.opam/5.3/lib/core_unix/iobuf_unix/iobuf_unix.cmxa -I /home/opam/.opam/5.3/lib/core_unix/iobuf_unix /home/opam/.opam/5.3/lib/core_unix/nano_mutex/nano_mutex.cmxa /home/opam/.opam/5.3/lib/async_kernel/read_write_pair/read_write_pair.cmxa /home/opam/.opam/5.3/lib/core_unix/squeue/squeue.cmxa /home/opam/.opam/5.3/lib/async_unix/thread_safe_ivar/thread_safe_ivar.cmxa /home/opam/.opam/5.3/lib/async_unix/thread_pool/thread_pool.cmxa /home/opam/.opam/5.3/lib/core_unix/time_stamp_counter/time_stamp_counter.cmxa -I /home/opam/.opam/5.3/lib/core_unix/time_stamp_counter /home/opam/.opam/5.3/lib/async_unix/async_unix.cmxa -I /home/opam/.opam/5.3/lib/async_unix /home/opam/.opam/5.3/lib/core_unix/command_unix/command_unix.cmxa /home/opam/.opam/5.3/lib/async/async_command/async_command.cmxa /home/opam/.opam/5.3/lib/core_kernel/univ/univ.cmxa /home/opam/.opam/5.3/lib/core_kernel/uuid/uuid.cmxa /home/opam/.opam/5.3/lib/async_log/kernel/async_log_kernel.cmxa /home/opam/.opam/5.3/lib/async_log/async_log.cmxa /home/opam/.opam/5.3/lib/async/async_quickcheck/async_quickcheck.cmxa /home/opam/.opam/5.3/lib/core_kernel/bus/bus.cmxa /home/opam/.opam/5.3/lib/async_kernel/persistent_connection_kernel/persistent_connection_kernel.cmxa /home/opam/.opam/5.3/lib/protocol_version_header/protocol_version_header.cmxa /home/opam/.opam/5.3/lib/core_kernel/reversed_list/reversed_list.cmxa /home/opam/.opam/5.3/lib/async_rpc_kernel/async_rpc_kernel.cmxa /home/opam/.opam/5.3/lib/async/async_rpc/async_rpc.cmxa -I /home/opam/.opam/5.3/lib/async/async_rpc /home/opam/.opam/5.3/lib/async/async.cmxa /home/opam/.opam/5.3/lib/delimited_parsing/delimited.cmxa /home/opam/.opam/5.3/lib/core_bench/core_bench.cmxa bench/.bench.eobjs/native/dune__exe.cmx bench/.bench.eobjs/native/dune__exe__Bench.cmx) /usr/bin/ld: /home/opam/.opam/5.3/lib/core_unix/time_stamp_counter/libtime_stamp_counter_stubs.a(time_stamp_counter_stubs.o): in function `caml_rdtsc_unboxed': /home/opam/.opam/5.3/.opam-switch/build/core_unix.v0.17.1/_build/default/time_stamp_counter/src/time_stamp_counter_stubs.c:51: undefined reference to `rdtsc' /usr/bin/ld: /home/opam/.opam/5.3/lib/core_unix/time_stamp_counter/libtime_stamp_counter_stubs.a(time_stamp_counter_stubs.o): in function `caml_rdtsc': /home/opam/.opam/5.3/.opam-switch/build/core_unix.v0.17.1/_build/default/time_stamp_counter/src/time_stamp_counter_stubs.c:56: undefined reference to `rdtsc' collect2: error: ld returned 1 exit status
File "caml_startup", line 1:
Error: Error during linking (exit code 1)
```

(In the error message you see that the offending C stub is from `core_unix`, hence adding the restriction there)

1. [Failure on ppc64](https://ocaml.ci.dev/github/ocaml-community/yojson/commit/aa1a43fbb946203852d4dcdcceaf4d60442752a0/variant/debian-12-5.3_ppc64_opam-2.3)
2. [Failure on s390x](https://ocaml.ci.dev/github/ocaml-community/yojson/commit/aa1a43fbb946203852d4dcdcceaf4d60442752a0/variant/debian-12-5.3_s390x_opam-2.3)