### PR TITLE
Publish Mirage/Unikraft packages v1.0.0

### DIFF
--- a/packages/mirage-block-unikraft/mirage-block-unikraft.1.0.0/opam
+++ b/packages/mirage-block-unikraft/mirage-block-unikraft.1.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Unikraft implementation of MirageOS block interface"
+description:
+  "This library implements the MirageOS block interface for Unikraft targets."
+maintainer: ["team@mirage.org"]
+authors: [
+  "Fabrice Buoro <fabrice@tarides.com>" "Samuel Hym <samuel@tarides.com>"
+]
+license: "BSD-3-Clause"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/mirage-block-unikraft"
+bug-reports: "https://github.com/mirage/mirage-block-unikraft/issues"
+depends: [
+  "ocaml" {>= "5.2.0"}
+  "dune" {>= "3.0" & >= "3.0"}
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-unikraft" {>= "1.0.0"}
+  "fmt" {>= "0.8.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block-unikraft.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-block-unikraft/archive/refs/tags/v1.0.0.tar.gz"
+  checksum:
+    "sha256=281449a4bf028fd8439e95468145d158f9a2c0de27d3240e46acc1140e5d017e"
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/mirage-net-unikraft/mirage-net-unikraft.1.0.0/opam
+++ b/packages/mirage-net-unikraft/mirage-net-unikraft.1.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Unikraft implementation of MirageOS network interface"
+description:
+  "This library implements the MirageOS network interface for Unikraft targets."
+maintainer: ["team@mirage.org"]
+authors: ["Fabrice Buoro <fabrice@tarides.com>"]
+license: "BSD-3-Clause"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/mirage-net-unikraft"
+bug-reports: "https://github.com/mirage/mirage-net-unikraft/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "5.2.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "mirage-unikraft" {>= "1.0.0"}
+  "logs" {>= "0.6.0"}
+  "metrics"
+  "fmt" {>= "0.8.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/mirage-net-unikraft.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-net-unikraft/archive/refs/tags/v1.0.0.tar.gz"
+  checksum:
+    "sha256=8d736b578da486bf7ba82879793354afbadc9a673da2e5a3cb0fb5d28b859a44"
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/mirage-unikraft/mirage-unikraft.1.0.0/opam
+++ b/packages/mirage-unikraft/mirage-unikraft.1.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Unikraft core platform libraries for MirageOS"
+description:
+  "This packages provides the MirageOS `OS` library for Unikraft targets."
+maintainer: ["Fabrice Buoro" "Samuel Hym"]
+authors: ["Fabrice Buoro" "Samuel Hym"]
+license: "MIT"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/mirage-unikraft"
+bug-reports: "https://github.com/mirage/mirage-unikraft/issues"
+depends: [
+  "ocaml" {>= "5.3.0"}
+  "dune" {>= "3.16"}
+  "mirage-runtime"
+  "mirage-sleep"
+  "bheap"
+  "lwt"
+  "metrics"
+  "duration"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/mirage-unikraft.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-unikraft/archive/refs/tags/v1.0.0.tar.gz"
+  checksum:
+    "sha256=c48d534a366d25d1c4959535595f48b16d91ca44fc19399710a9231405fa7eab"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
Publish the 3 implementation packages for MirageOS on Unikraft:
- mirage-unikraft for the OS interface
- mirage-net-unikraft for the network interface
- mirage-block-unikraft for the block devices

This is joint work with @fabbing and @Firobe.