### PR TITLE
Package patch.3.0.0

### DIFF
--- a/packages/patch/patch.3.0.0/opam
+++ b/packages/patch/patch.3.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Patch library purely in OCaml"
+description: """\
+This is a library which parses unified diff and git diff output, and can
+apply a patch in memory."""
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>" "Kate <kit-ty-kate@exn.st>"]
+license: "ISC"
+homepage: "https://github.com/hannesm/patch"
+doc: "https://hannesm.github.io/patch/"
+bug-reports: "https://github.com/hannesm/patch/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "crowbar" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/patch.git"
+url {
+  src:
+    "https://github.com/hannesm/patch/releases/download/v3.0.0/patch-3.0.0.tar.gz"
+  checksum: [
+    "md5=75aca1ed79a9807e4d4fc6c85aa31b0f"
+    "sha512=7ff530c6a6985fa32d1e7f64070e56540e13d4a6b622afdf60ee7c9638cc08505dd75cb2c23e0ade3b88e7ae6ed76dcdff858a557134dfbd44f774364de0bde0"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `patch.3.0.0`
Patch library purely in OCaml
This is a library which parses unified diff and git diff output, and can
apply a patch in memory.



---
* Homepage: https://github.com/hannesm/patch
* Source repo: git+https://github.com/hannesm/patch.git
* Bug tracker: https://github.com/hannesm/patch/issues

---
:camel: Pull-request generated by opam-publish v2.5.0