### PR TITLE
patch.3.0.0~alpha2: Add missing avoid-version flag

### DIFF
--- a/packages/patch/patch.3.0.0~alpha2/opam
+++ b/packages/patch/patch.3.0.0~alpha2/opam
@@ -15,6 +15,8 @@ depends: [
   "alcotest" {with-test & >= "1.7.0"}
   "crowbar" {with-test}
 ]
+available: opam-version >= "2.1.0"
+flags: avoid-version
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
I seem to have forgotten to use `opam publish --pre-release` when i published #27842 