### PR TITLE
mark gmp-xen and minios-xen as unmaintained

### DIFF
--- a/packages/gmp-xen/gmp-xen.6.0.0-1/opam
+++ b/packages/gmp-xen/gmp-xen.6.0.0-1/opam
@@ -58,3 +58,4 @@ extra-source "gmp-6a.diff" {
     "md5=ef379d00b52fd8138627e8d13606736c"
   ]
 }
+x-maintenance-intent: [ "(none)" ]

--- a/packages/minios-xen/minios-xen.0.9/opam
+++ b/packages/minios-xen/minios-xen.0.9/opam
@@ -44,3 +44,4 @@ extra-source "build-opam.sh" {
     "md5=93746a0c93f75851c8a8f81e7e8b5d82"
   ]
 }
+x-maintenance-intent: [ "(none)" ]


### PR DESCRIPTION
these are relicts from earlier MirageOS compilation strategies, and have not been used since mirage 3