### PR TITLE
Package binaryen.0.25.0

### DIFF
--- a/packages/binaryen/binaryen.0.25.0/opam
+++ b/packages/binaryen/binaryen.0.25.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "4.1.0" & < "6.0.0"}
+  "libbinaryen" {>= "115.0.0" & < "116.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.25.0/binaryen-archive-v0.25.0.tar.gz"
+  checksum: [
+    "md5=9995941f04c211047dcfdd21a7613013"
+    "sha512=98a0f7dd181feec963209996e1a8cb6a62a90f9d54860a81c162ca77909f219de851a854ab263c351b10a54e9f4a600596dd71b0bd93cc71a1da5b99b74eb4a4"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.25.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.25.0](https://github.com/grain-lang/binaryen.ml/compare/v0.24.0...v0.25.0) (2025-05-15)


### ⚠ BREAKING CHANGES

* Upgrade to Binaryen v115 ([#200](https://github.com/grain-lang/binaryen.ml/issues/200))
* Drop support for OCaml 4.12
* Pin CI dependencies and require Node 22 ([#214](https://github.com/grain-lang/binaryen.ml/issues/214))

### Features

* Upgrade to Binaryen v115 ([#200](https://github.com/grain-lang/binaryen.ml/issues/200)) ([e35c596](https://github.com/grain-lang/binaryen.ml/commit/e35c596aae01935b88aa3bbda5078517b1fae36a))


### Miscellaneous Chores

* Drop support for OCaml 4.12 ([971b06e](https://github.com/grain-lang/binaryen.ml/commit/971b06ee542b37b56a6041bbbd16017fa6510d45))
* Pin CI dependencies and require Node 22 ([#214](https://github.com/grain-lang/binaryen.ml/issues/214)) ([971b06e](https://github.com/grain-lang/binaryen.ml/commit/971b06ee542b37b56a6041bbbd16017fa6510d45))


---
:camel: Pull-request generated by opam-publish v2.4.0