### PR TITLE
6 packages from zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.5.0.tar.bz2

### DIFF
--- a/packages/stk/stk.0.5.0/opam
+++ b/packages/stk/stk.0.5.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "SDL-based GUI toolkit"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "5.2.0"}
+  "css" {>= "0.3.0"}
+  "fmt" {>= "0.9.0"}
+  "higlo" {>= "0.10.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.2"}
+  "pcre" {>= "7.5.0"}
+  "ocf" {>= "0.9.0"}
+  "ocf_ppx" {>= "0.9.0"}
+  "ppx_blob" {>= "0.9.0"}
+  "ptime" {>= "1.1.0"}
+  "sedlex" {>= "1.2"}
+  "stk_ppx" {= version}
+  "tsdl" {>= "1.1.0"}
+  "tsdl-image" {>= "0.3.2"}
+  "tsdl-ttf" {>= "0.3.2"}
+  "uunf" {>= "15.0.0"}
+  "uutf" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.5.0.tar.bz2"
+  checksum: [
+    "md5=beeed5752ff67b3abeb1bcf8fb6b9098"
+    "sha512=c1603ae66956a674864ad875212fdbfc8d8016983202108d492b0d8722106b1e982e9fdc04b20d1b7adf5013343252fc5173851751906271731bc81d70dc789c"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/stk_iconv/stk_iconv.0.5.0/opam
+++ b/packages/stk_iconv/stk_iconv.0.5.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Bindings to GNU libiconv"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ctypes" {>= "0.20.1"}
+  "ctypes-foreign" {>= "0.18.0"}
+  "logs" {>= "0.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.5.0.tar.bz2"
+  checksum: [
+    "md5=beeed5752ff67b3abeb1bcf8fb6b9098"
+    "sha512=c1603ae66956a674864ad875212fdbfc8d8016983202108d492b0d8722106b1e982e9fdc04b20d1b7adf5013343252fc5173851751906271731bc81d70dc789c"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/stk_ocf/stk_ocf.0.5.0/opam
+++ b/packages/stk_ocf/stk_ocf.0.5.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Utils to build GUI above Ocf"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocf" {>= "0.9.0"}
+  "stk" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.5.0.tar.bz2"
+  checksum: [
+    "md5=beeed5752ff67b3abeb1bcf8fb6b9098"
+    "sha512=c1603ae66956a674864ad875212fdbfc8d8016983202108d492b0d8722106b1e982e9fdc04b20d1b7adf5013343252fc5173851751906271731bc81d70dc789c"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/stk_ppx/stk_ppx.0.5.0/opam
+++ b/packages/stk_ppx/stk_ppx.0.5.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "PPX used for debug logging in Stk"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "5.2.0"}
+  "ppxlib"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.5.0.tar.bz2"
+  checksum: [
+    "md5=beeed5752ff67b3abeb1bcf8fb6b9098"
+    "sha512=c1603ae66956a674864ad875212fdbfc8d8016983202108d492b0d8722106b1e982e9fdc04b20d1b7adf5013343252fc5173851751906271731bc81d70dc789c"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/stk_rdf/stk_rdf.0.5.0/opam
+++ b/packages/stk_rdf/stk_rdf.0.5.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Utilities to display and edit RDF data"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "rdf" {>= "1.0.0"}
+  "stk" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.5.0.tar.bz2"
+  checksum: [
+    "md5=beeed5752ff67b3abeb1bcf8fb6b9098"
+    "sha512=c1603ae66956a674864ad875212fdbfc8d8016983202108d492b0d8722106b1e982e9fdc04b20d1b7adf5013343252fc5173851751906271731bc81d70dc789c"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/stk_xml/stk_xml.0.5.0/opam
+++ b/packages/stk_xml/stk_xml.0.5.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Library to display xml/html"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ldp" {>= "0.4.0"}
+  "ppx_blob" {>= "0.9.0"}
+  "stk" {= version}
+  "stk_rdf" {= version}
+  "xtmpl" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-stk/releases/ocaml-stk-0.5.0.tar.bz2"
+  checksum: [
+    "md5=beeed5752ff67b3abeb1bcf8fb6b9098"
+    "sha512=c1603ae66956a674864ad875212fdbfc8d8016983202108d492b0d8722106b1e982e9fdc04b20d1b7adf5013343252fc5173851751906271731bc81d70dc789c"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `stk.0.5.0`: SDL-based GUI toolkit
- `stk_iconv.0.5.0`: Bindings to GNU libiconv
- `stk_ocf.0.5.0`: Utils to build GUI above Ocf
- `stk_ppx.0.5.0`: PPX used for debug logging in Stk
- `stk_rdf.0.5.0`: Utilities to display and edit RDF data
- `stk_xml.0.5.0`: Library to display xml/html



---
* Homepage: https://zoggy.frama.io/ocaml-stk/
* Source repo: git+https://framagit.org/zoggy/ocaml-stk.git
* Bug tracker: https://framagit.org/zoggy/ocaml-stk/issues

---
:camel: Pull-request generated by opam-publish v2.5.1