### PR TITLE
CamlIDL 1.13

### DIFF
--- a/packages/camlidl/camlidl.1.13/opam
+++ b/packages/camlidl/camlidl.1.13/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: ["Xavier Leroy <xavier.leroy@college-de-france.fr>"]
+authors: ["Xavier Leroy"]
+homepage: "https://github.com/xavierleroy/camlidl"
+dev-repo: "git+https://github.com/xavierleroy/camlidl.git"
+bug-reports: "https://github.com/xavierleroy/camlidl/issues"
+license: [
+  "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
+]
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["mv" "config/Makefile.unix" "config/Makefile"] {os != "win32"}
+  ["mv" "config/Makefile.mingw" "config/Makefile"] {os = "win32"}
+  [make "all"]
+]
+synopsis: "Stub code generator for OCaml"
+description: """
+CamlIDL is a stub code generator for OCaml. It automates the
+generation of C stub code required for the Caml/C interface, based on
+an MIDL specification. Also provides some support for Microsoft's COM
+software components."""
+depends: [
+  "ocaml" {>= "4.05"}
+]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
+url {
+  src: "https://github.com/xavierleroy/camlidl/archive/camlidl113.tar.gz"
+  checksum: [
+    "sha256=c82bfd106208ebedd8c264300e939010f87eed83e6f6339e3a6cf8f66caeed54"
+    "sha512=c9a33d6b49bf51f1957941bac591090e568ffc2d56b75ed777141ef4fd599c87ae968cdc473d8cee325083aa1a0bbc31215540f19fcfc8bb94f8db2ce9deb35c"
+  ]
+}


### PR DESCRIPTION
- Include OPAM files in the sources, to support opam pin (https://github.com/xavierleroy/camlidl/pull/26)
- Honor $(DESTDIR) for the traditional, non-OPAM installation method (https://github.com/xavierleroy/camlidl/pull/28)
- Use Val_unit instead of 0 to initialize local roots, for compatibility with OCaml 5 and OCaml 4 in no-page-table mode (https://github.com/xavierleroy/camlidl/pull/29)