### PR TITLE
[new release] qcow (4 packages) (0.12.1)

### DIFF
--- a/packages/qcow-stream/qcow-stream.0.12.1/opam
+++ b/packages/qcow-stream/qcow-stream.0.12.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Library offering QCOW streaming capabilities"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "qcow-types" {= version}
+  "cstruct-lwt"
+  "io-page"
+  "lwt" {>= "5.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.1/qcow-0.12.1.tbz"
+  checksum: [
+    "sha256=c799f3c2eda00b345d37ccd759bcd7b8be8744216b77a38883ff4cd99727ae37"
+    "sha512=2160598f460240f9580991e7f7d69e3ef83a2e6ec62268b711840d359cd303d4e14a5d65d89ceb82a6f77b434d06a01af9daa7780808a885f3307909c11dcfd8"
+  ]
+}
+x-commit-hash: "e9f228b3626aef9275c43f539bb9959d8d167314"

--- a/packages/qcow-tool/qcow-tool.0.12.1/opam
+++ b/packages/qcow-tool/qcow-tool.0.12.1/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "A command-line tool for manipulating qcow2-formatted data"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "qcow" {= version}
+  "qcow-stream" {= version}
+  "conf-qemu-img" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "cstruct"
+  "result"
+  "unix-type-representations"
+  "lwt"
+  "mirage-block" {>= "3.0.0"}
+  "sha" {>= "1.10"}
+  "sexplib"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "astring"
+  "io-page" {>= "2.4.0"}
+  "ounit" {with-test}
+  "mirage-block-ramdisk" {with-test}
+  "ezjsonm" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.1/qcow-0.12.1.tbz"
+  checksum: [
+    "sha256=c799f3c2eda00b345d37ccd759bcd7b8be8744216b77a38883ff4cd99727ae37"
+    "sha512=2160598f460240f9580991e7f7d69e3ef83a2e6ec62268b711840d359cd303d4e14a5d65d89ceb82a6f77b434d06a01af9daa7780808a885f3307909c11dcfd8"
+  ]
+}
+x-commit-hash: "e9f228b3626aef9275c43f539bb9959d8d167314"

--- a/packages/qcow-types/qcow-types.0.12.1/opam
+++ b/packages/qcow-types/qcow-types.0.12.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Minimal set of dependencies for qcow-stream, shared with qcow"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "astring"
+  "cstruct" {>= "6.1.0"}
+  "logs"
+  "lwt"
+  "mirage-block" {>= "3.0.0"}
+  "ppx_sexp_conv"
+  "prometheus"
+  "sexplib"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.1/qcow-0.12.1.tbz"
+  checksum: [
+    "sha256=c799f3c2eda00b345d37ccd759bcd7b8be8744216b77a38883ff4cd99727ae37"
+    "sha512=2160598f460240f9580991e7f7d69e3ef83a2e6ec62268b711840d359cd303d4e14a5d65d89ceb82a6f77b434d06a01af9daa7780808a885f3307909c11dcfd8"
+  ]
+}
+x-commit-hash: "e9f228b3626aef9275c43f539bb9959d8d167314"

--- a/packages/qcow/qcow.0.12.1/opam
+++ b/packages/qcow/qcow.0.12.1/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Support for Qcow2 images"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "qcow-types" {= version}
+  "base-bytes"
+  "cstruct" {>= "3.4.0"}
+  "result"
+  "io-page" {>= "2.4.0"}
+  "lwt" {>= "5.5.0"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-block-unix" {>= "2.5.0"}
+  "mirage-block-combinators"
+  "mirage-sleep"
+  "sexplib"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "astring"
+  "prometheus"
+  "unix-type-representations"
+  "stdlib-shims"
+  "sha"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ounit" {with-test}
+  "mirage-block-ramdisk" {with-test & >= "0.5"}
+  "ezjsonm" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.1/qcow-0.12.1.tbz"
+  checksum: [
+    "sha256=c799f3c2eda00b345d37ccd759bcd7b8be8744216b77a38883ff4cd99727ae37"
+    "sha512=2160598f460240f9580991e7f7d69e3ef83a2e6ec62268b711840d359cd303d4e14a5d65d89ceb82a6f77b434d06a01af9daa7780808a885f3307909c11dcfd8"
+  ]
+}
+x-commit-hash: "e9f228b3626aef9275c43f539bb9959d8d167314"


### PR DESCRIPTION
Support for Qcow2 images

- Project page: <a href="https://github.com/mirage/ocaml-qcow">https://github.com/mirage/ocaml-qcow</a>

##### CHANGES:

- Fix dune and opam metadata issues (@psafont mirage/ocaml-qcow#129)
- Build fixes (@last-genius, mirage/ocaml-qcow#123)
- Further fixes: parsing, CLI, overallocation (@last-genius, mirage/ocaml-qcow#124)
- remove mirage-types, add mirage-sleep dependency (@hannesm, mirage/ocaml-qcow#125)
- Add x-maintenance-intent to opam files (@hannesm, mirage/ocaml-qcow#126)
- Add a Qcow_stream module (@last-genius, mirage/ocaml-qcow#127)
