### PR TITLE
Fix typo in conf-freeglut from #27846

### DIFF
--- a/packages/conf-freeglut/conf-freeglut.1/opam
+++ b/packages/conf-freeglut/conf-freeglut.1/opam
@@ -5,7 +5,7 @@ homepage: "https://freeglut.sourceforge.net/"
 license: "X11"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
-  ["pkg-config" "--print-errors" "--exists" "freeglut"] {os = "win32" & os-distribution = "msys"}
+  ["pkg-config" "--print-errors" "--exists" "freeglut"] {os = "win32" & os-distribution = "msys2"}
   ["pkg-config" "--print-errors" "--exists" "glut"] {os != "win32" & os-distribution != "debian" & os-distribution != "ubuntu" & !(os-distribution = "ol" & os-version < "9")}
 ]
 depends: [


### PR DESCRIPTION
It's `"msys2"` not `"msys"` ... and no, I didn't add it on purpose, but a CI workflow to test MSys2 support would have helped here #27914 :slightly_smiling_face: 