### PR TITLE
[new release] opam-monorepo (0.4.3)

### DIFF
--- a/packages/opam-monorepo/opam-monorepo.0.4.3/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.4.3/opam
@@ -16,6 +16,7 @@ depends: [
   "dune" {>= "3.6"}
   "ocaml" {>= "4.13.0"}
   "odoc" {with-doc}
+  "conf-pkg-config"
 ]
 conflicts: [
   "dune-build-info" {= "2.7.0" | = "2.7.1"}
@@ -24,26 +25,6 @@ conflicts: [
 dev-repo: "git+https://github.com/tarides/opam-monorepo.git"
 build: [ "dune" "build" "-p" name "-j" jobs "@install" "@test/lib/runtest" {with-test} ]
 flags: [ plugin ]
-depexts: [
-  ["devel/pkgconf"] {os = "openbsd"}
-  ["pkg-config"] {os-distribution = "nixos"}
-  ["pkg-config"] {os-family = "debian"}
-  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
-  ["pkgconf"] {os = "cygwin"}
-  ["pkgconf"] {os = "freebsd"}
-  ["pkgconf"] {os-distribution = "alpine"}
-  ["pkgconf"] {os-distribution = "arch"}
-  ["pkgconf-pkg-config"] {os-distribution = "fedora"}
-  ["pkgconf-pkg-config"] {os-distribution = "mageia"}
-  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
-  ["pkgconf-pkg-config"] {os-distribution = "ol" & os-version >= "8"}
-  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
-  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
-  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
-  ["pkgconfig"] {os-distribution = "ol" & os-version <= "7"}
-  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
-  ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
-]
 url {
   src:
     "https://github.com/tarides/opam-monorepo/releases/download/0.4.3/opam-monorepo-0.4.3.tbz"


### PR DESCRIPTION
Assemble and manage fully vendored Dune repositories

- Project page: <a href="https://github.com/tarides/opam-monorepo">https://github.com/tarides/opam-monorepo</a>
- Documentation: <a href="https://tarides.github.io/opam-monorepo">https://tarides.github.io/opam-monorepo</a>

##### CHANGES:

### Added

### Changed

### Deprecated

### Fixed

- Avoid generating conflicts with virtual packages: virtual and non-virtual
  packages in the same repository are not considered incompatible anymore
  (tarides/opam-monorepo#415, @shym)

### Removed

### Security
