### PR TITLE
Source archive url for ocamlnet-4.1.9

### DIFF
--- a/packages/ocamlnet/ocamlnet.4.1.9-1/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.9-1/opam
@@ -55,7 +55,7 @@ conflicts: [
   "base-domains"
 ]
 url {
-  src: "http://download.camlcity.org/download/ocamlnet-4.1.9.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamlnet-4.1.9.tar.gz"
   checksum: "sha256=f98ed19979848f1949b1b001e30ac132b254d0f4a705150c6dcf9094bbec9cee"
   mirrors: "http://download2.camlcity.org/download/ocamlnet-4.1.9.tar.gz"
 }

--- a/packages/ocamlnet/ocamlnet.4.1.9-2/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.9-2/opam
@@ -55,7 +55,7 @@ conflicts: [
   "base-domains"
 ]
 url {
-  src: "http://download.camlcity.org/download/ocamlnet-4.1.9.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamlnet-4.1.9.tar.gz"
   checksum: "sha256=f98ed19979848f1949b1b001e30ac132b254d0f4a705150c6dcf9094bbec9cee"
   mirrors: "http://download2.camlcity.org/download/ocamlnet-4.1.9.tar.gz"
 }

--- a/packages/ocamlnet/ocamlnet.4.1.9/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.9/opam
@@ -54,7 +54,7 @@ conflicts: [
   "base-domains"
 ]
 url {
-  src: "http://download.camlcity.org/download/ocamlnet-4.1.9.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamlnet-4.1.9.tar.gz"
   checksum: "sha256=f98ed19979848f1949b1b001e30ac132b254d0f4a705150c6dcf9094bbec9cee"
   mirrors: "http://download2.camlcity.org/download/ocamlnet-4.1.9.tar.gz"
 }


### PR DESCRIPTION
The original source url for this package doesn't seem to be available. Merge after https://github.com/ocaml/opam-source-archives/pull/46.