### PR TITLE
add bitset (v0.17 preview) missing from JS public release

### DIFF
--- a/packages/bitset/bitset.v0.17~preview.129.36+325/opam
+++ b/packages/bitset/bitset.v0.17~preview.129.36+325/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/bitset"
+bug-reports: "https://github.com/janestreet/bitset/issues"
+dev-repo: "git+https://github.com/janestreet/bitset.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/bitset/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"                   {>= "5.1.0"}
+  "core"                    {>= "v0.17" & < "v0.18"}
+  "ocaml_intrinsics_kernel" {>= "v0.17" & < "v0.18"}
+  "ppx_jane"                {>= "v0.17" & < "v0.18"}
+  "dune"                    {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "A library for flat bitsets"
+description: "
+ An efficient mutable bitset.
+"
+url {
+src: "https://github.com/janestreet/bitset/archive/7307c4d85443ba63a5f44d7d94e7fc39a3a72bc6.tar.gz"
+checksum: "sha256=dbff4d47be22ca9cff14955a211b44d911106148cc32d094057e65891fad65f1"
+}


### PR DESCRIPTION
This package was contained in the v0.17 public release sources, but never added to this opam repository.
This PR adds the package (with the version number from the jane-street opam repository) so that it can be used until the v0.18 public release from Jane Street.

@dkalinichenko-js : does that sound like a good plan?

(FWIW, I want to release some packages that depend on this package soon)