### PR TITLE
9 packages from mbarbin/vcs at 0.0.18

### DIFF
--- a/packages/volgo-base/volgo-base.0.0.18/opam
+++ b/packages/volgo-base/volgo-base.0.0.18/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis: "An Extension of volgo.Vcs to use with Base"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "base" {>= "v0.17"}
+  "fpath" {>= "0.7.3"}
+  "fpath-base" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "ppx_compare" {>= "v0.17"}
+  "ppx_enumerate" {>= "v0.17"}
+  "ppx_hash" {>= "v0.17"}
+  "ppx_here" {>= "v0.17"}
+  "ppx_let" {>= "v0.17"}
+  "ppx_sexp_conv" {>= "v0.17"}
+  "ppx_sexp_value" {>= "v0.17"}
+  "ppxlib" {>= "0.33"}
+  "volgo" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[Volgo_base] is a library that extends the [Vcs] library with
+additional modules and functionalities to improve compatibility with
+programs using [base].
+
+For example, it adds [Comparable.S] to all container key modules so
+that they can be used with [base]-style containers such as [Map] and
+[Hashtbl].
+
+It also exports a module [Vcs.Or_error] to make it easy to use [Vcs]
+with the [Or_error] monad.
+
+The library is designed to be used as a drop-in replacement for [Vcs].
+To achieve this, it includes a single module named [Vcs] which must be
+set up to shadow the regular [Vcs] module.
+
+[base]: https://github.com/janestreet/base
+
+"""
+tags: [ "git" "vcs" "base" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.18/volgo-0.0.18.tbz"
+  checksum: [
+    "sha256=b387e24af5d12de7fd50194b9ccd73d271c92161110e860a4481b92e4d0c04a1"
+    "sha512=a8afaf6fe9b9ab4b638af4fc064afda937bfbdcf4d92ecc6ac287a4e57bcba27e24742b33a4f7f2e71cb511e3510789c5f57ba10270f8ee37aaaa4e55db6078e"
+  ]
+}
+x-commit-hash: "705c2d04c7fcb8f8b1356b8bf7f15a32b1c57580"

--- a/packages/volgo-git-backend/volgo-git-backend.0.0.18/opam
+++ b/packages/volgo-git-backend/volgo-git-backend.0.0.18/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "An IO-free library that parses the output of Git commands"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "astring" {>= "0.8.5"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "ppx_sexp_conv" {>= "v0.16"}
+  "ppx_sexp_value" {>= "v0.16"}
+  "ppxlib" {>= "0.33"}
+  "sexplib0" {>= "v0.16"}
+  "volgo" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo] is a set of OCaml libraries for interacting with Git
+repositories. It provides a type-safe and direct-style API to
+programmatically perform Git operations, ranging from creating commits
+and branches to loading and navigating commit graphs in memory,
+computing diffs between revisions, and more.
+
+[Volgo_git_backend] is not meant to be used directly by a user. Rather
+it is a helper library for building Git CLI backends for [volgo]. Given
+the ability to run a [git] process, this library knows which commands
+to run, how to parse their output, and how to interpret their exit
+codes to turn them into typed results.
+
+"""
+tags: [ "cli" "git" "vcs" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.18/volgo-0.0.18.tbz"
+  checksum: [
+    "sha256=b387e24af5d12de7fd50194b9ccd73d271c92161110e860a4481b92e4d0c04a1"
+    "sha512=a8afaf6fe9b9ab4b638af4fc064afda937bfbdcf4d92ecc6ac287a4e57bcba27e24742b33a4f7f2e71cb511e3510789c5f57ba10270f8ee37aaaa4e55db6078e"
+  ]
+}
+x-commit-hash: "705c2d04c7fcb8f8b1356b8bf7f15a32b1c57580"

--- a/packages/volgo-git-eio/volgo-git-eio.0.0.18/opam
+++ b/packages/volgo-git-eio/volgo-git-eio.0.0.18/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis: "A Git backend for Vcs based on Volgo_git_backend for Eio programs"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "conf-git" {with-test}
+  "eio" {>= "1.0"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "ppx_sexp_conv" {>= "v0.17"}
+  "ppx_sexp_value" {>= "v0.17"}
+  "ppxlib" {>= "0.33"}
+  "sexplib0" {>= "v0.17"}
+  "volgo" {= version}
+  "volgo-git-backend" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo] is a set of OCaml libraries for interacting with Git
+repositories. It provides a type-safe and direct-style API to
+programmatically perform Git operations, ranging from creating
+commits and branches to loading and navigating commit graphs in
+memory, computing diffs between revisions, and more.
+
+[Volgo_git_eio] implements a Git backend for [volgo] based on [eio].
+It runs the [git] CLI as a subprocess in a non-blocking fashion.
+
+[eio]: https://github.com/ocaml-multicore/eio
+
+"""
+tags: [ "eio" "git" "vcs" "non-blocking-io" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.18/volgo-0.0.18.tbz"
+  checksum: [
+    "sha256=b387e24af5d12de7fd50194b9ccd73d271c92161110e860a4481b92e4d0c04a1"
+    "sha512=a8afaf6fe9b9ab4b638af4fc064afda937bfbdcf4d92ecc6ac287a4e57bcba27e24742b33a4f7f2e71cb511e3510789c5f57ba10270f8ee37aaaa4e55db6078e"
+  ]
+}
+x-commit-hash: "705c2d04c7fcb8f8b1356b8bf7f15a32b1c57580"

--- a/packages/volgo-git-unix/volgo-git-unix.0.0.18/opam
+++ b/packages/volgo-git-unix/volgo-git-unix.0.0.18/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis:
+  "A Git backend for Vcs based on Volgo_git_backend and the Unix library"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "conf-git" {with-test}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "ppx_sexp_conv" {>= "v0.16"}
+  "ppx_sexp_value" {>= "v0.16"}
+  "ppxlib" {>= "0.33"}
+  "sexplib0" {>= "v0.16"}
+  "spawn" {>= "v0.16"}
+  "volgo" {= version}
+  "volgo-git-backend" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo] is a set of OCaml libraries for interacting with Git
+repositories. It provides a type-safe and direct-style API to
+programmatically perform Git operations, ranging from creating
+commits and branches to loading and navigating commit graphs in
+memory, computing diffs between revisions, and more.
+
+[Volgo_git_unix] implements a Git backend for [volgo] based on the
+OCaml standard library. It runs the [git] CLI as a subprocess in a
+blocking fashion, similar to the Stdlib's [Unix] module.
+
+"""
+tags: [ "git" "vcs" "blocking-io" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.18/volgo-0.0.18.tbz"
+  checksum: [
+    "sha256=b387e24af5d12de7fd50194b9ccd73d271c92161110e860a4481b92e4d0c04a1"
+    "sha512=a8afaf6fe9b9ab4b638af4fc064afda937bfbdcf4d92ecc6ac287a4e57bcba27e24742b33a4f7f2e71cb511e3510789c5f57ba10270f8ee37aaaa4e55db6078e"
+  ]
+}
+x-commit-hash: "705c2d04c7fcb8f8b1356b8bf7f15a32b1c57580"

--- a/packages/volgo-hg-backend/volgo-hg-backend.0.0.18/opam
+++ b/packages/volgo-hg-backend/volgo-hg-backend.0.0.18/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "An IO-free library that parses the output of Mercurial commands"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "astring" {>= "0.8.5"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "ppx_sexp_conv" {>= "v0.16"}
+  "ppx_sexp_value" {>= "v0.16"}
+  "ppxlib" {>= "0.33"}
+  "sexplib0" {>= "v0.16"}
+  "volgo" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo] is a set of OCaml libraries for interacting with Git
+repositories. It provides a type-safe and direct-style API to
+programmatically perform Git operations, ranging from creating commits
+and branches to loading and navigating commit graphs in memory,
+computing diffs between revisions, and more.
+
+[Volgo_hg_backend] is not meant to be used directly by a user. Rather
+it is a helper library for building Mercurial CLI backends for
+[volgo]. Given the ability to run a [hg] process, this library knows
+which commands to run, how to parse their output, and how to
+interpret their exit codes to turn them into typed results.
+
+"""
+tags: [ "cli" "git" "mercurial" "vcs" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.18/volgo-0.0.18.tbz"
+  checksum: [
+    "sha256=b387e24af5d12de7fd50194b9ccd73d271c92161110e860a4481b92e4d0c04a1"
+    "sha512=a8afaf6fe9b9ab4b638af4fc064afda937bfbdcf4d92ecc6ac287a4e57bcba27e24742b33a4f7f2e71cb511e3510789c5f57ba10270f8ee37aaaa4e55db6078e"
+  ]
+}
+x-commit-hash: "705c2d04c7fcb8f8b1356b8bf7f15a32b1c57580"

--- a/packages/volgo-hg-eio/volgo-hg-eio.0.0.18/opam
+++ b/packages/volgo-hg-eio/volgo-hg-eio.0.0.18/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis:
+  "A Mercurial backend for Vcs based on Volgo_hg_backend for Eio programs"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "eio" {>= "1.0"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "ppx_sexp_conv" {>= "v0.17"}
+  "ppx_sexp_value" {>= "v0.17"}
+  "ppxlib" {>= "0.33"}
+  "sexplib0" {>= "v0.17"}
+  "volgo" {= version}
+  "volgo-git-eio" {= version}
+  "volgo-hg-backend" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo] is a set of OCaml libraries for interacting with Git
+repositories. It provides a type-safe and direct-style API to
+programmatically perform Git operations, ranging from creating
+commits and branches to loading and navigating commit graphs in
+memory, computing diffs between revisions, and more.
+
+[Volgo_hg_eio] implements a Mercurial backend for [volgo] based on
+[eio]. It runs the [hg] CLI as a subprocess in a non-blocking
+fashion.
+
+"""
+tags: [ "eio" "git" "mercurial" "vcs" "non-blocking-io" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.18/volgo-0.0.18.tbz"
+  checksum: [
+    "sha256=b387e24af5d12de7fd50194b9ccd73d271c92161110e860a4481b92e4d0c04a1"
+    "sha512=a8afaf6fe9b9ab4b638af4fc064afda937bfbdcf4d92ecc6ac287a4e57bcba27e24742b33a4f7f2e71cb511e3510789c5f57ba10270f8ee37aaaa4e55db6078e"
+  ]
+}
+x-commit-hash: "705c2d04c7fcb8f8b1356b8bf7f15a32b1c57580"

--- a/packages/volgo-hg-unix/volgo-hg-unix.0.0.18/opam
+++ b/packages/volgo-hg-unix/volgo-hg-unix.0.0.18/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis:
+  "A Mercurial backend for Vcs based on Volgo_hg_backend and the Unix library"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "ppx_sexp_conv" {>= "v0.16"}
+  "ppx_sexp_value" {>= "v0.16"}
+  "ppxlib" {>= "0.33"}
+  "sexplib0" {>= "v0.16"}
+  "volgo" {= version}
+  "volgo-git-unix" {= version}
+  "volgo-hg-backend" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo] is a set of OCaml libraries for interacting with Git
+repositories. It provides a type-safe and direct-style API to
+programmatically perform Git operations, ranging from creating
+commits and branches to loading and navigating commit graphs in
+memory, computing diffs between revisions, and more.
+
+[Volgo_hg_unix] implements a Mercurial backend for [volgo] based on
+the OCaml standard library. It runs the [hg] CLI as a subprocess in
+a blocking fashion, similar to the Stdlib's [Unix] module.
+
+"""
+tags: [ "git" "mercurial" "vcs" "blocking-io" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.18/volgo-0.0.18.tbz"
+  checksum: [
+    "sha256=b387e24af5d12de7fd50194b9ccd73d271c92161110e860a4481b92e4d0c04a1"
+    "sha512=a8afaf6fe9b9ab4b638af4fc064afda937bfbdcf4d92ecc6ac287a4e57bcba27e24742b33a4f7f2e71cb511e3510789c5f57ba10270f8ee37aaaa4e55db6078e"
+  ]
+}
+x-commit-hash: "705c2d04c7fcb8f8b1356b8bf7f15a32b1c57580"

--- a/packages/volgo-vcs/volgo-vcs.0.0.18/opam
+++ b/packages/volgo-vcs/volgo-vcs.0.0.18/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis:
+  "A command line tool for vcs operations based on the volgo libraries"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "cmdlang" {>= "0.0.9"}
+  "conf-git" {with-test}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "ppx_sexp_value" {>= "v0.16"}
+  "ppxlib" {>= "0.33"}
+  "sexplib0" {>= "v0.16"}
+  "volgo" {= version}
+  "volgo-git-backend" {= version}
+  "volgo-git-unix" {= version}
+  "volgo-hg-backend" {= version}
+  "volgo-hg-unix" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo-vcs] is a package from the [volgo] project that provides a
+command-line interface called [volgo-vcs]. This CLI is implemented
+on top of the other packages from the project.
+
+It allows users to run exploratory tests using the [volgo] interfaces
+and the Git backends available on actual repositories, directly from
+the command line.
+
+This tool can be helpful for reproducing issues with the library or
+getting familiar with some functionality of the project in an
+interactive fashion using real live data.
+
+"""
+tags: [ "cli" "git" "vcs" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.18/volgo-0.0.18.tbz"
+  checksum: [
+    "sha256=b387e24af5d12de7fd50194b9ccd73d271c92161110e860a4481b92e4d0c04a1"
+    "sha512=a8afaf6fe9b9ab4b638af4fc064afda937bfbdcf4d92ecc6ac287a4e57bcba27e24742b33a4f7f2e71cb511e3510789c5f57ba10270f8ee37aaaa4e55db6078e"
+  ]
+}
+x-commit-hash: "705c2d04c7fcb8f8b1356b8bf7f15a32b1c57580"

--- a/packages/volgo/volgo.0.0.18/opam
+++ b/packages/volgo/volgo.0.0.18/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "A Versatile OCaml Library for Git Operations"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "astring" {>= "0.8.5"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "ppx_enumerate" {>= "v0.16"}
+  "ppx_sexp_conv" {>= "v0.16"}
+  "ppx_sexp_value" {>= "v0.16"}
+  "ppxlib" {>= "0.33"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo] is a set of OCaml libraries for interacting with Git
+repositories. It provides a type-safe and direct-style API to
+programmatically perform Git operations, ranging from creating
+commits and branches to loading and navigating commit graphs in
+memory, computing diffs between revisions, and more.
+
+[Vcs] is the user-facing OCaml module for the project and
+dynamically dispatches its implementation at runtime.
+
+"""
+tags: [ "git" "vcs" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.18/volgo-0.0.18.tbz"
+  checksum: [
+    "sha256=b387e24af5d12de7fd50194b9ccd73d271c92161110e860a4481b92e4d0c04a1"
+    "sha512=a8afaf6fe9b9ab4b638af4fc064afda937bfbdcf4d92ecc6ac287a4e57bcba27e24742b33a4f7f2e71cb511e3510789c5f57ba10270f8ee37aaaa4e55db6078e"
+  ]
+}
+x-commit-hash: "705c2d04c7fcb8f8b1356b8bf7f15a32b1c57580"


### PR DESCRIPTION
This pull-request concerns:
- `volgo.0.0.18`: A Versatile OCaml Library for Git Operations
- `volgo-base.0.0.18`: An Extension of volgo.Vcs to use with Base
- `volgo-git-backend.0.0.18`: An IO-free library that parses the output of Git commands
- `volgo-git-eio.0.0.18`: A Git backend for Vcs based on Volgo_git_backend for Eio programs
- `volgo-git-unix.0.0.18`: A Git backend for Vcs based on Volgo_git_backend and the Unix library
- `volgo-hg-backend.0.0.18`: An IO-free library that parses the output of Mercurial commands
- `volgo-hg-eio.0.0.18`: A Mercurial backend for Vcs based on Volgo_hg_backend for Eio programs
- `volgo-hg-unix.0.0.18`: A Mercurial backend for Vcs based on Volgo_hg_backend and the Unix library
- `volgo-vcs.0.0.18`: A command line tool for vcs operations based on the volgo libraries



---
* Homepage: https://github.com/mbarbin/vcs
* Source repo: git+https://github.com/mbarbin/vcs.git
* Bug tracker: https://github.com/mbarbin/vcs/issues

---
:camel: Pull-request generated by opam-publish v2.5.1