### PR TITLE
[new release] uspf (3 packages) (0.1.0)

### DIFF
--- a/packages/uspf-lwt/uspf-lwt.0.1.0/opam
+++ b/packages/uspf-lwt/uspf-lwt.0.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/uspf"
+bug-reports:  "https://github.com/mirage/uspf/issues"
+dev-repo:     "git+https://github.com/mirage/uspf.git"
+doc:          "https://mirage.github.io/uspf/"
+license:      "MIT"
+synopsis:     "SPF implementation in OCaml (with LWT)"
+description: """uspf-lwt is an implementation of the SPF verifier in OCaml
+compatible with MirageOS. It uses LWT as the scheduler."""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.12.0"}
+  "dune"        {>= "2.8.0"}
+  "uspf"        {= version}
+  "lwt"
+  "dns-client-lwt"
+  "alcotest"    {with-test}
+  "rresult"     {>= "0.7.0" & with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/uspf/releases/download/0.1.0/uspf-0.1.0.tbz"
+  checksum: [
+    "sha256=4ca264d7a354adceadc1344728b28af1c21436ad25cc642ee6b5658bb4789caa"
+    "sha512=08d7ede78617e6a1a9282f883bc89acd27325831f586956a1a274581ac1eb8c8a7a4cd34c9e00781f0c6ca0f6f31a41e6c4aaa93053807ee54116eeff920abbf"
+  ]
+}
+x-commit-hash: "a8f3ac137dbc63f7f8c088375452236c5eea8bdc"

--- a/packages/uspf-mirage/uspf-mirage.0.1.0/opam
+++ b/packages/uspf-mirage/uspf-mirage.0.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/uspf"
+bug-reports:  "https://github.com/mirage/uspf/issues"
+dev-repo:     "git+https://github.com/mirage/uspf.git"
+doc:          "https://mirage.github.io/uspf/"
+license:      "MIT"
+synopsis:     "SPF implementation in OCaml (with for Mirage)"
+description: """uspf-mirage is an implementation of the SPF verifier in OCaml
+compatible with MirageOS. It uses LWT as the scheduler."""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.12.0"}
+  "dune"        {>= "2.8.0"}
+  "uspf"        {= version}
+  "lwt"
+  "dns-client-mirage"
+  "alcotest"    {with-test}
+  "rresult"     {>= "0.7.0" & with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/uspf/releases/download/0.1.0/uspf-0.1.0.tbz"
+  checksum: [
+    "sha256=4ca264d7a354adceadc1344728b28af1c21436ad25cc642ee6b5658bb4789caa"
+    "sha512=08d7ede78617e6a1a9282f883bc89acd27325831f586956a1a274581ac1eb8c8a7a4cd34c9e00781f0c6ca0f6f31a41e6c4aaa93053807ee54116eeff920abbf"
+  ]
+}
+x-commit-hash: "a8f3ac137dbc63f7f8c088375452236c5eea8bdc"

--- a/packages/uspf/uspf.0.1.0/opam
+++ b/packages/uspf/uspf.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/uspf"
+bug-reports:  "https://github.com/mirage/uspf/issues"
+dev-repo:     "git+https://github.com/mirage/uspf.git"
+doc:          "https://mirage.github.io/uspf/"
+license:      "MIT"
+synopsis:     "SPF implementation in OCaml"
+description: """uspf is an implementation of the SPF verifier in OCaml
+compatible with MirageOS."""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.12.0"}
+  "dune"        {>= "2.8.0"}
+  "logs"
+  "colombe"     {>= "0.4.2"}
+  "mrmime"      {>= "0.5.0"}
+  "ipaddr"      {>= "5.2.0"}
+  "hmap"
+  "angstrom"    {>= "0.15.0"}
+  "domain-name"
+  "dns"         {>= "5.0.1"}
+  "lwt"
+  "dns-client"  {>= "6.1.0"}
+  "fmt"         {>= "0.8.9"}
+  "alcotest"    {with-test}
+  "rresult"     {>= "0.7.0" & with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/uspf/releases/download/0.1.0/uspf-0.1.0.tbz"
+  checksum: [
+    "sha256=4ca264d7a354adceadc1344728b28af1c21436ad25cc642ee6b5658bb4789caa"
+    "sha512=08d7ede78617e6a1a9282f883bc89acd27325831f586956a1a274581ac1eb8c8a7a4cd34c9e00781f0c6ca0f6f31a41e6c4aaa93053807ee54116eeff920abbf"
+  ]
+}
+x-commit-hash: "a8f3ac137dbc63f7f8c088375452236c5eea8bdc"


### PR DESCRIPTION
SPF implementation in OCaml

- Project page: <a href="https://github.com/mirage/uspf">https://github.com/mirage/uspf</a>
- Documentation: <a href="https://mirage.github.io/uspf/">https://mirage.github.io/uspf/</a>

##### CHANGES:

- Remove Higher Kinded Polymorphism (mirage/uspf#26, mirage/uspf#27, @dinosaure)
- Be able to merge multiple SPF contexts (mirage/uspf#30, @dinosaure)
- Lint the library and delete useless code (mirage/uspf#29, @dinosaure)
- Be able to emit a `Received-SPF` without IP address
