### PR TITLE
Mark ocaml-system with avoid-version

### DIFF
--- a/packages/ocaml-system/ocaml-system.3.07+1/opam
+++ b/packages/ocaml-system/ocaml-system.3.07+1/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.07+1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.07+2/opam
+++ b/packages/ocaml-system/ocaml-system.3.07+2/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.07+2"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.07/opam
+++ b/packages/ocaml-system/ocaml-system.3.07/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.07"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.08.0/opam
+++ b/packages/ocaml-system/ocaml-system.3.08.0/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.08.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.08.1/opam
+++ b/packages/ocaml-system/ocaml-system.3.08.1/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.08.1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.08.2/opam
+++ b/packages/ocaml-system/ocaml-system.3.08.2/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.08.2"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.08.3/opam
+++ b/packages/ocaml-system/ocaml-system.3.08.3/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.08.3"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.08.4/opam
+++ b/packages/ocaml-system/ocaml-system.3.08.4/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.08.4"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.09.0/opam
+++ b/packages/ocaml-system/ocaml-system.3.09.0/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.09.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.09.1/opam
+++ b/packages/ocaml-system/ocaml-system.3.09.1/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.09.1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.09.2/opam
+++ b/packages/ocaml-system/ocaml-system.3.09.2/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.09.2"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.09.3/opam
+++ b/packages/ocaml-system/ocaml-system.3.09.3/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.09.3"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.10.0/opam
+++ b/packages/ocaml-system/ocaml-system.3.10.0/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.10.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.10.1/opam
+++ b/packages/ocaml-system/ocaml-system.3.10.1/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.10.1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.10.2/opam
+++ b/packages/ocaml-system/ocaml-system.3.10.2/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.10.2"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.11.0/opam
+++ b/packages/ocaml-system/ocaml-system.3.11.0/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.11.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.11.1/opam
+++ b/packages/ocaml-system/ocaml-system.3.11.1/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.11.1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.11.2/opam
+++ b/packages/ocaml-system/ocaml-system.3.11.2/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.11.2"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.12.0/opam
+++ b/packages/ocaml-system/ocaml-system.3.12.0/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.12.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.3.12.1/opam
+++ b/packages/ocaml-system/ocaml-system.3.12.1/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "3.12.1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.00.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.00.0/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.00.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.00.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.00.1/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.00.1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.01.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.01.0/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.01.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.02.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.02.0/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.02.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.02.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.02.1/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.02.1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.02.2/opam
+++ b/packages/ocaml-system/ocaml-system.4.02.2/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.02.2"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.02.3/opam
+++ b/packages/ocaml-system/ocaml-system.4.02.3/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.02.3"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.03.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.03.0/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.03.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.04.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.04.0/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.04.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.04.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.04.1/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.04.1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.04.2/opam
+++ b/packages/ocaml-system/ocaml-system.4.04.2/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.04.2"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.05.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.05.0/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.05.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.06.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.06.0/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.06.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.06.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.06.1/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.06.1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.07.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.07.0/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.07.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.07.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.07.1/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.07.1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.08.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.08.0/opam
@@ -12,7 +12,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.08.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.08.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.08.1/opam
@@ -12,7 +12,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.08.1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.09.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.09.0/opam
@@ -12,7 +12,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.09.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.09.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.09.1/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.09.1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.10.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.10.0/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.10.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.10.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.10.1/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.10.1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.10.2/opam
+++ b/packages/ocaml-system/ocaml-system.4.10.2/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.10.2"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.11.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.11.0/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.11.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.11.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.11.1/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.11.1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.11.2/opam
+++ b/packages/ocaml-system/ocaml-system.4.11.2/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.11.2"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.12.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.12.0/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.12.0"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.12.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.12.1/opam
@@ -17,7 +17,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.12.1"
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.13.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.13.0/opam
@@ -43,7 +43,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.13.0" & (os != "win32" | sys-ocaml-libc = "msvc")
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.13.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.13.1/opam
@@ -43,7 +43,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.13.1" & (os != "win32" | sys-ocaml-libc = "msvc")
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.14.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.0/opam
@@ -43,7 +43,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.14.0" & (os != "win32" | sys-ocaml-libc = "msvc")
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.14.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.1/opam
@@ -43,7 +43,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.14.1" & (os != "win32" | sys-ocaml-libc = "msvc")
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.4.14.2/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.2/opam
@@ -43,7 +43,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "4.14.2" & (os != "win32" | sys-ocaml-libc = "msvc")
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.5.0.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.0.0/opam
@@ -46,7 +46,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "5.0.0" & (os != "win32" | sys-ocaml-libc = "msvc")
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.5.1.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.1.0/opam
@@ -48,7 +48,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "5.1.0" & (os != "win32" | sys-ocaml-libc = "msvc")
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.5.1.1/opam
+++ b/packages/ocaml-system/ocaml-system.5.1.1/opam
@@ -48,7 +48,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "5.1.1" & (os != "win32" | sys-ocaml-libc = "msvc")
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.5.2.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.2.0/opam
@@ -48,7 +48,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "5.2.0" & (os != "win32" | sys-ocaml-libc = "msvc")
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.5.2.1/opam
+++ b/packages/ocaml-system/ocaml-system.5.2.1/opam
@@ -48,7 +48,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "5.2.1" & (os != "win32" | sys-ocaml-libc = "msvc")
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {

--- a/packages/ocaml-system/ocaml-system.5.3.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.3.0/opam
@@ -48,7 +48,7 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 available: sys-ocaml-version = "5.3.0" & (os != "win32" | sys-ocaml-libc = "msvc")
-flags: compiler
+flags: [compiler avoid-version]
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
 extra-source "gen_ocaml_config.ml.in" {


### PR DESCRIPTION
This makes sure opam switches do not end up with ocaml-system unknowingly. opam switches can still use it as long as that requirement is explicit. This fixes a large number of issues encountered by users.

See https://github.com/ocaml/opam/pull/6494 and https://github.com/ocaml/opam/pull/6307
cc @Octachron @dra27 