### PR TITLE
goblint.2.1.0: add catapult upper bound < 0.2

### DIFF
--- a/packages/goblint/goblint.2.1.0/opam
+++ b/packages/goblint/goblint.2.1.0/opam
@@ -42,7 +42,7 @@ depends: [
   "arg-complete"
   "yaml" {>= "3.0.0"}
   "uuidm"
-  "catapult"
+  "catapult" {< "0.2"}
   "catapult-file"
   "conf-gmp" {>= "3"}
   "conf-ruby" {with-test}


### PR DESCRIPTION
I noticed warnings the related partial application warnings in the CI for #28155. This is the only version on opam which doesn't include the fix https://github.com/goblint/analyzer/commit/4577d4774361443b063ef6f975cd609b9dc95f93.

There will probably be the same CI failures for it as in #28155, which are a bigger problem, but at least this fixes one small issue.