### PR TITLE
[new release] postgresql (5.2.0)

### DIFF
--- a/packages/postgresql/postgresql.5.2.0/opam
+++ b/packages/postgresql/postgresql.5.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Bindings to the PostgreSQL library"
+description:
+  "Postgresql offers library functions for accessing PostgreSQL databases."
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "dune-configurator"
+  "conf-postgresql" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/postgresql-ocaml/releases/download/5.2.0/postgresql-5.2.0.tbz"
+  checksum: [
+    "sha256=b94fcaee1bd09631a75330a53d1768777dada5500677fb06aa1dcda88ca02780"
+    "sha512=efcfbf65fba55b0c90eda97982a3e83f51021b899b032333b51e4908ab6cb77d546c5a10df0986ce4fb86df45c438c3947b37f1751e097c70ace02aff945b469"
+  ]
+}
+x-commit-hash: "ab0050d77fe5f26532c3af224c8d3a64dcf8b606"


### PR DESCRIPTION
Bindings to the PostgreSQL library

- Project page: <a href="https://mmottl.github.io/postgresql-ocaml">https://mmottl.github.io/postgresql-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/postgresql-ocaml/api">https://mmottl.github.io/postgresql-ocaml/api</a>

##### CHANGES:

### Added

- `binary_result` to `send_query` and `send_query_prepared`. Thanks to
  Christophe Raffalli for the contribution.
- `pre-commit` configuration and GitHub workflow.
