### PR TITLE
small fix for conf-mariadb.2

### DIFF
--- a/packages/conf-mariadb/conf-mariadb.2/opam
+++ b/packages/conf-mariadb/conf-mariadb.2/opam
@@ -6,7 +6,8 @@ bug-reports: "https://jira.mariadb.org/projects/MDEV/issues"
 dev-repo: "git+https://github.com/MariaDB/server.git"
 license: "GPL-2.0-only"
 build: [
-  ["sh" "-exc" "pkg-config --exists libmariadb || pkg-config --exists mariadb"] # libmariadb is a newer library name
+  ["sh" "-exc" "pkg-config --exists libmariadb || pkg-config --exists mariadb"] { os != "win32" } # libmariadb is a newer library name
+  ["pkgconf" "--exists" "libmariadb"] { os = "win32" & os-distribution != msys2" }
 ]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-mariadb/conf-mariadb.2/opam
+++ b/packages/conf-mariadb/conf-mariadb.2/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/MariaDB/server.git"
 license: "GPL-2.0-only"
 build: [
   ["sh" "-exc" "pkg-config --exists libmariadb || pkg-config --exists mariadb"] { os != "win32" } # libmariadb is a newer library name
-  ["pkgconf" "--exists" "libmariadb"] { os = "win32" & os-distribution != msys2" }
+  ["pkgconf" "--exists" "libmariadb"] { os = "win32" & os-distribution != "msys2" }
 ]
 depends: [
   "conf-pkg-config" {build}


### PR DESCRIPTION
To attempt to fix the windows error observed in https://github.com/ocaml/opam-repository/pull/27862

```
   #=== ERROR while compiling conf-mariadb.2 =====================================#
  # context     2.3.0 | win32/x86_64 | ocaml.5.3.0 | file://D:/a/opam-repository/opam-repository
  # path        D:\opamroot\default\.opam-switch\build\conf-mariadb.2
  # command     D:\opamroot\.cygwin\root\bin\sh.exe -exc pkg-config --exists libmariadb || pkg-config --exists mariadb
  # exit-code   2
  # env-file    D:\opamroot\log\conf-mariadb-4432-27ba11.env
  # output-file D:\opamroot\log\conf-mariadb-4432-27ba11.out
  ### output ###
  # + pkg-config --exists libmariadb
  # Can't open perl script "/cygdrive/c/Strawberry/perl/bin/pkg-config": No such file or directory
  # + pkg-config --exists mariadb
  # Can't open perl script "/cygdrive/c/Strawberry/perl/bin/pkg-config": No such file or directory
```