### PR TITLE
Extend ocaml-option-fp for ARM64 and OCaml 5.4

### DIFF
--- a/packages/ocaml-option-fp/ocaml-option-fp.1/opam
+++ b/packages/ocaml-option-fp/ocaml-option-fp.1/opam
@@ -8,9 +8,12 @@ homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "CC0-1.0+"
 depends: [
-  "ocaml-variants" {post & (os = "linux" & >= "4.12.0~" | os = "macos" & >= "5.3.0~")}
+  "ocaml-variants" {post & (os = "linux" & >= "4.12.0~" & arch = "x86_64"
+                           |os = "linux" & >= "5.4.0~"  & arch = "arm64" 
+                           |os = "macos" & >= "5.3.0~"  & arch = "x86_64"
+                           |os = "macos" & >= "5.4.0~"  & arch = "arm64")}
 ]
 conflicts: ["ocaml-option-musl"]
-available: (os = "linux" | os = "macos") & arch = "x86_64"
+available: (os = "linux" | os = "macos") & (arch = "x86_64" | arch = "arm64")
 maintainer: "David Allsopp <david@tarides.com>"
 flags: compiler


### PR DESCRIPTION
In preparation for a future OCaml 5.4 release which will include frame pointers for ARM64. 

Opening as a Draft since 5.4 is not released yet or available on opam.ci.ocaml.org CI system.