### PR TITLE
[new release] js_of_ocaml (8 packages) (6.1.0+beta2)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.1.0+beta2/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.1.0+beta2/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.13" & < "5.5"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.16.1" & with-test}
+  "ppxlib" {>= "0.35"}
+  "re" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "sedlex" {>= "3.3"}
+  "qcheck" {with-test}
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson" {>= "2.1"}
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.1.0%2Bbeta2/js_of_ocaml-6.1.0.beta2.tbz"
+  checksum: [
+    "sha256=61a0069c646183a6b6b377528725d17a62f65bc616603c97c67fe75b5a959cdc"
+    "sha512=db60a1c40970a6304f98876dd7445a16be670f86a56794a0c1925243e59d0e93fcd7cf678c3f8cd55d022781b9f0d6760c39b4c99cf4c09820edd12d5332e504"
+  ]
+}
+x-commit-hash: "e7c930ed2dac6dafb077a5feae1db692cbfb7891"

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.6.1.0+beta2/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.6.1.0+beta2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "lwt" {>= "2.4.4"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["graphics" "lwt_log"]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.1.0%2Bbeta2/js_of_ocaml-6.1.0.beta2.tbz"
+  checksum: [
+    "sha256=61a0069c646183a6b6b377528725d17a62f65bc616603c97c67fe75b5a959cdc"
+    "sha512=db60a1c40970a6304f98876dd7445a16be670f86a56794a0c1925243e59d0e93fcd7cf678c3f8cd55d022781b9f0d6760c39b4c99cf4c09820edd12d5332e504"
+  ]
+}
+x-commit-hash: "e7c930ed2dac6dafb077a5feae1db692cbfb7891"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.6.1.0+beta2/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.6.1.0+beta2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.35"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.1.0%2Bbeta2/js_of_ocaml-6.1.0.beta2.tbz"
+  checksum: [
+    "sha256=61a0069c646183a6b6b377528725d17a62f65bc616603c97c67fe75b5a959cdc"
+    "sha512=db60a1c40970a6304f98876dd7445a16be670f86a56794a0c1925243e59d0e93fcd7cf678c3f8cd55d022781b9f0d6760c39b4c99cf4c09820edd12d5332e504"
+  ]
+}
+x-commit-hash: "e7c930ed2dac6dafb077a5feae1db692cbfb7891"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.6.1.0+beta2/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.6.1.0+beta2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.35"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.1.0%2Bbeta2/js_of_ocaml-6.1.0.beta2.tbz"
+  checksum: [
+    "sha256=61a0069c646183a6b6b377528725d17a62f65bc616603c97c67fe75b5a959cdc"
+    "sha512=db60a1c40970a6304f98876dd7445a16be670f86a56794a0c1925243e59d0e93fcd7cf678c3f8cd55d022781b9f0d6760c39b4c99cf4c09820edd12d5332e504"
+  ]
+}
+x-commit-hash: "e7c930ed2dac6dafb077a5feae1db692cbfb7891"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.6.1.0+beta2/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.6.1.0+beta2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml-compiler" {= version}
+  "ocamlfind" {>= "1.5.1"}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.35"}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.1.0%2Bbeta2/js_of_ocaml-6.1.0.beta2.tbz"
+  checksum: [
+    "sha256=61a0069c646183a6b6b377528725d17a62f65bc616603c97c67fe75b5a959cdc"
+    "sha512=db60a1c40970a6304f98876dd7445a16be670f86a56794a0c1925243e59d0e93fcd7cf678c3f8cd55d022781b9f0d6760c39b4c99cf4c09820edd12d5332e504"
+  ]
+}
+x-commit-hash: "e7c930ed2dac6dafb077a5feae1db692cbfb7891"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.6.1.0+beta2/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.6.1.0+beta2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "react" {>= "1.2.2"}
+  "reactiveData" {>= "0.2"}
+  "tyxml" {>= "4.6"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.1.0%2Bbeta2/js_of_ocaml-6.1.0.beta2.tbz"
+  checksum: [
+    "sha256=61a0069c646183a6b6b377528725d17a62f65bc616603c97c67fe75b5a959cdc"
+    "sha512=db60a1c40970a6304f98876dd7445a16be670f86a56794a0c1925243e59d0e93fcd7cf678c3f8cd55d022781b9f0d6760c39b4c99cf4c09820edd12d5332e504"
+  ]
+}
+x-commit-hash: "e7c930ed2dac6dafb077a5feae1db692cbfb7891"

--- a/packages/js_of_ocaml/js_of_ocaml.6.1.0+beta2/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.6.1.0+beta2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml-compiler" {= version}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.35"}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.1.0%2Bbeta2/js_of_ocaml-6.1.0.beta2.tbz"
+  checksum: [
+    "sha256=61a0069c646183a6b6b377528725d17a62f65bc616603c97c67fe75b5a959cdc"
+    "sha512=db60a1c40970a6304f98876dd7445a16be670f86a56794a0c1925243e59d0e93fcd7cf678c3f8cd55d022781b9f0d6760c39b4c99cf4c09820edd12d5332e504"
+  ]
+}
+x-commit-hash: "e7c930ed2dac6dafb077a5feae1db692cbfb7891"

--- a/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.1.0+beta2/opam
+++ b/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.1.0+beta2/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to WebAssembly"
+description:
+  "Wasm_of_ocaml is a compiler from OCaml bytecode to WebAssembly. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.14"}
+  "js_of_ocaml" {= version}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.35"}
+  "re" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "opam-format" {with-test}
+  "sedlex" {>= "2.3"}
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson" {>= "2.1"}
+  "binaryen-bin"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.1.0%2Bbeta2/js_of_ocaml-6.1.0.beta2.tbz"
+  checksum: [
+    "sha256=61a0069c646183a6b6b377528725d17a62f65bc616603c97c67fe75b5a959cdc"
+    "sha512=db60a1c40970a6304f98876dd7445a16be670f86a56794a0c1925243e59d0e93fcd7cf678c3f8cd55d022781b9f0d6760c39b4c99cf4c09820edd12d5332e504"
+  ]
+}
+x-commit-hash: "e7c930ed2dac6dafb077a5feae1db692cbfb7891"


### PR DESCRIPTION
Compiler from OCaml bytecode to JavaScript

- Project page: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>
- Documentation: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>

##### CHANGES:

## Features/Changes
* Misc: drop support for OCaml 4.12 and bellow
* Misc: switch to dune.3.19
* Misc: initial support for ocaml 5.4 (ocsigen/js_of_ocaml#2030, ocsigen/js_of_ocaml#2058)
* Compiler: support for OCaml 4.14.3+trunk (ocsigen/js_of_ocaml#1844)
* Compiler: add the `--empty-sourcemap` flag
* Compiler: improve debug/sourcemap location of closures (ocsigen/js_of_ocaml#1947)
* Compiler: optimize compilation of switches (ocsigen/js_of_ocaml#1921, ocsigen/js_of_ocaml#2057)
* Compiler: evaluate statically more primitives (ocsigen/js_of_ocaml#1912, ocsigen/js_of_ocaml#1915, ocsigen/js_of_ocaml#1965, ocsigen/js_of_ocaml#1969)
* Compiler: rewrote inlining pass (ocsigen/js_of_ocaml#1935, ocsigen/js_of_ocaml#2018, ocsigen/js_of_ocaml#2027)
* Compiler: improve tailcall optimization (ocsigen/js_of_ocaml#1943)
* Compiler: improve deadcode optimization (ocsigen/js_of_ocaml#1963, ocsigen/js_of_ocaml#1962, ocsigen/js_of_ocaml#1967)
* Compiler: deadcode elimination of cyclic values (ocsigen/js_of_ocaml#1978)
* Compiler: remove empty blocks (ocsigen/js_of_ocaml#1934)
* Compiler: improve coloring optimization (ocsigen/js_of_ocaml#1971, ocsigen/js_of_ocaml#1984, ocsigen/js_of_ocaml#1986, ocsigen/js_of_ocaml#1989)
* Compiler: faster constant sharing (ocsigen/js_of_ocaml#1988)
* Compiler: faster js code generation (ocsigen/js_of_ocaml#1985, ocsigen/js_of_ocaml#2066)
* Compiler: improve performance of Javascript linking
* Compiler: more efficient code generation from bytecode (ocsigen/js_of_ocaml#1972)
* Compiler: faster compilation by improving the scheduling of optimization passes (ocsigen/js_of_ocaml#1962, ocsigen/js_of_ocaml#2001, ocsigen/js_of_ocaml#2012, ocsigen/js_of_ocaml#2027)
* Compiler: faster compilation by stopping sooner when optimizations become unproductive (ocsigen/js_of_ocaml#1939)
* Compiler: Propagate arity between compilation units (ocsigen/js_of_ocaml#1594)
* Compiler: Add flags to enable/disable warnings (ocsigen/js_of_ocaml#2052)
* Compiler/wasm: directly write Wasm binary modules (ocsigen/js_of_ocaml#2000, ocsigen/js_of_ocaml#2003)
* Compiler/wasm: faster wat output (ocsigen/js_of_ocaml#1992)
* Compiler/wasm: use a Wasm text files preprocessor (ocsigen/js_of_ocaml#1822)
* Compiler/wasm: optimize integer operations (ocsigen/js_of_ocaml#2032)
* Compiler/wasm: use type analysis to remove some unnecessary uses of JavasScript strict equality (ocsigen/js_of_ocaml#2040)
* Compiler/wasm: use more precise environment types (ocsigen/js_of_ocaml#2041)
* Compiler/wasm: optimize calls to statically known function (ocsigen/js_of_ocaml#2044)
* Runtime: use es6 class (ocsigen/js_of_ocaml#1840)
* Runtime: support more Unix functions (ocsigen/js_of_ocaml#1829)
* Runtime: remove polyfill for Map to simplify MlObjectTable implementation (ocsigen/js_of_ocaml#1846)
* Runtime: refactor caml_xmlhttprequest_create implementation (ocsigen/js_of_ocaml#1846)
* Runtime: update constant imports to use `node:fs` module (ocsigen/js_of_ocaml#1850)
* Runtime: make Obj.dup work with floats and boxed numbers (ocsigen/js_of_ocaml#1871)
* Runtime: delete BigStringReader, one should use UInt8ArrayReader instead
* Runtime: less conversion during un-marshalling (ocsigen/js_of_ocaml#1889)
* Runtime: use TextEncoder/TextDecoder for utf8-utf16 conversions
* Runtime: use Dataview to convert between floats and bit representation
* Runtime: optimize Str.search_forward/search_backward (ocsigen/js_of_ocaml#2056)
* Runtime: deprecate caml_ba_create_from (ocsigen/js_of_ocaml#2056)
* Runtime: check for unused variable in the runtime (ocsigen/js_of_ocaml#2056)
* Runtime/wasm: implement BLAKE2b primitives for Wasm (ocsigen/js_of_ocaml#1873)
* Runtime/wasm: support jsoo_env and keep track of backtrace status (ocsigen/js_of_ocaml#1881)
* Runtime/wasm: support unmarshaling compressed data (ocsigen/js_of_ocaml#1898)
* Runtime/wasm: make resuming a continuation more efficient in Wasm (ocsigen/js_of_ocaml#1892)
* Runtime/wasm: use imported string constants for JavaScript strings (ocsigen/js_of_ocaml#2022)
* Runtime/wasm: use DataView primitives to implement bigarrays (ocsigen/js_of_ocaml#1979)
* Ppx: explicitly disallow polymorphic method (ocsigen/js_of_ocaml#1897)
* Ppx: allow "function" in object literals (ocsigen/js_of_ocaml#1897)
* Lib: add Dom_html.window.matchMedia & Dom_html.mediaQueryList (ocsigen/js_of_ocaml#2017)
* Lib: make the Wasm version of Json.output work with native ints and JavaScript objects (ocsigen/js_of_ocaml#1872)

## Bug fixes
* Compiler: fix stack overflow issues with double translation (ocsigen/js_of_ocaml#1869)
* Compiler: minifier fix (ocsigen/js_of_ocaml#1867)
* Compiler: fix shortvar with --enable es6 (AssignTarget was not properly handled)
* Compiler: fix assert failure with double translation (ocsigen/js_of_ocaml#1870)
* Compiler: fix path rewriting of Wasm source maps (ocsigen/js_of_ocaml#1882)
* Compiler: fix global dead code in presence of dead tailcall (ocsigen/js_of_ocaml#2010)
* Compiler/wasm: fix bound check for empty float array (ocsigen/js_of_ocaml#1904)
* Runtime: fix path normalization (ocsigen/js_of_ocaml#1848)
* Runtime: fix reading from the pseudo-filesystem (ocsigen/js_of_ocaml#1859)
* Runtime: fix initialization of standard streams under Windows (ocsigen/js_of_ocaml#1849)
* Runtime: fix Int64.of_string overflow check (ocsigen/js_of_ocaml#1874)
* Runtime: fix caml_string_concat when not using JS strings (ocsigen/js_of_ocaml#1874)
* Runtime: consistent bigarray hashing across all architectures (ocsigen/js_of_ocaml#1977)
* Runtime: fix caml_utf8_of_utf16 bug in high surrogate case (ocsigen/js_of_ocaml#2008)
* Runtime: fix method lookup (ocsigen/js_of_ocaml#2034, ocsigen/js_of_ocaml#2038, ocsigen/js_of_ocaml#2039)
* Lib: fix Dom_html.Keyboard_code.of_event (ocsigen/js_of_ocaml#1878)
* Tools: fix jsoo_mktop and jsoo_mkcmis (ocsigen/js_of_ocaml#1877)
* Toplevel: fix for when use-js-strings is disabled (ocsigen/js_of_ocaml#1997)
