### PR TITLE
[new release] merlin and ocaml-lsp (6 packages) (4.19-414)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.19-414/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.19-414/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {>= "4.17"}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.19-414/merlin-4.19-414.tbz"
+  checksum: [
+    "sha256=60a630f59203a9ce7047a5f04d0f239945960dac6f38102922e328b6d2657384"
+    "sha512=19f8ec152356873e29c05b971a529146bb7079929037c2b35a5c0afb0b3adf662341ee8527282c5fdd16de391d01c2c469fc8629af9e0ae443fa9f42472b70bb"
+  ]
+}
+x-commit-hash: "de2dc6fc7863b1624e7dbb9c6af6a6fb9b30c644"

--- a/packages/dot-merlin-reader/dot-merlin-reader.4.19-414/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.19-414/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.0.0"}
-  "merlin-lib" {>= "4.17"}
+  "merlin-lib" {= version}
   "ocamlfind" {>= "1.6.0"}
 ]
 description:

--- a/packages/jsonrpc/jsonrpc.1.21.0-4.14/opam
+++ b/packages/jsonrpc/jsonrpc.1.21.0-4.14/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.21.0-4.14/lsp-1.21.0-4.14.tbz"
+  checksum: [
+    "sha256=f2de91772b72116d4746e1208c28ebe61a09e000313c9af92a0616df639637ec"
+    "sha512=bc823d8b60b4fa31f75fb25edda405a016b621a676bde5f3d44b484e0ed67a91a885f19918a2a1d7c299823fac9900c5db9beb2c37d3a5dfe8f3ef78a40999fe"
+  ]
+}
+x-commit-hash: "4fb73155251d669f21bcfef14ba2a1890869a11b"

--- a/packages/lsp/lsp.1.21.0-4.14/opam
+++ b/packages/lsp/lsp.1.21.0-4.14/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "jsonrpc" {= version}
+  "yojson" {< "3.0.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "cinaps" {with-test}
+  "ppx_expect" {>= "v0.15.0" & < "0.17.0" & with-test}
+  "uutf" {>= "1.0.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.14"}
+  "ppx_yojson_conv" {with-dev-setup}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.21.0-4.14/lsp-1.21.0-4.14.tbz"
+  checksum: [
+    "sha256=f2de91772b72116d4746e1208c28ebe61a09e000313c9af92a0616df639637ec"
+    "sha512=bc823d8b60b4fa31f75fb25edda405a016b621a676bde5f3d44b484e0ed67a91a885f19918a2a1d7c299823fac9900c5db9beb2c37d3a5dfe8f3ef78a40999fe"
+  ]
+}
+x-commit-hash: "4fb73155251d669f21bcfef14ba2a1890869a11b"

--- a/packages/merlin-lib/merlin-lib.4.19-414/opam
+++ b/packages/merlin-lib/merlin-lib.4.19-414/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test & >= "1.3.0" }
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.19-414/merlin-4.19-414.tbz"
+  checksum: [
+    "sha256=60a630f59203a9ce7047a5f04d0f239945960dac6f38102922e328b6d2657384"
+    "sha512=19f8ec152356873e29c05b971a529146bb7079929037c2b35a5c0afb0b3adf662341ee8527282c5fdd16de391d01c2c469fc8629af9e0ae443fa9f42472b70bb"
+  ]
+}
+x-commit-hash: "de2dc6fc7863b1624e7dbb9c6af6a6fb9b30c644"

--- a/packages/merlin/merlin.4.19-414/opam
+++ b/packages/merlin/merlin.4.19-414/opam
@@ -1,0 +1,82 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.17.1"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.19-414/merlin-4.19-414.tbz"
+  checksum: [
+    "sha256=60a630f59203a9ce7047a5f04d0f239945960dac6f38102922e328b6d2657384"
+    "sha512=19f8ec152356873e29c05b971a529146bb7079929037c2b35a5c0afb0b3adf662341ee8527282c5fdd16de391d01c2c469fc8629af9e0ae443fa9f42472b70bb"
+  ]
+}
+x-commit-hash: "de2dc6fc7863b1624e7dbb9c6af6a6fb9b30c644"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.20.1-4.14/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.20.1-4.14/opam
@@ -44,7 +44,7 @@ depends: [
   "csexp" {>= "1.5"}
   "ocamlformat-rpc-lib" {>= "0.21.0"}
   "odoc" {with-doc}
-  "merlin-lib" {>= "4.18" & < "5.0"}
+  "merlin-lib" {>= "4.18" & < "4.19"}
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.21.0-4.14/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.21.0-4.14/opam
@@ -44,7 +44,7 @@ depends: [
   "csexp" {>= "1.5"}
   "ocamlformat-rpc-lib" {>= "0.21.0"}
   "odoc" {with-doc}
-  "merlin-lib" {>= "4.18" & < "5.0"}
+  "merlin-lib" {>= "4.19" & < "5.0"}
   "ppx_yojson_conv" {with-dev-setup}
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.21.0-4.14/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.21.0-4.14/opam
@@ -23,7 +23,7 @@ depends: [
   "base" {>= "v0.16.0"}
   "lsp" {= version}
   "jsonrpc" {= version}
-  "re" {>= "1.5.0"}
+  "re" {>= "1.7.2"}
   "ppx_yojson_conv_lib" {>= "v0.14"}
   "dune-rpc" {>= "3.4.0"}
   "chrome-trace" {>= "3.3.0"}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.21.0-4.14/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.21.0-4.14/opam
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson" {< "3.0.0"}
+  "base" {>= "v0.16.0"}
+  "lsp" {= version}
+  "jsonrpc" {= version}
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc" {>= "3.4.0"}
+  "chrome-trace" {>= "3.3.0"}
+  "dyn"
+  "stdune"
+  "fiber" {>= "3.1.1" & < "4.0.0"}
+  "ocaml" {>= "4.14.0" & < "5.0"}
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "astring"
+  "camlp-streams"
+  "ppx_expect" {>= "v0.15.0" & < "0.17.0" & with-test}
+  "ocamlformat" {with-test & = "0.27.0"}
+  "ocamlc-loc" {>= "3.7.0"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "merlin-lib" {>= "4.18" & < "5.0"}
+  "ppx_yojson_conv" {with-dev-setup}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.21.0-4.14/lsp-1.21.0-4.14.tbz"
+  checksum: [
+    "sha256=f2de91772b72116d4746e1208c28ebe61a09e000313c9af92a0616df639637ec"
+    "sha512=bc823d8b60b4fa31f75fb25edda405a016b621a676bde5f3d44b484e0ed67a91a885f19918a2a1d7c299823fac9900c5db9beb2c37d3a5dfe8f3ef78a40999fe"
+  ]
+}
+x-commit-hash: "4fb73155251d669f21bcfef14ba2a1890869a11b"


### PR DESCRIPTION
Editor helper, provides completion, typing and source browsing in Vim and Emacs

- Project page: <a href="https://github.com/ocaml/merlin">https://github.com/ocaml/merlin</a>

# Merlin CHANGES:

Mon Jun 23 10:10:42 CEST 2025

  + merlin library
    - Expose utilities to manipulate typed-holes in `Merlin_analysis.Typed_hole`
      (ocaml/merlin#1888)
    - `inlay-hints` fix inlay hints on function parameters (ocaml/merlin#1923)
    - Handle class type in outline (ocaml/merlin#1932)
    - Handle locally defined value in outline (ocaml/merlin#1936)
  + vim plugin
    - Added support for search-by-type (ocaml/merlin#1846)
      This is exposed through the existing `:MerlinSearch` command, that
      switches between search-by-type and polarity search depending on the
      first character of the query.

# OCaml-LSP CHANGES:

## Features

- Make `inlay-hint` for function parameters configurable (https://github.com/ocaml/ocaml-lsp/pull/1515)

- Add custom `ocamllsp/jumpToTypedHole` to navigate through typed holes (https://github.com/ocaml/ocaml-lsp/pull/1516)

- Add a code-action for combining pattern cases (just relaying on regex) (https://github.com/ocaml/ocaml-lsp/pull/1514)

- Allow (by configuration) shortening of diagnostics (just highlighting the first line) (https://github.com/ocaml/ocaml-lsp/pull/1513)

- Fix `yojson_of_t` for `Nullable_option`: serialize `None` as `Null` instead of asserting false (https://github.com/ocaml/ocaml-lsp/pull/1525 fixes https://github.com/ocaml/ocaml-lsp/issues/1524)

## Fixes

- Support for `class`, `class type`, `method` and `property` for `DocumentSymbol` query (https://github.com/ocaml/ocaml-lsp/pull/1487 fixes https://github.com/ocaml/ocaml-lsp/issues/1449)

- Fix `inlay-hint` for function parameters (https://github.com/ocaml/ocaml-lsp/pull/1515)

- More precise diagnostics in the event of a failed identifier search (`Definition_query`) (https://github.com/ocaml/ocaml-lsp/pull/1518)

- Remove `ocamlformat` application after `destruct` (that remove some useful parenthesis) (https://github.com/ocaml/ocaml-lsp/pull/1519)

- Add a new server option `standardHover`, that can be used by clients to
  disable the default hover provider.  When `standardHover = false`
  `textDocument/hover` requests always returns with empty result. (https://github.com/ocaml/ocaml-lsp/pull/1416)