### PR TITLE
ppx_deriving 6 is not compatible with ocaml 5.4

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.6.0.3/opam
+++ b/packages/ppx_deriving/ppx_deriving.6.0.3/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.4"}
   "dune" {>= "1.6.3"}
   "cppo" {>= "1.1.0" & build}
   "ocamlfind"

--- a/packages/ppx_deriving/ppx_deriving.6.1.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.6.1.0/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.4"}
   "dune" {>= "1.6.3"}
   "cppo" {>= "1.1.0" & build}
   "ocamlfind"


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/28086

Failure:
```
=== ERROR while compiling ppx_deriving.6.1.0 =================================#
 context              2.3.0 | linux/x86_64 | ocaml-base-compiler.5.4.0~alpha1 | file:///home/opam/opam-repository
 path                 ~/.opam/5.4~alpha1/.opam-switch/build/ppx_deriving.6.1.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ppx_deriving -j 255
 exit-code            1
 env-file             ~/.opam/log/ppx_deriving-7-a67723.env
 output-file          ~/.opam/log/ppx_deriving-7-a67723.out
 (cd _build/default && /home/opam/.opam/5.4~alpha1/bin/ocamlopt.opt -w -40 -w -27-9 -g -I src/api/.ppx_deriving_api.objs/byte -I src/api/.ppx_deriving_api.objs/native -I /home/opam/.opam/5.4~alpha1/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.4~alpha1/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.4~alpha1/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4~alpha1/lib/ppx_derivers -I /home/opam/.opam/5.4~alpha1/lib/ppxlib -I /home/opam/.opam/5.4~alpha1/lib/ppxlib/ast -I /home/opam/.opam/5.4~alpha1/lib/ppxlib/astlib -I /home/opam/.opam/5.4~alpha1/lib/ppxlib/print_diff -I /home/opam/.opam/5.4~alpha1/lib/ppxlib/stdppx -I /home/opam/.opam/5.4~alpha1/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.4~alpha1/lib/sexplib0 -I /home/opam/.opam/5.4~alpha1/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -o src/api/.ppx_deriving_api.objs/native/ppx_deriving.cmx -c -impl src/api/ppx_deriving.pp.ml)
 File "ppx_deriving.cppo.ml", line 352, characters 54-57:
 Error: The value lid has type Ppxlib.longident = Astlib.Longident.t
        but an expression was expected of type
          Ocaml_common.Longident.t = Longident.t
 (cd _build/default && /home/opam/.opam/5.4~alpha1/bin/ocamlc.opt -w -40 -w -27-9 -g -bin-annot -bin-annot-occurrences -I src/api/.ppx_deriving_api.objs/byte -I /home/opam/.opam/5.4~alpha1/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.4~alpha1/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.4~alpha1/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4~alpha1/lib/ppx_derivers -I /home/opam/.opam/5.4~alpha1/lib/ppxlib -I /home/opam/.opam/5.4~alpha1/lib/ppxlib/ast -I /home/opam/.opam/5.4~alpha1/lib/ppxlib/astlib -I /home/opam/.opam/5.4~alpha1/lib/ppxlib/print_diff -I /home/opam/.opam/5.4~alpha1/lib/ppxlib/stdppx -I /home/opam/.opam/5.4~alpha1/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.4~alpha1/lib/sexplib0 -I /home/opam/.opam/5.4~alpha1/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -o src/api/.ppx_deriving_api.objs/byte/ppx_deriving.cmo -c -impl src/api/ppx_deriving.pp.ml)
 File "ppx_deriving.cppo.ml", line 352, characters 54-57:
 Error: The value lid has type Ppxlib.longident = Astlib.Longident.t
        but an expression was expected of type
          Ocaml_common.Longident.t = Longident.t
```