### PR TITLE
[new release] metrics (5 packages) (0.5.0)

### DIFF
--- a/packages/albatross/albatross.1.0.1/opam
+++ b/packages/albatross/albatross.1.0.1/opam
@@ -31,7 +31,7 @@ depends: [
   "duration"
   "decompress" {>= "0.9.0" & < "1.0.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
 ]

--- a/packages/albatross/albatross.1.1.0/opam
+++ b/packages/albatross/albatross.1.1.0/opam
@@ -33,7 +33,7 @@ depends: [
   "decompress" {>= "1.2.0" & < "1.3.0"}
   "bigstringaf"
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "hex"

--- a/packages/albatross/albatross.1.1.0/opam
+++ b/packages/albatross/albatross.1.1.0/opam
@@ -31,7 +31,7 @@ depends: [
   "asn1-combinators" {>= "0.2.0" & < "0.3.0"}
   "duration"
   "decompress" {>= "1.2.0" & < "1.3.0"}
-  "bigstringaf"
+  "bigstringaf" {>= "0.2.0"}
   "checkseum"
   "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}

--- a/packages/albatross/albatross.1.1.1/opam
+++ b/packages/albatross/albatross.1.1.1/opam
@@ -31,7 +31,7 @@ depends: [
   "asn1-combinators" {>= "0.2.0" & < "0.3.0"}
   "duration"
   "decompress" {>= "1.3.0"}
-  "bigstringaf"
+  "bigstringaf" {>= "0.2.0"}
   "checkseum"
   "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}

--- a/packages/albatross/albatross.1.1.1/opam
+++ b/packages/albatross/albatross.1.1.1/opam
@@ -33,7 +33,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf"
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "hex"

--- a/packages/albatross/albatross.1.2.0/opam
+++ b/packages/albatross/albatross.1.2.0/opam
@@ -33,7 +33,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.1.3.0/opam
+++ b/packages/albatross/albatross.1.3.0/opam
@@ -32,7 +32,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.1.3.1/opam
+++ b/packages/albatross/albatross.1.3.1/opam
@@ -31,7 +31,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.1.4.0/opam
+++ b/packages/albatross/albatross.1.4.0/opam
@@ -29,7 +29,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.1.4.1/opam
+++ b/packages/albatross/albatross.1.4.1/opam
@@ -29,7 +29,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.1.4.2/opam
+++ b/packages/albatross/albatross.1.4.2/opam
@@ -29,7 +29,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.1.4.3/opam
+++ b/packages/albatross/albatross.1.4.3/opam
@@ -29,7 +29,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.1.5.0/opam
+++ b/packages/albatross/albatross.1.5.0/opam
@@ -29,7 +29,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.1.5.1/opam
+++ b/packages/albatross/albatross.1.5.1/opam
@@ -29,7 +29,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.1.5.2/opam
+++ b/packages/albatross/albatross.1.5.2/opam
@@ -29,7 +29,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.1.5.3/opam
+++ b/packages/albatross/albatross.1.5.3/opam
@@ -29,7 +29,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.1.5.4/opam
+++ b/packages/albatross/albatross.1.5.4/opam
@@ -29,7 +29,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.1.5.5/opam
+++ b/packages/albatross/albatross.1.5.5/opam
@@ -29,7 +29,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.1.5.6/opam
+++ b/packages/albatross/albatross.1.5.6/opam
@@ -30,7 +30,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.2.0.0/opam
+++ b/packages/albatross/albatross.2.0.0/opam
@@ -30,7 +30,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.2.1.0/opam
+++ b/packages/albatross/albatross.2.1.0/opam
@@ -30,7 +30,7 @@ depends: [
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "checkseum"
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.2.2.0/opam
+++ b/packages/albatross/albatross.2.2.0/opam
@@ -26,7 +26,7 @@ depends: [
   "duration"
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.2.3.0/opam
+++ b/packages/albatross/albatross.2.3.0/opam
@@ -26,7 +26,7 @@ depends: [
   "duration"
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.2.4.0/opam
+++ b/packages/albatross/albatross.2.4.0/opam
@@ -26,7 +26,7 @@ depends: [
   "duration"
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/albatross/albatross.2.4.1/opam
+++ b/packages/albatross/albatross.2.4.1/opam
@@ -26,7 +26,7 @@ depends: [
   "duration"
   "decompress" {>= "1.3.0"}
   "bigstringaf" {>= "0.2.0"}
-  "metrics" {>= "0.2.0"}
+  "metrics" {>= "0.2.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"

--- a/packages/builder-web/builder-web.0.1.0/opam
+++ b/packages/builder-web/builder-web.0.1.0/opam
@@ -32,7 +32,7 @@ depends: [
   "alcotest" {with-test}
   "opam-core"
   "opam-format" {>= "2.1.0"}
-  "metrics" {>= "0.3.0"}
+  "metrics" {>= "0.3.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.3.0"}
   "metrics-influx" {>= "0.3.0"}
   "metrics-rusage" {>= "0.3.0"}

--- a/packages/builder-web/builder-web.0.2.0/opam
+++ b/packages/builder-web/builder-web.0.2.0/opam
@@ -29,7 +29,7 @@ depends: [
   "kdf"
   "opam-core"
   "opam-format" {>= "2.1.0"}
-  "metrics" {>= "0.3.0"}
+  "metrics" {>= "0.3.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.3.0"}
   "metrics-influx" {>= "0.3.0"}
   "metrics-rusage" {>= "0.3.0"}

--- a/packages/metrics-influx/metrics-influx.0.5.0/opam
+++ b/packages/metrics-influx/metrics-influx.0.5.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Hannes Mehnert"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.4"}
+  "metrics" {= version}
+  "fmt" {>= "0.8.7"}
+  "duration"
+  "lwt" {>= "2.4.7"}
+]
+synopsis: "Influx reporter for the Metrics library"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.5.0/metrics-0.5.0.tbz"
+  checksum: [
+    "sha256=df356380909d06461bcd097ef6063ca9f3c51365f476a797c03664b53c05715d"
+    "sha512=06e0aef8ba7a09a350cbf7219822c01047afcc9cd2870ca153040e1232d2b8560882ae6823e7797f061fa0b34da750d88365c8817cd025715b2e891320d77c19"
+  ]
+}
+x-commit-hash: "5d3133c4a461d00eb97cc31b09d8126e49632c0f"

--- a/packages/metrics-lwt/metrics-lwt.0.5.0/opam
+++ b/packages/metrics-lwt/metrics-lwt.0.5.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.4"}
+  "metrics" {= version}
+  "lwt" {>= "2.4.7"}
+  "logs"
+]
+synopsis: "Lwt backend for the Metrics library"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.5.0/metrics-0.5.0.tbz"
+  checksum: [
+    "sha256=df356380909d06461bcd097ef6063ca9f3c51365f476a797c03664b53c05715d"
+    "sha512=06e0aef8ba7a09a350cbf7219822c01047afcc9cd2870ca153040e1232d2b8560882ae6823e7797f061fa0b34da750d88365c8817cd025715b2e891320d77c19"
+  ]
+}
+x-commit-hash: "5d3133c4a461d00eb97cc31b09d8126e49632c0f"

--- a/packages/metrics-rusage/metrics-rusage.0.5.0/opam
+++ b/packages/metrics-rusage/metrics-rusage.0.5.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "team@robur.coop"
+authors:      ["Reynir Bjoernsson" "Hannes Mehnert"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.4"}
+  "metrics" {= version}
+  "logs"
+  "fmt" {>= "0.8.7"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "Resource usage (getrusage) sources for the Metrics library"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.5.0/metrics-0.5.0.tbz"
+  checksum: [
+    "sha256=df356380909d06461bcd097ef6063ca9f3c51365f476a797c03664b53c05715d"
+    "sha512=06e0aef8ba7a09a350cbf7219822c01047afcc9cd2870ca153040e1232d2b8560882ae6823e7797f061fa0b34da750d88365c8817cd025715b2e891320d77c19"
+  ]
+}
+x-commit-hash: "5d3133c4a461d00eb97cc31b09d8126e49632c0f"

--- a/packages/metrics-unix/metrics-unix.0.5.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.5.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.4"}
+  "uuidm" {>= "0.9.9"}
+  "metrics" {= version}
+  "mtime" {>= "1.0.0"}
+  "lwt" {>= "2.4.7"}
+  "metrics-lwt" {= version & with-test}
+  "conf-gnuplot"
+  "fmt" {>= "0.8.7"}
+]
+synopsis: "Unix backend for the Metrics library"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.5.0/metrics-0.5.0.tbz"
+  checksum: [
+    "sha256=df356380909d06461bcd097ef6063ca9f3c51365f476a797c03664b53c05715d"
+    "sha512=06e0aef8ba7a09a350cbf7219822c01047afcc9cd2870ca153040e1232d2b8560882ae6823e7797f061fa0b34da750d88365c8817cd025715b2e891320d77c19"
+  ]
+}
+x-commit-hash: "5d3133c4a461d00eb97cc31b09d8126e49632c0f"

--- a/packages/metrics/metrics.0.5.0/opam
+++ b/packages/metrics/metrics.0.5.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.4"}
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+]
+synopsis: "Metrics infrastructure for OCaml"
+description: """
+Metrics provides a basic infrastructure to monitor and gather runtime
+metrics for OCaml program. Monitoring is performed on sources, indexed
+by tags, allowing users to enable or disable at runtime the gathering
+of data-points. As disabled metric sources have a low runtime cost
+(only a closure allocation), the library is designed to instrument
+production systems.
+
+Metric reporting is decoupled from monitoring and is handled by a
+custom reporter. A few reporters are (will be) provided by default.
+
+Metrics is heavily inspired by
+[Logs](http://erratique.ch/software/logs).
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.5.0/metrics-0.5.0.tbz"
+  checksum: [
+    "sha256=df356380909d06461bcd097ef6063ca9f3c51365f476a797c03664b53c05715d"
+    "sha512=06e0aef8ba7a09a350cbf7219822c01047afcc9cd2870ca153040e1232d2b8560882ae6823e7797f061fa0b34da750d88365c8817cd025715b2e891320d77c19"
+  ]
+}
+x-commit-hash: "5d3133c4a461d00eb97cc31b09d8126e49632c0f"

--- a/packages/mirage-monitoring/mirage-monitoring.0.0.1/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.11.0"}
   "dune"
   "logs" {>= "0.6.3"}
-  "metrics" {>= "0.4.0"}
+  "metrics" {>= "0.4.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/mirage-monitoring/mirage-monitoring.0.0.2/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.2/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.11.0"}
   "dune"
   "logs" {>= "0.6.3"}
-  "metrics" {>= "0.4.0"}
+  "metrics" {>= "0.4.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/mirage-monitoring/mirage-monitoring.0.0.3/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.3/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.11.0"}
   "dune"
   "logs" {>= "0.6.3"}
-  "metrics" {>= "0.4.0"}
+  "metrics" {>= "0.4.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/mirage-monitoring/mirage-monitoring.0.0.4/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.4/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.11.0"}
   "dune"
   "logs" {>= "0.6.3"}
-  "metrics" {>= "0.4.0"}
+  "metrics" {>= "0.4.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/mirage-monitoring/mirage-monitoring.0.0.5/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.5/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.11.0"}
   "dune"
   "logs" {>= "0.6.3"}
-  "metrics" {>= "0.4.0"}
+  "metrics" {>= "0.4.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "mirage-time" {>= "2.0.0"}

--- a/packages/mirage-monitoring/mirage-monitoring.0.0.6/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.6/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.11.0"}
   "dune"
   "logs" {>= "0.6.3"}
-  "metrics" {>= "0.4.0"}
+  "metrics" {>= "0.4.0" & < "0.5.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
   "mirage-sleep" {>= "4.0.0"}


### PR DESCRIPTION
Metrics infrastructure for OCaml

- Project page: <a href="https://github.com/mirage/metrics">https://github.com/mirage/metrics</a>
- Documentation: <a href="https://mirage.github.io/metrics/">https://mirage.github.io/metrics/</a>

##### CHANGES:

- Cache_reporter: add a get_cache function, remove the returned get_cache
  function, document get_cache depends on cache_reporter (mirage/metrics#63 @reynir @hannesm)
- Cache_reporter: add a callback function for pushing updates (mirage/metrics#63 @hannesm)
- Cache_reporter: preserve a list of (tags, data), fixes mirage/metrics#59 (mirage/metrics#68 @hannesm)
- Update uuidm (mirage/metrics#61 @reynir)
- Fix documentation link (reported in mirage/metrics#62 by @reynir, fixed mirage/metrics#69 by @hannesm)
- Fix documentation of Src.v (reported in mirage/metrics#64 by @reynir, fixed mirage/metrics#69 by @hannesm)
