### PR TITLE
Mark iomux unavailable on Windows

### DIFF
--- a/packages/iomux/iomux.0.1/opam
+++ b/packages/iomux/iomux.0.1/opam
@@ -9,7 +9,7 @@ tags: ["io" "multiplexing" "poll" "ppoll" "epoll" "kevent" "kqueue"]
 homepage: "https://github.com/haesbaert/ocaml-iomux"
 doc: "https://haesbaert.github.io/ocaml-iomux"
 bug-reports: "https://github.com/haesbaert/ocaml-iomux/issues"
-available: os != "macos"
+available: os != "macos" & os-family != "windows"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "3.6"}

--- a/packages/iomux/iomux.0.2/opam
+++ b/packages/iomux/iomux.0.2/opam
@@ -9,6 +9,7 @@ tags: ["io" "multiplexing" "poll" "ppoll" "epoll" "kevent" "kqueue"]
 homepage: "https://github.com/haesbaert/ocaml-iomux"
 doc: "https://haesbaert.github.io/ocaml-iomux"
 bug-reports: "https://github.com/haesbaert/ocaml-iomux/issues"
+available: os-family != "windows"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "3.6"}

--- a/packages/iomux/iomux.0.3/opam
+++ b/packages/iomux/iomux.0.3/opam
@@ -9,6 +9,7 @@ tags: ["io" "multiplexing" "poll" "ppoll" "epoll" "kevent" "kqueue"]
 homepage: "https://github.com/haesbaert/ocaml-iomux"
 doc: "https://haesbaert.github.io/ocaml-iomux"
 bug-reports: "https://github.com/haesbaert/ocaml-iomux/issues"
+available: os-family != "windows"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "3.6"}


### PR DESCRIPTION
As per https://github.com/ocaml-multicore/ocaml-iomux#portability and noted by @c-cube on
https://github.com/ocaml/opam-repository/pull/27859#issuecomment-2867338310

FYI @haesbaert !