### PR TITLE
Publish OCaml/Unikraft packages v1.0.0

### DIFF
--- a/packages/ocaml-unikraft-arm64/ocaml-unikraft-arm64.1.0.0/opam
+++ b/packages/ocaml-unikraft-arm64/ocaml-unikraft-arm64.1.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis: "OCaml cross compiler to the freestanding Unikraft arm64 backends"
+description:
+  "This package provides an OCaml cross compiler, suitable for linking with a Unikraft arm64 unikernel."
+authors: "Samuel Hym"
+license: ["MIT" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"]
+depends: [
+  "ocaml" {= "5.3.0"}
+  "ocaml-unikraft-toolchain-arm64"
+  "ocamlfind"
+  "ocaml-src" {build}
+  "conf-git" {build}
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "prefix=%{prefix}%"
+    "BIN=%{bin}%"
+    "LIB=%{lib}%"
+    "SHARE=%{share}%"
+    "OCUKARCH=arm64"
+    "%{name}%.install"
+  ]
+]
+install: [
+  [make "install-ocaml"]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.0.0.tar.gz"
+  checksum:
+    "sha256=1953d51bee391e11676da7234854fb2d87443abb984d625c8e96db47bf5a85e4"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-backend-firecracker-arm64/ocaml-unikraft-backend-firecracker-arm64.0.18.0/opam
+++ b/packages/ocaml-unikraft-backend-firecracker-arm64/ocaml-unikraft-backend-firecracker-arm64.0.18.0/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis: "Firecracker/arm64 Unikraft backend for OCaml"
+authors: ["Samuel Hym" "Unikraft contributors"]
+license: ["MIT" "BSD-3-Clause" "GPL-2.0-only"]
+depends: [
+  "unikraft" {= version}
+]
+depopts: [
+  "ocaml-unikraft-option-debug"
+]
+depexts: [
+  ["gcc-aarch64-linux-gnu"] {os-family = "debian" & arch != "arm64"}
+  ["aarch64-linux-gnu-gcc"] {os-family = "arch" & arch != "arm64"}
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "UNIKRAFT=%{unikraft:lib}%"
+    "OCUKPLAT=firecracker"
+    "OCUKARCH=arm64"
+    "OCUKEXTLIBS=musl"
+    "OCUKCONFIGOPTS+=debug" {ocaml-unikraft-option-debug:installed}
+    "UK_CFLAGS=-std=gnu17"
+    "%{name}%.install"
+  ]
+]
+extra-source "lib-musl.tar.gz" {
+  src:
+    "https://github.com/unikraft/lib-musl/archive/refs/tags/RELEASE-0.18.0.tar.gz"
+  checksum:
+    "sha256=b51afee0227c0c8c419dd001fb6b6f57b529e5cadcd437afdd05e2e8667a1e2e"
+}
+extra-source "patches/lib-musl/main-tsd.patch" {
+  src:
+    "https://raw.githubusercontent.com/shym/lib-musl/refs/heads/patches/main-tsd.patch"
+  checksum:
+    "sha256=9b87cbf0743492e6949de61af6423b463031da8b14b799a775c34886cabffd28"
+}
+extra-source "patches/lib-musl/arm64.patch" {
+  src:
+    "https://raw.githubusercontent.com/shym/lib-musl/refs/heads/patches/arm64.patch"
+  checksum:
+    "sha256=d83043f534a8da4f0133f4fbde0d78bc3a5d996ca6f7fc91b42ccf2874515514"
+}
+extra-source "patches/lib-musl/exit.patch" {
+  src:
+    "https://raw.githubusercontent.com/shym/lib-musl/refs/heads/patches/exit.patch"
+  checksum:
+    "sha256=41e72b400071b146dde8ecd7be09a4a6187d2ed448ae200581de5405f84db1ee"
+}
+extra-source "musl-1.2.3.tar.gz" {
+  src: "https://www.musl-libc.org/releases/musl-1.2.3.tar.gz"
+  checksum:
+    "sha256=7d5b0b6062521e4627e099e4c9dc8248d32a30285e959b7eecaa780cf8cfd4a4"
+}
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.0.0.tar.gz"
+  checksum:
+    "sha256=1953d51bee391e11676da7234854fb2d87443abb984d625c8e96db47bf5a85e4"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-backend-firecracker-x86_64/ocaml-unikraft-backend-firecracker-x86_64.0.18.0/opam
+++ b/packages/ocaml-unikraft-backend-firecracker-x86_64/ocaml-unikraft-backend-firecracker-x86_64.0.18.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis: "Firecracker/x86_64 Unikraft backend for OCaml"
+authors: ["Samuel Hym" "Unikraft contributors"]
+license: ["MIT" "BSD-3-Clause" "GPL-2.0-only"]
+depends: [
+  "unikraft" {= version}
+]
+depopts: [
+  "ocaml-unikraft-option-debug"
+]
+depexts: [
+  ["gcc-x86_64-linux-gnu"] {os-family = "debian" & arch != "x86_64"}
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "UNIKRAFT=%{unikraft:lib}%"
+    "OCUKPLAT=firecracker"
+    "OCUKARCH=x86_64"
+    "OCUKEXTLIBS=musl"
+    "OCUKCONFIGOPTS+=debug" {ocaml-unikraft-option-debug:installed}
+    "UK_CFLAGS=-std=gnu17"
+    "%{name}%.install"
+  ]
+]
+extra-source "lib-musl.tar.gz" {
+  src:
+    "https://github.com/unikraft/lib-musl/archive/refs/tags/RELEASE-0.18.0.tar.gz"
+  checksum:
+    "sha256=b51afee0227c0c8c419dd001fb6b6f57b529e5cadcd437afdd05e2e8667a1e2e"
+}
+extra-source "patches/lib-musl/main-tsd.patch" {
+  src:
+    "https://raw.githubusercontent.com/shym/lib-musl/refs/heads/patches/main-tsd.patch"
+  checksum:
+    "sha256=9b87cbf0743492e6949de61af6423b463031da8b14b799a775c34886cabffd28"
+}
+extra-source "patches/lib-musl/arm64.patch" {
+  src:
+    "https://raw.githubusercontent.com/shym/lib-musl/refs/heads/patches/arm64.patch"
+  checksum:
+    "sha256=d83043f534a8da4f0133f4fbde0d78bc3a5d996ca6f7fc91b42ccf2874515514"
+}
+extra-source "patches/lib-musl/exit.patch" {
+  src:
+    "https://raw.githubusercontent.com/shym/lib-musl/refs/heads/patches/exit.patch"
+  checksum:
+    "sha256=41e72b400071b146dde8ecd7be09a4a6187d2ed448ae200581de5405f84db1ee"
+}
+extra-source "musl-1.2.3.tar.gz" {
+  src: "https://www.musl-libc.org/releases/musl-1.2.3.tar.gz"
+  checksum:
+    "sha256=7d5b0b6062521e4627e099e4c9dc8248d32a30285e959b7eecaa780cf8cfd4a4"
+}
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.0.0.tar.gz"
+  checksum:
+    "sha256=1953d51bee391e11676da7234854fb2d87443abb984d625c8e96db47bf5a85e4"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-backend-firecracker/ocaml-unikraft-backend-firecracker.0.18.0/opam
+++ b/packages/ocaml-unikraft-backend-firecracker/ocaml-unikraft-backend-firecracker.0.18.0/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "Virtual package to ensure the Firecracker Unikraft backend is installed for the default cross compiler"
+description:
+  "This virtual package ensures that the Firecracker backend is installed for the default `unikraft` ocamlfind cross toolchain."
+authors: "Samuel Hym"
+license: "MIT"
+depends: [
+  "ocaml-unikraft"
+  ("ocaml-unikraft-default-x86_64" & "ocaml-unikraft-backend-firecracker-x86_64") |
+  ("ocaml-unikraft-default-arm64" & "ocaml-unikraft-backend-firecracker-arm64")
+]
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-backend-qemu-arm64/ocaml-unikraft-backend-qemu-arm64.0.18.0/opam
+++ b/packages/ocaml-unikraft-backend-qemu-arm64/ocaml-unikraft-backend-qemu-arm64.0.18.0/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis: "QEMU/arm64 Unikraft backend for OCaml"
+authors: ["Samuel Hym" "Unikraft contributors"]
+license: ["MIT" "BSD-3-Clause" "GPL-2.0-only"]
+depends: [
+  "unikraft" {= version}
+]
+depopts: [
+  "ocaml-unikraft-option-debug"
+]
+depexts: [
+  ["gcc-aarch64-linux-gnu"] {os-family = "debian" & arch != "arm64"}
+  ["aarch64-linux-gnu-gcc"] {os-family = "arch" & arch != "arm64"}
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "UNIKRAFT=%{unikraft:lib}%"
+    "OCUKPLAT=qemu"
+    "OCUKARCH=arm64"
+    "OCUKEXTLIBS=musl"
+    "OCUKCONFIGOPTS+=debug" {ocaml-unikraft-option-debug:installed}
+    "UK_CFLAGS=-std=gnu17"
+    "%{name}%.install"
+  ]
+]
+extra-source "lib-musl.tar.gz" {
+  src:
+    "https://github.com/unikraft/lib-musl/archive/refs/tags/RELEASE-0.18.0.tar.gz"
+  checksum:
+    "sha256=b51afee0227c0c8c419dd001fb6b6f57b529e5cadcd437afdd05e2e8667a1e2e"
+}
+extra-source "patches/lib-musl/main-tsd.patch" {
+  src:
+    "https://raw.githubusercontent.com/shym/lib-musl/refs/heads/patches/main-tsd.patch"
+  checksum:
+    "sha256=9b87cbf0743492e6949de61af6423b463031da8b14b799a775c34886cabffd28"
+}
+extra-source "patches/lib-musl/arm64.patch" {
+  src:
+    "https://raw.githubusercontent.com/shym/lib-musl/refs/heads/patches/arm64.patch"
+  checksum:
+    "sha256=d83043f534a8da4f0133f4fbde0d78bc3a5d996ca6f7fc91b42ccf2874515514"
+}
+extra-source "patches/lib-musl/exit.patch" {
+  src:
+    "https://raw.githubusercontent.com/shym/lib-musl/refs/heads/patches/exit.patch"
+  checksum:
+    "sha256=41e72b400071b146dde8ecd7be09a4a6187d2ed448ae200581de5405f84db1ee"
+}
+extra-source "musl-1.2.3.tar.gz" {
+  src: "https://www.musl-libc.org/releases/musl-1.2.3.tar.gz"
+  checksum:
+    "sha256=7d5b0b6062521e4627e099e4c9dc8248d32a30285e959b7eecaa780cf8cfd4a4"
+}
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.0.0.tar.gz"
+  checksum:
+    "sha256=1953d51bee391e11676da7234854fb2d87443abb984d625c8e96db47bf5a85e4"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-backend-qemu-x86_64/ocaml-unikraft-backend-qemu-x86_64.0.18.0/opam
+++ b/packages/ocaml-unikraft-backend-qemu-x86_64/ocaml-unikraft-backend-qemu-x86_64.0.18.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis: "QEMU/x86_64 Unikraft backend for OCaml"
+authors: ["Samuel Hym" "Unikraft contributors"]
+license: ["MIT" "BSD-3-Clause" "GPL-2.0-only"]
+depends: [
+  "unikraft" {= version}
+]
+depopts: [
+  "ocaml-unikraft-option-debug"
+]
+depexts: [
+  ["gcc-x86_64-linux-gnu"] {os-family = "debian" & arch != "x86_64"}
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "UNIKRAFT=%{unikraft:lib}%"
+    "OCUKPLAT=qemu"
+    "OCUKARCH=x86_64"
+    "OCUKEXTLIBS=musl"
+    "OCUKCONFIGOPTS+=debug" {ocaml-unikraft-option-debug:installed}
+    "UK_CFLAGS=-std=gnu17"
+    "%{name}%.install"
+  ]
+]
+extra-source "lib-musl.tar.gz" {
+  src:
+    "https://github.com/unikraft/lib-musl/archive/refs/tags/RELEASE-0.18.0.tar.gz"
+  checksum:
+    "sha256=b51afee0227c0c8c419dd001fb6b6f57b529e5cadcd437afdd05e2e8667a1e2e"
+}
+extra-source "patches/lib-musl/main-tsd.patch" {
+  src:
+    "https://raw.githubusercontent.com/shym/lib-musl/refs/heads/patches/main-tsd.patch"
+  checksum:
+    "sha256=9b87cbf0743492e6949de61af6423b463031da8b14b799a775c34886cabffd28"
+}
+extra-source "patches/lib-musl/arm64.patch" {
+  src:
+    "https://raw.githubusercontent.com/shym/lib-musl/refs/heads/patches/arm64.patch"
+  checksum:
+    "sha256=d83043f534a8da4f0133f4fbde0d78bc3a5d996ca6f7fc91b42ccf2874515514"
+}
+extra-source "patches/lib-musl/exit.patch" {
+  src:
+    "https://raw.githubusercontent.com/shym/lib-musl/refs/heads/patches/exit.patch"
+  checksum:
+    "sha256=41e72b400071b146dde8ecd7be09a4a6187d2ed448ae200581de5405f84db1ee"
+}
+extra-source "musl-1.2.3.tar.gz" {
+  src: "https://www.musl-libc.org/releases/musl-1.2.3.tar.gz"
+  checksum:
+    "sha256=7d5b0b6062521e4627e099e4c9dc8248d32a30285e959b7eecaa780cf8cfd4a4"
+}
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.0.0.tar.gz"
+  checksum:
+    "sha256=1953d51bee391e11676da7234854fb2d87443abb984d625c8e96db47bf5a85e4"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-backend-qemu/ocaml-unikraft-backend-qemu.0.18.0/opam
+++ b/packages/ocaml-unikraft-backend-qemu/ocaml-unikraft-backend-qemu.0.18.0/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "Virtual package to ensure the QEMU Unikraft backend is installed for the default cross compiler"
+description:
+  "This virtual package ensures that the QEMU backend is installed for the default `unikraft` ocamlfind cross toolchain."
+authors: "Samuel Hym"
+license: "MIT"
+depends: [
+  "ocaml-unikraft"
+  ("ocaml-unikraft-default-x86_64" & "ocaml-unikraft-backend-qemu-x86_64") |
+  ("ocaml-unikraft-default-arm64" & "ocaml-unikraft-backend-qemu-arm64")
+]
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-default-arm64/ocaml-unikraft-default-arm64.1.0.0/opam
+++ b/packages/ocaml-unikraft-default-arm64/ocaml-unikraft-default-arm64.1.0.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "OCaml default cross compiler to the freestanding Unikraft arm64 backends"
+description:
+  "This package provides an OCaml cross compiler, suitable for linking with a Unikraft arm64 unikernel, as the default `unikraft` ocamlfind toolchain."
+authors: "Samuel Hym"
+license: "MIT"
+depends: ["ocaml-unikraft-arm64" "ocamlfind"]
+conflict-class: "ocaml-unikraft-default"
+build: [
+  [make "prefix=%{prefix}%" "OCUKARCH=arm64" "%{name}%.install"]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.0.0.tar.gz"
+  checksum:
+    "sha256=1953d51bee391e11676da7234854fb2d87443abb984d625c8e96db47bf5a85e4"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-default-x86_64/ocaml-unikraft-default-x86_64.1.0.0/opam
+++ b/packages/ocaml-unikraft-default-x86_64/ocaml-unikraft-default-x86_64.1.0.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "OCaml default cross compiler to the freestanding Unikraft x86_64 backends"
+description:
+  "This package provides an OCaml cross compiler, suitable for linking with a Unikraft x86_64 unikernel, as the default `unikraft` ocamlfind toolchain."
+authors: "Samuel Hym"
+license: "MIT"
+depends: ["ocaml-unikraft-x86_64" "ocamlfind"]
+conflict-class: "ocaml-unikraft-default"
+build: [
+  [make "prefix=%{prefix}%" "OCUKARCH=x86_64" "%{name}%.install"]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.0.0.tar.gz"
+  checksum:
+    "sha256=1953d51bee391e11676da7234854fb2d87443abb984d625c8e96db47bf5a85e4"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-option-debug/ocaml-unikraft-option-debug.0.18.0/opam
+++ b/packages/ocaml-unikraft-option-debug/ocaml-unikraft-option-debug.0.18.0/opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "Virtual package to enable debugging in the Unikraft backends"
+authors: "Samuel Hym"
+license: "MIT"
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-toolchain-arm64/ocaml-unikraft-toolchain-arm64.0.18.0/opam
+++ b/packages/ocaml-unikraft-toolchain-arm64/ocaml-unikraft-toolchain-arm64.0.18.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "C toolchain to build an OCaml cross compiler to the freestanding Unikraft arm64 backends"
+description:
+  "This package provides a C toolchain to build an OCaml cross compiler, suitable for linking with a Unikraft arm64 unikernel."
+authors: "Samuel Hym"
+license: "MIT"
+depends: [
+  "ocaml-unikraft-backend-qemu-arm64" | "ocaml-unikraft-backend-firecracker-arm64"
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "LIB=%{lib}%"
+    "SHARE=%{share}%"
+    "OCUKARCH=arm64"
+    "%{name}%.install"
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.0.0.tar.gz"
+  checksum:
+    "sha256=1953d51bee391e11676da7234854fb2d87443abb984d625c8e96db47bf5a85e4"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-toolchain-x86_64/ocaml-unikraft-toolchain-x86_64.0.18.0/opam
+++ b/packages/ocaml-unikraft-toolchain-x86_64/ocaml-unikraft-toolchain-x86_64.0.18.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "C toolchain to build an OCaml cross compiler to the freestanding Unikraft x86_64 backends"
+description:
+  "This package provides a C toolchain to build an OCaml cross compiler, suitable for linking with a Unikraft x86_64 unikernel."
+authors: "Samuel Hym"
+license: "MIT"
+depends: [
+  "ocaml-unikraft-backend-qemu-x86_64" | "ocaml-unikraft-backend-firecracker-x86_64"
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "LIB=%{lib}%"
+    "SHARE=%{share}%"
+    "OCUKARCH=x86_64"
+    "%{name}%.install"
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.0.0.tar.gz"
+  checksum:
+    "sha256=1953d51bee391e11676da7234854fb2d87443abb984d625c8e96db47bf5a85e4"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-x86_64/ocaml-unikraft-x86_64.1.0.0/opam
+++ b/packages/ocaml-unikraft-x86_64/ocaml-unikraft-x86_64.1.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis: "OCaml cross compiler to the freestanding Unikraft x86_64 backends"
+description:
+  "This package provides an OCaml cross compiler, suitable for linking with a Unikraft x86_64 unikernel."
+authors: "Samuel Hym"
+license: ["MIT" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"]
+depends: [
+  "ocaml" {= "5.3.0"}
+  "ocaml-unikraft-toolchain-x86_64"
+  "ocamlfind"
+  "ocaml-src" {build}
+  "conf-git" {build}
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "prefix=%{prefix}%"
+    "BIN=%{bin}%"
+    "LIB=%{lib}%"
+    "SHARE=%{share}%"
+    "OCUKARCH=x86_64"
+    "%{name}%.install"
+  ]
+]
+install: [
+  [make "install-ocaml"]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.0.0.tar.gz"
+  checksum:
+    "sha256=1953d51bee391e11676da7234854fb2d87443abb984d625c8e96db47bf5a85e4"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft/ocaml-unikraft.1.0.0/opam
+++ b/packages/ocaml-unikraft/ocaml-unikraft.1.0.0/opam
@@ -1,0 +1,14 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "Virtual package to install one of the OCaml default cross compilers to the freestanding Unikraft backends"
+description:
+  "This virtual package ensures that an OCaml cross compiler is available for linking with a Unikraft unikernel as the default `unikraft` ocamlfind toolchain. Explicitly choose one among the ocaml-unikraft-default-* packages to control which one is actually installed."
+authors: "Samuel Hym"
+license: "MIT"
+depends: ["ocaml-unikraft-default-x86_64" | "ocaml-unikraft-default-arm64"]
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/unikraft/unikraft.0.18.0/opam
+++ b/packages/unikraft/unikraft.0.18.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Unikraft sources"
+description: "Source package for Unikraft"
+maintainer: "samuel@tarides.com"
+authors: "Unikraft contributors"
+license: ["BSD-3-Clause" "MIT" "GPL-2.0"]
+homepage: "https://unikraft.org"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+depends: [
+    "conf-bison"
+    "conf-flex"
+    "conf-python-3"
+]
+install: [
+  ["rm" "-rf" ".github" ".gitignore"]
+  ["cp" "-r" "." "%{unikraft:lib}%"]
+]
+dev-repo: "git+https://github.com/unikraft/unikraft.git"
+patches: [ "strong-main.patch" "ibm-vs-arm.patch" ]
+url {
+  src:
+    "https://github.com/unikraft/unikraft/archive/refs/tags/RELEASE-0.18.0.tar.gz"
+  checksum:
+    "sha256=680836d192e69167c3ce8c19892d5440c63885308aed0f40764d1ed42ed1f8e5"
+}
+extra-source "strong-main.patch" {
+  src:
+    "https://raw.githubusercontent.com/shym/unikraft/refs/heads/patches/strong-main.patch"
+  checksum:
+    "sha256=0889759befcc6a0cd350ac49d6356133393de59188173bffb4f37ca4c7f007a3"
+}
+extra-source "ibm-vs-arm.patch" {
+  src:
+    "https://raw.githubusercontent.com/shym/unikraft/refs/heads/patches/ibm-vs-arm.patch"
+  checksum:
+    "sha256=484043e9fd9afe09416155644a7d1d7cd92a5eff2563ce98c95db37cea00869e"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
OCaml/Unikraft: an OCaml cross compiler to Unikraft backends

OCaml/Unikraft is structured into many packages to allow users to build only what they need.

Packages use one of two version numbers:
- 0.18.0, the upstream release number of Unikraft: used for `unikraft` and backend packages,
- 1.0.0, for packages that are more on the OCaml side.

The 15 packages are as follows:

- `unikraft`: the upstream sources.
- `ocaml-unikraft-backend-<backend>-<arch>`: all the object files and headers necessary to build a unikernel for the specific `<backend>` and `<arch>` combination.
- `ocaml-unikraft-option-debug`: if that package is installed, the backends will be built with debugging messages.
- `ocaml-unikraft-toolchain-<arch>`: a toolchain using the `<arch>-unikraft-ocaml-` prefix; the toolchain is a set of wrapper shell scripts to add the necessary options to drive the underlying tools.
- `ocaml-unikraft-<arch>`: the actual OCaml cross compilers for the given `<arch>`.
- `ocaml-unikraft-default-<arch>`: simple packages that only install a `ocamlfind` toolchain named `unikraft` (so that switching between architecture do not require to rebuild the full OCaml compiler).
- `ocaml-unikraft-backend-<backend>`: virtual packages to ensure that the given `<backend>` is installed for the default architecture, as set by which `ocaml-unikraft-default-<arch>` package is installed.
- `ocaml-unikraft`: the virtual package to ensure one of the default compiler package is installed.