### PR TITLE
[new release] dream-inertia (0.0.1)

### DIFF
--- a/packages/dream-inertia/dream-inertia.0.0.1/opam
+++ b/packages/dream-inertia/dream-inertia.0.0.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Inertia protocol for OCaml Dream"
+description:
+  "Server side implementation of the Inertia protocol for OCaml Dream web framework"
+maintainer: ["Joris Gundermann"]
+authors: ["Joris Gundermann"]
+license: "MIT"
+tags: ["inertia" "dream" "protocol" "web"]
+homepage: "https://github.com/Naora/dream-inertia"
+bug-reports: "https://github.com/Naora/dream-inertia/issues"
+depends: [
+  "ocaml"
+  "dream" {>= "1.0.0~alpha8"}
+  "fmt"
+  "yojson"
+  "ppx_yojson_conv"
+  "ocamlformat" {with-dev}
+  "lwt_ppx" {with-test}
+  "dune" {>= "3.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Naora/dream-inertia.git"
+url {
+  src:
+    "https://github.com/Naora/dream-inertia/releases/download/v0.0.1/dream-inertia-0.0.1.tbz"
+  checksum: [
+    "sha256=f06fdf957a9719fc7b1a1263337fab8370390cd6b0046fc706d4479824611e89"
+    "sha512=52248f1c428fdc21404748167303dbf64bc972ae4b133f1be4551972ca60b2f31c78577d9d47d587c604fc8bb0bc460d71ab2af309e5593ee02c1278fb226e3b"
+  ]
+}
+x-commit-hash: "2f4b51011d62b556e7d3779ab346b5455d39b5bb"


### PR DESCRIPTION
CHANGES:

### Added

This is the initial public release of `dream-inertia`, providing a backend adapter for using Inertia.js with the Dream web framework in OCaml.

-   Core Inertia protocol handling
-   Property handling
-   Asset versioning
-   Partial reloads
-   External redirects
-   Helper Functions:
    -   `Inertia.prop` for creating standard property definitions.
    -   `Inertia.defer` for creating deferred property definitions.
-   Mergeable props