### PR TITLE
Add ocaml-base-compiler to dependency of hol_light

### DIFF
--- a/packages/hol_light/hol_light.3.0.0/opam
+++ b/packages/hol_light/hol_light.3.0.0/opam
@@ -50,7 +50,7 @@ depends: [
    "ledit")
   |
   ("ocaml" {>= "4.14.0"} &
-   "ocaml-base-compiler" {} &
+   "ocaml-base-compiler" &
    "camlp5" {>= "8.0"} &
    "zarith" {>= "1.5"} &
    "ledit")

--- a/packages/hol_light/hol_light.3.0.0/opam
+++ b/packages/hol_light/hol_light.3.0.0/opam
@@ -50,6 +50,7 @@ depends: [
    "ledit")
   |
   ("ocaml" {>= "4.14.0"} &
+   "ocaml-base-compiler" {} &
    "camlp5" {>= "8.0"} &
    "zarith" {>= "1.5"} &
    "ledit")


### PR DESCRIPTION
This is necessary because hol_light uses ocamlmktop and Topfind may not work on top of it.

https://discuss.ocaml.org/t/which-opam-package-is-needed-to-use-ocamlmktop/16665/8

This only applies to OCaml >= 4.14 because HOL Light uses Topfind for OCaml >= 4.14 only.