### PR TITLE
FlexDLL 0.44

### DIFF
--- a/packages/flexdll/flexdll.0.44/opam
+++ b/packages/flexdll/flexdll.0.44/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+authors: "Alain Frisch"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/flexdll/issues"
+dev-repo: "git+https://github.com/ocaml/flexdll.git"
+homepage: "https://github.com/ocaml/flexdll#readme"
+license: "Zlib"
+synopsis: "FlexDLL Sources"
+description: "Source package for FlexDLL. Installs the required files for
+bootstrapping FlexDLL as part of an OCaml build."
+url {
+  src: "https://github.com/ocaml/flexdll/archive/refs/tags/0.44.tar.gz"
+  checksum: [
+    "sha256=b7c6a92286f1f3065324d51083dcb16eec436a4e6e3b8df7cf836b6d7a8b9491"
+    "sha512=87c5e38810dcf4bba43472e6c4e2ea25081a92664e37269f782ef9412e81d37d53edbbeb0acbf5eb821cc5105085a99337b30e55409057121a68472eb51db7c8"
+  ]
+}


### PR DESCRIPTION
[FlexDLL 0.44](https://github.com/ocaml/flexdll/releases/tag/0.44) has been released, just under two years after its predecessor.

This release includes https://github.com/ocaml/flexdll/pull/135, which means that the `extra-source` for the `.install` file present in in the 0.43 version:
https://github.com/ocaml/opam-repository/blob/8ae853b39e5c409b481d0d5d9318e0d8e6eee41d/packages/flexdll/flexdll.0.43/opam#L18-L24
is no longer required.

FlexDLL in opam is bootstrapped as part of the build of the compiler - this package will necessarily trigger rebuilds on all Windows opam switches.