### PR TITLE
fix Base v0.15.1

### DIFF
--- a/packages/base/base.v0.14.3/opam
+++ b/packages/base/base.v0.14.3/opam
@@ -34,3 +34,11 @@ url {
   src: "https://github.com/janestreet/base/archive/v0.14.3.tar.gz"
   checksum: "sha256=e34dc0dd052a386c84f5f67e71a90720dff76e0edd01f431604404bee86ebe5a"
 }
+patches: ["fix-mpopcnt.patch" { arch="arm64" & os="macos"} ]
+extra-source "fix-mpopcnt.patch" {
+  src:
+    "https://patch-diff.githubusercontent.com/raw/janestreet/base/pull/185.diff"
+  checksum: [
+    "sha256=0fa6c87a379b3b35ffe3db3c8e1674dbc70cef91b5b457a35ed6d758a8f9ca80"
+  ]
+}

--- a/packages/base/base.v0.15.1/opam
+++ b/packages/base/base.v0.15.1/opam
@@ -34,3 +34,11 @@ url {
 src: "https://github.com/janestreet/base/archive/refs/tags/v0.15.1.tar.gz"
 checksum: "sha256=755e303171ea267e3ba5af7aa8ea27537f3394d97c77d340b10f806d6ef61a14"
 }
+patches: ["fix-mpopcnt.patch" { arch="arm64" & os="macos"} ]
+extra-source "fix-mpopcnt.patch" {
+  src:
+    "https://patch-diff.githubusercontent.com/raw/janestreet/base/pull/184.diff"
+  checksum: [
+    "sha256=0fa6c87a379b3b35ffe3db3c8e1674dbc70cef91b5b457a35ed6d758a8f9ca80"
+  ]
+}


### PR DESCRIPTION
Propagate #27716, with janestreet/base#184 and janestreet/base#185