### PR TITLE
[new release] merge-fmt (0.4)

### DIFF
--- a/packages/merge-fmt/merge-fmt.0.4/opam
+++ b/packages/merge-fmt/merge-fmt.0.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Git mergetool leveraging code formatters"
+description:
+  "`merge-fmt` is a small wrapper on top git commands to help resolve conflicts by leveraging code formatters."
+maintainer: ["hugo.heuzard@gmail.com"]
+authors: ["Hugo Heuzard"]
+license: "MIT"
+homepage: "https://github.com/hhugo/merge-fmt"
+doc: "https://hhugo.github.io/merge-fmt/"
+bug-reports: "https://github.com/hhugo/merge-fmt/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.8"}
+  "cmdliner" {>= "1.1.0"}
+  "base"
+  "stdio"
+  "ppx_expect" {with-test}
+  "core_unix" {with-test}
+  "ocamlformat" {= "0.27.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hhugo/merge-fmt.git"
+url {
+  src:
+    "https://github.com/hhugo/merge-fmt/releases/download/0.4/merge-fmt-0.4.tbz"
+  checksum: [
+    "sha256=48f104bf49166e055a6221d8875107e3b3de60a9a1f7bed96363830a99a3ac58"
+    "sha512=cfd5bca5bd0813085e0cd4443907086079f4d5c165b582ea0cc88adbf60a8f3237b31a72141f3c72d557f7215af6b5cba9b9f04298e62a76b56936432c975106"
+  ]
+}
+x-commit-hash: "75fe62161292f8ce41d186e99d696957abdc7760"


### PR DESCRIPTION
Git mergetool leveraging code formatters

- Project page: <a href="https://github.com/hhugo/merge-fmt">https://github.com/hhugo/merge-fmt</a>
- Documentation: <a href="https://hhugo.github.io/merge-fmt/">https://hhugo.github.io/merge-fmt/</a>

##### CHANGES:

- Add support of dune formatter. (hhugo/merge-fmt#3)
