### PR TITLE
15 packages (base_quickcheck.v0.17.1, ppx_bench.v0.17.1, etc.)

### DIFF
--- a/packages/base_quickcheck/base_quickcheck.v0.17.1/opam
+++ b/packages/base_quickcheck/base_quickcheck.v0.17.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/base_quickcheck"
+bug-reports: "https://github.com/janestreet/base_quickcheck/issues"
+dev-repo: "git+https://github.com/janestreet/base_quickcheck.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base_quickcheck/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"             {>= "5.1.0"}
+  "base"              {>= "v0.17" & < "v0.18"}
+  "ppx_base"          {>= "v0.17" & < "v0.18"}
+  "ppx_fields_conv"   {>= "v0.17" & < "v0.18"}
+  "ppx_let"           {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_message"  {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_value"    {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane"       {>= "v0.17" & < "v0.18"}
+  "splittable_random" {>= "v0.17" & < "v0.18"}
+  "dune"              {>= "3.11.0"}
+  "ppxlib"            {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Randomized testing framework, designed for compatibility with Base"
+description: "
+Base_quickcheck provides randomized testing in the style of Haskell's Quickcheck library,
+with support for built-in types as well as types provided by Base.
+"
+url {
+  src:
+    "https://github.com/janestreet/base_quickcheck/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=df06909b62c9e34e9e5436993d6d998d"
+    "sha512=d345b0333508f6f49fe636455139e563b0594bd2cf56534d2f42ed083906e41bb4e009996ed7db8989d8409899d25cfcdbd71021260486c310f7e0fd63df56d9"
+  ]
+}

--- a/packages/ppx_bench/ppx_bench.v0.17.1/opam
+++ b/packages/ppx_bench/ppx_bench.v0.17.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_bench"
+bug-reports: "https://github.com/janestreet/ppx_bench/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_bench.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bench/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"           {>= "5.1.0"}
+  "ppx_inline_test" {>= "v0.17" & < "v0.18"}
+  "dune"            {>= "3.11.0"}
+  "ppxlib"          {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Syntax extension for writing in-line benchmarks in ocaml code"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_bench/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=496d7d989656c95860cf2434e1d8e0e0"
+    "sha512=7492c19b408709368f5a1ed020bea2c439ff562f765cd706637dbfb7ecdfc33478f9dd814fcf195292bf634769ae95f8b89b5b33b714e0fd6248f0754e1d37a4"
+  ]
+}

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.17.1/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.17.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_bin_prot"
+bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bin_prot/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"       {>= "5.1.0"}
+  "base"        {>= "v0.17" & < "v0.18"}
+  "bin_prot"    {>= "v0.17" & < "v0.18"}
+  "ppx_here"    {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane" {>= "v0.17" & < "v0.18"}
+  "dune"        {>= "3.11.0"}
+  "ppxlib"      {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Generation of bin_prot readers and writers from types"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_bin_prot/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=17521ea48abfdb8d433f1f8822791289"
+    "sha512=b5fd4b5718a1486b3f6e5c3ae424a254e30776499ed1d64df7679b7d3f30c1155cfeff0abe29b1426a3b0b58a7bb1bb9fdfb04076bcd6be8ce093c882bae8bf7"
+  ]
+}

--- a/packages/ppx_diff/ppx_diff.v0.17.1/opam
+++ b/packages/ppx_diff/ppx_diff.v0.17.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_diff"
+bug-reports: "https://github.com/janestreet/ppx_diff/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_diff.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_diff/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"         {>= "5.1.0"}
+  "base"          {>= "v0.17" & < "v0.18"}
+  "gel"           {>= "v0.17" & < "v0.18"}
+  "ppx_compare"   {>= "v0.17" & < "v0.18"}
+  "ppx_enumerate" {>= "v0.17" & < "v0.18"}
+  "ppx_jane"      {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane"   {>= "v0.17" & < "v0.18"}
+  "dune"          {>= "3.11.0"}
+  "ppxlib"        {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "A PPX rewriter that genreates the implementation of [Ldiffable.S]."
+description: "
+A PPX rewriter that generates the implementation of [Ldiffable.S]. Generates diffs and update functions for OCaml types.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_diff/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=cfec5d638a1bf1ea77707d10eed5d2d7"
+    "sha512=5848274cb0c5acd1ee3f29318e6111c5fef4b357aeda78120e0370067b9b23f62bb57e1e0be948c3af385b5900a3e0fb657f26dd4fe7ee95cd7002b9d8b68547"
+  ]
+}

--- a/packages/ppx_expect/ppx_expect.v0.17.3/opam
+++ b/packages/ppx_expect/ppx_expect.v0.17.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_expect"
+bug-reports: "https://github.com/janestreet/ppx_expect/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_expect.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_expect/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"           {>= "5.1.0"}
+  "base"            {>= "v0.17" & < "v0.18"}
+  "ppx_here"        {>= "v0.17" & < "v0.18"}
+  "ppx_inline_test" {>= "v0.17" & < "v0.18"}
+  "stdio"           {>= "v0.17" & < "v0.18"}
+  "dune"            {>= "3.11.0"}
+  "ppxlib"          {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+conflicts: [
+  "js_of_ocaml-compiler" {< "5.8"}
+]
+
+synopsis: "Cram like framework for OCaml"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_expect/archive/refs/tags/v0.17.3.tar.gz"
+  checksum: [
+    "md5=a7daa59114638fd80f52b6adbb0db7ed"
+    "sha512=d26364f2c7c0a3d83e5ecc144f77875a00887853c72c03e0122d658acb4d1cb4c6d77fabc1222d775663db74f0345be2a33518dffac9feef57ece5e9e40dc709"
+  ]
+}

--- a/packages/ppx_globalize/ppx_globalize.v0.17.2/opam
+++ b/packages/ppx_globalize/ppx_globalize.v0.17.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_globalize"
+bug-reports: "https://github.com/janestreet/ppx_globalize/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_globalize.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_globalize/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"       {>= "5.1.0"}
+  "base"        {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane" {>= "v0.17" & < "v0.18"}
+  "dune"        {>= "3.11.0"}
+  "ppxlib"      {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "A ppx rewriter that generates functions to copy local values to the global heap"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_globalize/archive/refs/tags/v0.17.2.tar.gz"
+  checksum: [
+    "md5=9df1288f1113c1daffd13cfced63a77e"
+    "sha512=9eb4908e8cd92ed79a73fb82a70d9f68fcdeec58e7b2e4e37b536716f4bf4f31866376cb1102cb44e62a40b4ead3c6d5d448872a62803ebb3ea7284c9d082b4a"
+  ]
+}

--- a/packages/ppx_inline_test/ppx_inline_test.v0.17.1/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.17.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_inline_test"
+bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_inline_test/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"    {>= "5.1.0"}
+  "base"     {>= "v0.17" & < "v0.18"}
+  "time_now" {>= "v0.17" & < "v0.18"}
+  "dune"     {>= "3.11.0"}
+  "ppxlib"   {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Syntax extension for writing in-line tests in ocaml code"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_inline_test/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=38196081de2fab8321b71addbe769b73"
+    "sha512=e5c2dc8e519bbdadb5b1472ee5c5d08c547395e46c294962f1ac830461bb2d30d16894395ba95866713a099ef3565d83e67dda48d6ed26b55ad7cb36a8f7f6aa"
+  ]
+}

--- a/packages/ppx_let/ppx_let.v0.17.1/opam
+++ b/packages/ppx_let/ppx_let.v0.17.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_let"
+bug-reports: "https://github.com/janestreet/ppx_let/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_let.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_let/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"    {>= "5.1.0"}
+  "base"     {>= "v0.17" & < "v0.18"}
+  "ppx_here" {>= "v0.17" & < "v0.18"}
+  "dune"     {>= "3.11.0"}
+  "ppxlib"   {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Monadic let-bindings"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_let/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=e9f7f37e7d73e131ed3664da66e09a46"
+    "sha512=bd08d0bc7f37dff97a1500fdd145e978e9693382c5ac11305751a60d11f0ecea4afc319920c804f5e7b8ebadde365c31564851a14c41e9cac2956fc7b5a71a9d"
+  ]
+}

--- a/packages/ppx_optcomp/ppx_optcomp.v0.17.1/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.17.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_optcomp"
+bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_optcomp/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"  {>= "5.1.0"}
+  "base"   {>= "v0.17" & < "v0.18"}
+  "stdio"  {>= "v0.17" & < "v0.18"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Optional compilation for OCaml"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_optcomp/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=0bf43393409414c655c4473d79480fdf"
+    "sha512=2e7c41f168c004cf3be1cd768a5406c61af135c0b084ffdfc39555b4be8c21a227c56cffbfb66de8dc3de35f735277d330f3cc6762e6ba8708deebb78f9fd49b"
+  ]
+}

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.17.1/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.17.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_sexp_conv"
+bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"       {>= "5.1.0"}
+  "base"        {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane" {>= "v0.17" & < "v0.18"}
+  "sexplib0"    {>= "v0.17" & < "v0.18"}
+  "dune"        {>= "3.11.0"}
+  "ppxlib"      {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_sexp_conv/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=acbe8a2727a29c8f2fa8da42046f5861"
+    "sha512=036582cbcd49aad0737bbbdf5f680192e55a9f3051c8dece439a6c6ea989b59077c88130d833b01a38d990e563f7dde9f5be7e1cd0ffaaf59bd913d6fbd63bb3"
+  ]
+}

--- a/packages/ppx_stable/ppx_stable.v0.17.1/opam
+++ b/packages/ppx_stable/ppx_stable.v0.17.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_stable"
+bug-reports: "https://github.com/janestreet/ppx_stable/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_stable.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_stable/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"  {>= "5.1.0"}
+  "base"   {>= "v0.17" & < "v0.18"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Stable types conversions generator"
+description: "
+A ppx extension for easier implementation of conversion functions between almost
+identical types.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_stable/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=5a651fd55763fbdb58385dd232c1d222"
+    "sha512=aff081814ac95dc4ebcaa275ccd6fb4e6d7de5de4ef3fc6a633debeeae213136d46c526fb8dc33896542dcde0319957d04308f4a5b8012342fc6a9ccfb5dc072"
+  ]
+}

--- a/packages/ppx_tydi/ppx_tydi.v0.17.1/opam
+++ b/packages/ppx_tydi/ppx_tydi.v0.17.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_tydi"
+bug-reports: "https://github.com/janestreet/ppx_tydi/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_tydi.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_tydi/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"  {>= "5.1.0"}
+  "base"   {>= "v0.17" & < "v0.18"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Let expressions, inferring pattern type from expression."
+description: "
+Provides a ppx for [let%tydi]: type-directed [let] bindings. In [let%tydi a = b in ...], [a]'s type is inferred from [b] rather than the other way around. This is convenient for record patterns whose fields are not in scope.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_tydi/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=6adffe5f073bc33bbbdbf3c39fe36959"
+    "sha512=f4af5b32a537cb72ffc6a331f73e90eb650e6116ca130d785eda78fb9de5764a1d990ff6929fd6fb695bfeb35d2685f4b35c344125208733b08953ca13410cc5"
+  ]
+}

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.17.1/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.17.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_typerep_conv"
+bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_typerep_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"   {>= "5.1.0"}
+  "base"    {>= "v0.17" & < "v0.18"}
+  "typerep" {>= "v0.17" & < "v0.18"}
+  "dune"    {>= "3.11.0"}
+  "ppxlib"  {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Generation of runtime types from type declarations"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_typerep_conv/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=1b1e21a87c3f4cef7852733f2c7db3f5"
+    "sha512=8184722762d1e848b16f5409ecf478d0e60fadac590fba1d9355bd7efa09c25e4b87cdc0d117a77386b8da6fcf2bf13c7cf6150f3090686e354a2354ad52e1c5"
+  ]
+}

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.17.1/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.17.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_variants_conv"
+bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_variants_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"       {>= "5.1.0"}
+  "base"        {>= "v0.17" & < "v0.18"}
+  "variantslib" {>= "v0.17" & < "v0.18"}
+  "dune"        {>= "3.11.0"}
+  "ppxlib"      {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Generation of accessor and iteration functions for ocaml variant types"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_variants_conv/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=b9c62fd9b545437fe5ed24ceaa1b485b"
+    "sha512=23c9866b2f07e8e55fb7c19bbddbd1c424410fcb590c2b5039b0d194274fd5cfe6a58da55db83cfaddc698c00e42cad95756f49ef0f3d3163fd5f362ebd5e25a"
+  ]
+}

--- a/packages/ppxlib_jane/ppxlib_jane.v0.17.3/opam
+++ b/packages/ppxlib_jane/ppxlib_jane.v0.17.3/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppxlib_jane"
+bug-reports: "https://github.com/janestreet/ppxlib_jane/issues"
+dev-repo: "git+https://github.com/janestreet/ppxlib_jane.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppxlib_jane/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.3.0"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Utilities for working with Jane Street AST constructs"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppxlib_jane/archive/refs/tags/v0.17.3.tar.gz"
+  checksum: [
+    "md5=6791e791ff1d4672fba0ff53feb79ff1"
+    "sha512=e15027371e7241ffc35e05d32f82e8ed229ea37659b81f91045f20040a6be61a49f45e367f84918d3f3967f35b542069cefabd929fe157fb636ff78bfa87c7c5"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `base_quickcheck.v0.17.1`: Randomized testing framework, designed for compatibility with Base
- `ppx_bench.v0.17.1`: Syntax extension for writing in-line benchmarks in ocaml code
- `ppx_bin_prot.v0.17.1`: Generation of bin_prot readers and writers from types
- `ppx_diff.v0.17.1`: A PPX rewriter that genreates the implementation of [Ldiffable.S].
- `ppx_expect.v0.17.3`: Cram like framework for OCaml
- `ppx_globalize.v0.17.2`: A ppx rewriter that generates functions to copy local values to the global heap
- `ppx_inline_test.v0.17.1`: Syntax extension for writing in-line tests in ocaml code
- `ppx_let.v0.17.1`: Monadic let-bindings
- `ppx_optcomp.v0.17.1`: Optional compilation for OCaml
- `ppx_sexp_conv.v0.17.1`: [@@deriving] plugin to generate S-expression conversion functions
- `ppx_stable.v0.17.1`: Stable types conversions generator
- `ppx_tydi.v0.17.1`: Let expressions, inferring pattern type from expression.
- `ppx_typerep_conv.v0.17.1`: Generation of runtime types from type declarations
- `ppx_variants_conv.v0.17.1`: Generation of accessor and iteration functions for ocaml variant types
- `ppxlib_jane.v0.17.3`: Utilities for working with Jane Street AST constructs



---

---
:camel: Pull-request generated by opam-publish v2.5.1