### PR TITLE
Attempt to fix nuscr 2.0.0 cram tests

### DIFF
--- a/packages/nuscr/nuscr.2.0.0/opam
+++ b/packages/nuscr/nuscr.2.0.0/opam
@@ -11,7 +11,6 @@ license: "GPL-3.0-or-later"
 homepage: "https://nuscr.dev/"
 doc: "https://nuscr.dev/nuscr/docs/"
 bug-reports: "https://github.com/nuscr/nuscr/issues"
-available: [ os != "freebsd" ]
 depends: [
   "ocaml" {>= "4.08"}
   "menhir" {>= "20190924" & < "20211215"}
@@ -53,7 +52,7 @@ url {
 x-commit-hash: "376b3b0af868aea0a7be12423b9724afdec21154"
 extra-source "fix-cram-tests.patch" {
   src:
-    "https://gist.githubusercontent.com/smuenzel/2752f84b7535431d8cb3ae05b1e55f21/raw/275366a225f5c9ba8be058b51b01701303e02ac5/nuscr-2.0.0.patch"
+    "https://github.com/ocaml/opam-source-archives/raw/refs/heads/main/patches/nuscr/fix-cram-tests.2.0.0.patch"
   checksum:
     "sha256=d507ff18224ae597ce1989cdf22fe91290061d0d7de71b7c1fed45b9c2c28a6d"
 }

--- a/packages/nuscr/nuscr.2.0.0/opam
+++ b/packages/nuscr/nuscr.2.0.0/opam
@@ -52,7 +52,7 @@ url {
 x-commit-hash: "376b3b0af868aea0a7be12423b9724afdec21154"
 extra-source "fix-cram-tests.patch" {
   src:
-    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/nuscr/fix-cram-tests.patch"
+    "https://gist.githubusercontent.com/smuenzel/2752f84b7535431d8cb3ae05b1e55f21/raw/275366a225f5c9ba8be058b51b01701303e02ac5/nuscr-2.0.0.patch"
   checksum:
-    "sha256=5978c44e5e66b601db71722bf591bad780fcfc02c7cae59db54690726cc1f8a3"
+    "sha256=d507ff18224ae597ce1989cdf22fe91290061d0d7de71b7c1fed45b9c2c28a6d"
 }

--- a/packages/nuscr/nuscr.2.0.0/opam
+++ b/packages/nuscr/nuscr.2.0.0/opam
@@ -41,6 +41,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/nuscr/nuscr.git"
+patches: ["fix-cram-tests.patch"]
 url {
   src: "https://github.com/nuscr/nuscr/releases/download/2.0.0/nuscr-web-2.0.0.tbz"
   checksum: [
@@ -49,3 +50,9 @@ url {
   ]
 }
 x-commit-hash: "376b3b0af868aea0a7be12423b9724afdec21154"
+extra-source "fix-cram-tests.patch" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/nuscr/fix-cram-tests.patch"
+  checksum:
+    "sha256=5978c44e5e66b601db71722bf591bad780fcfc02c7cae59db54690726cc1f8a3"
+}

--- a/packages/nuscr/nuscr.2.0.0/opam
+++ b/packages/nuscr/nuscr.2.0.0/opam
@@ -11,6 +11,7 @@ license: "GPL-3.0-or-later"
 homepage: "https://nuscr.dev/"
 doc: "https://nuscr.dev/nuscr/docs/"
 bug-reports: "https://github.com/nuscr/nuscr/issues"
+available: [ os != "freebsd" ]
 depends: [
   "ocaml" {>= "4.08"}
   "menhir" {>= "20190924" & < "20211215"}

--- a/packages/nuscr/nuscr.2.0.0/opam
+++ b/packages/nuscr/nuscr.2.0.0/opam
@@ -54,5 +54,5 @@ extra-source "fix-cram-tests.patch" {
   src:
     "https://github.com/ocaml/opam-source-archives/raw/refs/heads/main/patches/nuscr/fix-cram-tests.2.0.0.patch"
   checksum:
-    "sha256=d507ff18224ae597ce1989cdf22fe91290061d0d7de71b7c1fed45b9c2c28a6d"
+    "sha256=47de3ba7be65eacbf55fa04534354857f99f7baf0e5c4f553a3774abb61dca15"
 }


### PR DESCRIPTION
This failure always causes z3 lower-bound builds to fail: https://github.com/ocaml/opam-repository/pull/28096