### PR TITLE
Fix lower bound of `csexp` in `lsp`

### DIFF
--- a/packages/lsp/lsp.1.6.0/opam
+++ b/packages/lsp/lsp.1.6.0/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.7"}
   "jsonrpc" {= version}
   "yojson"
-  "ppx_yojson_conv_lib"
+  "ppx_yojson_conv_lib" {>= "v0.14.0"}
   "csexp" {>= "1.4.0"}
   "uutf"
   "result" {>= "1.5"}


### PR DESCRIPTION
While working on #27956 it revealed that the lower bound of `lsp` was too low.

This suggestion was provided by @mseri (thanks!), but to avoid unnecessary churn in that PR I made it a separate PR.