### PR TITLE
cohttp-async 6.1.1 is compatible with ocaml 5.3.0

### DIFF
--- a/packages/cohttp-async/cohttp-async.6.1.1/opam
+++ b/packages/cohttp-async/cohttp-async.6.1.1/opam
@@ -24,7 +24,7 @@ doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.14" & < "5.3.0"}
+  "ocaml" {>= "4.14"}
   "http" {= version}
   "cohttp" {= version}
   "async_kernel" {>= "v0.17.0"}


### PR DESCRIPTION
The bound was apparently added in https://github.com/ocaml/opam-repository/pull/27537, but I can't see why. Tested locally and it seems to install fine.