### PR TITLE
[new release] mariadb (1.3.0)

### DIFF
--- a/packages/mariadb/mariadb.1.3.0/opam
+++ b/packages/mariadb/mariadb.1.3.0/opam
@@ -21,7 +21,6 @@ depends: [
   "ctypes" {>= "0.13.0"}
   "conf-mariadb"
   "conf-gcc"
-  "conf-pkg-config"
   "dune" {>= "3.15.0"}
   "dune-configurator"
   "async" {with-test}

--- a/packages/mariadb/mariadb.1.3.0/opam
+++ b/packages/mariadb/mariadb.1.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Andre Nathan <andrenth@gmail.com>"
+homepage: "https://github.com/ocaml-community/ocaml-mariadb"
+bug-reports: "https://github.com/ocaml-community/ocaml-mariadb/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/ocaml-community/ocaml-mariadb.git"
+synopsis: "OCaml bindings for MariaDB"
+description: "OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its nonblocking API."
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "ctypes" {>= "0.13.0"}
+  "conf-mariadb"
+  "conf-gcc"
+  "conf-pkg-config"
+  "dune" {>= "3.15.0"}
+  "dune-configurator"
+  "async" {with-test}
+  "lwt" {with-test}
+]
+conflicts: [ "ocaml-option-bytecode-only" ]
+url {
+  src:
+    "https://github.com/ocaml-community/ocaml-mariadb/releases/download/1.3.0/mariadb-1.3.0.tbz"
+  checksum: [
+    "sha256=99892d153503680ffffd2cd3320403357b58897c6790cadfe04ba38a3a668cc6"
+    "sha512=dd645f268479b73e0bfb16e75295df1dfcfbcc74ab4ea100a09b1eb2331a4e66270b90c37c9973545c3576ba86c76ab780a3ae095730c17d89bb6cbd1cfce9ef"
+  ]
+}
+x-commit-hash: "bf55bb3331216a76fbefe4571f5837511c46186d"


### PR DESCRIPTION
OCaml bindings for MariaDB

- Project page: <a href="https://github.com/ocaml-community/ocaml-mariadb">https://github.com/ocaml-community/ocaml-mariadb</a>

##### CHANGES:

  - The `mariadb_config` and `mysql_config` scripts are now used, if
    available, to discover MariaDB client library (ocaml-community/ocaml-mariadb#65 by Albert Peschar).
  - Added server-side properties `get_server_info`, `get_server_version`,
    `get_host_info` and `get_proto_info` (ocaml-community/ocaml-mariadb#62 by Petter A. Urkedal).
  - Avoid calling `mysql_stmt_free_result` if there is no result set, since
    this is not allowed by recent versions of the client library (by Petter
    A. Urkedal, fixes ocaml-community/ocaml-mariadb#64).
  - Avoid possibly blocking calls to `mysql_free_result` in the nonblocking
    implementation.  This was only an issue if a previous result set had not
    been consumed (ocaml-community/ocaml-mariadb#68 by Petter A. Urkedal, fixes ocaml-community/ocaml-mariadb#67).
  - Fix memory leak in non-blocking test suite (Petter A.  Urkedal, fixes
    ocaml-community/ocaml-mariadb#29).
