### PR TITLE
Upper bound qcheck in prbnmcn-stats 0.0.2-0.0.8

### DIFF
--- a/packages/prbnmcn-stats/prbnmcn-stats.0.0.2/opam
+++ b/packages/prbnmcn-stats/prbnmcn-stats.0.0.2/opam
@@ -9,7 +9,7 @@ bug-reports: "http://github.com/igarnier/prbnmcn-stats"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.12.0"}
-  "qcheck" {>= "0.17" & with-test}
+  "qcheck" {>= "0.17" & < "0.26" & with-test}
   "prbnmcn-basic-structures" {= "0.0.1"}
   "prbnmcn-linalg" {= "0.0.1"}
   "odoc" {with-doc}

--- a/packages/prbnmcn-stats/prbnmcn-stats.0.0.3/opam
+++ b/packages/prbnmcn-stats/prbnmcn-stats.0.0.3/opam
@@ -11,7 +11,7 @@ bug-reports: "http://github.com/igarnier/prbnmcn-stats"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.12.0"}
-  "qcheck" {>= "0.17" & with-test}
+  "qcheck" {>= "0.17" & < "0.26" & with-test}
   "prbnmcn-basic-structures" {= "0.0.1"}
   "prbnmcn-linalg" {= "0.0.1"}
   "odoc" {with-doc}

--- a/packages/prbnmcn-stats/prbnmcn-stats.0.0.4/opam
+++ b/packages/prbnmcn-stats/prbnmcn-stats.0.0.4/opam
@@ -11,7 +11,7 @@ bug-reports: "http://github.com/igarnier/prbnmcn-stats"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.12.0"}
-  "qcheck" {>= "0.17" & with-test}
+  "qcheck" {>= "0.17" & < "0.26" & with-test}
   "prbnmcn-basic-structures" {= "0.0.1"}
   "prbnmcn-linalg" {= "0.0.1"}
   "odoc" {with-doc}

--- a/packages/prbnmcn-stats/prbnmcn-stats.0.0.5/opam
+++ b/packages/prbnmcn-stats/prbnmcn-stats.0.0.5/opam
@@ -11,7 +11,7 @@ bug-reports: "http://github.com/igarnier/prbnmcn-stats"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.12.0"}
-  "qcheck" {>= "0.17" & with-test}
+  "qcheck" {>= "0.17" & < "0.26" & with-test}
   "ocamlgraph" {>= "2.0.0" & with-test}
   "prbnmcn-basic-structures" {= "0.0.1"}
   "prbnmcn-linalg" {= "0.0.1"}

--- a/packages/prbnmcn-stats/prbnmcn-stats.0.0.6/opam
+++ b/packages/prbnmcn-stats/prbnmcn-stats.0.0.6/opam
@@ -11,7 +11,7 @@ bug-reports: "http://github.com/igarnier/prbnmcn-stats"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.14"}
-  "qcheck" {>= "0.17" & with-test}
+  "qcheck" {>= "0.17" & < "0.26" & with-test}
   "ocamlgraph" {>= "2.0.0" & with-test}
   "prbnmcn-basic-structures" {= "0.0.1"}
   "odoc" {with-doc}

--- a/packages/prbnmcn-stats/prbnmcn-stats.0.0.7/opam
+++ b/packages/prbnmcn-stats/prbnmcn-stats.0.0.7/opam
@@ -11,7 +11,7 @@ bug-reports: "http://github.com/igarnier/prbnmcn-stats"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.14"}
-  "qcheck" {>= "0.17" & with-test}
+  "qcheck" {>= "0.17" & < "0.26" & with-test}
   "ocamlgraph" {>= "2.0.0" & with-test}
   "prbnmcn-basic-structures" {= "0.0.1"}
   "odoc" {with-doc}

--- a/packages/prbnmcn-stats/prbnmcn-stats.0.0.8/opam
+++ b/packages/prbnmcn-stats/prbnmcn-stats.0.0.8/opam
@@ -11,7 +11,7 @@ bug-reports: "http://github.com/igarnier/prbnmcn-stats"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.14"}
-  "qcheck" {>= "0.17" & with-test}
+  "qcheck" {>= "0.17" & < "0.26" & with-test}
   "ocamlgraph" {>= "2.0.0" & with-test}
   "prbnmcn-basic-structures" {= "0.0.1"}
   "odoc" {with-doc}


### PR DESCRIPTION
The forthcoming QCheck 0.26 release in #28148 patches the `float` generators to avoid blind spots: c-cube/qcheck#350.
The CI run for the release however revealed such a blind spot, causing a `prbnmcn-stats` QCheck test to start failing when run with QCheck 0.26:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/c715a95fe87d4397d1f0658b2ae5acd528de705e

This PR therefore adds an upper bound of `qcheck` for `prbnmcn-stats` for already existing releases, so that their tests run predictably.

I've filed an upstream PR to restore the property for the next `prbnmcn-stats` release: https://github.com/igarnier/prbnmcn-stats/pull/5