### PR TITLE
Package opam-ci-check-lint.0.1

### DIFF
--- a/packages/opam-ci-check-lint/opam-ci-check-lint.0.1/opam
+++ b/packages/opam-ci-check-lint/opam-ci-check-lint.0.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Library to lint opam files submitted to the opam repository"
+description:
+  "opam-ci-check-lint exposes the lint functionality used in the opam repo CI and opam-ci-check. It can be used in other packages such as opam publishing tools to ensure that the published package opam files are correct."
+maintainer: [
+  "Puneeth Chaganti <punchagan@muse-amuse.in>"
+  "Shon Feder <shon.feder@gmail.com>"
+]
+authors: [
+  "Puneeth Chaganti <punchagan@muse-amuse.in>"
+  "Shon Feder <shon.feder@gmail.com>"
+]
+license: "Apache-2.0"
+tags: ["opam" "ci" "lint"]
+homepage: "https://github.com/ocurrent/opam-repo-ci/tree/master/opam-ci-check"
+doc: "https://www.ocurrent.org/opam-repo-ci/opam-ci-check-lint/index.html"
+bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.16"}
+  "sexplib"
+  "opam-state" {>= "2.3.0~alpha1"}
+  "opam-format" {>= "2.3.0~alpha1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
+url {
+  src:
+    "https://github.com/ocurrent/opam-repo-ci/archive/12810c8cc0b9a02e7b22f660387b76c6e70aa685.tar.gz"
+  checksum: [
+    "md5=ecf9bfdbe72256fbb3f66b359dc277ef"
+    "sha512=f8984939d945184ed44ba694b4f8936991c220d5fc4d57120d2f70d6da6972bf441e2bb174e36181a521589d8db5829a7521caa366b2a3b13f3b2501c057aee6"
+  ]
+}


### PR DESCRIPTION
### `opam-ci-check-lint.0.1`
Library to lint opam files submitted to the opam repository
opam-ci-check-lint exposes the lint functionality used in the opam repo CI and opam-ci-check. It can be used in other packages such as opam publishing tools to ensure that the published package opam files are correct.



---
* Homepage: https://github.com/ocurrent/opam-repo-ci/tree/master/opam-ci-check
* Source repo: git+https://github.com/ocurrent/opam-repo-ci.git
* Bug tracker: https://github.com/ocurrent/opam-repo-ci/issues

---
:camel: Pull-request generated by opam-publish v2.5.1