### PR TITLE
[new release] xenstore (2.4.0)

### DIFF
--- a/packages/xenstore/xenstore.2.4.0/opam
+++ b/packages/xenstore/xenstore.2.4.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Xenstore protocol in pure OCam"
+description: """
+This repo contains:
+
+  1. a xenstore client library, a merge of the Mirage and XCP ones
+
+  2. a xenstore server library
+
+  3. a xenstore server instance which runs under Unix with libxc
+
+  4. a xenstore server instance which runs on mirage.
+
+
+  The client and the server libraries have sets of unit-tests.
+"""
+maintainer: ["Hannes Mehnert <hannes@mehnert.org>"]
+authors: [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Dave Scott"
+  "Anil Madhavapeddy"
+  "Vincent Bernardoff"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/mirage/ocaml-xenstore"
+bug-reports: "https://github.com/mirage/ocaml-xenstore/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.13.0"}
+  "ounit2" {>= "2.2.2"}
+  "lwt" {>= "4.5.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-xenstore.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-xenstore/releases/download/2.4.0/xenstore-2.4.0.tbz"
+  checksum: [
+    "sha256=11b63bb2a5a8bc487d36f36ecb195b2a2135aa13ab401cbc73da67505c08faa4"
+    "sha512=b921aa4265503677f4984007efee6865461a18031dc49583be040781307cc6cbfcd84bc11e9ebc0a23e9b0cf281bd94528c475624bc30471ad8ff70607e0732f"
+  ]
+}
+x-commit-hash: "0dc6db269b6176160f945376bb91c342ba39f00d"


### PR DESCRIPTION
Xenstore protocol in pure OCam

- Project page: <a href="https://github.com/mirage/ocaml-xenstore">https://github.com/mirage/ocaml-xenstore</a>

##### CHANGES:

* minor performance fixes (mirage/ocaml-xenstore#53 by freddy77)
* use dune 2.0 (mirage/ocaml-xenstore#54 by lindig)
* require OCaml 4.13 (mirage/ocaml-xenstore#56 by last-genius)
* Add support `XS_DIRECTORY_PART` to the client (mirage/ocaml-xenstore#55 by last-genius)
* Add x-maintenance-intent to opam  metadata (mirage/ocaml-xenstore#57 by hannesm)
