### PR TITLE
more precise constraint for gen_js_api

### DIFF
--- a/packages/gen_js_api/gen_js_api.1.0.6/opam
+++ b/packages/gen_js_api/gen_js_api.1.0.6/opam
@@ -10,11 +10,11 @@ license: "MIT"
 dev-repo: "git+https://github.com/LexiFi/gen_js_api.git"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
-  "ocaml" {>= "4.08.0" & < "5.3.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.11"}
   "js_of_ocaml"  {>= "3.1.0"}
   "ocaml-migrate-parsetree" {>= "1.6.0" & < "2.0.0"}
-  "ppxlib" {>= "0.11"}
+  "ppxlib" {>= "0.11" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
 ]
 synopsis: "Easy OCaml bindings for Javascript libraries"
 description: """

--- a/packages/gen_js_api/gen_js_api.1.0.7/opam
+++ b/packages/gen_js_api/gen_js_api.1.0.7/opam
@@ -19,8 +19,8 @@ homepage: "https://github.com/LexiFi/gen_js_api"
 bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
 depends: [
   "dune" {>= "2.0"}
-  "ocaml" {>= "4.08" & < "5.3.0"}
-  "ppxlib" {>= "0.18"}
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.18" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
   "ocaml-migrate-parsetree" {>= "1.6.0" & < "2.0.0"}
   "js_of_ocaml-compiler" {with-test}
   "conf-npm" {with-test}

--- a/packages/gen_js_api/gen_js_api.1.0.8/opam
+++ b/packages/gen_js_api/gen_js_api.1.0.8/opam
@@ -19,8 +19,8 @@ homepage: "https://github.com/LexiFi/gen_js_api"
 bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08" & < "5.3.0"}
-  "ppxlib" {>= "0.22"}
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.22" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
   "ppxlib" {with-test & < "0.26.0"}
   "js_of_ocaml-compiler" {with-test}
   "conf-npm" {with-test}

--- a/packages/gen_js_api/gen_js_api.1.0.9/opam
+++ b/packages/gen_js_api/gen_js_api.1.0.9/opam
@@ -19,8 +19,8 @@ homepage: "https://github.com/LexiFi/gen_js_api"
 bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08" & < "5.3.0"}
-  "ppxlib" {>= "0.22"}
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.22" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
   "ppxlib" {with-test & < "0.26.0"}
   "js_of_ocaml-compiler" {with-test}
   "conf-npm" {with-test}

--- a/packages/gen_js_api/gen_js_api.1.1.0/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.0/opam
@@ -20,8 +20,8 @@ homepage: "https://github.com/LexiFi/gen_js_api"
 bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08" & < "5.3.0"}
-  "ppxlib" {>= "0.22"}
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.22" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
   "ppxlib" {with-test & < "0.26.0"}
   "js_of_ocaml-compiler" {with-test}
   "conf-npm" {with-test}

--- a/packages/gen_js_api/gen_js_api.1.1.1/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.1/opam
@@ -20,8 +20,8 @@ homepage: "https://github.com/LexiFi/gen_js_api"
 bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08" & < "5.3.0"}
-  "ppxlib" {>= "0.26"}
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.26" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
   "js_of_ocaml-compiler" {with-test}
   "conf-npm" {with-test}
   "ojs" {= "1.1.1"}

--- a/packages/gen_js_api/gen_js_api.1.1.2/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.2/opam
@@ -20,8 +20,8 @@ homepage: "https://github.com/LexiFi/gen_js_api"
 bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08" & < "5.3.0"}
-  "ppxlib" {>= "0.26"}
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.26" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
   "js_of_ocaml-compiler" {with-test}
   "conf-npm" {with-test}
   "ojs" {= version}

--- a/packages/gen_js_api/gen_js_api.1.1.3/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.3/opam
@@ -20,8 +20,8 @@ homepage: "https://github.com/LexiFi/gen_js_api"
 bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08" & < "5.3.0"}
-  "ppxlib" {>= "0.26"}
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.26" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
   "js_of_ocaml-compiler" {with-test}
   "conf-npm" {with-test}
   "ojs" {= version}

--- a/packages/gen_js_api/gen_js_api.1.1.4/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.4/opam
@@ -20,8 +20,8 @@ homepage: "https://github.com/LexiFi/gen_js_api"
 bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08" & < "5.3.0"}
-  "ppxlib" {>= "0.26"}
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.26" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
   "js_of_ocaml-compiler" {with-test}
   "ojs" {= version}
   "odoc" {with-doc}


### PR DESCRIPTION
#28115 made gen_js_api unavailable on OCaml 5.3 but it turns out it only fails together with ppxlib.0.36.