### PR TITLE
kappa-library 4.1.3 needs an upper bound on yojson

### DIFF
--- a/packages/kappa-library/kappa-library.4.1.3/opam
+++ b/packages/kappa-library/kappa-library.4.1.3/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/Kappa-Dev/KappaTools/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.13.0" & < "5.0.0"}
-  "yojson" {>= "2.0"}
+  "yojson" {>= "2.0" & < "2.2.0"}
   "lwt" {>= "4.2.0"}
   "num"
   "re"


### PR DESCRIPTION
```
=== ERROR while compiling kappa-library.4.1.3 ================================#
 context              2.3.0 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
 path                 ~/.opam/4.14/.opam-switch/build/kappa-library.4.1.3
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p kappa-library -j 255 --promote-install-files=false @install
 exit-code            1
 env-file             ~/.opam/log/kappa-library-7-865747.env
 output-file          ~/.opam/log/kappa-library-7-865747.out
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w @a -g -bin-annot -I core/dataStructures/.kappa_data_structures.objs/byte -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/yojson -intf-suffix .ml -no-alias-deps -open Kappa_data_structures -o core/dataStructures/.kappa_data_structures.objs/byte/kappa_data_structures__Result_util.cmo -c -impl core/dataStructures/result_util.ml)
 File "core/dataStructures/result_util.ml", line 159, characters 8-38:
 159 |   match Yojson.Basic.start_any_variant p lb with
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Unbound value Yojson.Basic.start_any_variant
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -w @a -g -I core/dataStructures/.kappa_data_structures.objs/byte -I core/dataStructures/.kappa_data_structures.objs/native -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/yojson -intf-suffix .ml -no-alias-deps -open Kappa_data_structures -o core/dataStructures/.kappa_data_structures.objs/native/kappa_data_structures__Result_util.cmx -c -impl core/dataStructures/result_util.ml)
 File "core/dataStructures/result_util.ml", line 159, characters 8-38:
 159 |   match Yojson.Basic.start_any_variant p lb with
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Unbound value Yojson.Basic.start_any_variant
```

Seen on https://github.com/ocaml/opam-repository/pull/28017