### PR TITLE
[new release] lwt-dllist (1.1.0)

### DIFF
--- a/packages/lwt-dllist/lwt-dllist.1.1.0/opam
+++ b/packages/lwt-dllist/lwt-dllist.1.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune"
 ]
 build: [
- ["dune" "subst" ] {pinned}
+ ["dune" "subst" ] {dev}
  ["dune" "build" "-p" name "-j" jobs]
  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/packages/lwt-dllist/lwt-dllist.1.1.0/opam
+++ b/packages/lwt-dllist/lwt-dllist.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: [ "Anil Madhavapeddy <anil@recoil.org>" ]
+authors: ["Jérôme Vouillon" "Jérémie Dimino"]
+license: "MIT"
+homepage: "https://github.com/mirage/lwt-dllist"
+doc: "https://mirage.github.io/lwt-dllist/"
+bug-reports: "https://github.com/mirage/lwt-dllist/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "lwt" {with-test}
+  "dune"
+]
+build: [
+ ["dune" "subst" ] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/lwt-dllist.git"
+synopsis: "Mutable doubly-linked list with Lwt iterators"
+description: """
+A sequence is an object holding a list of elements which support
+the following operations:
+
+- adding an element to the left or the right in time and space O(1)
+- taking an element from the left or the right in time and space O(1)
+- removing a previously added element from a sequence in time and space O(1)
+- removing an element while the sequence is being transversed.
+"""
+url {
+  src:
+    "https://github.com/mirage/lwt-dllist/releases/download/v1.1.0/lwt-dllist-1.1.0.tbz"
+  checksum: [
+    "sha256=b0200651e37eaa24f027177bc01e266db43da48aa18146973d1d18336c325d69"
+    "sha512=0a34795203d1d6601285b631ac5016beece436ffe49eb2896fdf730913b66b0dc6192fdad6bd3d5cc3ad22a19627a9d6198189597ecd520af44b0b3db5e81f00"
+  ]
+}
+x-commit-hash: "e6a7a5a105ab0b88788e67d901474b280b4eebe1"


### PR DESCRIPTION
Mutable doubly-linked list with Lwt iterators

- Project page: <a href="https://github.com/mirage/lwt-dllist">https://github.com/mirage/lwt-dllist</a>
- Documentation: <a href="https://mirage.github.io/lwt-dllist/">https://mirage.github.io/lwt-dllist/</a>

##### CHANGES:

- Add missing primitive `clear` (@raphael-proust, mirage/lwt-dllist#7)
- Fix documentation typo (@raphael-proust, mirage/lwt-dllist#7)
