### PR TITLE
Package ppxlib_jane.v0.17.4

### DIFF
--- a/packages/ppxlib_jane/ppxlib_jane.v0.17.4/opam
+++ b/packages/ppxlib_jane/ppxlib_jane.v0.17.4/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppxlib_jane"
+bug-reports: "https://github.com/janestreet/ppxlib_jane/issues"
+dev-repo: "git+https://github.com/janestreet/ppxlib_jane.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppxlib_jane/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.3.0"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Utilities for working with Jane Street AST constructs"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppxlib_jane/archive/refs/tags/v0.17.4.tar.gz"
+  checksum: [
+    "md5=98e9ff635c515e55b70a2c5239c520ee"
+    "sha512=7ac1faa8e74da195165edc8d3e21b3c6a5c28b340232a7536a12041e5a0ce451e3c3338d9d5444284b15c416da435d3633d095eef8d24bf3b68dc290a5d33b00"
+  ]
+}


### PR DESCRIPTION
### `ppxlib_jane.v0.17.4`
Utilities for working with Jane Street AST constructs
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppxlib_jane
* Source repo: git+https://github.com/janestreet/ppxlib_jane.git
* Bug tracker: https://github.com/janestreet/ppxlib_jane/issues

---
:camel: Pull-request generated by opam-publish v2.5.1