### PR TITLE
[new release] ppxlib (3 packages) (0.36.1)

### DIFF
--- a/packages/ppxlib-tools/ppxlib-tools.0.36.1/opam
+++ b/packages/ppxlib-tools/ppxlib-tools.0.36.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Tools for PPX users and authors"
+description: """
+Set of helper tools for PPX users and authors.
+
+ppxlib-pp-ast: Command line tool to pretty print OCaml ASTs in a human readable
+format."""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0"}
+  "ppxlib" {= version}
+  "cmdliner" {>= "1.3.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.36.1/ppxlib-0.36.1.tbz"
+  checksum: [
+    "sha256=6152bac3eea1854416a435a62fa407a402abf347be623c241fbf46480e71efb3"
+    "sha512=d5663e200f976e12617ffabdb631221eea1d03e26a64b01c444c59fcfcf98628f9d958b5726b19655214d3b67557d13903d3bf0d9571fb4a6ada17c03293abdc"
+  ]
+}
+x-commit-hash: "246131bbcd9b528cecdd0d68c4ccb4fd1f9d8546"

--- a/packages/ppxlib/ppxlib.0.36.1/opam
+++ b/packages/ppxlib/ppxlib.0.36.1/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "Standard infrastructure for ppx rewriters"
+description: """
+Ppxlib is the standard infrastructure for ppx rewriters
+and other programs that manipulate the in-memory representation of
+OCaml programs, a.k.a the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0" & < "5.4.0"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0" {>= "v0.12"}
+  "sexplib0" {with-test & >= "v0.15"}
+  "stdlib-shims"
+  "ocamlfind" {with-test}
+  "re" {with-test & >= "1.9.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "ocamlformat" {with-dev-setup & = "0.26.2"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-migrate-parsetree" {< "2.0.0"}
+  "ocaml-base-compiler" {= "5.1.0~alpha1"}
+  "ocaml-variants" {= "5.1.0~alpha1+options"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.36.1/ppxlib-0.36.1.tbz"
+  checksum: [
+    "sha256=6152bac3eea1854416a435a62fa407a402abf347be623c241fbf46480e71efb3"
+    "sha512=d5663e200f976e12617ffabdb631221eea1d03e26a64b01c444c59fcfcf98628f9d958b5726b19655214d3b67557d13903d3bf0d9571fb4a6ada17c03293abdc"
+  ]
+}
+x-commit-hash: "246131bbcd9b528cecdd0d68c4ccb4fd1f9d8546"


### PR DESCRIPTION
Standard infrastructure for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Fix ppxlib driver's AST to source printer. Our copy of pprintast was not
  properly updated which resulted in incorrect printing of value bindings'
  constraints (ocaml-ppx/ppxlib#585, @NathanReb)
