### PR TITLE
Package ocaml-lsp-server.1.22.1~5.4preview

### DIFF
--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.22.1~5.4preview/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.22.1~5.4preview/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: "Rudi Grinberg <me@rgrinberg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson"
+  "base" {>= "v0.16.0"}
+  "lsp" {= version}
+  "jsonrpc" {= version}
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc" {>= "3.4.0"}
+  "chrome-trace" {>= "3.3.0"}
+  "dyn"
+  "stdune"
+  "fiber" {>= "3.1.1" & < "4.0.0"}
+  "ocaml" {>= "5.4" & < "5.5"}
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "astring"
+  "camlp-streams"
+  "ppx_expect" {>= "v0.17.0" & with-test}
+  "ocamlformat" {with-test & = "0.27.0"}
+  "ocamlc-loc" {>= "3.7.0"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "merlin-lib" {>= "5.4" & < "6.0"}
+  "ppx_yojson_conv" {with-dev-setup}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+url {
+  src:
+    "https://github.com/voodoos/ocaml-lsp/archive/ce8357b4e3f3af77305612640b74ede59638a16f.tar.gz"
+  checksum: [
+    "md5=8eb757084370e254275d98d68d18f6fd"
+    "sha512=d3d206a6d62f4dec7e5e163901050e7f22f2af94d39c887d2b3eae3fc48f492f82713269322893ce803aa9b7a8d2d961e0e2599a5c018ecadbcb427aa2fccaef"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `ocaml-lsp-server.1.22.1~5.4preview`
LSP Server for OCaml
An LSP server for OCaml.



---
* Homepage: https://github.com/ocaml/ocaml-lsp
* Source repo: git+https://github.com/ocaml/ocaml-lsp.git
* Bug tracker: https://github.com/ocaml/ocaml-lsp/issues

---
:camel: Pull-request generated by opam-publish v2.5.0