### PR TITLE
Package iri.1.1.0

### DIFF
--- a/packages/iri/iri.1.1.0/opam
+++ b/packages/iri/iri.1.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Implementation of Internationalized Resource Identifiers (IRIs)"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["iri" "web" "rfc3987"]
+homepage: "https://framagit.org/zoggy/ocaml-iri/"
+doc: "https://zoggy.frama.io/ocaml-iri/refdoc/iri/IRI/index.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-iri/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "sedlex" {>= "2.3"}
+  "uunf" {>= "0.9.7"}
+  "uutf" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-iri.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-iri/releases/ocaml-iri-1.1.0.tar.bz2"
+  checksum: [
+    "md5=7ad954858ca5127f23b83a750d349435"
+    "sha512=2ed315880978f7d11e3561ba7af90d4bc5c04b3bd34e7b842de8b6cc694c8137dc30b913e6624dc8117a1a4d6a248b07d905992e683a6d080db8817e0018e5bb"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `iri.1.1.0`
Implementation of Internationalized Resource Identifiers (IRIs)



---
* Homepage: https://framagit.org/zoggy/ocaml-iri/
* Source repo: git+https://framagit.org/zoggy/ocaml-iri.git
* Bug tracker: https://framagit.org/zoggy/ocaml-iri/issues

---
:camel: Pull-request generated by opam-publish v2.5.1