### PR TITLE
Lift the restriction on installing 5.3.0+BER on macos+arm64

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.3.0+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0+BER/opam
@@ -76,4 +76,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: !(os = "macos" & arch = "arm64") & os != "win32" & arch != "arm32" & arch != "x86_32"
+available: os != "win32" & arch != "arm32" & arch != "x86_32"


### PR DESCRIPTION
@kayceesrk reports that MetaOCaml 5.3.0+BER can be installed successfully on macos+arm64, so the current constraint is apparently unnecessary.