### PR TITLE
[new release] slipshow (0.3.0)

### DIFF
--- a/packages/slipshow/slipshow.0.3.0/opam
+++ b/packages/slipshow/slipshow.0.3.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "A compiler from markdown to slipshow"
+description:
+  "Slipshow is an engine to write slips, a concept evolved from slides."
+maintainer: ["Paul-Elliot"]
+authors: ["Paul-Elliot"]
+license: "GPL-3.0-or-later"
+tags: ["slipshow" "presentation" "slideshow" "beamer"]
+homepage: "https://github.com/panglesd/slipshow"
+doc: "https://slipshow.readthedocs.io"
+bug-reports: "https://github.com/panglesd/slipshow/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.6"}
+  "crunch" {with-dev-setup}
+  "cmdliner" {>= "1.3.0"}
+  "base64"
+  "bos"
+  "lwt"
+  "inotify" {os = "linux"}
+  "cf-lwt" {>= "0.4"}
+  "astring"
+  "fmt"
+  "logs"
+  "fsevents-lwt"
+  "js_of_ocaml-compiler"
+  "js_of_ocaml-lwt"
+  "magic-mime"
+  "dream" {>= "1.0.0~alpha5"}
+  "fpath"
+  "ppx_blob" {>= "0.8.0"}
+  "sexplib"
+  "ppx_sexp_conv"
+  "odoc" {with-doc}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/panglesd/slipshow.git"
+# We avoid 32 bits arcitecture because our usage of ppx_blob generates strings
+# whose size exceed the maximum size in 32 bits OCaml...
+available: arch != "arm32" & arch != "x86_32"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/panglesd/slipshow/releases/download/v0.3.0/slipshow-0.3.0.tbz"
+  checksum: [
+    "sha256=fd5fe1d51413e6391d7f06543240040b2b2b6b50d166c971c743a16534c17ca5"
+    "sha512=264144cafe390b7a90d033bc1502812f2f69de1d1f99687263ee2e2a321a943814a2b94c941d7b44f64eada81776ffa89f0ee4d041f88bd7af4cd0e259ea931e"
+  ]
+}
+x-commit-hash: "5b1fccb00c93d1710758dacc936301253a978150"


### PR DESCRIPTION
See the [release notes](https://github.com/panglesd/slipshow/releases/tag/v0.3.0).

CHANGES:

- Fix file watching issues by vendoring a (modified) irmin-watcher, and watching all files the presentation depends on (images, themes, ...) (panglesd/slipshow#113)
- Adds a favicon to the presentation file (panglesd/slipshow#115)
- Fix missing attributes on images (panglesd/slipshow#117)
- Fix missing mime type on images that made svg undisplayable (panglesd/slipshow#120)
- Fix detection of math inside inline attributes (panglesd/slipshow#124)
- Add `--dimension` to specify the dimension of the presentation (panglesd/slipshow#131)
- Add less boring name for versions (panglesd/slipshow#132)

- Add `{include src="path/to/file.md"}` to include a file in another (panglesd/slipshow#114)
- Allow `pause` to have a target (panglesd/slipshow#118)
- Remove the need for `step` to execute actions (panglesd/slipshow#118)
- Added support for subslips and slides (panglesd/slipshow#118)
- Added pause blocks (panglesd/slipshow#127)
- Use horizontal lines (`---`) to group blocks (panglesd/slipshow#129)
- Pass attributes to children with `children:` (panglesd/slipshow#130)
- Consistently remove the need for `-at-unpause` (panglesd/slipshow#133)

- Simplify table of content by removing preview (panglesd/slipshow#118)
- Fix wrong computation of location (panglesd/slipshow#118, panglesd/slipshow#119)
- Improve zooming behaviour and performance (panglesd/slipshow#121)
- Add PageUp and PageDown as navigation keys, adding support for pointers (panglesd/slipshow#126)
- Do not act when control is pressed (panglesd/slipshow#126)
- Fix wrong positioning on scaled slips (panglesd/slipshow#128)