### PR TITLE
Package vscoq-language-server.2.2.6

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.2.6/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.2.6/opam
@@ -12,8 +12,8 @@ build: [
 depends: [
   "ocaml" { >= "4.14" }
   "dune" { >= "3.5" }
-  "coq-core" { ((>= "8.18" < "8.21") | (= "dev")) }
-  "coq-stdlib" { ((>= "8.18" < "8.21") | (= "dev")) }
+  "coq-core" { ((>= "8.18" < "9.1") | (= "dev")) }
+  "coq-stdlib" { ((>= "8.18" < "9.1") | (= "dev")) }
   "yojson"
   "jsonrpc" { >= "1.15"}
   "ocamlfind"

--- a/packages/vscoq-language-server/vscoq-language-server.2.2.6/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.2.6/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/coq-community/vscoq"
+bug-reports: "https://github.com/coq-community/vscoq/issues"
+dev-repo: "git+https://github.com/coq-community/vscoq"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { >= "4.14" }
+  "dune" { >= "3.5" }
+  "coq-core" { ((>= "8.18" < "8.21") | (= "dev")) }
+  "coq-stdlib" { ((>= "8.18" < "8.21") | (= "dev")) }
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "ppx_optcomp"
+  "result" { >= "1.5" }
+  "lsp" { >= "1.15"}
+  "sel" {>= "0.6.0"}
+]
+synopsis: "VSCoq language server"
+available: arch != "arm32" & arch != "x86_32"
+description: """
+LSP based language server for Coq and its VSCoq user interface
+"""
+url {
+  src:
+    "https://github.com/coq/vscoq/releases/download/v2.2.6/vscoq-language-server-2.2.6.tar.gz"
+  checksum: [
+    "md5=f528c1760966ac10d48b5f1c5531411a"
+    "sha512=1f69538ae5f78854b34e3f1a9d408714843e899bb96d063c2bfac410339b6a13ee5f30d5e7b3cd2bbd673169bcfdb550153ba741092cdc3ee3a8ca6446cc2240"
+  ]
+}


### PR DESCRIPTION
### `vscoq-language-server.2.2.6`
VSCoq language server
LSP based language server for Coq and its VSCoq user interface



---
* Homepage: https://github.com/coq-community/vscoq
* Source repo: git+https://github.com/coq-community/vscoq
* Bug tracker: https://github.com/coq-community/vscoq/issues

---
:camel: Pull-request generated by opam-publish v2.5.0