### PR TITLE
Switch from `os-distribution = "fedora"` to `os-family = "fedora"`

### DIFF
--- a/packages/alsa/alsa.0.2.3/opam
+++ b/packages/alsa/alsa.0.2.3/opam
@@ -14,7 +14,7 @@ depends: ["ocaml" "ocamlfind" "conf-pkg-config" {build}]
 depexts: [
   ["alsa-lib-dev"] {os-distribution = "alpine"}
   ["alsa-lib-devel"] {os-distribution = "centos"}
-  ["alsa-lib-devel"] {os-distribution = "fedora"}
+  ["alsa-lib-devel"] {os-family = "fedora"}
   ["alsa-lib-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libasound2-dev"] {os-family = "debian"}
 ]

--- a/packages/ao/ao.0.2.1/opam
+++ b/packages/ao/ao.0.2.1/opam
@@ -13,7 +13,7 @@ remove: ["ocamlfind" "remove" "ao"]
 depends: ["ocaml" "ocamlfind" "conf-pkg-config" {build}]
 depexts: [
   ["libao-devel"] {os-distribution = "centos"}
-  ["libao-devel"] {os-distribution = "fedora"}
+  ["libao-devel"] {os-family = "fedora"}
   ["libao-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libao"] {os = "macos" & os-distribution = "homebrew"}
   ["libao-dev"] {os-family = "debian"}

--- a/packages/argon2/argon2.1.0.2/opam
+++ b/packages/argon2/argon2.1.0.2/opam
@@ -22,7 +22,7 @@ build: [
 depexts: [
   ["libargon2-dev"] {os-family = "debian"}
   ["libargon2-dev"] {os-family = "ubuntu"}
-  ["libargon2-devel"] {os-distribution = "fedora"}
+  ["libargon2-devel"] {os-family = "fedora"}
 ]
 synopsis: "OCaml bindings to Argon2"
 description: """

--- a/packages/augeas/augeas.0.6/opam
+++ b/packages/augeas/augeas.0.6/opam
@@ -26,7 +26,7 @@ depexts: [
   ["libaugeas-dev"] {os-family = "debian"}
   ["augeas-devel"] {os-distribution = "centos"}
   ["augeas-devel"] {os-distribution = "ol"}
-  ["augeas-devel"] {os-distribution = "fedora"}
+  ["augeas-devel"] {os-family = "fedora"}
   ["augeas-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libaugeas-devel"] {os-distribution = "mageia"}
   ["augeas"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/bap-llvm/bap-llvm.2.2.0/opam
+++ b/packages/bap-llvm/bap-llvm.2.2.0/opam
@@ -40,7 +40,7 @@ depexts: [
   ["clang" "libncurses5-dev"] {os-distribution = "ubuntu"}
   ["clang"] {os-distribution = "debian"}
   ["clang" "libxml2-dev"] {os-distribution = "alpine"}
-  ["clang"] {os-distribution = "fedora"}
+  ["clang"] {os-family = "fedora"}
 ]
 synopsis: "BAP LLVM backend"
 description:

--- a/packages/bap-llvm/bap-llvm.2.3.0/opam
+++ b/packages/bap-llvm/bap-llvm.2.3.0/opam
@@ -40,7 +40,7 @@ depexts: [
   ["clang" "libncurses5-dev"] {os-distribution = "ubuntu"}
   ["clang"] {os-distribution = "debian"}
   ["clang" "libxml2-dev"] {os-distribution = "alpine"}
-  ["clang"] {os-distribution = "fedora"}
+  ["clang"] {os-family = "fedora"}
 ]
 synopsis: "BAP LLVM backend"
 description:

--- a/packages/bap-llvm/bap-llvm.2.4.0/opam
+++ b/packages/bap-llvm/bap-llvm.2.4.0/opam
@@ -40,7 +40,7 @@ depexts: [
   ["clang" "libncurses5-dev"] {os-distribution = "ubuntu"}
   ["clang"] {os-distribution = "debian"}
   ["clang" "libxml2-dev"] {os-distribution = "alpine"}
-  ["clang"] {os-distribution = "fedora"}
+  ["clang"] {os-family = "fedora"}
 ]
 synopsis: "BAP LLVM backend"
 description:

--- a/packages/bap-llvm/bap-llvm.2.5.0/opam
+++ b/packages/bap-llvm/bap-llvm.2.5.0/opam
@@ -40,7 +40,7 @@ depexts: [
   ["clang" "libncurses5-dev"] {os-distribution = "ubuntu"}
   ["clang"] {os-distribution = "debian"}
   ["clang" "libxml2-dev"] {os-distribution = "alpine"}
-  ["clang"] {os-distribution = "fedora"}
+  ["clang"] {os-family = "fedora"}
 ]
 synopsis: "BAP LLVM backend"
 description:

--- a/packages/bwrap/bwrap.0.1/opam
+++ b/packages/bwrap/bwrap.0.1/opam
@@ -28,7 +28,7 @@ depexts: [
   ["bubblewrap"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["bubblewrap"] {os-distribution = "ubuntu" & os-version >= "17.0"}
   ["bubblewrap"] {os-distribution = "alpine"}
-  ["bubblewrap"] {os-distribution = "fedora"}
+  ["bubblewrap"] {os-family = "fedora"}
   ["bubblewrap"] {os-distribution = "rhel"}
   ["bubblewrap" "epel-release"] {os-distribution = "centos" & os-version >= "7"}
   ["bubblewrap"] {(os-family = "suse" | os-family = "opensuse") & os-version >= "15"}

--- a/packages/camlzip/camlzip.1.06/opam
+++ b/packages/camlzip/camlzip.1.06/opam
@@ -21,7 +21,7 @@ depexts: [
   ["zlib1g-dev"] {os-family = "debian"}
   ["zlib-devel"] {os-distribution = "centos"}
   ["zlib-devel"] {os-distribution = "rhel"}
-  ["zlib-devel"] {os-distribution = "fedora"}
+  ["zlib-devel"] {os-family = "fedora"}
   ["zlib-dev"] {os-distribution = "alpine"}
 ]
 patches: [

--- a/packages/camlzip/camlzip.1.07/opam
+++ b/packages/camlzip/camlzip.1.07/opam
@@ -21,7 +21,7 @@ depexts: [
   ["zlib1g-dev"] {os-family = "debian"}
   ["zlib-devel"] {os-distribution = "centos"}
   ["zlib-devel"] {os-distribution = "rhel"}
-  ["zlib-devel"] {os-distribution = "fedora"}
+  ["zlib-devel"] {os-family = "fedora"}
   ["zlib-dev"] {os-distribution = "alpine"}
   ["zlib"] {os-distribution = "nixos"}
 ]

--- a/packages/conf-aclocal/conf-aclocal.1.0.0/opam
+++ b/packages/conf-aclocal/conf-aclocal.1.0.0/opam
@@ -8,7 +8,7 @@ build: [["which" "aclocal"]]
 depexts: [
   ["automake"] {os-distribution = "alpine"}
   ["automake"] {os-distribution = "centos"}
-  ["automake"] {os-distribution = "fedora"}
+  ["automake"] {os-family = "fedora"}
   ["automake"] {os-family = "suse" | os-family = "opensuse"}
   ["automake"] {os-family = "debian"}
   ["automake"] {os-distribution = "nixos"}

--- a/packages/conf-age/conf-age.1/opam
+++ b/packages/conf-age/conf-age.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["age"] {os-distribution = "alpine"}
   ["age"] {os-distribution = "nixos"}
   ["age"] {os-distribution = "arch"}
-  ["age"] {os-distribution = "fedora"}
+  ["age"] {os-family = "fedora"}
   ["age"] {os-distribution = "centos"}
   ["age"] {os = "macos" & os-distribution = "homebrew"}
   ["age"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-allegro5/conf-allegro5.1/opam
+++ b/packages/conf-allegro5/conf-allegro5.1/opam
@@ -15,7 +15,7 @@ depexts: [
     "allegro5-addon-physfs-devel"
     "allegro5-addon-ttf-devel"
     "allegro5-addon-video-devel"
-  ] {os-distribution = "centos" | os-distribution = "fedora"}
+  ] {os-distribution = "centos" | os-family = "fedora"}
   ["allegro"] {os-family = "suse" | os-family = "opensuse"}
   [
     "liballegro5-dev"

--- a/packages/conf-alsa/conf-alsa.1/opam
+++ b/packages/conf-alsa/conf-alsa.1/opam
@@ -11,7 +11,7 @@ depends: [
 depexts: [
   ["alsa-lib"] {os-distribution = "nixos" | os-family = "arch" | os = "freebsd"}
   ["alsa-lib-dev"] {os-distribution = "alpine"}
-  ["alsa-lib-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse" | os-distribution = "ol"}
+  ["alsa-lib-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse" | os-distribution = "ol"}
   ["libasound2-dev"] {os-family = "debian" | os-family = "ubuntu"}
 ]
 available: [ os = "linux" | os = "freebsd" ]

--- a/packages/conf-antic/conf-antic.1/opam
+++ b/packages/conf-antic/conf-antic.1/opam
@@ -22,7 +22,7 @@ depexts: [
   ["libantic-dev"] {os-family = "debian"}
   ["libantic-dev"] {os-family = "ubuntu"}
   ["antic" "antic-devel"] {os-distribution = "centos"}
-  ["antic" "antic-devel"] {os-distribution = "fedora"}
+  ["antic" "antic-devel"] {os-family = "fedora"}
   ["antic" "antic-devel"] {os-distribution = "ol"}
   ["libantic-dev"] {os-distribution = "alpine"}
   ["antic-devel"] {os-family = "suse"}

--- a/packages/conf-ao/conf-ao.1/opam
+++ b/packages/conf-ao/conf-ao.1/opam
@@ -9,7 +9,7 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libao-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["libao-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["libao"] {os = "freebsd" | (os = "macos" & os-distribution = "homebrew") | os-distribution = "nixos" | os-family = "arch"}
   ["libao-dev"] {os-family = "debian" | os-family = "ubuntu" | os-distribution = "alpine"}
 ]

--- a/packages/conf-arb/conf-arb.1/opam
+++ b/packages/conf-arb/conf-arb.1/opam
@@ -22,7 +22,7 @@ depexts: [
   ["libflint-arb-dev"] {os-family = "ubuntu"}
   ["arb"] {os = "macos" & os-distribution = "homebrew"}
   ["arb" "arb-devel"] {os-distribution = "centos"}
-  ["arb" "arb-devel"] {os-distribution = "fedora"}
+  ["arb" "arb-devel"] {os-family = "fedora"}
   ["arb" "arb-devel"] {os-distribution = "ol"}
   ["libarb-dev"] {os-distribution = "alpine"}
   ["arb-devel"] {os-family = "suse"}

--- a/packages/conf-asciidoc/conf-asciidoc.1/opam
+++ b/packages/conf-asciidoc/conf-asciidoc.1/opam
@@ -8,7 +8,7 @@ build: ["asciidoc" "--version"]
 depexts: [
   ["asciidoc"] {os-family = "debian"}
   ["asciidoc"] {os-family = "ubuntu"}
-  ["asciidoc"] {os-distribution = "fedora"}
+  ["asciidoc"] {os-family = "fedora"}
   ["asciidoc"] {os-distribution = "centos"}
   ["asciidoc"] {os-distribution = "rhel"}
   ["asciidoc"] {os-distribution = "ol" & os-version >= "8"}

--- a/packages/conf-assimp/conf-assimp.1/opam
+++ b/packages/conf-assimp/conf-assimp.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["assimp-utils" "libassimp-dev"] {os-family = "debian"}
   ["assimp-utils" "libassimp-dev"] {os-family = "ubuntu"}
   ["assimp"] {os-family = "arch"}
-  ["assimp-devel"] {os-distribution = "fedora"}
+  ["assimp-devel"] {os-family = "fedora"}
   ["assimp-devel"] {os-distribution = "ol"}
   ["assimp" "libassimp-dev"] {os-family = "suse" | os-family = "opensuse"}
   ["lib64assimp-devel"] {os-distribution = "mageia"}

--- a/packages/conf-autoconf/conf-autoconf.0.1/opam
+++ b/packages/conf-autoconf/conf-autoconf.0.1/opam
@@ -11,7 +11,7 @@ depends: ["conf-which" {build}]
 depexts: [
   ["autoconf"] {os-family = "debian" | os-family = "ubuntu"}
   ["autoconf"] {os-distribution = "centos"}
-  ["autoconf"] {os-distribution = "fedora"}
+  ["autoconf"] {os-family = "fedora"}
   ["autoconf"] {os-distribution = "arch"}
   ["sys-devel/autoconf"] {os-distribution = "gentoo"}
   ["autoconf"] {os-distribution = "nixos"}

--- a/packages/conf-autoconf/conf-autoconf.0.2/opam
+++ b/packages/conf-autoconf/conf-autoconf.0.2/opam
@@ -11,7 +11,7 @@ build: [
 depexts: [
   ["autoconf"] {os-family = "debian" | os-family = "ubuntu"}
   ["autoconf"] {os-distribution = "centos"}
-  ["autoconf"] {os-distribution = "fedora"}
+  ["autoconf"] {os-family = "fedora"}
   ["autoconf"] {os-distribution = "arch"}
   ["dev-build/autoconf"] {os-distribution = "gentoo"}
   ["autoconf"] {os-distribution = "nixos"}

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.3/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.3/opam
@@ -23,7 +23,7 @@ depexts: [
   ["llvm-6.0-dev"] {os-distribution = "ubuntu" & os-version = "18.04"} #bionic
 
   # fedora
-  ["llvm-devel" "llvm-static"] {os-distribution = "fedora"}
+  ["llvm-devel" "llvm-static"] {os-family = "fedora"}
 
   # macos
   ["llvm-6.0"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.4/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.4/opam
@@ -24,7 +24,7 @@ depexts: [
   ["llvm-6.0-dev"] {os-distribution = "ubuntu" & os-version = "18.10"}
 
   # fedora
-  ["llvm-devel" "llvm-static"] {os-distribution = "fedora"}
+  ["llvm-devel" "llvm-static"] {os-family = "fedora"}
 
   # macos
   ["llvm-6.0"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.5/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.5/opam
@@ -24,7 +24,7 @@ depexts: [
   ["llvm-6.0-dev"] {os-distribution = "ubuntu" & os-version = "18.10"}
 
   # fedora
-  ["llvm-devel" "llvm-static"] {os-distribution = "fedora"}
+  ["llvm-devel" "llvm-static"] {os-family = "fedora"}
 
   # macos
   ["llvm-6.0"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.6/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.6/opam
@@ -25,7 +25,7 @@ depexts: [
   ["llvm-10-dev"]  {os-distribution = "ubuntu" & os-version = "20.04"} #focal
 
   # fedora
-  ["llvm-devel" "llvm-static"] {os-distribution = "fedora"}
+  ["llvm-devel" "llvm-static"] {os-family = "fedora"}
 
   # macos
   ["llvm-6.0"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.7/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.7/opam
@@ -25,7 +25,7 @@ depexts: [
   ["llvm-10-dev"]  {os-distribution = "ubuntu" & os-version = "20.04"} #focal
 
   # fedora
-  ["llvm-devel" "llvm-static"] {os-distribution = "fedora"}
+  ["llvm-devel" "llvm-static"] {os-family = "fedora"}
 
   # macos
   ["llvm-6.0"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.8/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.8/opam
@@ -29,7 +29,7 @@ depexts: [
   ["llvm-14-dev"]  {os-distribution = "ubuntu" & os-version = "22.04"} #jammy
 
   # fedora
-  ["llvm-devel" "llvm-static"] {os-distribution = "fedora"}
+  ["llvm-devel" "llvm-static"] {os-family = "fedora"}
 
   # macos
   ["llvm-6.0"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-blas/conf-blas.1/opam
+++ b/packages/conf-blas/conf-blas.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["libblas-dev"] {os-family = "ubuntu"}
   ["libblas-devel"] {os-distribution = "mageia"}
   ["blas-devel"] {os-distribution = "centos"}
-  ["blas-devel"] {os-distribution = "fedora"}
+  ["blas-devel"] {os-family = "fedora"}
   ["blas-devel"] {os-distribution = "rhel"}
   ["lapack-dev"] {os-distribution = "alpine"}
   ["blas-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-bluetooth/conf-bluetooth.1/opam
+++ b/packages/conf-bluetooth/conf-bluetooth.1/opam
@@ -12,7 +12,7 @@ build: [
 depexts: [
   ["libbluetooth-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["bluez-libs-devel"] {os-distribution = "centos"}
-  ["bluez-libs-devel"] {os-distribution = "fedora"}
+  ["bluez-libs-devel"] {os-family = "fedora"}
   ["bluez-libs-devel"] {os-distribution = "mageia"}
   ["bluez-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["bluez-dev"] {os-distribution = "alpine"}

--- a/packages/conf-bmake/conf-bmake.1.0/opam
+++ b/packages/conf-bmake/conf-bmake.1.0/opam
@@ -12,7 +12,7 @@ depexts: [
   ["bmake"] {os-family = "debian"}
   ["bmake"] {os-family = "ubuntu"}
   ["bmake"] {os-distribution = "centos"}
-  ["bmake"] {os-distribution = "fedora"}
+  ["bmake"] {os-family = "fedora"}
   ["bmake"] {os-distribution = "arch"}
   ["sys-devel/bmake"] {os-distribution = "gentoo"}
   ["bmake"] {os-distribution = "nixos"}

--- a/packages/conf-boost/conf-boost.1/opam
+++ b/packages/conf-boost/conf-boost.1/opam
@@ -8,7 +8,7 @@ depexts: [
   ["libboost-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["boost"] {os-distribution = "nixos"}
   ["boost-dev"] {os-distribution = "alpine"}
-  ["boost-devel"] {os-distribution = "fedora"}
+  ["boost-devel"] {os-family = "fedora"}
   ["boost-devel"] {os-distribution = "ol"}
   ["boost-devel"] {os-distribution = "centos"}
   ["boost-devel"] {os-distribution = "rhel"}

--- a/packages/conf-bpftool/conf-bpftool.0.1.0/opam
+++ b/packages/conf-bpftool/conf-bpftool.0.1.0/opam
@@ -10,7 +10,7 @@ available: [ os = "linux" ]
 depexts: [
   [ "linux-tools-common" ] {os-distribution = "ubuntu"}
   [ "bpftool" ]            {os-distribution = "debian"}
-  [ "bpftool" ]		   {os-distribution = "fedora"}
+  [ "bpftool" ]		   {os-family = "fedora"}
 ]
 flags: conf
 x-commit-hash: "c7ac4c7ff9f2aa23c374a619990c0bdd78976102"

--- a/packages/conf-brotli/conf-brotli.0.0.1/opam
+++ b/packages/conf-brotli/conf-brotli.0.0.1/opam
@@ -9,7 +9,7 @@ depexts: [
   ["brotli-dev"] {os-distribution = "alpine"}
   ["brotli"] {os-distribution = "arch"}
   ["libbrotli-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["brotli-devel"] {os-distribution = "fedora"}
+  ["brotli-devel"] {os-family = "fedora"}
   ["libbrotli-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["brotli"] {os = "freebsd"}
   ["brotli"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/conf-c++/conf-c++.1.0/opam
+++ b/packages/conf-c++/conf-c++.1.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depexts: [
   ["gcc-c++"] {os-distribution = "centos"}
-  ["gcc-c++"] {os-distribution = "fedora"}
+  ["gcc-c++"] {os-family = "fedora"}
   ["gcc-c++"] {os-family = "suse" | os-family = "opensuse"}
   ["g++"] {os-family = "debian"}
   ["g++"] {os-family = "ubuntu"}

--- a/packages/conf-cairo/conf-cairo.1/opam
+++ b/packages/conf-cairo/conf-cairo.1/opam
@@ -16,7 +16,7 @@ depexts: [
   ["libcairo2-dev"] {os-family = "ubuntu"}
   ["libcairo-devel"] {os-distribution = "mageia"}
   ["cairo" "cairo-devel"] {os-distribution = "centos"}
-  ["cairo-devel"] {os-distribution = "fedora"}
+  ["cairo-devel"] {os-family = "fedora"}
   ["cairo-devel"] {os-distribution = "ol"}
   ["cairo-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["cairo-dev"] {os-family = "alpine"}

--- a/packages/conf-calcium/conf-calcium.1/opam
+++ b/packages/conf-calcium/conf-calcium.1/opam
@@ -25,7 +25,7 @@ depexts: [
   ["libcalcium-dev"] {os-family = "debian"}
   ["libcalcium-dev"] {os-family = "ubuntu"}
   ["calcium" "calcium-devel"] {os-distribution = "centos"}
-  ["calcium" "calcium-devel"] {os-distribution = "fedora"}
+  ["calcium" "calcium-devel"] {os-family = "fedora"}
   ["calcium" "calcium-devel"] {os-distribution = "ol"}
   ["calcium-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["calcium"] {os-distribution = "nixos"}

--- a/packages/conf-capnproto/conf-capnproto.0/opam
+++ b/packages/conf-capnproto/conf-capnproto.0/opam
@@ -17,7 +17,7 @@ depexts: [
   ["capnproto"] {os-distribution = "arch"}
   ["capnproto" "epel-release"] {os-distribution = "centos"}
   ["capnproto" "libcapnp-dev"] {os-family = "debian"}
-  ["capnproto"] {os-distribution = "fedora"}
+  ["capnproto"] {os-family = "fedora"}
   ["capnproto"] {os-distribution = "gentoo"}
   ["capnp"] {os-distribution = "homebrew" & os = "macos"}
   ["capnproto"] {os-distribution = "macports" & os = "macos"}

--- a/packages/conf-capnproto/conf-capnproto.1/opam
+++ b/packages/conf-capnproto/conf-capnproto.1/opam
@@ -17,7 +17,7 @@ depexts: [
   ["capnproto"] {os-distribution = "arch"}
   ["capnproto" "capnproto-devel" "epel-release"] {os-distribution = "centos"}
   ["capnproto" "libcapnp-dev"] {os-family = "debian"}
-  ["capnproto" "capnproto-devel"] {os-distribution = "fedora"}
+  ["capnproto" "capnproto-devel"] {os-family = "fedora"}
   ["capnproto"] {os-distribution = "gentoo"}
   ["capnp"] {os-distribution = "homebrew" & os = "macos"}
   ["capnproto"] {os-distribution = "macports" & os = "macos"}

--- a/packages/conf-capnproto/conf-capnproto.2/opam
+++ b/packages/conf-capnproto/conf-capnproto.2/opam
@@ -18,7 +18,7 @@ depexts: [
   ["capnproto" "capnproto-devel" "epel-release"] {os-distribution = "centos"}
   ["capnproto" "libcapnp-dev"] {os-family = "debian"}
   ["capnproto" "libcapnp-dev"] {os-family = "ubuntu"}
-  ["capnproto" "capnproto-devel"] {os-distribution = "fedora"}
+  ["capnproto" "capnproto-devel"] {os-family = "fedora"}
   ["capnproto"] {os-family = "gentoo"}
   ["capnp"] {os-distribution = "homebrew" & os = "macos"}
   ["capnproto"] {os-distribution = "macports" & os = "macos"}

--- a/packages/conf-clang/conf-clang.1/opam
+++ b/packages/conf-clang/conf-clang.1/opam
@@ -8,7 +8,7 @@ build: ["clang" "--version"]
 depexts: [
   ["clang"] {os-family = "debian"}
   ["clang"] {os-family = "ubuntu"}
-  ["clang"] {os-distribution = "fedora"}
+  ["clang"] {os-family = "fedora"}
   ["clang"] {os-distribution = "rhel"}
   ["clang"] {os-distribution = "centos"}
   ["clang"] {os-distribution = "alpine"}

--- a/packages/conf-cmake/conf-cmake.1/opam
+++ b/packages/conf-cmake/conf-cmake.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["cmake"] {os-family = "debian"}
   ["cmake"] {os-family = "ubuntu"}
   ["cmake3" "epel-release"] {os-distribution = "centos"}
-  ["cmake"] {os-distribution = "fedora"}
+  ["cmake"] {os-family = "fedora"}
   ["cmake"] {os-distribution = "alpine"}
   ["cmake"] {os-distribution = "arch"}
   ["cmake"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-cpio/conf-cpio.1/opam
+++ b/packages/conf-cpio/conf-cpio.1/opam
@@ -8,7 +8,7 @@ build: ["cpio" "--version"]
 depexts: [
   ["cpio"] {os-family = "debian"}
   ["cpio"] {os-family = "ubuntu"}
-  ["cpio"] {os-distribution = "fedora"}
+  ["cpio"] {os-family = "fedora"}
   ["cpio"] {os-distribution = "rhel"}
   ["cpio"] {os-distribution = "centos"}
   ["cpio"] {os-distribution = "alpine"}

--- a/packages/conf-csdp/conf-csdp.1/opam
+++ b/packages/conf-csdp/conf-csdp.1/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/coin-or/Csdp/wiki"
 build: ["sh" "-exc" "command -v csdp"]
 depexts: [
   ["coinor-csdp"] {os-family = "debian" | os-family = "ubuntu"}
-  ["csdp-tools"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
+  ["csdp-tools"] {os-distribution = "centos" | os-family = "fedora" | os-distribution = "ol"}
   ["coin-or-csdp"] {os-distribution = "arch"}
   ["coin-or-csdp"] {os = "freebsd"}
 ]

--- a/packages/conf-dbm/conf-dbm.1.0.0/opam
+++ b/packages/conf-dbm/conf-dbm.1.0.0/opam
@@ -13,7 +13,7 @@ depexts: [
   ["gdbm"] {os-distribution = "nixos"}
   ["gdbm-devel"] {os-distribution = "centos"}
   ["gdbm-devel"] {os-distribution = "rhel"}
-  ["gdbm-devel"] {os-distribution = "fedora"}
+  ["gdbm-devel"] {os-family = "fedora"}
   ["gdbm-devel"] {os-distribution = "ol"}
   ["gdbm-dev"] {os-distribution = "alpine"}
   ["gdbm"] {os-distribution = "arch"}

--- a/packages/conf-diffutils/conf-diffutils.1.1/opam
+++ b/packages/conf-diffutils/conf-diffutils.1.1/opam
@@ -7,7 +7,7 @@ license: "GPL-3.0-or-later"
 build: [["diff" "--help"]]
 depexts: [
   ["diffutils"] {os-family = "debian"}
-  ["diffutils"] {os-distribution = "fedora"}
+  ["diffutils"] {os-family = "fedora"}
   ["diffutils"] {os-distribution = "rhel"}
   ["diffutils"] {os-distribution = "centos"}
   ["diffutils"] {os-distribution = "alpine"}

--- a/packages/conf-diffutils/conf-diffutils.1/opam
+++ b/packages/conf-diffutils/conf-diffutils.1/opam
@@ -7,7 +7,7 @@ license: "GPL-3.0-or-later"
 build: [["diff" "--help"]]
 depexts: [
   ["diffutils"] {os-family = "debian"}
-  ["diffutils"] {os-distribution = "fedora"}
+  ["diffutils"] {os-family = "fedora"}
   ["diffutils"] {os-distribution = "rhel"}
   ["diffutils"] {os-distribution = "centos"}
   ["diffutils"] {os-distribution = "alpine"}

--- a/packages/conf-diffutils/conf-diffutils.2/opam
+++ b/packages/conf-diffutils/conf-diffutils.2/opam
@@ -11,7 +11,7 @@ build: [
 depexts: [
   ["diffutils"] {os-family = "debian"}
   ["diffutils"] {os-family = "ubuntu"}
-  ["diffutils"] {os-distribution = "fedora"}
+  ["diffutils"] {os-family = "fedora"}
   ["diffutils"] {os-distribution = "rhel"}
   ["diffutils"] {os-distribution = "centos"}
   ["diffutils"] {os-distribution = "alpine"}

--- a/packages/conf-dpkg/conf-dpkg.1/opam
+++ b/packages/conf-dpkg/conf-dpkg.1/opam
@@ -7,7 +7,7 @@ license: "GPL-2.0-only"
 build: ["dpkg" "--version"]
 depexts: [
   # Assumed to be there by default on debian/ubuntu based systems
-  ["dpkg"] {os-distribution = "fedora"}
+  ["dpkg"] {os-family = "fedora"}
   ["epel-release" "dpkg"] {os-distribution = "centos"}
   ["dpkg"] {os-distribution = "rhel"}
   ["dpkg"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-dssi/conf-dssi.1/opam
+++ b/packages/conf-dssi/conf-dssi.1/opam
@@ -9,7 +9,7 @@ depends: [
 ]
 depexts: [
   ["dssi-dev"] {os-family = "debian" | os-family = "ubuntu" | os-distribution = "alpine"}
-  ["dssi-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["dssi-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["dssi"] {os-distribution = "nixos" | os-distribution = "arch" | os = "freebsd"}
   ["drfill/liquidsoap/libdssi"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-efl/conf-efl.1.8/opam
+++ b/packages/conf-efl/conf-efl.1.8/opam
@@ -9,7 +9,7 @@ depexts: [
   ["efl"] {os-distribution = "arch"}
   ["efl-dev"] {os-distribution = "alpine"}
   ["libefl-all-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["elementary-devel"] {os-distribution = "fedora"}
+  ["elementary-devel"] {os-family = "fedora"}
   ["efl"] {os = "freebsd"}
   ["efl"] {os-distribution = "gentoo"}
   ["efl"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-emacs/conf-emacs.1/opam
+++ b/packages/conf-emacs/conf-emacs.1/opam
@@ -9,8 +9,8 @@ depexts: [
   ["emacs"] {os-distribution = "ubuntu"}
   ["emacs-nox"] {os-distribution = "centos"}
   ["emacs-nox"] {os-distribution = "rhel"}
-  ["emacs-nox"] {os-distribution = "fedora" & os-version < "40" }
-  ["emacs-nw"] {os-distribution = "fedora" & os-version >= "40" }
+  ["emacs-nox"] {os-family = "fedora" & os-version < "40" }
+  ["emacs-nw"] {os-family = "fedora" & os-version >= "40" }
   ["emacs-nox"] {os-distribution = "alpine"}
   ["emacs-nox"] {os-family = "suse" | os-family = "opensuse"}
   ["emacs-nox"] {os-distribution = "ol"}

--- a/packages/conf-expat/conf-expat.1/opam
+++ b/packages/conf-expat/conf-expat.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["libexpat1-dev"] {os-family = "ubuntu"}
   ["libexpat1-devel"] {os-distribution = "mageia"}
   ["expat"] {os = "win32" & os-distribution = "cygwinports"}
-  ["expat-devel"] {os-distribution = "fedora"}
+  ["expat-devel"] {os-family = "fedora"}
   ["expat"] {os-distribution = "nixos"}
   ["expat-dev"] {os-family = "alpine"}
   ["libexpat-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-faad/conf-faad.1/opam
+++ b/packages/conf-faad/conf-faad.1/opam
@@ -10,7 +10,7 @@ depends: [
 ]
 depexts: [
   ["faad2-dev"] {os-distribution = "alpine"}
-  ["faad2-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["faad2-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["faad2"] {os = "macos" & os-distribution = "homebrew" | os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os-distribution = "ol"}
   ["libfaad-dev"] {os-family = "debian" | os-family = "ubuntu"}
 ]

--- a/packages/conf-ffmpeg/conf-ffmpeg.1/opam
+++ b/packages/conf-ffmpeg/conf-ffmpeg.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libavutil-dev" "libavformat-dev" "libavcodec-dev" "libavdevice-dev" "libavfilter-dev" "libswresample-dev" "libswscale-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os = "freebsd" | os-distribution = "arch" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
-  ["ffmpeg-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["ffmpeg-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on FFmpeg"
 description:

--- a/packages/conf-fftw3/conf-fftw3.1/opam
+++ b/packages/conf-fftw3/conf-fftw3.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["fftw"] {os-family = "arch"}
   ["fftw-devel"] {os-distribution = "centos"}
   ["fftw-dev"] {os-distribution = "alpine"}
-  ["fftw-devel"] {os-distribution = "fedora"}
+  ["fftw-devel"] {os-family = "fedora"}
   ["fftw-devel"] {os-distribution = "rhel"}
   ["libfftw-devel"] {os-distribution = "mageia"}
   ["fftw3-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-findutils/conf-findutils.1/opam
+++ b/packages/conf-findutils/conf-findutils.1/opam
@@ -7,7 +7,7 @@ build: [["sh" "-exc" "find . -name ."]]
 depexts: [
   ["findutils"] {os-family = "debian"}
   ["findutils"] {os-family = "ubuntu"}
-  ["findutils"] {os-distribution = "fedora"}
+  ["findutils"] {os-family = "fedora"}
   ["findutils"] {os-distribution = "rhel"}
   ["findutils"] {os-distribution = "centos"}
   ["findutils"] {os-distribution = "alpine"}

--- a/packages/conf-flint/conf-flint.1/opam
+++ b/packages/conf-flint/conf-flint.1/opam
@@ -23,7 +23,7 @@ depexts: [
   ["flint"] {os = "macos" & os-distribution = "homebrew"}
   ["flint"] {os-distribution = "macports" & os = "macos"}
   ["flint" "flint-devel"] {os-distribution = "centos"}
-  ["flint" "flint-devel"] {os-distribution = "fedora"}
+  ["flint" "flint-devel"] {os-family = "fedora"}
   ["flint" "flint-devel"] {os-distribution = "ol"}
   ["flint-dev"] {os-distribution = "alpine"}
   ["flint-devel"] {os-family = "suse"}

--- a/packages/conf-flint/conf-flint.3.0/opam
+++ b/packages/conf-flint/conf-flint.3.0/opam
@@ -23,7 +23,7 @@ depexts: [
   ["flint"] {os = "macos" & os-distribution = "homebrew"}
   ["flint"] {os-distribution = "macports" & os = "macos"}
   ["flint" "flint-devel"] {os-distribution = "centos"}
-  ["flint" "flint-devel"] {os-distribution = "fedora"}
+  ["flint" "flint-devel"] {os-family = "fedora"}
   ["flint" "flint-devel"] {os-distribution = "ol"}
   ["flint-dev"] {os-distribution = "alpine"}
   ["flint-devel"] {os-family = "opensuse"}
@@ -34,7 +34,7 @@ depexts: [
 available: [
    !(os-distribution = "ubuntu" & os-version < "24.04") &
    !(os-distribution = "debian" & os-version <= "12") &
-   !(os-distribution = "fedora" & os-version <= "39") &
+   !(os-family = "fedora" & os-version <= "39") &
    !(os-family = "suse")
 ]
 

--- a/packages/conf-freeglut/conf-freeglut.1/opam
+++ b/packages/conf-freeglut/conf-freeglut.1/opam
@@ -13,7 +13,7 @@ depends: [
 depexts: [
   ["freeglut3-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["freeglut-dev"] {os-distribution = "alpine"}
-  ["freeglut-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
+  ["freeglut-devel"] {os-distribution = "centos" | os-family = "fedora" | os-distribution = "ol"}
   ["freeglut-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["freeglut"] {os-family = "arch"}
   ["freeglut"] {os = "freebsd"}

--- a/packages/conf-frei0r/conf-frei0r.1/opam
+++ b/packages/conf-frei0r/conf-frei0r.1/opam
@@ -11,7 +11,7 @@ depends: [
 depexts: [
   ["frei0r-plugins"] {os-distribution = "arch"}
   ["frei0r-plugins-dev"] {os-distribution = "alpine" | os-family = "debian" | os-family = "ubuntu"}
-  ["frei0r-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["frei0r-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["frei0r"] {os = "freebsd" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on frei0r"

--- a/packages/conf-ftgl/conf-ftgl.1/opam
+++ b/packages/conf-ftgl/conf-ftgl.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["ftgl-dev"] {os-distribution = "alpine"}
   ["libftgl-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libftgl-devel"] {os-distribution = "mageia"}
-  ["ftgl-devel"] {os-distribution = "fedora"}
+  ["ftgl-devel"] {os-family = "fedora"}
   ["ftgl-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["ftgl"] {os = "freebsd"}
 ]

--- a/packages/conf-g++/conf-g++.1.0/opam
+++ b/packages/conf-g++/conf-g++.1.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depexts: [
   ["gcc-c++"] {os-distribution = "centos"}
-  ["gcc-c++"] {os-distribution = "fedora"}
+  ["gcc-c++"] {os-family = "fedora"}
   ["gcc-c++"] {os-family = "suse" | os-family = "opensuse"}
   ["g++"] {os-family = "debian"}
   ["g++"] {os-family = "ubuntu"}

--- a/packages/conf-gcc/conf-gcc.1.0/opam
+++ b/packages/conf-gcc/conf-gcc.1.0/opam
@@ -7,7 +7,7 @@ license: "GPL-2.0-or-later"
 build: [["gcc" "--version"]]
 depexts: [
   ["gcc"] {os-distribution = "centos"}
-  ["gcc"] {os-distribution = "fedora"}
+  ["gcc"] {os-family = "fedora"}
   ["gcc"] {os-family = "suse" | os-distribution = "opensuse"}
   ["gcc"] {os-distribution = "debian"}
   ["gcc"] {os-distribution = "ubuntu"}

--- a/packages/conf-gd/conf-gd.1/opam
+++ b/packages/conf-gd/conf-gd.1/opam
@@ -9,7 +9,7 @@ depexts: [
     {os-distribution = "alpine"}
   ["gd"] {os-distribution = "arch"}
   ["libgd3-devel"] {os-distribution = "centos"}
-  ["libgd3-devel"] {os-distribution = "fedora"}
+  ["libgd3-devel"] {os-family = "fedora"}
   ["libgd3-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libgd-dev"] {os-family = "debian"}
   ["libgd-dev"] {os-family = "ubuntu"}

--- a/packages/conf-gfortran/conf-gfortran.0/opam
+++ b/packages/conf-gfortran/conf-gfortran.0/opam
@@ -11,7 +11,7 @@ depexts: [
   ["gfortran"] {os-family = "debian"}
   ["gfortran"] {os-family = "ubuntu"}
   ["gfortran"] {os-distribution = "alpine"}
-  ["gcc-gfortran"] {os-distribution = "fedora"}
+  ["gcc-gfortran"] {os-family = "fedora"}
   ["gcc-gfortran"] {os-distribution = "centos"}
   ["gcc-gfortran"] {os-distribution = "mageia"}
   ["gcc-gfortran"] {os-distribution = "rhel"}

--- a/packages/conf-ghostscript/conf-ghostscript.1/opam
+++ b/packages/conf-ghostscript/conf-ghostscript.1/opam
@@ -8,7 +8,7 @@ build: ["gs" "--version"]
 depexts: [
   ["ghostscript"] {os-family = "debian"}
   ["ghostscript"] {os-family = "ubuntu"}
-  ["ghostscript"] {os-distribution = "fedora"}
+  ["ghostscript"] {os-family = "fedora"}
   ["ghostscript"] {os-distribution = "rhel"}
   ["ghostscript"] {os-distribution = "ol"}
   ["ghostscript"] {os-distribution = "centos"}

--- a/packages/conf-git/conf-git.1.0/opam
+++ b/packages/conf-git/conf-git.1.0/opam
@@ -10,7 +10,7 @@ depends: [
 ]
 depexts: [
   ["git"] {os-distribution = "centos"}
-  ["git"] {os-distribution = "fedora"}
+  ["git"] {os-family = "fedora"}
   ["git"] {os-family = "suse" | os-family = "opensuse"}
   ["git"] {os-family = "debian"}
   ["git"] {os-distribution = "nixos"}

--- a/packages/conf-git/conf-git.1.1/opam
+++ b/packages/conf-git/conf-git.1.1/opam
@@ -7,7 +7,7 @@ license: "GPL-2.0-or-later"
 build: ["git" "--version"]
 depexts: [
   ["git"] {os-distribution = "centos"}
-  ["git"] {os-distribution = "fedora"}
+  ["git"] {os-family = "fedora"}
   ["git"] {os-distribution = "ol"}
   ["git"] {os-family = "suse" | os-family = "opensuse"}
   ["git"] {os-family = "debian"}

--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -18,7 +18,7 @@ build: [
 depexts: [
   ["libglade2-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libglade2.0"] {os = "win32" & os-distribution = "cygwinports"}
-  ["libglade2-devel"] {os-distribution = "fedora"}
+  ["libglade2-devel"] {os-family = "fedora"}
   ["gnome2.libglade"] {os-distribution = "nixos"}
   ["libglade-dev"] {os-distribution = "alpine"}
   ["libglade"] {os-distribution = "arch"}

--- a/packages/conf-glew/conf-glew.1/opam
+++ b/packages/conf-glew/conf-glew.1/opam
@@ -17,7 +17,7 @@ depexts: [
   ["libglew-dev"] {os-family = "ubuntu"}
   ["libglew-devel"] {os-distribution = "mageia"}
   ["glew"] {os = "win32" & os-distribution = "cygwinports"}
-  ["glew-devel"] {os-distribution = "fedora"}
+  ["glew-devel"] {os-family = "fedora"}
   ["glew-devel"] {os-distribution = "centos"}
   ["glu-devel" "glew-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["glew-dev"] {os-family = "alpine"}

--- a/packages/conf-glfw3/conf-glfw3.1/opam
+++ b/packages/conf-glfw3/conf-glfw3.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libglfw3-dev"] {os-family = "debian"}
   ["glfw-devel" "epel-release"] {os-distribution = "centos"}
   ["glfw-devel"] {os-distribution = "rhel"}
-  ["glfw-devel"] {os-distribution = "fedora"}
+  ["glfw-devel"] {os-family = "fedora"}
   ["glfw-dev"] {os-distribution = "alpine"}
   ["libglfw-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libglfw-devel"] {os-distribution = "mageia"}

--- a/packages/conf-glfw3/conf-glfw3.2/opam
+++ b/packages/conf-glfw3/conf-glfw3.2/opam
@@ -17,7 +17,7 @@ depexts: [
   ["glfw-devel" "epel-release" "mesa-libGL-devel"]
     {os-distribution = "centos"}
   ["glfw-devel" "mesa-libGL-devel"] {os-distribution = "rhel"}
-  ["glfw-devel" "mesa-libGL-devel"] {os-distribution = "fedora"}
+  ["glfw-devel" "mesa-libGL-devel"] {os-family = "fedora"}
   ["libglfw-devel" "mesagl-devel"] {os-distribution = "mageia"}
   ["libglfw-devel" "Mesa-libGL-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["glfw-dev"] {os-family = "alpine"}

--- a/packages/conf-glib-2/conf-glib-2.1/opam
+++ b/packages/conf-glib-2/conf-glib-2.1/opam
@@ -8,7 +8,7 @@ build: [["pkg-config" "glib-2.0"]]
 depexts: [
   ["libglib2.0-dev"] {os-family = "debian"}
   ["libglib2.0-dev"] {os-family = "ubuntu"}
-  ["glib2-devel"] {os-distribution = "fedora"}
+  ["glib2-devel"] {os-family = "fedora"}
   ["glib2-devel"] {os-distribution = "centos"}
   ["glib-dev"] {os-distribution = "alpine"}
   ["glib"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-glpk/conf-glpk.1/opam
+++ b/packages/conf-glpk/conf-glpk.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["libglpk-dev"] {os-family = "debian"}
   ["libglpk-dev"] {os-family = "ubuntu"}
   ["glpk-dev@testing"] {os-family = "alpine"}
-  ["glpk-devel"] {os-distribution = "fedora"}
+  ["glpk-devel"] {os-family = "fedora"}
   ["epel-release" "glpk-devel"] {os-distribution = "centos"}
   ["glpk-devel"] {os-distribution = "rhel"}
   ["glpk-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-gmp-paths/conf-gmp-paths.1/opam
+++ b/packages/conf-gmp-paths/conf-gmp-paths.1/opam
@@ -28,7 +28,7 @@ depexts: [
   ["gmp"] {os = "macos" & os-distribution = "homebrew"}
   ["gmp"] {os-distribution = "macports" & os = "macos"}
   ["gmp" "gmp-devel"] {os-distribution = "centos"}
-  ["gmp" "gmp-devel"] {os-distribution = "fedora"}
+  ["gmp" "gmp-devel"] {os-family = "fedora"}
   ["gmp" "gmp-devel"] {os-distribution = "ol"}
   ["gmp"] {os = "openbsd"}
   ["gmp"] {os = "freebsd"}

--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -16,7 +16,7 @@ depexts: [
   ["gmp"] {os = "macos" & os-distribution = "homebrew"}
   ["gmp"] {os-distribution = "macports" & os = "macos"}
   ["gmp" "gmp-devel"] {os-distribution = "centos"}
-  ["gmp" "gmp-devel"] {os-distribution = "fedora"}
+  ["gmp" "gmp-devel"] {os-family = "fedora"}
   ["gmp"] {os = "openbsd"}
   ["gmp"] {os = "freebsd"}
   ["gmp-dev"] {os-distribution = "alpine"}

--- a/packages/conf-gmp/conf-gmp.2/opam
+++ b/packages/conf-gmp/conf-gmp.2/opam
@@ -16,7 +16,7 @@ depexts: [
   ["gmp"] {os = "macos" & os-distribution = "homebrew"}
   ["gmp"] {os-distribution = "macports" & os = "macos"}
   ["gmp" "gmp-devel"] {os-distribution = "centos"}
-  ["gmp" "gmp-devel"] {os-distribution = "fedora"}
+  ["gmp" "gmp-devel"] {os-family = "fedora"}
   ["gmp" "gmp-devel"] {os-distribution = "ol"}
   ["gmp"] {os = "openbsd"}
   ["gmp"] {os = "freebsd"}

--- a/packages/conf-gmp/conf-gmp.3/opam
+++ b/packages/conf-gmp/conf-gmp.3/opam
@@ -17,7 +17,7 @@ depexts: [
   ["gmp"] {os = "macos" & os-distribution = "homebrew"}
   ["gmp"] {os-distribution = "macports" & os = "macos"}
   ["gmp" "gmp-devel"] {os-distribution = "centos"}
-  ["gmp" "gmp-devel"] {os-distribution = "fedora"}
+  ["gmp" "gmp-devel"] {os-family = "fedora"}
   ["gmp" "gmp-devel"] {os-distribution = "ol"}
   ["gmp"] {os = "openbsd"}
   ["gmp"] {os = "freebsd"}

--- a/packages/conf-gmp/conf-gmp.4/opam
+++ b/packages/conf-gmp/conf-gmp.4/opam
@@ -31,7 +31,7 @@ depexts: [
   ["gmp"] {os = "macos" & os-distribution = "homebrew"}
   ["gmp"] {os-distribution = "macports" & os = "macos"}
   ["gmp" "gmp-devel"] {os-distribution = "centos"}
-  ["gmp" "gmp-devel"] {os-distribution = "fedora" | os-family = "fedora"}
+  ["gmp" "gmp-devel"] {os-family = "fedora" | os-family = "fedora"}
   ["gmp" "gmp-devel"] {os-distribution = "ol"}
   ["gmp"] {os = "openbsd"}
   ["gmp"] {os = "freebsd"}

--- a/packages/conf-gmp/conf-gmp.5/opam
+++ b/packages/conf-gmp/conf-gmp.5/opam
@@ -27,7 +27,7 @@ depexts: [
   ["gmp"] {os = "macos" & os-distribution = "homebrew"}
   ["gmp"] {os-distribution = "macports" & os = "macos"}
   ["gmp" "gmp-devel"] {os-distribution = "centos"}
-  ["gmp" "gmp-devel"] {os-distribution = "fedora" | os-family = "fedora"}
+  ["gmp" "gmp-devel"] {os-family = "fedora" | os-family = "fedora"}
   ["gmp" "gmp-devel"] {os-distribution = "ol"}
   ["gmp"] {os = "openbsd"}
   ["gmp"] {os = "freebsd"}

--- a/packages/conf-gnuplot/conf-gnuplot.0.1/opam
+++ b/packages/conf-gnuplot/conf-gnuplot.0.1/opam
@@ -9,7 +9,7 @@ depexts: [
   ["gnuplot-x11"] {os-family = "debian"}
   ["gnuplot-x11"] {os-family = "ubuntu"}
   ["gnuplot"] {os-distribution = "centos"}
-  ["gnuplot"] {os-distribution = "fedora"}
+  ["gnuplot"] {os-family = "fedora"}
   ["gnuplot"] {os-distribution = "ol"}
   ["gnuplot"] {os = "macos" & os-distribution = "homebrew"}
   ["gnuplot"] {os-distribution = "alpine"}

--- a/packages/conf-gnustep-base/conf-gnustep-base.1/opam
+++ b/packages/conf-gnustep-base/conf-gnustep-base.1/opam
@@ -5,14 +5,14 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "The GNUstep devs"
 license: "LGPL-2.1-only"
 build: [
-  ["rpm" "-q" "gnustep-base-devel"] {os-distribution = "fedora" | os-family = "opensuse"}
+  ["rpm" "-q" "gnustep-base-devel"] {os-family = "fedora" | os-family = "opensuse"}
   ["pkg" "info" "gnustep-base"] {os = "freebsd"}
 ]
 depexts: [
-  ["gnustep-base-devel"] {os-distribution = "fedora" | os-family = "opensuse"}
+  ["gnustep-base-devel"] {os-family = "fedora" | os-family = "opensuse"}
   ["gnustep-base"] {os = "freebsd"}
 ]
-available: os = "freebsd" | os-distribution = "fedora" | os-family = "opensuse"
+available: os = "freebsd" | os-family = "fedora" | os-family = "opensuse"
 synopsis: "Virtual package relying on gnustep-base lib system installation"
 description:
   "This package can only install if the gnustep-base lib is installed on the system."

--- a/packages/conf-gnustep-gui/conf-gnustep-gui.1/opam
+++ b/packages/conf-gnustep-gui/conf-gnustep-gui.1/opam
@@ -10,7 +10,7 @@ build: [
 depexts: [
   ["gnustep-gui"] {os = "freebsd"}
 ]
-available: os = "freebsd" | os-distribution = "fedora"
+available: os = "freebsd" | os-family = "fedora"
 synopsis: "Virtual package relying on gnustep-gui lib system installation"
 description:
   "This package can only install if the gnustep-gui lib is installed on the system."

--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -32,7 +32,7 @@ depexts: [
   ["gnutls-dev"] {os-distribution = "alpine"}
   ["gnutls"] {os-distribution = "arch"}
   ["libgnutls-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["gnutls-devel" "nettle-devel"] {os-distribution = "fedora"}
+  ["gnutls-devel" "nettle-devel"] {os-family = "fedora"}
   ["gnutls"] {os = "macos" & os-distribution = "homebrew"}
   ["gnutls"] {os = "win32" & os-distribution = "cygwinports"}
   ["gnutls-devel"] {os-distribution = "ol"}

--- a/packages/conf-gobject-introspection/conf-gobject-introspection.1.0/opam
+++ b/packages/conf-gobject-introspection/conf-gobject-introspection.1.0/opam
@@ -8,7 +8,7 @@ license: "various"
 build: [["pkg-config" "gobject-introspection-1.0"]]
 depexts: [
   ["libgirepository1.0-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["gobject-introspection-devel"] {os-distribution = "fedora"}
+  ["gobject-introspection-devel"] {os-family = "fedora"}
   ["gobject-introspection-devel"] {os-distribution = "centos"}
   ["gobject-introspection-dev"] {os-distribution = "alpine"}
   ["gobject-introspection-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-goocanvas2/conf-goocanvas2.0/opam
+++ b/packages/conf-goocanvas2/conf-goocanvas2.0/opam
@@ -10,7 +10,7 @@ depexts: [
   ["goocanvas2"] {os-distribution = "arch"}
   ["epel-release" "goocanvas2-devel"] {os-distribution = "centos"}
   ["libgoocanvas-2.0-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["goocanvas2-devel"] {os-distribution = "fedora"}
+  ["goocanvas2-devel"] {os-family = "fedora"}
   ["goocanvas2"] {os = "freebsd"}
   ["goocanvas2"] {os = "openbsd"}
   ["goocanvas2-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-gpiod/conf-gpiod.1/opam
+++ b/packages/conf-gpiod/conf-gpiod.1/opam
@@ -15,7 +15,7 @@ depexts: [
   [ "libgpiod-dev" ] { os-distribution = "alpine" }
   [ "libgpiod-dev" ] { os-family = "debian" }
   [ "libgpiod-dev" ] { os-family = "ubuntu" }
-  [ "libgpiod-devel" ] { os-distribution = "fedora" }
+  [ "libgpiod-devel" ] { os-family = "fedora" }
   [ "libgpiod-devel" ] { os-distribution = "centos" }
   [ "libgpiod-devel" ] { os-family = "suse" | os-family = "opensuse" }
 ]

--- a/packages/conf-graphviz/conf-graphviz.0.1/opam
+++ b/packages/conf-graphviz/conf-graphviz.0.1/opam
@@ -9,7 +9,7 @@ depexts: [
   ["graphviz"] {os-family = "debian"}
   ["graphviz"] {os-family = "ubuntu"}
   ["graphviz"] {os-family = "suse" | os-family = "opensuse"}
-  ["graphviz"] {os-distribution = "fedora"}
+  ["graphviz"] {os-family = "fedora"}
   ["graphviz"] {os-distribution = "centos"}
   ["graphviz"] {os-family = "arch"}
   ["graphviz"] {os-family = "alpine"}

--- a/packages/conf-gsl/conf-gsl.1/opam
+++ b/packages/conf-gsl/conf-gsl.1/opam
@@ -8,7 +8,7 @@ depexts: [
   ["libgsl0-dev"] {os-family = "debian"}
   ["libgsl-devel"] {os-distribution = "mageia"}
   ["gsl-devel"] {os-distribution = "centos"}
-  ["gsl-devel"] {os-distribution = "fedora"}
+  ["gsl-devel"] {os-family = "fedora"}
   ["gsl-devel"] {os-distribution = "rhel"}
   ["gsl-dev"] {os-distribution = "alpine"}
   ["gsl-devel"] {os-distribution = "ol"}

--- a/packages/conf-gsl/conf-gsl.2/opam
+++ b/packages/conf-gsl/conf-gsl.2/opam
@@ -9,7 +9,7 @@ depexts: [
   ["libgsl-dev"] {os-family = "ubuntu"}
   ["libgsl-devel"] {os-distribution = "mageia"}
   ["gsl-devel"] {os-distribution = "centos"}
-  ["gsl-devel"] {os-distribution = "fedora"}
+  ["gsl-devel"] {os-family = "fedora"}
   ["gsl-devel"] {os-distribution = "rhel"}
   ["gsl-dev"] {os-distribution = "alpine"}
   ["gsl-devel"] {os-distribution = "ol"}

--- a/packages/conf-gssapi/conf-gssapi.1/opam
+++ b/packages/conf-gssapi/conf-gssapi.1/opam
@@ -8,7 +8,7 @@ depexts: [
   ["libkrb5-dev"] {os-family = "ubuntu"}
   ["krb5-dev"] {os-distribution = "alpine"}
   ["krb5"] {os-distribution = "arch"}
-  ["krb5-devel"] {os-distribution = "fedora"}
+  ["krb5-devel"] {os-family = "fedora"}
   ["krb5"] {os-family = "suse" | os-family = "opensuse"}
   ["krb5-devel"]  {os = "freebsd"}
 ]

--- a/packages/conf-gstreamer/conf-gstreamer.1/opam
+++ b/packages/conf-gstreamer/conf-gstreamer.1/opam
@@ -13,7 +13,7 @@ depexts: [
   ["gstreamer-devel" "gstreamer-plugins-base-devel"]
     {os-family = "suse" | os-family = "opensuse"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]
-    {os-distribution = "fedora"}
+    {os-family = "fedora"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]
     {os-distribution = "centos"}
   ["libgstreamer1.0-dev" "libgstreamer-plugins-base1.0-dev"]

--- a/packages/conf-gtk2/conf-gtk2.1/opam
+++ b/packages/conf-gtk2/conf-gtk2.1/opam
@@ -13,7 +13,7 @@ depexts: [
   ["libgtk2.0-dev" "libexpat1-dev"] {os-family = "ubuntu"}
   ["gtk+2.0-dev"] {os-family = "alpine"}
   ["gtk2-devel"] {os-distribution = "centos"}
-  ["gtk2-devel"] {os-distribution = "fedora"}
+  ["gtk2-devel"] {os-family = "fedora"}
   ["gtk2-devel"] {os-distribution = "ol"}
   ["gtk2-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gtk2"] {os-family = "arch"}

--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -10,7 +10,7 @@ depexts: [
   ["gtk+3" "expat"] {os-distribution = "homebrew" & os = "macos"}
   ["gtk3 +quartz" "expat"] {os-distribution = "macports" & os = "macos"}
   ["gtk3-devel"] {os-distribution = "centos"}
-  ["gtk3-devel"] {os-distribution = "fedora"}
+  ["gtk3-devel"] {os-family = "fedora"}
   ["gtk3-devel"] {os-distribution = "ol"}
   ["gtk+3.0-dev"] {os-distribution = "alpine"}
   ["gtk3-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-gtksourceview/conf-gtksourceview.2/opam
+++ b/packages/conf-gtksourceview/conf-gtksourceview.2/opam
@@ -11,7 +11,7 @@ depexts: [
   ["gtksourceview2"] {os-distribution = "arch"}
   ["epel-release" "gtksourceview2-devel"] {os-distribution = "centos" & os-version < "8"}
   ["libgtksourceview2.0-dev"] {os-family = "debian"}
-  ["gtksourceview2-devel"] {os-distribution = "fedora"}
+  ["gtksourceview2-devel"] {os-family = "fedora"}
   ["gtksourceview2"] {os = "freebsd"}
   ["gtksourceview"] {os = "openbsd"}
   ["gtksourceview2-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0+1/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0+1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["gtksourceview3"] {os-distribution = "arch"}
   ["epel-release" "gtksourceview3-devel"] {os-distribution = "centos"}
   ["libgtksourceview-3.0-dev"] {os-family = "debian"}
-  ["gtksourceview3-devel"] {os-distribution = "fedora"}
+  ["gtksourceview3-devel"] {os-family = "fedora"}
   ["gtksourceview3"] {os = "freebsd"}
   ["gtksourceview3"] {os = "openbsd"}
   ["gtksourceview-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
@@ -11,7 +11,7 @@ depexts: [
   ["gtksourceview3"] {os-distribution = "arch"}
   ["epel-release" "gtksourceview3-devel"] {os-distribution = "centos"}
   ["libgtksourceview-3.0-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["gtksourceview3-devel"] {os-distribution = "fedora"}
+  ["gtksourceview3-devel"] {os-family = "fedora"}
   ["gtksourceview3"] {os = "freebsd"}
   ["gtksourceview3"] {os = "openbsd"}
   ["gtksourceview-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
@@ -11,7 +11,7 @@ depexts: [
   ["gtksourceview3"] {os-family = "arch"}
   ["epel-release" "gtksourceview3-devel"] {os-distribution = "centos"}
   ["libgtksourceview-3.0-dev"] {os-family = "debian"}
-  ["gtksourceview3-devel"] {os-distribution = "fedora"}
+  ["gtksourceview3-devel"] {os-family = "fedora"}
   ["gtksourceview3"] {os = "freebsd"}
   ["gtksourceview3"] {os = "openbsd"}
   ["gtksourceview3-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-guile/conf-guile.1/opam
+++ b/packages/conf-guile/conf-guile.1/opam
@@ -18,7 +18,7 @@ depexts: [
   ["database/guile"] {os = "openbsd"}
   ["guile-devel"] {os-distribution = "centos"}
   ["guile-devel"] {os-distribution = "rhel"}
-  ["guile30-devel"] {os-distribution = "fedora"}
+  ["guile30-devel"] {os-family = "fedora"}
   ["guile-devel"] {os-distribution = "ol"}
   ["guile-dev"] {os-distribution = "alpine"}
   ["guile-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-haveged/conf-haveged.1.0.0/opam
+++ b/packages/conf-haveged/conf-haveged.1.0.0/opam
@@ -9,7 +9,7 @@ depexts: [
   ["haveged"] {os-family = "debian" | os-family = "ubuntu"}
 # ["haveged"] {os = "macos" & os-distribution = "homebrew"} # not in brew?!
   ["haveged"] {os-distribution = "centos"}
-  ["haveged"] {os-distribution = "fedora"}
+  ["haveged"] {os-family = "fedora"}
   ["haveged"] {os-distribution = "alpine"}
   ["haveged"] {os-distribution = "arch"}
   ["haveged"] {os-distribution = "gentoo"}

--- a/packages/conf-hidapi/conf-hidapi.0/opam
+++ b/packages/conf-hidapi/conf-hidapi.0/opam
@@ -14,7 +14,7 @@ depexts: [
   ["libhidapi-dev"] {os-family = "ubuntu"}
   ["libhidapi-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["hidapi" "libusb"] {os-distribution = "arch"}
-  ["hidapi-devel"] {os-distribution = "fedora"}
+  ["hidapi-devel"] {os-family = "fedora"}
   ["hidapi"] {os = "macos" & os-distribution = "homebrew"}
   ["hidapi"] {os = "freebsd"}
   ["hidapi-dev"] {os-distribution = "alpine"}

--- a/packages/conf-jack/conf-jack.1/opam
+++ b/packages/conf-jack/conf-jack.1/opam
@@ -10,7 +10,7 @@ depends: [
 ]
 depexts: [
   ["jack-dev"] {os-distribution = "alpine"}
-  ["jack-audio-connection-kit-devel"] {os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["jack-audio-connection-kit-devel"] {os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["epel-release" "jack-audio-connection-kit-devel"] {os-distribution = "centos"}
   ["libjack-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["jack"] {os-distribution = "nixos"}

--- a/packages/conf-jq/conf-jq.1/opam
+++ b/packages/conf-jq/conf-jq.1/opam
@@ -8,7 +8,7 @@ build: ["jq" "--version"]
 depexts: [
   ["jq"] {os-family = "debian"}
   ["jq"] {os-family = "ubuntu"}
-  ["jq"] {os-distribution = "fedora"}
+  ["jq"] {os-family = "fedora"}
   ["jq"] {os-distribution = "rhel"}
   ["epel-release" "jq"] {os-distribution = "centos"}
   ["jq"] {os-distribution = "alpine"}

--- a/packages/conf-ladspa/conf-ladspa.1/opam
+++ b/packages/conf-ladspa/conf-ladspa.1/opam
@@ -6,7 +6,7 @@ authors: "ladspa dev team"
 license: "LGPL-2.1-or-later"
 depexts: [
   ["ladspa-dev"] {os-distribution = "alpine"}
-  ["ladspa-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["ladspa-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["ladspa-sdk"] {os-family = "debian" | os-family = "ubuntu"}
   ["drfill/liquidsoap/ladspa_header"]
     {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-lame/conf-lame.1/opam
+++ b/packages/conf-lame/conf-lame.1/opam
@@ -6,7 +6,7 @@ authors: "lame dev team"
 license: "BSD-2-Clause"
 depexts: [
   ["lame-dev"] {os-distribution = "alpine"}
-  ["lame-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse"}
+  ["lame-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse"}
   ["libmp3lame-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libmp3lame-devel"] {os-family = "opensuse"}
   ["lame"] {os = "win32" & os-distribution = "cygwinports"}

--- a/packages/conf-lapack/conf-lapack.1/opam
+++ b/packages/conf-lapack/conf-lapack.1/opam
@@ -16,7 +16,7 @@ depexts: [
   ["liblapack-dev"] {os-family = "ubuntu"}
   ["liblapack-devel"] {os-distribution = "mageia"}
   ["lapack-devel"] {os-distribution = "centos"}
-  ["lapack-devel"] {os-distribution = "fedora"}
+  ["lapack-devel"] {os-family = "fedora"}
   ["lapack-devel"] {os-distribution = "rhel"}
   ["lapack-dev"] {os-distribution = "alpine"}
   ["lapack-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-leveldb/conf-leveldb.1/opam
+++ b/packages/conf-leveldb/conf-leveldb.1/opam
@@ -10,7 +10,7 @@ depexts: [
   ["libleveldb-dev"] {os-family = "ubuntu"}
   ["leveldb-dev"] {os-family = "alpine"}
   ["leveldb-devel" "epel-release"] {os-distribution = "centos"}
-  ["leveldb-devel"] {os-distribution = "fedora"}
+  ["leveldb-devel"] {os-family = "fedora"}
   ["leveldb-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["dev-libs/leveldb"] {os-family = "gentoo"}
   ["leveldb"] {os-family = "arch"}

--- a/packages/conf-leveldb/conf-leveldb.2/opam
+++ b/packages/conf-leveldb/conf-leveldb.2/opam
@@ -10,7 +10,7 @@ depexts: [
   ["libleveldb-dev"] {os-family = "ubuntu"}
   ["leveldb-dev"] {os-family = "alpine"}
   ["leveldb-devel" "epel-release"] {os-distribution = "centos"}
-  ["leveldb-devel"] {os-distribution = "fedora"}
+  ["leveldb-devel"] {os-family = "fedora"}
   ["leveldb-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["dev-libs/leveldb"] {os-family = "gentoo"}
   ["leveldb"] {os-family = "arch"}

--- a/packages/conf-libMagickCore/conf-libMagickCore.1/opam
+++ b/packages/conf-libMagickCore/conf-libMagickCore.1/opam
@@ -8,7 +8,7 @@ depexts: [
   ["imagemagick"] {os-distribution = "arch"}
   ["imagemagick-dev"] {os-distribution = "alpine"}
   ["libmagickcore-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["ImageMagick-devel"] {os-distribution = "fedora"}
+  ["ImageMagick-devel"] {os-family = "fedora"}
   ["libMagick-devel"] {os-distribution = "mageia"}
   ["ImageMagick-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["ImageMagick7"] {os = "freebsd"}

--- a/packages/conf-libX11/conf-libX11.1/opam
+++ b/packages/conf-libX11/conf-libX11.1/opam
@@ -14,7 +14,7 @@ build: [
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libx11-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["libX11-devel"] {os-distribution = "centos" | os-distribution = "ol" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["libX11-devel"] {os-distribution = "centos" | os-distribution = "ol" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["libx11-dev"] {os-distribution = "alpine"}
   ["libx11"] {os-distribution = "arch"}
   ["libX11-dev"] {os = "cygwin"}

--- a/packages/conf-libXft/conf-libXft.1/opam
+++ b/packages/conf-libXft/conf-libXft.1/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["libxft-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["libXft-devel"] {os-distribution = "centos" | os-distribution = "ol" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["libXft-devel"] {os-distribution = "centos" | os-distribution = "ol" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["libxft-dev"] {os-distribution = "alpine"}
   ["libxft"] {os-distribution = "arch"}
   ["libXft-devel"] {os = "cygwin"}

--- a/packages/conf-libargon2/conf-libargon2.1/opam
+++ b/packages/conf-libargon2/conf-libargon2.1/opam
@@ -8,7 +8,7 @@ depexts: [
   ["libargon2-0"] {os-family = "debian"}
   ["libargon2-0"] {os-family = "ubuntu"}
   ["argon2-libs"] {os-family = "alpine"}
-  ["libargon2"] {os-distribution = "fedora"}
+  ["libargon2"] {os-family = "fedora"}
   ["libargon2"] {os-distribution = "rhel"}
   ["libargon2"] {os-distribution = "centos"}
   ["libargon2"] {os-distribution = "ol"}

--- a/packages/conf-libblake3/conf-libblake3.1.5.1/opam
+++ b/packages/conf-libblake3/conf-libblake3.1.5.1/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["blake3-devel"] {os-distribution = "fedora"}
+  ["blake3-devel"] {os-family = "fedora"}
   ["blake3"] {os-distribution = "homebrew" & os = "macos"}
 ]
 synopsis: "Virtual package relying on libblake3"

--- a/packages/conf-libbpf/conf-libbpf.0.1.0/opam
+++ b/packages/conf-libbpf/conf-libbpf.0.1.0/opam
@@ -11,7 +11,7 @@ available: [ os = "linux" ]
 depexts: [
   ["libbpf-dev"]   { os-distribution = "ubuntu" & os-version >= "18.04" }
   ["libbpf-dev"]   { os-distribution = "debian" & os-version >= "9.0" }
-  ["libbpf-devel"] { os-distribution = "fedora" & os-version >= "38" }
+  ["libbpf-devel"] { os-family = "fedora" & os-version >= "38" }
 ]
 flags: conf
 x-commit-hash: "c7ac4c7ff9f2aa23c374a619990c0bdd78976102"

--- a/packages/conf-libbz2/conf-libbz2.1/opam
+++ b/packages/conf-libbz2/conf-libbz2.1/opam
@@ -13,7 +13,7 @@ depexts: [
   ["libbz2-dev"] {os-family = "debian"}
   ["libbz2-dev"] {os-family = "ubuntu"}
   ["bzip2-dev"] {os-family = "alpine"}
-  ["bzip2-devel"] {os-distribution = "fedora"}
+  ["bzip2-devel"] {os-family = "fedora"}
   ["bzip2-devel"] {os-distribution = "rhel"}
   ["bzip2-devel"] {os-distribution = "centos"}
   ["bzip2-devel"] {os-distribution = "ol"}

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -18,7 +18,7 @@ depexts: [
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
     {os-distribution = "centos"}
   ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
-    {os-distribution = "fedora"}
+    {os-family = "fedora"}
   ["llvm-clang-devel"] {os-family = "suse" | os-family = "opensuse"}
 #  ["devel/clang" "devel/llvm"] {os = "freebsd"}
   ["sys-devel/clang"] {os-distribution = "gentoo"}

--- a/packages/conf-libclang/conf-libclang.10/opam
+++ b/packages/conf-libclang/conf-libclang.10/opam
@@ -21,7 +21,7 @@ depexts: [
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
     {os-distribution = "centos"}
   ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
-    {os-distribution = "fedora"}
+    {os-family = "fedora"}
   ["llvm-clang-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["devel/llvm10"] {os = "freebsd"}
   ["sys-devel/clang"] {os-distribution = "gentoo"}

--- a/packages/conf-libclang/conf-libclang.11/opam
+++ b/packages/conf-libclang/conf-libclang.11/opam
@@ -21,7 +21,7 @@ depexts: [
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
     {os-distribution = "centos"}
   ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
-    {os-distribution = "fedora"}
+    {os-family = "fedora"}
   ["llvm-clang-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["devel/llvm11"] {os = "freebsd"}
   ["sys-devel/clang"] {os-distribution = "gentoo"}

--- a/packages/conf-libclang/conf-libclang.12/opam
+++ b/packages/conf-libclang/conf-libclang.12/opam
@@ -21,7 +21,7 @@ depexts: [
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
     {os-distribution = "centos"}
   ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
-    {os-distribution = "fedora"}
+    {os-family = "fedora"}
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
     {os-distribution = "ol" & os-version >= "8"}
   ["llvm-clang-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-libclang/conf-libclang.13/opam
+++ b/packages/conf-libclang/conf-libclang.13/opam
@@ -29,9 +29,9 @@ depexts: [
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
     {os-distribution = "centos"}
   ["clang13-devel" "llvm13-devel" "zlib-devel" "redhat-rpm-config"]
-    {os-distribution = "fedora" & os-version >= "36"}
+    {os-family = "fedora" & os-version >= "36"}
   ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
-    {os-distribution = "fedora" & os-version < "36"}
+    {os-family = "fedora" & os-version < "36"}
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
     {os-distribution = "ol" & os-version >= "8"}
   ["llvm-clang-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-libclang/conf-libclang.14/opam
+++ b/packages/conf-libclang/conf-libclang.14/opam
@@ -29,9 +29,9 @@ depexts: [
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
     {os-distribution = "centos"}
   ["clang14-devel" "llvm14-devel" "zlib-devel" "redhat-rpm-config"]
-    {os-distribution = "fedora" & os-version >= "37"}
+    {os-family = "fedora" & os-version >= "37"}
   ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
-    {os-distribution = "fedora" & os-version < "37"}
+    {os-family = "fedora" & os-version < "37"}
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
     {os-distribution = "ol" & os-version >= "8"}
   ["llvm-clang-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-libclang/conf-libclang.15/opam
+++ b/packages/conf-libclang/conf-libclang.15/opam
@@ -32,7 +32,7 @@ depexts: [
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
     {os-distribution = "centos"}
   ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
-    {os-distribution = "fedora"}
+    {os-family = "fedora"}
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
     {os-distribution = "ol" & os-version >= "8"}
   ["llvm-clang-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-libcorosync/conf-libcorosync.3/opam
+++ b/packages/conf-libcorosync/conf-libcorosync.3/opam
@@ -11,7 +11,7 @@ depexts: [
   ["libcpg-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libquorum-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libvotequorum-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["corosynclib-devel"] {os-distribution = "fedora"}
+  ["corosynclib-devel"] {os-family = "fedora"}
   ["lib64corosync-devel"] {os-distribution = "mageia"}
   ["libcorosync-devel"] {os-family = "suse"}
   ["corosync-devel"] {os-family = "opensuse"}

--- a/packages/conf-libcurl/conf-libcurl.1/opam
+++ b/packages/conf-libcurl/conf-libcurl.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["curl"] {os = "win32" & os-distribution = "cygwinports"}
   ["curl-dev"] {os-distribution = "alpine"}
   ["libcurl-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["libcurl-devel"] {os-distribution = "fedora"}
+  ["libcurl-devel"] {os-family = "fedora"}
   ["libcurl-devel"] {os-distribution = "ol"}
   ["curl"] {os-distribution = "homebrew" & os = "macos"}
   ["curl"] {os-distribution = "macports" & os = "macos"}

--- a/packages/conf-libcurl/conf-libcurl.2/opam
+++ b/packages/conf-libcurl/conf-libcurl.2/opam
@@ -17,7 +17,7 @@ depexts: [
   ["curl"] {os = "win32" & os-distribution = "cygwinports"}
   ["curl-dev"] {os-distribution = "alpine"}
   ["libcurl-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["libcurl-devel"] {os-distribution = "fedora"}
+  ["libcurl-devel"] {os-family = "fedora"}
   ["libcurl-devel"] {os-distribution = "ol"}
   ["curl"] {os-distribution = "homebrew" & os = "macos"}
   ["curl"] {os-distribution = "macports" & os = "macos"}

--- a/packages/conf-libdw/conf-libdw.1/opam
+++ b/packages/conf-libdw/conf-libdw.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libdw-dev" "zlib1g-dev" "liblzma-dev"] {os-family = "debian"}
   ["libdw-dev" "zlib1g-dev" "liblzma-dev"] {os-family = "ubuntu"}
   ["elfutils-devel"] {os-distribution = "centos"}
-  ["elfutils-devel"] {os-distribution = "fedora"}
+  ["elfutils-devel"] {os-family = "fedora"}
   ["elfutils-devel"] {os-distribution = "ol"}
   ["libdw-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["elfutils-dev"] {os-family = "alpine"}

--- a/packages/conf-libev/conf-libev.4-11/opam
+++ b/packages/conf-libev/conf-libev.4-11/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libev"] {os = "macos" & os-distribution = "homebrew"}
   ["libev-dev"] {os-distribution = "alpine"}
   ["libev"] {os-distribution = "arch"}
-  ["libev-devel"] {os-distribution = "fedora"}
+  ["libev-devel"] {os-family = "fedora"}
   ["libev-devel"] {os-distribution = "rhel"}
   ["libev-devel"] {os-distribution = "centos"}
   ["libev-devel"] {os-distribution = "ol" & os-version >= "8"}

--- a/packages/conf-libev/conf-libev.4-12/opam
+++ b/packages/conf-libev/conf-libev.4-12/opam
@@ -13,7 +13,7 @@ depexts: [
   ["libev"] {os = "macos" & os-distribution = "homebrew"}
   ["libev-dev"] {os-family = "alpine"}
   ["libev"] {os-family = "arch"}
-  ["libev-devel"] {os-distribution = "fedora"}
+  ["libev-devel"] {os-family = "fedora"}
   ["libev-devel"] {os-distribution = "rhel"}
   ["libev-devel"] {os-distribution = "centos"}
   ["libev-devel"] {os-distribution = "ol" & os-version >= "8"}

--- a/packages/conf-libevent/conf-libevent.1/opam
+++ b/packages/conf-libevent/conf-libevent.1/opam
@@ -28,7 +28,7 @@ depexts: [
   ["libevent-dev"] {os-family = "debian"}
   ["libevent-dev"] {os-family = "ubuntu"}
   ["libevent-dev"] {os-family = "alpine"}
-  ["libevent-devel"] {os-distribution = "fedora"}
+  ["libevent-devel"] {os-family = "fedora"}
   ["libevent-devel"] {os-distribution = "rhel"}
   ["libevent-devel"] {os-distribution = "centos"}
   ["libevent-devel"] {os-distribution = "ol" & os-version >= "8"}

--- a/packages/conf-libffi/conf-libffi.2.0.0/opam
+++ b/packages/conf-libffi/conf-libffi.2.0.0/opam
@@ -17,7 +17,7 @@ depexts: [
   ["libffi-dev"] {os-family = "debian"}
   ["libffi-dev"] {os-family = "ubuntu"}
   ["libffi-devel"] {os-distribution = "centos"}
-  ["libffi-devel"] {os-distribution = "fedora"}
+  ["libffi-devel"] {os-family = "fedora"}
   ["libffi-devel"] {os-distribution = "mageia"}
   ["libffi-devel"] {os-distribution = "ol"}
   ["libffi-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-libflac/conf-libflac.1/opam
+++ b/packages/conf-libflac/conf-libflac.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libflac-dev"] {os-family = "debian"}
   ["libflac-dev"] {os-family = "ubuntu"}
   ["flac-devel"] {os-distribution = "centos"}
-  ["flac-devel"] {os-distribution = "fedora"}
+  ["flac-devel"] {os-family = "fedora"}
   ["flac-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["flac-dev"] {os-distribution = "alpine"}
   ["flac"] {os-distribution = "nixos"}

--- a/packages/conf-libfuse/conf-libfuse.1/opam
+++ b/packages/conf-libfuse/conf-libfuse.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libfuse-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["fuse-dev"] {os-distribution = "alpine"}
   ["fuse-devel"] {os-distribution = "centos"}
-  ["fuse-devel"] {os-distribution = "fedora"}
+  ["fuse-devel"] {os-family = "fedora"}
   ["fuse-devel"] {os-distribution = "ol"}
   ["fuse-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["fuse2"] {os-family = "arch"}

--- a/packages/conf-libgccjit/conf-libgccjit.1/opam
+++ b/packages/conf-libgccjit/conf-libgccjit.1/opam
@@ -42,7 +42,7 @@ depexts: [
   ["libgccjit-13-dev"] {os-distribution = "linuxmint" & os-version >= "22"}
   ["libgccjit"] {os-family = "nixos"}
   ["libgccjit-devel"] {os-distribution = "centos"}
-  ["libgccjit-devel"] {os-distribution = "fedora"}
+  ["libgccjit-devel"] {os-family = "fedora"}
   ["libgccjit-devel"] {os-distribution = "ol" & os-version >= "9"}
   ["libgccjit"] {os-family = "arch"}
   ["libgccjit-dev"] {os-family = "alpine"}

--- a/packages/conf-libgl/conf-libgl.1/opam
+++ b/packages/conf-libgl/conf-libgl.1/opam
@@ -11,7 +11,7 @@ depends: [
 ]
 depexts: [
   ["mesa-common-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["mesa-libGL-devel"] {os-distribution = "fedora" | os-distribution = "ol"}
+  ["mesa-libGL-devel"] {os-family = "fedora" | os-distribution = "ol"}
   ["Mesa-libGL-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["mesa-dev"] {os-distribution = "alpine"}
   ["libgl"] {os-family = "arch"}

--- a/packages/conf-libglu/conf-libglu.1/opam
+++ b/packages/conf-libglu/conf-libglu.1/opam
@@ -12,7 +12,7 @@ depends: [
 ]
 depexts: [
   ["libglu1-mesa-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["mesa-libGLU-devel"] {os-distribution = "fedora" | os-distribution = "ol"}
+  ["mesa-libGLU-devel"] {os-family = "fedora" | os-distribution = "ol"}
   ["glu-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["glu"] {os-family = "arch"}
   ["glu-dev"] {os-distribution = "alpine"}

--- a/packages/conf-libgsasl/conf-libgsasl.1/opam
+++ b/packages/conf-libgsasl/conf-libgsasl.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libgsasl"] {os = "freebsd"}
   ["libgsasl-dev"] {os-distribution = "alpine"}
   ["libgsasl-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["libgsasl-devel"] {os-distribution = "fedora"}
+  ["libgsasl-devel"] {os-family = "fedora"}
   ["gsasl"] {os-distribution = "arch"}
 ]
 synopsis: "Virtual package relying on a GSASL lib system installation"

--- a/packages/conf-libjpeg/conf-libjpeg.1/opam
+++ b/packages/conf-libjpeg/conf-libjpeg.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["libjpeg-turbo"] {os-distribution = "arch"}
   ["libjpeg-dev"] {os-family = "debian"}
   ["libjpeg-dev"] {os-family = "ubuntu"}
-  ["libjpeg-turbo-devel"] {os-distribution = "fedora"}
+  ["libjpeg-turbo-devel"] {os-family = "fedora"}
   ["libjpeg-devel"] {os-family = "mageia"}
   ["jpeg-turbo"] {os = "macos" & os-distribution = "homebrew"}
   ["libjpeg8-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-liblinear-tools/conf-liblinear-tools.1.0.0/opam
+++ b/packages/conf-liblinear-tools/conf-liblinear-tools.1.0.0/opam
@@ -12,7 +12,7 @@ depends: ["conf-which" {build}]
 depexts: [
   ["liblinear-tools"] {os-family = "debian" | os-family = "ubuntu"}
   ["liblinear-cli"] {os-distribution = "centos"}
-  ["liblinear-cli"] {os-distribution = "fedora"}
+  ["liblinear-cli"] {os-family = "fedora"}
   ["liblinear"] {os-distribution = "nixos"}
   ["liblinear"] {os = "macos" & os-distribution = "homebrew"}
   ["liblinear"] {os = "freebsd"}

--- a/packages/conf-liblz4/conf-liblz4.1/opam
+++ b/packages/conf-liblz4/conf-liblz4.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["liblz4-dev"] {os-family = "ubuntu"}
   ["lz4-devel"] {os-distribution = "centos"}
   ["lz4-devel"] {os-distribution = "rhel"}
-  ["lz4-devel"] {os-distribution = "fedora"}
+  ["lz4-devel"] {os-family = "fedora"}
   ["lz4-devel"] {os-distribution = "ol"}
   ["lz4-dev"] {os-distribution = "alpine"}
   ["liblz4-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-liblzma/conf-liblzma.1/opam
+++ b/packages/conf-liblzma/conf-liblzma.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["liblzma-dev"] {os-family = "debian"}
   ["liblzma-dev"] {os-family = "ubuntu"}
   ["xz-dev"] {os-family = "alpine"}
-  ["xz-devel"] {os-distribution = "fedora"}
+  ["xz-devel"] {os-family = "fedora"}
   ["xz-devel"] {os-distribution = "rhel"}
   ["xz-devel"] {os-distribution = "centos"}
   ["xz-devel"] {os-distribution = "ol"}

--- a/packages/conf-libmagic/conf-libmagic.1/opam
+++ b/packages/conf-libmagic/conf-libmagic.1/opam
@@ -7,7 +7,7 @@ depexts: [
   ["file"] {os-distribution = "arch"}
   ["file-dev"] {os-distribution = "alpine"}
   ["file-devel"] {os-distribution = "centos"}
-  ["file-devel"] {os-distribution = "fedora"}
+  ["file-devel"] {os-family = "fedora"}
   ["file-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libmagic-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libmagic"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-libmaxminddb/conf-libmaxminddb.1/opam
+++ b/packages/conf-libmaxminddb/conf-libmaxminddb.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["net/libmaxminddb"] {os = "freebsd"}
   ["libmaxminddb"] {os-distribution = "homebrew" & os = "macos"}
   ["libmaxminddb-dev"] {os-distribution = "alpine"}
-  ["libmaxminddb-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "mageia"}
+  ["libmaxminddb-devel"] {os-distribution = "centos" | os-family = "fedora" | os-distribution = "mageia"}
   ["libmaxminddb-devel"] {os-family = "suse" | os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on a libmaxminddb system installation"

--- a/packages/conf-libmosquitto/conf-libmosquitto.1/opam
+++ b/packages/conf-libmosquitto/conf-libmosquitto.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["libmosquitto-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["mosquitto-dev"] {os-distribution = "alpine"}
   ["mosquitto-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["mosquitto-devel"] {os-distribution = "fedora"}
+  ["mosquitto-devel"] {os-family = "fedora"}
   ["mosquitto"] {os = "macos" & os-distribution = "homebrew"}
   ["mosquitto"] {os = "freebsd"}
 ]

--- a/packages/conf-libnl3/conf-libnl3.1/opam
+++ b/packages/conf-libnl3/conf-libnl3.1/opam
@@ -11,7 +11,7 @@ depends: ["conf-pkg-config"]
 depexts: [
   ["libnl-3-dev" "libnl-route-3-dev"] {os-family = "debian"}
   ["libnl-3-dev" "libnl-route-3-dev"] {os-family = "ubuntu"}
-  ["libnl3" "libnl3-devel"] {os-distribution = "centos" | os-distribution = "fedora"}
+  ["libnl3" "libnl3-devel"] {os-distribution = "centos" | os-family = "fedora"}
   ["libnl3" "libnl3-devel"] {os-distribution = "ol" & os-version >= "8"}
   ["libnl3-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libnl"] {os-family = "arch"}

--- a/packages/conf-libobjc2/conf-libobjc2.1/opam
+++ b/packages/conf-libobjc2/conf-libobjc2.1/opam
@@ -5,14 +5,14 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "The GNUstep devs"
 license: "MIT"
 build: [
-  ["rpm" "-q" "libobjc2-devel"] {os-distribution = "fedora" | os-family = "opensuse"}
+  ["rpm" "-q" "libobjc2-devel"] {os-family = "fedora" | os-family = "opensuse"}
   ["pkg" "info" "libobjc2"] {os = "freebsd"}
 ]
 depexts: [
-  ["libobjc2-devel"] {os-distribution = "fedora" | os-family = "opensuse"}
+  ["libobjc2-devel"] {os-family = "fedora" | os-family = "opensuse"}
   ["libobjc2"] {os = "freebsd"}
 ]
-available: os = "freebsd" | os-distribution = "fedora" | os-family = "opensuse"
+available: os = "freebsd" | os-family = "fedora" | os-family = "opensuse"
 synopsis: "Virtual package relying on libobjc2 lib system installation"
 description:
   "This package can only install if the libobjc2 lib is installed on the system."

--- a/packages/conf-libogg/conf-libogg.1/opam
+++ b/packages/conf-libogg/conf-libogg.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["libogg-dev"] {os-family = "debian"}
   ["libogg-dev"] {os-family = "ubuntu"}
   ["libogg-devel"] {os-distribution = "centos"}
-  ["libogg-devel"] {os-distribution = "fedora"}
+  ["libogg-devel"] {os-family = "fedora"}
   ["libogg-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libogg"] {os-distribution = "nixos"}
   ["libogg"] {os-family = "bsd"}

--- a/packages/conf-libpcre/conf-libpcre.1/opam
+++ b/packages/conf-libpcre/conf-libpcre.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["libpcre3-dev"] {os-family = "ubuntu"}
   ["libpcre-devel"] {os-distribution = "mageia"}
   ["pcre-devel"] {os-distribution = "centos"}
-  ["pcre-devel"] {os-distribution = "fedora"}
+  ["pcre-devel"] {os-family = "fedora"}
   ["pcre-devel"] {os-distribution = "rhel"}
   ["pcre-devel"] {os-distribution = "ol"}
   ["pcre-dev"] {os-distribution = "alpine"}

--- a/packages/conf-libpcre/conf-libpcre.2/opam
+++ b/packages/conf-libpcre/conf-libpcre.2/opam
@@ -24,7 +24,7 @@ depexts: [
   ["libpcre3-dev"] {os-family = "ubuntu"}
   ["libpcre-devel"] {os-distribution = "mageia"}
   ["pcre-devel"] {os-distribution = "centos"}
-  ["pcre-devel"] {os-distribution = "fedora"}
+  ["pcre-devel"] {os-family = "fedora"}
   ["pcre-devel"] {os-distribution = "rhel"}
   ["pcre-devel"] {os-distribution = "ol"}
   ["pcre-dev"] {os-distribution = "alpine"}

--- a/packages/conf-libpcre2-8/conf-libpcre2-8.1/opam
+++ b/packages/conf-libpcre2-8/conf-libpcre2-8.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["libpcre2-dev"] {os-family = "ubuntu"}
   ["libpcre2-devel"] {os-distribution = "mageia"}
   ["pcre2-devel"] {os-distribution = "centos"}
-  ["pcre2-devel"] {os-distribution = "fedora"}
+  ["pcre2-devel"] {os-family = "fedora"}
   ["pcre2-devel"] {os-distribution = "rhel"}
   ["pcre2-devel"] {os-distribution = "ol"}
   ["pcre2-dev"] {os-distribution = "alpine"}

--- a/packages/conf-libpcre2-8/conf-libpcre2-8.2/opam
+++ b/packages/conf-libpcre2-8/conf-libpcre2-8.2/opam
@@ -27,7 +27,7 @@ depexts: [
   ["libpcre2-dev"] {os-family = "ubuntu"}
   ["libpcre2-devel"] {os-distribution = "mageia"}
   ["pcre2-devel"] {os-distribution = "centos"}
-  ["pcre2-devel"] {os-distribution = "fedora"}
+  ["pcre2-devel"] {os-family = "fedora"}
   ["pcre2-devel"] {os-distribution = "rhel"}
   ["pcre2-devel"] {os-distribution = "ol"}
   ["pcre2-dev"] {os-distribution = "alpine"}

--- a/packages/conf-librsvg2/conf-librsvg2.0/opam
+++ b/packages/conf-librsvg2/conf-librsvg2.0/opam
@@ -11,7 +11,7 @@ depexts: [
   ["librsvg"] {os-distribution = "arch"}
   ["epel-release" "librsvg2-devel"] {os-distribution = "centos"}
   ["librsvg2-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["librsvg2-devel"] {os-distribution = "fedora"}
+  ["librsvg2-devel"] {os-family = "fedora"}
   ["librsvg2-devel"] {os-distribution = "ol"}
   ["librsvg2"] {os = "freebsd"}
   ["libsrvg2"] {os = "openbsd"}

--- a/packages/conf-libseccomp/conf-libseccomp.1/opam
+++ b/packages/conf-libseccomp/conf-libseccomp.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["libseccomp-dev"] {os-family = "alpine"}
   ["libseccomp-dev"] {os-family = "debian"}
   ["libseccomp-dev"] {os-family = "ubuntu"}
-  ["libseccomp-devel"] {os-distribution = "fedora"}
+  ["libseccomp-devel"] {os-family = "fedora"}
   ["libseccomp-devel"] {os-distribution = "rhel"}
   ["libseccomp-devel"] {os-distribution = "centos"}
   ["libseccomp-devel"] {os-distribution = "ol" & os-version >= "8"}

--- a/packages/conf-libsodium/conf-libsodium.1/opam
+++ b/packages/conf-libsodium/conf-libsodium.1/opam
@@ -27,7 +27,7 @@ depexts: [
   ["libsodium"] {os-distribution = "homebrew" & os = "macos"}
   ["libsodium"] {os-distribution = "arch"}
   ["libsodium-dev"] {os-distribution = "alpine"}
-  ["libsodium-devel"] {os-distribution = "fedora"}
+  ["libsodium-devel"] {os-family = "fedora"}
   ["libsodium"] {os-family = "suse" | os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on a libsodium system installation"

--- a/packages/conf-libspeex/conf-libspeex.1/opam
+++ b/packages/conf-libspeex/conf-libspeex.1/opam
@@ -11,7 +11,7 @@ depends: [
 depexts: [
   ["speex-dev"] {os-distribution = "alpine"}
   ["speex-devel"] {os-distribution = "centos"}
-  ["speex-devel"] {os-distribution = "fedora"}
+  ["speex-devel"] {os-family = "fedora"}
   ["speex-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libspeex-dev"] {os-family = "debian"}
   ["libspeex-dev"] {os-family = "ubuntu"}

--- a/packages/conf-libssl/conf-libssl.1/opam
+++ b/packages/conf-libssl/conf-libssl.1/opam
@@ -17,7 +17,7 @@ depexts: [
   ["libssl-dev"] {os-family = "debian"}
   ["openssl-devel"] {os-distribution = "centos"}
   ["openssl-devel"] {os-distribution = "ol"}
-  ["openssl-devel"] {os-distribution = "fedora"}
+  ["openssl-devel"] {os-family = "fedora"}
   ["openssl"] {os = "macos" & os-distribution = "homebrew"}
   ["openssl"] {os = "macos" & os-distribution = "macports"}
   ["openssl-dev"] {os-distribution = "alpine"}

--- a/packages/conf-libssl/conf-libssl.2/opam
+++ b/packages/conf-libssl/conf-libssl.2/opam
@@ -18,7 +18,7 @@ depexts: [
   ["libssl-dev"] {os-family = "debian"}
   ["openssl-devel"] {os-distribution = "centos"}
   ["openssl-devel"] {os-distribution = "ol"}
-  ["openssl-devel"] {os-distribution = "fedora"}
+  ["openssl-devel"] {os-family = "fedora"}
   ["openssl"] {os = "macos" & os-distribution = "homebrew"}
   ["openssl"] {os = "macos" & os-distribution = "macports"}
   ["openssl-dev"] {os-distribution = "alpine"}

--- a/packages/conf-libssl/conf-libssl.3/opam
+++ b/packages/conf-libssl/conf-libssl.3/opam
@@ -24,7 +24,7 @@ depexts: [
   ["libssl-dev"] {os-family = "ubuntu"}
   ["openssl-devel"] {os-distribution = "centos"}
   ["openssl-devel"] {os-distribution = "ol"}
-  ["openssl-devel"] {os-distribution = "fedora"}
+  ["openssl-devel"] {os-family = "fedora"}
   ["libopenssl-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["openssl-dev"] {os-family = "alpine"}
   ["openssl"] {os-family = "arch"}

--- a/packages/conf-libssl/conf-libssl.4/opam
+++ b/packages/conf-libssl/conf-libssl.4/opam
@@ -30,7 +30,7 @@ depexts: [
   ["libssl-dev"] {os-family = "ubuntu"}
   ["openssl-devel"] {os-distribution = "centos"}
   ["openssl-devel"] {os-distribution = "ol"}
-  ["openssl-devel"] {os-distribution = "fedora" | os-family = "fedora"}
+  ["openssl-devel"] {os-family = "fedora" | os-family = "fedora"}
   ["libopenssl-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["openssl-dev"] {os-family = "alpine"}
   ["openssl"] {os-family = "arch"}

--- a/packages/conf-libsvm-tools/conf-libsvm-tools.1.0.0/opam
+++ b/packages/conf-libsvm-tools/conf-libsvm-tools.1.0.0/opam
@@ -11,8 +11,8 @@ build: [
 ]
 depexts: [
   ["libsvm-tools"] {os-family = "debian" | os-family = "ubuntu"}
-  ["libsvm"] {os-distribution = "fedora" & os-version >= "38"}
-  ["libsvm-tools"] {os-distribution = "fedora" & os-version < "38"}
+  ["libsvm"] {os-family = "fedora" & os-version >= "38"}
+  ["libsvm-tools"] {os-family = "fedora" & os-version < "38"}
   ["libsvm-tools"] {os-distribution = "centos"}
   ["sci-libs/libsvm"] {os-distribution = "gentoo"}
   ["libsvm"] {os-distribution = "arch"}

--- a/packages/conf-libsvm/conf-libsvm.3/opam
+++ b/packages/conf-libsvm/conf-libsvm.3/opam
@@ -13,7 +13,7 @@ depexts: [
   ["libsvm-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libsvm"] {os-distribution = "arch"}
   ["sci-libs/libsvm"] {os-distribution = "gentoo"}
-  ["libsvm-devel"] {os-distribution = "fedora"}
+  ["libsvm-devel"] {os-family = "fedora"}
   ["libsvm-devel"] {os-distribution = "centos"}
   ["libsvm-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libsvm"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-libtool/conf-libtool.1/opam
+++ b/packages/conf-libtool/conf-libtool.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libtool"] {os-family = "debian"}
   ["libtool"] {os-family = "ubuntu"}
   ["libtool"] {os-distribution = "centos"}
-  ["libtool"] {os-distribution = "fedora"}
+  ["libtool"] {os-family = "fedora"}
   ["libtool"] {os-distribution = "arch"}
   ["sys-devel/libtool"] {os-distribution = "gentoo"}
   ["libtool"] {os-distribution = "nixos"}

--- a/packages/conf-libudev/conf-libudev.1/opam
+++ b/packages/conf-libudev/conf-libudev.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["libudev-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["eudev-dev"] {os-distribution = "alpine"}
   ["systemd-devel"] {os-distribution = "centos"}
-  ["systemd-devel"] {os-distribution = "fedora"}
+  ["systemd-devel"] {os-family = "fedora"}
   ["systemd-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["systemd-devel"] {os-distribution = "ol"}
 ]

--- a/packages/conf-liburing/conf-liburing.0.1.0/opam
+++ b/packages/conf-liburing/conf-liburing.0.1.0/opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/koonwen/uring-trace.git"
 depexts: [
   ["liburing-dev"]   { os-distribution = "ubuntu" }
   ["liburing-dev"]   { os-distribution = "debian" }
-  ["liburing-devel"] { os-distribution = "fedora" }
+  ["liburing-devel"] { os-family = "fedora" }
 ]
 flags: conf
 x-commit-hash: "732869041422ada630d065f937ba210c20b8bf5c"

--- a/packages/conf-libuv/conf-libuv.1/opam
+++ b/packages/conf-libuv/conf-libuv.1/opam
@@ -16,7 +16,7 @@ depexts: [
   ["libuv-dev"] {os-distribution = "alpine"}
   ["libuv-devel"] {os-distribution = "centos"}
   ["libuv-devel"] {os-distribution = "rhel"}
-  ["libuv-devel"] {os-distribution = "fedora"}
+  ["libuv-devel"] {os-family = "fedora"}
   ["libuv"] {os-family = "suse" | os-family = "opensuse"}
   ["libuv"] {os-distribution = "arch"}
 ]

--- a/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
+++ b/packages/conf-linux-libc-dev/conf-linux-libc-dev.0/opam
@@ -12,7 +12,7 @@ depexts: [
   ["linux-libc-dev"] {os-family = "debian"}
   ["linux-libc-dev"] {os-family = "ubuntu"}
   ["linux-glibc-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["kernel-headers"] {os-distribution = "fedora" | os-distribution = "rhel" | os-distribution = "centos" | os-distribution = "ol"}
+  ["kernel-headers"] {os-family = "fedora" | os-distribution = "rhel" | os-distribution = "centos" | os-distribution = "ol"}
   ["linux-headers"] {os-family = "alpine"}
   ["linux-api-headers"] {os-family = "arch"}
 ]

--- a/packages/conf-lld/conf-lld.1/opam
+++ b/packages/conf-lld/conf-lld.1/opam
@@ -18,7 +18,7 @@ depexts: [
   ["lld"] { os-family = "ubuntu" }
 
   ["lld"] { os-distribution = "centos" }
-  ["lld"] { os-distribution = "fedora" }
+  ["lld"] { os-family = "fedora" }
   ["llvm" "lld"] { os-distribution = "homebrew" }
 ]
 x-ci-accept-failures: [

--- a/packages/conf-llvm-shared/conf-llvm-shared.18/opam
+++ b/packages/conf-llvm-shared/conf-llvm-shared.18/opam
@@ -17,8 +17,8 @@ depexts: [
   ["llvm18-dev"] {os-distribution = "alpine"}
   ["llvm18"] {os-family = "arch"}
   ["llvm18-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm18-devel"] {os-distribution = "fedora" & os-version >= "41"}
-  ["llvm-devel"] {os-distribution = "fedora" & os-version = "40"}
+  ["llvm18-devel"] {os-family = "fedora" & os-version >= "41"}
+  ["llvm-devel"] {os-family = "fedora" & os-version = "40"}
   ["llvm18-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm18"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm-static/conf-llvm-static.18/opam
+++ b/packages/conf-llvm-static/conf-llvm-static.18/opam
@@ -17,8 +17,8 @@ depexts: [
   ["llvm18-dev"] {os-distribution = "alpine"}
   ["llvm18"] {os-family = "arch"}
   ["llvm18-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm18-devel"] {os-distribution = "fedora" & os-version >= "41"}
-  ["llvm-devel"] {os-distribution = "fedora" & os-version = "40"}
+  ["llvm18-devel"] {os-family = "fedora" & os-version >= "41"}
+  ["llvm-devel"] {os-family = "fedora" & os-version = "40"}
   ["llvm18-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm18"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.10.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.10.0.0/opam
@@ -16,7 +16,7 @@ depexts: [
   ["llvm-10-dev"] {os-family = "debian"}
   ["llvm10-dev"] {os-distribution = "alpine"}
   ["llvm10-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm10-devel"] {os-distribution = "fedora"}
+  ["llvm10-devel"] {os-family = "fedora"}
   ["llvm10-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm10"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.11.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.11.0.0/opam
@@ -16,7 +16,7 @@ depexts: [
   ["llvm-11-dev"] {os-family = "debian"}
   ["llvm11-dev"] {os-distribution = "alpine"}
   ["llvm11-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm11-devel"] {os-distribution = "fedora"}
+  ["llvm11-devel"] {os-family = "fedora"}
   ["llvm11-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm11"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.12.0.1/opam
+++ b/packages/conf-llvm/conf-llvm.12.0.1/opam
@@ -16,7 +16,7 @@ depexts: [
   ["llvm-12-dev"] {os-family = "debian"}
   ["llvm12-dev"] {os-distribution = "alpine"}
   ["llvm12-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm12-devel"] {os-distribution = "fedora"}
+  ["llvm12-devel"] {os-family = "fedora"}
   ["llvm12-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm12"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.13.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.13.0.0/opam
@@ -16,7 +16,7 @@ depexts: [
   ["llvm-13-dev"] {os-family = "debian"}
   ["llvm13-dev"] {os-distribution = "alpine"}
   ["llvm13-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm13-devel"] {os-distribution = "fedora"}
+  ["llvm13-devel"] {os-family = "fedora"}
   ["llvm13-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm13"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.14.0.6/opam
+++ b/packages/conf-llvm/conf-llvm.14.0.6/opam
@@ -17,7 +17,7 @@ depexts: [
   ["llvm14-dev"] {os-distribution = "alpine"}
   ["llvm14"] {os-family = "arch"}
   ["llvm14-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm14-devel"] {os-distribution = "fedora"}
+  ["llvm14-devel"] {os-family = "fedora"}
   ["llvm14-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm14"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.15/opam
+++ b/packages/conf-llvm/conf-llvm.15/opam
@@ -17,7 +17,7 @@ depexts: [
   ["llvm15-dev"] {os-distribution = "alpine"}
   ["llvm15"] {os-family = "arch"}
   ["llvm15-devel"] {os-family = "suse"}
-  ["llvm15-devel"] {os-distribution = "fedora"}
+  ["llvm15-devel"] {os-family = "fedora"}
   ["llvm15-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm15"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.16/opam
+++ b/packages/conf-llvm/conf-llvm.16/opam
@@ -17,8 +17,8 @@ depexts: [
   ["llvm16-dev"] {os-distribution = "alpine"}
   ["llvm16"] {os-family = "arch"}
   ["llvm16-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm16-devel"] {os-distribution = "fedora" & os-version >= "39"}
-  ["llvm-devel"] {os-distribution = "fedora" & os-version = "38"}
+  ["llvm16-devel"] {os-family = "fedora" & os-version >= "39"}
+  ["llvm-devel"] {os-family = "fedora" & os-version = "38"}
   ["llvm16-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm16"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.17/opam
+++ b/packages/conf-llvm/conf-llvm.17/opam
@@ -17,8 +17,8 @@ depexts: [
   ["llvm17-dev"] {os-distribution = "alpine"}
   ["llvm17"] {os-family = "arch"}
   ["llvm17-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm17-devel"] {os-distribution = "fedora" & os-version >= "39"}
-  ["llvm-devel"] {os-distribution = "fedora" & os-version = "38"}
+  ["llvm17-devel"] {os-family = "fedora" & os-version >= "39"}
+  ["llvm-devel"] {os-family = "fedora" & os-version = "38"}
   ["llvm17-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm17"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.3.9/opam
+++ b/packages/conf-llvm/conf-llvm.3.9/opam
@@ -14,7 +14,7 @@ depexts: [
   ["llvm@3.9"] {os-distribution = "homebrew" & os = "macos"}
   ["llvm-3.9"] {os-distribution = "macports" & os = "macos"}
   ["llvm-3.9-dev"] {os-family = "debian"}
-  ["llvm3.9-devel"] {os-distribution = "fedora"}
+  ["llvm3.9-devel"] {os-family = "fedora"}
   ["llvm3.9-dev"] {os-distribution = "alpine"}
   ["devel/llvm39"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.4.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.4.0.0/opam
@@ -16,7 +16,7 @@ depexts: [
   ["llvm-4.0-dev"] {os-family = "debian"}
   ["llvm4-dev"] {os-distribution = "alpine"}
   ["llvm4"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm4.0-devel"] {os-distribution = "fedora"}
+  ["llvm4.0-devel"] {os-family = "fedora"}
   ["llvm4.0-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm40"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.5.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.5.0.0/opam
@@ -16,7 +16,7 @@ depexts: [
   ["llvm-5.0-dev"] {os-family = "debian"}
   ["llvm5-dev"] {os-distribution = "alpine"}
   ["llvm5-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm5.0-devel"] {os-distribution = "fedora"}
+  ["llvm5.0-devel"] {os-family = "fedora"}
   ["llvm5.0-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm50"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.6.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.6.0.0/opam
@@ -16,7 +16,7 @@ depexts: [
   ["llvm-6.0-dev"] {os-family = "debian"}
   ["llvm6-dev"] {os-distribution = "alpine"}
   ["llvm6-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm6.0-devel"] {os-distribution = "fedora"}
+  ["llvm6.0-devel"] {os-family = "fedora"}
   ["llvm6.0-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm60"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.7.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.7.0.0/opam
@@ -16,7 +16,7 @@ depexts: [
   ["llvm-7-dev"] {os-family = "debian"}
   ["llvm7-dev"] {os-distribution = "alpine"}
   ["llvm7-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm7.0-devel"] {os-distribution = "fedora"}
+  ["llvm7.0-devel"] {os-family = "fedora"}
   ["llvm7.0-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm70"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.8.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.8.0.0/opam
@@ -16,7 +16,7 @@ depexts: [
   ["llvm-8-dev"] {os-family = "debian"}
   ["llvm8-dev"] {os-distribution = "alpine"}
   ["llvm8-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm8.0-devel"] {os-distribution = "fedora"}
+  ["llvm8.0-devel"] {os-family = "fedora"}
   ["llvm8.0-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm80"] {os = "freebsd"}
 ]

--- a/packages/conf-llvm/conf-llvm.9.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.9.0.0/opam
@@ -16,7 +16,7 @@ depexts: [
   ["llvm-9-dev"] {os-family = "debian"}
   ["llvm9-dev"] {os-distribution = "alpine"}
   ["llvm9-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["llvm9.0-devel"] {os-distribution = "fedora"}
+  ["llvm9.0-devel"] {os-family = "fedora"}
   ["llvm9.0-devel" "epel-release"] {os-distribution = "centos"}
   ["devel/llvm90"] {os = "freebsd"}
 ]

--- a/packages/conf-lz4/conf-lz4.1.0.0/opam
+++ b/packages/conf-lz4/conf-lz4.1.0.0/opam
@@ -11,7 +11,7 @@ depexts: [
   ["lz4"] {os-distribution = "centos"}
   ["lz4"] {os-distribution = "ol"}
   ["lz4"] {os-distribution = "rhel"}
-  ["lz4"] {os-distribution = "fedora"}
+  ["lz4"] {os-family = "fedora"}
   ["lz4"] {os-family = "alpine"}
   ["lz4"] {os-family = "suse" | os-family = "opensuse"}
   ["lz4"] {os-family = "arch"}

--- a/packages/conf-m4/conf-m4.1/opam
+++ b/packages/conf-m4/conf-m4.1/opam
@@ -14,7 +14,7 @@ install: [
 depexts: [
   ["m4"] {os-family = "debian"}
   ["m4"] {os-family = "ubuntu"}
-  ["m4"] {os-distribution = "fedora"}
+  ["m4"] {os-family = "fedora"}
   ["m4"] {os-distribution = "rhel"}
   ["m4"] {os-distribution = "centos"}
   ["m4"] {os-distribution = "alpine"}

--- a/packages/conf-mad/conf-mad.1/opam
+++ b/packages/conf-mad/conf-mad.1/opam
@@ -14,7 +14,7 @@ depends: [
 depexts: [
   ["libmad-dev"] {os-distribution = "alpine"}
   ["libmad"] {os-distribution = "archlinux" | os-distribution = "nixos"}
-  ["libmad-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["libmad-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["libmad0-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libmad"] {os = "win32" & os-distribution = "cygwinports"}
   ["mad"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-mad/conf-mad.2/opam
+++ b/packages/conf-mad/conf-mad.2/opam
@@ -13,7 +13,7 @@ depends: [
 depexts: [
   ["libmad-dev"] {os-distribution = "alpine"}
   ["libmad"] {os-distribution = "arch" | os-distribution = "nixos"}
-  ["libmad-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["libmad-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["libmad0-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libmad"] {os = "win32" & os-distribution = "cygwinports"}
   ["mad"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-mariadb/conf-mariadb.2/opam
+++ b/packages/conf-mariadb/conf-mariadb.2/opam
@@ -19,7 +19,7 @@ depexts: [
   ["libmariadbclient-dev"] {os-distribution = "ubuntu" & os-version >= "18.04" & os-version < "19.04"}
   ["mariadb-connector-c-dev"] {os-family = "alpine"}
   ["mariadb-connector-c-devel"] {os-distribution = "centos" & os-version >= "8"}
-  ["mariadb-connector-c-devel"] {os-distribution = "fedora"}
+  ["mariadb-connector-c-devel"] {os-family = "fedora"}
   ["mariadb-connector-c-devel"] {os-distribution = "ol" & os-version >= "8"}
   ["libmariadb-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["mariadb-libs"] {os-family = "arch"}

--- a/packages/conf-mbedtls/conf-mbedtls.1/opam
+++ b/packages/conf-mbedtls/conf-mbedtls.1/opam
@@ -11,7 +11,7 @@ build: [
 depexts: [
   ["mbedtls-dev"] {os-distribution = "alpine"}
   ["libmbedtls-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["mbedtls-devel"] {os-distribution = "fedora"}
+  ["mbedtls-devel"] {os-family = "fedora"}
   ["mbedtls-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["mbedtls-devel" "epel-release"] {os-distribution = "centos"}
   ["mbedtls"] {os-distribution = "nixos"}

--- a/packages/conf-mbedtls/conf-mbedtls.2/opam
+++ b/packages/conf-mbedtls/conf-mbedtls.2/opam
@@ -16,7 +16,7 @@ depends: [
 depexts: [
   ["mbedtls-dev"] {os-distribution = "alpine"}
   ["libmbedtls-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["mbedtls-devel"] {os-distribution = "fedora"}
+  ["mbedtls-devel"] {os-family = "fedora"}
   ["mbedtls-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["mbedtls-devel" "epel-release"] {os-distribution = "centos"}
   ["mbedtls"] {os-distribution = "nixos"}

--- a/packages/conf-mecab/conf-mecab.0.996/opam
+++ b/packages/conf-mecab/conf-mecab.0.996/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depexts: [
   ["mecab" "libmecab-dev"] {os-family = "debian"}
-  ["mecab" "mecab-devel"] {os-distribution = "fedora"}
+  ["mecab" "mecab-devel"] {os-family = "fedora"}
   ["mecab"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on MeCab library installation"

--- a/packages/conf-mpfr-paths/conf-mpfr-paths.1/opam
+++ b/packages/conf-mpfr-paths/conf-mpfr-paths.1/opam
@@ -29,7 +29,7 @@ post-messages: [
 depexts: [
   ["libmpfr-dev"] {os-family = "debian"}
   ["libmpfr-dev"] {os-family = "ubuntu"}
-  ["mpfr-devel"] {os-distribution = "fedora"}
+  ["mpfr-devel"] {os-family = "fedora"}
   ["mpfr-devel"] {os-distribution = "ol"}
   ["mpfr-devel"] {os-distribution = "centos"}
   ["mpfr"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-mpfr/conf-mpfr.1/opam
+++ b/packages/conf-mpfr/conf-mpfr.1/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depexts: [
   ["libmpfr-dev"] {os-family = "debian"}
-  ["mpfr-devel"] {os-distribution = "fedora"}
+  ["mpfr-devel"] {os-family = "fedora"}
   ["mpfr"] {os = "macos" & os-distribution = "homebrew"}
   ["mpfr"] {os = "freebsd"}
   ["mpfr"] {os = "openbsd"}

--- a/packages/conf-mpfr/conf-mpfr.2/opam
+++ b/packages/conf-mpfr/conf-mpfr.2/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depexts: [
   ["libmpfr-dev"] {os-family = "debian"}
-  ["mpfr-devel"] {os-distribution = "fedora"}
+  ["mpfr-devel"] {os-family = "fedora"}
   ["mpfr-devel"] {os-distribution = "ol"}
   ["mpfr"] {os = "macos" & os-distribution = "homebrew"}
   ["mpfr"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-mpfr/conf-mpfr.3/opam
+++ b/packages/conf-mpfr/conf-mpfr.3/opam
@@ -14,7 +14,7 @@ depends: [
 depexts: [
   ["libmpfr-dev"] {os-family = "debian"}
   ["libmpfr-dev"] {os-family = "ubuntu"}
-  ["mpfr-devel"] {os-distribution = "fedora"}
+  ["mpfr-devel"] {os-family = "fedora"}
   ["mpfr-devel"] {os-distribution = "ol"}
   ["mpfr-devel"] {os-distribution = "centos"}
   ["mpfr"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-mpi/conf-mpi.1/opam
+++ b/packages/conf-mpi/conf-mpi.1/opam
@@ -9,7 +9,7 @@ depexts: [
   ["mpi-default-dev"] {os-family = "debian"}
   ["mpi-default-dev"] {os-family = "ubuntu"}
   ["openmpi-devel"] {os-distribution = "centos"}
-  ["openmpi-devel"] {os-distribution = "fedora"}
+  ["openmpi-devel"] {os-family = "fedora"}
   ["openmpi"] {os-family = "suse" | os-family = "opensuse"}
   ["openmpi"] {os-distribution = "arch"}
   ["openmpi-dev"] {os-distribution = "alpine"}

--- a/packages/conf-mysql/conf-mysql.1/opam
+++ b/packages/conf-mysql/conf-mysql.1/opam
@@ -10,7 +10,7 @@ depexts: [
   ["libmysqlclient-dev"] {os-distribution = "ubuntu" | (os-distribution = "debian" & os-version < "9")}
   ["default-libmysqlclient-dev"] {os-family = "debian" & ! (os-distribution = "ubuntu" | (os-distribution = "debian" & os-version < "9"))}
   ["default-libmysqlclient-dev"] {os-family = "ubuntu"}
-  ["community-mysql-devel"] {os-distribution = "fedora"}
+  ["community-mysql-devel"] {os-family = "fedora"}
   ["libmysqld-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["mysql-devel"] {os-distribution = "centos"}
   ["mysql"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-nanomsg/conf-nanomsg.0/opam
+++ b/packages/conf-nanomsg/conf-nanomsg.0/opam
@@ -8,7 +8,7 @@ depexts: [
   ["libnanomsg-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["nanomsg-dev"] {os-distribution = "alpine"}
   ["nanomsg"] {os-distribution = "arch"}
-  ["nanomsg-devel"] {os-distribution = "fedora"}
+  ["nanomsg-devel"] {os-family = "fedora"}
   ["nanomsg-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["nanomsg"] {os = "macos" & os-distribution = "homebrew"}
   ["nanomsg"] {os = "freebsd"}

--- a/packages/conf-nauty/conf-nauty.1.0/opam
+++ b/packages/conf-nauty/conf-nauty.1.0/opam
@@ -11,7 +11,7 @@ depends: [
 depexts: [
   ["nauty-dev"] {os-distribution = "alpine"}
   ["libnauty2-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["libnauty-devel"] {os-distribution = "fedora"}
+  ["libnauty-devel"] {os-family = "fedora"}
   ["nauty-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["nauty"] {os = "macos" & os-distribution = "homebrew"}
   ["nauty"] {os = "freebsd"}

--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -29,7 +29,7 @@ depexts: [
   ["lib64ncurses-dev"] {os-family = "ubuntu"}
   ["ncurses"] {os-distribution = "nixos"}
   ["ncurses-dev"] {os-distribution = "alpine"}
-  ["ncurses-devel"] {os-distribution = "fedora"}
+  ["ncurses-devel"] {os-family = "fedora"}
   ["ncurses-devel"] {os-distribution = "ol"}
   ["ncurses-devel"] {os-distribution = "centos"}
   ["ncurses-devel"] {os-distribution = "rhel"}

--- a/packages/conf-neko/conf-neko.1/opam
+++ b/packages/conf-neko/conf-neko.1/opam
@@ -8,7 +8,7 @@ depexts: [
   ["neko-dev"] {os-distribution = "alpine"}
   ["neko" "neko-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["neko"] {os-family = "suse" | os-family = "opensuse"}
-  ["nekovm-devel"] {os-distribution = "fedora"}
+  ["nekovm-devel"] {os-family = "fedora"}
   ["neko"] {os-distribution = "nixos"}
   ["neko"] {os-distribution = "homebrew" & os = "macos"}
   ["neko"] {os-distribution = "arch"}

--- a/packages/conf-netsnmp/conf-netsnmp.1.0.0/opam
+++ b/packages/conf-netsnmp/conf-netsnmp.1.0.0/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://www.github.com/stevebleazard/ocaml-conf-netsnmp.git"
 depexts: [
   ["libsnmp-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["net-snmp-libs" "net-snmp-devel"] {os-distribution = "centos"}
-  ["net-snmp-libs" "net-snmp-devel"] {os-distribution = "fedora"}
+  ["net-snmp-libs" "net-snmp-devel"] {os-family = "fedora"}
   ["libsnmp30" "net-snmp-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["net-snmp-libs" "net-snmp-dev"] {os-distribution = "alpine"}
   ["net-snmp"] {os-family = "arch"}

--- a/packages/conf-nlopt/conf-nlopt.1/opam
+++ b/packages/conf-nlopt/conf-nlopt.1/opam
@@ -11,7 +11,7 @@ depends: [
 depexts: [
   ["libnlopt-dev"] {os-family = "debian"}
   ["libnlopt-dev"] {os-family = "ubuntu"}
-  ["NLopt-devel"] {os-distribution = "fedora"}
+  ["NLopt-devel"] {os-family = "fedora"}
   ["NLopt-devel"] {os-distribution = "rhel"}
   ["NLopt-devel" "epel-release"] {os-distribution = "centos" & os-version < "8"}
   ["nlopt-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-nmap/conf-nmap.1.0.0/opam
+++ b/packages/conf-nmap/conf-nmap.1.0.0/opam
@@ -12,7 +12,7 @@ depexts: [
   ["nmap" "ncat"] {os-family = "debian"}
   ["nmap" "ncat"] {os-family = "ubuntu"}
   ["nmap"] {os-distribution = "centos"}
-  ["nmap"] {os-distribution = "fedora"}
+  ["nmap"] {os-family = "fedora"}
   ["nmap"] {os-family = "suse" | os-family = "opensuse"}
   ["nmap"] {os-family = "arch"}
   ["nmap"] {os-distribution = "ol"}

--- a/packages/conf-npm/conf-npm.1/opam
+++ b/packages/conf-npm/conf-npm.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["npm"] {os-distribution = "ol" & os-version >= "8"}
   ["npm"] {os-family = "debian"}
   ["npm"] {os-family = "ubuntu"}
-  ["npm"] {os-distribution = "fedora"}
+  ["npm"] {os-family = "fedora"}
   ["npm"] {os = "freebsd"}
   ["nodejs"] {os-distribution = "gentoo"}
   ["node"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/conf-numa/conf-numa.0.1.0/opam
+++ b/packages/conf-numa/conf-numa.0.1.0/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://www.github.com/stevebleazard/ocaml-conf-numa.git"
 depexts: [
   ["libnuma-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["numactl-libs" "numactl-devel"] {os-distribution = "centos"}
-  ["numactl-libs" "numactl-devel"] {os-distribution = "fedora"}
+  ["numactl-libs" "numactl-devel"] {os-family = "fedora"}
   ["numactl-devel"] {os-distribution = "ol"}
   ["libnuma-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libnuma-dev"] {os-distribution = "alpine"}

--- a/packages/conf-ode/conf-ode.1/opam
+++ b/packages/conf-ode/conf-ode.1/opam
@@ -8,7 +8,7 @@ depexts: [
   ["libode-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["ode-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["ode"] {os-distribution = "arch"}
-  ["ode-devel"] {os-distribution = "fedora"}
+  ["ode-devel"] {os-family = "fedora"}
   ["libode-devel"] {os-distribution = "mageia"}
   ["ode"] {os-distribution = "homebrew" & os = "macos"}
   ["ode"] {os = "freebsd"}

--- a/packages/conf-oniguruma/conf-oniguruma.1/opam
+++ b/packages/conf-oniguruma/conf-oniguruma.1/opam
@@ -9,7 +9,7 @@ depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libonig-dev"] {os-family = "debian"}
   ["libonig-dev"] {os-family = "ubuntu"}
-  ["oniguruma-devel"] {os-distribution = "fedora"}
+  ["oniguruma-devel"] {os-family = "fedora"}
   ["oniguruma-devel"] {os-distribution = "centos"}
   ["oniguruma-devel"] {os-distribution = "ol"}
   ["oniguruma-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-openbabel/conf-openbabel.0.1/opam
+++ b/packages/conf-openbabel/conf-openbabel.0.1/opam
@@ -17,7 +17,7 @@ x-ci-accept-failures: [
 depexts: [
   ["libopenbabel-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["openbabel"] {os-distribution = "arch"}
-  ["openbabel-devel"] {os-distribution = "fedora"}
+  ["openbabel-devel"] {os-family = "fedora"}
   ["openbabel-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["open-babel"] {os = "macos" & os-distribution = "homebrew"}
   ["openbabel-devel"] {os-distribution = "centos"}

--- a/packages/conf-openblas/conf-openblas.0.1/opam
+++ b/packages/conf-openblas/conf-openblas.0.1/opam
@@ -19,7 +19,7 @@ build: [
      os != "alpine"}
 ]
 depexts: [
-  ["openblas-devel"] {os-distribution = "fedora"}
+  ["openblas-devel"] {os-family = "fedora"}
   ["libc-dev" "openblas-dev"] {os-distribution = "alpine"}
   ["libopenblas-dev" "liblapacke-dev"] {os-family = "debian"}
   ["homebrew/science/openblas"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-openblas/conf-openblas.0.2.0/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "BSD-3-Clause"
 build: [
   ["sh" "-exc" "cc $CFLAGS -I/usr/include/openblas test.c -lopenblas"]
-    {os-distribution = "fedora" | os-distribution = "centos" | os-family = "suse" | os-family = "opensuse"}
+    {os-family = "fedora" | os-distribution = "centos" | os-family = "suse" | os-family = "opensuse"}
   [
     "sh"
     "-exc"
@@ -23,7 +23,7 @@ depexts: [
   ["libc-dev" "openblas-dev"] {os-distribution = "alpine"}
   ["epel-release" "openblas-devel"] {os-distribution = "centos"}
   ["libopenblas-dev" "liblapacke-dev"] {os-family = "debian"}
-  ["openblas-devel"] {os-distribution = "fedora"}
+  ["openblas-devel"] {os-family = "fedora"}
   ["openblas-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["openblas" "lapacke" "cblas"] {os-distribution = "arch"}
   ["openblas"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-openblas/conf-openblas.0.2.1/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.1/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "BSD-3-Clause"
 build: [
   ["sh" "-exc" "cc $CFLAGS -I/usr/include/openblas test.c -lopenblas"]
-    {os-distribution = "fedora" | os-distribution = "centos" | os-family = "suse" | os-family = "opensuse"}
+    {os-family = "fedora" | os-distribution = "centos" | os-family = "suse" | os-family = "opensuse"}
   [
     "sh"
     "-exc"
@@ -25,7 +25,7 @@ depexts: [
   ["libc-dev" "openblas-dev" "lapack-dev"] {os-distribution = "alpine"}
   ["epel-release" "openblas-devel"] {os-distribution = "centos"}
   ["libopenblas-dev" "liblapacke-dev"] {os-family = "debian"}
-  ["openblas-devel"] {os-distribution = "fedora"}
+  ["openblas-devel"] {os-family = "fedora"}
   ["openblas-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["openblas" "lapacke" "cblas"] {os-distribution = "arch"}
   ["openblas"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-openblas/conf-openblas.0.2.2/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.2/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "BSD-3-Clause"
 build: [
   ["sh" "-exc" "cc $CFLAGS -I/usr/include/openblas test.c -lopenblas"]
-    {os-distribution = "fedora" | os-distribution = "centos" | os-family = "suse" | os-family = "opensuse"}
+    {os-family = "fedora" | os-distribution = "centos" | os-family = "suse" | os-family = "opensuse"}
   [
     "sh"
     "-exc"
@@ -30,7 +30,7 @@ depexts: [
   ["epel-release" "openblas-devel"] {os-distribution = "centos"}
   ["libopenblas-dev" "liblapacke-dev"] {os-family = "debian"}
   ["libopenblas-dev" "liblapacke-dev"] {os-family = "ubuntu"}
-  ["openblas-devel"] {os-distribution = "fedora"}
+  ["openblas-devel"] {os-family = "fedora"}
   ["libopenblas_openmp-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["openblas" "lapacke" "cblas"] {os-distribution = "arch"}
   ["openblas"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-opencc1/conf-opencc1.1/opam
+++ b/packages/conf-opencc1/conf-opencc1.1/opam
@@ -18,7 +18,7 @@ depexts: [
   ["libopencc2"] {os-family = "suse" | os-family = "opensuse"}
   ["opencc"] {os-distribution = "arch"}
   ["app-i18n/opencc"] {os-distribution = "gentoo"}
-  ["opencc"] {os-distribution = "fedora"}
+  ["opencc"] {os-family = "fedora"}
   ["opencc"] {os-distribution = "centos"}
   ["opencc"] {os = "freebsd"}
   ["opencc"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-opencc1_1/conf-opencc1_1.1/opam
+++ b/packages/conf-opencc1_1/conf-opencc1_1.1/opam
@@ -21,7 +21,7 @@ depexts: [
   ["opencc"] {os-family = "suse" | os-family = "opensuse"}
   ["opencc"] {os-distribution = "arch"}
   ["app-i18n/opencc"] {os-distribution = "gentoo"}
-  ["opencc"] {os-distribution = "fedora"}
+  ["opencc"] {os-family = "fedora"}
   ["opencc"] {os-distribution = "centos"}
   ["opencc"] {os = "macos" & os-distribution = "homebrew"}
   ["chinese/opencc"] {os = "freebsd"}

--- a/packages/conf-openimageio/conf-openimageio.1/opam
+++ b/packages/conf-openimageio/conf-openimageio.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["libopenexr-dev"] {os-distribution = "debian" & os-version >= "11"}
   ["libopenimageio-dev"] {os-family = "debian"}
   ["libopenimageio-dev"] {os-family = "ubuntu"}
-  ["OpenImageIO-devel"] {os-distribution = "fedora"}
+  ["OpenImageIO-devel"] {os-family = "fedora"}
   ["OpenImageIO-devel" "epel-release"] {os-distribution = "centos"}
   ["OpenImageIO-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["openimageio-dev@testing" "boost1.76-filesystem@edge" "boost1.76-thread@edge"] {os-family = "alpine"}

--- a/packages/conf-openjdk/conf-openjdk.1/opam
+++ b/packages/conf-openjdk/conf-openjdk.1/opam
@@ -7,7 +7,7 @@ license: "GPLv2 with linking exception"
 build: ["javac" "-version"]
 depexts: [
   ["default-jdk"] {os-family = "debian" | os-family = "ubuntu"}
-  ["java-latest-openjdk-devel"] {os-distribution = "fedora"}
+  ["java-latest-openjdk-devel"] {os-family = "fedora"}
   ["java-latest-openjdk-devel"] {os-distribution = "rhel"}
   ["java-latest-openjdk-devel"] {os-distribution = "ol"}
   ["java-latest-openjdk-devel"] {os-distribution = "centos"}

--- a/packages/conf-openssl/conf-openssl.2/opam
+++ b/packages/conf-openssl/conf-openssl.2/opam
@@ -10,7 +10,7 @@ depexts: [
   ["openssl"] {os-family = "ubuntu"}
   ["openssl"] {os-distribution = "centos"}
   ["openssl"] {os-distribution = "ol"}
-  ["openssl"] {os-distribution = "fedora"}
+  ["openssl"] {os-family = "fedora"}
   ["openssl"] {os = "macos" & os-distribution = "homebrew"}
   ["openssl"] {os = "macos" & os-distribution = "macports"}
   ["openssl"] {os-distribution = "alpine"}

--- a/packages/conf-pam/conf-pam.1/opam
+++ b/packages/conf-pam/conf-pam.1/opam
@@ -6,7 +6,7 @@ license: "BSD-3-Clause"
 depexts: [
   ["libpam0g-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["pam-devel"] {os-distribution = "centos"}
-  ["pam-devel"] {os-distribution = "fedora"}
+  ["pam-devel"] {os-family = "fedora"}
   ["pam-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["pam-devel"] {os-distribution = "ol"}
   ["pam"] {os-distribution = "arch"}

--- a/packages/conf-pandoc/conf-pandoc.0.1/opam
+++ b/packages/conf-pandoc/conf-pandoc.0.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["pandoc"] {os-family = "arch"}
   ["pandoc"] {os-family = "debian" | os-family = "ubuntu"}
   ["pandoc" "epel-release"] {os-distribution = "centos"}
-  ["pandoc"] {os-distribution = "fedora"}
+  ["pandoc"] {os-family = "fedora"}
   ["pandoc"] {os = "macos" & os-distribution = "homebrew"}
   ["pandoc"] {os-family = "suse" | os-family = "opensuse"}
   ["hs-pandoc"] {os = "freebsd"}

--- a/packages/conf-pango/conf-pango.1/opam
+++ b/packages/conf-pango/conf-pango.1/opam
@@ -12,7 +12,7 @@ depends: [
 ]
 depexts: [
   ["libpango1.0-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["pango-devel"] {os-distribution = "fedora"}
+  ["pango-devel"] {os-family = "fedora"}
   ["pango-devel"] {os-distribution = "rhel"}
   ["pango-devel"] {os-distribution = "centos"}
   ["pango-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.1/opam
+++ b/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.1/opam
@@ -17,7 +17,7 @@ depexts: [
   ["epel-release" "perl-IPC-System-Simple"] {os-distribution = "centos"}
   ["perl-IPC-System-Simple"] {os-distribution = "ol" & os-version >= "8"}
   ["perl-IPC-System-Simple"] {os-family = "suse" | os-family = "opensuse"}
-  ["perl-IPC-System-Simple"] {os-distribution = "fedora"}
+  ["perl-IPC-System-Simple"] {os-family = "fedora"}
   ["perl-ipc-system-simple"] {os-family = "arch"}
   ["system:perl-IPC-System-Simple"] {os = "win32" & os-distribution = "cygwinports"}
   ["perl-IPC-System-Simple"] {os-distribution = "cygwin"}

--- a/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.2/opam
+++ b/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.2/opam
@@ -17,7 +17,7 @@ depexts: [
   ["epel-release" "perl-IPC-System-Simple"] {os-distribution = "centos"}
   ["perl-IPC-System-Simple"] {os-distribution = "ol" & os-version >= "8"}
   ["perl-IPC-System-Simple"] {os-family = "suse" | os-family = "opensuse"}
-  ["perl-IPC-System-Simple"] {os-distribution = "fedora"}
+  ["perl-IPC-System-Simple"] {os-family = "fedora"}
   ["perl-ipc-system-simple"] {os-family = "arch"}
   ["p5-ipc-system-simple"] {os-distribution = "macports" & os = "macos"}
 ]

--- a/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.3/opam
+++ b/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.3/opam
@@ -18,7 +18,7 @@ depexts: [
   ["epel-release" "perl-IPC-System-Simple"] {os-distribution = "centos"}
   ["perl-IPC-System-Simple"] {os-distribution = "ol" & os-version >= "8"}
   ["perl-IPC-System-Simple"] {os-family = "suse" | os-family = "opensuse"}
-  ["perl-IPC-System-Simple"] {os-distribution = "fedora"}
+  ["perl-IPC-System-Simple"] {os-family = "fedora"}
   ["perl-ipc-system-simple"] {os-family = "arch"}
   ["p5-ipc-system-simple"] {os-distribution = "macports" & os = "macos"}
   ["p5-IPC-System-Simple"] {os = "freebsd"}

--- a/packages/conf-perl/conf-perl.1/opam
+++ b/packages/conf-perl/conf-perl.1/opam
@@ -10,7 +10,7 @@ depexts: [
   ["perl"] {os-distribution = "alpine"}
   ["perl"] {os-distribution = "nixos"}
   ["perl"] {os-distribution = "arch"}
-  ["perl-Pod-Html"] {os-distribution = "fedora"}
+  ["perl-Pod-Html"] {os-family = "fedora"}
   ["perl-Pod-Html"] {os-distribution = "centos" & os-version >= "8"}
 ]
 synopsis: "Virtual package relying on perl"

--- a/packages/conf-perl/conf-perl.2/opam
+++ b/packages/conf-perl/conf-perl.2/opam
@@ -11,7 +11,7 @@ depexts: [
   ["perl"] {os-distribution = "alpine"}
   ["perl"] {os-distribution = "nixos"}
   ["perl"] {os-distribution = "arch"}
-  ["perl-Pod-Html"] {os-distribution = "fedora"}
+  ["perl-Pod-Html"] {os-family = "fedora"}
   ["perl-Pod-Html"] {os-distribution = "centos" & os-version >= "8"}
   ["perl5"] {os-distribution = "macports" & os = "macos"}
   ["perl5"] {os = "freebsd"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.0/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.0/opam
@@ -10,7 +10,7 @@ build: [
 depexts: [
   ["pkg-config"] {os-family = "debian"}
   ["pkgconf"] {os-distribution = "arch"}
-  ["pkgconfig"] {os-distribution = "fedora"}
+  ["pkgconfig"] {os-family = "fedora"}
   ["pkgconfig"] {os-distribution = "centos"}
   ["pkgconfig"] {os-distribution = "mageia"}
   ["pkgconfig"] {os-distribution = "rhel"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.1/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.1/opam
@@ -20,7 +20,7 @@ post-messages: [
 depexts: [
   ["pkg-config"] {os-family = "debian"}
   ["pkgconf"] {os-distribution = "arch"}
-  ["pkgconfig"] {os-distribution = "fedora"}
+  ["pkgconfig"] {os-family = "fedora"}
   ["pkgconfig"] {os-distribution = "centos"}
   ["pkgconfig"] {os-distribution = "mageia"}
   ["pkgconfig"] {os-distribution = "rhel"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.2/opam
@@ -20,7 +20,7 @@ post-messages: [
 depexts: [
   ["pkg-config"] {os-family = "debian"}
   ["pkgconf"] {os-distribution = "arch"}
-  ["pkgconfig"] {os-distribution = "fedora"}
+  ["pkgconfig"] {os-family = "fedora"}
   ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
   ["pkgconfig"] {os-distribution = "mageia"}
   ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}

--- a/packages/conf-pkg-config/conf-pkg-config.1.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.3/opam
@@ -20,7 +20,7 @@ post-messages: [
 depexts: [
   ["pkg-config"] {os-family = "debian"}
   ["pkgconf"] {os-distribution = "arch"}
-  ["pkgconfig"] {os-distribution = "fedora"}
+  ["pkgconfig"] {os-family = "fedora"}
   ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
   ["pkgconfig"] {os-distribution = "mageia"}
   ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}

--- a/packages/conf-pkg-config/conf-pkg-config.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.2/opam
@@ -20,7 +20,7 @@ post-messages: [
 depexts: [
   ["pkg-config"] {os-family = "debian"}
   ["pkgconf"] {os-distribution = "arch"}
-  ["pkgconf-pkg-config"] {os-distribution = "fedora"}
+  ["pkgconf-pkg-config"] {os-family = "fedora"}
   ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
   ["pkgconf-pkg-config"] {os-distribution = "mageia"}
   ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}

--- a/packages/conf-pkg-config/conf-pkg-config.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.3/opam
@@ -15,7 +15,7 @@ build: [
 depexts: [
   ["pkg-config"] {os-family = "debian" | os-family = "ubuntu"}
   ["pkgconf"] {os-distribution = "arch"}
-  ["pkgconf-pkg-config"] {os-distribution = "fedora"}
+  ["pkgconf-pkg-config"] {os-family = "fedora"}
   ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
   ["pkgconf-pkg-config"] {os-distribution = "mageia"}
   ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}

--- a/packages/conf-pkg-config/conf-pkg-config.4/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.4/opam
@@ -15,7 +15,7 @@ build: [
 depexts: [
   ["pkg-config"] {os-family = "debian" | os-family = "ubuntu"}
   ["pkgconf"] {os-distribution = "arch"}
-  ["pkgconf-pkg-config"] {os-distribution = "fedora"}
+  ["pkgconf-pkg-config"] {os-family = "fedora"}
   ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
   ["pkgconf-pkg-config"] {os-distribution = "mageia"}
   ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}

--- a/packages/conf-plplot/conf-plplot.1/opam
+++ b/packages/conf-plplot/conf-plplot.1/opam
@@ -13,7 +13,7 @@ depexts: [
   ["libplplot-dev" "libshp-dev"] {os-family = "ubuntu"}
   ["plplot"] {os = "macos" & os-distribution = "homebrew"}
   ["plplot-devel"] {os-family = "rhel"}
-  ["plplot-devel"] {os-distribution = "fedora"}
+  ["plplot-devel"] {os-family = "fedora"}
   ["plplot-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["plplot-devel" "epel-release"] {os-distribution = "centos"}
   ["plplot"] {os-distribution = "nixos"}

--- a/packages/conf-portaudio/conf-portaudio.1/opam
+++ b/packages/conf-portaudio/conf-portaudio.1/opam
@@ -10,7 +10,7 @@ depends: [
 ]
 depexts: [
   ["portaudio-dev"] {os-distribution = "alpine"}
-  ["portaudio-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["portaudio-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["portaudio"] {os = "macos" & os-distribution = "homebrew"}
   ["portaudio"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os-distribution = "ol"}
   ["portaudio"] {os = "win32" & os-distribution = "cygwinports"}

--- a/packages/conf-postgresql/conf-postgresql.1/opam
+++ b/packages/conf-postgresql/conf-postgresql.1/opam
@@ -16,14 +16,14 @@ depexts: [
   ["libpq-devel"] {os-distribution = "centos" & os-version >= "8"}
   ["libpq-devel"] {os-distribution = "rhel" & os-version >= "8"}
   ["libpq-devel"] {os-distribution = "ol" & os-version >= "8"}
-  ["libpq-devel"] {os-distribution = "fedora" & os-version >= "30"}
+  ["libpq-devel"] {os-family = "fedora" & os-version >= "30"}
   ["postgresql15-client"] {os-distribution = "freebsd" & os-version >= "13"}
   ["postgresql96-client"] {os-distribution = "freebsd" & os-version < "13"}
   ["postgresql96-client"] {os-distribution = "openbsd"}
   ["postgresql-devel"] {os-distribution = "centos" & os-version < "8"}
   ["postgresql-devel"] {os-distribution = "rhel" & os-version < "8"}
   ["postgresql-devel"] {os-distribution = "ol" & os-version < "8"}
-  ["postgresql-devel"] {os-distribution = "fedora" & os-version < "30"}
+  ["postgresql-devel"] {os-family = "fedora" & os-version < "30"}
   ["postgresql-server-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["postgresql-dev"] {os-distribution = "alpine" & os-version < "3.15"}
   ["postgresql14-dev"] {os-distribution = "alpine" & os-version >= "3.15"}

--- a/packages/conf-postgresql/conf-postgresql.2/opam
+++ b/packages/conf-postgresql/conf-postgresql.2/opam
@@ -24,14 +24,14 @@ depexts: [
   ["libpq-devel"] {os-distribution = "centos" & os-version >= "8"}
   ["libpq-devel"] {os-distribution = "rhel" & os-version >= "8"}
   ["libpq-devel"] {os-distribution = "ol" & os-version >= "8"}
-  ["libpq-devel"] {os-distribution = "fedora" & os-version >= "30"}
+  ["libpq-devel"] {os-family = "fedora" & os-version >= "30"}
   ["postgresql15-client"] {os-distribution = "freebsd" & os-version >= "13"}
   ["postgresql96-client"] {os-distribution = "freebsd" & os-version < "13"}
   ["postgresql96-client"] {os-distribution = "openbsd"}
   ["postgresql-devel"] {os-distribution = "centos" & os-version < "8"}
   ["postgresql-devel"] {os-distribution = "rhel" & os-version < "8"}
   ["postgresql-devel"] {os-distribution = "ol" & os-version < "8"}
-  ["postgresql-devel"] {os-distribution = "fedora" & os-version < "30"}
+  ["postgresql-devel"] {os-family = "fedora" & os-version < "30"}
   ["postgresql-server-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["postgresql-dev"] {os-distribution = "alpine" & os-version < "3.15"}
   ["postgresql14-dev"] {os-distribution = "alpine" & os-version >= "3.15"}

--- a/packages/conf-ppl/conf-ppl.1/opam
+++ b/packages/conf-ppl/conf-ppl.1/opam
@@ -21,7 +21,7 @@ depexts: [
   ["ppl"] {os = "freebsd"}
   ["ppl"] {os = "openbsd"}
   ["ppl"] {os = "macos" & os-distribution = "homebrew"}
-  ["ppl-devel"] {os-distribution = "fedora"}
+  ["ppl-devel"] {os-family = "fedora"}
   ["ppl-devel"] {os-family = "suse" | os-family = "opensuse"}
 ]
 synopsis:

--- a/packages/conf-protoc-dev/conf-protoc-dev.1.0.0/opam
+++ b/packages/conf-protoc-dev/conf-protoc-dev.1.0.0/opam
@@ -15,7 +15,7 @@ depexts: [
   ["libprotoc-dev"]       {os-family = "ubuntu"}
   ["lib64protobuf-devel"] {os-distribution = "mageia"}
   ["protobuf-devel"]      {os-distribution = "centos"}
-  ["protobuf-devel"]      {os-distribution = "fedora"}
+  ["protobuf-devel"]      {os-family = "fedora"}
   ["protobuf-devel"]      {os-distribution = "rhel"}
   ["protobuf-dev"]        {os-family = "alpine"}
   ["protobuf"]            {os-family = "arch"}

--- a/packages/conf-protoc/conf-protoc.0.9/opam
+++ b/packages/conf-protoc/conf-protoc.0.9/opam
@@ -11,7 +11,7 @@ depexts: [
   ["protobuf-compiler"] {os-family = "debian"}
   ["protobuf-compiler"] {os-distribution = "mageia"}
   ["protobuf-compiler"] {os-distribution = "centos"}
-  ["protobuf-compiler"] {os-distribution = "fedora"}
+  ["protobuf-compiler"] {os-family = "fedora"}
   ["protobuf-compiler"] {os-distribution = "rhel"}
   ["protobuf"]          {os-distribution = "alpine"}
   ["protobuf"]          {os-distribution = "arch"}

--- a/packages/conf-protoc/conf-protoc.1.0.0/opam
+++ b/packages/conf-protoc/conf-protoc.1.0.0/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libprotobuf-dev" "protobuf-compiler"]   {os-family = "ubuntu"}
   ["libprotobuf-devel" "protobuf-compiler"] {os-distribution = "mageia"}
   ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "centos"}
-  ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "fedora"}
+  ["protobuf-devel" "protobuf-compiler"]    {os-family = "fedora"}
   ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "rhel"}
   ["protobuf" "protobuf-dev"]               {os-family = "alpine"}
   ["protobuf"]                              {os-family = "arch"}

--- a/packages/conf-protoc/conf-protoc.4.4.0/opam
+++ b/packages/conf-protoc/conf-protoc.4.4.0/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libprotobuf-dev" "protobuf-compiler"]   {os-family = "ubuntu"}
   ["libprotobuf-devel" "protobuf-compiler"] {os-distribution = "mageia"}
   ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "centos"}
-  ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "fedora"}
+  ["protobuf-devel" "protobuf-compiler"]    {os-family = "fedora"}
   ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "rhel"}
   ["protobuf" "protobuf-dev"]               {os-family = "alpine"}
   ["protobuf"]                              {os-family = "arch"}

--- a/packages/conf-pulseaudio/conf-pulseaudio.1/opam
+++ b/packages/conf-pulseaudio/conf-pulseaudio.1/opam
@@ -10,7 +10,7 @@ depends: [
 ]
 depexts: [
   ["pulseaudio-dev"] {os-distribution = "alpine"}
-  ["pulseaudio-libs-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse" | os-distribution = "ol"}
+  ["pulseaudio-libs-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse" | os-distribution = "ol"}
   ["pulseaudio"] {os = "macos" & os-distribution = "homebrew"}
   ["pulseaudio"] {os = "freebsd" }
   ["libpulseaudio"] { os-distribution = "nixos" }

--- a/packages/conf-python-2-7/conf-python-2-7.1.0/opam
+++ b/packages/conf-python-2-7/conf-python-2-7.1.0/opam
@@ -10,7 +10,7 @@ depexts: [
   ["python27"] {os-distribution = "nixos"}
   ["python"] {os-distribution = "alpine"}
   ["python"] {os-distribution = "centos"}
-  ["python2"] {os-distribution = "fedora"}
+  ["python2"] {os-family = "fedora"}
   ["python2"] {os-distribution = "arch"}
   ["python"] {os-family = "suse" | os-family = "opensuse"}
   ["dev-lang/python:2.7"] {os-distribution = "gentoo"}

--- a/packages/conf-python-2-7/conf-python-2-7.1.1/opam
+++ b/packages/conf-python-2-7/conf-python-2-7.1.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["python2"] {os-distribution = "alpine"}
   ["python2"] {os-distribution = "centos"}
   ["python2"] {os-distribution = "ol"}
-  ["python2"] {os-distribution = "fedora"}
+  ["python2"] {os-family = "fedora"}
   ["python2"] {os-distribution = "arch"}
   ["python"] {os-family = "suse" | os-family = "opensuse"}
   ["dev-lang/python:2.7"] {os-distribution = "gentoo"}

--- a/packages/conf-python-2-7/conf-python-2-7.1.2/opam
+++ b/packages/conf-python-2-7/conf-python-2-7.1.2/opam
@@ -12,7 +12,7 @@ depexts: [
   ["python2"] {os-distribution = "alpine"}
   ["python2"] {os-distribution = "centos"}
   ["python2"] {os-distribution = "ol"}
-  ["python2.7"] {os-distribution = "fedora"}
+  ["python2.7"] {os-family = "fedora"}
   ["python2"] {os-family = "arch"}
   ["python"] {os-family = "suse" | os-family = "opensuse"}
   ["dev-lang/python:2.7"] {os-distribution = "gentoo"}

--- a/packages/conf-python-3-7/conf-python-3-7.1.0.0/opam
+++ b/packages/conf-python-3-7/conf-python-3-7.1.0.0/opam
@@ -16,7 +16,7 @@ depexts: [
   ["python3"] {os-distribution = "nixos"}
   ["python3"] {os-distribution = "alpine"}
   ["python37" "epel-release"] {os-distribution = "centos"}
-  ["python3"] {os-distribution = "fedora"}
+  ["python3"] {os-family = "fedora"}
   ["python3"] {os-distribution = "ol" & os-version >= "9"}
   ["python38"] {os-distribution = "ol" & os-version < "9"} # No python37 package
   ["python"] {os-distribution = "arch"}

--- a/packages/conf-python-3-dev/conf-python-3-dev.1/opam
+++ b/packages/conf-python-3-dev/conf-python-3-dev.1/opam
@@ -10,7 +10,7 @@ build: [
 depexts: [
   ["python3-dev"] {os-family = "debian"}
   ["python3-dev"] {os-family = "ubuntu"}
-  ["python3-devel"] {os-distribution = "fedora"}
+  ["python3-devel"] {os-family = "fedora"}
   ["python3-devel" "epel-release"] {os-distribution = "centos"}
   ["python3-devel"] {os-distribution = "ol"}
   ["python3-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-python-3/conf-python-3.1.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.1.0.0/opam
@@ -10,7 +10,7 @@ depexts: [
   ["python3"] {os-distribution = "nixos"}
   ["python3"] {os-distribution = "alpine"}
   ["python36" "epel-release"] {os-distribution = "centos"}
-  ["python3"] {os-distribution = "fedora"}
+  ["python3"] {os-family = "fedora"}
   ["python3"] {os-distribution = "ol"}
   ["python"] {os-distribution = "arch"}
   ["python3"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-python-3/conf-python-3.9.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.9.0.0/opam
@@ -10,7 +10,7 @@ depexts: [
   ["python3"] {os-distribution = "nixos"}
   ["python3"] {os-distribution = "alpine"}
   ["python39" "epel-release"] {os-distribution = "centos"}
-  ["python3"] {os-distribution = "fedora"}
+  ["python3"] {os-family = "fedora"}
   ["python3"] {os-distribution = "ol"}
   ["python"] {os-distribution = "arch"}
   ["python3"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-python3-pyparsing/conf-python3-pyparsing.1/opam
+++ b/packages/conf-python3-pyparsing/conf-python3-pyparsing.1/opam
@@ -14,7 +14,7 @@ depends: [
 depexts: [
   ["python3-pyparsing"] {os-family = "debian"}
   ["python3-pyparsing"] {os-family = "ubuntu"}
-  ["python3-pyparsing"] {os-distribution = "fedora"}
+  ["python3-pyparsing"] {os-family = "fedora"}
   ["python3-pyparsing"] {os-family = "suse" | os-family = "opensuse"}
   ["python-pyparsing"] {os-family = "arch"}
   ["py3-parsing"] {os-family = "alpine"}

--- a/packages/conf-python3-tomli/conf-python3-tomli.1/opam
+++ b/packages/conf-python3-tomli/conf-python3-tomli.1/opam
@@ -14,7 +14,7 @@ depends: [
 depexts: [
   ["python3-tomli"] {os-family = "debian"}
   ["python3-tomli"] {os-family = "ubuntu"}
-  ["python3-tomli"] {os-distribution = "fedora"}
+  ["python3-tomli"] {os-family = "fedora"}
   ["python-tomli"] {os-family = "suse" | os-family = "opensuse"}
   ["python-tomli"] {os-family = "arch"}
   ["py3-tomli"] {os-family = "alpine"}

--- a/packages/conf-python3-yaml/conf-python3-yaml.1/opam
+++ b/packages/conf-python3-yaml/conf-python3-yaml.1/opam
@@ -14,7 +14,7 @@ depends: [
 depexts: [
   ["python3-yaml"] {os-family = "debian"}
   ["python3-yaml"] {os-family = "ubuntu"}
-  ["python3-pyyaml"] {os-distribution = "fedora"}
+  ["python3-pyyaml"] {os-family = "fedora"}
   ["epel-release" "python36-PyYAML"] {os-distribution = "centos" & os-version < "8"}
   ["python3-pyyaml"] {os-distribution = "centos" & os-version >= "8"}
   ["python3-pyyaml"] {os-distribution = "ol" & os-version >= "8"}

--- a/packages/conf-r-mathlib/conf-r-mathlib.1/opam
+++ b/packages/conf-r-mathlib/conf-r-mathlib.1/opam
@@ -9,7 +9,7 @@ depexts: [
   ["r-mathlib"] {os-family = "debian" | os-family = "ubuntu"}
   ["libRmath-devel"] {os-distribution = "mageia"}
   ["libRmath-devel"] {os-distribution = "centos"}
-  ["libRmath-devel"] {os-distribution = "fedora"}
+  ["libRmath-devel"] {os-family = "fedora"}
   ["libRmath-devel"] {os-distribution = "rhel"}
   ["R-mathlib"] {os-distribution = "alpine"}
   ["R-base"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-r/conf-r.1.0.0/opam
+++ b/packages/conf-r/conf-r.1.0.0/opam
@@ -13,7 +13,7 @@ depexts: [
   ["R-core"] {os-family = "suse" | os-family = "opensuse"}
   ["R"] {os-distribution = "alpine"}
   ["epel-release" "R"] {os-distribution = "centos"}
-  ["R"] {os-distribution = "fedora"}
+  ["R"] {os-family = "fedora"}
   ["R"] {os-distribution = "nixos"}
   ["math/R"] {os = "freebsd"}
 ]

--- a/packages/conf-radare2/conf-radare2.0.1/opam
+++ b/packages/conf-radare2/conf-radare2.0.1/opam
@@ -18,7 +18,7 @@ flags: [ conf ]
 
 depexts: [
   ["radare2"] {os-family = "debian"}
-  ["radare2"] {os-distribution = "fedora"}
+  ["radare2"] {os-family = "fedora"}
   ["radare2"] {os-distribution = "arch"}
   ["radare2"] {os-distribution = "alpine"}
   ["radare2"] {os-distribution = "gentoo"}

--- a/packages/conf-rdkit/conf-rdkit.1/opam
+++ b/packages/conf-rdkit/conf-rdkit.1/opam
@@ -16,7 +16,7 @@ depexts: [
   ["librdkit-dev" "python-rdkit"] {os-distribution = "ubuntu" & os-version < "20.04"}
   ["librdkit-dev" "python3-rdkit"] {os-distribution = "ubuntu" & os-version >= "20.04"}
   ["librdkit-dev" "python3-rdkit"] {(os-family = "debian" | os-family = "ubuntu") & os-distribution != "debian" & os-distribution != "ubuntu"}
-  ["rdkit-devel" "python3-rdkit"] {os-distribution = "fedora"}
+  ["rdkit-devel" "python3-rdkit"] {os-family = "fedora"}
   ["rdkit"] {os = "freebsd"}
 ]
 x-ci-accept-failures: [ # RDKit does not exist by default on these distributions

--- a/packages/conf-readline/conf-readline.1/opam
+++ b/packages/conf-readline/conf-readline.1/opam
@@ -6,7 +6,7 @@ depexts: [
   ["libreadline-dev"] {os-family = "debian"}
   ["libreadline-dev"] {os-family = "ubuntu"}
   ["readline-devel"] {os-distribution = "centos"}
-  ["readline-devel"] {os-distribution = "fedora"}
+  ["readline-devel"] {os-family = "fedora"}
   ["readline-devel"] {os-distribution = "ol"}
   ["readline-dev"] {os-family = "alpine"}
   ["readline"] {os-family = "arch"}

--- a/packages/conf-rocksdb/conf-rocksdb.1/opam
+++ b/packages/conf-rocksdb/conf-rocksdb.1/opam
@@ -9,7 +9,7 @@ depexts: [
   ["rocksdb"] {os-distribution = "arch"}
   ["rocksdb-dev"] {os-distribution = "alpine"} # community package
   ["librocksdb-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["rocksdb-devel"] {os-distribution = "fedora"}
+  ["rocksdb-devel"] {os-family = "fedora"}
   ["rocksdb-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["rocksdb"] {os-distribution = "homebrew" & os = "macos"}
   ["rocksdb"] {os = "freebsd"}

--- a/packages/conf-ruby/conf-ruby.1.0.0/opam
+++ b/packages/conf-ruby/conf-ruby.1.0.0/opam
@@ -13,7 +13,7 @@ depexts: [
   ["ruby"] {os-distribution = "centos"}
   ["ruby"] {os-family = "debian"}
   ["ruby"] {os-family = "ubuntu"}
-  ["ruby"] {os-distribution = "fedora"}
+  ["ruby"] {os-family = "fedora"}
   ["dev-lang/ruby"] {os-distribution = "gentoo"}
   ["ruby"] {os-distribution = "homebrew" & os = "macos"}
   ["ruby"] {os = "freebsd"}

--- a/packages/conf-rust-2018/conf-rust-2018.1/opam
+++ b/packages/conf-rust-2018/conf-rust-2018.1/opam
@@ -11,7 +11,7 @@ build: [
 depexts: [
   ["cargo"] {os-distribution = "centos" & os-version >= "8"}
   ["cargo"] {os-distribution = "ol" & os-version >= "8"}
-  ["cargo"] {os-distribution = "fedora"}
+  ["cargo"] {os-family = "fedora"}
   ["cargo"] {os-family = "suse" | os-family = "opensuse"}
   ["cargo"] {os-family = "debian"}
   ["cargo"] {os-family = "ubuntu"}

--- a/packages/conf-rust-2021/conf-rust-2021.1/opam
+++ b/packages/conf-rust-2021/conf-rust-2021.1/opam
@@ -14,7 +14,7 @@ build: [
 depexts: [
   ["cargo"] {os-distribution = "centos" & os-version >= "8"}
   ["cargo"] {os-distribution = "ol" & os-version >= "8"}
-  ["cargo"] {os-distribution = "fedora"}
+  ["cargo"] {os-family = "fedora"}
   ["cargo"] {os-family = "suse" | os-family = "opensuse"}
   ["cargo"] {os-family = "debian"}
   ["cargo"] {os-family = "ubuntu"}

--- a/packages/conf-rust-2024/conf-rust-2024.1/opam
+++ b/packages/conf-rust-2024/conf-rust-2024.1/opam
@@ -14,7 +14,7 @@ build: [
 depexts: [
   ["cargo"] {os-distribution = "centos" & os-version >= "8"}
   ["cargo"] {os-distribution = "ol" & os-version >= "8"}
-  ["cargo"] {os-distribution = "fedora"}
+  ["cargo"] {os-family = "fedora"}
   ["cargo"] {os-family = "suse" | os-family = "opensuse"}
   ["cargo"] {os-family = "debian"}
   ["cargo"] {os-family = "ubuntu"}

--- a/packages/conf-rust-llvm/conf-rust-llvm.1/opam
+++ b/packages/conf-rust-llvm/conf-rust-llvm.1/opam
@@ -22,6 +22,6 @@ depexts: [
   ["rust-llvm"] { os-family = "suse" }
   ["rust-llvm"] { os-distribution = "centos" }
 ]
-x-ci-accept-failures: os-distribution = "freebsd" | os-distribution = "fedora"
+x-ci-accept-failures: os-distribution = "freebsd" | os-family = "fedora"
 synopsis: "Virtual package relying on an installation of the integration of Rust with LLVM tools"
 flags: conf

--- a/packages/conf-rust-wasm/conf-rust-wasm.1/opam
+++ b/packages/conf-rust-wasm/conf-rust-wasm.1/opam
@@ -17,7 +17,7 @@ depexts: [
   ["libstd-rust-dev-wasm32"] { os-family = "ubuntu" }
 
   ["libstd-rust-dev-wasm32"] { os-distribution = "centos" }
-  ["rust-std-static-wasm32-unknown-unknown"] { os-distribution = "fedora" }
+  ["rust-std-static-wasm32-unknown-unknown"] { os-family = "fedora" }
 ]
 synopsis: "Virtual package relying on an installation of standard Rust libraries including development files, needed to cross-compile Rust programs to the wasm32-unknown-unknown and wasm32-wasip1/wasm32-wasip2 targets"
 flags: conf

--- a/packages/conf-rust/conf-rust.0.1/opam
+++ b/packages/conf-rust/conf-rust.0.1/opam
@@ -11,7 +11,7 @@ build: [
 depexts: [
   ["cargo"] {os-distribution = "centos" & os-version >= "8"}
   ["cargo"] {os-distribution = "ol" & os-version >= "8"}
-  ["cargo"] {os-distribution = "fedora"}
+  ["cargo"] {os-family = "fedora"}
   ["cargo"] {os-family = "suse" | os-family = "opensuse"}
   ["cargo"] {os-family = "debian"}
   ["cargo"] {os-family = "ubuntu"}

--- a/packages/conf-samplerate/conf-samplerate.1/opam
+++ b/packages/conf-samplerate/conf-samplerate.1/opam
@@ -9,7 +9,7 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libsamplerate-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["libsamplerate-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["libsamplerate-dev"] {os-distribution = "alpine"}
   ["libsamplerate0-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libsamplerate"] {os-family = "arch" | os = "freebsd" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-scdoc/conf-scdoc.1/opam
+++ b/packages/conf-scdoc/conf-scdoc.1/opam
@@ -9,7 +9,7 @@ depexts: [
   ["scdoc"] {os-family = "arch" | os-family = "archlinux"}
   ["scdoc"] {os-family = "debian"}
   ["scdoc"] {os-family = "ubuntu"}
-  ["scdoc"] {os-distribution = "fedora"}
+  ["scdoc"] {os-family = "fedora"}
   ["scdoc"] {os-distribution = "nixos"}
   ["scdoc"] {os-distribution = "alpine"}
   ["scdoc"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-sdl-gfx/conf-sdl-gfx.1/opam
+++ b/packages/conf-sdl-gfx/conf-sdl-gfx.1/opam
@@ -8,7 +8,7 @@ depexts: [
   ["libsdl-gfx1.2-dev"] {os-family = "ubuntu"}
   ["sdl_gfx"] {os-distribution = "arch"}
   ["libSDL_gfx-devel"] {os-distribution = "mageia"}
-  ["SDL_gfx-devel"] {os-distribution = "fedora"}
+  ["SDL_gfx-devel"] {os-family = "fedora"}
   ["SDL_gfx"] {os-family = "suse" | os-family = "opensuse"}
   ["sdl_gfx"] {os = "macos" & os-distribution = "homebrew"}
   ["sdl_gfx"] {os = "freebsd"}

--- a/packages/conf-sdl-image/conf-sdl-image.1/opam
+++ b/packages/conf-sdl-image/conf-sdl-image.1/opam
@@ -9,7 +9,7 @@ depexts: [
   ["libsdl-image1.2-dev"] {os-family = "debian"}
   ["libsdl-image1.2-dev"] {os-family = "ubuntu"}
   ["libSDL_image-devel"] {os-distribution = "mageia"}
-  ["SDL_image-devel"] {os-distribution = "fedora"}
+  ["SDL_image-devel"] {os-family = "fedora"}
   ["SDL_image"] {os-family = "suse" | os-family = "opensuse"}
   ["SDL_image"] {os = "win32" & os-distribution = "cygwinports"}
   ["sdl_image"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-sdl-mixer/conf-sdl-mixer.1/opam
+++ b/packages/conf-sdl-mixer/conf-sdl-mixer.1/opam
@@ -9,7 +9,7 @@ depexts: [
   ["libsdl-mixer1.2-dev"] {os-family = "debian"}
   ["libsdl-mixer1.2-dev"] {os-family = "ubuntu"}
   ["libSDL_mixer-devel"] {os-distribution = "mageia"}
-  ["SDL_mixer-devel"] {os-distribution = "fedora"}
+  ["SDL_mixer-devel"] {os-family = "fedora"}
   ["SDL_mixer"] {os-family = "suse" | os-family = "opensuse"}
   ["SDL_mixer"] {os = "win32" & os-distribution = "cygwinports"}
   ["sdl_mixer"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-sdl-net/conf-sdl-net.1/opam
+++ b/packages/conf-sdl-net/conf-sdl-net.1/opam
@@ -8,7 +8,7 @@ depexts: [
   ["libsdl-net1.2-dev"] {os-family = "debian"}
   ["libsdl-net1.2-dev"] {os-family = "ubuntu"}
   ["libSDL_net-devel"] {os-distribution = "mageia"}
-  ["SDL_net-devel"] {os-distribution = "fedora"}
+  ["SDL_net-devel"] {os-family = "fedora"}
   ["SDL_net"] {os-family = "suse" | os-family = "opensuse"}
   ["SDL_net"] {os = "win32" & os-distribution = "cygwinports"}
   ["sdl_net"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-sdl-ttf/conf-sdl-ttf.1/opam
+++ b/packages/conf-sdl-ttf/conf-sdl-ttf.1/opam
@@ -8,7 +8,7 @@ depexts: [
   ["libsdl-ttf2.0-dev"] {os-family = "debian"}
   ["libsdl-ttf2.0-dev"] {os-family = "ubuntu"}
   ["libSDL_ttf-devel"] {os-distribution = "mageia"}
-  ["SDL_ttf-devel"] {os-distribution = "fedora"}
+  ["SDL_ttf-devel"] {os-family = "fedora"}
   ["SDL_ttf"] {os-family = "suse" | os-family = "opensuse"}
   ["SDL_ttf"] {os = "win32" & os-distribution = "cygwinports"}
   ["sdl_ttf"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-sdl2-image/conf-sdl2-image.1/opam
+++ b/packages/conf-sdl2-image/conf-sdl2-image.1/opam
@@ -7,7 +7,7 @@ depexts: [
   ["sdl2_image-dev"] {os-distribution = "alpine"}
   ["libsdl2-image-dev"] {os-family = "debian"}
   ["libsdl2-image-dev"] {os-family = "ubuntu"}
-  ["SDL2_image-devel"] {os-distribution = "fedora"}
+  ["SDL2_image-devel"] {os-family = "fedora"}
   ["epel-release" "SDL2_image-devel"] {os-distribution = "centos"}
   ["SDL2_image-devel"] {os-distribution = "ol"}
   ["libsdl2_image-devel"] {os-distribution = "mageia"}

--- a/packages/conf-sdl2-mixer/conf-sdl2-mixer.1/opam
+++ b/packages/conf-sdl2-mixer/conf-sdl2-mixer.1/opam
@@ -8,7 +8,7 @@ depexts: [
   ["libsdl2-mixer-dev"] {os-family = "debian"}
   ["libsdl2-mixer-dev"] {os-family = "ubuntu"}
   ["libsdl2_mixer-devel"] {os-distribution = "mageia"}
-  ["SDL2_mixer-devel"] {os-distribution = "fedora"}
+  ["SDL2_mixer-devel"] {os-family = "fedora"}
   ["SDL2_mixer-devel"] {os-distribution = "ol"}
   ["libSDL2_mixer-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["sdl2_mixer"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/conf-sdl2-net/conf-sdl2-net.1/opam
+++ b/packages/conf-sdl2-net/conf-sdl2-net.1/opam
@@ -7,7 +7,7 @@ depexts: [
   ["sdl2_net"] {os-family = "arch"}
   ["sdl2_net-dev"] {os-distribution = "alpine"}
   ["libsdl2-net-dev"] {os-family = "debian" | os-family = "ubuntu"}
-  ["SDL2_net-devel"] {os-distribution = "fedora"}
+  ["SDL2_net-devel"] {os-family = "fedora"}
   ["libSDL2_net-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libsdl2_net-devel"] {os-distribution = "mageia"}
   ["sdl2_net"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/conf-sdl2-ttf/conf-sdl2-ttf.1/opam
+++ b/packages/conf-sdl2-ttf/conf-sdl2-ttf.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libsdl2-ttf-dev"] {os-family = "ubuntu"}
   ["libsdl2_ttf-devel"] {os-family = "mageia"}
   ["SDL2_ttf-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["SDL2_ttf-devel"] {os-distribution = "fedora"}
+  ["SDL2_ttf-devel"] {os-family = "fedora"}
   # oraclelinux does not seem to have sdl2-ttf
   ["epel-release" "SDL2_ttf-devel"] {os-distribution = "centos"}
   ["sdl2_ttf"] {os-family = "arch"}

--- a/packages/conf-sdl2/conf-sdl2.1/opam
+++ b/packages/conf-sdl2/conf-sdl2.1/opam
@@ -20,8 +20,8 @@ depexts: [
   ["sdl2"] {os-distribution = "arch"}
   ["libsdl2-dev"] {os-family = "debian"}
   ["libsdl2-dev"] {os-family = "ubuntu"}
-  ["SDL2-devel"] {os-distribution = "fedora"}
-  ["SDL2-devel" "libwayland-egl" "adwaita-cursor-theme"] {os-distribution = "fedora" & (os-version = "37" | os-version = "36")}
+  ["SDL2-devel"] {os-family = "fedora"}
+  ["SDL2-devel" "libwayland-egl" "adwaita-cursor-theme"] {os-family = "fedora" & (os-version = "37" | os-version = "36")}
   ["epel-release" "SDL2-devel"] {os-distribution = "centos"}
   ["SDL2-devel"] {os-distribution = "ol"}
   ["sdl2"] {os = "freebsd"}

--- a/packages/conf-secp256k1/conf-secp256k1.1.0.0/opam
+++ b/packages/conf-secp256k1/conf-secp256k1.1.0.0/opam
@@ -12,7 +12,7 @@ depexts: [
   ["domt4/crypto/secp256k1"] {os-distribution = "homebrew" & os = "macos"}
   ["libsecp256k1-git"] {os-distribution = "arch"}
   ["libsecp256k1" "libsecp256k1-dev"] {os-distribution = "alpine"}
-  ["libsecp256k1" "libsecp256k1-devel"] {os-distribution = "fedora"}
+  ["libsecp256k1" "libsecp256k1-devel"] {os-family = "fedora"}
   ["libsecp256k1"] {os-family = "suse" | os-family = "opensuse"}
   ["libsecp256k1" "libsecp256k1-devel"] {os-distribution = "ol"}
 ]

--- a/packages/conf-secp256k1/conf-secp256k1.2/opam
+++ b/packages/conf-secp256k1/conf-secp256k1.2/opam
@@ -12,7 +12,7 @@ depexts: [
   ["domt4/crypto/libsecp256k1"] {os-distribution = "homebrew" & os = "macos"}
   ["libsecp256k1-git"] {os-distribution = "arch"}
   ["libsecp256k1" "libsecp256k1-dev"] {os-distribution = "alpine"}
-  ["libsecp256k1" "libsecp256k1-devel"] {os-distribution = "fedora"}
+  ["libsecp256k1" "libsecp256k1-devel"] {os-family = "fedora"}
   ["libsecp256k1"] {os-family = "suse" | os-family = "opensuse"}
   ["libsecp256k1" "libsecp256k1-devel"] {os-distribution = "ol"}
   ["secp256k1"] {os = "freebsd"}

--- a/packages/conf-sfml2/conf-sfml2.1/opam
+++ b/packages/conf-sfml2/conf-sfml2.1/opam
@@ -9,7 +9,7 @@ depexts: [
   ["libsfml-dev"] {os-family = "ubuntu"}
   ["sfml"] {os-family = "arch"}
   ["sfml-dev"] {os-family = "alpine"}
-  ["SFML-devel"] {os-distribution = "fedora"}
+  ["SFML-devel"] {os-family = "fedora"}
   ["sfml2-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libsfml-devel"] {os-distribution = "mageia"}
   ["sfml"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-shine/conf-shine.1/opam
+++ b/packages/conf-shine/conf-shine.1/opam
@@ -10,7 +10,7 @@ depends: [
 ]
 depexts: [
   ["shine"] {os-distribution = "alpine"}
-  ["shine-devel"] {os-distribution = "centos" | os-distribution = "fedora"}
+  ["shine-devel"] {os-distribution = "centos" | os-family = "fedora"}
   ["libshine-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libshine-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["drfill/liquidsoap/libshine"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-snappy/conf-snappy.1/opam
+++ b/packages/conf-snappy/conf-snappy.1/opam
@@ -13,7 +13,7 @@ depexts: [
   ["libsnappy-dev"] {os-family = "debian"}
   ["libsnappy-dev"] {os-family = "ubuntu"}
   ["snappy"] {os = "macos" & os-distribution = "homebrew"}
-  ["snappy-devel"] {os-distribution = "fedora"}
+  ["snappy-devel"] {os-family = "fedora"}
   ["snappy"] {os-family = "suse" | os-family = "opensuse"}
   ["snappy"] {os = "freebsd"}
 ]

--- a/packages/conf-sndfile/conf-sndfile.1/opam
+++ b/packages/conf-sndfile/conf-sndfile.1/opam
@@ -14,7 +14,7 @@ depends: [
 depexts: [
   ["libsndfile-dev"] {os-family = "debian" | os-family = "ubuntu" | os-distribution = "alpine"}
   ["libsndfile"] {os-family = "arch" | os = "freebsd" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
-  ["libsndfile-devel"] {os = "win32" & os-distribution = "cygwin" | os-family = "suse" | os-family = "opensuse" | os-distribution = "centos" | os-distribution = "fedora"}
+  ["libsndfile-devel"] {os = "win32" & os-distribution = "cygwin" | os-family = "suse" | os-family = "opensuse" | os-distribution = "centos" | os-family = "fedora"}
   ["mingw-w64-x86_64-libsndfile"] {os = "win32" & os-distribution = "msys2" & arch = "x86_64"}
   ["mingw-w64-i686-libsndfile"] {os = "win32" & os-distribution = "msys2" & arch = "x86_32"}
 ]

--- a/packages/conf-soundtouch/conf-soundtouch.1/opam
+++ b/packages/conf-soundtouch/conf-soundtouch.1/opam
@@ -10,7 +10,7 @@ depends: [
 ]
 depexts: [
   ["soundtouch-dev"] {os-distribution = "alpine"}
-  ["soundtouch-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["soundtouch-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["libsoundtouch-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["soundtouch"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os-distribution = "ol"}
   ["sound-touch"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-sqlite3/conf-sqlite3.1/opam
+++ b/packages/conf-sqlite3/conf-sqlite3.1/opam
@@ -29,7 +29,7 @@ depexts: [
   ["database/sqlite3"] {os = "openbsd"}
   ["sqlite-devel"] {os-distribution = "centos"}
   ["sqlite-devel"] {os-distribution = "rhel"}
-  ["sqlite-devel"] {os-distribution = "fedora"}
+  ["sqlite-devel"] {os-family = "fedora"}
   ["sqlite-devel"] {os-distribution = "ol"}
   ["sqlite-dev"] {os-distribution = "alpine"}
   ["sqlite3-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-srt/conf-srt.1/opam
+++ b/packages/conf-srt/conf-srt.1/opam
@@ -9,7 +9,7 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["srt-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["srt-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["libsrt-gnutls-dev" "libgnutls28-dev"] {os-distribution = "debian"}
   ["libsrt-dev"] {os-distribution = "ubuntu" | os-distribution = "alpine"}
   ["srt"] {os = "freebsd" | os-distribution = "arch" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-srt/conf-srt.2/opam
+++ b/packages/conf-srt/conf-srt.2/opam
@@ -10,7 +10,7 @@ depends: [
   "conf-srt-openssl" {os-family = "debian" | os-family = "ubuntu" | os = "macos" & os-distribution = "homebrew"} | "conf-srt-gnutls" {os-family = "debian" | os-family = "ubuntu"}
 ]
 depexts: [
-  ["srt-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["srt-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
   ["libsrt-dev"] {os-distribution = "alpine"}
   ["srt"] {os = "freebsd" | os-distribution = "arch" | os-distribution = "nixos"}
 ]

--- a/packages/conf-sundials/conf-sundials.1/opam
+++ b/packages/conf-sundials/conf-sundials.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["libsundials-dev"] {os-distribution = "ubuntu" & os-version >= "18.04"}
   ["libsundials-serial-dev"] {os-distribution = "debian" & os-version < "10"}
   ["libsundials-serial-dev"] {os-distribution = "ubuntu" & os-version < "18.04"}
-  ["sundials-devel"] {os-distribution = "fedora"}
+  ["sundials-devel"] {os-family = "fedora"}
   ["epel-release" "sundials-devel"] {os-distribution = "centos"}
   ["sundials-devel"] {os-distribution = "rhel"}
   ["sundials-devel"] {os-distribution = "ol"}

--- a/packages/conf-sundials/conf-sundials.2/opam
+++ b/packages/conf-sundials/conf-sundials.2/opam
@@ -17,7 +17,7 @@ depexts: [
   ["libsundials-dev"] {os-distribution = "ubuntu" & os-version >= "18.04"}
   ["libsundials-serial-dev"] {os-distribution = "debian" & os-version < "10"}
   ["libsundials-serial-dev"] {os-distribution = "ubuntu" & os-version < "18.04"}
-  ["suitesparse-devel" "sundials-devel"] {os-distribution = "fedora"}
+  ["suitesparse-devel" "sundials-devel"] {os-family = "fedora"}
   ["epel-release" "lapack-devel" "suitesparse-devel" "sundials-devel"] {os-distribution = "centos"}
   ["sundials-devel"] {os-distribution = "rhel"}
   ["sundials-devel"] {os-distribution = "ol"}

--- a/packages/conf-texlive/conf-texlive.1/opam
+++ b/packages/conf-texlive/conf-texlive.1/opam
@@ -8,7 +8,7 @@ build: ["pdflatex" "-version"]
 depexts: [
   ["texlive-latex-base"] {os-family = "debian"}
   ["texlive-latex-base"] {os-family = "ubuntu"}
-  ["texlive-latex"] {os-distribution = "fedora"}
+  ["texlive-latex"] {os-family = "fedora"}
   ["texlive-latex"] {os-distribution = "rhel"}
   ["texlive-latex"] {os-distribution = "ol"}
   ["texlive-latex-bin-bin"] {os-distribution = "ol" & os-version < "8"}

--- a/packages/conf-tidy/conf-tidy.1/opam
+++ b/packages/conf-tidy/conf-tidy.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["tidy"] {os-distribution = "arch"}
   ["tidyhtml-dev"] {os-distribution = "alpine"}
   ["app-text/tidy-html5"] {os-distribution = "gentoo"}
-  ["libtidy-devel"] {os-distribution = "fedora"}
+  ["libtidy-devel"] {os-family = "fedora"}
   ["libtidy-devel"] {os-distribution = "centos"}
   ["tidy-html5"] {os = "macos" & os-distribution = "homebrew"}
   ["tidy-html5"] {os = "freebsd"}

--- a/packages/conf-time/conf-time.1/opam
+++ b/packages/conf-time/conf-time.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["time"] {os-family = "debian"}
   ["time"] {os-family = "ubuntu"}
   ["time"] {os-distribution = "centos"}
-  ["time"] {os-distribution = "fedora"}
+  ["time"] {os-family = "fedora"}
   ["time"] {os-distribution = "ol"}
   ["time"] {os-family = "suse" | os-family = "opensuse"}
   ["time"] {os-family = "arch"}

--- a/packages/conf-timeout/conf-timeout.1/opam
+++ b/packages/conf-timeout/conf-timeout.1/opam
@@ -7,7 +7,7 @@ license: "GPL-1.0-or-later"
 build: [["sh" "-c" "command -v timeout || exit 1"]]
 depexts: [
   ["coreutils"] {os-family = "debian"}
-  ["coreutils"] {os-distribution = "fedora"}
+  ["coreutils"] {os-family = "fedora"}
   ["coreutils"] {os-distribution = "arch"}
   ["coreutils"] {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-unwind/conf-unwind.0/opam
+++ b/packages/conf-unwind/conf-unwind.0/opam
@@ -10,7 +10,7 @@ depexts: [
   ["libunwind-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libunwind-devel"] {os-distribution = "centos"}
   ["libunwind-devel"] {os-distribution = "rhel"}
-  ["libunwind-devel"] {os-distribution = "fedora" | os-family = "fedora"}
+  ["libunwind-devel"] {os-family = "fedora" | os-family = "fedora"}
   ["libunwind-dev"] {os-distribution = "alpine"}
   ["libunwind"] {os-distribution = "arch"}
   ["libunwind-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-vim/conf-vim.1/opam
+++ b/packages/conf-vim/conf-vim.1/opam
@@ -10,7 +10,7 @@ depexts: [
   ["vim-nox"] {os-family = "debian" | os-family = "ubuntu"}
   ["vim"] {os-distribution = "centos"}
   ["vim"] {os-distribution = "rhel"}
-  ["vim"] {os-distribution = "fedora"}
+  ["vim"] {os-family = "fedora"}
   ["vim"] {os-family = "suse" | os-family = "opensuse"}
   ["vim"] {os-distribution = "ol"}
   ["vim"] {os = "freebsd"}

--- a/packages/conf-wget/conf-wget.1/opam
+++ b/packages/conf-wget/conf-wget.1/opam
@@ -9,7 +9,7 @@ depends: ["conf-which" {build}]
 depexts: [
   ["wget"] {os-family = "debian"}
   ["wget"] {os-family = "ubuntu"}
-  ["wget"] {os-distribution = "fedora"}
+  ["wget"] {os-family = "fedora"}
   ["wget"] {os-distribution = "arch"}
   ["wget"] {os-distribution = "nixos"}
   ["net-misc/wget"] {os-distribution = "gentoo"}

--- a/packages/conf-which/conf-which.1/opam
+++ b/packages/conf-which/conf-which.1/opam
@@ -7,7 +7,7 @@ license: "GPL-2.0-or-later"
 build: [["which" "which"]]
 depexts: [
   ["which"] {os-distribution = "centos"}
-  ["which"] {os-distribution = "fedora"}
+  ["which"] {os-family = "fedora"}
   ["which"] {os-distribution = "ol"}
   ["which"] {os-family = "suse" | os-family = "opensuse"}
   ["debianutils"] {os-family = "debian"}

--- a/packages/conf-xen/conf-xen.1/opam
+++ b/packages/conf-xen/conf-xen.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libxen-dev"] {os-family = "debian"}
   ["libxen-dev"] {os-family = "ubuntu"}
   ["xen-devel"] {os-distribution = "centos"}
-  ["xen-devel"] {os-distribution = "fedora"}
+  ["xen-devel"] {os-family = "fedora"}
   ["xen-devel"] {os-distribution = "rhel"}
   ["xen-devel"] {os-distribution = "ol"}
   ["xen-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-xxhash/conf-xxhash.1/opam
+++ b/packages/conf-xxhash/conf-xxhash.1/opam
@@ -10,7 +10,7 @@ depexts: [
   ["xxhash-dev"] {os-family = "alpine"}
   ["xxhash"] {os-family = "arch"}
   ["xxhash-devel"] {os-family = "rhel"}
-  ["xxhash-devel"] {os-distribution = "fedora"}
+  ["xxhash-devel"] {os-family = "fedora"}
   ["libxxhash-dev"] {os-family = "debian"}
   ["libxxhash-dev"] {os-family = "ubuntu"}
   ["xxhash"] {os-family = "gentoo"}

--- a/packages/conf-zig/conf-zig.1/opam
+++ b/packages/conf-zig/conf-zig.1/opam
@@ -7,7 +7,7 @@ license: "MIT"
 build: ["zig" "version"]
 depexts: [
   ["zig"] {os-family = "debian"}
-  ["zig"] {os-distribution = "fedora"}
+  ["zig"] {os-family = "fedora"}
   ["zig"] {os-distribution = "rhel"}
   ["zig"] {os-distribution = "centos"}
   ["zig"] {os-distribution = "alpine"}

--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -20,8 +20,8 @@ depexts: [
   ["zlib1g-dev"] {os-family = "debian"}
   ["zlib1g-dev"] {os-family = "ubuntu"}
   ["zlib-devel"] {os-distribution = "centos"}
-  ["zlib-devel"] {os-distribution = "fedora" & os-version < "40" }
-  ["zlib-ng-compat-devel"] {os-distribution = "fedora" & os-version >= "40" }
+  ["zlib-devel"] {os-family = "fedora" & os-version < "40" }
+  ["zlib-ng-compat-devel"] {os-family = "fedora" & os-version >= "40" }
   ["zlib-devel"] {os-distribution = "ol"}
   ["zlib"] {os-distribution = "nixos"}
   ["zlib"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -17,7 +17,7 @@ depexts: [
   ["zeromq"] {os = "win32" & os-distribution = "cygwinports"}
   ["epel-release" "zeromq-devel"] {os-distribution = "centos"}
   ["zeromq"] {os-distribution = "arch"}
-  ["zeromq-devel"] {os-distribution = "fedora"}
+  ["zeromq-devel"] {os-family = "fedora"}
   ["zeromq-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libzmq4"] {os = "freebsd"}
 ]

--- a/packages/conf-zstd/conf-zstd.0.1/opam
+++ b/packages/conf-zstd/conf-zstd.0.1/opam
@@ -10,7 +10,7 @@ depexts: [
   ["libzstd-dev"] {os-family = "debian"}
   ["libzstd-devel"] {os-distribution = "centos"}
   ["libzstd-devel"] {os-distribution = "rhel"}
-  ["libzstd-devel"] {os-distribution = "fedora"}
+  ["libzstd-devel"] {os-family = "fedora"}
   ["libzstd-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["zstd-dev"] {os-distribution = "alpine"}
   ["zstd"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/conf-zstd/conf-zstd.1.3.8/opam
+++ b/packages/conf-zstd/conf-zstd.1.3.8/opam
@@ -21,7 +21,7 @@ depexts: [
   ["libzstd-dev"] {os-family = "ubuntu"}
   ["libzstd-devel"] {os-distribution = "centos"}
   ["libzstd-devel"] {os-distribution = "rhel"}
-  ["libzstd-devel"] {os-distribution = "fedora"}
+  ["libzstd-devel"] {os-family = "fedora"}
   ["libzstd-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["zstd-dev"] {os-distribution = "alpine"}
   ["zstd"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/dbm/dbm.1.0/opam
+++ b/packages/dbm/dbm.1.0/opam
@@ -19,7 +19,7 @@ depexts: [
   ["gdbm"] {os-distribution = "nixos"}
   ["gdbm-devel"] {os-distribution = "centos"}
   ["gdbm-devel"] {os-distribution = "rhel"}
-  ["gdbm-devel"] {os-distribution = "fedora"}
+  ["gdbm-devel"] {os-family = "fedora"}
   ["gdbm-dev"] {os-distribution = "alpine"}
   ["gdbm"] {os-distribution = "arch"}
 ]

--- a/packages/dbm/dbm.1.1/opam
+++ b/packages/dbm/dbm.1.1/opam
@@ -19,7 +19,7 @@ depexts: [
   ["gdbm"] {os-distribution = "nixos"}
   ["gdbm-devel"] {os-distribution = "centos"}
   ["gdbm-devel"] {os-distribution = "rhel"}
-  ["gdbm-devel"] {os-distribution = "fedora"}
+  ["gdbm-devel"] {os-family = "fedora"}
   ["gdbm-dev"] {os-distribution = "alpine"}
   ["gdbm"] {os = "macos" & os-distribution = "homebrew"}
   ["gdbm"] {os-distribution = "arch"}

--- a/packages/dlm/dlm.0.3.0/opam
+++ b/packages/dlm/dlm.0.3.0/opam
@@ -24,7 +24,7 @@ depexts: [
   ["libdlm-dev"] {os-family = "debian"}
   ["dlm-devel"] {os-distribution = "rhel"}
   ["dlm-devel"] {os-distribution = "centos"}
-  ["dlm-devel"] {os-distribution = "fedora"}
+  ["dlm-devel"] {os-family = "fedora"}
   ["dlm-devel"] {os-distribution = "ol"}
   ["libdlm-devel"] {os-family = "suse" | os-family = "opensuse"}
 ]

--- a/packages/dlm/dlm.0.3.1/opam
+++ b/packages/dlm/dlm.0.3.1/opam
@@ -25,7 +25,7 @@ depexts: [
   ["libdlm-dev"] {os-distribution = "ubuntu"}
   ["dlm-devel"] {os-distribution = "rhel"}
   ["dlm-devel"] {os-distribution = "centos"}
-  ["dlm-devel"] {os-distribution = "fedora"}
+  ["dlm-devel"] {os-family = "fedora"}
   ["dlm-devel"] {os-distribution = "ol"}
   ["libdlm-devel"] {os-family = "suse" | os-family = "opensuse"}
 ]

--- a/packages/dssi/dssi.0.1.2/opam
+++ b/packages/dssi/dssi.0.1.2/opam
@@ -18,7 +18,7 @@ depends: [
 depexts: [
   ["dssi-dev"] {os-family = "debian"}
   ["dssi-devel"] {os-distribution = "centos"}
-  ["dssi-devel"] {os-distribution = "fedora"}
+  ["dssi-devel"] {os-family = "fedora"}
   ["dssi-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["dssi"] {os-distribution = "nixos"}
   ["dssi"] {os-distribution = "arch"}

--- a/packages/faad/faad.0.4.0/opam
+++ b/packages/faad/faad.0.4.0/opam
@@ -27,7 +27,7 @@ depexts: [
   ["faad2-dev"] {os-distribution = "alpine"}
   ["faad2"] {os-distribution = "arch"}
   ["faad2-devel"] {os-distribution = "centos"}
-  ["faad2-devel"] {os-distribution = "fedora"}
+  ["faad2-devel"] {os-family = "fedora"}
   ["faad2-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libfaad-dev"] {os-family = "debian"}
   ["faad2"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/faad/faad.0.5.0/opam
+++ b/packages/faad/faad.0.5.0/opam
@@ -29,7 +29,7 @@ depexts: [
   ["faad2-dev"] {os-distribution = "alpine"}
   ["faad2"] {os-distribution = "arch"}
   ["faad2-devel"] {os-distribution = "centos"}
-  ["faad2-devel"] {os-distribution = "fedora"}
+  ["faad2-devel"] {os-family = "fedora"}
   ["faad2-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libfaad-dev"] {os-family = "debian"}
   ["faad2"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/farmhash/farmhash.0.3/opam
+++ b/packages/farmhash/farmhash.0.3/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 depexts: [
   ["g++"] {os-family = "debian"}
-  ["gcc-c++"] {os-distribution = "fedora"}
+  ["gcc-c++"] {os-family = "fedora"}
 ]
 synopsis: "Bindings for Google's farmhash library"
 flags: light-uninstall

--- a/packages/fdkaac/fdkaac.0.2.1/opam
+++ b/packages/fdkaac/fdkaac.0.2.1/opam
@@ -21,7 +21,7 @@ depexts: [
   ["fdk-aac-dev"] {os-distribution = "alpine"}
   ["libfdk-aac"] {os-distribution = "arch"}
   ["fdk-aac-devel"] {os-distribution = "centos"}
-  ["fdk-aac-devel"] {os-distribution = "fedora"}
+  ["fdk-aac-devel"] {os-family = "fedora"}
   ["fdk-aac-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libfdk-aac-dev"] {os-family = "debian"}
   ["fdk-aac"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/fdkaac/fdkaac.0.3.0/opam
+++ b/packages/fdkaac/fdkaac.0.3.0/opam
@@ -24,7 +24,7 @@ depexts: [
   ["fdk-aac-dev"] {os-distribution = "alpine"}
   ["libfdk-aac"] {os-distribution = "arch"}
   ["fdk-aac-devel"] {os-distribution = "centos"}
-  ["fdk-aac-devel"] {os-distribution = "fedora"}
+  ["fdk-aac-devel"] {os-family = "fedora"}
   ["fdk-aac-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libfdk-aac-dev"] {os-family = "debian"}
   ["fdk-aac"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/fdkaac/fdkaac.0.3.1/opam
+++ b/packages/fdkaac/fdkaac.0.3.1/opam
@@ -25,7 +25,7 @@ depexts: [
   ["fdk-aac-dev"] {os-distribution = "alpine"}
   ["libfdk-aac"] {os-distribution = "arch"}
   ["fdk-aac-devel"] {os-distribution = "centos"}
-  ["fdk-aac-devel"] {os-distribution = "fedora"}
+  ["fdk-aac-devel"] {os-family = "fedora"}
   ["fdk-aac-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libfdk-aac-dev"] {os-family = "debian"}
   ["fdk-aac"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/fdkaac/fdkaac.0.3.2/opam
+++ b/packages/fdkaac/fdkaac.0.3.2/opam
@@ -30,7 +30,7 @@ depexts: [
   ["fdk-aac-dev"] {os-distribution = "alpine"}
   ["libfdk-aac"] {os-distribution = "arch"}
   ["fdk-aac-devel"] {os-distribution = "centos"}
-  ["fdk-aac-devel"] {os-distribution = "fedora"}
+  ["fdk-aac-devel"] {os-family = "fedora"}
   ["fdk-aac-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libfdk-aac-dev"] {os-family = "debian"}
   ["fdk-aac"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ffmpeg/ffmpeg.0.1.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.1.1/opam
@@ -21,7 +21,7 @@ depexts: [
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
-  ["ffmpeg-devel"] {os-distribution = "fedora"}
+  ["ffmpeg-devel"] {os-family = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ffmpeg/ffmpeg.0.1.2/opam
+++ b/packages/ffmpeg/ffmpeg.0.1.2/opam
@@ -20,7 +20,7 @@ depexts: [
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
-  ["ffmpeg-devel"] {os-distribution = "fedora"}
+  ["ffmpeg-devel"] {os-family = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ffmpeg/ffmpeg.0.2.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.2.0/opam
@@ -22,7 +22,7 @@ depexts: [
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
-  ["ffmpeg-devel"] {os-distribution = "fedora"}
+  ["ffmpeg-devel"] {os-family = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ffmpeg/ffmpeg.0.2.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.2.1/opam
@@ -29,7 +29,7 @@ depexts: [
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
-  ["ffmpeg-devel"] {os-distribution = "fedora"}
+  ["ffmpeg-devel"] {os-family = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ffmpeg/ffmpeg.0.3.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.3.0/opam
@@ -33,7 +33,7 @@ depexts: [
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
-  ["ffmpeg-devel"] {os-distribution = "fedora"}
+  ["ffmpeg-devel"] {os-family = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ffmpeg/ffmpeg.0.4.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.4.0/opam
@@ -33,7 +33,7 @@ depexts: [
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
-  ["ffmpeg-devel"] {os-distribution = "fedora"}
+  ["ffmpeg-devel"] {os-family = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ffmpeg/ffmpeg.0.4.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.4.1/opam
@@ -33,7 +33,7 @@ depexts: [
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
-  ["ffmpeg-devel"] {os-distribution = "fedora"}
+  ["ffmpeg-devel"] {os-family = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ffmpeg/ffmpeg.0.4.2/opam
+++ b/packages/ffmpeg/ffmpeg.0.4.2/opam
@@ -28,7 +28,7 @@ depexts: [
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
-  ["ffmpeg-devel"] {os-distribution = "fedora"}
+  ["ffmpeg-devel"] {os-family = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ffmpeg/ffmpeg.0.4.3/opam
+++ b/packages/ffmpeg/ffmpeg.0.4.3/opam
@@ -28,7 +28,7 @@ depexts: [
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os-distribution = "arch"}
   ["ffmpeg-devel"] {os-distribution = "centos"}
-  ["ffmpeg-devel"] {os-distribution = "fedora"}
+  ["ffmpeg-devel"] {os-family = "fedora"}
   ["ffmpeg-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["ffmpeg"] {os-distribution = "nixos"}
   ["ffmpeg"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/fftw3/fftw3.0.8.1/opam
+++ b/packages/fftw3/fftw3.0.8.1/opam
@@ -35,7 +35,7 @@ depexts: [
   ["libfftw3-dev"] {os-family = "debian"}
   ["fftw-devel"] {os-distribution = "centos"}
   ["fftw-dev"] {os-distribution = "alpine"}
-  ["fftw-devel"] {os-distribution = "fedora"}
+  ["fftw-devel"] {os-family = "fedora"}
   ["fftw-devel"] {os-distribution = "rhel"}
   ["libfftw-devel"] {os-distribution = "mageia"}
   ["fftw3-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/freetds/freetds.0.4.1/opam
+++ b/packages/freetds/freetds.0.4.1/opam
@@ -33,7 +33,7 @@ install: [make "install"]
 depexts: [
   ["autoconf" "automake" "freetds-devel"] {os-distribution = "centos"}
   ["autoconf" "automake" "freetds-dev"] {os-family = "debian"}
-  ["autoconf" "automake" "freetds-devel"] {os-distribution = "fedora"}
+  ["autoconf" "automake" "freetds-devel"] {os-family = "fedora"}
   ["autoconf" "automake" "freetds"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/freetds/freetds.0.4.2/opam
+++ b/packages/freetds/freetds.0.4.2/opam
@@ -33,7 +33,7 @@ install: [make "install"]
 depexts: [
   ["autoconf" "automake" "freetds-devel"] {os-distribution = "centos"}
   ["autoconf" "automake" "freetds-dev"] {os-family = "debian"}
-  ["autoconf" "automake" "freetds-devel"] {os-distribution = "fedora"}
+  ["autoconf" "automake" "freetds-devel"] {os-family = "fedora"}
   ["autoconf" "automake" "freetds"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/freetds/freetds.0.4/opam
+++ b/packages/freetds/freetds.0.4/opam
@@ -29,7 +29,7 @@ install: [make "install"]
 depexts: [
   ["autoconf" "automake" "freetds-devel"] {os-distribution = "centos"}
   ["autoconf" "automake" "freetds-dev"] {os-family = "debian"}
-  ["autoconf" "automake" "freetds-devel"] {os-distribution = "fedora"}
+  ["autoconf" "automake" "freetds-devel"] {os-family = "fedora"}
   ["autoconf" "automake" "freetds"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/freetds/freetds.0.5.1/opam
+++ b/packages/freetds/freetds.0.5.1/opam
@@ -31,7 +31,7 @@ depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["autoconf" "automake" "freetds-devel"] {os-distribution = "centos"}
   ["autoconf" "automake" "freetds-dev"] {os-family = "debian"}
-  ["autoconf" "automake" "freetds-devel"] {os-distribution = "fedora"}
+  ["autoconf" "automake" "freetds-devel"] {os-family = "fedora"}
   ["autoconf" "automake" "freetds"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/freetds/freetds.0.5.2/opam
+++ b/packages/freetds/freetds.0.5.2/opam
@@ -27,7 +27,7 @@ depexts: [
   ["freetds-dev"] {os-distribution = "alpine"}
   ["freetds-devel"] {os-distribution = "centos"}
   ["freetds-dev"] {os-family = "debian"}
-  ["freetds-devel"] {os-distribution = "fedora"}
+  ["freetds-devel"] {os-family = "fedora"}
   ["freetds"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Binding to the FreeTDS library"

--- a/packages/freetds/freetds.0.5/opam
+++ b/packages/freetds/freetds.0.5/opam
@@ -33,7 +33,7 @@ install: [make "install"]
 depexts: [
   ["autoconf" "automake" "freetds-devel"] {os-distribution = "centos"}
   ["autoconf" "automake" "freetds-dev"] {os-family = "debian"}
-  ["autoconf" "automake" "freetds-devel"] {os-distribution = "fedora"}
+  ["autoconf" "automake" "freetds-devel"] {os-family = "fedora"}
   ["autoconf" "automake" "freetds"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/freetds/freetds.0.6/opam
+++ b/packages/freetds/freetds.0.6/opam
@@ -32,7 +32,7 @@ depexts: [
   ["epel-release" "freetds-devel"] {os-distribution = "centos"}
   ["freetds-dev"] {os-family = "debian"}
   ["freetds-dev"] {os-distribution = "alpine"}
-  ["freetds-devel"] {os-distribution = "fedora"}
+  ["freetds-devel"] {os-family = "fedora"}
   ["freetds-devel"] {os-distribution = "rhel"}
   ["libfreetds-devel"] {os-distribution = "mageia"}
   ["freetds-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/freetds/freetds.0.7/opam
+++ b/packages/freetds/freetds.0.7/opam
@@ -30,7 +30,7 @@ depexts: [
   ["epel-release" "freetds-devel"] {os-distribution = "centos"}
   ["freetds-dev"] {os-family = "debian"}
   ["freetds-dev"] {os-distribution = "alpine"}
-  ["freetds-devel"] {os-distribution = "fedora"}
+  ["freetds-devel"] {os-family = "fedora"}
   ["freetds-devel"] {os-distribution = "rhel"}
   ["libfreetds-devel"] {os-distribution = "mageia"}
   ["freetds-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/frei0r/frei0r.0.1.1/opam
+++ b/packages/frei0r/frei0r.0.1.1/opam
@@ -14,7 +14,7 @@ depends: ["ocaml" "ocamlfind" "conf-pkg-config"]
 depexts: [
   ["frei0r-plugins-dev"] {os-distribution = "alpine"}
   ["frei0r-devel"] {os-distribution = "centos"}
-  ["frei0r-devel"] {os-distribution = "fedora"}
+  ["frei0r-devel"] {os-family = "fedora"}
   ["frei0r-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["frei0r"] {os = "macos" & os-distribution = "homebrew"}
   ["frei0r-plugins-dev"] {os-family = "debian"}

--- a/packages/gammu/gammu.0.9.3/opam
+++ b/packages/gammu/gammu.0.9.3/opam
@@ -28,7 +28,7 @@ depopts: [
 depexts: [
   ["libgammu-dev"] {os-family = "debian"}
   ["epel-release" "gammu-devel"] {os-distribution = "centos"}
-  ["gammu-devel"] {os-distribution = "fedora"}
+  ["gammu-devel"] {os-family = "fedora"}
   ["lib64gammu-devel"] {os-distribution = "mageia"}
   ["gammu-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gammu-dev"] {os-distribution = "alpine"}

--- a/packages/gammu/gammu.0.9.4/opam
+++ b/packages/gammu/gammu.0.9.4/opam
@@ -26,7 +26,7 @@ depends: [
 depexts: [
   ["libgammu-dev"] {os-family = "debian"}
   ["epel-release" "gammu-devel"] {os-distribution = "centos"}
-  ["gammu-devel"] {os-distribution = "fedora"}
+  ["gammu-devel"] {os-family = "fedora"}
   ["lib64gammu-devel"] {os-distribution = "mageia"}
   ["gammu-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gammu-dev"] {os-distribution = "alpine"}

--- a/packages/gavl/gavl.0.1.6/opam
+++ b/packages/gavl/gavl.0.1.6/opam
@@ -14,7 +14,7 @@ depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["gavl-dev"] {os-distribution = "alpine"}
   ["gavl-devel"] {os-distribution = "centos"}
-  ["gavl-devel"] {os-distribution = "fedora"}
+  ["gavl-devel"] {os-family = "fedora"}
   ["gavl-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libgavl-dev"] {os-family = "debian"}
   ["drfill/liquidsoap/libgavl"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/gles3/gles3.20160307.alpha/opam
+++ b/packages/gles3/gles3.20160307.alpha/opam
@@ -18,7 +18,7 @@ depexts: [
   ["libgles2-mesa-dev"] {os-family = "debian"}
   ["libmesaglesv2_2-devel"] {os-distribution = "mageia"}
   ["mesa-libGLES" "mesa-libGLES-devel"] {os-distribution = "centos"}
-  ["mesa-libGLES-devel"] {os-distribution = "fedora"}
+  ["mesa-libGLES-devel"] {os-family = "fedora"}
 ]
 x-ci-accept-failures: ["debian-unstable"]
 post-messages: [

--- a/packages/goblint-cil/goblint-cil.1.7.4/opam
+++ b/packages/goblint-cil/goblint-cil.1.7.4/opam
@@ -20,7 +20,7 @@ depends: [
   "hevea" {with-doc | with-test}
 ]
 depexts: [
-  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-distribution = "fedora"}
+  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-family = "fedora"}
 ]
 conflicts: ["cil"]
 synopsis:

--- a/packages/goblint-cil/goblint-cil.1.8.0/opam
+++ b/packages/goblint-cil/goblint-cil.1.8.0/opam
@@ -50,8 +50,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/goblint/cil.git"
 depexts: [
-  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
-  ["perl-FindBin"] {os-distribution = "fedora"}
+  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-family = "fedora" | os-distribution = "ol"}
+  ["perl-FindBin"] {os-family = "fedora"}
   ["build-base"] {os-distribution = "alpine"}
 ]
 available: arch != "ppc32" & arch != "ppc64"

--- a/packages/goblint-cil/goblint-cil.1.8.2/opam
+++ b/packages/goblint-cil/goblint-cil.1.8.2/opam
@@ -52,8 +52,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/goblint/cil.git"
 depexts: [
-  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
-  ["perl-FindBin"] {os-distribution = "fedora"}
+  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-family = "fedora" | os-distribution = "ol"}
+  ["perl-FindBin"] {os-family = "fedora"}
   ["build-base"] {os-distribution = "alpine"}
 ]
 available: arch != "ppc32" & arch != "ppc64"

--- a/packages/goblint-cil/goblint-cil.2.0.0/opam
+++ b/packages/goblint-cil/goblint-cil.2.0.0/opam
@@ -59,8 +59,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/goblint/cil.git"
 depexts: [
-  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
-  ["perl-FindBin"] {os-distribution = "fedora"}
+  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-family = "fedora" | os-distribution = "ol"}
+  ["perl-FindBin"] {os-family = "fedora"}
   ["build-base"] {os-distribution = "alpine"}
 ]
 available: arch != "x86_32" & arch != "arm32" & arch != "ppc32" & arch != "ppc64" & arch != "s390x"

--- a/packages/goblint-cil/goblint-cil.2.0.1/opam
+++ b/packages/goblint-cil/goblint-cil.2.0.1/opam
@@ -59,8 +59,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/goblint/cil.git"
 depexts: [
-  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
-  ["perl-FindBin"] {os-distribution = "fedora"}
+  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-family = "fedora" | os-distribution = "ol"}
+  ["perl-FindBin"] {os-family = "fedora"}
   ["build-base"] {os-distribution = "alpine"}
 ]
 available: arch = "x86_64"

--- a/packages/goblint-cil/goblint-cil.2.0.2/opam
+++ b/packages/goblint-cil/goblint-cil.2.0.2/opam
@@ -58,8 +58,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/goblint/cil.git"
 depexts: [
-  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
-  ["perl-FindBin"] {os-distribution = "fedora"}
+  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-family = "fedora" | os-distribution = "ol"}
+  ["perl-FindBin"] {os-family = "fedora"}
   ["build-base"] {os-distribution = "alpine"}
 ]
 available: arch = "x86_64"

--- a/packages/goblint-cil/goblint-cil.2.0.3/opam
+++ b/packages/goblint-cil/goblint-cil.2.0.3/opam
@@ -58,8 +58,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/goblint/cil.git"
 depexts: [
-  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
-  ["perl-FindBin"] {os-distribution = "fedora"}
+  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-family = "fedora" | os-distribution = "ol"}
+  ["perl-FindBin"] {os-family = "fedora"}
   ["build-base"] {os-distribution = "alpine"}
 ]
 available: arch = "x86_64"

--- a/packages/goblint-cil/goblint-cil.2.0.4/opam
+++ b/packages/goblint-cil/goblint-cil.2.0.4/opam
@@ -58,8 +58,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/goblint/cil.git"
 depexts: [
-  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
-  ["perl-FindBin"] {os-distribution = "fedora"}
+  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-family = "fedora" | os-distribution = "ol"}
+  ["perl-FindBin"] {os-family = "fedora"}
   ["build-base"] {os-distribution = "alpine"}
 ]
 available: arch = "x86_64" | arch = "arm64"

--- a/packages/goblint-cil/goblint-cil.2.0.5/opam
+++ b/packages/goblint-cil/goblint-cil.2.0.5/opam
@@ -58,8 +58,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/goblint/cil.git"
 depexts: [
-  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
-  ["perl-FindBin"] {os-distribution = "fedora"}
+  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-family = "fedora" | os-distribution = "ol"}
+  ["perl-FindBin"] {os-family = "fedora"}
   ["build-base"] {os-distribution = "alpine"}
 ]
 available: arch = "x86_64" | arch = "arm64"

--- a/packages/goblint-cil/goblint-cil.2.0.6/opam
+++ b/packages/goblint-cil/goblint-cil.2.0.6/opam
@@ -58,8 +58,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/goblint/cil.git"
 depexts: [
-  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
-  ["perl-FindBin"] {os-distribution = "fedora"}
+  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-family = "fedora" | os-distribution = "ol"}
+  ["perl-FindBin"] {os-family = "fedora"}
   ["build-base"] {os-distribution = "alpine"}
 ]
 available: arch = "x86_64" | arch = "arm64"

--- a/packages/gstreamer/gstreamer.0.2.3/opam
+++ b/packages/gstreamer/gstreamer.0.2.3/opam
@@ -18,7 +18,7 @@ depexts: [
   ["gstreamer1-dev" "gst-plugins-base1-dev"] {os-distribution = "alpine"}
   ["gstreamer-devel" "gstreamer-plugins-base-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]
-    {os-distribution = "fedora"}
+    {os-family = "fedora"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]
     {os-distribution = "centos"}
   ["libgstreamer1.0-dev" "libgstreamer-plugins-base1.0-dev"]

--- a/packages/gstreamer/gstreamer.0.3.0/opam
+++ b/packages/gstreamer/gstreamer.0.3.0/opam
@@ -18,7 +18,7 @@ depexts: [
   ["gstreamer-dev" "gst-plugins-base-dev"] {os-distribution = "alpine"}
   ["gstreamer-devel" "gstreamer-plugins-base-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]
-    {os-distribution = "fedora"}
+    {os-family = "fedora"}
   ["gstreamer1-devel" "gstreamer1-plugins-base-devel"]
     {os-distribution = "centos"}
   ["libgstreamer1.0-dev" "libgstreamer-plugins-base1.0-dev"]

--- a/packages/hvsock/hvsock.2.0.0/opam
+++ b/packages/hvsock/hvsock.2.0.0/opam
@@ -36,7 +36,7 @@ depends: [
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-family = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
 synopsis: "Bindings for Hyper-V AF_VSOCK"

--- a/packages/hvsock/hvsock.3.0.0/opam
+++ b/packages/hvsock/hvsock.3.0.0/opam
@@ -37,7 +37,7 @@ depends: [
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-family = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
 synopsis: "Bindings for Hyper-V AF_VSOCK"

--- a/packages/jemalloc/jemalloc.0.1/opam
+++ b/packages/jemalloc/jemalloc.0.1/opam
@@ -26,7 +26,7 @@ depends: [
 depexts: [
   ["jemalloc-dev"] {os-distribution = "alpine"}
   ["libjemalloc-dev"] {os-family = "debian"}
-  ["jemalloc-devel"] {os-distribution = "fedora"}
+  ["jemalloc-devel"] {os-family = "fedora"}
   ["jemalloc-devel"] {os-distribution = "mageia"}
   ["jemalloc-devel"] {os-distribution = "rhel"}
   ["jemalloc-devel"] {os-distribution = "centos"}

--- a/packages/jemalloc/jemalloc.0.2/opam
+++ b/packages/jemalloc/jemalloc.0.2/opam
@@ -18,7 +18,7 @@ depends: [
 depexts: [
   ["jemalloc-dev"] {os-distribution = "alpine"}
   ["libjemalloc-dev"] {os-family = "debian"}
-  ["jemalloc-devel"] {os-distribution = "fedora"}
+  ["jemalloc-devel"] {os-family = "fedora"}
   ["jemalloc-devel"] {os-distribution = "mageia"}
   ["jemalloc-devel"] {os-distribution = "rhel"}
   ["jemalloc-devel"] {os-distribution = "centos"}

--- a/packages/kafka/kafka.0.3/opam
+++ b/packages/kafka/kafka.0.3/opam
@@ -17,7 +17,7 @@ depexts: [
   ["zlib-dev" "librdkafka-dev"] {os-distribution = "alpine"}
   ["zlib-devel" "librdkafka-devel"] {os-distribution = "centos"}
   ["zlib1g-dev" "librdkafka-dev"] {os-family = "debian"}
-  ["zlib-devel" "librdkafka-devel"] {os-distribution = "fedora"}
+  ["zlib-devel" "librdkafka-devel"] {os-family = "fedora"}
   ["zlib" "librdkafka"] {os-distribution = "homebrew" & os = "macos"}
 ]
 synopsis: "OCaml bindings for Kafka"

--- a/packages/kafka/kafka.0.4/opam
+++ b/packages/kafka/kafka.0.4/opam
@@ -17,7 +17,7 @@ depexts: [
   ["librdkafka-dev" "zlib-dev"] {os-distribution = "alpine"}
   ["librdkafka-devel" "zlib-devel"] {os-distribution = "centos"}
   ["librdkafka-dev" "zlib1g-dev"] {os-family = "debian"}
-  ["librdkafka-devel" "zlib-devel"] {os-distribution = "fedora"}
+  ["librdkafka-devel" "zlib-devel"] {os-family = "fedora"}
   ["librdkafka" "zlib"] {os-distribution = "homebrew" & os = "macos"}
 ]
 synopsis: "OCaml bindings for Kafka"

--- a/packages/kafka/kafka.0.5/opam
+++ b/packages/kafka/kafka.0.5/opam
@@ -27,7 +27,7 @@ depexts: [
   ["librdkafka"] {os-distribution = "archlinux"}
   ["librdkafka-devel"] {os-distribution = "centos"}
   ["librdkafka-dev"] {os-distribution = "debian"}
-  ["librdkafka-devel"] {os-distribution = "fedora"}
+  ["librdkafka-devel"] {os-family = "fedora"}
   ["librdkafka"] {os-distribution = "homebrew" & os = "macos"}
   ["librdkafka-dev"] {os-distribution = "ubuntu"}
   ["net/librdkafka"] {os = "freebsd"}

--- a/packages/kyotocabinet/kyotocabinet.0.1/opam
+++ b/packages/kyotocabinet/kyotocabinet.0.1/opam
@@ -25,7 +25,7 @@ depends: [
 ]
 depexts: [
   ["libkyotocabinet-dev"] {os-family = "debian"}
-  ["kyotocabinet-devel"] {os-distribution = "fedora"}
+  ["kyotocabinet-devel"] {os-family = "fedora"}
   ["kyoto-cabinet"] {os = "macos" & os-distribution = "homebrew"}
   ["kyotocabinet"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/kyotocabinet/kyotocabinet.0.2/opam
+++ b/packages/kyotocabinet/kyotocabinet.0.2/opam
@@ -15,7 +15,7 @@ depends: [
 ]
 depexts: [
   ["libkyotocabinet-dev"] {os-family = "debian"}
-  ["kyotocabinet-devel"] {os-distribution = "fedora"}
+  ["kyotocabinet-devel"] {os-family = "fedora"}
   ["kyoto-cabinet"] {os-distribution = "homebrew" & os = "macos"}
   ["kyotocabinet"] {os-distribution = "macports" & os = "macos"}
 ]

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta5/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta5/opam
@@ -29,7 +29,7 @@ depexts: [
   ["gtkspell3"] {os-distribution = "arch"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
   ["libgtkspell3-3-dev"] {os-family = "debian"}
-  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3-devel"] {os-family = "fedora"}
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta6/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta6/opam
@@ -28,7 +28,7 @@ depexts: [
   ["gtkspell3"] {os-distribution = "arch"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
   ["libgtkspell3-3-dev"] {os-family = "debian"}
-  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3-devel"] {os-family = "fedora"}
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta7/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta7/opam
@@ -28,7 +28,7 @@ depexts: [
   ["gtkspell3"] {os-distribution = "arch"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
   ["libgtkspell3-3-dev"] {os-distribution = "debian"}
-  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3-devel"] {os-family = "fedora"}
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta8/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.0.beta8/opam
@@ -26,7 +26,7 @@ depexts: [
   ["gtkspell3"] {os-distribution = "arch"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
   ["libgtkspell3-3-dev"] {os-distribution = "debian"}
-  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3-devel"] {os-family = "fedora"}
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.0/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.0/opam
@@ -26,7 +26,7 @@ depexts: [
   ["gtkspell3"] {os-distribution = "arch"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
   ["libgtkspell3-3-dev"] {os-distribution = "debian"}
-  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3-devel"] {os-family = "fedora"}
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.1/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.1/opam
@@ -26,7 +26,7 @@ depexts: [
   ["gtkspell3"] {os-distribution = "archlinux"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
   ["libgtkspell3-3-dev"] {os-distribution = "debian"}
-  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3-devel"] {os-family = "fedora"}
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.2/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.2/opam
@@ -26,7 +26,7 @@ depexts: [
   ["gtkspell3"] {os-distribution = "archlinux"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
   ["libgtkspell3-3-dev"] {os-distribution = "debian"}
-  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3-devel"] {os-family = "fedora"}
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.3/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.3/opam
@@ -26,7 +26,7 @@ depexts: [
   ["gtkspell3"] {os-distribution = "archlinux"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
   ["libgtkspell3-3-dev"] {os-distribution = "debian"}
-  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3-devel"] {os-family = "fedora"}
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.4/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.4/opam
@@ -26,7 +26,7 @@ depexts: [
   ["gtkspell3"] {os-distribution = "archlinux"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
   ["libgtkspell3-3-dev"] {os-distribution = "debian"}
-  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3-devel"] {os-family = "fedora"}
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse"}

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.5/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.5/opam
@@ -26,7 +26,7 @@ depexts: [
   ["gtkspell3"] {os-distribution = "archlinux"}
   ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
   ["libgtkspell3-3-dev"] {os-distribution = "debian"}
-  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3-devel"] {os-family = "fedora"}
   ["gtkspell3"] {os = "freebsd"}
   ["gtkspell3"] {os = "openbsd"}
   ["gtkspell3-devel"] {os-family = "suse"}

--- a/packages/lablqml/lablqml.0.5.2/opam
+++ b/packages/lablqml/lablqml.0.5.2/opam
@@ -8,10 +8,10 @@ license: "LGPL-2.1-or-later"
 tags: [ "gui" "ui" "qt" ]
 
 build: [
-  ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH ./configure"] {os-distribution = "alpine" | os-distribution = "centos" | os-distribution = "fedora" }
-  ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH make"]        {os-distribution = "alpine" | os-distribution = "centos" | os-distribution = "fedora" }
+  ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH ./configure"] {os-distribution = "alpine" | os-distribution = "centos" | os-family = "fedora" }
+  ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH make"]        {os-distribution = "alpine" | os-distribution = "centos" | os-family = "fedora" }
 #  ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH make demos"]
-#    { (os-distribution = "alpine"  | os-distribution = "centos" | os-distribution = "fedora") & with-test }
+#    { (os-distribution = "alpine"  | os-distribution = "centos" | os-family = "fedora") & with-test }
 
   ["./configure"]            { os-distribution != "alpine" & os-distribution != "centos" & os-distribution != "fedora" }
   [make]                     { os-distribution != "alpine" & os-distribution != "centos" & os-distribution != "fedora" }

--- a/packages/lablqml/lablqml.0.6.2/opam
+++ b/packages/lablqml/lablqml.0.6.2/opam
@@ -11,7 +11,7 @@ post-messages: [ "On OPAM 2.1 this package may be not installable because CI use
 
 build: [
   ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH ./configure"]
-      {os-distribution = "alpine" | os-distribution = "centos" | os-distribution = "fedora" }
+      {os-distribution = "alpine" | os-distribution = "centos" | os-family = "fedora" }
   ["./configure"]
       { os-distribution != "alpine" & os-distribution != "centos" & os-distribution != "fedora" }
   ["dune" "build" "-p" "lablqml,ppx_qt" "-j" jobs]

--- a/packages/lablqml/lablqml.0.6/opam
+++ b/packages/lablqml/lablqml.0.6/opam
@@ -8,10 +8,10 @@ license: "LGPL-2.1-or-later"
 tags: [ "gui" "ui" "qt" ]
 
 build: [
-  ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH ./configure"] {os-distribution = "alpine" | os-distribution = "centos" | os-distribution = "fedora" }
-  ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH make"]        {os-distribution = "alpine" | os-distribution = "centos" | os-distribution = "fedora" }
+  ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH ./configure"] {os-distribution = "alpine" | os-distribution = "centos" | os-family = "fedora" }
+  ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH make"]        {os-distribution = "alpine" | os-distribution = "centos" | os-family = "fedora" }
   ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH make demos"]
-    { (os-distribution = "alpine"  | os-distribution = "centos" | os-distribution = "fedora") & with-test }
+    { (os-distribution = "alpine"  | os-distribution = "centos" | os-family = "fedora") & with-test }
 
   ["./configure"]            { os-distribution != "alpine" & os-distribution != "centos" & os-distribution != "fedora" }
   [make]                     { os-distribution != "alpine" & os-distribution != "centos" & os-distribution != "fedora" }

--- a/packages/labrys/labrys.0.1/opam
+++ b/packages/labrys/labrys.0.1/opam
@@ -27,7 +27,7 @@ depends: [
 depexts: [
   ["libgc-dev"] {os-family = "debian"}
   ["gc-devel"] {os-distribution = "centos"}
-  ["gc-devel"] {os-distribution = "fedora"}
+  ["gc-devel"] {os-family = "fedora"}
   ["gc-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gc"] {os-distribution = "arch"}
   ["gc-dev"] {os-distribution = "alpine"}

--- a/packages/ladspa/ladspa.0.1.5/opam
+++ b/packages/ladspa/ladspa.0.1.5/opam
@@ -22,7 +22,7 @@ depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["ladspa-dev"] {os-distribution = "alpine"}
   ["ladspa-devel"] {os-distribution = "centos"}
-  ["ladspa-devel"] {os-distribution = "fedora"}
+  ["ladspa-devel"] {os-family = "fedora"}
   ["ladspa-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["ladspa-sdk"] {os-family = "debian"}
   ["drfill/liquidsoap/ladspa_header"]

--- a/packages/lame/lame.0.3.3/opam
+++ b/packages/lame/lame.0.3.3/opam
@@ -22,7 +22,7 @@ depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["lame-dev"] {os-distribution = "alpine"}
   ["lame-devel"] {os-distribution = "centos"}
-  ["lame-devel"] {os-distribution = "fedora"}
+  ["lame-devel"] {os-family = "fedora"}
   ["lame-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libmp3lame-dev"] {os-family = "debian"}
   ["lame"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/lame/lame.0.3.4/opam
+++ b/packages/lame/lame.0.3.4/opam
@@ -29,7 +29,7 @@ dev-repo: "git+https://github.com/savonet/ocaml-lame.git"
 depexts: [
   ["lame-dev"] {os-distribution = "alpine"}
   ["lame-devel"] {os-distribution = "centos"}
-  ["lame-devel"] {os-distribution = "fedora"}
+  ["lame-devel"] {os-family = "fedora"}
   ["lame-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libmp3lame-dev"] {os-family = "debian"}
   ["lame"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/lbfgs/lbfgs.0.9.1/opam
+++ b/packages/lbfgs/lbfgs.0.9.1/opam
@@ -26,7 +26,7 @@ depexts: [
   ["gfortran"] {os-family = "debian"}
   ["gfortran"] {os-distribution = "alpine"}
   ["gcc-gfortran"] {os-distribution = "centos"}
-  ["gcc-gfortran"] {os-distribution = "fedora"}
+  ["gcc-gfortran"] {os-family = "fedora"}
   ["gcc-gfortran"] {os-distribution = "mageia"}
   ["gcc-gfortran"] {os-distribution = "rhel"}
   ["gcc-fortran"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/lbfgs/lbfgs.0.9/opam
+++ b/packages/lbfgs/lbfgs.0.9/opam
@@ -28,7 +28,7 @@ depexts: [
   ["gfortran"] {os-family = "debian"}
   ["gfortran"] {os-distribution = "alpine"}
   ["gcc-gfortran"] {os-distribution = "centos"}
-  ["gcc-gfortran"] {os-distribution = "fedora"}
+  ["gcc-gfortran"] {os-family = "fedora"}
   ["gcc-gfortran"] {os-distribution = "mageia"}
   ["gcc-gfortran"] {os-distribution = "rhel"}
   ["gcc-fortran"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/libbpf/libbpf.0.1.0/opam
+++ b/packages/libbpf/libbpf.0.1.0/opam
@@ -39,7 +39,7 @@ dev-repo: "git+https://github.com/koonwen/ocaml-libbpf.git"
 available: [ os = "linux" &
 	   (( os-distribution = "debian" & os-version >= "12" )    # Linux 6.1 & Libbpf 1.1.0
  	   |( os-distribution = "ubuntu" & os-version >= "23.04" ) # Linux 6.2 & Libbpf 1.1.0
-	   |( os-distribution = "fedora" & os-version >= "38" ))   # Linux 6.2 & Libbpf 1.1.0
+	   |( os-family = "fedora" & os-version >= "38" ))   # Linux 6.2 & Libbpf 1.1.0
 	   ]
 url {
   src:

--- a/packages/lmdb/lmdb.0.1/opam
+++ b/packages/lmdb/lmdb.0.1/opam
@@ -29,7 +29,7 @@ depexts: [
   ["liblmdb-dev"] {os-family = "debian"}
   ["lmdb"] {os = "macos" & os-distribution = "homebrew"}
   ["lmdb"] {os = "macos" & os-distribution = "macports"}
-  ["lmdb-devel"] {os-distribution = "fedora"}
+  ["lmdb-devel"] {os-family = "fedora"}
   ["lmdb-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["lmdb"] {os-distribution = "arch"}
 ]

--- a/packages/lo/lo.0.1.2/opam
+++ b/packages/lo/lo.0.1.2/opam
@@ -23,7 +23,7 @@ depexts: [
   ["liblo"] {os = "macos" & os-distribution = "homebrew"}
   ["liblo"] {os-distribution = "arch"}
   ["liblo-devel"] {os-distribution = "centos"}
-  ["liblo-devel"] {os-distribution = "fedora"}
+  ["liblo-devel"] {os-family = "fedora"}
   ["liblo-devel"] {os-family = "suse" | os-family = "opensuse"}
 ]
 bug-reports: "https://github.com/savonet/ocaml-lo/issues"

--- a/packages/lzo/lzo.0.0.3/opam
+++ b/packages/lzo/lzo.0.0.3/opam
@@ -22,7 +22,7 @@ depexts: [
   ["lzo"] {os-distribution = "homebrew"}
   ["lzo-dev"] {os-distribution = "alpine"}
   ["lzo-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["lzo-devel"] {os-distribution = "centos" | os-distribution = "fedora"}
+  ["lzo-devel"] {os-distribution = "centos" | os-family = "fedora"}
   ["lzo"] {os-family = "archlinux"}
   ["lzo-devel"] {os-distribution = "ol"}
 ]

--- a/packages/mad/mad.0.4.5/opam
+++ b/packages/mad/mad.0.4.5/opam
@@ -15,7 +15,7 @@ depexts: [
   ["libmad-dev"] {os-distribution = "alpine"}
   ["libmad"] {os-distribution = "arch"}
   ["libmad-devel"] {os-distribution = "centos"}
-  ["libmad-devel"] {os-distribution = "fedora"}
+  ["libmad-devel"] {os-family = "fedora"}
   ["libmad-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libmad0-dev"] {os-family = "debian"}
   ["libmad"] {os-distribution = "nixos"}

--- a/packages/mad/mad.0.5.0/opam
+++ b/packages/mad/mad.0.5.0/opam
@@ -30,7 +30,7 @@ depexts: [
   ["libmad-dev"] {os-distribution = "alpine"}
   ["libmad"] {os-distribution = "archlinux"}
   ["libmad-devel"] {os-distribution = "centos"}
-  ["libmad-devel"] {os-distribution = "fedora"}
+  ["libmad-devel"] {os-family = "fedora"}
   ["libmad-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libmad0-dev"] {os-family = "debian"}
   ["libmad"] {os-distribution = "nixos"}

--- a/packages/magic/magic.0.7.3/opam
+++ b/packages/magic/magic.0.7.3/opam
@@ -16,7 +16,7 @@ depends: [
 depexts: [
   ["file-dev"] {os-distribution = "alpine"}
   ["file-devel"] {os-distribution = "centos"}
-  ["file-devel"] {os-distribution = "fedora"}
+  ["file-devel"] {os-family = "fedora"}
   ["file-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libmagic-dev"] {os-family = "debian"}
   ["libmagic"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/magic/magic.0.7.4/opam
+++ b/packages/magic/magic.0.7.4/opam
@@ -17,7 +17,7 @@ depends: [
 depexts: [
   ["libmagic-dev"] {os-family = "debian"}
   ["file-devel"] {os-distribution = "centos"}
-  ["file-devel"] {os-distribution = "fedora"}
+  ["file-devel"] {os-family = "fedora"}
   ["file-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["file-dev"] {os-family = "alpine"}
   ["file"] {os-family = "arch"}

--- a/packages/milter/milter.1.0.4/opam
+++ b/packages/milter/milter.1.0.4/opam
@@ -14,7 +14,7 @@ depexts: [
   ["libmilter-dev"] {os-distribution = "alpine"}
   ["libmilter"] {os-distribution = "arch"}
   ["sendmail-devel"] {os-distribution = "centos"}
-  ["sendmail-milter-devel"] {os-distribution = "fedora"}
+  ["sendmail-milter-devel"] {os-family = "fedora"}
   ["libmilter"] {os = "freebsd"}
   ["libmilter"] {os-distribution = "gentoo"}
   ["libmilter"] {os-distribution = "macports"}

--- a/packages/misuja/misuja.0.0.0/opam
+++ b/packages/misuja/misuja.0.0.0/opam
@@ -16,7 +16,7 @@ depends: [
 depexts: [
   ["libjack-jackd2-dev"] {os-family = "debian"}
   ["jack-dev"] {os-distribution = "alpine"}
-  ["jack-audio-connection-kit-devel"] {os-distribution = "fedora"}
+  ["jack-audio-connection-kit-devel"] {os-family = "fedora"}
   ["epel-release" "jack-audio-connection-kit-devel"]
     {os-distribution = "centos"}
   ["jack-audio-connection-kit-devel"] {os-distribution = "rhel"}

--- a/packages/ocaml-systemd/ocaml-systemd.1.2/opam
+++ b/packages/ocaml-systemd/ocaml-systemd.1.2/opam
@@ -19,7 +19,7 @@ depends: [
 depexts: [
   ["libsystemd-dev"] {os-family = "debian"}
   ["systemd-devel"] {os-distribution = "centos"}
-  ["systemd-devel"] {os-distribution = "fedora"}
+  ["systemd-devel"] {os-family = "fedora"}
 ]
 synopsis: "OCaml module for native access to the systemd facilities"
 description: """

--- a/packages/ogg/ogg.0.5.2/opam
+++ b/packages/ogg/ogg.0.5.2/opam
@@ -20,7 +20,7 @@ depexts: [
   ["libogg"] {os-distribution = "arch"}
   ["libogg-dev"] {os-family = "debian"}
   ["libogg-devel"] {os-distribution = "centos"}
-  ["libogg-devel"] {os-distribution = "fedora"}
+  ["libogg-devel"] {os-family = "fedora"}
   ["libogg-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libogg"] {os-distribution = "nixos"}
   ["libogg"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/ogg/ogg.0.6.0/opam
+++ b/packages/ogg/ogg.0.6.0/opam
@@ -32,7 +32,7 @@ depexts: [
   ["libogg"] {os-distribution = "arch"}
   ["libogg-dev"] {os-family = "debian"}
   ["libogg-devel"] {os-distribution = "centos"}
-  ["libogg-devel"] {os-distribution = "fedora"}
+  ["libogg-devel"] {os-family = "fedora"}
   ["libogg-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libogg"] {os-distribution = "nixos"}
   ["libogg"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/opus/opus.0.1.2/opam
+++ b/packages/opus/opus.0.1.2/opam
@@ -20,7 +20,7 @@ depexts: [
   ["opus"] {os-distribution = "arch"}
   ["libopus-dev"] {os-family = "debian"}
   ["opus-devel"] {os-distribution = "centos"}
-  ["opus-devel"] {os-distribution = "fedora"}
+  ["opus-devel"] {os-family = "fedora"}
   ["opus-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libopus"] {os-distribution = "nixos"}
   ["opus"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/opus/opus.0.1.3/opam
+++ b/packages/opus/opus.0.1.3/opam
@@ -21,7 +21,7 @@ depexts: [
   ["opus"] {os-distribution = "arch"}
   ["libopus-dev"] {os-family = "debian"}
   ["opus-devel"] {os-distribution = "centos"}
-  ["opus-devel"] {os-distribution = "fedora"}
+  ["opus-devel"] {os-family = "fedora"}
   ["libopus-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libopus"] {os-distribution = "nixos"}
   ["opus"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/pci/pci.1.0.1/opam
+++ b/packages/pci/pci.1.0.1/opam
@@ -27,7 +27,7 @@ depexts: [
   ["hwdata" "libpci-dev"] {os-family = "debian"}
   ["hwdata" "pciutils-devel"] {os-distribution = "centos"}
   ["hwdata" "pciutils-dev"] {os-distribution = "alpine"}
-  ["hwdata" "pciutil-devel"] {os-distribution = "fedora"}
+  ["hwdata" "pciutil-devel"] {os-family = "fedora"}
 ]
 post-messages: [
   "This package requires libpci-dev (>= 3.2.0) to be installed on your system"     {failure & (os = "debian")}

--- a/packages/pcre/pcre.7.2.3/opam
+++ b/packages/pcre/pcre.7.2.3/opam
@@ -26,7 +26,7 @@ depends: [
 ]
 depexts: [
   ["ocaml-ocamldoc"] {os-distribution = "centos"}
-  ["ocaml-ocamldoc"] {os-distribution = "fedora"}
+  ["ocaml-ocamldoc"] {os-family = "fedora"}
   ["ocaml-ocamldoc"] {os-family = "suse" | os-family = "opensuse"}
 ]
 synopsis:

--- a/packages/postgresql/postgresql.3.2.1/opam
+++ b/packages/postgresql/postgresql.3.2.1/opam
@@ -46,7 +46,7 @@ depopts: [
 ]
 depexts: [
   ["libpq-dev"] {os-family = "debian"}
-  ["postgresql-devel"] {os-distribution = "fedora"}
+  ["postgresql-devel"] {os-family = "fedora"}
   ["postgresql-libs"] {os-distribution = "arch"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql-devel"] {os-distribution = "centos"}

--- a/packages/postgresql/postgresql.4.0.0/opam
+++ b/packages/postgresql/postgresql.4.0.0/opam
@@ -49,7 +49,7 @@ depopts: [
 ]
 depexts: [
   ["libpq-dev"] {os-family = "debian"}
-  ["postgresql-devel"] {os-distribution = "fedora"}
+  ["postgresql-devel"] {os-family = "fedora"}
   ["postgresql-libs"] {os-distribution = "arch"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql-devel"] {os-distribution = "centos"}

--- a/packages/postgresql/postgresql.4.0.1/opam
+++ b/packages/postgresql/postgresql.4.0.1/opam
@@ -46,7 +46,7 @@ depopts: [
 ]
 depexts: [
   ["libpq-dev"] {os-family = "debian"}
-  ["postgresql-devel"] {os-distribution = "fedora"}
+  ["postgresql-devel"] {os-family = "fedora"}
   ["postgresql-libs"] {os-distribution = "arch"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql-devel"] {os-distribution = "centos"}

--- a/packages/postgresql/postgresql.4.1.0/opam
+++ b/packages/postgresql/postgresql.4.1.0/opam
@@ -31,7 +31,7 @@ depexts: [
   ["database/postgresql96-client"] {os = "openbsd"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
-  ["postgresql-devel"] {os-distribution = "fedora"}
+  ["postgresql-devel"] {os-family = "fedora"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql"] {os-family = "suse" | os-family = "opensuse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/postgresql/postgresql.4.2.0/opam
+++ b/packages/postgresql/postgresql.4.2.0/opam
@@ -31,7 +31,7 @@ depexts: [
   ["database/postgresql96-client"] {os = "openbsd"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
-  ["postgresql-devel"] {os-distribution = "fedora"}
+  ["postgresql-devel"] {os-family = "fedora"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql"] {os-family = "suse" | os-family = "opensuse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/postgresql/postgresql.4.2.1/opam
+++ b/packages/postgresql/postgresql.4.2.1/opam
@@ -31,7 +31,7 @@ depexts: [
   ["database/postgresql96-client"] {os = "openbsd"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
-  ["postgresql-devel"] {os-distribution = "fedora"}
+  ["postgresql-devel"] {os-family = "fedora"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql"] {os-family = "suse" | os-family = "opensuse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/postgresql/postgresql.4.3.0/opam
+++ b/packages/postgresql/postgresql.4.3.0/opam
@@ -31,7 +31,7 @@ depexts: [
   ["database/postgresql96-client"] {os = "openbsd"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
-  ["postgresql-devel"] {os-distribution = "fedora"}
+  ["postgresql-devel"] {os-family = "fedora"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql"] {os-family = "suse" | os-family = "opensuse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/postgresql/postgresql.4.4.0/opam
+++ b/packages/postgresql/postgresql.4.4.0/opam
@@ -30,7 +30,7 @@ depexts: [
   ["database/postgresql96-client"] {os = "openbsd"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
-  ["postgresql-devel"] {os-distribution = "fedora"}
+  ["postgresql-devel"] {os-family = "fedora"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql"] {os-family = "suse" | os-family = "opensuse"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/postgresql/postgresql.4.4.1/opam
+++ b/packages/postgresql/postgresql.4.4.1/opam
@@ -31,7 +31,7 @@ depexts: [
   ["database/postgresql96-client"] {os-distribution = "openbsd"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
-  ["postgresql-devel"] {os-distribution = "fedora"}
+  ["postgresql-devel"] {os-family = "fedora"}
   ["postgresql-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/postgresql/postgresql.4.4.2/opam
+++ b/packages/postgresql/postgresql.4.4.2/opam
@@ -31,7 +31,7 @@ depexts: [
   ["database/postgresql96-client"] {os-distribution = "openbsd"}
   ["postgresql-devel"] {os-distribution = "centos"}
   ["postgresql-devel"] {os-distribution = "rhel"}
-  ["postgresql-devel"] {os-distribution = "fedora"}
+  ["postgresql-devel"] {os-family = "fedora"}
   ["postgresql-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/protocell/protocell.1.0.0/opam
+++ b/packages/protocell/protocell.1.0.0/opam
@@ -11,7 +11,7 @@ depexts: [
   ["libprotoc-dev" "protobuf-compiler"] {os-family = "debian"}
   ["libprotoc-devel" "protobuf-compiler"] {os-distribution = "mageia"}
   ["protobuf-devel" "protobuf-compiler"] {os-distribution = "centos"}
-  ["protobuf-devel" "protobuf-compiler"] {os-distribution = "fedora"}
+  ["protobuf-devel" "protobuf-compiler"] {os-family = "fedora"}
   ["protobuf-devel" "protobuf-compiler"] {os-distribution = "rhel"}
   ["protobuf-dev" "protobuf"] {os-distribution = "alpine"}
   ["protobuf-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/pulseaudio/pulseaudio.0.1.2/opam
+++ b/packages/pulseaudio/pulseaudio.0.1.2/opam
@@ -9,7 +9,7 @@ depends: ["ocaml" "ocamlfind" "conf-pkg-config"]
 depexts: [
   ["pulseaudio-dev"] {os-distribution = "alpine"}
   ["pulseaudio-libs-devel"] {os-distribution = "centos"}
-  ["pulseaudio-libs-devel"] {os-distribution = "fedora"}
+  ["pulseaudio-libs-devel"] {os-family = "fedora"}
   ["pulseaudio-libs-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["pulseaudio"] {os = "macos" & os-distribution = "homebrew"}
   ["libpulse-dev"] {os-family = "debian"}

--- a/packages/pulseaudio/pulseaudio.0.1.3/opam
+++ b/packages/pulseaudio/pulseaudio.0.1.3/opam
@@ -14,7 +14,7 @@ depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["pulseaudio-dev"] {os-distribution = "alpine"}
   ["pulseaudio-libs-devel"] {os-distribution = "centos"}
-  ["pulseaudio-libs-devel"] {os-distribution = "fedora"}
+  ["pulseaudio-libs-devel"] {os-family = "fedora"}
   ["pulseaudio-libs-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["pulseaudio"] {os = "macos" & os-distribution = "homebrew"}
   ["libpulse-dev"] {os-family = "debian"}

--- a/packages/py/py.1.0/opam
+++ b/packages/py/py.1.0/opam
@@ -17,7 +17,7 @@ depends: [
 ]
 depexts: [
   ["python3-dev"] {os-family = "debian"}
-  ["python3-devel"] {os-distribution = "fedora"}
+  ["python3-devel"] {os-family = "fedora"}
   ["python3-dev"] {os-distribution = "alpine"}
 ]
 build: [

--- a/packages/radare2/radare2.0.0.2/opam
+++ b/packages/radare2/radare2.0.0.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depexts: [
   ["radare2"] {os-family = "debian"}
-  ["radare2"] {os-distribution = "fedora"}
+  ["radare2"] {os-family = "fedora"}
   ["radare2"] {os-distribution = "arch"}
   ["radare2"] {os-distribution = "gentoo"}
   ["radare2"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/radare2/radare2.0.0.3/opam
+++ b/packages/radare2/radare2.0.0.3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depexts: [
   ["radare2"] {os-family = "debian"}
-  ["radare2"] {os-distribution = "fedora"}
+  ["radare2"] {os-family = "fedora"}
   ["radare2"] {os-distribution = "arch"}
   ["radare2"] {os-distribution = "gentoo"}
   ["radare2"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/radare2/radare2.0.0.4/opam
+++ b/packages/radare2/radare2.0.0.4/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depexts: [
   ["radare2"] {os-family = "debian"}
-  ["radare2"] {os-distribution = "fedora"}
+  ["radare2"] {os-family = "fedora"}
   ["radare2"] {os-distribution = "arch"}
   ["radare2"] {os-distribution = "gentoo"}
   ["radare2"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/radare2/radare2.0.0.5/opam
+++ b/packages/radare2/radare2.0.0.5/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depexts: [
   ["radare2"] {os-family = "debian"}
-  ["radare2"] {os-distribution = "fedora"}
+  ["radare2"] {os-family = "fedora"}
   ["radare2"] {os-distribution = "arch"}
   ["radare2"] {os-distribution = "gentoo"}
   ["radare2"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/radare2/radare2.0.0.6/opam
+++ b/packages/radare2/radare2.0.0.6/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depexts: [
   ["radare2"] {os-family = "debian"}
-  ["radare2"] {os-distribution = "fedora"}
+  ["radare2"] {os-family = "fedora"}
   ["radare2"] {os-distribution = "arch"}
   ["radare2"] {os-distribution = "gentoo"}
   ["radare2"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/raylib/raylib.0.1.0/opam
+++ b/packages/raylib/raylib.0.1.0/opam
@@ -30,7 +30,7 @@ build: [
 dev-repo: "git+https://github.com/tjammer/raylib-ocaml.git"
 depexts: [
   ["libasound2-dev" "libx11-dev" "libxrandr-dev" "libxi-dev" "xorg-dev" "libgl1-mesa-dev"] {os-family = "debian"}
-  ["alsa-lib-devel" "mesa-libGL-devel" "libX11-devel" "libXrandr-devel" "libXi-devel" "libXcursor-devel" "libXinerama-devel"] {os-distribution = "fedora"}
+  ["alsa-lib-devel" "mesa-libGL-devel" "libX11-devel" "libXrandr-devel" "libXi-devel" "libXcursor-devel" "libXinerama-devel"] {os-family = "fedora"}
 ]
 available: [os = "linux" ]
 url {

--- a/packages/raylib/raylib.0.2.2/opam
+++ b/packages/raylib/raylib.0.2.2/opam
@@ -30,7 +30,7 @@ build: [
 dev-repo: "git+https://github.com/tjammer/raylib-ocaml.git"
 depexts: [
   ["libasound2-dev" "libx11-dev" "libxrandr-dev" "libxi-dev" "xorg-dev" "libgl1-mesa-dev"] {os-family = "debian"}
-  ["alsa-lib-devel" "mesa-libGL-devel" "libX11-devel" "libXrandr-devel" "libXi-devel" "libXcursor-devel" "libXinerama-devel"] {os-distribution = "fedora"}
+  ["alsa-lib-devel" "mesa-libGL-devel" "libX11-devel" "libXrandr-devel" "libXi-devel" "libXcursor-devel" "libXinerama-devel"] {os-family = "fedora"}
   ["alsa-lib-devel" "mesa-libGL-devel" "libX11-devel" "libXrandr-devel" "libXi-devel" "libXcursor-devel" "libXinerama-devel"] {os-distribution = "centos"}
   ["alsa-lib-dev" "mesa-dev" "libx11-dev" "libxrandr-dev" "libxi-dev" "libxcursor-dev" "libxinerama-dev"] {os-distribution = "alpine"}
   ["alsa-devel" "Mesa-libGL-devel" "libX11-devel" "libXrandr-devel" "libXi-devel" "libXcursor-devel" "libXinerama-devel"] {os-family = "suse" | os-family = "opensuse"}

--- a/packages/re2/re2.v0.12.0/opam
+++ b/packages/re2/re2.v0.12.0/opam
@@ -18,7 +18,7 @@ depends: [
 available: arch != "arm32"
 synopsis: "OCaml bindings for RE2, Google's regular expression library"
 depexts: [
- ["gcc-c++"] {os-distribution = "fedora"}
+ ["gcc-c++"] {os-family = "fedora"}
  ["gcc-c++"] {os-distribution = "ol"}
 ]
 url {

--- a/packages/samplerate/samplerate.0.1.4/opam
+++ b/packages/samplerate/samplerate.0.1.4/opam
@@ -13,7 +13,7 @@ remove: ["ocamlfind" "remove" "samplerate"]
 depends: ["ocaml" "ocamlfind"]
 depexts: [
   ["libsamplerate-devel"] {os-distribution = "centos"}
-  ["libsamplerate-devel"] {os-distribution = "fedora"}
+  ["libsamplerate-devel"] {os-family = "fedora"}
   ["libsamplerate-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libsamplerate-dev"] {os-distribution = "alpine"}
   ["libsamplerate0-dev"] {os-family = "debian"}

--- a/packages/shine/shine.0.2.1/opam
+++ b/packages/shine/shine.0.2.1/opam
@@ -20,7 +20,7 @@ depends: [
 depexts: [
   ["shine"] {os-distribution = "alpine"}
   ["libshine-devel"] {os-distribution = "centos"}
-  ["libshine-devel"] {os-distribution = "fedora"}
+  ["libshine-devel"] {os-family = "fedora"}
   ["libshine-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libshine-dev"] {os-family = "debian"}
   ["drfill/liquidsoap/libshine"]

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.0/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.0/opam
@@ -18,7 +18,7 @@ x-ci-accept-failures: ["debian-unstable"]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-family = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.1/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.1/opam
@@ -18,7 +18,7 @@ x-ci-accept-failures: ["debian-unstable"]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-family = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.2/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.2/opam
@@ -24,7 +24,7 @@ x-ci-accept-failures: ["debian-unstable"]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-family = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.3/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.3/opam
@@ -27,7 +27,7 @@ flags: deprecated # ./configure.sh is broken for gcc>=10
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-family = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.4/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.4/opam
@@ -27,7 +27,7 @@ flags: deprecated # ./configure.sh is broken for gcc>=10
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-distribution = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.5/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.5/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.6/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.6/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.7/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.7/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.8/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.8/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.9/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.9/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.2/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.2/opam
@@ -24,11 +24,11 @@ flags: deprecated # ./configure.sh is broken for gcc>=10
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-family = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["libseccomp-dev"] {os-distribution = "alpine"}
   ["libseccomp-dev"] {os-family = "debian"}
-  ["libseccomp-devel"] {os-distribution = "fedora"}
+  ["libseccomp-devel"] {os-family = "fedora"}
   ["libseccomp-devel"] {os-distribution = "rhel"}
   ["libseccomp-devel"] {os-distribution = "suse" | os-family = "opensuse"}
 ]

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.3/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.3/opam
@@ -27,7 +27,7 @@ flags: deprecated # ./configure.sh is broken for gcc>=10
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-family = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.4/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.4/opam
@@ -27,7 +27,7 @@ flags: deprecated # ./configure.sh is broken for gcc>=10
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-distribution = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.5/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.5/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.6/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.6/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.7/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.7/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.8/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.8/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.9/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.9/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.0/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.0/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
   ["gcc-aarch64-linux-gnu"] {os-family = "debian"}

--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.1/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.1/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
   ["gcc-aarch64-linux-gnu"] {os-family = "debian"}

--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.2/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.2/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
   ["gcc-aarch64-linux-gnu"] {os-family = "debian"}

--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.3/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.3/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
   ["gcc-aarch64-linux-gnu"] {os-family = "debian"}

--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.4/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.4/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
   ["gcc-aarch64-linux-gnu"] {os-family = "debian"}

--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.5/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.5/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
   ["gcc-aarch64-linux-gnu"] {os-family = "debian"}

--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.8.0/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.8.0/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
   ["gcc-aarch64-linux-gnu"] {os-family = "debian"}

--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.8.1/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.8.1/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
   ["gcc-aarch64-linux-gnu"] {os-family = "debian"}

--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.9.0/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.9.0/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
   ["gcc-aarch64-linux-gnu"] {os-family = "debian"}

--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.9.1/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.9.1/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
   ["gcc-aarch64-linux-gnu"] {os-family = "debian"}

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.1.1/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.1.1/opam
@@ -19,7 +19,7 @@ depends: [
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-family = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
 conflicts: "solo5-kernel-virtio"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.1/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.1/opam
@@ -19,7 +19,7 @@ depends: [
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-family = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
 conflicts: "solo5-kernel-virtio"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2-1/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2-1/opam
@@ -19,7 +19,7 @@ depends: [
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-family = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
 conflicts: "solo5-kernel-virtio"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2/opam
@@ -19,7 +19,7 @@ depends: [
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-family = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
 conflicts: "solo5-kernel-virtio"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.0/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.0/opam
@@ -19,7 +19,7 @@ depends: [
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-family = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
 conflicts: [

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.1/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.1/opam
@@ -20,7 +20,7 @@ depends: [
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
   ["linux-libc-dev"] {os-family = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
 conflicts: [

--- a/packages/solo5/solo5.0.7.0/opam
+++ b/packages/solo5/solo5.0.7.0/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5/solo5.0.7.1/opam
+++ b/packages/solo5/solo5.0.7.1/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5/solo5.0.7.2/opam
+++ b/packages/solo5/solo5.0.7.2/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5/solo5.0.7.3/opam
+++ b/packages/solo5/solo5.0.7.3/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5/solo5.0.7.4/opam
+++ b/packages/solo5/solo5.0.7.4/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5/solo5.0.7.5/opam
+++ b/packages/solo5/solo5.0.7.5/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5/solo5.0.8.0/opam
+++ b/packages/solo5/solo5.0.8.0/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5/solo5.0.8.1/opam
+++ b/packages/solo5/solo5.0.8.1/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5/solo5.0.9.0/opam
+++ b/packages/solo5/solo5.0.9.0/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/solo5/solo5.0.9.1/opam
+++ b/packages/solo5/solo5.0.9.1/opam
@@ -20,7 +20,7 @@ depends: [
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-family = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
 ]

--- a/packages/soundtouch/soundtouch.0.1.8/opam
+++ b/packages/soundtouch/soundtouch.0.1.8/opam
@@ -14,7 +14,7 @@ depends: ["ocaml" "ocamlfind" "conf-pkg-config"]
 depexts: [
   ["soundtouch-dev"] {os-distribution = "alpine"}
   ["soundtouch-devel"] {os-distribution = "centos"}
-  ["soundtouch-devel"] {os-distribution = "fedora"}
+  ["soundtouch-devel"] {os-family = "fedora"}
   ["soundtouch-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libsoundtouch-dev"] {os-family = "debian"}
   ["drfill/homebrew-liquidsoap/soundtouch"]

--- a/packages/speex/speex.0.2.1/opam
+++ b/packages/speex/speex.0.2.1/opam
@@ -26,7 +26,7 @@ depends: [
 depexts: [
   ["speex-dev"] {os-distribution = "alpine"}
   ["speex-devel"] {os-distribution = "centos"}
-  ["speex-devel"] {os-distribution = "fedora"}
+  ["speex-devel"] {os-family = "fedora"}
   ["speex-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libspeex-dev"] {os-family = "debian"}
   ["speex"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/spf/spf.2.0.2/opam
+++ b/packages/spf/spf.2.0.2/opam
@@ -15,7 +15,7 @@ depexts: [
   ["libspf2"] {os-distribution = "arch"}
   ["epel-release" "libspf2-devel"] {os-distribution = "centos"}
   ["libspf2-dev"] {os-family = "debian"}
-  ["libspf2-devel"] {os-distribution = "fedora"}
+  ["libspf2-devel"] {os-family = "fedora"}
   ["libspf2"] {os = "freebsd"}
   ["libspf2"] {os-distribution = "gentoo"}
   ["libspf2-devel"] {os-distribution = "mageia"}

--- a/packages/srt/srt.0.1.0/opam
+++ b/packages/srt/srt.0.1.0/opam
@@ -19,7 +19,7 @@ depends: [
 ]
 depexts: [
   ["srt-devel"] {os-distribution = "centos"}
-  ["srt-devel"] {os-distribution = "fedora"}
+  ["srt-devel"] {os-family = "fedora"}
   ["srt-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libsrt-dev"] {os-family = "debian"}
   ["srt"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/srt/srt.0.1.1/opam
+++ b/packages/srt/srt.0.1.1/opam
@@ -34,7 +34,7 @@ build: [
 dev-repo: "git+https://github.com/savonet/ocaml-srt.git"
 depexts: [
   ["srt-devel"] {os-distribution = "centos"}
-  ["srt-devel"] {os-distribution = "fedora"}
+  ["srt-devel"] {os-family = "fedora"}
   ["srt-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["libsrt-dev"] {os-family = "debian"}
   ["srt"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/taglib/taglib.0.3.3/opam
+++ b/packages/taglib/taglib.0.3.3/opam
@@ -18,7 +18,7 @@ depends: [
 depexts: [
   ["taglib-dev"] {os-distribution = "alpine"}
   ["gcc-c++" "taglib-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["gcc-c++" "taglib-devel"] {os-distribution = "fedora"}
+  ["gcc-c++" "taglib-devel"] {os-family = "fedora"}
   ["gcc-c++" "taglib-devel"] {os-distribution = "centos"}
   ["libtag1-dev"] {os-family = "debian"}
   ["taglib"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/taglib/taglib.0.3.6/opam
+++ b/packages/taglib/taglib.0.3.6/opam
@@ -20,7 +20,7 @@ install: [make "install"]
 depexts: [
   ["taglib-dev"] {os-distribution = "alpine"}
   ["gcc-c++" "taglib-devel"] {os-family = "suse" | os-family = "opensuse"}
-  ["gcc-c++" "taglib-devel"] {os-distribution = "fedora"}
+  ["gcc-c++" "taglib-devel"] {os-family = "fedora"}
   ["gcc-c++" "taglib-devel"] {os-distribution = "centos"}
   ["libtag1-dev"] {os-family = "debian"}
   ["taglib"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/theora/theora.0.3.1/opam
+++ b/packages/theora/theora.0.3.1/opam
@@ -18,7 +18,7 @@ depends: [
 depexts: [
   ["libtheora-dev"] {os-distribution = "alpine"}
   ["libtheora-devel"] {os-distribution = "centos"}
-  ["libtheora-devel"] {os-distribution = "fedora"}
+  ["libtheora-devel"] {os-family = "fedora"}
   ["libtheora-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["theora"] {os = "macos" & os-distribution = "homebrew"}
   ["libtheora-dev"] {os-family = "debian"}

--- a/packages/travis-opam/travis-opam.1.1.0/opam
+++ b/packages/travis-opam/travis-opam.1.1.0/opam
@@ -17,7 +17,7 @@ depexts: [
   ["jq"] {os-distribution = "alpine"}
   ["jq"] {os-distribution = "centos"}
   ["jq"] {os-family = "debian"}
-  ["jq"] {os-distribution = "fedora"}
+  ["jq"] {os-family = "fedora"}
   ["jq"] {os-distribution = "homebrew" & os = "macos"}
   ["jq"] {os-family = "suse" | os-family = "opensuse"}
   ["jq"] {os-distribution = "ol"}

--- a/packages/vorbis/vorbis.0.7.1/opam
+++ b/packages/vorbis/vorbis.0.7.1/opam
@@ -18,7 +18,7 @@ depends: [
 depexts: [
   ["libvorbis-dev"] {os-distribution = "alpine"}
   ["libvorbis-devel"] {os-distribution = "centos"}
-  ["libvorbis-devel"] {os-distribution = "fedora"}
+  ["libvorbis-devel"] {os-family = "fedora"}
   ["libvorbis-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["pkg-config" "libvorbis-dev"] {os-family = "debian"}
   ["libvorbis"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/xen-evtchn/xen-evtchn.1.0.7/opam
+++ b/packages/xen-evtchn/xen-evtchn.1.0.7/opam
@@ -22,7 +22,7 @@ depexts: [
   ["xen-dev"] {os-distribution = "alpine"}
   ["libxen-dev"] {os-family = "debian"}
   ["xen-devel"] {os-distribution = "centos"}
-  ["xen-devel"] {os-distribution = "fedora"}
+  ["xen-devel"] {os-family = "fedora"}
   ["xenstore"] {os-distribution = "arch"}
 ]
 synopsis: "Xen event channel bindings."

--- a/packages/yara/yara.0.1/opam
+++ b/packages/yara/yara.0.1/opam
@@ -21,7 +21,7 @@ depexts: [
   ["libyara-dev"] {os-family = "debian"}
   ["libyara-dev"] {os-distribution = "alpine"}
   ["epel-release" "yara-devel"] {os-distribution = "centos"}
-  ["yara-devel"] {os-distribution = "fedora"}
+  ["yara-devel"] {os-family = "fedora"}
   ["yara"] {os-distribution = "arch"}
   ["yara"] {os-distribution = "gentoo"}
   ["yara"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/yara/yara.0.2/opam
+++ b/packages/yara/yara.0.2/opam
@@ -18,7 +18,7 @@ depexts: [
   ["libyara-dev"] {os-family = "debian"}
   ["libyara-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["epel-release" "yara-devel"] {os-distribution = "centos"}
-  ["yara-devel"] {os-distribution = "fedora"}
+  ["yara-devel"] {os-family = "fedora"}
   ["yara"] {os-distribution = "alpine"}
   ["yara"] {os-distribution = "arch"}
   ["yara"] {os-distribution = "gentoo"}


### PR DESCRIPTION
Fedora Asahi Remix is a port of Fedora to Apple ARM64 machines. opam 2.3 reports:

    $ opam var
    os                linux               # Inferred from system
    os-distribution   fedora-asahi-remix  # Inferred from system
    os-family         fedora              # Inferred from system

The packages are shared with Fedora, but the distribution is different. The `os-family` is shared, that's `"fedora"`!

This was done using `sed -i 's/os-distribution = "fedora"/os-family = "fedora"/g' **/opam`.
cc @kit-ty-kate, another user of Asahi Linux that I know of ;)