### PR TITLE
[new release] ledes (0.1.0)

### DIFF
--- a/packages/ledes/ledes.0.1.0/opam
+++ b/packages/ledes/ledes.0.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Legal Electronic Data Exchange Standard"
+description: "Legal Electronic Data Exchange Standard"
+maintainer: ["Geoffrey Borough <geoffrey.borough@outlook.com>"]
+authors: ["Geoffrey Borough <geoffrey.borough@outlook.com>"]
+license: "MIT"
+tags: ["parser" "legal"]
+homepage: "https://github.com/lexitree-labs/LEDES"
+doc: "https://lexitree-labs.github.io/LEDES/LEDES"
+bug-reports: "https://github.com/lexitree-labs/LEDES/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.08.0"}
+  "cmdliner" {>= "1.2.0"}
+  "angstrom" {>= "0.16.0"}
+  "ptime"
+  "re" {>= "1.7.2"}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lexitree-labs/LEDES.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/Lexitree-Labs/LEDES/releases/download/0.1.0/ledes-0.1.0.tbz"
+  checksum: [
+    "sha256=0687b2c6627d3e5a530e2e96c83dc1ffe402cc5ce9faed0c401a5a82c9917034"
+    "sha512=bf6463929f4aaea10bf073e7391c36b4bc96c4b758116e4de9a43a50b4a55609bb5a00d6d3913a5b4973589571db2b4ed208033dc3bb321983478a411ab274e2"
+  ]
+}
+x-commit-hash: "823594fecf42e4ef581f213840904c193bee62c5"


### PR DESCRIPTION
Legal Electronic Data Exchange Standard

Currently supports the parsing and validation of the following formats:

- LEDES98BI

- LEDES1998B


Project page: <a href="https://github.com/lexitree-labs/LEDES">https://github.com/lexitree-labs/LEDES</a>
Documentation: <a href="https://lexitree-labs.github.io/LEDES/LEDES">https://lexitree-labs.github.io/LEDES/LEDES</a>


