### PR TITLE
Add: tgls.0.9.0

### DIFF
--- a/packages/tgls/tgls.0.9.0/opam
+++ b/packages/tgls/tgls.0.9.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Thin bindings to OpenGL {3,4} and OpenGL ES {2,3} for OCaml"
+description: """\
+Tgls is a set of independent OCaml libraries providing thin bindings
+to OpenGL libraries. It has support for core OpenGL 3.{2,3} and
+4.{0,1,2,3,4} and OpenGL ES 2 and 3.{0,1,2}.
+
+Tgls depends on [ocaml-ctypes][ctypes] and the C OpenGL library of your
+platform. It is distributed under the ISC license.
+          
+[ctypes]: https://github.com/ocamllabs/ocaml-ctypes
+
+Home page: <http://erratique.ch/software/tgls>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The tgls programmers"
+license: "ISC"
+tags: ["bindings" "opengl" "opengl-es" "graphics" "org:erratique"]
+homepage: "https://erratique.ch/software/tgls"
+doc: "https://erratique.ch/software/tgls/doc/"
+bug-reports: "https://github.com/dbuenzli/tgls/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "ctypes" {>= "0.21.1"}
+  "ctypes-foreign" {>= "0.21.1"}
+  "xmlm" {dev}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/tgls.git"
+url {
+  src: "https://erratique.ch/software/tgls/releases/tgls-0.9.0.tbz"
+  checksum:
+    "sha512=66f6d3db01c38a6238f46a5b74630e112c178648877c6d39dcb6f0ed646a799db66b8dd6d1070ab063a04fec6244483b6fd46e6bfb13798f91191dcbaac71bc9"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `tgls.0.9.0` [home](https://erratique.ch/software/tgls), [doc](https://erratique.ch/software/tgls/doc/), [issues](https://github.com/dbuenzli/tgls/issues)  
  *Thin bindings to OpenGL {3,4} and OpenGL ES {2,3} for OCaml*


---

#### `tgls` v0.9.0 2025-06-05 Zagreb

* Install each library in its own directory.
* Remove `tgls.*.top` libraries. They were just opening the
  API toplevel module. Not worth the maintenance trouble.
* Fix Tgls on Windows + MingW64
  * Try to load [opengl32.dll] at startup on Windows.
  * Bring 64-bit Windows support by fixing selection of FFI ABI.
  * Unlock the full OpenGL API on Windows by implementing indirect
    procedure lookup with [wglGetProcAddress].
  Thanks to Benjamin Canou for the patches ([#33](https://github.com/dbuenzli/tgls/issues/33)).
* Fix build system. Explicitely depend on `ctypes-foreign`. 
  Thanks to Etienne Millon for the patch ([#29](https://github.com/dbuenzli/tgls/issues/29)).
* Fix `Gl.debug_message_callback` raising `Ffi_stubs.CallToExpiredClosure`. 
  Thanks to Edwin Török for the report and the patch ([#6](https://github.com/dbuenzli/tgls/issues/6)).

---

Use `b0 -- .opam publish tgls.0.9.0` to update the pull request.