### PR TITLE
[new release] ocamlformat-mlx (2 packages) (0.27.0.1)

### DIFF
--- a/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.27.0.1/opam
+++ b/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.27.0.1/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "OCaml .mlx Code Formatter"
+description:
+  "OCamlFormat is a tool to automatically format OCaml .mlx code in a uniform style."
+maintainer: ["Andrey Popp <me@andreypopp.com>"]
+authors: [
+  "Andrey Popp <me@andreypopp.com>"
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+homepage: "https://github.com/ocaml-mlx/ocamlformat-mlx"
+bug-reports: "https://github.com/ocaml-mlx/ocamlformat-mlx/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "alcotest" {with-test & >= "1.3.0"}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.8"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath" {>= "0.7.3"}
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.5.0"}
+  "ocp-indent" {with-test = "false" & >= "1.8.0" | with-test & >= "1.8.1"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "astring"
+  "camlp-streams"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-mlx/ocamlformat-mlx.git"
+# OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-mlx/ocamlformat-mlx/releases/download/0.27.0.1/ocamlformat-mlx-0.27.0.1.tbz"
+  checksum: [
+    "sha256=4557bcca3d2bd2b6d37b046a84a82a1bed83e46e45e363c0b209d30d70c0ec77"
+    "sha512=2802651c733bf3535ce9d2e4e533729da75b17e9507d911f4d79d1a68f35ddfb82db1daf8815a46d57a9937dea5b5466d523739c217ace0e446738208037ec2d"
+  ]
+}
+x-commit-hash: "0bfdee6b33e413afc70a2c8f0c1e06e46e40efb7"

--- a/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.27.0.1/opam
+++ b/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.27.0.1/opam
@@ -14,7 +14,7 @@ authors: [
 homepage: "https://github.com/ocaml-mlx/ocamlformat-mlx"
 bug-reports: "https://github.com/ocaml-mlx/ocamlformat-mlx/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.4"}
   "alcotest" {with-test & >= "1.3.0"}
   "base" {>= "v0.12.0"}
   "cmdliner" {>= "1.1.0"}

--- a/packages/ocamlformat-mlx/ocamlformat-mlx.0.27.0.1/opam
+++ b/packages/ocamlformat-mlx/ocamlformat-mlx.0.27.0.1/opam
@@ -19,7 +19,7 @@ authors: [
 homepage: "https://github.com/ocaml-mlx/ocamlformat-mlx"
 bug-reports: "https://github.com/ocaml-mlx/ocamlformat-mlx/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.4"}
   "cmdliner" {with-test = "false" & >= "1.1.0" | with-test & >= "1.2.0"}
   "csexp" {>= "1.4.0"}
   "dune" {>= "2.8"}

--- a/packages/ocamlformat-mlx/ocamlformat-mlx.0.27.0.1/opam
+++ b/packages/ocamlformat-mlx/ocamlformat-mlx.0.27.0.1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml .mlx code"
+description: """
+**ocamlformat** is a code formatter for OCaml. It comes with opinionated default settings but is also fully customizable to suit your coding style.
+
+- **Profiles:** ocamlformat offers profiles we predefined formatting configurations. Profiles include `default`, `ocamlformat`, `janestreet`.
+- **Configurable:** Users can change the formatting profile and configure every option in their `.ocamlformat` configuration file.
+- **Format Comments:** ocamlformat can format comments, docstrings, and even code blocks in your comments.
+- **RPC:** ocamlformat provides an RPC server that can be used by other tools to easily format OCaml Code."""
+maintainer: ["Andrey Popp <me@andreypopp.com>"]
+authors: [
+  "Andrey Popp <me@andreypopp.com>"
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+homepage: "https://github.com/ocaml-mlx/ocamlformat-mlx"
+bug-reports: "https://github.com/ocaml-mlx/ocamlformat-mlx/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "cmdliner" {with-test = "false" & >= "1.1.0" | with-test & >= "1.2.0"}
+  "csexp" {>= "1.4.0"}
+  "dune" {>= "2.8"}
+  "ocamlformat-mlx-lib" {= version}
+  "re" {>= "1.10.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-mlx/ocamlformat-mlx.git"
+# OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-mlx/ocamlformat-mlx/releases/download/0.27.0.1/ocamlformat-mlx-0.27.0.1.tbz"
+  checksum: [
+    "sha256=4557bcca3d2bd2b6d37b046a84a82a1bed83e46e45e363c0b209d30d70c0ec77"
+    "sha512=2802651c733bf3535ce9d2e4e533729da75b17e9507d911f4d79d1a68f35ddfb82db1daf8815a46d57a9937dea5b5466d523739c217ace0e446738208037ec2d"
+  ]
+}
+x-commit-hash: "0bfdee6b33e413afc70a2c8f0c1e06e46e40efb7"


### PR DESCRIPTION
Auto-formatter for OCaml .mlx code

- Project page: <a href="https://github.com/ocaml-mlx/ocamlformat-mlx">https://github.com/ocaml-mlx/ocamlformat-mlx</a>

##### CHANGES:

- relax OCaml constraints, compatible with OCaml 5.3
