### PR TITLE
[new release] happy-eyeballs (4 packages) (2.0.1)

### DIFF
--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.2.0.1/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.2.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/happy-eyeballs"
+dev-repo: "git+https://github.com/robur-coop/happy-eyeballs.git"
+bug-reports: "https://github.com/robur-coop/happy-eyeballs/issues"
+doc: "https://robur-coop.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner" {>= "1.1.0"}
+  "duration"
+  "dns" {>= "7.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/happy-eyeballs/releases/download/v2.0.1/happy-eyeballs-2.0.1.tbz"
+  checksum: [
+    "sha256=b2554588302931ba85e18861e610a3ada7823496d4d49a195e953556c351d269"
+    "sha512=947f78b27b0e16328b2db8e894f4dfeeae5183297d1860bb8ab214dad8a4c1a7243fecd8db538a8f7d9979ca5c8f22a5a21012907258a4ae6b0e975758bb61b3"
+  ]
+}
+x-commit-hash: "0564cb98fd4bec3f0655c486550e5863641f98db"

--- a/packages/happy-eyeballs-miou-unix/happy-eyeballs-miou-unix.2.0.1/opam
+++ b/packages/happy-eyeballs-miou-unix/happy-eyeballs-miou-unix.2.0.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/happy-eyeballs"
+dev-repo: "git+https://github.com/robur-coop/happy-eyeballs.git"
+bug-reports: "https://github.com/robur-coop/happy-eyeballs/issues"
+doc: "https://robur-coop.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {= version}
+  "miou" {>= "0.2.0"}
+  "mtime" {>= "2.0.0"}
+  "duration"
+  "domain-name"
+  "ipaddr" {>= "5.6.0"}
+  "fmt"
+  "logs" {>= "0.7.0"}
+  "cmdliner" {>= "1.3.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Miou"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Miou for side effects.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/happy-eyeballs/releases/download/v2.0.1/happy-eyeballs-2.0.1.tbz"
+  checksum: [
+    "sha256=b2554588302931ba85e18861e610a3ada7823496d4d49a195e953556c351d269"
+    "sha512=947f78b27b0e16328b2db8e894f4dfeeae5183297d1860bb8ab214dad8a4c1a7243fecd8db538a8f7d9979ca5c8f22a5a21012907258a4ae6b0e975758bb61b3"
+  ]
+}
+x-commit-hash: "0564cb98fd4bec3f0655c486550e5863641f98db"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.2.0.1/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.2.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/happy-eyeballs"
+dev-repo: "git+https://github.com/robur-coop/happy-eyeballs.git"
+bug-reports: "https://github.com/robur-coop/happy-eyeballs/issues"
+doc: "https://robur-coop.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-mtime" {>= "4.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-sleep" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/happy-eyeballs/releases/download/v2.0.1/happy-eyeballs-2.0.1.tbz"
+  checksum: [
+    "sha256=b2554588302931ba85e18861e610a3ada7823496d4d49a195e953556c351d269"
+    "sha512=947f78b27b0e16328b2db8e894f4dfeeae5183297d1860bb8ab214dad8a4c1a7243fecd8db538a8f7d9979ca5c8f22a5a21012907258a4ae6b0e975758bb61b3"
+  ]
+}
+x-commit-hash: "0564cb98fd4bec3f0655c486550e5863641f98db"

--- a/packages/happy-eyeballs/happy-eyeballs.2.0.1/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.2.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/happy-eyeballs"
+dev-repo: "git+https://github.com/robur-coop/happy-eyeballs.git"
+bug-reports: "https://github.com/robur-coop/happy-eyeballs/issues"
+doc: "https://robur-coop.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/happy-eyeballs/releases/download/v2.0.1/happy-eyeballs-2.0.1.tbz"
+  checksum: [
+    "sha256=b2554588302931ba85e18861e610a3ada7823496d4d49a195e953556c351d269"
+    "sha512=947f78b27b0e16328b2db8e894f4dfeeae5183297d1860bb8ab214dad8a4c1a7243fecd8db538a8f7d9979ca5c8f22a5a21012907258a4ae6b0e975758bb61b3"
+  ]
+}
+x-commit-hash: "0564cb98fd4bec3f0655c486550e5863641f98db"


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/robur-coop/happy-eyeballs">https://github.com/robur-coop/happy-eyeballs</a>
- Documentation: <a href="https://robur-coop.github.io/happy-eyeballs/">https://robur-coop.github.io/happy-eyeballs/</a>

##### CHANGES:

* mirage & lwt: provide the appropriate event, Resolved_aaaa_failed, when IPv6
  resolution failed. This fixes happy-eyeballs being stuck trying a connection
  (robur-coop/happy-eyeballs#48 @hannesm)
