### PR TITLE
4 packages from voodoos/merlin at 5.4.2~5.4preview

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.5.4.2~5.4preview/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.4.2~5.4preview/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Reads config files for merlin"
+description: """\
+Helper process: reads .merlin files and outputs the normalized content to
+  stdout."""
+maintainer: "defree@gmail.com"
+authors: "The Merlin team"
+license: "MIT"
+homepage: "https://github.com/ocaml/merlin"
+bug-reports: "https://github.com/ocaml/merlin/issues"
+depends: [
+  "ocaml" {>= "5.2"}
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "ocamlfind" {>= "1.6.0"}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+url {
+  src:
+    "https://github.com/voodoos/merlin/archive/9cd9e4870d5bca509f0f40ee8532ad206a2721a5.tar.gz"
+  checksum: [
+    "md5=ffbb615406722b1f3b7f8b839c57fcc3"
+    "sha512=48c98bf93ce9a2e0c2e7e51c8b2c341e756b80b6a0967afacd2fcd7ef27f056d2feed2226c48c1ee83c9059380552b00d850654ddd4017ff4dacfa803b08e577"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/merlin-lib/merlin-lib.5.4.2~5.4preview/opam
+++ b/packages/merlin-lib/merlin-lib.5.4.2~5.4preview/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Merlin's libraries"
+description: """\
+These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."""
+maintainer: "defree@gmail.com"
+authors: "The Merlin team"
+license: "MIT"
+homepage: "https://github.com/ocaml/merlin"
+bug-reports: "https://github.com/ocaml/merlin/issues"
+depends: [
+  "ocaml" {>= "5.4" & < "5.5"}
+  "dune" {>= "3.0.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test & >= "1.3.0"}
+  "menhir" {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+url {
+  src:
+    "https://github.com/voodoos/merlin/archive/9cd9e4870d5bca509f0f40ee8532ad206a2721a5.tar.gz"
+  checksum: [
+    "md5=ffbb615406722b1f3b7f8b839c57fcc3"
+    "sha512=48c98bf93ce9a2e0c2e7e51c8b2c341e756b80b6a0967afacd2fcd7ef27f056d2feed2226c48c1ee83c9059380552b00d850654ddd4017ff4dacfa803b08e577"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/merlin/merlin.5.4.2~5.4preview/opam
+++ b/packages/merlin/merlin.5.4.2~5.4preview/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+maintainer: "defree@gmail.com"
+authors: "The Merlin team"
+license: "MIT"
+homepage: "https://github.com/ocaml/merlin"
+bug-reports: "https://github.com/ocaml/merlin/issues"
+depends: [
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {= version}
+  "ocaml-index" {>= "1.0" & post}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+post-messages:
+  """\
+merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute "set rtp+=" . g:opamshare . "/merlin/vim"
+
+Also run the following line in vim to index the documentation:
+  :execute "helptags " . g:opamshare . "/merlin/vim/doc"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines "opam" "var" "share")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name "emacs/site-lisp" opam-share))
+    (autoload 'merlin-mode "merlin" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its "OPSW" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup"""
+    {success & !user-setup:installed}
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+url {
+  src:
+    "https://github.com/voodoos/merlin/archive/9cd9e4870d5bca509f0f40ee8532ad206a2721a5.tar.gz"
+  checksum: [
+    "md5=ffbb615406722b1f3b7f8b839c57fcc3"
+    "sha512=48c98bf93ce9a2e0c2e7e51c8b2c341e756b80b6a0967afacd2fcd7ef27f056d2feed2226c48c1ee83c9059380552b00d850654ddd4017ff4dacfa803b08e577"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-index/ocaml-index.5.4.2~5.4preview/opam
+++ b/packages/ocaml-index/ocaml-index.5.4.2~5.4preview/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A tool that indexes value usages from cmt files"
+description:
+  "ocaml-index should integrate with the build system to index codebase and allow tools such as Merlin to perform project-wide occurrences queries."
+maintainer: "ulysse@tarides.com"
+authors: "ulysse@tarides.com"
+license: "MIT"
+homepage: "https://github.com/ocaml/merlin/ocaml-index"
+bug-reports: "https://github.com/ocaml/merlin/issues"
+depends: [
+  "dune" {>= "3.0.0"}
+  "ocaml" {>= "5.4"}
+  "merlin-lib" {= version}
+  "odoc" {with-doc}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+url {
+  src:
+    "https://github.com/voodoos/merlin/archive/9cd9e4870d5bca509f0f40ee8532ad206a2721a5.tar.gz"
+  checksum: [
+    "md5=ffbb615406722b1f3b7f8b839c57fcc3"
+    "sha512=48c98bf93ce9a2e0c2e7e51c8b2c341e756b80b6a0967afacd2fcd7ef27f056d2feed2226c48c1ee83c9059380552b00d850654ddd4017ff4dacfa803b08e577"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `dot-merlin-reader.5.4.2~5.4preview`: Reads config files for merlin
- `merlin.5.4.2~5.4preview`: Editor helper, provides completion, typing and source browsing in Vim and
  Emacs
- `merlin-lib.5.4.2~5.4preview`: Merlin's libraries
- `ocaml-index.5.4.2~5.4preview`: A tool that indexes value usages from cmt files



---
* Source repo: git+https://github.com/ocaml/merlin.git
* Bug tracker: https://github.com/ocaml/merlin/issues

---
:camel: Pull-request generated by opam-publish v2.5.0