### PR TITLE
Package pageantty.0.0.2

### DIFF
--- a/packages/pageantty/pageantty.0.0.2/opam
+++ b/packages/pageantty/pageantty.0.0.2/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Run a pager to display diffs and other outputs in the terminal"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/git-pager"
+doc: "https://mbarbin.github.io/git-pager/"
+bug-reports: "https://github.com/mbarbin/git-pager/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.13"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/git-pager.git"
+description: """\
+
+[pageantty] provides utility libraries for running pagers in the
+terminal.
+
+It includes [Git_pager], a small one-module library for displaying
+Git diffs and other custom outputs in a terminal pager.
+
+This is useful for tools that integrate with Git and need to display
+output exceeding one screen, while respecting user color preferences
+and Git's configuration.
+
+"""
+tags: [ "git" "pager" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/git-pager/releases/download/0.0.2/pageantty-0.0.2.tbz"
+  checksum: [
+    "sha256=e5d5a75f322ebdd4a54f66ca3b0c2574514537cf6f9bfec6d4db7d57cea9f7f5"
+    "sha512=69aee81a3bd2bc4bb9d12d87c7bc157167d52f2ceb3eebd4433cc983f10141d21185ced5f7e330fedbe58e19c9e3bc5097671f72ab1685314c8dbe7e13aeb318"
+  ]
+}
+x-commit-hash: "46140407a7a860c794f6771a7f195a520c28a221"


### PR DESCRIPTION
### `pageantty.0.0.2`
Run a pager to display diffs and other outputs in the terminal
[pageantty] provides utility libraries for running pagers in the
terminal.

It includes [Git_pager], a small one-module library for displaying
Git diffs and other custom outputs in a terminal pager.

This is useful for tools that integrate with Git and need to display
output exceeding one screen, while respecting user color preferences
and Git's configuration.



---
* Homepage: https://github.com/mbarbin/git-pager
* Source repo: git+https://github.com/mbarbin/git-pager.git
* Bug tracker: https://github.com/mbarbin/git-pager/issues

---
## 0.0.2 (2025-05-30)

### Added

- Complete ci scripts build matrix and add jobs for OCaml 4.14 (mbarbin/git-pager#4, @mbarbin).

### Changed

- Repackage the project for publication to opam using `pageantty` as namespacing prefix (mbarbin/git-pager#5, @mbarbin).
- Update from `vcs` to `volgo` library (mbarbin/git-pager#3, @mbarbin).
- Enabled build with OCaml 4.14 (mbarbin/git-pager#2, @mbarbin).

## 0.0.1 (2025-04-30)

### Added

- Added tests.
- Import code from work-in-progress project.


---
:camel: Pull-request generated by opam-publish v2.5.1