### PR TITLE
[new release] fast_bitvector (0.0.3)

### DIFF
--- a/packages/fast_bitvector/fast_bitvector.0.0.3.1/opam
+++ b/packages/fast_bitvector/fast_bitvector.0.0.3.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A bitvector library"
+description: "Bitvector represented as bytes internally"
+maintainer: ["Stefan Muenzel <source@s.muenzel.net>"]
+authors: ["Stefan Muenzel <source@s.muenzel.net>"]
+license: "MPL-2.0"
+tags: ["bitvector" "bitset"]
+homepage: "https://github.com/engineeredabstraction/fast_bitvector"
+bug-reports: "https://github.com/engineeredabstraction/fast_bitvector/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.1.0"}
+  "ocaml_intrinsics_kernel"
+  "ppx_sexp_conv"
+  "ppx_sexp_value"
+  "expect_test_helpers_core" {with-test}
+  "ppx_jane" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/engineeredabstraction/fast_bitvector.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/engineeredabstraction/fast_bitvector/releases/download/0.0.3.1/fast_bitvector-0.0.3.1.tbz"
+  checksum: [
+    "sha256=d7726d17f1f95a10fc14ff0e112921e5f14dd585a999c18c71dfd5d308bee7eb"
+    "sha512=1cb02509c87f893f291a3f9c4fd2a0a2cb0691a051079b80eb068893320d4d104fccaf41b4f3fcbe4ba3231326189a3cfb039efb67702557f80e24278b0fdbcf"
+  ]
+}
+x-commit-hash: "97a404753f50b78c43154f6617f38c06595ef6a2"


### PR DESCRIPTION
A bitvector library

- Project page: <a href="https://github.com/engineeredabstraction/fast_bitvector">https://github.com/engineeredabstraction/fast_bitvector</a>

##### CHANGES:
- add `set_all` and `clear_all`
- add basic testing
- add endianness in sexp conversion
- add `is_empty` and `is_full`
- add set operations
- add `create_full`
- fix `set_to`
- Initial release
