### PR TITLE
[new release] ppx_deriving_yaml (2 packages) (0.4.1)

### DIFF
--- a/packages/ppx_deriving_ezjsonm/ppx_deriving_ezjsonm.0.4.1/opam
+++ b/packages/ppx_deriving_ezjsonm/ppx_deriving_ezjsonm.0.4.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Ezjsonm PPX"
+description:
+  "Deriving conversion functions to and from JSON for your OCaml types."
+maintainer: ["patrick@sirref.org"]
+authors: ["Patrick Ferris"]
+license: "ISC"
+tags: ["ppx" "deriver" "json"]
+homepage: "https://github.com/patricoferris/ppx_deriving_yaml"
+bug-reports: "https://github.com/patricoferris/ppx_deriving_yaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ezjsonm"
+  "alcotest" {with-test}
+  "mdx" {with-test & >= "2.4.1"}
+  "ppx_deriving" {with-test}
+  "ocaml" {>= "4.08.1"}
+  "ppxlib" {>= "0.36.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/patricoferris/ppx_deriving_yaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v0.4.1/ppx_deriving_yaml-0.4.1.tbz"
+  checksum: [
+    "sha256=dc2bef3043aaff7237589e97e44ca8a6268c8ec859a0430f9362b82f1d25752a"
+    "sha512=da2801971d93a2c19196d724e08883c87dd1025f5491e54ccef81b26a9f133872d2c195065092bd2d753f78748065b0db6801a58cbbc0d5bbfcbdbe9509196f4"
+  ]
+}
+x-commit-hash: "a46e6088926d21cca045b58cd369d752706dfe3b"

--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.4.1/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.4.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Yaml PPX"
+description:
+  "Deriving conversion functions to and from yaml for your OCaml types."
+maintainer: ["patrick@sirref.org"]
+authors: ["Patrick Ferris"]
+license: "ISC"
+tags: ["ppx" "deriver" "yaml"]
+homepage: "https://github.com/patricoferris/ppx_deriving_yaml"
+bug-reports: "https://github.com/patricoferris/ppx_deriving_yaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "yaml"
+  "alcotest" {with-test}
+  "mdx" {with-test & >= "2.4.1"}
+  "ppx_deriving" {with-test}
+  "ocaml" {>= "4.08.1"}
+  "ppxlib" {>= "0.36.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/patricoferris/ppx_deriving_yaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v0.4.1/ppx_deriving_yaml-0.4.1.tbz"
+  checksum: [
+    "sha256=dc2bef3043aaff7237589e97e44ca8a6268c8ec859a0430f9362b82f1d25752a"
+    "sha512=da2801971d93a2c19196d724e08883c87dd1025f5491e54ccef81b26a9f133872d2c195065092bd2d753f78748065b0db6801a58cbbc0d5bbfcbdbe9509196f4"
+  ]
+}
+x-commit-hash: "a46e6088926d21cca045b58cd369d752706dfe3b"


### PR DESCRIPTION
Yaml PPX

- Project page: <a href="https://github.com/patricoferris/ppx_deriving_yaml">https://github.com/patricoferris/ppx_deriving_yaml</a>

##### CHANGES:

- Update for latest ppxlib (patricoferris/ppx_deriving_yaml#61, @patricoferris)
