### PR TITLE
Fix base.v0.17.1 patch checksum

### DIFF
--- a/packages/base/base.v0.17.1/opam
+++ b/packages/base/base.v0.17.1/opam
@@ -44,6 +44,6 @@ extra-source "fix-mpopcnt.patch" {
   src:
     "https://patch-diff.githubusercontent.com/raw/janestreet/base/pull/180.diff"
   checksum: [
-    "sha256=78fecf4719e82aec5fc17a1140df18b07c1a640d3336c39dcd5cd85206bcede3"
+    "sha256=bf1bdef00acd7a75ff84ad56b951cc68f0a08404629e4560762fafe622ecfda3"
   ]
 }


### PR DESCRIPTION
I don't know how it happened, but the checksum is currently wrong, which makes `base.v0.17.1` uninstallable.

```
$ wget https://patch-diff.githubusercontent.com/raw/janestreet/base/pull/180.diff
[...]
$ sha256sum 180.diff
bf1bdef00acd7a75ff84ad56b951cc68f0a08404629e4560762fafe622ecfda3  180.diff
```