### PR TITLE
[new release] ppx_unreachable (1.0)

### DIFF
--- a/packages/ppx_unreachable/ppx_unreachable.1.0/opam
+++ b/packages/ppx_unreachable/ppx_unreachable.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "A PPX that denotes unreachable code and prints descriptive errors when the code is reached"
+description:
+  "A PPX that denotes unreachable code and prints descriptive errors when the code is reached"
+maintainer: ["Charles Averill"]
+authors: ["Charles Averill"]
+license: "MIT"
+homepage: "https://github.com/CharlesAverill/ppx_unreachable"
+doc: "https://github.com/CharlesAverill/ppx_unreachable"
+bug-reports: "https://github.com/CharlesAverill/ppx_unreachable/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.9"}
+  "ppxlib" {>= "0.36"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CharlesAverill/ppx_unreachable.git"
+url {
+  src:
+    "https://github.com/CharlesAverill/ppx_unreachable/releases/download/1.0/ppx_unreachable-1.0.tbz"
+  checksum: [
+    "sha256=8af03f3cf8ccb52f3bd7f95f49474f9060ce37d0d21ad82e569352e48e1d5fac"
+    "sha512=2e7820f5fe8b8c113bdd0715e3a1e1afac851538fc865d4755ab64a8b34bd5a4bdb2641e09508f51d86e20920156fed2f685409736766dd6e560d50d76720159"
+  ]
+}
+x-commit-hash: "66f71709e07af4df4502623627b0ed1a09574e2d"


### PR DESCRIPTION
A PPX that denotes unreachable code and prints descriptive errors when the code is reached

- Project page: <a href="https://github.com/CharlesAverill/ppx_unreachable">https://github.com/CharlesAverill/ppx_unreachable</a>
- Documentation: <a href="https://github.com/CharlesAverill/ppx_unreachable">https://github.com/CharlesAverill/ppx_unreachable</a>

##### CHANGES:

Provides `[%unreachable]` ppx that prints filename and line number
