### PR TITLE
[new release] coq-lsp (0.2.3+9.0)

### DIFF
--- a/packages/coq-lsp/coq-lsp.0.2.3+9.0/opam
+++ b/packages/coq-lsp/coq-lsp.0.2.3+9.0/opam
@@ -1,0 +1,74 @@
+synopsis: "Language Server Protocol native server for Coq"
+description:
+"""
+Language Server Protocol native server for Coq
+"""
+opam-version: "2.0"
+maintainer: "e@x80.org"
+bug-reports: "https://github.com/ejgallego/coq-lsp/issues"
+homepage: "https://github.com/ejgallego/coq-lsp"
+dev-repo: "git+https://github.com/ejgallego/coq-lsp.git"
+authors: [
+  "Emilio Jesús Gallego Arias <e@x80.org>"
+  "Ali Caglayan <alizter@gmail.com>"
+  "Shachar Itzhaky <shachari@cs.technion.ac.il>"
+  "Ramkumar Ramachandra <r@artagnon.com>"
+]
+license: "LGPL-2.1-or-later"
+doc: "https://ejgallego.github.io/coq-lsp/"
+
+depends: [
+
+  ("ocaml" {>= "5.0"} | ("ocaml" {<= "5.0"} & "memprof-limits" { >= "0.2.1" } ))
+
+  "dune"         { >= "3.13.0" } # Version interval [3.8-3.12] was
+                                 # broken for composed builds with Coq
+
+  # lsp dependencies
+  "cmdliner"     { >= "1.1.0" }
+  "yojson"       { >= "1.7.0" }
+  "uri"          { >= "4.2.0" }
+  "dune-build-info" { >= "3.2.0" }
+
+  # waterproof json parser
+  "menhir"       { >= "20220210" }
+
+  # unit testing
+  "ppx_inline_test"     { >= "v0.15.0" }
+
+  "rocq-prover"         { >= "9.0" < "9.1" }
+
+  # [release branch] Remove
+  "ocamlfind" {>= "1.9.1" & (>= "1.9.8" | os != "windows") }
+  "zarith" {>= "1.13"}
+
+  # serlib deps: see what we need to keep for release
+  "ppx_deriving"        { >= "5.2"                 }
+  "ppx_deriving_yojson" { >= "3.7.0"               }
+  "ppx_import"          { >= "1.11.0"              }
+  "sexplib"             { >= "v0.15.0" & < "v0.18" }
+  "ppx_sexp_conv"       { >= "v0.15.0" & < "v0.18" }
+  "ppx_compare"         { >= "v0.15.0" & < "v0.18" }
+  "ppx_hash"            { >= "v0.15.0" & < "v0.18" }
+]
+
+# older results get in mess with ppx_deriving, we cannot control how
+# it gets pulled, often in min-bound rev-dep, so we conflict with it
+conflicts: [ "result" { < "1.5" } ]
+
+depopts: ["lwt" "logs"]
+
+build: [
+  [ "rm" "-rf" "vendor" ]
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [ [ "dune" "runtest" "-p" name "-j" jobs ] ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-lsp/releases/download/0.2.3%2B9.0/coq-lsp-0.2.3.9.0.tbz"
+  checksum: [
+    "sha256=8776582dddfe768623870cf540ff6ba1e96a44a36e85db18ab93d238d640f92a"
+    "sha512=2837889bf99bfe715bd0e752782211a76a14aac71ed37a4fb784f4f0abe338352c9c6d8caa37daf79c036997add1cb306c523f793625b38709f3b5e245380223"
+  ]
+}
+x-commit-hash: "17df8cfdf317f9cbf38fe125e465623008b7df39"


### PR DESCRIPTION
Language Server Protocol native server for Coq

- Project page: <a href="https://github.com/ejgallego/coq-lsp">https://github.com/ejgallego/coq-lsp</a>
- Documentation: <a href="https://ejgallego.github.io/coq-lsp/">https://ejgallego.github.io/coq-lsp/</a>

##### CHANGES:

------------------------

 - [fleche] fix quick fixes for errors being lost due to incorrect
   handling of `send_diags_extra_data` (@ejgallego, ejgallego/coq-lsp#850)
 - [vscode] Syntax highlighting for Coq 8.17-8.20 (@4ever2, ejgallego/coq-lsp#872)
 - [build] Adapt to Coq -> Rocq renaming (@ejgallego, @proux, ejgallego/coq-lsp#879)
 - [js worker] Update js_of_ocaml to 5.9.1 , thanks a lot to Hugo
   Heuzard for longstanding continued support of the jsCoq and coq-lsp
   projects (@ejgallego, @hhugo, ejgallego/coq-lsp#881)
 - [js worker] Update stubs (@ejgallego, @hhugo, ejgallego/coq-lsp#881)
 - [js worker] Fix build for Coq -> Rocq renaming and stdlib split
   (@ejgallego, ejgallego/coq-lsp#881)
 - [general] Adapt to Coq -> Rocq renaming (@ejgallego, @SkySkimmer,
   ejgallego/coq-lsp#883)
 - [general] [js] Adapt to Rocq stdlib split (@ejgallego, ejgallego/coq-lsp#890)
 - [ci] Bump setup-ocaml to v3 (@ejgallego, ejgallego/coq-lsp#890)
 - [ci] [windows] Use Opam 2.2 to build on windows (@ejgallego, ejgallego/coq-lsp#815,
   ejgallego/coq-lsp#890)
 - [petanque] `petanque/start` now fails when the theorem was parsed
   but not successfully executed (@ejgallego, reported by @gbdrt,
   ejgallego/coq-lsp#901, fixes ejgallego/coq-lsp#886)
 - [ci] Test Ocaml 5.3 (@ejgallego, ejgallego/coq-lsp#904)
 - [js worker] Add Shachar Itzhaky's trampoline patch; this greatly
   reduces the Stack Overflow in the proof engine (@ejgallego,
   @corwin-of-amber, ejgallego/coq-lsp#905)
 - [js worker] [build] Include Coq WaterProof in the default Web
   Worker build (@ejgallego, waterproof team, ejgallego/coq-lsp#905, closes ejgallego/coq-lsp#888)
 - [vscode] [web] Fix web extension not exporting the coq-lsp
   extension API (@ejgallego, reported by @amblafont, ejgallego/coq-lsp#911, fixes
   ejgallego/coq-lsp#877)
 - [build] [general] Rename our internal `Lsp` library to
   `Fleche_lsp`; this should help avoiding conflicts with the OCaml
   `lsp` library (@ejgallego, reported by @blackbird1128, ejgallego/coq-lsp#912, fixes
   ejgallego/coq-lsp#861)
 - [workspace] Remove support legacy ML-search path semantics. These
   were basically unused since Coq 8.16. As a consequence, `coq-lsp` /
   `fcc` don't accept the `-I` flag anymore, use `OCAMLPATH` or the
   `--ocamlpath=` option to pass extra `findlib` paths. We still
   respect the -I flag in `_CoqMakefile` (@ejgallego, ejgallego/coq-lsp#916)
 - [lsp] [debug] Respect `$/setTrace` call , refactor logging system,
   and allow file logging of protocol traces again (@ejgallego, ejgallego/coq-lsp#919,
   fixes ejgallego/coq-lsp#868)
 - [coq] Support Coq relocatable mode (@SkySkimmer, ejgallego/coq-lsp#891)
 - [ci] [deps] Remove support for OCaml 4.12 and 4.13, following
   upstream's coq/coq#20576 Note that these compiler versions have
   been unsupported for a long time, please upgrade (@ejgallego, ejgallego/coq-lsp#951)
 - [hover] New option `show_state_hash_on_hover` that displays state
    hash on hover for debug (@ejgallego, ejgallego/coq-lsp#954)
 - [doc] [faq] Updated FAQ to account for VSCoq 2 release in 2023,
   thanks to Patrick Nicodemus for pointing out the outdated
   documentation (@ejgallego, ejgallego/coq-lsp#846, fixes ejgallego/coq-lsp#817)
 - [vscode] [macos] Resolve keybinding conflict with Cmd+N and
   Cmd+Enter, we now use Alt+N and Alt+Shift+Enter, (Andrei
   Listochkin, ejgallego/coq-lsp#926)
 - [rocq] [fleche] Disable memprof-limits interruption backend by
   default, as released Rocq versions are not safe yet. If you want to
   enable it, you can still do it with the `--int_backend=Mp` command
   line option (@ejgallego, ejgallego/coq-lsp#957, fixes ejgallego/coq-lsp#857, reported by @dariusf,
   cc: rocq-prover/rocq#19177)
 - [lsp] [controller] Include Rocq feedback on request errors, using
   the optional `data` field. This is useful to still be able to
   obtain feedback messages such as debug messages even when a request
   fails. This also opens the door to better protocol handling and
   petanque integration (@ejgallego, ejgallego/coq-lsp#959, ejgallego/coq-lsp#961)
 - [petanque] Add feedback field to `Run_result.t`, this is important
   for many use cases. We also return feedback on petanque errors.
   (@ejgallego, @JulesViennotFranca, ejgallego/coq-lsp#960)
 - [petanque] new `get_state_at_pos` and `get_root_state` calls, that
   allow to retrieve a petanque proof state from position
   (@JulesViennotFranca, @ejgallego, ejgallego/coq-lsp#962)
 - [doc] [petanque] Document petanque v1, improve readme (@ejgallego,
   ejgallego/coq-lsp#963)
 - [plugin] [astdump] Make the JSON and SEXP output into a line per
   object by default (@blackbird1128, @ejgallego, ejgallego/coq-lsp#874)
 - [doc] [emacs] [protocol] Improve documentation for `proof/goals`,
   add link to official emacs mode by Josselin Poiret (@ejgallego,
   ejgallego/coq-lsp#969, thanks to @jpoiret, cc: ejgallego/coq-lsp#941)
 - [goals] Include `range` in `proof/goals` answer. This is useful for
   clients willing to do highlighting (@ejgallego, @jpoiret, ejgallego/coq-lsp#970)
