### PR TITLE
[new release] lwd (7 packages) (0.4)

### DIFF
--- a/packages/brr-lwd/brr-lwd.0.4/opam
+++ b/packages/brr-lwd/brr-lwd.0.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Make reactive webpages in Js_of_ocaml using Brr and Lwd"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "lwd" {= version}
+  "brr" {>= "0.0.4"}
+  "js_of_ocaml"
+  "js_of_ocaml-lwt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+url {
+  src: "https://github.com/let-def/lwd/releases/download/v0.4/lwd-0.4.tbz"
+  checksum: [
+    "sha256=9e7165b650567cf39eac5e07b95346cd7719c5149db0cf9a6de0f965d43ec7c5"
+    "sha512=7e015ecbdf19dbf503e70fb1fb8f6e2f78182cafbda172d9849a910d92c4a44e0c4d0fe8fb7a81515ba224ce9e624fac79ef41ad04a010af460dc2c0c2f261bc"
+  ]
+}
+x-commit-hash: "4d139dbb3e85b623a06093f5757d820138f405a0"

--- a/packages/docfd/docfd.0.3.3/opam
+++ b/packages/docfd/docfd.0.3.3/opam
@@ -19,7 +19,7 @@ depends: [
   "spelll"
   "notty"
   "nottui"
-  "lwd" {>= "0.2"}
+  "lwd" {>= "0.2" & < "0.4"}
   "cmdliner" {>= "1.1.0"}
   "odoc" {with-doc}
 ]

--- a/packages/docfd/docfd.0.5.8/opam
+++ b/packages/docfd/docfd.0.5.8/opam
@@ -19,7 +19,7 @@ depends: [
   "spelll"
   "notty"
   "nottui"
-  "lwd" {>= "0.2"}
+  "lwd" {>= "0.2" & < "0.4"}
   "cmdliner" {>= "1.1.0"}
   "odoc" {with-doc}
 ]

--- a/packages/docfd/docfd.0.6.1/opam
+++ b/packages/docfd/docfd.0.6.1/opam
@@ -19,7 +19,7 @@ depends: [
   "spelll"
   "notty"
   "nottui"
-  "lwd" {>= "0.2"}
+  "lwd" {>= "0.2" & < "0.4"}
   "cmdliner" {>= "1.1.0"}
   "odoc" {with-doc}
 ]

--- a/packages/lwd/lwd.0.4/opam
+++ b/packages/lwd/lwd.0.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Lightweight reactive documents"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "seq"
+  "ocaml" {>= "4.03"}
+  "qtest" {with-test}
+  "qcheck" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+url {
+  src: "https://github.com/let-def/lwd/releases/download/v0.4/lwd-0.4.tbz"
+  checksum: [
+    "sha256=9e7165b650567cf39eac5e07b95346cd7719c5149db0cf9a6de0f965d43ec7c5"
+    "sha512=7e015ecbdf19dbf503e70fb1fb8f6e2f78182cafbda172d9849a910d92c4a44e0c4d0fe8fb7a81515ba224ce9e624fac79ef41ad04a010af460dc2c0c2f261bc"
+  ]
+}
+x-commit-hash: "4d139dbb3e85b623a06093f5757d820138f405a0"

--- a/packages/nottui-lwt/nottui-lwt.0.4/opam
+++ b/packages/nottui-lwt/nottui-lwt.0.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Run Nottui UIs in Lwt"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "lwt"
+  "nottui" {= version}
+  "notty" {>= "0.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+url {
+  src: "https://github.com/let-def/lwd/releases/download/v0.4/lwd-0.4.tbz"
+  checksum: [
+    "sha256=9e7165b650567cf39eac5e07b95346cd7719c5149db0cf9a6de0f965d43ec7c5"
+    "sha512=7e015ecbdf19dbf503e70fb1fb8f6e2f78182cafbda172d9849a910d92c4a44e0c4d0fe8fb7a81515ba224ce9e624fac79ef41ad04a010af460dc2c0c2f261bc"
+  ]
+}
+x-commit-hash: "4d139dbb3e85b623a06093f5757d820138f405a0"

--- a/packages/nottui-pretty/nottui-pretty.0.4/opam
+++ b/packages/nottui-pretty/nottui-pretty.0.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A pretty-printer based on PPrint rendering UIs"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "nottui" {= version}
+  "notty" {>= "0.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+url {
+  src: "https://github.com/let-def/lwd/releases/download/v0.4/lwd-0.4.tbz"
+  checksum: [
+    "sha256=9e7165b650567cf39eac5e07b95346cd7719c5149db0cf9a6de0f965d43ec7c5"
+    "sha512=7e015ecbdf19dbf503e70fb1fb8f6e2f78182cafbda172d9849a910d92c4a44e0c4d0fe8fb7a81515ba224ce9e624fac79ef41ad04a010af460dc2c0c2f261bc"
+  ]
+}
+x-commit-hash: "4d139dbb3e85b623a06093f5757d820138f405a0"

--- a/packages/nottui-unix/nottui-unix.0.4/opam
+++ b/packages/nottui-unix/nottui-unix.0.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "UI toolkit for the UNIX terminal built on top of Notty and Lwd"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "lwd" {= version}
+  "notty" {>= "0.2"}
+  "nottui" {= version}
+  "cbor" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+url {
+  src: "https://github.com/let-def/lwd/releases/download/v0.4/lwd-0.4.tbz"
+  checksum: [
+    "sha256=9e7165b650567cf39eac5e07b95346cd7719c5149db0cf9a6de0f965d43ec7c5"
+    "sha512=7e015ecbdf19dbf503e70fb1fb8f6e2f78182cafbda172d9849a910d92c4a44e0c4d0fe8fb7a81515ba224ce9e624fac79ef41ad04a010af460dc2c0c2f261bc"
+  ]
+}
+x-commit-hash: "4d139dbb3e85b623a06093f5757d820138f405a0"

--- a/packages/nottui/nottui.0.4/opam
+++ b/packages/nottui/nottui.0.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "UI toolkit for the terminal built on top of Notty and Lwd"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "lwd" {= version}
+  "notty" {>= "0.2"}
+  "cbor" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+url {
+  src: "https://github.com/let-def/lwd/releases/download/v0.4/lwd-0.4.tbz"
+  checksum: [
+    "sha256=9e7165b650567cf39eac5e07b95346cd7719c5149db0cf9a6de0f965d43ec7c5"
+    "sha512=7e015ecbdf19dbf503e70fb1fb8f6e2f78182cafbda172d9849a910d92c4a44e0c4d0fe8fb7a81515ba224ce9e624fac79ef41ad04a010af460dc2c0c2f261bc"
+  ]
+}
+x-commit-hash: "4d139dbb3e85b623a06093f5757d820138f405a0"

--- a/packages/tyxml-lwd/tyxml-lwd.0.4/opam
+++ b/packages/tyxml-lwd/tyxml-lwd.0.4/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/let-def/lwd/issues"
 depends: [
   "dune" {>= "3.5"}
   "lwd" {= version}
-  "tyxml" {>= "4.5.0"}
+  "tyxml" {>= "4.6.0"}
   "js_of_ocaml"
   "js_of_ocaml-ppx"
   "odoc" {with-doc}

--- a/packages/tyxml-lwd/tyxml-lwd.0.4/opam
+++ b/packages/tyxml-lwd/tyxml-lwd.0.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Make reactive webpages in Js_of_ocaml using Tyxml and Lwd"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "lwd" {= version}
+  "tyxml" {>= "4.5.0"}
+  "js_of_ocaml"
+  "js_of_ocaml-ppx"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+url {
+  src: "https://github.com/let-def/lwd/releases/download/v0.4/lwd-0.4.tbz"
+  checksum: [
+    "sha256=9e7165b650567cf39eac5e07b95346cd7719c5149db0cf9a6de0f965d43ec7c5"
+    "sha512=7e015ecbdf19dbf503e70fb1fb8f6e2f78182cafbda172d9849a910d92c4a44e0c4d0fe8fb7a81515ba224ce9e624fac79ef41ad04a010af460dc2c0c2f261bc"
+  ]
+}
+x-commit-hash: "4d139dbb3e85b623a06093f5757d820138f405a0"


### PR DESCRIPTION
Lightweight reactive documents

- Project page: <a href="https://github.com/let-def/lwd">https://github.com/let-def/lwd</a>
- Documentation: <a href="https://let-def.github.io/lwd/doc">https://let-def.github.io/lwd/doc</a>

##### CHANGES:

- Add Lwd.update (by @OlivierNicole and @Julow) and Lwd.may_update functions
- Lwd.set: change binding before invalidation, otherwise the old value could be re-observed (reported by @voodoos)
- brr-lwd: support declarative events and set of css classes
- Nottui: fix treatment of some terminal events that were delayed because of improper buffer flushing, reported by @darrenldl
- Introduce Nottui_unix: move platform-specific code of Nottui to a separate library (by @Dinosaure and @Reynir, let-def/lwd#44, let-def/lwd#51)
