### PR TITLE
Package patch.3.0.0~alpha2

### DIFF
--- a/packages/opam-core/opam-core.2.4.0~alpha1/opam
+++ b/packages/opam-core/opam-core.2.4.0~alpha1/opam
@@ -29,7 +29,7 @@ depends: [
   "sha" {>= "1.13"}
   "jsonm"
   "swhid_core"
-  "patch" {>= "3.0.0~alpha1"}
+  "patch" {>= "3.0.0~alpha1" & < "3.0.0~alpha2"}
   "uutf"
   (("host-system-mingw" {os = "win32" & os-distribution != "cygwinports"} &
     "conf-mingw-w64-gcc-i686"

--- a/packages/opam-repository/opam-repository.2.4.0~alpha1/opam
+++ b/packages/opam-repository/opam-repository.2.4.0~alpha1/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "patch" {>= "3.0.0~alpha1"}
+  "patch" {>= "3.0.0~alpha1" & < "3.0.0~alpha2"}
   "dune" {>= "2.8.0"}
 ]
 available: opam-version >= "2.1.0"

--- a/packages/patch/patch.3.0.0~alpha2/opam
+++ b/packages/patch/patch.3.0.0~alpha2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Patch library purely in OCaml"
+description: """\
+This is a library which parses unified diff and git diff output, and can
+apply a patch in memory."""
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>" "Kate <kit-ty-kate@exn.st>"]
+license: "ISC"
+homepage: "https://github.com/hannesm/patch"
+doc: "https://hannesm.github.io/patch/"
+bug-reports: "https://github.com/hannesm/patch/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "crowbar" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/patch.git"
+url {
+  src:
+    "https://github.com/hannesm/patch/releases/download/v3.0.0-alpha2/patch-3.0.0-alpha2.tar.gz"
+  checksum: [
+    "md5=7f11023c7231b916cfe3dd28ff6ce948"
+    "sha512=e896382c90325af485a0fdea719f8ef4705d8b5db500fcb7df3f5c260c08686087a3f225cefcfb44a1c0ea2fecdb901e932f0d8195175ab53d82c667dd5ef845"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `patch.3.0.0~alpha2`
Patch library purely in OCaml
This is a library which parses unified diff and git diff output, and can
apply a patch in memory.



---
* Homepage: https://github.com/hannesm/patch
* Source repo: git+https://github.com/hannesm/patch.git
* Bug tracker: https://github.com/hannesm/patch/issues

---
:camel: Pull-request generated by opam-publish v2.5.0