### PR TITLE
[new release] dkim (4 packages) (0.8.0)

### DIFF
--- a/packages/dkim-bin/dkim-bin.0.8.0/opam
+++ b/packages/dkim-bin/dkim-bin.0.8.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/ocaml-dkim"
+bug-reports:  "https://github.com/mirage/ocaml-dkim/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-dkim.git"
+doc:          "https://mirage.github.io/ocaml-dkim/"
+license:      "MIT"
+synopsis:     "Implementation of DKIM in OCaml"
+description: """A library and a binary to verify and sign an email
+with the DKIM mechanism described by the RFC 6376"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.0.0"}
+  "dkim"              {= version}
+  "ca-certs"
+  "cmdliner"          {>= "1.1.0"}
+  "logs"
+  "fmt"               {>= "0.8.7"}
+  "fpath"
+  "dkim-lwt-unix"     {= version}
+  "alcotest"          {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dkim/releases/download/v0.8.0/dkim-0.8.0.tbz"
+  checksum: [
+    "sha256=ab97ca216abcd82bd9bdc0d73a6840e1df0e03b15a1ba646a6acecb90c35d998"
+    "sha512=5cc6db969a00ba5ffeebe28cb7f762a565f6d11668b03f91f9d557d12bef93e0be785b32034a7d52ce9f3de8be1a119bf431b6239fe2f10706bb205f13358887"
+  ]
+}
+x-commit-hash: "896a193c4402724bc596a5686f5489a4aee1467d"

--- a/packages/dkim-lwt-unix/dkim-lwt-unix.0.8.0/opam
+++ b/packages/dkim-lwt-unix/dkim-lwt-unix.0.8.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/ocaml-dkim"
+bug-reports:  "https://github.com/mirage/ocaml-dkim/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-dkim.git"
+doc:          "https://mirage.github.io/ocaml-dkim/"
+license:      "MIT"
+synopsis:     "Implementation of DKIM in OCaml with LWT"
+description: """A library and a binary to verify and sign an email
+with the DKIM mechanism described by the RFC 6376"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.0.0"}
+  "dkim"              {= version}
+  "lwt"
+  "dns-client-lwt"
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dkim/releases/download/v0.8.0/dkim-0.8.0.tbz"
+  checksum: [
+    "sha256=ab97ca216abcd82bd9bdc0d73a6840e1df0e03b15a1ba646a6acecb90c35d998"
+    "sha512=5cc6db969a00ba5ffeebe28cb7f762a565f6d11668b03f91f9d557d12bef93e0be785b32034a7d52ce9f3de8be1a119bf431b6239fe2f10706bb205f13358887"
+  ]
+}
+x-commit-hash: "896a193c4402724bc596a5686f5489a4aee1467d"

--- a/packages/dkim-mirage/dkim-mirage.0.8.0/opam
+++ b/packages/dkim-mirage/dkim-mirage.0.8.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/ocaml-dkim"
+bug-reports:  "https://github.com/mirage/ocaml-dkim/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-dkim.git"
+doc:          "https://mirage.github.io/ocaml-dkim/"
+license:      "MIT"
+synopsis:     "Implementation of DKIM in OCaml for MirageOS"
+description: """A light layer of the dkim library for MirageOS"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.0.0"}
+  "dkim"              {= version}
+  "dns-client-mirage" {>= "8.0.0"}
+  "mirage-ptime"
+  "lwt"
+  "alcotest"          {with-test}
+  "digestif"          {with-test}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test & >= "1.0.0"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dkim/releases/download/v0.8.0/dkim-0.8.0.tbz"
+  checksum: [
+    "sha256=ab97ca216abcd82bd9bdc0d73a6840e1df0e03b15a1ba646a6acecb90c35d998"
+    "sha512=5cc6db969a00ba5ffeebe28cb7f762a565f6d11668b03f91f9d557d12bef93e0be785b32034a7d52ce9f3de8be1a119bf431b6239fe2f10706bb205f13358887"
+  ]
+}
+x-commit-hash: "896a193c4402724bc596a5686f5489a4aee1467d"

--- a/packages/dkim/dkim.0.8.0/opam
+++ b/packages/dkim/dkim.0.8.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/ocaml-dkim"
+bug-reports:  "https://github.com/mirage/ocaml-dkim/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-dkim.git"
+doc:          "https://mirage.github.io/ocaml-dkim/"
+license:      "MIT"
+synopsis:     "Implementation of DKIM in OCaml"
+description: """A library and a binary to verify and sign an email
+with the DKIM mechanism described by the RFC 6376"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.0.0"}
+  "mrmime"            {>= "0.5.0"}
+  "digestif"          {>= "0.9.0"}
+  "ipaddr"
+  "base-unix"
+  "hmap"
+  "domain-name"
+  "dns-client"        {>= "6.4.0"}
+  "cmdliner"          {>= "1.1.0"}
+  "logs"
+  "fmt"               {>= "0.8.7"}
+  "fpath"
+  "base64"            {>= "3.0.0"}
+  "mirage-crypto"     {>= "1.0.0"}
+  "mirage-crypto-pk"  {>= "1.0.0"}
+  "x509"              {>= "1.0.0"}
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
+  "alcotest"          {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dkim/releases/download/v0.8.0/dkim-0.8.0.tbz"
+  checksum: [
+    "sha256=ab97ca216abcd82bd9bdc0d73a6840e1df0e03b15a1ba646a6acecb90c35d998"
+    "sha512=5cc6db969a00ba5ffeebe28cb7f762a565f6d11668b03f91f9d557d12bef93e0be785b32034a7d52ce9f3de8be1a119bf431b6239fe2f10706bb205f13358887"
+  ]
+}
+x-commit-hash: "896a193c4402724bc596a5686f5489a4aee1467d"


### PR DESCRIPTION
Implementation of DKIM in OCaml

- Project page: <a href="https://github.com/mirage/ocaml-dkim">https://github.com/mirage/ocaml-dkim</a>
- Documentation: <a href="https://mirage.github.io/ocaml-dkim/">https://mirage.github.io/ocaml-dkim/</a>

##### CHANGES:

- Fix unknown tag (@dinosaure, mirage/ocaml-dkim#46)
- Remove the high-kinded polymorphism (@dinosaure, mirage/ocaml-dkim#47)
- Expose useful functions (@dinosaure, mirage/ocaml-dkim#48, mirage/ocaml-dkim#53, mirage/ocaml-dkim#55)
- Fix generated signature (@dinosaure, mirage/ocaml-dkim#49)
- Export the `Decoder` module (@dinosaure, mirage/ocaml-dkim#50)
- Lint dependencies for the mirage-layer (@hannesm, mirage/ocaml-dkim#51)
- Factorize the way we digest things (@dinosaure, mirage/ocaml-dkim#54)
- Be compatible with `X509.Public_key.t` (@dinosaure, mirage/ocaml-dkim#56)
- Add `x-maintenance-intent` (@dinosaure, mirage/ocaml-dkim#52)
