### PR TITLE
[new release] jsonschema (0.1.0)

### DIFF
--- a/packages/jsonschema/jsonschema.0.1.0/opam
+++ b/packages/jsonschema/jsonschema.0.1.0/opam
@@ -9,12 +9,12 @@ tags: ["json" "jsonschema"]
 homepage: "https://github.com/tmattio/ocaml-jsonschema"
 bug-reports: "https://github.com/tmattio/ocaml-jsonschema/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.13"}
   "dune" {>= "3.19"}
-  "re"
+  "re" {>= "1.7.2"}
   "yojson"
   "ppx_deriving_yojson"
-  "base64"
+  "base64" {>= "3.0.0"}
   "uri"
   "odoc" {with-doc}
 ]

--- a/packages/jsonschema/jsonschema.0.1.0/opam
+++ b/packages/jsonschema/jsonschema.0.1.0/opam
@@ -28,7 +28,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+#    "@runtest" {with-test} # requires updating git submodules, but this is not supported
     "@doc" {with-doc}
   ]
 ]

--- a/packages/jsonschema/jsonschema.0.1.0/opam
+++ b/packages/jsonschema/jsonschema.0.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "JSON Schema validator for OCaml"
+description:
+  "A comprehensive JSON Schema validator implementation for OCaml supporting drafts 4, 6, 7, 2019-09, and 2020-12. This library provides full validation of JSON documents against JSON Schema definitions with detailed error reporting, support for all standard validation keywords, format validators, and content encoding/decoding. It includes features like remote schema resolution, custom format validators, and multiple output formats for validation results."
+maintainer: ["Thibaut Mattio <thibaut.mattio@gmail.com>"]
+authors: ["Thibaut Mattio <thibaut.mattio@gmail.com>"]
+license: "ISC"
+tags: ["json" "jsonschema"]
+homepage: "https://github.com/tmattio/ocaml-jsonschema"
+bug-reports: "https://github.com/tmattio/ocaml-jsonschema/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.19"}
+  "re"
+  "yojson"
+  "ppx_deriving_yojson"
+  "base64"
+  "uri"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tmattio/ocaml-jsonschema.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/tmattio/ocaml-jsonschema/releases/download/0.1.0/jsonschema-0.1.0.tbz"
+  checksum: [
+    "sha256=21a3ff475202fe598f639c4dc5b03355f169d9d77b4f17ecd5a1aca9b475b93e"
+    "sha512=ce90853ca15dfe5e52289f4fb5ce92275dcde931114312f77fd6e817c0727708ebb006546a6b5ce05332a9c1a49c07d7c6a8131e54a02085cc999a6d823a06e8"
+  ]
+}
+x-commit-hash: "30de41f2c0a58d57424c2b2d46304274adfd3cf3"


### PR DESCRIPTION
JSON Schema validator for OCaml

- Project page: <a href="https://github.com/tmattio/ocaml-jsonschema">https://github.com/tmattio/ocaml-jsonschema</a>

##### CHANGES:

### Features

- Initial release with support for JSON Schema drafts 4, 6, 7, 2019-09, and 2020-12
- Complete type validation system (null, boolean, number, integer, string, array, object)
- Schema composition with allOf, anyOf, oneOf, not, and if/then/else
- Full object validation including properties, patternProperties, and additionalProperties
- Array validation with items, contains, and uniqueItems support
- JSON Reference resolution with $ref, $id, and $anchor support
- Format validation for common formats (email, date, time, ipv4, ipv6, uri, uuid, etc.)
- JSON Pointer implementation (RFC 6901)
- Content validation with base64 encoding and JSON media type support
