### PR TITLE
[new release] curl (3 packages) (0.10.0)

### DIFF
--- a/packages/curl/curl.0.10.0/opam
+++ b/packages/curl/curl.0.10.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Bindings to libcurl"
+description:
+  "libcurl is a client-side URL transfer library, supporting HTTP and a multitude of other network protocols (FTP/SMTP/RTSP/etc). This library wrap easy synchronous API (Curl) and synchronous parallel and generic asynchronous API (Curl.Multi). For the Lwt-enabled asynchronous interface (Curl_lwt) see curl_lwt package."
+maintainer: ["ygrek@autistici.org" "Antonin Décimo <antonin@tarides.com>"]
+authors: ["Lars Nilsson" "ygrek"]
+license: "MIT"
+tags: ["org:ygrek" "clib:curl"]
+homepage: "https://ygrek.org/p/ocurl"
+doc: "https://ygrek.org/p/ocurl/api/index.html"
+bug-reports: "https://github.com/ygrek/ocurl/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.11"}
+  "dune-configurator" {>= "3.18.1"}
+  "base-bigarray"
+  "base-unix"
+  "conf-libcurl"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocurl" {!= "transition"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ygrek/ocurl.git"
+url {
+  src:
+    "https://github.com/ygrek/ocurl/releases/download/0.10.0/curl-0.10.0.tbz"
+  checksum: [
+    "sha256=c14e215fda7f94292a758d9ae90f7bcbc21564c919190064011fccdcf7a12914"
+    "sha512=10e089942a496c739f9468155c992f194b315abe6c63d7f72551ff4bf052e96e5dd25b85254e3ab144d330f33ed83864b185389ffe35c2bfeeb2cbf505b47600"
+  ]
+}
+x-commit-hash: "c961aab97cfe64670bcd80278e393bcff7219792"

--- a/packages/curl_lwt/curl_lwt.0.10.0/opam
+++ b/packages/curl_lwt/curl_lwt.0.10.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Bindings to libcurl (lwt variant)"
+description:
+  "libcurl is a client-side URL transfer library, supporting HTTP and a multitude of other network protocols (FTP/SMTP/RTSP/etc). This library  provides an Lwt-enabled asynchronous interface (Curl_lwt)."
+maintainer: ["ygrek@autistici.org" "Antonin Décimo <antonin@tarides.com>"]
+authors: ["Lars Nilsson" "ygrek"]
+license: "MIT"
+tags: ["org:ygrek" "clib:curl"]
+homepage: "https://ygrek.org/p/ocurl"
+doc: "https://ygrek.org/p/ocurl/api/index.html"
+bug-reports: "https://github.com/ygrek/ocurl/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.11"}
+  "base-unix"
+  "curl" {= version}
+  "lwt"
+  "lwt_ppx" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ygrek/ocurl.git"
+url {
+  src:
+    "https://github.com/ygrek/ocurl/releases/download/0.10.0/curl-0.10.0.tbz"
+  checksum: [
+    "sha256=c14e215fda7f94292a758d9ae90f7bcbc21564c919190064011fccdcf7a12914"
+    "sha512=10e089942a496c739f9468155c992f194b315abe6c63d7f72551ff4bf052e96e5dd25b85254e3ab144d330f33ed83864b185389ffe35c2bfeeb2cbf505b47600"
+  ]
+}
+x-commit-hash: "c961aab97cfe64670bcd80278e393bcff7219792"

--- a/packages/ocurl/ocurl.transition/opam
+++ b/packages/ocurl/ocurl.transition/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis:
+  "This is a transition package, ocurl is now named curl. Use the curl package instead"
+description:
+  "This is a transition package, ocurl is now named curl. Use the curl package instead."
+maintainer: ["ygrek@autistici.org" "Antonin Décimo <antonin@tarides.com>"]
+authors: ["Lars Nilsson" "ygrek"]
+license: "MIT"
+homepage: "https://ygrek.org/p/ocurl"
+doc: "https://ygrek.org/p/ocurl/api/index.html"
+bug-reports: "https://github.com/ygrek/ocurl/issues"
+dev-repo: "git+https://github.com/ygrek/ocurl.git"
+depends: [
+  "curl"
+  "curl_lwt"
+]
+flags: deprecated
+post-messages: [
+  "ocurl has been renamed and the ocurl package is now a transition \
+   package. Use the curl package instead."
+]
+url {
+  src:
+    "https://github.com/ygrek/ocurl/releases/download/0.10.0/curl-0.10.0.tbz"
+  checksum: [
+    "sha256=c14e215fda7f94292a758d9ae90f7bcbc21564c919190064011fccdcf7a12914"
+    "sha512=10e089942a496c739f9468155c992f194b315abe6c63d7f72551ff4bf052e96e5dd25b85254e3ab144d330f33ed83864b185389ffe35c2bfeeb2cbf505b47600"
+  ]
+}
+x-commit-hash: "c961aab97cfe64670bcd80278e393bcff7219792"


### PR DESCRIPTION
Bindings to libcurl

- Project page: <a href="https://ygrek.org/p/ocurl">https://ygrek.org/p/ocurl</a>
- Documentation: <a href="https://ygrek.org/p/ocurl/api/index.html">https://ygrek.org/p/ocurl/api/index.html</a>

##### CHANGES:

* Transition from the ocurl package name to curl.
  (Nicolás Ojeda Bär, ygrek)
* Split curl_lwt into its own package. The new library name is curl.lwt.
  (Rudi Grinberg, kit-ty-kate, ygrek)

* Fix handling of the runtime lock when calling curl multi callback cleanups.
  (Malcolm, review by ygrek, Nicolás Ojeda Bär, and Antonin Décimo)
+ Support CURL_NOPROXY.
  (Luke Palmer)
+ Get a list of headers with [get_headers] that result from repeatedly calling
  [curl_easy_nextheader] with the supplied origins and request.
  (Luke Palmer)
* Remove the Autoconf build to fully use Dune instead.
  (Nicolás Ojeda Bär, Jonah Beckford, Antonin Décimo)
* Build fixes. Bug fixes.
  (David Allsopp, ygrek, Nicolás Ojeda Bär, Luke Palmer)
+ Support CURLOPT_CLOSESOCKETFUNCTION.
  (Luke Palmer)
+ Support CURLOPT_PROXY_SSL_OPTIONS.
  (Nicolás Ojeda Bär)
+ Bind extra_fds argument to curl_multi_wait and curl_multi_poll.
  (Nicolás Ojeda Bär)
+ Add support for TCP_KEEPALIVE, TCP_KEEPIDLE, TCP_KEEPINTVL options.
  (Sewen Thy)
+ Support CURLOPT_PREREQFUNCTION. Support CURLOPT_AWS_SIGV4.
  (Albert Peschar)
* Add missing dependency on Unix.
  (David Allsopp)
+ Check for CURLOPT_XFERINFOFUNCTION.
  (ygrek)
+ Check for curl_global_sslset.
  (Nicolás Ojeda Bär)
