### PR TITLE
Package ppxlib_jane.v0.17.4

### DIFF
--- a/packages/ppxlib_jane/ppxlib_jane.v0.17.4/opam
+++ b/packages/ppxlib_jane/ppxlib_jane.v0.17.4/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppxlib_jane"
+bug-reports: "https://github.com/janestreet/ppxlib_jane/issues"
+dev-repo: "git+https://github.com/janestreet/ppxlib_jane.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppxlib_jane/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.3.0"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Utilities for working with Jane Street AST constructs"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppxlib_jane/archive/refs/tags/v0.17.4.tar.gz"
+  checksum: [
+    "md5=d572c6d6c3b4da9e480c65ba85d3c50a"
+    "sha512=e2931de633d9dcce2ca121e1cf117e159af4ccc52a7e420c328021da0145b6b90194e4545f97afe9cd032c04c6bc2563faa2d852ad45b041b014c688153799d6"
+  ]
+}


### PR DESCRIPTION
### `ppxlib_jane.v0.17.4`
Utilities for working with Jane Street AST constructs
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppxlib_jane
* Source repo: git+https://github.com/janestreet/ppxlib_jane.git
* Bug tracker: https://github.com/janestreet/ppxlib_jane/issues

---
:camel: Pull-request generated by opam-publish v2.5.1