### PR TITLE
[new release] colombe, sendmail, sendmail-lwt, sendmail-miou-unix and sendmail-mirage (0.12.0)

### DIFF
--- a/packages/colombe/colombe.0.12.0/opam
+++ b/packages/colombe/colombe.0.12.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+synopsis:     "SMTP protocol in OCaml"
+doc:          "https://mirage.github.io/colombe/"
+description: """SMTP protocol according RFC5321 without extension."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "3.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "ocaml-syntax-shims"
+  "alcotest" {with-test}
+  "crowbar" {>= "0.2" & with-test}
+]
+depopts: [ "emile" ]
+conflicts: [ "emile" {< "0.8"} ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.12.0/colombe-0.12.0.tbz"
+  checksum: [
+    "sha256=f60f65d304f3957b4448d7a8071863331957d1b445635f53dbe3cdd6567ba231"
+    "sha512=d4ec2cdf8241af0342ee442b468297a8c39fa36381bcb96cc418ad4593dd860042a85fe6807c4d40dbc95a226bb8fb9d0a8231a1c3e440af74f3da437d34eb3b"
+  ]
+}
+x-commit-hash: "e570de7fddca6c5f1d6870bafafae274719bdedd"

--- a/packages/sendmail-lwt/sendmail-lwt.0.12.0/opam
+++ b/packages/sendmail-lwt/sendmail-lwt.0.12.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT and TLS."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "sendmail" {= version}
+  "domain-name"
+  "ipaddr"
+  "ca-certs"
+  "lwt"
+  "tls" {>= "0.13.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "x509" {>= "0.12.0"}
+  "alcotest" {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.12.0/colombe-0.12.0.tbz"
+  checksum: [
+    "sha256=f60f65d304f3957b4448d7a8071863331957d1b445635f53dbe3cdd6567ba231"
+    "sha512=d4ec2cdf8241af0342ee442b468297a8c39fa36381bcb96cc418ad4593dd860042a85fe6807c4d40dbc95a226bb8fb9d0a8231a1c3e440af74f3da437d34eb3b"
+  ]
+}
+x-commit-hash: "e570de7fddca6c5f1d6870bafafae274719bdedd"

--- a/packages/sendmail-miou-unix/sendmail-miou-unix.0.12.0/opam
+++ b/packages/sendmail-miou-unix/sendmail-miou-unix.0.12.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT and TLS."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "2.0"}
+  "sendmail" {= version}
+  "domain-name"
+  "happy-eyeballs-miou-unix"
+  "tls-miou-unix" {>= "1.0.3"}
+  "x509"
+  "ca-certs"
+  "alcotest" {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.12.0/colombe-0.12.0.tbz"
+  checksum: [
+    "sha256=f60f65d304f3957b4448d7a8071863331957d1b445635f53dbe3cdd6567ba231"
+    "sha512=d4ec2cdf8241af0342ee442b468297a8c39fa36381bcb96cc418ad4593dd860042a85fe6807c4d40dbc95a226bb8fb9d0a8231a1c3e440af74f3da437d34eb3b"
+  ]
+}
+x-commit-hash: "e570de7fddca6c5f1d6870bafafae274719bdedd"

--- a/packages/sendmail-mirage/sendmail-mirage.0.12.0/opam
+++ b/packages/sendmail-mirage/sendmail-mirage.0.12.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT and TLS."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "sendmail" {= version}
+  "domain-name"
+  "happy-eyeballs-mirage"
+  "mirage-flow"
+  "ca-certs-nss" {>= "3.108-1"}
+  "lwt"
+  "tls" {>= "0.13.0"}
+  "tls-mirage" {>= "0.16.0"}
+  "x509" {>= "0.12.0"}
+  "alcotest" {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.12.0/colombe-0.12.0.tbz"
+  checksum: [
+    "sha256=f60f65d304f3957b4448d7a8071863331957d1b445635f53dbe3cdd6567ba231"
+    "sha512=d4ec2cdf8241af0342ee442b468297a8c39fa36381bcb96cc418ad4593dd860042a85fe6807c4d40dbc95a226bb8fb9d0a8231a1c3e440af74f3da437d34eb3b"
+  ]
+}
+x-commit-hash: "e570de7fddca6c5f1d6870bafafae274719bdedd"

--- a/packages/sendmail/sendmail.0.12.0/opam
+++ b/packages/sendmail/sendmail.0.12.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command"
+description: """A library to be able to send an email."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "colombe" {= version}
+  "tls" {>= "1.0.2"}
+  "base64" {>= "3.0.0"}
+  "ke" {>= "0.4"}
+  "logs"
+  "rresult"
+  "hxd" {>= "0.3.2"}
+  "bigstringaf" {>= "0.2.0"}
+  "emile" {>= "0.8" & with-test}
+  "mrmime" {>= "0.3.2" & with-test}
+  "cstruct" {>= "6.0.0"}
+  "alcotest" {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.12.0/colombe-0.12.0.tbz"
+  checksum: [
+    "sha256=f60f65d304f3957b4448d7a8071863331957d1b445635f53dbe3cdd6567ba231"
+    "sha512=d4ec2cdf8241af0342ee442b468297a8c39fa36381bcb96cc418ad4593dd860042a85fe6807c4d40dbc95a226bb8fb9d0a8231a1c3e440af74f3da437d34eb3b"
+  ]
+}
+x-commit-hash: "e570de7fddca6c5f1d6870bafafae274719bdedd"


### PR DESCRIPTION
SMTP protocol in OCaml

- Project page: <a href="https://github.com/mirage/colombe">https://github.com/mirage/colombe</a>
- Documentation: <a href="https://mirage.github.io/colombe/">https://mirage.github.io/colombe/</a>

##### CHANGES:

- Remove the useless `Mirage_clock.PCLOCK` functor (@hannesm, mirage/colombe#82)
