### PR TITLE
[new release] dream-html (2 packages) (3.11.0)

### DIFF
--- a/packages/dream-html/dream-html.3.11.0/opam
+++ b/packages/dream-html/dream-html.3.11.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.14.0"}
+  "ppxlib" {>= "0.33.0" & < "1.0.0"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.11.0/dream-html-3.11.0.tbz"
+  checksum: [
+    "sha256=d1ac64685188a5b41834c8e1ffc4187f8dfdbc27a972898e6bb833ca4c715811"
+    "sha512=43ae60f49d3ada8cd633e0fbe6bf892094eb46a8f8ff1c7605c33724e6f44abcb3466dc61511994a8ac63a5ccd9421c53ce6f5f703bd307d9da3de7b6dbdf85e"
+  ]
+}
+x-commit-hash: "294e8966b7f130766ccdfdd14cae2bfef9488600"

--- a/packages/pure-html/pure-html.3.11.0/opam
+++ b/packages/pure-html/pure-html.3.11.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.11.0/dream-html-3.11.0.tbz"
+  checksum: [
+    "sha256=d1ac64685188a5b41834c8e1ffc4187f8dfdbc27a972898e6bb833ca4c715811"
+    "sha512=43ae60f49d3ada8cd633e0fbe6bf892094eb46a8f8ff1c7605c33724e6f44abcb3466dc61511994a8ac63a5ccd9421c53ce6f5f703bd307d9da3de7b6dbdf85e"
+  ]
+}
+x-commit-hash: "294e8966b7f130766ccdfdd14cae2bfef9488600"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

See https://github.com/yawaramin/dream-html/tags
