### PR TITLE
conf-libcurl: Add mingw-w64-shims as a dependency

### DIFF
--- a/packages/conf-libcurl/conf-libcurl.2/opam
+++ b/packages/conf-libcurl/conf-libcurl.2/opam
@@ -24,6 +24,7 @@ depexts: [
   ["curl"] {os = "freebsd"}
 ]
 depends: [
+  "mingw-w64-shims" {os-distribution = "cygwin" & build}
   ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-i686" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-x86_64" {os = "win32" & os-distribution != "cygwinports"})
 ]


### PR DESCRIPTION
Installing `conf-libcurl` can trigger a rebuild of `mingw-w64-shims`, which adjusts the `PATH` to include the `curl-config` script required during the build. However, since `mingw-w64-shims` is not listed as a direct dependency, it may be installed too late, leading to build failures when `curl-config` is not found in the PATH.

This commit fixes the issue by declaring `mingw-w64-shims` as a direct build dependency of `conf-libcurl`.

Here is a [failing build](https://github.com/punchagan/test-setup-ocaml/actions/runs/15181111083/job/42690527297) on a test repository for [this workflow file](https://github.com/punchagan/test-setup-ocaml/actions/runs/15181111083/workflow). And a [successful build](https://github.com/punchagan/test-setup-ocaml/actions/runs/15183256190/job/42697546447) with its [workflow file](https://github.com/punchagan/test-setup-ocaml/actions/runs/15183256190/workflow).