### PR TITLE
dune 3.15.3 is not compatible with ocaml 5.4

### DIFF
--- a/packages/dune/dune.3.15.3/opam
+++ b/packages/dune/dune.3.15.3/opam
@@ -26,6 +26,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 conflicts: [
+  "ocaml" {< "5.4"}
   "merlin" {< "3.4.0"}
   "ocaml-lsp-server" {< "1.3.0"}
   "dune-configurator" {< "2.3.0"}


### PR DESCRIPTION
This was reintroduced from the opam repo and lacks the usual upper bound. One of the vendored libraries fails with
```

=== ERROR while compiling dune.3.15.3 ========================================#
 context              2.3.0 | linux/x86_64 | ocaml-base-compiler.5.4.0~alpha1 | file:///home/opam/opam-repository
 path                 ~/.opam/5.4~alpha1/.opam-switch/build/dune.3.15.3
 command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml boot/bootstrap.ml -j 71
 exit-code            2
 env-file             ~/.opam/log/dune-7-81be09.env
 output-file          ~/.opam/log/dune-7-81be09.out
 ocamlc -output-complete-exe -w -24 -g -o .duneboot.exe -I boot -I +unix unix.cma boot/libs.ml boot/duneboot.ml
 ./.duneboot.exe -j 71
 cd _boot && /home/opam/.opam/5.4~alpha1/bin/ocamlopt.opt -c -g -no-alias-deps -w -49-6 -alert -unstable -I +unix -I +threads ocamlc_loc.mli
 File "otherlibs/ocamlc-loc/src/ocamlc_loc.mli", line 1, characters 4-9:
 Warning 53 [misplaced-attribute]: the alert attribute cannot appear in this context
 cd _boot && /home/opam/.opam/5.4~alpha1/bin/ocamlopt.opt -c -g -no-alias-deps -w -49-6 -alert -unstable -I +unix -I +threads notty.ml
 File "vendor/notty/src/notty.ml", lines 387-397, characters 43-7:
 Error: Some record fields are undefined: out_width

```