### PR TITLE
[new release] ocamlmig (5.3-20250429)

### DIFF
--- a/packages/ocamlmig/ocamlmig.5.3-20250429/opam
+++ b/packages/ocamlmig/ocamlmig.5.3-20250429/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis: "OCaml source code rewriting tool"
+description:
+  "Ocamlmig is a command line tool to rewrite ocaml source code, especially to make updating to newer interfaces easier."
+maintainer: ["Valentin Gatien-Baron <valentin.gatienbaron@gmail.com>"]
+authors: ["Valentin Gatien-Baron <valentin.gatienbaron@gmail.com>"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/v-gb/ocamlmig"
+doc: "https://github.com/v-gb/ocamlmig/blob/main/README.md"
+bug-reports: "https://github.com/v-gb/ocamlmig/issues"
+depends: [
+  "ocaml" {>= "5.3" & < "5.4"}
+  "dune" {>= "3.15"}
+  "base"
+  "core"
+  "core_unix"
+  "csexp"
+  "ppx_partial"
+  "ocaml" {>= "4.08"}
+  "alcotest" {"1" = "0" & >= "1.3.0"}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune"
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath" {>= "0.7.3"}
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.5.0"}
+  "ocamlformat-rpc-lib" {"1" = "0" & = version}
+  "ocp-indent" {>= "1.8.0" | "1" = "0" & >= "1.8.1"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "astring"
+  "camlp-streams"
+  "re" {>= "1.10.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/v-gb/ocamlmig.git"
+# due to core_unix, but why do we need to restate it? Maybe they added windows to
+# the opam CI without ensuring that existing packages work on it.
+available: os != "win32"
+url {
+  src:
+    "https://github.com/v-gb/ocamlmig/releases/download/5.3-20250429/ocamlmig-5.3-20250429.tbz"
+  checksum: [
+    "sha256=51e13b4a6bbc86eb2470a5a33087714a8c0895b05d912e1706e7a95c6b1b11d3"
+    "sha512=d6b5b2b0af6b5976dac08c3c821faa1a5690ce56485cc29ac427046de2a4c446c6212bbf4ef5821503d57163634ec5ad78b3d4b452359096a23a6f08b5e9c9e1"
+  ]
+}
+x-commit-hash: "f8d0aa86d1dd26a543fc4c54b8433815ab5d98ab"


### PR DESCRIPTION
CHANGES:

- Switch to ocaml 5.3.
- Added experimental `ocamlmig replace` command, for a sed-like rewrites but working on ASTs instead of bytes.
- Reduce slightly dependency on ocamlformat, so this can be used on the compiler codebase
- Added `ocamlmig check` to typecheck the replacement in things like `val foo : int [@migrate { repl = bar }]`