### PR TITLE
ppx deriving is not compatible with ocaml 5.4

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.6.1.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.6.1.0/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.4"}
   "dune" {>= "1.6.3"}
   "cppo" {>= "1.1.0" & build}
   "ocamlfind"


### PR DESCRIPTION
See, for example 
- https://github.com/ocaml/opam-repository/pull/28086