### PR TITLE
Extend conf-gnomecanvas support to MinGW and MSys2

### DIFF
--- a/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
+++ b/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
@@ -3,7 +3,13 @@ maintainer: "virgile.prevosto@m4x.org"
 homepage: "https://developer.gnome.org/libgnomecanvas/2.30/"
 authors: "The GNOME Project"
 license: "LGPL-2.1-or-later"
-build: [["pkg-config" "libgnomecanvas-2.0"]]
+build: [
+  ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution != "cygwin"}
+   "libgnomecanvas-2.0"]
+]
 depexts: [
   ["libgnomecanvas2-dev"] {os-family = "debian"}
   ["libgnomecanvas2-dev"] {os-family = "ubuntu"}
@@ -26,6 +32,10 @@ synopsis: "Virtual package relying on a Gnomecanvas system installation"
 description: """
 This package can only install if libgnomecanvas2-dev is installed
 on the system."""
-depends: ["conf-pkg-config" {build}]
+depends: [
+  "conf-pkg-config" {build}
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gnomecanvas-i686" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gnomecanvas-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf

--- a/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
+++ b/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
@@ -15,6 +15,7 @@ depexts: [
   ["libgnomecanvas2-dev"] {os-family = "ubuntu"}
   ["libgnomecanvas-devel"] {os-family = "fedora" | os-family = "rhel"}
   ["libgnomecanvas"] {os = "macos" & os-distribution = "homebrew"}
+  ["libgnomecanvas"] {os = "macos" & os-distribution = "macports"}
   ["libgnomecanvas-dev@testing" "libart-lgpl-dev"] {os-family = "alpine"}
   ["libgnomecanvas2"] {os = "win32" & os-distribution = "cygwinports"}
   ["libgnomecanvas"] {os-family = "arch"}

--- a/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
+++ b/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
@@ -18,6 +18,7 @@ depexts: [
   ["libgnomecanvas-dev@testing" "libart-lgpl-dev"] {os-family = "alpine"}
   ["libgnomecanvas2"] {os = "win32" & os-distribution = "cygwinports"}
   ["libgnomecanvas"] {os-family = "arch"}
+  ["libgnomecanvas-devel"] {os-family = "opensuse"}
   ["libgnomecanvas"] {os = "freebsd"}
   ["libgnomecanvas"] {os = "openbsd"}
   ["gnome2.libgnomecanvas"] {os-distribution = "nixos"}

--- a/packages/conf-mingw-w64-gnomecanvas-i686/conf-mingw-w64-gnomecanvas-i686.1/opam
+++ b/packages/conf-mingw-w64-gnomecanvas-i686/conf-mingw-w64-gnomecanvas-i686.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "gnomecanvas for i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of gnomecanvas for the mingw-w64 project is available"
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "The GNOME Project"
+license: "LGPL-2.1-or-later"
+homepage: "https://developer.gnome.org/libgnomecanvas/2.30/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32" & os-distribution = "cygwin"
+build: ["pkgconf" "--personality=i686-w64-mingw32" "libgnomecanvas-2.0"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-i686" {build}
+]
+depexts: [
+  ["mingw64-i686-libgnomecanvas2"] {os = "win32" & os-distribution = "cygwin"}
+  # i686 variant not available on MSys https://packages.msys2.org/base/mingw-w64-libgnomecanvas
+]

--- a/packages/conf-mingw-w64-gnomecanvas-x86_64/conf-mingw-w64-gnomecanvas-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gnomecanvas-x86_64/conf-mingw-w64-gnomecanvas-x86_64.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "gnomecanvas for x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of gnomecanvas for the mingw-w64 project is available"
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "The GNOME Project"
+license: "LGPL-2.1-or-later"
+homepage: "https://developer.gnome.org/libgnomecanvas/2.30/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32"
+build: [
+  ["pkgconf" "--personality=x86_64-w64-mingw32" "libgnomecanvas-2.0"] {os = "win32" & os-distribution = "cygwin"}
+  ["pkg-config" "libgnomecanvas-2.0"] {os = "win32" & os-distribution = "msys2"}
+]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-x86_64" {build}
+]
+depexts: [
+  ["mingw64-x86_64-libgnomecanvas2"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-x86_64-libgnomecanvas"] {os = "win32" & os-distribution = "msys2"}
+]


### PR DESCRIPTION
Again, this is modeled after #26072

https://www.cygwin.com/packages/summary/mingw64-x86_64-libgnomecanvas2.html
https://www.cygwin.com/packages/summary/mingw64-i686-libgnomecanvas2.htm
and
https://packages.msys2.org/base/mingw-w64-libgnomecanvas

Note: the latter doesn't offer a i686 package.