### PR TITLE
[ocamlfind] add download mirror urls

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.9.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.1/opam
@@ -41,4 +41,5 @@ url {
     "md5=65e6dc9b305ccbed1267275fe180f538"
     "sha512=83a05f3e310fa7cabb0475c5525f7a87c1b6bc2dc5e39f094cabfb5d944a826a5581844ba00ec1a48dd96184eb9de3c4d1055cdddee2b83c700a2de5a6dc6f84"
   ]
+  mirrors: "http://download2.camlcity.org/download/findlib-1.9.1.tar.gz"
 }

--- a/packages/ocamlfind/ocamlfind.1.9.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.2/opam
@@ -41,4 +41,5 @@ url {
     "md5=180b69dd4474614ad6044d879c467232"
     "sha512=c43d43e502869d52e7eb0e5fcf900039fd4ce0c997a4c823f8d5d9ead0c62120447a787723b884bda0db210e9e60fb513d767c4ea6c18bb38effdc8e35a4b75e"
   ]
+  mirrors: "http://download2.camlcity.org/download/findlib-1.9.2.tar.gz"
 }

--- a/packages/ocamlfind/ocamlfind.1.9.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.3/opam
@@ -41,4 +41,5 @@ url {
     "md5=24047dd8a0da5322253de9b7aa254e42"
     "sha512=27cc4ce141576bf477fb9d61a82ad65f55478740eed59fb43f43edb794140829fd2ff89ad27d8a890cfc336b54c073a06de05b31100fc7c01cacbd7d88e928ea"
   ]
+  mirrors: "http://download2.camlcity.org/download/findlib-1.9.3.tar.gz"
 }

--- a/packages/ocamlfind/ocamlfind.1.9.5/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.5/opam
@@ -42,6 +42,7 @@ url {
     "md5=8b893525ce36cb3d4d4952483bcc7cf4"
     "sha512=03514c618a16b02889db997c6c4789b3436b3ad7d974348d2c6dea53eb78898ab285ce5f10297c074bab4fd2c82931a8b7c5c113b994447a44abb30fca74c715"
   ]
+  mirrors: "http://download2.camlcity.org/download/findlib-1.9.5.tar.gz"
 }
 extra-source "0001-Fix-bug-when-installing-with-a-system-compiler.patch" {
   src:

--- a/packages/ocamlfind/ocamlfind.1.9.6/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.6/opam
@@ -43,6 +43,7 @@ url {
     "md5=96c6ee50a32cca9ca277321262dbec57"
     "sha512=cfaf1872d6ccda548f07d32cc6b90c3aafe136d2aa6539e03143702171ee0199add55269bba894c77115535dc46a5835901a5d7c75768999e72db503bfd83027"
   ]
+  mirrors: "http://download2.camlcity.org/download/findlib-1.9.6.tar.gz"
 }
 available: os != "win32"
 extra-source "0001-Harden-test-for-OCaml-5.patch" {


### PR DESCRIPTION
`download.camlcity.org` has been unavailable for some weeks, but `download2.camlcity.org` still works.

Such a mirror already existed for ocamlfind.1.8.1, but not for the remaining versions. Version 1.9.8's URL is already on Github.

These URLs should hopefully help our CI and Docker images succeed, without having to rewrite them all to use ocamlfind 1.9.8.