### PR TITLE
jsonrpc is not compatible with yojson < 3.0.0

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.15.1-5.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.15.1-5.0/opam
@@ -22,6 +22,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
+conflicts: [ "yojson" {>= "3.0.0"} ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/jsonrpc/jsonrpc.1.17.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.17.0/opam
@@ -22,6 +22,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
+conflicts: [ "yojson" {>= "3.0.0"} ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/jsonrpc/jsonrpc.1.18.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.18.0/opam
@@ -22,6 +22,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
+conflicts: [ "yojson" {>= "3.0.0"} ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/jsonrpc/jsonrpc.1.20.1/opam
+++ b/packages/jsonrpc/jsonrpc.1.20.1/opam
@@ -22,6 +22,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
+conflicts: [ "yojson" {>= "3.0.0"} ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/jsonrpc/jsonrpc.1.21.0-4.14/opam
+++ b/packages/jsonrpc/jsonrpc.1.21.0-4.14/opam
@@ -22,6 +22,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
+conflicts: [ "yojson" {>= "3.0.0"} ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/jsonrpc/jsonrpc.1.21.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.21.0/opam
@@ -22,6 +22,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
+conflicts: [ "yojson" {>= "3.0.0"} ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/jsonrpc/jsonrpc.1.22.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.22.0/opam
@@ -22,6 +22,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
+conflicts: [ "yojson" {>= "3.0.0"} ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/jsonrpc/jsonrpc.1.23.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.23.0/opam
@@ -22,6 +22,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
+conflicts: [ "yojson" {>= "3.0.0"} ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/jsonrpc/jsonrpc.1.4.1/opam
+++ b/packages/jsonrpc/jsonrpc.1.4.1/opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/ocaml/ocaml-lsp"
 bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
   "dune" {>= "2.5"}
-  "yojson"
+  "yojson" {< "3.0.0"}
   "stdlib-shims"
   "ocaml-syntax-shims"
   "ppx_yojson_conv_lib"

--- a/packages/jsonrpc/jsonrpc.1.5.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.5.0/opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/ocaml/ocaml-lsp"
 bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
   "dune" {>= "2.5"}
-  "yojson"
+  "yojson" {< "3.0.0"}
   "stdlib-shims"
   "ocaml-syntax-shims"
   "ppx_yojson_conv_lib"

--- a/packages/jsonrpc/jsonrpc.1.6.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.6.0/opam
@@ -19,6 +19,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
+conflicts: [ "yojson" {>= "3.0.0"} ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Due to the removal of the Tuple and Variant variants. See also https://github.com/ocaml/ocaml-lsp/pull/1534.