### PR TITLE
[new release] awa (2 packages) (0.5.2)

### DIFF
--- a/packages/awa-mirage/awa-mirage.0.5.2/opam
+++ b/packages/awa-mirage/awa-mirage.0.5.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime" {>= "1.0.0"}
+  "lwt" {>= "5.3.0"}
+  "mirage-sleep" {>= "4.0.0"}
+  "duration" {>= "0.2.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "mirage-mtime" {>= "4.0.0"}
+  "logs"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.5.2/awa-0.5.2.tbz"
+  checksum: [
+    "sha256=eb8825a1e91537462c07052876b25ce9068d5373c628c21930f256bc17f36a3d"
+    "sha512=15c72fcc6e2f89e7e2920ee12782f8edfe739a54a636c9fb41c6d6f9c6ea4ec1d0eb08f3e622859a7c071602f8902c085c6ec3295eccec443f3534bc022a26d6"
+  ]
+}
+x-commit-hash: "21b1ec635c8b7fa7794bfff717937a376e0ace25"

--- a/packages/awa/awa.0.5.2/opam
+++ b/packages/awa/awa.0.5.2/opam
@@ -30,6 +30,7 @@ depends: [
   "base64" {>= "3.0.0"}
   "zarith"
   "eqaf" {>= "0.8"}
+  "mirage-mtime" {with-test & >= "4.0.0"}
 ]
 conflicts: [ "result" {< "1.5"} ]
 synopsis: "SSH implementation in OCaml"

--- a/packages/awa/awa.0.5.2/opam
+++ b/packages/awa/awa.0.5.2/opam
@@ -30,7 +30,7 @@ depends: [
   "base64" {>= "3.0.0"}
   "zarith"
   "eqaf" {>= "0.8"}
-  "mirage-mtime" {with-test & >= "4.0.0"}
+  "mirage-mtime" {>= "4.0.0"}
 ]
 conflicts: [ "result" {< "1.5"} ]
 synopsis: "SSH implementation in OCaml"

--- a/packages/awa/awa.0.5.2/opam
+++ b/packages/awa/awa.0.5.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.7"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "1.0.0"}
+  "x509" {>= "1.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-unix"
+  "mtime" {>= "1.0.0"}
+  "logs"
+  "fmt"
+  "cmdliner" {>= "1.1.0"}
+  "base64" {>= "3.0.0"}
+  "zarith"
+  "eqaf" {>= "0.8"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.5.2/awa-0.5.2.tbz"
+  checksum: [
+    "sha256=eb8825a1e91537462c07052876b25ce9068d5373c628c21930f256bc17f36a3d"
+    "sha512=15c72fcc6e2f89e7e2920ee12782f8edfe739a54a636c9fb41c6d6f9c6ea4ec1d0eb08f3e622859a7c071602f8902c085c6ec3295eccec443f3534bc022a26d6"
+  ]
+}
+x-commit-hash: "21b1ec635c8b7fa7794bfff717937a376e0ace25"


### PR DESCRIPTION
SSH implementation in OCaml

- Project page: <a href="https://github.com/mirage/awa-ssh">https://github.com/mirage/awa-ssh</a>
- Documentation: <a href="https://mirage.github.io/awa-ssh/api">https://mirage.github.io/awa-ssh/api</a>

##### CHANGES:

* Add `Server.close`, fix close message semantics (mirage/awa-ssh#79 @reynir, review @hannesm)
* Add authentication information in `Server.auth_state` `Done _` constructor (mirage/awa-ssh#80 @reynir, review @hannesm)
* Make `Awa_mirage.Auth.lookup_user` public as it were before mirage/awa-ssh#74 (mirage/awa-ssh#81 @palainp, review @reynir)
