### PR TITLE
[new release] runtime_events_tools (2 packages) (0.5.2)

### DIFF
--- a/packages/runtime_events_tools/runtime_events_tools.0.5.2/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.5.2/opam
@@ -7,7 +7,7 @@ license: "ISC"
 homepage: "https://github.com/tarides/runtime_events_tools"
 bug-reports: "https://github.com/tarides/runtime_events_tools/issues"
 depends: [
-  "dune" {>= "3.2"}
+  "dune" {>= "3.16.1"}
   "ocaml" {>= "5.0.0~"}
   "hdr_histogram"
   "cmdliner" {>= "1.1.0"}

--- a/packages/runtime_events_tools/runtime_events_tools.0.5.2/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.5.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Tools for the runtime events tracing system in OCaml"
+description: "Various tools for the runtime events tracing system in OCaml"
+maintainer: ["Sadiq Jaffer" "KC Sivaramakrishnan" "Sudha Parimala"]
+authors: ["Sadiq Jaffer"]
+license: "ISC"
+homepage: "https://github.com/tarides/runtime_events_tools"
+bug-reports: "https://github.com/tarides/runtime_events_tools/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "5.0.0~"}
+  "hdr_histogram"
+  "cmdliner" {>= "1.1.0"}
+  "tracing"
+  "ocaml_intrinsics" {>= "v0.16.1"}
+  "menhir" {with-test}
+  "alcotest" {with-test & >= "1.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/runtime_events_tools.git"
+available: (arch = "x86_64" | arch = "arm64") & os != "win32"
+url {
+  src:
+    "https://github.com/tarides/runtime_events_tools/releases/download/0.5.2/runtime_events_tools-0.5.2.tbz"
+  checksum: [
+    "sha256=45482905c25bf6a192bc82c4018eaaee2bc6209147e4b8775a20e679fdc1c4a8"
+    "sha512=e539fbe25a7757c5ea7389c9ef25cfdc37767608983569e74109a67bf3c624801478be5d2f035ec8134b1c19f9f9e2dcfb186e16fba162216fee8afbd2103260"
+  ]
+}
+x-commit-hash: "a7763ee5b440b67fbd3eb2c413f0261408539ebe"

--- a/packages/runtime_events_tools_bare/runtime_events_tools_bare.0.5.2/opam
+++ b/packages/runtime_events_tools_bare/runtime_events_tools_bare.0.5.2/opam
@@ -8,7 +8,7 @@ license: "ISC"
 homepage: "https://github.com/tarides/runtime_events_tools"
 bug-reports: "https://github.com/tarides/runtime_events_tools/issues"
 depends: [
-  "dune" {>= "3.2"}
+  "dune" {>= "3.16.1"}
   "ocaml" {>= "5.0.0~"}
   "cmdliner" {>= "1.1.0"}
   "odoc" {with-doc}

--- a/packages/runtime_events_tools_bare/runtime_events_tools_bare.0.5.2/opam
+++ b/packages/runtime_events_tools_bare/runtime_events_tools_bare.0.5.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Tools for the runtime events tracing system in OCaml"
+description:
+  "Various tools for the runtime events tracing system in OCaml: minimal dependencies"
+maintainer: ["Sadiq Jaffer" "KC Sivaramakrishnan" "Sudha Parimala"]
+authors: ["Sadiq Jaffer"]
+license: "ISC"
+homepage: "https://github.com/tarides/runtime_events_tools"
+bug-reports: "https://github.com/tarides/runtime_events_tools/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "5.0.0~"}
+  "cmdliner" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/runtime_events_tools.git"
+url {
+  src:
+    "https://github.com/tarides/runtime_events_tools/releases/download/0.5.2/runtime_events_tools-0.5.2.tbz"
+  checksum: [
+    "sha256=45482905c25bf6a192bc82c4018eaaee2bc6209147e4b8775a20e679fdc1c4a8"
+    "sha512=e539fbe25a7757c5ea7389c9ef25cfdc37767608983569e74109a67bf3c624801478be5d2f035ec8134b1c19f9f9e2dcfb186e16fba162216fee8afbd2103260"
+  ]
+}
+x-commit-hash: "a7763ee5b440b67fbd3eb2c413f0261408539ebe"


### PR DESCRIPTION
Tools for the runtime events tracing system in OCaml

- Project page: <a href="https://github.com/tarides/runtime_events_tools">https://github.com/tarides/runtime_events_tools</a>

##### CHANGES:

- Allow olly to attach to an external process ([#45](https://github.com/tarides/runtime_events_tools/pull/45), @eutro)
- Fix executable arguments when launching a process. ([#55](https://github.com/tarides/runtime_events_tools/pull/55), @tmcgilchrist)
- Emit runtime counter events for tracing ([#46](https://github.com/tarides/runtime_events_tools/pull/46), @kayceesrk)
- Make counters optional. ([#49](https://github.com/tarides/runtime_events_tools/pull/49), @kayceesrk)
- Fix GC stats to use timestamp from events ([#48](https://github.com/tarides/runtime_events_tools/pull/48), @kayceesrk)

