### PR TITLE
Package base.v0.17.2

### DIFF
--- a/packages/base/base.v0.17.2/opam
+++ b/packages/base/base.v0.17.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/base"
+bug-reports: "https://github.com/janestreet/base/issues"
+dev-repo: "git+https://github.com/janestreet/base.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "ocaml_intrinsics_kernel"
+  "sexplib0"
+  "dune"                    {>= "3.11.0"}
+  "dune-configurator"
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Full standard library replacement for OCaml"
+description: "
+Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio
+"
+url {
+  src: "https://github.com/janestreet/base/archive/refs/tags/v0.17.2.tar.gz"
+  checksum: [
+    "md5=11de9f28abbd131d778b5665126ec7e8"
+    "sha512=202bec57f9bf846cae1e6a9a51fb82128ff9744959550e1c6645fa02baf8f24225f2a409e820d325d89eb4422eba6f6b4304f9b78b94660283c477749d63ca8f"
+  ]
+}

--- a/packages/base/base.v0.17.2/opam
+++ b/packages/base/base.v0.17.2/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "5.1.0"}
   "ocaml_intrinsics_kernel"
-  "sexplib0"
+  "sexplib0" {>= "v0.16.0" }
   "dune"                    {>= "3.11.0"}
   "dune-configurator"
 ]


### PR DESCRIPTION
### `base.v0.17.2`
Full standard library replacement for OCaml
Full standard library replacement for OCaml

Base is a complete and portable alternative to the OCaml standard
library. It provides all standard functionalities one would expect
from a language standard library. It uses consistent conventions
across all of its module.

Base aims to be usable in any context. As a result system dependent
features such as I/O are not offered by Base. They are instead
provided by companion libraries such as stdio:

  https://github.com/janestreet/stdio



---
* Homepage: https://github.com/janestreet/base
* Source repo: git+https://github.com/janestreet/base.git
* Bug tracker: https://github.com/janestreet/base/issues

---
:camel: Pull-request generated by opam-publish v2.3.0