### PR TITLE
Deprecate duppy and dtools, remove from liquidsoap dependencies.

### DIFF
--- a/packages/dtools/dtools.0.3.0/opam
+++ b/packages/dtools/dtools.0.3.0/opam
@@ -19,7 +19,7 @@ It includes support for:
  * logging
  * detaching and writing PID file
  * start-up and shutdown task manager"""
-flags: light-uninstall
+flags: [ light-uninstall deprecated ]
 url {
   src:
     "http://downloads.sourceforge.net/project/savonet/ocaml-dtools/0.3.0/ocaml-dtools-0.3.0.tar.gz"
@@ -28,3 +28,4 @@ url {
     "md5=0cbf60f517a936244ad4d98c6d904907"
   ]
 }
+x-maintenance-intent: ["(latest)"]

--- a/packages/dtools/dtools.0.3.2/opam
+++ b/packages/dtools/dtools.0.3.2/opam
@@ -22,7 +22,7 @@ It includes support for:
  * logging
  * detaching and writing PID file
  * start-up and shutdown task manager"""
-flags: light-uninstall
+flags: [ light-uninstall deprecated ]
 url {
   src:
     "https://github.com/savonet/ocaml-dtools/releases/download/0.3.2/ocaml-dtools-0.3.2.tar.gz"
@@ -31,3 +31,4 @@ url {
     "md5=804d89075e50f4db71cbd7d6f3c100e1"
   ]
 }
+x-maintenance-intent: ["(latest)"]

--- a/packages/dtools/dtools.0.3.3/opam
+++ b/packages/dtools/dtools.0.3.3/opam
@@ -22,7 +22,7 @@ It includes support for:
  * logging
  * detaching and writing PID file
  * start-up and shutdown task manager"""
-flags: light-uninstall
+flags: [ light-uninstall deprecated ]
 url {
   src:
     "https://github.com/savonet/ocaml-dtools/releases/download/0.3.3/ocaml-dtools-0.3.3.tar.gz"
@@ -31,3 +31,4 @@ url {
     "md5=ca5df5709d6298315689c8b0c2bdb2a1"
   ]
 }
+x-maintenance-intent: ["(latest)"]

--- a/packages/dtools/dtools.0.3.4/opam
+++ b/packages/dtools/dtools.0.3.4/opam
@@ -22,7 +22,7 @@ It includes support for:
  * logging
  * detaching and writing PID file
  * start-up and shutdown task manager"""
-flags: light-uninstall
+flags: [ light-uninstall deprecated ]
 url {
   src:
     "https://github.com/savonet/ocaml-dtools/releases/download/0.3.4/ocaml-dtools-0.3.4.tar.gz"
@@ -31,3 +31,4 @@ url {
     "md5=6f4c0467f469b8a1e03f34d35309a0b4"
   ]
 }
+x-maintenance-intent: ["(latest)"]

--- a/packages/dtools/dtools.0.4.0/opam
+++ b/packages/dtools/dtools.0.4.0/opam
@@ -25,7 +25,7 @@ It includes support for:
  * logging
  * detaching and writing PID file
  * start-up and shutdown task manager"""
-flags: light-uninstall
+flags: [ light-uninstall deprecated ]
 url {
   src:
     "https://github.com/savonet/ocaml-dtools/releases/download/0.4.0/ocaml-dtools-0.4.0.tar.gz"
@@ -34,3 +34,4 @@ url {
     "md5=2d351fbf5a4f5aef4963221c20ca5b00"
   ]
 }
+x-maintenance-intent: ["(latest)"]

--- a/packages/dtools/dtools.0.4.1/opam
+++ b/packages/dtools/dtools.0.4.1/opam
@@ -25,7 +25,7 @@ It includes support for:
  * logging
  * detaching and writing PID file
  * start-up and shutdown task manager"""
-flags: light-uninstall
+flags: [ light-uninstall deprecated ]
 url {
   src:
     "https://github.com/savonet/ocaml-dtools/releases/download/0.4.1/ocaml-dtools-0.4.1.tar.gz"
@@ -34,3 +34,4 @@ url {
     "md5=f211ec4634755271b80bf5d71091f21c"
   ]
 }
+x-maintenance-intent: ["(latest)"]

--- a/packages/dtools/dtools.0.4.2/opam
+++ b/packages/dtools/dtools.0.4.2/opam
@@ -32,3 +32,5 @@ url {
     "sha512=abd158530fc136598e6fdba6c70cc433984ef5d5e9abda80e1f5ac1b6975869b99cdff62dba96510f1bd64b4035ac7c8462a7e0a801a55158bf3204fb2771869"
   ]
 }
+x-maintenance-intent: ["(latest)"]
+flags: deprecated

--- a/packages/dtools/dtools.0.4.3/opam
+++ b/packages/dtools/dtools.0.4.3/opam
@@ -33,3 +33,5 @@ url {
     "sha512=643aeb7cbfcdab79110daf85a29c4a6fff7a965888820859a6c0d9cc14ba92a5ad3a1e84cb60176ac8cbe4a7cd30602032a05924d2d48795c62867b09dc290d8"
   ]
 }
+x-maintenance-intent: ["(latest)"]
+flags: deprecated

--- a/packages/dtools/dtools.0.4.4/opam
+++ b/packages/dtools/dtools.0.4.4/opam
@@ -33,3 +33,5 @@ url {
     "sha512=8416c3bfc49de7bfb92e6921c37512882589f3b7a6b9f51cb75e761697204b99a37827028a828861134c067a2efc06e80073dc0b5f5fb6529c7f4ff04f957984"
   ]
 }
+x-maintenance-intent: ["(latest)"]
+flags: deprecated

--- a/packages/dtools/dtools.0.4.5/opam
+++ b/packages/dtools/dtools.0.4.5/opam
@@ -35,3 +35,5 @@ url {
     "sha512=096ffdfc8ba04add0e106034d9f739b841763b28e05f947dc975665ce8ce6e7a66084f67e27e9843e07079588d1640f5077b0073427b614dc061d2a02ef323b5"
   ]
 }
+x-maintenance-intent: ["(latest)"]
+flags: deprecated

--- a/packages/dtools/dtools.0.4.6/opam
+++ b/packages/dtools/dtools.0.4.6/opam
@@ -35,3 +35,5 @@ url {
     "sha512=ceb00c45909c75590c4cbdd1f96461009f56c068cf6206153ab7e8c75e6e5f07119624f70bda8a265a93659d7036c4523a66ce2113e7edf576e26064e153fe9d"
   ]
 }
+x-maintenance-intent: ["(latest)"]
+flags: deprecated

--- a/packages/duppy/duppy.0.7.0/opam
+++ b/packages/duppy/duppy.0.7.0/opam
@@ -24,7 +24,7 @@ conflicts: ["liquidsoap" {<= "1.2.1"}]
 bug-reports: "https://github.com/savonet/ocaml-duppy/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-duppy.git"
 synopsis: "Library providing monadic threads"
-flags: light-uninstall
+flags: [ light-uninstall deprecated ]
 url {
   src:
     "https://github.com/savonet/ocaml-duppy/releases/download/0.7.0/ocaml-duppy-0.7.0.tar.gz"
@@ -33,3 +33,4 @@ url {
     "md5=609d9116adc8835abb088d7e0bc27ac9"
   ]
 }
+x-maintenance-intent: ["(latest)"]

--- a/packages/duppy/duppy.0.7.1/opam
+++ b/packages/duppy/duppy.0.7.1/opam
@@ -24,7 +24,7 @@ conflicts: ["liquidsoap" {<= "1.2.1"}]
 bug-reports: "https://github.com/savonet/ocaml-duppy/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-duppy.git"
 synopsis: "Library providing monadic threads"
-flags: light-uninstall
+flags: [ light-uninstall deprecated ]
 url {
   src:
     "https://github.com/savonet/ocaml-duppy/releases/download/0.7.1/ocaml-duppy-0.7.1.tar.gz"
@@ -33,3 +33,4 @@ url {
     "md5=c620df5edfadde598e575e618f0b9486"
   ]
 }
+x-maintenance-intent: ["(latest)"]

--- a/packages/duppy/duppy.0.7.3/opam
+++ b/packages/duppy/duppy.0.7.3/opam
@@ -24,7 +24,7 @@ conflicts: ["liquidsoap" {<= "1.2.1"}]
 bug-reports: "https://github.com/savonet/ocaml-duppy/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-duppy.git"
 synopsis: "Library providing monadic threads"
-flags: light-uninstall
+flags: [ light-uninstall deprecated ]
 url {
   src:
     "https://github.com/savonet/ocaml-duppy/releases/download/0.7.3/ocaml-duppy-0.7.3.tar.gz"
@@ -33,3 +33,4 @@ url {
     "md5=e76fa658d5b4ec81fd341d041b9ca9df"
   ]
 }
+x-maintenance-intent: ["(latest)"]

--- a/packages/duppy/duppy.0.8.0/opam
+++ b/packages/duppy/duppy.0.8.0/opam
@@ -23,7 +23,7 @@ conflicts: ["liquidsoap" {<= "1.2.1"}]
 bug-reports: "https://github.com/savonet/ocaml-duppy/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-duppy.git"
 synopsis: "Library providing monadic threads"
-flags: light-uninstall
+flags: [ light-uninstall deprecated ]
 url {
   src:
     "https://github.com/savonet/ocaml-duppy/releases/download/0.8.0/ocaml-duppy-0.8.0.tar.gz"
@@ -32,3 +32,4 @@ url {
     "md5=07c0eab9584b2236e90e2b88ee246677"
   ]
 }
+x-maintenance-intent: ["(latest)"]

--- a/packages/duppy/duppy.0.9.0/opam
+++ b/packages/duppy/duppy.0.9.0/opam
@@ -31,3 +31,5 @@ url {
     "sha512=f847e1ad9ff36f6107d4518296ba794085e8897539c4fb7ba98d3709708bd069b0467465a939bf6738966192219d9bc64eee9db40c55be8195df24390570eb3f"
   ]
 }
+x-maintenance-intent: ["(latest)"]
+flags: deprecated

--- a/packages/duppy/duppy.0.9.1/opam
+++ b/packages/duppy/duppy.0.9.1/opam
@@ -32,3 +32,5 @@ url {
     "sha512=f802a6d82f54970ef10d0a76cf8989cfcba509e10b4b04b0d0a3eac24c4a488d56f899fa92d879a52d82c139dc0d3dcd61d9cffa43d163dc6e3abc3840f3de67"
   ]
 }
+x-maintenance-intent: ["(latest)"]
+flags: deprecated

--- a/packages/duppy/duppy.0.9.2/opam
+++ b/packages/duppy/duppy.0.9.2/opam
@@ -32,3 +32,5 @@ url {
     "sha512=380947d4fa4d03c46ad5de82d8e9fbbd1fe3f0489ca7d3ef14de28f65aa189128a5496a194a35f833d29b0e7f32a4b90da76c68b83b729c536991c47fc4813b4"
   ]
 }
+x-maintenance-intent: ["(latest)"]
+flags: deprecated

--- a/packages/duppy/duppy.0.9.3/opam
+++ b/packages/duppy/duppy.0.9.3/opam
@@ -35,3 +35,5 @@ url {
     "sha512=a28afdf46521b3c3e4730af142dc24a7cdd7073857f30e394737caf5ca17afb97374078c2d54cfd9a5016d73203f03d5bd43d74e8c5fc96599dc6c81d861738a"
   ]
 }
+x-maintenance-intent: ["(latest)"]
+flags: deprecated

--- a/packages/duppy/duppy.0.9.4/opam
+++ b/packages/duppy/duppy.0.9.4/opam
@@ -35,3 +35,5 @@ url {
     "sha512=c2167c6217fd14b51e77cdc5d818907b6957c099892a7a8c2ce6b1a46daa05b753062930002575744315b5363f05bc56832792f8968da19c75aa8da3ee338e70"
   ]
 }
+x-maintenance-intent: ["(latest)"]
+flags: deprecated

--- a/packages/duppy/duppy.0.9.5/opam
+++ b/packages/duppy/duppy.0.9.5/opam
@@ -35,3 +35,5 @@ url {
     "sha512=9859a933d20777a0c1c12388b27953a391f71fe699c421ac52505ffab7321cef10454833927bf27355b0775192d8e6a2647c4fa5efe4874289db81577b9955d5"
   ]
 }
+x-maintenance-intent: ["(latest)"]
+flags: deprecated

--- a/packages/liquidsoap/liquidsoap.2.3.3/opam
+++ b/packages/liquidsoap/liquidsoap.2.3.3/opam
@@ -17,8 +17,6 @@ bug-reports: "https://github.com/savonet/liquidsoap/issues"
 depends: [
   "dune" {>= "3.18"}
   "ocaml" {>= "4.14"}
-  "dtools" {>= "0.4.6"}
-  "duppy" {>= "0.9.4"}
   "mm" {>= "0.8.6"}
   "re" {>= "1.11.0"}
   "ocurl" {>= "0.9.2"}


### PR DESCRIPTION
Some house keeping that was overlooked during the last liquidsoap release:
* Liquidsoap now includes the code for `duppy` and `dtools`
* `dtools` and `duppy` are now deprecated and can be removed from the repository whenever appropriate

Those two packages never saw a wide adoption outside of liquidsoap's codebase so it makes sense to remove them this way in an effort to declutter the packages repository.