### PR TITLE
Allow ocaml-option-fp on arm64 starting with OCaml 5.4

### DIFF
--- a/packages/ocaml-option-fp/ocaml-option-fp.1/opam
+++ b/packages/ocaml-option-fp/ocaml-option-fp.1/opam
@@ -8,9 +8,11 @@ homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "CC0-1.0+"
 depends: [
-  "ocaml-variants" {post & (os = "linux" & >= "4.12.0~" | os = "macos" & >= "5.3.0~")}
+  "ocaml-variants" {post & ((os = "linux" & arch = "x86_64" & >= "4.12.0~") |
+                            (os = "macos" & arch = "x86_64" & >= "5.3.0~") |
+                            (arch = "arm64" & >= "5.4.0~"))}
 ]
 conflicts: ["ocaml-option-musl"]
-available: (os = "linux" | os = "macos") & arch = "x86_64"
+available: (os = "linux" | os = "macos") & (arch = "x86_64" | arch = "arm64")
 maintainer: "David Allsopp <david@tarides.com>"
 flags: compiler


### PR DESCRIPTION
The changelog states:
```
- #13500: Add frame pointers support for ARM64 on Linux and macOS.
  (Tim McGilchrist, review by KC Sivaramakrishnan, Fabrice Buoro
   and Miod Vallat)
```