### PR TITLE
Restrict non-working ocaml version for dune

### DIFF
--- a/packages/dune/dune.3.10.0/opam
+++ b/packages/dune/dune.3.10.0/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & "5.3"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.3"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.10.0/opam
+++ b/packages/dune/dune.3.10.0/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & "5.3"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.17.2/opam
+++ b/packages/dune/dune.3.17.2/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.4"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
   "lwt" { with-dev-setup & os != "win32" }

--- a/packages/dune/dune.3.18.2/opam
+++ b/packages/dune/dune.3.18.2/opam
@@ -43,7 +43,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.4"}
   "base-unix"
   "base-threads"
   "lwt" { with-dev-setup & os != "win32" }

--- a/packages/dune/dune.3.18.2/opam
+++ b/packages/dune/dune.3.18.2/opam
@@ -43,7 +43,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  "ocaml" {>= "4.08" & < "5.4"}
+  "ocaml" {>= "4.08"}
   "base-unix"
   "base-threads"
   "lwt" { with-dev-setup & os != "win32" }

--- a/packages/dune/dune.3.5.0/opam
+++ b/packages/dune/dune.3.5.0/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.3"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]


### PR DESCRIPTION
Similar to:
- #28091

Related PRs adapting dune to ocaml 5.4:
- https://github.com/ocaml/dune/pull/11639 (first present in dune `3.19.0_alpha0`)
- https://github.com/ocaml/dune/pull/11482 (first present in dune `3.18.0_alpha0`)