### PR TITLE
Camlimages 5.0.5 only supports OCaml 5

### DIFF
--- a/packages/camlimages/camlimages.5.0.5/opam
+++ b/packages/camlimages/camlimages.5.0.5/opam
@@ -8,7 +8,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://gitlab.com/camlspotter/camlimages"
 bug-reports: "https://gitlab.com/camlspotter/camlimages/-/issues"
 depends: [
-  "ocaml" {>= "4.12.1"}
+  "ocaml" {>= "5.0.0"}
   "dune" {>= "3.2"}
   "base" {build & < "v0.17"}
   "stdio" {build}


### PR DESCRIPTION
https://gitlab.com/camlspotter/camlimages/-/blob/5.0.5/freetype/ftintf.c?ref_type=tags#L29 requires `Ptr_val`, which was first introduced in ocaml/ocaml@36c3999

Cc: @camlspotter 