### PR TITLE
[new release] spurs (0.1.0)

### DIFF
--- a/packages/spurs/spurs.0.1.0/opam
+++ b/packages/spurs/spurs.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A lightweight native sparse matrix library"
+maintainer: ["Nikhil Kamath <nikhil.k123234@gmail.com"]
+authors: ["Nikhil Kamath <nikhil.k123234@gmail.com>"]
+license: "MIT"
+tags: ["sparse" "matrices"]
+homepage: "https://github.com/nikhil-kamath/spurs"
+doc: "https://nikhil-kamath.github.io/spurs/"
+bug-reports: "https://github.com/nikhil-kamath/spurs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.3.0"}
+  "ppx_deriving"
+  "ppx_fields_conv"
+  "fmt"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/nikhil-kamath/spurs.git"
+url {
+  src:
+    "https://github.com/nikhil-kamath/spurs/releases/download/v0.1.0/spurs-0.1.0.tbz"
+  checksum: [
+    "sha256=5fcb6c01718552fb6df959bbb065e4163ab89bd5b2aa1888e77dc9b3e43c5e28"
+    "sha512=7e03e2f1b1fe27e81f985341a526e964053fea3f22593b171f817d3bf27b02061efcf89687c01873d4b4c3204c174d02441a28a35272a823cb6017148c8cfcd5"
+  ]
+}
+x-commit-hash: "2e8e703993ce221767d0c87f58c1ff0d2c84ef2b"


### PR DESCRIPTION
hi friends! 

This is my first time contributing to OCaml; I've been developing some other projects in OCaml that would benefit from a sparse matrix library, and I've noticed in a few discussions ([here](https://discuss.ocaml.org/t/sparse-matrices/12955)) that OCaml doesn't have a go-to natively implemented sparse matrix library. 

Owl used to have C bindings, but those were removed [a few years ago](https://github.com/owlbarn/owl/pull/633/files#diff-d7668578ea208b31df65c2098d203d43c8b0cacae8834913efc802462e37548b).

I'm working on `spurs`, a port of Rust's [sprs](https://docs.rs/sprs/latest/sprs/) library as a lightweight native implementation! It currently doesn't have the multiplication implemented but the data structures are implemented properly.

- Project page: <a href="https://github.com/nikhil-kamath/spurs">https://github.com/nikhil-kamath/spurs</a>
- Documentation: <a href="https://nikhil-kamath.github.io/spurs/">https://nikhil-kamath.github.io/spurs/</a>

##### CHANGES:


