### PR TITLE
[new release] fast_bitvector (0.0.4)

### DIFF
--- a/packages/fast_bitvector/fast_bitvector.0.0.4.2/opam
+++ b/packages/fast_bitvector/fast_bitvector.0.0.4.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A bitvector library"
+description: "Bitvector represented as bytes internally"
+maintainer: ["Stefan Muenzel <source@s.muenzel.net>"]
+authors: ["Stefan Muenzel <source@s.muenzel.net>"]
+license: "MPL-2.0"
+tags: ["bitvector" "bitset"]
+homepage: "https://github.com/engineeredabstraction/fast_bitvector"
+bug-reports: "https://github.com/engineeredabstraction/fast_bitvector/issues"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/engineeredabstraction/fast_bitvector.git"
+x-maintenance-intent: ["(latest)"]
+depends: [
+  "dune" {>= "3.18"}
+  (("ocaml" {>= "4.14.0" & <"5.1.0"}) | ("ocaml" {>= "5.1.0"} & "ocaml_intrinsics_kernel"))
+  "ppx_sexp_conv"
+  "ppx_sexp_value" { >= "v0.16.0" }
+  "expect_test_helpers_core" {with-test}
+  "ppx_jane" {with-test}
+  "odoc" {with-doc}
+]
+available: (arch != "arm32") & (arch != "x86_32") & (arch != "ppc32") & (arch != "s390x")
+url {
+  src:
+    "https://github.com/engineeredabstraction/fast_bitvector/releases/download/0.0.4.2/fast_bitvector-0.0.4.2.tbz"
+  checksum: [
+    "sha256=8b8fe9e6879518ead3bc4488bdc13b7e607b576dde2355e7fecf9f992e5e9031"
+    "sha512=6dfd4d9298dba8c58fcbfe4cce7623cb26cfd5335d3f46eb9f98d6b6ca25a3d83aca40ac98eaebc2dfa4500295637de09b98f506d0b05433073bce9538b92847"
+  ]
+}
+x-commit-hash: "e5816552b52a6401e74930b166da728cd6f844b0"


### PR DESCRIPTION
A bitvector library

- Project page: <a href="https://github.com/engineeredabstraction/fast_bitvector">https://github.com/engineeredabstraction/fast_bitvector</a>

##### CHANGES:

- compatibility with ocaml 4.14
- use `~len` instead of `~length`
- fix append and add tests
