### PR TITLE
Package binaryen.0.26.0

### DIFF
--- a/packages/binaryen/binaryen.0.26.0/opam
+++ b/packages/binaryen/binaryen.0.26.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "4.1.0" & < "6.0.0"}
+  "libbinaryen" {>= "116.0.0" & < "117.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.26.0/binaryen-archive-v0.26.0.tar.gz"
+  checksum: [
+    "md5=fa1809e7e6d331c8c9495f1f6c47ce88"
+    "sha512=4d86679526d4997eb1d492697c7a2c2e95f0c2e018dc6b39a7f8497645333bab5cc9ec5e63329c71a74f286a2da77ccb1b4b664a7954622626c1fb612e0aabd2"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.26.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.26.0](https://github.com/grain-lang/binaryen.ml/compare/v0.25.0...v0.26.0) (2025-05-17)


### ⚠ BREAKING CHANGES

* Upgrade to Binaryen v116 ([#202](https://github.com/grain-lang/binaryen.ml/issues/202))

### Features

* Upgrade to Binaryen v116 ([#202](https://github.com/grain-lang/binaryen.ml/issues/202)) ([44bdd2a](https://github.com/grain-lang/binaryen.ml/commit/44bdd2a276b1478e0d5eb74cbd5135fdf504abcc))

---
:camel: Pull-request generated by opam-publish v2.4.0