### PR TITLE
Release of LAnnotate and LUncov 0.2.4

### DIFF
--- a/packages/frama-c-lannotate/frama-c-lannotate.0.2.4/opam
+++ b/packages/frama-c-lannotate/frama-c-lannotate.0.2.4/opam
@@ -14,7 +14,7 @@ authors: [
 license: "LGPL-2.1-only"
 tags: ["software testing" "Frama-C" "LTest"]
 homepage: "https://frama-c.com/"
-bug-reports: "https://git.frama-c.com/pub/lannotate/-/issues"
+bug-reports: "https://git.frama-c.com/pub/ltest/lannotate/-/issues"
 depends: [
   "ocaml" {>= "4.14.0"}
   "dune" {> "3.13.0"}
@@ -37,7 +37,7 @@ build: [
   ]
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
-dev-repo: "git+https://git.frama-c.com/pub/lannotate.git"
+dev-repo: "git+https://git.frama-c.com/pub/ltest/lannotate.git"
 url {
   src:
     "https://git.frama-c.com/pub/ltest/lannotate/-/archive/0.2.4/lannotate-0.2.4.tar.bz2"

--- a/packages/frama-c-lannotate/frama-c-lannotate.0.2.4/opam
+++ b/packages/frama-c-lannotate/frama-c-lannotate.0.2.4/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Lannotate plugin of Frama-C, part of the LTest suite"
+description: """\
+Lannotate is a plugin that introduces labels and hyperlabels formalizing
+test objectives corresponding to the coverage criteria selected by the user.
+It is part of LTest, a set of plug-in dedicated to managing test coverage.
+Other plug-ins in LTest include:
+- Luncov, for detecting polluting (infeasible or redundant) objectives
+- Lreplay, for executing a test suite and computing its coverage status"""
+maintainer: "virgile.prevosto@cea.fr"
+authors: [
+  "Omar Chebaro" "Mickaël Delahaye" "Michael Marcozzi" "Thibault Martin"
+]
+license: "LGPL-2.1-only"
+tags: ["software testing" "Frama-C" "LTest"]
+homepage: "https://frama-c.com/"
+bug-reports: "https://git.frama-c.com/pub/lannotate/-/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {> "3.13.0"}
+  "frama-c" {>= "31.0~" & < "32.0~"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/lannotate.git"
+url {
+  src:
+    "https://git.frama-c.com/pub/ltest/lannotate/-/archive/0.2.4/lannotate-0.2.4.tar.bz2"
+  checksum: [
+    "md5=a84542f799911d0c64e1db10be0f150e"
+    "sha512=dab4b833f3ac6d449f2ebbf7ac054f247c9f86d86acad14b78267c4719a6943f59a21be64c28d81baabf155948d335af1c41ab0ce44e96214bb6da4693705e15"
+  ]
+}

--- a/packages/frama-c-luncov/frama-c-luncov.0.2.4/opam
+++ b/packages/frama-c-luncov/frama-c-luncov.0.2.4/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Luncov plugin of Frama-C, part of the LTest suite"
+description: """\
+Luncov is a plugin that attempts to identify unreachable and/or redundant
+tests objectives, represented in the code by labels and hyperlabels, as
+defined in the LTest family of Frama-C plug-ins.
+Other plug-ins in LTest include:
+- Lannotate, for introducing (hyper)labels according to various criteria
+- Lreplay, for executing a test suite and computing its coverage status"""
+maintainer: "virgile.prevosto@cea.fr"
+authors: [
+  "Robin David" "Mickaël Delahaye" "Michael Marcozzi" "Thibault Martin"
+]
+license: "LGPL-2.1-only"
+tags: ["software testing" "Frama-C" "LTest"]
+homepage: "https://frama-c.com/"
+bug-reports: "https://git.frama-c.com/pub/ltest/luncov/-/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.13" & > "3.13.0"}
+  "menhir" {>= "20181006"}
+  "frama-c" {>= "31.0~" & < "32.0~"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/ltest/luncov.git"
+url {
+  src:
+    "https://git.frama-c.com/pub/ltest/luncov/-/archive/0.2.4/luncov-0.2.4.tar.bz2"
+  checksum: [
+    "md5=3d50489dbb7640f819afe7b2b508a462"
+    "sha512=cbcd586e971fbcbc4a6bafc435f763988bd66ea0d42ff3d241ad364ca569756fd57be30bdd876576e087fc2d2cb1cc34f477344696ff9fd39b74f7dfa454a1ee"
+  ]
+}


### PR DESCRIPTION
This update mainly updates version numbers and compatibility with Frama-C 31.0 (Gallium).

These are Frama-C plug-ins so CI fails will be caused by fails from the package Frama-C. They can be ignored.

Edit: I added LUncov to this MR instead of creating a new one.