### PR TITLE
Add bitmasks.1.5.0

### DIFF
--- a/packages/bitmasks/bitmasks.1.4.0/opam
+++ b/packages/bitmasks/bitmasks.1.4.0/opam
@@ -10,7 +10,7 @@ build: [
   [ make "doc" ] {with-doc}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.1"}
   "dune"
   "stdlib-shims"
   "seq"

--- a/packages/bitmasks/bitmasks.1.5.0/opam
+++ b/packages/bitmasks/bitmasks.1.5.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "david.allsopp@metastack.com"
+authors: [ "David Allsopp" ]
+license: "BSD-3-clause"
+homepage: "https://metastack.github.io/bitmasks"
+dev-repo: "git+https://github.com/metastack/bitmasks.git"
+bug-reports: "https://github.com/metastack/bitmasks/issues"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+  [ make "doc" ] {with-doc}
+]
+depends: [
+  "ocaml"
+  "dune"
+  "stdlib-shims"
+  "seq"
+  "odoc" {with-doc}
+]
+synopsis: "BitMasks over int and int64 exposed as sets"
+description: """
+Library for exposing bitmasks (typically as int or int64) in an
+implementation compatible with OCaml's Set. The underlying data
+representation is unaltered, allowing the value to be manipulated
+either as a bitmask or as a set without conversion."""
+url {
+  src: "https://github.com/metastack/bitmasks/archive/v1.5.0.tar.gz"
+  checksum: [
+    "md5=b3903418b69a71f27b86bc2e3a2a3bea"
+    "sha512=33b948682cc722262809620ddd23908c04bf7a877242a739ac3c63d83778499897fe303af5c2436d1364901eb846126fb1f1619033e9a3275dd9402fcba1a148"
+  ]
+}


### PR DESCRIPTION
First commit addresses https://github.com/ocaml/opam-repository/pull/27839#issuecomment-2851180027 (an unexpected revdep!) and the second commit releases a new version which addresses the underlying failure.