### PR TITLE
Package re.1.13.2

### DIFF
--- a/packages/re/re.1.13.2/opam
+++ b/packages/re/re.1.13.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "RE is a regular expression library for OCaml"
+description: """\
+Pure OCaml regular expressions with:
+* Perl-style regular expressions (module Re.Perl)
+* Posix extended regular expressions (module Re.Posix)
+* Emacs-style regular expressions (module Re.Emacs)
+* Shell-style file globbing (module Re.Glob)
+* Compatibility layer for OCaml's built-in Str module (module Re.Str)"""
+maintainer: "Rudi Grinberg <me@rgrinberg.com>"
+authors: [
+  "Jerome Vouillon"
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Rudi Grinberg"
+  "Gabriel Radanne"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/ocaml-re"
+bug-reports: "https://github.com/ocaml/ocaml-re/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.12.0"}
+  "seq"
+  "ppx_expect" {with-test}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-re.git"
+url {
+  src: "https://github.com/ocaml/ocaml-re/archive/refs/tags/1.13.2.tar.gz"
+  checksum: [
+    "md5=df37d9787450525a2182ce4364048d11"
+    "sha512=376b3ba1e351317a34b4c9a331fdc9ca5ae7c6a90eb2eb3393403a33b9f35ece63af7444a7c0c71ef29d512aa7fe56f7e485a118946e35d90039ddfd9127c020"
+  ]
+}


### PR DESCRIPTION
### `re.1.13.2`
RE is a regular expression library for OCaml
Pure OCaml regular expressions with:
* Perl-style regular expressions (module Re.Perl)
* Posix extended regular expressions (module Re.Posix)
* Emacs-style regular expressions (module Re.Emacs)
* Shell-style file globbing (module Re.Glob)
* Compatibility layer for OCaml's built-in Str module (module Re.Str)



---
* Homepage: https://github.com/ocaml/ocaml-re
* Source repo: git+https://github.com/ocaml/ocaml-re.git
* Bug tracker: https://github.com/ocaml/ocaml-re/issues

---
:camel: Pull-request generated by opam-publish v2.5.0