### PR TITLE
conf-clang-format.1: new depext for Alpine 22

### DIFF
--- a/packages/conf-clang-format/conf-clang-format.1/opam
+++ b/packages/conf-clang-format/conf-clang-format.1/opam
@@ -12,7 +12,8 @@ depexts: [
   ["clang15-extra-tools"] {os-distribution = "alpine" & os-version = "3.17" }
   ["clang16-extra-tools"] {os-distribution = "alpine" & os-version = "3.18" }
   ["clang17-extra-tools"] {os-distribution = "alpine" & os-version >= "3.19" & os-version < "3.21" }
-  ["clang19-extra-tools"] {os-distribution = "alpine" & os-version >= "3.21" }
+  ["clang19-extra-tools"] {os-distribution = "alpine" & os-version >= "3.21" & os-version < "3.22"}
+  ["clang20-extra-tools"] {os-distribution = "alpine" & os-version >= "3.22" }
   ["clang-tools"] {os-family = "suse" | os-family = "opensuse"}
   ["clang"] {os-distribution = "arch"}
   ["clang-format"] {os-distribution = "homebrew" & os = "macos"}


### PR DESCRIPTION
cmd:clang-format is now provided by LLVM 20 - cf. https://pkgs.alpinelinux.org/package/v3.22/main/x86_64/clang20-extra-tools