### PR TITLE
7 packages from zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.5.0.tar.gz

### DIFF
--- a/packages/ldp/ldp.0.5.0/opam
+++ b/packages/ldp/ldp.0.5.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "cohttp-lwt" {>= "5.3.0"}
+  "cohttp-lwt" {< "6"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.3"}
+  "ocaml" {>= "4.14.0"}
+  "ocf" {>= "0.8.0"}
+  "ocf_ppx" {>= "0.8.0"}
+  "rdf" {>= "1.0.0"}
+  "rdf_ppx" {>= "1.0.0"}
+  "sedlex" {>= "2.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.5.0.tar.gz"
+  checksum: [
+    "md5=fee838e51dd241528ad271c6ef56345a"
+    "sha512=cbb718fb10fbc12c3b2f38a57d87e6af13e108699bf5a812cc490ed3397ed9c0f5d2793b5848c7e6d75a47dd10cfa87ba8bacc119f01733f22cc116ea045b27f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/ldp_curl/ldp_curl.0.5.0/opam
+++ b/packages/ldp_curl/ldp_curl.0.5.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications using Curl"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "ocurl" {>= "0.9.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.5.0.tar.gz"
+  checksum: [
+    "md5=fee838e51dd241528ad271c6ef56345a"
+    "sha512=cbb718fb10fbc12c3b2f38a57d87e6af13e108699bf5a812cc490ed3397ed9c0f5d2793b5848c7e6d75a47dd10cfa87ba8bacc119f01733f22cc116ea045b27f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/ldp_js/ldp_js.0.5.0/opam
+++ b/packages/ldp_js/ldp_js.0.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications in JS"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "js_of_ocaml" {>= "6.0.1"}
+  "js_of_ocaml-ppx" {>= "6.0.1"}
+  "cohttp-lwt-jsoo" {>= "5.3.0"}
+  "cohttp-lwt-jsoo" {< "6"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.5.0.tar.gz"
+  checksum: [
+    "md5=fee838e51dd241528ad271c6ef56345a"
+    "sha512=cbb718fb10fbc12c3b2f38a57d87e6af13e108699bf5a812cc490ed3397ed9c0f5d2793b5848c7e6d75a47dd10cfa87ba8bacc119f01733f22cc116ea045b27f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/ldp_tls/ldp_tls.0.5.0/opam
+++ b/packages/ldp_tls/ldp_tls.0.5.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications using TLS"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "tls-lwt" {>= "1.0.2"}
+  "tls" {>= "1.0.2"}
+  "ppx_sexp_conv"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.5.0.tar.gz"
+  checksum: [
+    "md5=fee838e51dd241528ad271c6ef56345a"
+    "sha512=cbb718fb10fbc12c3b2f38a57d87e6af13e108699bf5a812cc490ed3397ed9c0f5d2793b5848c7e6d75a47dd10cfa87ba8bacc119f01733f22cc116ea045b27f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/solid/solid.0.5.0/opam
+++ b/packages/solid/solid.0.5.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Library to build SOLID applications"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.5.0.tar.gz"
+  checksum: [
+    "md5=fee838e51dd241528ad271c6ef56345a"
+    "sha512=cbb718fb10fbc12c3b2f38a57d87e6af13e108699bf5a812cc490ed3397ed9c0f5d2793b5848c7e6d75a47dd10cfa87ba8bacc119f01733f22cc116ea045b27f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/solid_server/solid_server.0.5.0/opam
+++ b/packages/solid_server/solid_server.0.5.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "SOLID server under development"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "calendar" {>= "2.04"}
+  "cohttp-lwt-unix" {>= "5.3.0"}
+  "cohttp-lwt-unix" {< "6"}
+  "cryptokit" {>= "1.16.1"}
+  "fpath" {>= "0.7.3"}
+  "git-unix" {>= "3.4.0"}
+  "ldp_curl" {= version}
+  "ldp_tls" {= version}
+  "ocaml" {>= "4.14.0"}
+  "ppx_blob" {>= "0.9.0"}
+  "solid" {= version}
+  "webmachine" {>= "0.7.0"}
+  "xtmpl" {>= "0.19.0"}
+  "xtmpl_ppx" {>= "0.19.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.5.0.tar.gz"
+  checksum: [
+    "md5=fee838e51dd241528ad271c6ef56345a"
+    "sha512=cbb718fb10fbc12c3b2f38a57d87e6af13e108699bf5a812cc490ed3397ed9c0f5d2793b5848c7e6d75a47dd10cfa87ba8bacc119f01733f22cc116ea045b27f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/solid_tools/solid_tools.0.5.0/opam
+++ b/packages/solid_tools/solid_tools.0.5.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Library to build SOLID tools"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.14.0"}
+  "ldp_curl" {= version}
+  "ldp_tls" {= version}
+  "solid" {= version}
+  "ocf" {>= "0.8.0"}
+  "ocf_ppx" {>= "0.8.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-ldp/releases/ocaml-ldp-0.5.0.tar.gz"
+  checksum: [
+    "md5=fee838e51dd241528ad271c6ef56345a"
+    "sha512=cbb718fb10fbc12c3b2f38a57d87e6af13e108699bf5a812cc490ed3397ed9c0f5d2793b5848c7e6d75a47dd10cfa87ba8bacc119f01733f22cc116ea045b27f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `ldp.0.5.0`: Library to build LDP applications
- `ldp_curl.0.5.0`: Library to build LDP applications using Curl
- `ldp_js.0.5.0`: Library to build LDP applications in JS
- `ldp_tls.0.5.0`: Library to build LDP applications using TLS
- `solid.0.5.0`: Library to build SOLID applications
- `solid_server.0.5.0`: SOLID server under development
- `solid_tools.0.5.0`: Library to build SOLID tools



---
* Homepage: https://zoggy.frama.io/ocaml-ldp/
* Source repo: git+https://framagit.org/zoggy/ocaml-ldp.git
* Bug tracker: https://framagit.org/zoggy/ocaml-ldp/issues

---
:camel: Pull-request generated by opam-publish v2.5.1