### PR TITLE
[new release] ocamlformat-mlx (2 packages) (0.27.0)

### DIFF
--- a/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.27.0/opam
+++ b/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.27.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "OCaml .mlx Code Formatter"
+description:
+  "OCamlFormat is a tool to automatically format OCaml .mlx code in a uniform style."
+maintainer: ["Andrey Popp <me@andreypopp.com>"]
+authors: [
+  "Andrey Popp <me@andreypopp.com>"
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+homepage: "https://github.com/ocaml-mlx/ocamlformat-mlx"
+bug-reports: "https://github.com/ocaml-mlx/ocamlformat-mlx/issues"
+depends: [
+  "ocaml" {>= "4.08" & < "5.3"}
+  "alcotest" {with-test & >= "1.3.0"}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.8"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath" {>= "0.7.3"}
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.5.0"}
+  "ocp-indent" {with-test = "false" & >= "1.8.0" | with-test & >= "1.8.1"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "astring"
+  "camlp-streams"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-mlx/ocamlformat-mlx.git"
+# OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-mlx/ocamlformat-mlx/releases/download/0.27.0/ocamlformat-mlx-0.27.0.tbz"
+  checksum: [
+    "sha256=6a40faa182faee55f32bc92387b7e7f97818e160e0f4ef0e0032c0b8b70b86d1"
+    "sha512=7df487ebdcddff3529886e034fa9d5476c765c60926b11b8d86fb0e42bea3ee41f693c898e7f95bfc19ca9fa0116825c040a3e027c1e3b7505ebe6c6508540ec"
+  ]
+}
+x-commit-hash: "01b7b3bebde025f2132e28a9f72acba7b247c104"

--- a/packages/ocamlformat-mlx/ocamlformat-mlx.0.27.0/opam
+++ b/packages/ocamlformat-mlx/ocamlformat-mlx.0.27.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml .mlx code"
+description: """
+**ocamlformat** is a code formatter for OCaml. It comes with opinionated default settings but is also fully customizable to suit your coding style.
+
+- **Profiles:** ocamlformat offers profiles we predefined formatting configurations. Profiles include `default`, `ocamlformat`, `janestreet`.
+- **Configurable:** Users can change the formatting profile and configure every option in their `.ocamlformat` configuration file.
+- **Format Comments:** ocamlformat can format comments, docstrings, and even code blocks in your comments.
+- **RPC:** ocamlformat provides an RPC server that can be used by other tools to easily format OCaml Code."""
+maintainer: ["Andrey Popp <me@andreypopp.com>"]
+authors: [
+  "Andrey Popp <me@andreypopp.com>"
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+homepage: "https://github.com/ocaml-mlx/ocamlformat-mlx"
+bug-reports: "https://github.com/ocaml-mlx/ocamlformat-mlx/issues"
+depends: [
+  "ocaml" {>= "4.08" & < "5.3"}
+  "cmdliner" {with-test = "false" & >= "1.1.0" | with-test & >= "1.2.0"}
+  "csexp" {>= "1.4.0"}
+  "dune" {>= "2.8"}
+  "ocamlformat-mlx-lib" {= version}
+  "re" {>= "1.10.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-mlx/ocamlformat-mlx.git"
+# OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-mlx/ocamlformat-mlx/releases/download/0.27.0/ocamlformat-mlx-0.27.0.tbz"
+  checksum: [
+    "sha256=6a40faa182faee55f32bc92387b7e7f97818e160e0f4ef0e0032c0b8b70b86d1"
+    "sha512=7df487ebdcddff3529886e034fa9d5476c765c60926b11b8d86fb0e42bea3ee41f693c898e7f95bfc19ca9fa0116825c040a3e027c1e3b7505ebe6c6508540ec"
+  ]
+}
+x-commit-hash: "01b7b3bebde025f2132e28a9f72acba7b247c104"


### PR DESCRIPTION
Auto-formatter for OCaml .mlx code

- Project page: <a href="https://github.com/ocaml-mlx/ocamlformat-mlx">https://github.com/ocaml-mlx/ocamlformat-mlx</a>

##### CHANGES:

### Highlight

- \* Support OCaml 5.2 syntax (ocaml-mlx/ocamlformat-mlx#2519, ocaml-mlx/ocamlformat-mlx#2544, ocaml-mlx/ocamlformat-mlx#2590, ocaml-mlx/ocamlformat-mlx#2596, ocaml-mlx/ocamlformat-mlx#2621, ocaml-mlx/ocamlformat-mlx#2628, @Julow, @EmileTrotignon, @hhugo)
  This includes local open in types, raw identifiers, and the new
  representation for functions.
  This might change the formatting of some functions due to the formatting code
  being completely rewritten.

- Support OCaml 5.3 syntax (ocaml-mlx/ocamlformat-mlx#2609, ocaml-mlx/ocamlformat-mlx#2610, ocaml-mlx/ocamlformat-mlx#2611, ocaml-mlx/ocamlformat-mlx#2622, ocaml-mlx/ocamlformat-mlx#2623, ocaml-mlx/ocamlformat-mlx#2562, ocaml-mlx/ocamlformat-mlx#2624, ocaml-mlx/ocamlformat-mlx#2625, ocaml-mlx/ocamlformat-mlx#2627, @Julow, @Zeta611)
  This adds support for effect patterns, short functor type arguments and utf8
  identifiers.
  To format code using the new `effect` syntax, add this option to your
  `.ocamlformat`:
  ```
  ocaml-version = 5.3
  ```

- Documentation comments are now formatted by default (ocaml-mlx/ocamlformat-mlx#2390, @Julow)
  Use the option `parse-docstrings = false` to restore the previous behavior.

- \* Consistent indentation of polymorphic variant arguments (ocaml-mlx/ocamlformat-mlx#2427, @Julow)
  Increases the indentation by one to make the formatting consistent with
  normal variants. For example:
  ```
    ...
    (* before *)
      (`Msg
        (foo bar))
    (* after *)
      (`Msg
         (foo bar))
  ```

- Build on OCaml 5.3 (ocaml-mlx/ocamlformat-mlx#2603, @adamchol, @Julow)

### Added

- Improve the emacs plugin (ocaml-mlx/ocamlformat-mlx#2577, ocaml-mlx/ocamlformat-mlx#2600, @gridbugs, @thibautbenjamin)
  Allow a custom command to be used to run ocamlformat and add compatibility
  with emacs ocaml tree-sitter modes.

- Added option `let-binding-deindent-fun` (ocaml-mlx/ocamlformat-mlx#2521, @henrytill)
  to control the indentation of the `fun` in:
  ```
  let f =
   fun foo ->
    bar
  ```

- Added back the flag `--disable-outside-detected-project` (ocaml-mlx/ocamlformat-mlx#2439, @gpetiot)
  It was removed in version 0.22.

- Support newer Odoc syntax (ocaml-mlx/ocamlformat-mlx#2631, ocaml-mlx/ocamlformat-mlx#2632, ocaml-mlx/ocamlformat-mlx#2633, @Julow)

### Changed

- \* Consistent formatting of comments (ocaml-mlx/ocamlformat-mlx#2371, ocaml-mlx/ocamlformat-mlx#2550, @Julow)
  This is mostly an internal change but some comments might be formatted differently.

- \* Improve formatting of type constraints with type variables (ocaml-mlx/ocamlformat-mlx#2437, @gpetiot)
  For example:
  ```
  let f : type a b c.
      a -> b -> c =
    ...
  ```

- \* Improve formatting of functor arguments (ocaml-mlx/ocamlformat-mlx#2505, @Julow)
  This also reduce the indentation of functor arguments with long signatures.

- Improvements to the Janestreet profile (ocaml-mlx/ocamlformat-mlx#2445, ocaml-mlx/ocamlformat-mlx#2314, ocaml-mlx/ocamlformat-mlx#2460, ocaml-mlx/ocamlformat-mlx#2593, ocaml-mlx/ocamlformat-mlx#2612, @Julow, @tdelvecchio-jsc)

- \* Undo let-bindings and methods normalizations (ocaml-mlx/ocamlformat-mlx#2523, ocaml-mlx/ocamlformat-mlx#2529, @gpetiot)
  This remove the rewriting of some forms of let-bindings and methods:
  + `let f x = (x : int)` is no longer rewritten into `let f x : int = x`
  + `let f (type a) (type b) ...` is no longer rewritten into `let f (type a b) ...`
  + `let f = fun x -> ...` is no longer rewritten into `let f x = ...`

- \* The `break-colon` option is now taken into account for method type constraints (ocaml-mlx/ocamlformat-mlx#2529, @gpetiot)

- \* Force a break around comments following an infix operator (fix non-stabilizing comments) (ocaml-mlx/ocamlformat-mlx#2478, @gpetiot)
  This adds a line break:
  ```
    a
    ||
    (* this comment is now on its own line *)
    b
  ```

### Fixed

- Fix placement of comments in some cases (ocaml-mlx/ocamlformat-mlx#2471, ocaml-mlx/ocamlformat-mlx#2503, ocaml-mlx/ocamlformat-mlx#2506, ocaml-mlx/ocamlformat-mlx#2540, ocaml-mlx/ocamlformat-mlx#2541, ocaml-mlx/ocamlformat-mlx#2592, ocaml-mlx/ocamlformat-mlx#2617, @gpetiot, @Julow)
  Some comments were being moved or causing OCamlformat to crash.
  OCamlformat refuses to format if a comment would be missing in its output, to avoid loosing code.

- Fix attributes being dropped or moved (ocaml-mlx/ocamlformat-mlx#2247, ocaml-mlx/ocamlformat-mlx#2459, ocaml-mlx/ocamlformat-mlx#2551, ocaml-mlx/ocamlformat-mlx#2564, ocaml-mlx/ocamlformat-mlx#2602, @EmileTrotignon, @tdelvecchio-jsc, @Julow)
  OCamlformat refuses to format if the formatted code has a different meaning than the original code, for example, if an attribute is removed.
  We also try to avoid moving attributes even if that doesn't change the original code, for example we no longer format `open[@attr] M` as `open M [@@attr]`.

- Remove trailing space inside a wrapping empty signature (ocaml-mlx/ocamlformat-mlx#2443, @Julow)
- Fix extension-point spacing in structures (ocaml-mlx/ocamlformat-mlx#2450, @Julow)
- \* Consistent break after string constant argument (ocaml-mlx/ocamlformat-mlx#2453, @Julow)
- \* Fix cinaps comment formatting to not change multiline string contents (ocaml-mlx/ocamlformat-mlx#2463, @tdelvecchio-jsc)
- \* Fix the indentation of tuples in attributes and extensions (ocaml-mlx/ocamlformat-mlx#2488, @Julow)
- \* Fix weird indentation and line breaks after comments (ocaml-mlx/ocamlformat-mlx#2507, ocaml-mlx/ocamlformat-mlx#2589, ocaml-mlx/ocamlformat-mlx#2606, @Julow)
- \* Fix unwanted alignment in if-then-else (ocaml-mlx/ocamlformat-mlx#2511, @Julow)
- Fix missing parentheses around constraint expressions with attributes (ocaml-mlx/ocamlformat-mlx#2513, @alanechang)
- Fix formatting of type vars in GADT constructors (ocaml-mlx/ocamlformat-mlx#2518, @Julow)
- Fix `[@ocamlformat "disable"]` in some cases (ocaml-mlx/ocamlformat-mlx#2242, ocaml-mlx/ocamlformat-mlx#2525, @EmileTrotignon)
  This caused a bug inside `class type` constructs and when attached to a `let ... in`
- Display `a##b` instead of `a ## b` and similarly for operators that start with # (ocaml-mlx/ocamlformat-mlx#2580, @v-gb)
- \* Fix arrow type indentation with `break-separators=before` (ocaml-mlx/ocamlformat-mlx#2598, @Julow)
- Fix missing parentheses around a let in class expressions (ocaml-mlx/ocamlformat-mlx#2599, @Julow)
- Fix formatting of paragraphs in lists in documentation (ocaml-mlx/ocamlformat-mlx#2607, @Julow)
- Avoid unwanted space in references and links text in documentation (ocaml-mlx/ocamlformat-mlx#2608, @Julow)
- \* Improve the indentation of attributes in patterns (ocaml-mlx/ocamlformat-mlx#2613, @Julow)
- \* Avoid large indentation in patterns after `let%ext` (ocaml-mlx/ocamlformat-mlx#2615, @Julow)
