### PR TITLE
[new release] mirage-block-ramdisk (0.6)

### DIFF
--- a/packages/mirage-block-ramdisk/mirage-block-ramdisk.0.6/opam
+++ b/packages/mirage-block-ramdisk/mirage-block-ramdisk.0.6/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: "David Scott"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-block-ramdisk"
+doc: "https://mirage.github.io/mirage-block-ramdisk/"
+bug-reports: "https://github.com/mirage/mirage-block-ramdisk/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "alcotest" {with-test}
+  "cstruct" {>= "6.0.0"}
+  "io-page" {>= "2.4.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-block-combinators" {with-test}
+  "lwt"
+  "fmt" {with-test & >= "0.8.7"}
+]
+build: [
+ [ "dune" "subst" ] {dev}
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-block-ramdisk.git"
+synopsis: "In-memory BLOCK device for MirageOS"
+description: """
+- Can be dynamically resized
+- Supports querying sparseness information
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-block-ramdisk/releases/download/0.6/mirage-block-ramdisk-0.6.tbz"
+  checksum: [
+    "sha256=81a40f3e923385ec304164e2b8984acddd01c496590260b305bc077e57056850"
+    "sha512=aa8aabb18c81cb6cdec404d404809faeb28be55f24f044aaca333f34ea2bbc2c064cfec3b32fef55e614a945bcd458b96d5c46067d454e188672ad6eeaa6b4b7"
+  ]
+}
+x-commit-hash: "2fb3c2837f9f8230a8919e33502362d821a8453c"


### PR DESCRIPTION
In-memory BLOCK device for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-block-ramdisk">https://github.com/mirage/mirage-block-ramdisk</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-ramdisk/">https://mirage.github.io/mirage-block-ramdisk/</a>

##### CHANGES:

- Restore compatibility with alcotest 1.4.0 (@craigfe mirage/mirage-block-ramdisk#23)
- Add x-maintenance-intent latest (@hannesm mirage/mirage-block-ramdisk#25)
- Fixes for the current mirage ecosystem (Cstruct.len being deprecated,
  io-page-unix being deprecated, Fmt.kstrf being deprecated)
  (@hannesm mirage/mirage-block-ramdisk#26)
