### PR TITLE
[new release] pcre (8.0.4)

### DIFF
--- a/packages/pcre/pcre.8.0.4/opam
+++ b/packages/pcre/pcre.8.0.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Bindings to the Perl Compatibility Regular Expressions library"
+description: """
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: ["Markus Mottl <markus.mottl@gmail.com>"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "dune-configurator"
+  "conf-libpcre" {build}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/pcre-ocaml/releases/download/8.0.4/pcre-8.0.4.tbz"
+  checksum: [
+    "sha256=088a32dc2a38627559e409048e451aaea574bb4f1902a534210b1a2f54a7b820"
+    "sha512=f42ceb53956e522dc0f364a0d9fc4e0699f9d08534e562b4b2ae20c9bb6c6423e9cb1d0b65eaab4c82244b8623707e9b314ae8ff9718061d6dc629bf0a8e3f95"
+  ]
+}
+x-commit-hash: "fe8118d39a1bcb679c37a54de9a44fda8f08444e"


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library

- Project page: <a href="https://mmottl.github.io/pcre-ocaml">https://mmottl.github.io/pcre-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/pcre-ocaml/api">https://mmottl.github.io/pcre-ocaml/api</a>

##### CHANGES:

### Fixed

- Squelch uninitialized-value warnings. Thanks to Nathan Taylor for the
  contribution.
