### PR TITLE
Package pplumbing.0.0.14

### DIFF
--- a/packages/pplumbing/pplumbing.0.0.14/opam
+++ b/packages/pplumbing/pplumbing.0.0.14/opam
@@ -1,0 +1,86 @@
+opam-version: "2.0"
+synopsis: "Utility libraries to use with [pp]"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/pplumbing"
+doc: "https://mbarbin.github.io/pplumbing/"
+bug-reports: "https://github.com/mbarbin/pplumbing/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "cmdlang" {>= "0.0.9"}
+  "cmdlang-to-cmdliner" {>= "0.0.9"}
+  "cmdliner" {>= "1.3.0"}
+  "dyn" {>= "3.17"}
+  "fmt" {>= "0.9.0"}
+  "loc" {>= "0.2.2"}
+  "logs" {>= "0.7.0"}
+  "ordering" {>= "3.17"}
+  "parsexp" {>= "v0.16"}
+  "pp" {>= "2.0.0"}
+  "sexplib0" {>= "v0.16"}
+  "stdune" {>= "3.17"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/pplumbing.git"
+description: """\
+
+[pplumbing] defines a set of utility libraries to use with [pp]. It
+is compatible with [logs] and inspired by design choices used by
+[dune] for user messages:
+
+- [Pp_tty] extends [pp] to build colored documents in the user's
+  terminal using ansi escape codes.
+
+- [Err] is an abstraction to report located errors and warnings to
+  the user.
+
+- [Log] is an interface to [logs] using [Pp_tty] rather than [Format].
+
+- [Log_cli] contains functions to work with [Err] on the side of end
+  programs (such as a command line tool). It defines command line
+  helpers to configure the [Err] library, while taking care of setting
+  the [logs] and [fmt] style rendering.
+
+- [Cmdlang_cmdliner_runner] is a library for running command line
+  programs specified with [cmdlang] with [cmdliner] as a backend and
+  making opinionated choices, assuming your dependencies are using
+  [Err].
+
+These libraries are meant to combine nicely into a small ecosystem of
+useful helpers to build CLIs in OCaml.
+
+[cmdlang]: https://github.com/mbarbin/cmdlang
+[cmdliner]: https://github.com/dbuenzli/cmdliner
+[dune]: https://github.com/ocaml/dune
+[fmt]: https://github.com/dbuenzli/fmt
+[logs]: https://github.com/dbuenzli/logs
+[pp]: https://github.com/ocaml-dune/pp
+
+"""
+tags: [ "cli" "cmdlang" "logs" "pp" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/pplumbing/releases/download/0.0.14/pplumbing-0.0.14.tbz"
+  checksum: [
+    "sha256=ed7eaba180378a59719e9af63ccdc89dde8e0a20f2cba420abb0080b0bc4a868"
+    "sha512=f168c37c1acd38c92e5b6d59321da4021195b6ddc49dde82de70e9282b55042621bea1b84a677d57f83604c06d6ee9c790b683fd589cd2097ab8f00c293f56af"
+  ]
+}
+x-commit-hash: "e77dc8813860b9d8d19d82725252770a3f55f79d"


### PR DESCRIPTION
### `pplumbing.0.0.14`
Utility libraries to use with [pp]
[pplumbing] defines a set of utility libraries to use with [pp]. It
is compatible with [logs] and inspired by design choices used by
[dune] for user messages:

- [Pp_tty] extends [pp] to build colored documents in the user's
  terminal using ansi escape codes.

- [Err] is an abstraction to report located errors and warnings to
  the user.

- [Log] is an interface to [logs] using [Pp_tty] rather than [Format].

- [Log_cli] contains functions to work with [Err] on the side of end
  programs (such as a command line tool). It defines command line
  helpers to configure the [Err] library, while taking care of setting
  the [logs] and [fmt] style rendering.

- [Cmdlang_cmdliner_runner] is a library for running command line
  programs specified with [cmdlang] with [cmdliner] as a backend and
  making opinionated choices, assuming your dependencies are using
  [Err].

These libraries are meant to combine nicely into a small ecosystem of
useful helpers to build CLIs in OCaml.

[cmdlang]: https://github.com/mbarbin/cmdlang
[cmdliner]: https://github.com/dbuenzli/cmdliner
[dune]: https://github.com/ocaml/dune
[fmt]: https://github.com/dbuenzli/fmt
[logs]: https://github.com/dbuenzli/logs
[pp]: https://github.com/ocaml-dune/pp



---
* Homepage: https://github.com/mbarbin/pplumbing
* Source repo: git+https://github.com/mbarbin/pplumbing.git
* Bug tracker: https://github.com/mbarbin/pplumbing/issues

---
Changelog below since the last version published to the public opam-repository (0.0.11).

## 0.0.14 (2025-05-26)

### Changed

- Conditional set implicit transitive deps in CI depending on the compiler version (mbarbin/pplumbing#12, @mbarbin).

## 0.0.13 (2025-05-22)

### Added

- Rename `--verbosity` flag into `--log-level`. Keep former as alias (mbarbin/pplumbing#5a88fb, @mbarbin).
- Add a type for message levels and add new `Err.emit t ~level` function (mbarbin/pplumbing#7, @mbarbin).

### Changed

- Improve rendering of err with context when printing to the console (mbarbin/pplumbing#11, @mbarbin).
- Support build with OCaml 4.14 (mbarbin/pplumbing#10, @mbarbin).
- Increment errors and warning counts even when the message is not shown (mbarbin/pplumbing#8, @mbarbin).

### Fixed

- Do not print raised errors and exceptions when in quiet mode (mbarbin/pplumbing#9, @mbarbin).

## 0.0.12 (2025-05-06)

This release prepares the deprecation of a few functions and contains `ocamlmig` annotations to help users with the migration.

To automatically apply the migration changes, first upgrade your `pplumbing` dependency and re-build your project. Then run the command `ocamlmig migrate` from the root of your project.

### Added

- Add concept of error "context" that can be augmented (mbarbin/pplumbing#6, @mbarbin).
- Better support and rendering of errors built with `Err.sexp` (mbarbin/pplumbing#6, @mbarbin).

### Changed

- Tweak some details in format of `Err.sexp_of_t` (mbarbin/pplumbing#6, @mbarbin).
- Do not include exit code in `Err.sexp_of_t` by default (mbarbin/pplumbing#6, @mbarbin).
- Rename `Err.pp_of_sexp` to `Err.sexp` to make it shorter (mbarbin/pplumbing#4, @mbarbin).

### Deprecated

- Prepare the deprecation of sexp based err constructors (mbarbin/pplumbing#4, @mbarbin).

### Removed

- Replaced `Err.append` by `Err.add_context` (mbarbin/pplumbing#6, @mbarbin).
- Removed `Stdune.User_message.t -> Err.t` helper (mbarbin/pplumbing#5, @mbarbin).


---
:camel: Pull-request generated by opam-publish v2.5.1