### PR TITLE
Extend lower bounds of fpath-sexp0

### DIFF
--- a/packages/fpath-sexp0/fpath-sexp0.0.2.1/opam
+++ b/packages/fpath-sexp0/fpath-sexp0.0.2.1/opam
@@ -9,9 +9,9 @@ doc: "https://mbarbin.github.io/fpath-base/"
 bug-reports: "https://github.com/mbarbin/fpath-base/issues"
 depends: [
   "dune" {>= "3.16"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "4.14.0"}
   "fpath" {>= "0.7.3"}
-  "sexplib0" {>= "v0.17" & < "v0.18"}
+  "sexplib0" {>= "v0.16" & < "v0.18"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/fpath-sexp0/fpath-sexp0.0.2.2/opam
+++ b/packages/fpath-sexp0/fpath-sexp0.0.2.2/opam
@@ -9,9 +9,9 @@ doc: "https://mbarbin.github.io/fpath-base/"
 bug-reports: "https://github.com/mbarbin/fpath-base/issues"
 depends: [
   "dune" {>= "3.16"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "4.14.0"}
   "fpath" {>= "0.7.3"}
-  "sexplib0" {>= "v0.17" & < "v0.18"}
+  "sexplib0" {>= "v0.16" & < "v0.18"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
This is a manual edit of the packages `fpath-sexp0` to extend the range of compatible versions of OCaml, notably to allow supporting `4.14`.