### PR TITLE
Package patch.3.0.0~beta1

### DIFF
--- a/packages/patch/patch.3.0.0~beta1/opam
+++ b/packages/patch/patch.3.0.0~beta1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Patch library purely in OCaml"
+description: """\
+This is a library which parses unified diff and git diff output, and can
+apply a patch in memory."""
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>" "Kate <kit-ty-kate@exn.st>"]
+license: "ISC"
+homepage: "https://github.com/hannesm/patch"
+doc: "https://hannesm.github.io/patch/"
+bug-reports: "https://github.com/hannesm/patch/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "crowbar" {with-test}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/patch.git"
+url {
+  src:
+    "https://github.com/hannesm/patch/releases/download/v3.0.0-beta1/patch-3.0.0-beta1.tar.gz"
+  checksum: [
+    "md5=e4654a4516a2841991ac17c1f07f6068"
+    "sha512=dbbf8f9366bdc8137424efeb31d245bac8aa8a5ff72b6e1e79d4199591ad871dbbde93d1202302cb0a12518d37e21fbbbe30bd8d2bfdd39adbdd0f17ba399ed6"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `patch.3.0.0~beta1`
Patch library purely in OCaml
This is a library which parses unified diff and git diff output, and can
apply a patch in memory.



---
* Homepage: https://github.com/hannesm/patch
* Source repo: git+https://github.com/hannesm/patch.git
* Bug tracker: https://github.com/hannesm/patch/issues

---
:camel: Pull-request generated by opam-publish v2.5.0