### PR TITLE
[new release] trace (4 packages) (0.10)

### DIFF
--- a/packages/moonpool-io/moonpool-io.0.7/opam
+++ b/packages/moonpool-io/moonpool-io.0.7/opam
@@ -10,7 +10,7 @@ depends: [
   "moonpool" {= version}
   "picos_io" {>= "0.5" & < "0.6"}
   "ocaml" {>= "5.0"}
-  "trace" {with-test}
+  "trace" {with-test & < "0.10"}
   "trace-tef" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/moonpool/moonpool.0.7/opam
+++ b/packages/moonpool/moonpool.0.7/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.0"}
   "either" {>= "1.0"}
-  "trace" {with-test}
+  "trace" {with-test & >= "0.6" & < "0.10"}
   "trace-tef" {with-test}
   "qcheck-core" {with-test & >= "0.19"}
   "thread-local-storage" {>= "0.2" & < "0.3"}

--- a/packages/moonpool/moonpool.0.7/opam
+++ b/packages/moonpool/moonpool.0.7/opam
@@ -22,7 +22,7 @@ depends: [
 ]
 depopts: [
   "hmap"
-  "trace" {>= "0.6"}
+  "trace" {>= "0.6" & < "0.10"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/opentelemetry/opentelemetry.0.11.1/opam
+++ b/packages/opentelemetry/opentelemetry.0.11.1/opam
@@ -25,7 +25,7 @@ depends: [
 ]
 depopts: ["trace" "lwt" "eio"]
 conflicts: [
-  "trace" {< "0.9"}
+  "trace" {(< "0.9") | (>= "0.10")}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/opentelemetry/opentelemetry.0.11.2/opam
+++ b/packages/opentelemetry/opentelemetry.0.11.2/opam
@@ -25,7 +25,7 @@ depends: [
 ]
 depopts: ["trace" "lwt" "eio"]
 conflicts: [
-  "trace" {(< "0.9") || (>= "0.10")}
+  "trace" {(< "0.9") | (>= "0.10")}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/opentelemetry/opentelemetry.0.11.2/opam
+++ b/packages/opentelemetry/opentelemetry.0.11.2/opam
@@ -25,7 +25,7 @@ depends: [
 ]
 depopts: ["trace" "lwt" "eio"]
 conflicts: [
-  "trace" {< "0.9"}
+  "trace" {(< "0.9") || (>= "0.10")}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/opentelemetry/opentelemetry.0.11/opam
+++ b/packages/opentelemetry/opentelemetry.0.11/opam
@@ -25,7 +25,7 @@ depends: [
 ]
 depopts: ["trace" "lwt" "eio"]
 conflicts: [
-  "trace" {< "0.9"}
+  "trace" {(< "0.9") | (>= "0.10")}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/ppx_trace/ppx_trace.0.10/opam
+++ b/packages/ppx_trace/ppx_trace.0.10/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A ppx-based preprocessor for trace"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "ppx"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "ppxlib" {>= "0.28" & < "0.36"}
+  "trace" {= version}
+  "trace-tef" {= version & with-test}
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "mtime" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.10/trace-0.10.tbz"
+  checksum: [
+    "sha256=c5a43827bbd5521e779c8856e44f4c718dccda902d00a242b598516110ada04d"
+    "sha512=f19cb25a767ed428cb1d4a497312267524bfaaf9550caa5fc1e84809494f0b7eaf26030d95563c75dea66606fcbec1be7e34baa4cba86fc57d64bc5d5b98efd5"
+  ]
+}
+x-commit-hash: "d9cd7621f54325d80114fc3d5be9ff59c98f7331"

--- a/packages/trace-fuchsia/trace-fuchsia.0.10/opam
+++ b/packages/trace-fuchsia/trace-fuchsia.0.10/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "A high-performance backend for trace, emitting a Fuchsia trace into a file"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "tracing" "fuchsia"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "trace" {= version}
+  "mtime" {>= "2.0"}
+  "thread-local-storage" {>= "0.2"}
+  "base-bigarray"
+  "base-unix"
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+available: arch != "s390x"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.10/trace-0.10.tbz"
+  checksum: [
+    "sha256=c5a43827bbd5521e779c8856e44f4c718dccda902d00a242b598516110ada04d"
+    "sha512=f19cb25a767ed428cb1d4a497312267524bfaaf9550caa5fc1e84809494f0b7eaf26030d95563c75dea66606fcbec1be7e34baa4cba86fc57d64bc5d5b98efd5"
+  ]
+}
+x-commit-hash: "d9cd7621f54325d80114fc3d5be9ff59c98f7331"

--- a/packages/trace-tef/trace-tef.0.10/opam
+++ b/packages/trace-tef/trace-tef.0.10/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "A simple backend for trace, emitting Catapult/TEF JSON into a file"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: [
+  "trace" "tracing" "catapult" "TEF" "chrome-format" "chrome-trace" "json"
+]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "trace" {= version}
+  "mtime" {>= "2.0"}
+  "base-unix"
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.10/trace-0.10.tbz"
+  checksum: [
+    "sha256=c5a43827bbd5521e779c8856e44f4c718dccda902d00a242b598516110ada04d"
+    "sha512=f19cb25a767ed428cb1d4a497312267524bfaaf9550caa5fc1e84809494f0b7eaf26030d95563c75dea66606fcbec1be7e34baa4cba86fc57d64bc5d5b98efd5"
+  ]
+}
+x-commit-hash: "d9cd7621f54325d80114fc3d5be9ff59c98f7331"

--- a/packages/trace/trace.0.10/opam
+++ b/packages/trace/trace.0.10/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "A stub for tracing/observability, agnostic in how data is collected"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "tracing" "observability" "profiling"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "hmap"
+  "unix"
+  "picos_aux" {>= "0.6"}
+  "mtime" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.10/trace-0.10.tbz"
+  checksum: [
+    "sha256=c5a43827bbd5521e779c8856e44f4c718dccda902d00a242b598516110ada04d"
+    "sha512=f19cb25a767ed428cb1d4a497312267524bfaaf9550caa5fc1e84809494f0b7eaf26030d95563c75dea66606fcbec1be7e34baa4cba86fc57d64bc5d5b98efd5"
+  ]
+}
+x-commit-hash: "d9cd7621f54325d80114fc3d5be9ff59c98f7331"


### PR DESCRIPTION
A stub for tracing/observability, agnostic in how data is collected

- Project page: <a href="https://github.com/c-cube/ocaml-trace">https://github.com/c-cube/ocaml-trace</a>

##### CHANGES:

- breaking: manual spans now take a `explicit_span_ctx` as parent, that
    can potentially be transmitted across processes/machines. It also
    is intended to be more compatible with OTEL.
- breaking `trace.subscriber`: timestamps are `int64`ns now, not floats
- breaking `trace`: pass a `string` trace_id in manual spans, which helps
    for backends such as opentelemetry. It's also useful for extensions.

- refactor `trace-fuchsia`: full revamp of the library, modularized, using subscriber API
- refactor `trace-tef`: split into exporter,writer,subscriber, using subscriber API
- feat: add `trace.event`, useful for background threads
- feat `trace.subscriber`: add `Span_tbl`, and a depopt on picos_aux
- feat `trace.subscriber`: tee a whole array at once
- feat tef-tldrs: use EMIT_TEF_AT_EXIT
- feat `trace.subscriber`: depopt on unix for timestamps
- refactor `trace-tef`: depopt on unix for TEF timestamps
