### PR TITLE
Upper bound qcheck-core in goblint 2.2.1-2.5.0

### DIFF
--- a/packages/goblint/goblint.2.0.0/opam
+++ b/packages/goblint/goblint.2.0.0/opam
@@ -25,7 +25,7 @@ depends: [
   "batteries" {>= "3.4.0"}
   "zarith" {>= "1.8"}
   "yojson" {>= "2.0.0" & < "3"}
-  "qcheck-core"
+  "qcheck-core" {>= "0.19" & < "0.26"}
   "ppx_deriving"
   "ppx_deriving_hash"
   "ppx_deriving_yojson" {>= "3.7.0"}

--- a/packages/goblint/goblint.2.0.1/opam
+++ b/packages/goblint/goblint.2.0.1/opam
@@ -25,7 +25,7 @@ depends: [
   "batteries" {>= "3.4.0"}
   "zarith" {>= "1.8"}
   "yojson" {>= "2.0.0" & < "3"}
-  "qcheck-core"
+  "qcheck-core" {>= "0.19" & < "0.26"}
   "ppx_deriving"
   "ppx_deriving_hash"
   "ppx_deriving_yojson" {>= "3.7.0"}

--- a/packages/goblint/goblint.2.1.0/opam
+++ b/packages/goblint/goblint.2.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "batteries" {>= "3.4.0"}
   "zarith" {>= "1.8"}
   "yojson" {>= "2.0.0" & < "3"}
-  "qcheck-core"
+  "qcheck-core" {>= "0.19" & < "0.26"}
   "ppx_deriving"
   "ppx_deriving_hash"
   "ppx_deriving_yojson" {>= "3.7.0"}

--- a/packages/goblint/goblint.2.2.1/opam
+++ b/packages/goblint/goblint.2.2.1/opam
@@ -24,7 +24,7 @@ depends: [
   "batteries" {>= "3.5.0"}
   "zarith" {>= "1.8"}
   "yojson" {>= "2.0.0" < "3"}
-  "qcheck-core" {>= "0.19"}
+  "qcheck-core" {>= "0.19" & < "0.26"}
   "ppx_deriving"
   "ppx_deriving_hash"
   "ppx_deriving_yojson" {>= "3.7.0"}

--- a/packages/goblint/goblint.2.3.0/opam
+++ b/packages/goblint/goblint.2.3.0/opam
@@ -24,7 +24,7 @@ depends: [
   "batteries" {>= "3.5.0"}
   "zarith" {>= "1.8"}
   "yojson" {>= "2.0.0" & < "3"}
-  "qcheck-core" {>= "0.19"}
+  "qcheck-core" {>= "0.19" & < "0.26"}
   "ppx_deriving"
   "ppx_deriving_hash"
   "ppx_deriving_yojson" {>= "3.7.0"}

--- a/packages/goblint/goblint.2.4.0/opam
+++ b/packages/goblint/goblint.2.4.0/opam
@@ -40,7 +40,7 @@ depends: [
   "batteries" {>= "3.5.1"}
   "zarith" {>= "1.10"}
   "yojson" {>= "2.0.0" & < "3"}
-  "qcheck-core" {>= "0.19"}
+  "qcheck-core" {>= "0.19" & < "0.26"}
   "ppx_deriving" {>= "6.0.2"}
   "ppx_deriving_hash" {>= "0.1.2"}
   "ppx_deriving_yojson" {>= "3.7.0"}

--- a/packages/goblint/goblint.2.5.0/opam
+++ b/packages/goblint/goblint.2.5.0/opam
@@ -40,7 +40,7 @@ depends: [
   "batteries" {>= "3.5.1"}
   "zarith" {>= "1.10"}
   "yojson" {>= "2.0.0" & < "3"}
-  "qcheck-core" {>= "0.19"}
+  "qcheck-core" {>= "0.19" & < "0.26"}
   "ppx_deriving" {>= "6.0.2"}
   "ppx_deriving_hash" {>= "0.1.2"}
   "ppx_deriving_yojson" {>= "3.7.0"}


### PR DESCRIPTION
The forthcoming QCheck 0.26 release in #28148 patches the `float` generators to avoid blind spots: c-cube/qcheck#350.
The CI run for the release however revealed such a blind spot, causing a `goblint` QCheck test to start failing when run with QCheck 0.26:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/c715a95fe87d4397d1f0658b2ae5acd528de705e

This PR therefore adds an upper bound of qcheck-core for `goblint` for releases 2.2.1-2.5.0, so that their tests run predictably.

I've filed an upstream PR to restore the property for the next `goblint` release: https://github.com/goblint/analyzer/pull/1778