### PR TITLE
Update opam

### DIFF
--- a/packages/dune/dune.3.12.1/opam
+++ b/packages/dune/dune.3.12.1/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.4"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]


### PR DESCRIPTION
Due to 
```
#=== ERROR while compiling dune.3.12.1 ========================================#
# context              2.3.0 | linux/x86_64 | ocaml-base-compiler.5.4.0~alpha1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.4~alpha1/.opam-switch/build/dune.3.12.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml boot/bootstrap.ml -j 71
# exit-code            2
# env-file             ~/.opam/log/dune-7-453624.env
# output-file          [...]
# File "vendor/notty/src/notty.ml", lines 387-397, characters 43-7:
# Error: Some record fields are undefined: out_width
```