### PR TITLE
[new release] dypgen (2 packages) (0.2.1)

### DIFF
--- a/packages/dypgen/dypgen.0.2.1/opam
+++ b/packages/dypgen/dypgen.0.2.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Self-extensible parsers and lexers for OCaml"
+description: """
+
+dypgen is a GLR parser generator for OCaml, it is able to
+generate self-extensible parsers (also called adaptive parsers) as
+well as extensible lexers for the parsers it produces.
+(fork of pre-4.06 dypgen: http://dypgen.free.fr/)"""
+maintainer: ["Frédéric Recoules"]
+authors: ["Emmanuel Onzo" "Philip Blair"]
+license: "CeCILL-B"
+homepage: "http://dypgen.free.fr/"
+bug-reports: "https://github.com/recoules/dypgen/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.07"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/recoules/dypgen.git"
+url {
+  src:
+    "https://github.com/recoules/dypgen/releases/download/0.2.1/dypgen-0.2.1.tbz"
+  checksum: [
+    "sha256=16436fbb322e59c9b0148e7c36c0a83ac6186a6ef78eb894efed6b543600bcbd"
+    "sha512=bd0d6144c66f4b42ea90bba4b87e1a24cf1ff9b50271ebb4fc701dc43733387a5c382da13a8a64e1f2b92562ed276c834a5d69a17a8d55c444397784f1113592"
+  ]
+}
+x-commit-hash: "ee4503fbd592a649b0c433ac79e1eb81cc3b1770"

--- a/packages/grain_dypgen/grain_dypgen.0.2.1/opam
+++ b/packages/grain_dypgen/grain_dypgen.0.2.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Self-extensible parsers and lexers for OCaml"
+description: """
+
+dypgen is a GLR parser generator for OCaml, it is able to
+generate self-extensible parsers (also called adaptive parsers) as
+well as extensible lexers for the parsers it produces.
+(fork of pre-4.06 dypgen: http://dypgen.free.fr/)"""
+maintainer: ["Frédéric Recoules"]
+authors: ["Emmanuel Onzo" "Philip Blair"]
+license: "CeCILL-B"
+homepage: "http://dypgen.free.fr/"
+bug-reports: "https://github.com/recoules/dypgen/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "dypgen"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/recoules/dypgen.git"
+url {
+  src:
+    "https://github.com/recoules/dypgen/releases/download/0.2.1/dypgen-0.2.1.tbz"
+  checksum: [
+    "sha256=16436fbb322e59c9b0148e7c36c0a83ac6186a6ef78eb894efed6b543600bcbd"
+    "sha512=bd0d6144c66f4b42ea90bba4b87e1a24cf1ff9b50271ebb4fc701dc43733387a5c382da13a8a64e1f2b92562ed276c834a5d69a17a8d55c444397784f1113592"
+  ]
+}
+x-commit-hash: "ee4503fbd592a649b0c433ac79e1eb81cc3b1770"


### PR DESCRIPTION
Self-extensible parsers and lexers for OCaml

- Project page: <a href="http://dypgen.free.fr/">http://dypgen.free.fr/</a>

##### CHANGES:

Transition to dune build system.

__________________________________________________________________________
2019/11/16

Fixed the project to work with OCaml versions >= 4.06.0.

__________________________________________________________________________
2012/06/19

Fixed a bug that made the parser return wrong beginning positions for the
matched symbols when the right hand side of the rule to reduce with would
begin with nullable non terminal symbols.
Section 2.4 of the manual has been updated.

__________________________________________________________________________
2012/05/28

Fixed a bug that made the parser return wrong beginning positions for the
matched symbols (layout characters were not skipped).

__________________________________________________________________________
2012/04/19

Fixed a bug that made the parser return wrong positions for the matched
symbols.

__________________________________________________________________________
2012/03/14

Added the function:
val is_re_name : ('t,'o,'gd,'ld,'l) parser_pilot -> string -> bool
Now you can ask the parser_pilot whether s is the name of a declared regexp:
>
> if is_re_name dyp.parser_pilot s
> then Regexp (RE_Name s)
> else failwith "regexp name undefined"

__________________________________________________________________________
2011/11/27

Fixed a bug that prevented merge to happen when reducing with a rule with
a right-hand side beginning with a non terminal reducing to the empty
string.

Fixed a bug that made the parser raise Syntax_error when the starting non
terminal (the entry point of the grammar) was present in a right-hand side.

Fixed a bug that prevented the ASTs of the parse forest to be returned
with their respective priorities (instead empty strings were returned).

Fixed a bug that prevented merge to happen when reducing with a rule that
had an inherited attribute or an early action in the right-hand side.

__________________________________________________________________________
2011/06/18

Added the option --Werror that makes the warnings become errors (except
for merge warnings).

__________________________________________________________________________
2011/03/28

Fixed a bug that prevented calls to functions parse and lexparse to work
properly.
Fixed a bug that happened when using Parser in the parser command list in
some instances (the number identifying the grammar was not updated).

__________________________________________________________________________
2011/02/13

Two functions now allow to save a parsing_device without any functional
value and to attach them after loading it. See manual section 7.4 for more
information.

__________________________________________________________________________
2011/02/02

Fixed a bug that made the functions parse and lexparse not take into
account the optional global_data and local_data.
The constructor Parser of the parser commands list now takes a value of
type parsing_device instead of parsing_pilot.
The type parser_pilot is now concrete:

type ('token,'obj,'global_data,'local_data,'lexbuf) parser_pilot = {
  pp_dev : ('token,'obj,'global_data,'local_data,'lexbuf) parsing_device;
  pp_par : ('token,'obj,'global_data,'local_data,'lexbuf) parser_parameters;
  pp_gd : 'global_data;
  pp_ld : 'local_data }

When you want to save the automaton to a file you marshal
dyp.parser_pilot.pp_dev instead of dyp.parser_pilot.

__________________________________________________________________________
2011/01/27

Code generated by dypgen now tests if the version of dypgen to generate
the code matches the version of the dyp library.
It is now possible to load a parser at parsing time using the constructor
  Parser of ('token, 'obj,'global_data,'local_data,'lexbuf) parser_pilot
of the parser commands list. See section 7.4 of the manual for more
information.

__________________________________________________________________________
2010/09/01

Fixed a bug that made the function next_lexeme raise
Invalid_argument("String")
Fixed a bug that made the function next_lexeme return an empty list
Fixed a bug that made the lexer raise Invalid_argument("String.create")
Note that the changes made to the lexer in the version 2009/11/15 are not
effective anymore (they did not work anyway).

__________________________________________________________________________
2010/06/20

Fixed a bug that exchanged inherited attributes between distinct parsing
paths inappropriately.

Fixed a bug that made the parser infinitely loop when a left recursive
rule had an early action.

Left recursive rules with inherited attributes do not make the parser loop
indefinitely anymore (but inherited attributes are still not properly
handled in this case, see the manual section 5.4 for more details).

__________________________________________________________________________
2009/11/15

The layout regexp are not prefered anymore over non layout regexp when
their match is longer. For instance a regexp that matches the empty string
and that is expected will be prefered over a layout character.
For example the following rule:
 a: "x" - "y"? "z"
now matches the string "x z", while it didn't previously (assuming space
is a layout character).

Fixed a bug that made a syntax error in the generated caml code. It
happened when the type of an entry point was declared and an early action
was used.

__________________________________________________________________________
2009/04/30

Improved the speed of generation of the automaton.

Fixed a bug that made some merges be performed several times instead of
just once.

Renamed the temporary files parser.temp.ml to parser_temp.ml to avoid
ocaml 3.11 emitting a warning.

__________________________________________________________________________
2009/04/11

Fixed a bug that raised Invalid_argument with large grammars using
priorities.

Fixed two bugs that made the parser consume a very large amount of memory
with large grammars using priorities.

Fixed a bug (introduced in the previous version) that made the parser
perform the reductions in a wrong order in some cases resulting in lost
parse trees.

__________________________________________________________________________
2009/04/09

Fixed a bug that raised Not_found with no reason in some instances.

Changed a data structure that made the parser use too much memory for large
grammars with priorities.

__________________________________________________________________________
2009/03/10

Fixed a bug with inherited attributes. They did not work when there was an
early action in the right-hand side of the rule.

The behavior of early actions with respect to dyp.local_data changes
slightly: the scope of local_data now is the whole right-hand side (final
action still excluded) even when there are early actions in the rhs.

Fixed a bug with inherited attributes that caused some parse trees to be
duplicated.

Fixed a bug with lexers generated with dypgen: when the character '-' was
used before a nullable non terminal nt in the rhs of a rule in the parser
definition, the forbidding to have a layout character would be applied
before the previous symbol instead of being applied before nt.

The temporary file is now named with the extension .temp.ml instead of
.ml.temp for compatibility with ocamlc 3.12.

__________________________________________________________________________
2009/02/23

Fixed 2 bugs with inherited attributes. Parsing would fail in some
instances when it shouldn't and the parser would not keep track correctly
of the different synthesized ASTs when the same rule appeared several
times with different inherited attributes.

__________________________________________________________________________
2009/02/21

Fixed a bug happening when extending the grammar in some instances. The
generated automaton would not parse as intended or the generation would
fail.

Added the option --cpp-options "options" to dypgen to pass options to cpp
when called by dypgen. It is useful to pass the flag -w to cpp to avoid
the warning messages. --cpp is not needed when using --cpp-options.

dypgen now supports a subset of the class of L-attribute grammars.
You can send down an inherited attribute except for left-recursive rules
which make the parser loop indefinitely when used with an inherited
attribute. See section 5.5 of the manual.

__________________________________________________________________________
2009/02/10

Nested rules are now enclosed between [ and ] instead of ( and ).

If the right-hand side of a rule is not empty you can state no action this
means that the value bound to the last symbol of the rhs is returned.
For example you can use it with nested rules this way: ["kw1" | "kw2"- ]
here "kw1" can be followed by layout characters while "kw2" cannot.
Another example: nt ["," nt]* to have a list of nt separated with commas.
Note that something like ['a'] will still be interpreted as a character
set and not as a nested rule, write ["a"] instead.

Bug fixed: dypgen raised a syntax error when named regexp were declared
without any main lexer.

__________________________________________________________________________
2009/02/05

Added the following functions to Dyp :
val set_newline : 'obj dyplexbuf -> unit
val set_fname : 'obj dyplexbuf -> string -> unit
documented at the end of section 2.1.

Line of the form:
