### PR TITLE
Add: logs.0.9.0

### DIFF
--- a/packages/logs-async/logs-async.1.1/opam
+++ b/packages/logs-async/logs-async.1.1/opam
@@ -8,7 +8,7 @@ doc: "https://vbmithr.github.io/logs-async/doc"
 build: [ "dune" "build" "-j" jobs "-p" name "@install" ]
 depends: [
   "dune" {>= "1.3.0"}
-  "logs" {>= "0.6.2"}
+  "logs" {>= "0.6.2" & < "0.9.0"}
   "async_kernel" {>= "v0.11.1"}
 ]
 synopsis: "Jane Street Async logging with Logs"

--- a/packages/logs-async/logs-async.1.3/opam
+++ b/packages/logs-async/logs-async.1.3/opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/vbmithr/logs-async/issues"
 depends: [
   "ocaml"
   "dune" {>= "3.10"}
-  "logs" {>= "0.7.0"}
+  "logs" {>= "0.7.0" & < "0.9.0"}
   "async_kernel" {>= "v0.16"}
   "odoc" {with-doc}
 ]

--- a/packages/logs/logs.0.9.0/opam
+++ b/packages/logs/logs.0.9.0/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "Logging infrastructure for OCaml"
+description: """\
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
+formatters depends on [Fmt][fmt].  The optional `Logs_browser`
+reporter that reports to the web browser console depends on
+[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
+command line support for controlling Logs depends on
+[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
+Lwt logging functions depends on [`Lwt`][lwt]
+
+Logs and its reporters are distributed under the ISC license.
+
+[fmt]: http://erratique.ch/software/fmt
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+[cmdliner]: http://erratique.ch/software/cmdliner
+[lwt]: http://ocsigen.org/lwt/
+
+Home page: <http://erratique.ch/software/logs>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The logs programmers"
+license: "ISC"
+tags: ["log" "system" "org:erratique"]
+homepage: "https://erratique.ch/software/logs"
+doc: "https://erratique.ch/software/logs/doc"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "mtime" {with-test}
+]
+depopts: ["cmdliner" "js_of_ocaml-compiler" "fmt" "lwt" "base-threads"]
+conflicts: [
+  "cmdliner" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "5.5.0"}
+  "fmt" {< "0.9.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-js_of_ocaml-compiler"
+  "%{js_of_ocaml-compiler:installed}%"
+  "--with-fmt"
+  "%{fmt:installed}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+  "--with-lwt"
+  "%{lwt:installed}%"
+  "--with-base-threads"
+  "%{base-threads:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/logs.git"
+url {
+  src: "https://erratique.ch/software/logs/releases/logs-0.9.0.tbz"
+  checksum:
+    "sha512=b75fb28e83f33461b06b5c9b60972c4a9a9a1599d637b4a0c7b1e86a87f34fe5361e817cb31f42ad7e7cbb822473b28fab9f58a02870eb189ebe88dae8e045ff"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `logs.0.9.0` [home](https://erratique.ch/software/logs), [doc](https://erratique.ch/software/logs/doc), [issues](https://github.com/dbuenzli/logs/issues)  
  *Logging infrastructure for OCaml*
* Incompatible: `logs-async`


---

#### `logs` v0.9.0 2025-07-08 Zagreb

* Replace references and mutable fields by atomic references to avoid
  race conditions ([#56](https://github.com/dbuenzli/logs/issues/56)). Thanks to Nathan Taylor for reporting.
* Fix `Logs.{err,warn}_count`. The counts were counting the reports
  not the logs which is not what the spec says. This means the counts
  were wrong when the reporting level was below the corresponding
  level ([#55](https://github.com/dbuenzli/logs/issues/55)). Thanks to Mathieu Barbin for the report.
* Fix `Log.Tag.list` always returning the empty list.
* `Logs.format_reporter` and `Logs_fmt.reporter` replace a few format 
  strings and `^^` uses by direct calls to `Format` primitives.
* Requires OCaml >= 4.14.
* Use Format.pp_print_text instead of our own.
* Export `logs` from each sub library.

---

Use `b0 -- .opam publish logs.0.9.0 -i logs-async` to update the pull request.