### PR TITLE
[new release] ppx_unreachable (1.1)

### DIFF
--- a/packages/ppx_unreachable/ppx_unreachable.1.1/opam
+++ b/packages/ppx_unreachable/ppx_unreachable.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A tool for denoting unreachable control flow paths"
+description:
+  "A PPX that denotes unreachable code and prints descriptive errors when the code is reached"
+maintainer: ["Charles Averill"]
+authors: ["Charles Averill"]
+license: "MIT"
+homepage: "https://github.com/CharlesAverill/ppx_unreachable"
+doc: "https://github.com/CharlesAverill/ppx_unreachable"
+bug-reports: "https://github.com/CharlesAverill/ppx_unreachable/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.9"}
+  "ppxlib" {>= "0.36"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CharlesAverill/ppx_unreachable.git"
+url {
+  src:
+    "https://github.com/CharlesAverill/ppx_unreachable/releases/download/1.1/ppx_unreachable-1.1.tbz"
+  checksum: [
+    "sha256=0979883ca31f4f1b8528769d779f25f149c2ccb0b039f7cc0bfe0d40654b1672"
+    "sha512=2f8d1cd3fa52f5ea13510d54aa957ab99b5097e8afec8888ceda2e827047218f5bb952e065db7c870f673a068db91ec9e2e6dd652a561ad46b73cfe23fe42128"
+  ]
+}
+x-commit-hash: "4e4e5721c85f63844d2f70509fb74ee8df253dcc"


### PR DESCRIPTION
A tool for denoting unreachable control flow paths

- Project page: <a href="https://github.com/CharlesAverill/ppx_unreachable">https://github.com/CharlesAverill/ppx_unreachable</a>
- Documentation: <a href="https://github.com/CharlesAverill/ppx_unreachable">https://github.com/CharlesAverill/ppx_unreachable</a>

##### CHANGES:

Add `[%unreachable_msg "custom error message"]` that prints the provided string
