### PR TITLE
[new release] pplumbing (0.0.11)

### DIFF
--- a/packages/pplumbing/pplumbing.0.0.11/opam
+++ b/packages/pplumbing/pplumbing.0.0.11/opam
@@ -1,0 +1,85 @@
+opam-version: "2.0"
+synopsis: "Utility libraries to use with [pp]"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/pplumbing"
+doc: "https://mbarbin.github.io/pplumbing/"
+bug-reports: "https://github.com/mbarbin/pplumbing/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "cmdlang" {>= "0.0.9"}
+  "cmdlang-to-cmdliner" {>= "0.0.9"}
+  "cmdliner" {>= "1.3.0"}
+  "dyn" {>= "3.17"}
+  "fmt" {>= "0.9.0"}
+  "loc" {>= "0.2.2"}
+  "logs" {>= "0.7.0"}
+  "ordering" {>= "3.17"}
+  "pp" {>= "2.0.0"}
+  "sexplib0" {>= "v0.17"}
+  "stdune" {>= "3.17"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/pplumbing.git"
+description: """\
+
+[pplumbing] defines a set of utility libraries to use with [pp]. It
+is compatible with [logs] and inspired by design choices used by
+[dune] for user messages:
+
+- [Pp_tty] extends [pp] to build colored documents in the user's
+  terminal using ansi escape codes.
+
+- [Err] is an abstraction to report located errors and warnings to
+  the user.
+
+- [Log] is an interface to [logs] using [Pp_tty] rather than [Format].
+
+- [Log_cli] contains functions to work with [Err] on the side of end
+  programs (such as a command line tool). It defines command line
+  helpers to configure the [Err] library, while taking care of setting
+  the [logs] and [fmt] style rendering.
+
+- [Cmdlang_cmdliner_runner] is a library for running command line
+  programs specified with [cmdlang] with [cmdliner] as a backend and
+  making opinionated choices, assuming your dependencies are using
+  [Err].
+
+These libraries are meant to combine nicely into a small ecosystem of
+useful helpers to build CLIs in OCaml.
+
+[cmdlang]: https://github.com/mbarbin/cmdlang
+[cmdliner]: https://github.com/dbuenzli/cmdliner
+[dune]: https://github.com/ocaml/dune
+[fmt]: https://github.com/dbuenzli/fmt
+[logs]: https://github.com/dbuenzli/logs
+[pp]: https://github.com/ocaml-dune/pp
+
+"""
+tags: [ "cli" "cmdlang" "logs" "pp" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/pplumbing/releases/download/0.0.11/pplumbing-0.0.11.tbz"
+  checksum: [
+    "sha256=469a458f9b70980d114a7548b1b0e3b08515da313456662e9b51bfdabc0c353c"
+    "sha512=56bbc7b0fbe9132aa0fd694eea7957530161d63ccf3e8f4cf0956d26660d0743591a5d6d642af4ae9b3f9635986679f1733c7eb57acd7da434dc9d448497ec22"
+  ]
+}
+x-commit-hash: "668980dfd89b6ed2a0275c5500ac73a6b8e58ea3"


### PR DESCRIPTION
## CHANGES

  See https://github.com/mbarbin/pplumbing/blob/main/CHANGES.md

--

This is a release aimed to improve support for cli parameters for the [dunolint](https://github.com/mbarbin/dunolint) and [crs](https://github.com/mbarbin/crs) project related to color and log level handling.

This should be mostly compatible with the existing, modulo perhaps some small fixes and renames.

### Added

- Add `Err.Color_mode` to access value of cli arg `--color=(auto|always|never)` (mbarbin/pplumbing#3, @mbarbin).
- Add `Err.Log_level` getters related to current log level (mbarbin/pplumbing#3, @mbarbin).

### Changed

- Add `Err.Log_level.App` for better compatibility with `Logs` (mbarbin/pplumbing#3, @mbarbin).

### Deprecated

- In `Log_cli.Config` depreate `logs_level` and `fmt_style_renderer` (mbarbin/pplumbing#3, @mbarbin).

### Fixed

- Make `Err.error_count` include errors emitted via `Logs.err` - same for warnings (mbarbin/pplumbing#3, @mbarbin).
- Make `Err.had_errors` include errors emitted via `Logs.err` (mbarbin/pplumbing#3, @mbarbin).

