### PR TITLE
Package b_tree.1.0

### DIFF
--- a/packages/b_tree/b_tree.1.0/opam
+++ b/packages/b_tree/b_tree.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "humamalhusaini@tutamail.com"
+authors: "Pierre Castoran, slightly modified by Humam Alhusaini"
+homepage: "https://github.com/Tralalero-Tralalal/Coq-b-tree"
+dev-repo: "git+https://github.com/Tralalero-Tralalal/Coq-b-tree"
+bug-reports: "https://github.com/Tralalero-Tralalal/Coq-b-tree/issues"
+license: "MIT"
+depends: [
+  "coq" {>= "8.0"}
+]
+build: [
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
+  [make]
+]
+install: [
+  ["mkdir" "-p" "%{lib}%/coq/user-contrib/BTree"]
+  ["cp" "b_tree.vo" "b_tree.glob" "%{lib}%/coq/user-contrib/BTree/"]
+]
+remove: [
+  ["rm" "-rf" "%{lib}%/coq/user-contrib/BTree"]
+]
+synopsis: "A Coq binary tree module"
+description: """
+This package provides a simple binary tree data structure and associated functions.
+"""
+url {
+  src:
+    "https://github.com/Tralalero-Tralalal/Coq-B-tree/archive/refs/tags/0.1.tar.gz"
+  checksum: [
+    "md5=b1304acf55d1289666425d43f12d8708"
+    "sha512=1797bf0c429b139a9f38d58c6febc21f8792ed302486000c94481382b472c36ab29db17048315a47ef2ad793cdafb86fea2925b6cc6494d6fb804c330ccb5887"
+  ]
+}


### PR DESCRIPTION
### `b_tree.1.0`
A Coq binary tree module
This package provides a simple binary tree data structure and associated functions.



---
* Homepage: https://github.com/Tralalero-Tralalal/Coq-b-tree
* Source repo: git+https://github.com/Tralalero-Tralalal/Coq-b-tree
* Bug tracker: https://github.com/Tralalero-Tralalal/Coq-b-tree/issues

---
:camel: Pull-request generated by opam-publish v2.5.1