### PR TITLE
[new release] qcow (4 packages) (0.12.0)

### DIFF
--- a/packages/qcow-stream/qcow-stream.0.12.0/opam
+++ b/packages/qcow-stream/qcow-stream.0.12.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Library offering QCOW streaming capabilities"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "qcow-types" {= version}
+  "cstruct-lwt"
+  "io-page"
+  "lwt"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.0/qcow-0.12.0.tbz"
+  checksum: [
+    "sha256=aa2c2e56d485a90029f288943fdffce91e4956d2b28d0de0c98cb676d8cccaf6"
+    "sha512=96360209a8b9f2c849adb67d361d403123bfeea6dfa6af4bd103cee847ea71534a1e75a4d1b32bee3dd8f662dbf1349193f4da7f3b90ed52d8970217bb75a717"
+  ]
+}
+x-commit-hash: "3c8f6c0fcaea0348977f3ffc386d89f3b4838cd5"

--- a/packages/qcow-tool/qcow-tool.0.12.0/opam
+++ b/packages/qcow-tool/qcow-tool.0.12.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "A command-line tool for manipulating qcow2-formatted data"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "qcow" {= version}
+  "qcow-stream" {= version}
+  "conf-qemu-img" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "cstruct"
+  "result"
+  "unix-type-representations"
+  "lwt"
+  "mirage-block" {>= "3.0.0"}
+  "sha" {>= "1.10"}
+  "sexplib"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "astring"
+  "io-page" {>= "2.4.0"}
+  "ounit" {with-test}
+  "mirage-block-ramdisk" {with-test}
+  "ezjsonm" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.0/qcow-0.12.0.tbz"
+  checksum: [
+    "sha256=aa2c2e56d485a90029f288943fdffce91e4956d2b28d0de0c98cb676d8cccaf6"
+    "sha512=96360209a8b9f2c849adb67d361d403123bfeea6dfa6af4bd103cee847ea71534a1e75a4d1b32bee3dd8f662dbf1349193f4da7f3b90ed52d8970217bb75a717"
+  ]
+}
+x-commit-hash: "3c8f6c0fcaea0348977f3ffc386d89f3b4838cd5"

--- a/packages/qcow-types/qcow-types.0.12.0/opam
+++ b/packages/qcow-types/qcow-types.0.12.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Minimal set of dependencies for qcow-stream, shared with qcow"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "astring"
+  "cstruct"
+  "logs"
+  "lwt"
+  "mirage-block"
+  "ppx_sexp_conv"
+  "prometheus"
+  "sexplib"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.0/qcow-0.12.0.tbz"
+  checksum: [
+    "sha256=aa2c2e56d485a90029f288943fdffce91e4956d2b28d0de0c98cb676d8cccaf6"
+    "sha512=96360209a8b9f2c849adb67d361d403123bfeea6dfa6af4bd103cee847ea71534a1e75a4d1b32bee3dd8f662dbf1349193f4da7f3b90ed52d8970217bb75a717"
+  ]
+}
+x-commit-hash: "3c8f6c0fcaea0348977f3ffc386d89f3b4838cd5"

--- a/packages/qcow/qcow.0.12.0/opam
+++ b/packages/qcow/qcow.0.12.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Support for Qcow2 images"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "qcow-types" {= version}
+  "base-bytes"
+  "cstruct" {>= "3.4.0"}
+  "result"
+  "io-page" {>= "2.4.0"}
+  "lwt" {>= "5.5.0"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-block-unix" {>= "2.5.0"}
+  "mirage-block-combinators"
+  "mirage-sleep"
+  "sexplib"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "astring"
+  "prometheus"
+  "unix-type-representations"
+  "stdlib-shims"
+  "sha"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ounit" {with-test}
+  "mirage-block-ramdisk" {with-test & >= "0.5"}
+  "ezjsonm" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.0/qcow-0.12.0.tbz"
+  checksum: [
+    "sha256=aa2c2e56d485a90029f288943fdffce91e4956d2b28d0de0c98cb676d8cccaf6"
+    "sha512=96360209a8b9f2c849adb67d361d403123bfeea6dfa6af4bd103cee847ea71534a1e75a4d1b32bee3dd8f662dbf1349193f4da7f3b90ed52d8970217bb75a717"
+  ]
+}
+x-commit-hash: "3c8f6c0fcaea0348977f3ffc386d89f3b4838cd5"


### PR DESCRIPTION
Support for Qcow2 images

- Project page: <a href="https://github.com/mirage/ocaml-qcow">https://github.com/mirage/ocaml-qcow</a>

##### CHANGES:

- Build fixes (@last-genius, mirage/ocaml-qcow#123)
- Further fixes: parsing, CLI, overallocation (@last-genius, mirage/ocaml-qcow#124)
- remove mirage-types, add mirage-sleep dependency (@hannesm, mirage/ocaml-qcow#125)
- Add x-maintenance-intent to opam files (@hannesm, mirage/ocaml-qcow#126)
- Add a Qcow_stream module (@last-genius, mirage/ocaml-qcow#127)
