### PR TITLE
[new release] merlin (4 packages) (5.5-503)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.5.5-503/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.5-503/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" }
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.5-503/merlin-5.5-503.tbz"
+  checksum: [
+    "sha256=67da3b34f2fea07678267309f61da4a2c6f08298de0dc59655b8d30fd8269af1"
+    "sha512=1fb3b5180d36aa82b82a319e15b743b802b6888f0dc67645baafdb4e18dfc23a7b90064ec9bc42f7424061cf8cde7f8839178d8a8537bf4596759f3ff4891873"
+  ]
+}
+x-commit-hash: "8b88b89ee7431a23eaf95e4e02e45dc65595aa74"

--- a/packages/merlin-lib/merlin-lib.5.5-503/opam
+++ b/packages/merlin-lib/merlin-lib.5.5-503/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="5.3" & <"5.4"}
+  "dune" {>= "3.0.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test & >= "1.3.0" }
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.5-503/merlin-5.5-503.tbz"
+  checksum: [
+    "sha256=67da3b34f2fea07678267309f61da4a2c6f08298de0dc59655b8d30fd8269af1"
+    "sha512=1fb3b5180d36aa82b82a319e15b743b802b6888f0dc67645baafdb4e18dfc23a7b90064ec9bc42f7424061cf8cde7f8839178d8a8537bf4596759f3ff4891873"
+  ]
+}
+x-commit-hash: "8b88b89ee7431a23eaf95e4e02e45dc65595aa74"

--- a/packages/merlin/merlin.5.5-503/opam
+++ b/packages/merlin/merlin.5.5-503/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {= version}
+  "ocaml-index" {>= "1.0" & post}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.5-503/merlin-5.5-503.tbz"
+  checksum: [
+    "sha256=67da3b34f2fea07678267309f61da4a2c6f08298de0dc59655b8d30fd8269af1"
+    "sha512=1fb3b5180d36aa82b82a319e15b743b802b6888f0dc67645baafdb4e18dfc23a7b90064ec9bc42f7424061cf8cde7f8839178d8a8537bf4596759f3ff4891873"
+  ]
+}
+x-commit-hash: "8b88b89ee7431a23eaf95e4e02e45dc65595aa74"

--- a/packages/ocaml-index/ocaml-index.5.5-503/opam
+++ b/packages/ocaml-index/ocaml-index.5.5-503/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A tool that indexes value usages from cmt files"
+description:
+  "ocaml-index should integrate with the build system to index codebase and allow tools such as Merlin to perform project-wide occurrences queries."
+maintainer: ["ulysse@tarides.com"]
+authors: ["ulysse@tarides.com"]
+license: "MIT"
+homepage: "https://github.com/ocaml/merlin/ocaml-index"
+bug-reports: "https://github.com/ocaml/merlin/issues"
+x-maintenance-intent: ["(latest)"]
+depends: [
+  "dune" {>= "3.0.0"}
+  "ocaml" {>= "5.3"}
+  "merlin-lib" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.5-503/merlin-5.5-503.tbz"
+  checksum: [
+    "sha256=67da3b34f2fea07678267309f61da4a2c6f08298de0dc59655b8d30fd8269af1"
+    "sha512=1fb3b5180d36aa82b82a319e15b743b802b6888f0dc67645baafdb4e18dfc23a7b90064ec9bc42f7424061cf8cde7f8839178d8a8537bf4596759f3ff4891873"
+  ]
+}
+x-commit-hash: "8b88b89ee7431a23eaf95e4e02e45dc65595aa74"


### PR DESCRIPTION
Editor helper, provides completion, typing and source browsing in Vim and Emacs

- Project page: <a href="https://github.com/ocaml/merlin">https://github.com/ocaml/merlin</a>

##### CHANGES:

Tue Jun 24 16:10:42 CEST 2025

  + merlin library
    - Expose utilities to manipulate typed-holes in `Merlin_analysis.Typed_hole`
      (ocaml/merlin#1888)
    - `locate` can now disambiguate between files with identical names and contents
      (ocaml/merlin#1882)
    - `occurrences` now reports stale files (ocaml/merlin#1885)
    - `inlay-hints` fix inlay hints on function parameters (ocaml/merlin#1923)
    - Fix issues with ident validation and Lid comparison for occurrences (ocaml/merlin#1924)
    - Handle class type in outline (ocaml/merlin#1932)
    - Handle locally defined value in outline (ocaml/merlin#1936)
    - Fix a typer issue triggering assertions in the short-paths graph (ocaml/merlin#1935,
      fixes ocaml/merlin#1913)
    - Downstreamed a typer fix from 5.3.X that would trigger assertions linked
      to scopes bit masks when backtracking the typer cache (ocaml/merlin#1935)
    - Add a new selection field to outline results that contains the location of
      the symbol itself. (ocaml/merlin#1942)
    - Fix destruct hanging when printing patterns with (::). (ocaml/merlin#1944, fixes
      ocaml/ocaml-lsp#1489)
    - Reproduce and fix a handful of jump-to-definition (locate) issues  (ocaml/merlin#1930,
      fixes ocaml/merlin#1580 and ocaml/merlin#1588, workaround for ocaml/merlin#1934)
  + ocaml-index
    - Improve the granularity of index reading by segmenting the marshalization
      of the involved data-structures. (ocaml/merlin#1889)
  + test suite
    - Add a test case illustrating wrong open order proposed in issue ocaml/merlin#1900. (ocaml/merlin#1901)
