### PR TITLE
Package opam-file-format.2.2.0

### DIFF
--- a/packages/opam-file-format/opam-file-format.2.2.0/opam
+++ b/packages/opam-file-format/opam-file-format.2.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Parser and printer for the opam file syntax"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-file-format/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "3.13"}
+  "menhir" {>= "20211230"}
+  "alcotest" {with-test & >= "0.4.8"}
+  "fmt" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml/opam-file-format"
+url {
+  src:
+    "https://github.com/ocaml/opam-file-format/releases/download/2.2.0/opam-file-format-2.2.0.tar.gz"
+  checksum: [
+    "md5=5b65ea84fa2e60e89c2c9f2ca3203e31"
+    "sha512=87e1ddae79c47f48090b5e3205e0d2598e22838e065d0ea8924494ba225a4f8a8b4985a7eb3563652e9a9a5419741af7327035a01d446ebc7fedab468a8edb98"
+  ]
+}


### PR DESCRIPTION
### `opam-file-format.2.2.0`
Parser and printer for the opam file syntax



---
* Homepage: https://opam.ocaml.org
* Source repo: git+https://github.com/ocaml/opam-file-format
* Bug tracker: https://github.com/ocaml/opam-file-format/issues

---
:camel: Pull-request generated by opam-publish v2.5.0