### PR TITLE
[new release] fast_bitvector (0.1.0.1)

### DIFF
--- a/packages/fast_bitvector/fast_bitvector.0.1.0.1/opam
+++ b/packages/fast_bitvector/fast_bitvector.0.1.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A bitvector library"
+description: "Bitvector represented as bytes internally"
+maintainer: ["Stefan Muenzel <source@s.muenzel.net>"]
+authors: ["Stefan Muenzel <source@s.muenzel.net>"]
+license: "MPL-2.0"
+tags: ["bitvector" "bitset"]
+homepage: "https://github.com/engineeredabstraction/fast_bitvector"
+bug-reports: "https://github.com/engineeredabstraction/fast_bitvector/issues"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/engineeredabstraction/fast_bitvector.git"
+x-maintenance-intent: ["(latest)"]
+depends: [
+  "dune" {>= "3.18"}
+  (("ocaml" {>= "4.14.0" & <"5.1.0"}) | ("ocaml" {>= "5.1.0"} & "ocaml_intrinsics_kernel" { arch != "arm32" & arch != "x86_32" }))
+  "ppx_sexp_conv"
+  "ppx_sexp_value" { >= "v0.16.0" }
+  "ppx_cold" { >= "v0.16.0" }
+  "expect_test_helpers_core" {with-test}
+  "ppx_jane" {with-test}
+  "odoc" {with-doc}
+]
+url {
+  src:
+    "https://github.com/engineeredabstraction/fast_bitvector/releases/download/0.1.0.1/fast_bitvector-0.1.0.1.tbz"
+  checksum: [
+    "sha256=ea40f4a178c3fe4844527e4a5c44a367a9e64cd12aa923f20215eb0fa9457305"
+    "sha512=2779a84412976122a9a6c24e350566623d4d5642053be49b7d04d2b7537a10f00f03ebb6264dd2c8f8bc381f534de790d1254c849cf301be9ac634e4d2e4fa5b"
+  ]
+}
+x-commit-hash: "b4aa08b970af114dd1b2db7ea073960ba94e56b4"


### PR DESCRIPTION
A bitvector library

- Project page: <a href="https://github.com/engineeredabstraction/fast_bitvector">https://github.com/engineeredabstraction/fast_bitvector</a>

##### CHANGES:

- New, more clear, sexp representation
- Better error messages for safe functions
- Fix big-endian architecture compatibility
- Remove returned bitvector in ops, user is now required to track it themselves
- Use `~dst` instead of `~result`
- Add `Allocate` variant of all ops in a submodule
- Allow equality check between different-length bitvectors
