### PR TITLE
[new release] fpath-sexp0 and fpath-base (0.3.0)

### DIFF
--- a/packages/fpath-base/fpath-base.0.3.0/opam
+++ b/packages/fpath-base/fpath-base.0.3.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Adds a few functions to Fpath to use alongside Base"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/fpath-base"
+doc: "https://mbarbin.github.io/fpath-base/"
+bug-reports: "https://github.com/mbarbin/fpath-base/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "base" {>= "v0.17"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/fpath-base.git"
+description: """\
+
+[Fpath_base] is an OCaml module designed to be opened to shadow and
+further extend the four modules from [fpath-sexplib0]: [Fpath],
+[Fsegment], [Absolute_path] and [Relative_path] for a better
+compatibility with [base].
+
+The extended modules export [hashable] and [comparable] interfaces,
+making them compatible with [base]-style containers such as [Map],
+[Set], [Hashtbl], and [Hash_set].
+
+[base]: https://github.com/janestreet/base
+[fpath]: https://github.com/dbuenzli/fpath
+
+"""
+tags: [ "fpath" "fpath-sexp0" "absolute-paths" "relative-paths" "base" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/fpath-base/releases/download/0.3.0/fpath-base-0.3.0.tbz"
+  checksum: [
+    "sha256=fc93586fe61bf610b35b4b47fc8e8bbabc48665205074fc621b1d74db8e8278e"
+    "sha512=fed6a7666df4db9416b5c6341d398fba663894cba39355cf01024b605a6556396f0b32adf322f3a37b75f84eec3ebbe4865455938f35b75daefb7a8e2f823e5b"
+  ]
+}
+x-commit-hash: "1b9234689acd747cd1d005f1c2798573368466ad"

--- a/packages/fpath-sexp0/fpath-sexp0.0.3.0/opam
+++ b/packages/fpath-sexp0/fpath-sexp0.0.3.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis:
+  "Adds Fpath.sexp_of_t and defines 3 new modules: Fsegment, Absolute_path and Relative_path"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/fpath-base"
+doc: "https://mbarbin.github.io/fpath-base/"
+bug-reports: "https://github.com/mbarbin/fpath-base/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "fpath" {>= "0.7.3"}
+  "sexplib0" {>= "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/fpath-base.git"
+description: """\
+
+[Fpath_sexplib0] is an OCaml module designed to be opened to extend
+the [fpath] package. It introduces three new modules to the scope:
+[Fsegment], [Absolute_path] and [Relative_path].
+
+[Absolute_path] and [Relative_path] are helper modules that
+distinguish between classes of paths in the type system, enhancing
+type safety for applications manipulating paths.
+
+[Fpath] is shadowed and retains all its original functionality, with
+the addition of a sexp serializer and new helpers for casting between
+the types of paths offered by the package (absolute and relative
+paths).
+
+[fpath]: https://github.com/dbuenzli/fpath
+
+"""
+tags: [ "fpath" "absolute-paths" "relative-paths" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/fpath-base/releases/download/0.3.0/fpath-base-0.3.0.tbz"
+  checksum: [
+    "sha256=fc93586fe61bf610b35b4b47fc8e8bbabc48665205074fc621b1d74db8e8278e"
+    "sha512=fed6a7666df4db9416b5c6341d398fba663894cba39355cf01024b605a6556396f0b32adf322f3a37b75f84eec3ebbe4865455938f35b75daefb7a8e2f823e5b"
+  ]
+}
+x-commit-hash: "1b9234689acd747cd1d005f1c2798573368466ad"


### PR DESCRIPTION
CHANGES:

### Added

- Add support for OCaml-4.14 to `fpath-sexp0` (mbarbin/fpath-base#14, @mbarbin).

### Deprecated

- Deprecate `Fpart` - renamed `Fsegment` and available since `0.2.2`.
