### PR TITLE
Package binary_tree.1.0

### DIFF
--- a/packages/binary_tree/binary_tree.1.0/opam
+++ b/packages/binary_tree/binary_tree.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "humamalhusaini@tutamail.com"
+authors: "Pierre Castoran, slightly modified by Humam Alhusaini"
+homepage: "https://github.com/Tralalero-Tralalal/Coq-b-tree"
+dev-repo: "git+https://github.com/Tralalero-Tralalal/Coq-b-tree"
+bug-reports: "https://github.com/Tralalero-Tralalal/Coq-b-tree/issues"
+license: "MIT"
+depends: [
+  "coq" {>= "8.16"}
+]
+build: [
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
+  [make]
+]
+install: [
+  ["mkdir" "-p" "%{lib}%/coq/user-contrib/BTree"]
+  ["cp" "b_tree.vo" "b_tree.glob" "%{lib}%/coq/user-contrib/BTree/"]
+]
+remove: [
+  ["rm" "-rf" "%{lib}%/coq/user-contrib/BTree"]
+]
+synopsis: "A Coq binary tree module"
+description: """
+This package provides a simple binary tree data structure and associated functions.
+"""
+url {
+  src:
+    "https://github.com/Tralalero-Tralalal/coq-binary-tree/archive/refs/tags/binary-tree.tar.gz"
+  checksum: [
+    "md5=46899bef1acd87c089b954ae9ba0e975"
+    "sha512=7091014ff2e378c8e193aca22da8cccdc5513350abddb78c2abf2ecccb3758db9b55e4d32831eeba170d2042473fcf3854a0d6bf1838d99088e73b27d3dffdbd"
+  ]
+}

--- a/packages/binary_tree/binary_tree.1.0/opam
+++ b/packages/binary_tree/binary_tree.1.0/opam
@@ -1,9 +1,9 @@
 opam-version: "2.0"
 maintainer: "humamalhusaini@tutamail.com"
 authors: "Pierre Castoran, slightly modified by Humam Alhusaini"
-homepage: "https://github.com/Tralalero-Tralalal/Coq-b-tree"
-dev-repo: "git+https://github.com/Tralalero-Tralalal/Coq-b-tree"
-bug-reports: "https://github.com/Tralalero-Tralalal/Coq-b-tree/issues"
+homepage: "https://github.com/Tralalero-Tralalal/coq-binary-tree"
+dev-repo: "git+https://github.com/Tralalero-Tralalal/coq-binary-tree"
+bug-reports: "https://github.com/Tralalero-Tralalal/coq-binary-tree/issues"
 license: "MIT"
 depends: [
   "coq" {>= "8.16"}
@@ -13,11 +13,11 @@ build: [
   [make]
 ]
 install: [
-  ["mkdir" "-p" "%{lib}%/coq/user-contrib/BTree"]
-  ["cp" "binary_tree.vo" "binary_tree.glob" "%{lib}%/coq/user-contrib/BTree/"]
+  ["mkdir" "-p" "%{lib}%/coq/user-contrib/coq-binary-tree"]
+  ["cp" "binary_tree.vo" "binary_tree.glob" "%{lib}%/coq/user-contrib/coq-binary-tree/"]
 ]
 remove: [
-  ["rm" "-rf" "%{lib}%/coq/user-contrib/BTree"]
+  ["rm" "-rf" "%{lib}%/coq/user-contrib/coq-binary-tree"]
 ]
 synopsis: "A Coq binary tree module"
 description: """

--- a/packages/binary_tree/binary_tree.1.0/opam
+++ b/packages/binary_tree/binary_tree.1.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 install: [
   ["mkdir" "-p" "%{lib}%/coq/user-contrib/BTree"]
-  ["cp" "b_tree.vo" "b_tree.glob" "%{lib}%/coq/user-contrib/BTree/"]
+  ["cp" "binary_tree.vo" "binary_tree.glob" "%{lib}%/coq/user-contrib/BTree/"]
 ]
 remove: [
   ["rm" "-rf" "%{lib}%/coq/user-contrib/BTree"]


### PR DESCRIPTION
### `binary_tree.1.0`
A Coq binary tree module
This package provides a simple binary tree data structure and associated functions.



---
* Homepage: https://github.com/Tralalero-Tralalal/Coq-b-tree
* Source repo: git+https://github.com/Tralalero-Tralalal/Coq-b-tree
* Bug tracker: https://github.com/Tralalero-Tralalal/Coq-b-tree/issues

---
:camel: Pull-request generated by opam-publish v2.5.1