### PR TITLE
[new release] bstr (3 packages) (0.0.2)

### DIFF
--- a/packages/bin/bin.0.0.2/opam
+++ b/packages/bin/bin.0.0.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://git.robur.coop/robur/bstr"
+bug-reports:  "https://git.robur.coop/robur/bstr"
+dev-repo:     "git+https://github.com/robur-coop/bstr"
+doc:          "https://robur-coop.github.io/bstr/"
+license:      "MIT"
+synopsis:     "A DSL to describe binary formats"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.14.0"}
+  "dune"        {>= "3.5.0"}
+  "slice"       {= version}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/bstr/releases/download/v0.0.2/bstr-0.0.2.tbz"
+  checksum: [
+    "sha256=ff3bf3081cd3d35e0e7ac4e6c4604307df19454fbe60d0cb519f2e6832b791e3"
+    "sha512=83ad7dcd09f9670efa8b78d7cbb36860da3d5d90dcbd9f5fadaa031a78354c6bdf7de88bce38afc5a221cb2b75bdaaa9062c6650813ec088b51686ee9a22e285"
+  ]
+}
+x-commit-hash: "0230273b9ee86175d9efe96f228c87a3fc06f17b"

--- a/packages/bstr/bstr.0.0.2/opam
+++ b/packages/bstr/bstr.0.0.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://git.robur.coop/robur/bstr"
+bug-reports:  "https://git.robur.coop/robur/bstr"
+dev-repo:     "git+https://github.com/robur-coop/bstr"
+doc:          "https://robur-coop.github.io/bstr/"
+license:      "MIT"
+synopsis:     "A simple library for bigstrings"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.14.0"}
+  "dune"        {>= "3.5.0"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/bstr/releases/download/v0.0.2/bstr-0.0.2.tbz"
+  checksum: [
+    "sha256=ff3bf3081cd3d35e0e7ac4e6c4604307df19454fbe60d0cb519f2e6832b791e3"
+    "sha512=83ad7dcd09f9670efa8b78d7cbb36860da3d5d90dcbd9f5fadaa031a78354c6bdf7de88bce38afc5a221cb2b75bdaaa9062c6650813ec088b51686ee9a22e285"
+  ]
+}
+x-commit-hash: "0230273b9ee86175d9efe96f228c87a3fc06f17b"

--- a/packages/slice/slice.0.0.2/opam
+++ b/packages/slice/slice.0.0.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://git.robur.coop/robur/bstr"
+bug-reports:  "https://git.robur.coop/robur/bstr"
+dev-repo:     "git+https://github.com/robur-coop/bstr"
+doc:          "https://robur-coop.github.io/bstr/"
+license:      "MIT"
+synopsis:     "A Slice type for bigstrings and bytes"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.14.0"}
+  "dune"        {>= "3.5.0"}
+  "bstr"        {= version}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/bstr/releases/download/v0.0.2/bstr-0.0.2.tbz"
+  checksum: [
+    "sha256=ff3bf3081cd3d35e0e7ac4e6c4604307df19454fbe60d0cb519f2e6832b791e3"
+    "sha512=83ad7dcd09f9670efa8b78d7cbb36860da3d5d90dcbd9f5fadaa031a78354c6bdf7de88bce38afc5a221cb2b75bdaaa9062c6650813ec088b51686ee9a22e285"
+  ]
+}
+x-commit-hash: "0230273b9ee86175d9efe96f228c87a3fc06f17b"


### PR DESCRIPTION
A simple library for bigstrings

- Project page: <a href="https://git.robur.coop/robur/bstr">https://git.robur.coop/robur/bstr</a>
- Documentation: <a href="https://robur-coop.github.io/bstr/">https://robur-coop.github.io/bstr/</a>

##### CHANGES:

- Fix SIGSEGV when we use `memmove`
