### PR TITLE
conf-cuda: fix regression depending on ocamlc binary

### DIFF
--- a/packages/conf-cuda/conf-cuda.1/opam
+++ b/packages/conf-cuda/conf-cuda.1/opam
@@ -16,7 +16,10 @@ build: [
 # Note: the minimal set of packages directly from NVidia repositories, e.g. for cudajit:
 # "cuda-cudart-X-Y" "cuda-cudart-dev-X-Y" "cuda-runtime-X-Y" "cuda-nvrtc-X-Y" "cuda-nvrtc-dev-X-Y"
 # where e.g. X=12, Y=4 is the CUDA version.
-depends: [ "conf-cuda-config" ]
+depends: [
+  "conf-cuda-config"
+  "ocaml"
+]
 setenv: [
   [ CUDA_PATH = "%{conf-cuda-config:cuda_path}%" ]
 ]


### PR DESCRIPTION
`opam update; opam upgrade` led to:

```ocaml
[ERROR] The compilation of conf-cuda.1 failed at "sh -exc $(ocamlc -config-var c_compiler) -c $CFLAGS -I'C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.8/include' test.c".
[ERROR] The compilation of ocaml-compiler.5.3.0 failed at "make -j23".

#=== ERROR while compiling ocaml-compiler.5.3.0 ===============================#
# context     2.3.0 | win32/x86_64 |  | https://opam.ocaml.org#0d013e603b5ebf0e9b404e10d5a6839f226e1739
# path        ~\AppData\Local\opam\5.3.0\.opam-switch\build\ocaml-compiler.5.3.0
# command     ~\AppData\Local\opam\.cygwin\root\bin\make.exe -j23
# exit-code   2
# env-file    ~\AppData\Local\opam\log\ocaml-compiler-25460-bfb95b.env
# output-file ~\AppData\Local\opam\log\ocaml-compiler-25460-bfb95b.out
### output ###
# [...]
# cd opt/bin; cp -pf ../../flexlink.opt.exe flexlink.exe
# cp byte/bin/flexdll_mingw64.o byte/bin/flexdll_initer_mingw64.o opt/bin
# make[2]: Leaving directory '/cygdrive/c/Users/lukst/AppData/Local/opam/5.3.0/.opam-switch/build/ocaml-compiler.5.3.0'
# /usr/bin/make ocamlc.opt
# make[2]: Entering directory '/cygdrive/c/Users/lukst/AppData/Local/opam/5.3.0/.opam-switch/build/ocaml-compiler.5.3.0'
#   OCAMLOPT utils/config.cmx
# make[2]: ./boot/ocamlrun.exe: Permission denied
# make[2]: *** [Makefile:2547: utils/config.cmx] Error 127
# make[2]: Leaving directory '/cygdrive/c/Users/lukst/AppData/Local/opam/5.3.0/.opam-switch/build/ocaml-compiler.5.3.0'
# make[1]: *** [Makefile:774: opt.opt] Error 2
# make[1]: Leaving directory '/cygdrive/c/Users/lukst/AppData/Local/opam/5.3.0/.opam-switch/build/ocaml-compiler.5.3.0'
# make: *** [Makefile:851: world.opt] Error 2


#=== ERROR while compiling conf-cuda.1 ========================================#
# context     2.3.0 | win32/x86_64 |  | https://opam.ocaml.org#0d013e603b5ebf0e9b404e10d5a6839f226e1739
# path        ~\AppData\Local\opam\5.3.0\.opam-switch\build\conf-cuda.1
# command     ~\AppData\Local\opam\.cygwin\root\bin\sh.exe -exc $(ocamlc -config-var c_compiler) -c $CFLAGS -I'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8/include' test.c    
# exit-code   127
# env-file    ~\AppData\Local\opam\log\conf-cuda-25460-8e8bd2.env
# output-file ~\AppData\Local\opam\log\conf-cuda-25460-8e8bd2.out
### output ###
# ++ ocamlc -config-var c_compiler
# /usr/bin/sh: line 1: ocamlc: command not found
# + -c '-IC:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8/include' test.c
# /usr/bin/sh: line 1: -c: command not found



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
┌─ The following actions failed
│ λ build conf-cuda      1
│ λ build ocaml-compiler 5.3.0
```

This PR is intended to address the issue `# /usr/bin/sh: line 1: ocamlc: command not found`. It seems to fix the problem locally, as with the PR `opam install conf-cuda` succeeds, while at head I get:

```shell
PS C:\Users\lukst\GitHub\ocannl> opam install conf-cuda
The following actions will be performed:
=== install 1 package
  ∗ conf-cuda 1

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
Processing  2/3: [conf-cuda: sh cat <<EOF > test.c
   #include  "cuda.h"
   #include  "nvrtc.h"
[ERROR] The compilation of conf-cuda.1 failed at "sh -exc $(ocamlc -config-var c_compiler) -c $CFLAGS -I'C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.8/include' test.c".

#=== ERROR while compiling conf-cuda.1 ========================================#
# context     2.3.0 | win32/x86_64 |  | https://opam.ocaml.org#0d013e603b5ebf0e9b404e10d5a6839f226e1739
# path        ~\AppData\Local\opam\5.3.0\.opam-switch\build\conf-cuda.1
# command     ~\AppData\Local\opam\.cygwin\root\bin\sh.exe -exc $(ocamlc -config-var c_compiler) -c $CFLAGS -I'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8/include' test.c    
# exit-code   127
# env-file    ~\AppData\Local\opam\log\conf-cuda-27832-74b7bf.env
# output-file ~\AppData\Local\opam\log\conf-cuda-27832-74b7bf.out
### output ###
# ++ ocamlc -config-var c_compiler
# /usr/bin/sh: line 1: ocamlc: command not found
# + -c '-IC:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8/include' test.c
# /usr/bin/sh: line 1: -c: command not found
```


