### PR TITLE
2 packages from mbarbin/fpath-base at 0.3.1

### DIFF
--- a/packages/fpath-base/fpath-base.0.3.1/opam
+++ b/packages/fpath-base/fpath-base.0.3.1/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Adds a few functions to Fpath to use alongside Base"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/fpath-base"
+doc: "https://mbarbin.github.io/fpath-base/"
+bug-reports: "https://github.com/mbarbin/fpath-base/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "base" {>= "v0.17"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/fpath-base.git"
+description: """\
+
+[Fpath_base] is an OCaml module designed to be opened to shadow and
+further extend the four modules from [fpath-sexplib0]: [Fpath],
+[Fsegment], [Absolute_path] and [Relative_path] for a better
+compatibility with [base].
+
+The extended modules export [hashable] and [comparable] interfaces,
+making them compatible with [base]-style containers such as [Map],
+[Set], [Hashtbl], and [Hash_set].
+
+[base]: https://github.com/janestreet/base
+[fpath]: https://github.com/dbuenzli/fpath
+
+"""
+tags: [ "fpath" "fpath-sexp0" "absolute-paths" "relative-paths" "base" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/fpath-base/releases/download/0.3.1/fpath-base-0.3.1.tbz"
+  checksum: [
+    "sha256=634acd1b009c6faf0bc57e18767820302d58a58ac2870238b5075c76a84a09a9"
+    "sha512=158c569ed51dd87e014de5823c2fb9893bd680887411715ee35682dcbd3736d11e8af78a242baac8c0d4716a8b554a816267c09c702c9f9b26268579f3d9a7ef"
+  ]
+}
+x-commit-hash: "f560b743a9d4279241fe48a8f5554eaf761c4feb"

--- a/packages/fpath-sexp0/fpath-sexp0.0.3.1/opam
+++ b/packages/fpath-sexp0/fpath-sexp0.0.3.1/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis:
+  "Adds Fpath.sexp_of_t and defines 3 new modules: Fsegment, Absolute_path and Relative_path"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/fpath-base"
+doc: "https://mbarbin.github.io/fpath-base/"
+bug-reports: "https://github.com/mbarbin/fpath-base/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "fpath" {>= "0.7.3"}
+  "sexplib0" {>= "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/fpath-base.git"
+description: """\
+
+[Fpath_sexplib0] is an OCaml module designed to be opened to extend
+the [fpath] package. It introduces three new modules to the scope:
+[Fsegment], [Absolute_path] and [Relative_path].
+
+[Absolute_path] and [Relative_path] are helper modules that
+distinguish between classes of paths in the type system, enhancing
+type safety for applications manipulating paths.
+
+[Fpath] is shadowed and retains all its original functionality, with
+the addition of a sexp serializer and new helpers for casting between
+the types of paths offered by the package (absolute and relative
+paths).
+
+[fpath]: https://github.com/dbuenzli/fpath
+
+"""
+tags: [ "fpath" "absolute-paths" "relative-paths" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/fpath-base/releases/download/0.3.1/fpath-base-0.3.1.tbz"
+  checksum: [
+    "sha256=634acd1b009c6faf0bc57e18767820302d58a58ac2870238b5075c76a84a09a9"
+    "sha512=158c569ed51dd87e014de5823c2fb9893bd680887411715ee35682dcbd3736d11e8af78a242baac8c0d4716a8b554a816267c09c702c9f9b26268579f3d9a7ef"
+  ]
+}
+x-commit-hash: "f560b743a9d4279241fe48a8f5554eaf761c4feb"


### PR DESCRIPTION
This pull-request concerns:
- `fpath-base.0.3.1`: Adds a few functions to Fpath to use alongside Base
- `fpath-sexp0.0.3.1`: Adds Fpath.sexp_of_t and defines 3 new modules: Fsegment, Absolute_path and Relative_path



---
* Homepage: https://github.com/mbarbin/fpath-base
* Source repo: git+https://github.com/mbarbin/fpath-base.git
* Bug tracker: https://github.com/mbarbin/fpath-base/issues

---
## 0.3.1 (2025-05-26)

### Changed

- Conditional set implicit transitive deps in CI depending on the compiler version (mbarbin/fpath-base#16, @mbarbin).


---
:camel: Pull-request generated by opam-publish v2.5.1