### PR TITLE
Fix Windows availability and installation of a bunch of conf- packages

### DIFF
--- a/packages/conf-cairo/conf-cairo.1/opam
+++ b/packages/conf-cairo/conf-cairo.1/opam
@@ -25,7 +25,7 @@ depexts: [
   ["cairo"] {os-family = "arch"}
   ["cairo"] {os = "macos" & os-distribution = "homebrew"}
   ["cairo"] {os = "win32" & os-distribution = "cygwinports"}
-  ["libcairo-devel"] {os = "cygwin"}
+  ["libcairo-devel"] {os = "win32" & os-distribution = "cygwin"}
 ]
 synopsis: "Virtual package relying on a Cairo system installation"
 description:

--- a/packages/conf-clang/conf-clang.1/opam
+++ b/packages/conf-clang/conf-clang.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["clang"] {os-distribution = "ol"}
   ["clang"] {os-distribution = "arch"}
   # on FreeBSD clang is already part of the base system in contrib/llvm-project/clang
+  ["clang"] {os = "win32"}
 ]
 synopsis: "Virtual package relying on clang"
 description:

--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -16,7 +16,7 @@ depexts: [
   ["gtk3-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gtk3"] {os-family = "arch"}
   ["gtk3"] {os = "win32" & os-distribution = "cygwinports"}
-  ["libgtk3-devel"] {os = "cygwin"}
+  ["libgtk3-devel"] {os = "win32" & os-distribution = "cygwin"}
   ["gtk3"] {os = "freebsd"}
 ]
 post-messages: [

--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -3,7 +3,10 @@ maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: "The GTK Toolkit"
 homepage: "https://developer.gnome.org/"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
-build: [["pkg-config" "--short-errors" "--print-errors" "--atleast-version" "3.18" "gtk+-3.0"]]
+build: [
+  ["pkgconf" "gtk+-3.0"] {os = "win32" & os-distribution != "cygwinports"}
+  ["pkg-config" "--short-errors" "--print-errors" "--atleast-version" "3.18" "gtk+-3.0"] {os != "win32" | os-distribution != "cygwin"}
+]
 depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libgtk-3-dev" "libexpat1-dev"] {os-family = "debian" | os-family = "ubuntu"}

--- a/packages/conf-libev/conf-libev.4-11/opam
+++ b/packages/conf-libev/conf-libev.4-11/opam
@@ -27,6 +27,7 @@ Libev is modelled (very loosely) after libevent and the Event perl
 module, but is faster, scales better and is more correct, and also more
 featureful. And also smaller. Yay."""
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
+available: os != "win32"
 flags: conf
 extra-source "discover.ml" {
   src:

--- a/packages/conf-mpfr/conf-mpfr.3/opam
+++ b/packages/conf-mpfr/conf-mpfr.3/opam
@@ -25,6 +25,7 @@ depexts: [
   ["mpfr-dev"] {os-family = "alpine"}
   ["mpfr-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["mpfr"] {os = "win32" & os-distribution = "cygwinports"}
+  ["libmpfr-devel"] {os = "win32" & os-distribution = "cygwin"}
 ]
 synopsis: "Virtual package relying on library MPFR installation"
 description:

--- a/packages/omake/omake.0.10.3/opam
+++ b/packages/omake/omake.0.10.3/opam
@@ -9,7 +9,7 @@ authors: [
 license: "GPL-2.0-only"
 dev-repo: "git+https://github.com/ocaml-omake/omake.git"
 homepage: "http://projects.camlcity.org/projects/omake.html"
-bug-reports: "https://github.com/ocaml-omake/issues"
+bug-reports: "https://github.com/ocaml-omake/omake/issues"
 
 patches: ["lib_build_OCaml.om.diff"]
 

--- a/packages/omake/omake.0.10.5/opam
+++ b/packages/omake/omake.0.10.5/opam
@@ -9,7 +9,7 @@ authors: [
 license: "GPL-2.0-only"
 dev-repo: "git+https://github.com/ocaml-omake/omake.git"
 homepage: "http://projects.camlcity.org/projects/omake.html"
-bug-reports: "https://github.com/ocaml-omake/issues"
+bug-reports: "https://github.com/ocaml-omake/omake/issues"
 
 build: [
   ["./configure" "-prefix" "%{prefix}%"]

--- a/packages/omake/omake.0.10.6/opam
+++ b/packages/omake/omake.0.10.6/opam
@@ -9,7 +9,7 @@ authors: [
 license: "GPL-2.0-only"
 dev-repo: "git+https://github.com/ocaml-omake/omake.git"
 homepage: "http://projects.camlcity.org/projects/omake.html"
-bug-reports: "https://github.com/ocaml-omake/issues"
+bug-reports: "https://github.com/ocaml-omake/omake/issues"
 
 build-env: OCAMLPARAM = "_,w=-46,keywords=5.2"
 

--- a/packages/omake/omake.0.10.7/opam
+++ b/packages/omake/omake.0.10.7/opam
@@ -10,7 +10,7 @@ authors: [
 license: "GPL-2.0-only"
 dev-repo: "git+https://github.com/ocaml-omake/omake.git"
 homepage: "http://projects.camlcity.org/projects/omake.html"
-bug-reports: "https://github.com/ocaml-omake/issues"
+bug-reports: "https://github.com/ocaml-omake/omake/issues"
 
 build: [
   ["./configure" "-prefix" "%{prefix}%"]


### PR DESCRIPTION
Since the Windows CI is currently down, I have a couple of builds using `setup-ocaml`:

1. [Build](https://github.com/punchagan/test-setup-ocaml/actions/runs/15565551143/job/43828623524) using current master of `opam-repository` ([workflow file](https://github.com/punchagan/test-setup-ocaml/actions/runs/15565551143/workflow))
2. [Build](https://github.com/punchagan/test-setup-ocaml/actions/runs/15565208386/job/43827479019) using the current branch as the default opam repository. ([workflow file](https://github.com/punchagan/test-setup-ocaml/actions/runs/15565208386/workflow))