### PR TITLE
Add win32+cygwin entry to conf-hg

### DIFF
--- a/packages/conf-hg/conf-hg.1.0/opam
+++ b/packages/conf-hg/conf-hg.1.0/opam
@@ -20,6 +20,7 @@ depexts: [
   ["mercurial"] {os-family = "ubuntu"}
   ["system:hg"] {os = "win32" & os-distribution = "cygwinports"}
   ["mercurial"] {os = "win32" & os-distribution = "msys2"}
+  ["mercurial"] {os = "win32" & os-distribution = "cygwin"}
   ["mercurial"] {os = "cygwin"}
 ]
 synopsis: "Virtual package relying on hg"


### PR DESCRIPTION
This is a follow-up to a discussion with @jmid in #27999 to add support for Mercurial package on more Windows CI environments.

I am not confident whether this change helps - now that the Windows CI is back on, maybe that can help validating this change.

I have tested a similar change [here](https://ocaml.ci.dev/github/mbarbin/vcs/commit/6506167311adde4c6a3a872402ac28bc6d833be2/variant/windows-server-2022-amd64-5.3_opam-2.3) and it there was a step to install the package during that CI, but the sequence failed later during the installation of `conf-hg` (`hg` command not found). I don't understand this atm.

I'm creating this PR in the hope other will be able to help. Thanks!