### PR TITLE
Stdcompat 1 incompatible with OCaml 5

### DIFF
--- a/packages/stdcompat/stdcompat.1/opam
+++ b/packages/stdcompat/stdcompat.1/opam
@@ -9,7 +9,7 @@ build: [make "all" "PREFIX=%{prefix}%"]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "ocaml" {< "5.2"}
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "cppo" {build}
 ]


### PR DESCRIPTION
https://github.com/ocamllibs/stdcompat/blob/1/Makefile#L51 expects OCaml version of syntax `5.00.0`, but turns out to be `5.0.0`.