### PR TITLE
gen_js_api 1.1.* tests are not compatible with latest js_of_ocaml

### DIFF
--- a/packages/gen_js_api/gen_js_api.1.1.0/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.22" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
   "ppxlib" {with-test & < "0.26.0"}
-  "js_of_ocaml-compiler" {with-test}
+  "js_of_ocaml-compiler" {with-test & < "6.1.1"}
   "conf-npm" {with-test}
   "ojs" {= "1.1.0"}
   "odoc" {with-doc}

--- a/packages/gen_js_api/gen_js_api.1.1.0/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.22" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
   "ppxlib" {with-test & < "0.26.0"}
-  "js_of_ocaml-compiler" {with-test & < "6.1.1"}
+  "js_of_ocaml-compiler" {with-test & < "6.0"}
   "conf-npm" {with-test}
   "ojs" {= "1.1.0"}
   "odoc" {with-doc}

--- a/packages/gen_js_api/gen_js_api.1.1.1/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.1/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.26" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
-  "js_of_ocaml-compiler" {with-test & < "6.1.1"}
+  "js_of_ocaml-compiler" {with-test & < "6.0"}
   "conf-npm" {with-test}
   "ojs" {= "1.1.1"}
   "odoc" {with-doc}

--- a/packages/gen_js_api/gen_js_api.1.1.1/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.1/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.26" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
-  "js_of_ocaml-compiler" {with-test}
+  "js_of_ocaml-compiler" {with-test & < "6.1.1"}
   "conf-npm" {with-test}
   "ojs" {= "1.1.1"}
   "odoc" {with-doc}

--- a/packages/gen_js_api/gen_js_api.1.1.2/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.2/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.26" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
-  "js_of_ocaml-compiler" {with-test & < "6.1.1"}
+  "js_of_ocaml-compiler" {with-test & < "6.0"}
   "conf-npm" {with-test}
   "ojs" {= version}
   "odoc" {with-doc}

--- a/packages/gen_js_api/gen_js_api.1.1.2/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.2/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.26" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
-  "js_of_ocaml-compiler" {with-test}
+  "js_of_ocaml-compiler" {with-test & < "6.1.1"}
   "conf-npm" {with-test}
   "ojs" {= version}
   "odoc" {with-doc}

--- a/packages/gen_js_api/gen_js_api.1.1.3/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.3/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.26" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
-  "js_of_ocaml-compiler" {with-test & < "6.1.1"}
+  "js_of_ocaml-compiler" {with-test & < "6.0"}
   "conf-npm" {with-test}
   "ojs" {= version}
   "odoc" {with-doc}

--- a/packages/gen_js_api/gen_js_api.1.1.3/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.3/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.26" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
-  "js_of_ocaml-compiler" {with-test}
+  "js_of_ocaml-compiler" {with-test & < "6.1.1"}
   "conf-npm" {with-test}
   "ojs" {= version}
   "odoc" {with-doc}

--- a/packages/gen_js_api/gen_js_api.1.1.4/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.4/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.26" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
-  "js_of_ocaml-compiler" {with-test & < "6.1.1"}
+  "js_of_ocaml-compiler" {with-test & < "6.0"}
   "ojs" {= version}
   "odoc" {with-doc}
 ]

--- a/packages/gen_js_api/gen_js_api.1.1.4/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.4/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.26" & < "0.36"} | ("ocaml" {< "5.3"} & "ppxlib" {>= "0.36"})
-  "js_of_ocaml-compiler" {with-test}
+  "js_of_ocaml-compiler" {with-test & < "6.1.1"}
   "ojs" {= version}
   "odoc" {with-doc}
 ]

--- a/packages/gen_js_api/gen_js_api.1.1.5/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.5/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.26"}
-  "js_of_ocaml-compiler" {with-test & < "6.1.1"}
+  "js_of_ocaml-compiler" {with-test & < "6.0"}
   "ojs" {= version}
   "odoc" {with-doc}
 ]

--- a/packages/gen_js_api/gen_js_api.1.1.5/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.5/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.26"}
-  "js_of_ocaml-compiler" {with-test}
+  "js_of_ocaml-compiler" {with-test & < "6.1.1"}
   "ojs" {= version}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Fails with
```
 -let (_ : string of_js) = Ojs.string_of_js
 -let (_ : string to_js) = Ojs.string_to_js
 -let (_ : int of_js) = Ojs.int_of_js
 -let (_ : int to_js) = Ojs.int_to_js
 -let (_ : bool of_js) = Ojs.bool_of_js
 -let (_ : bool to_js) = Ojs.bool_to_js
 -let (_ : float of_js) = Ojs.float_of_js
 -let (_ : float to_js) = Ojs.float_to_js
 -let (_ : Ojs.t of_js) = fun (x9 : Ojs.t) -> x9
 -let (_ : Ojs.t to_js) = fun (x10 : Ojs.t) -> x10
 -let (_ : (string * int) of_js) =
 +let _ = Ojs.string_of_js
 +let _ = Ojs.string_to_js
 +let _ = Ojs.int_of_js
 +let _ = Ojs.int_to_js
 +let _ = Ojs.bool_of_js
 +let _ = Ojs.bool_to_js
 +let _ = Ojs.float_of_js
 +let _ = Ojs.float_to_js
 +let _ = fun (x9 : Ojs.t) -> x9
 +let _ = fun (x10 : Ojs.t) -> x10
 +let _ =
    fun (x11 : Ojs.t) ->
      let x12 = x11 in
      ((Ojs.string_of_js (Ojs.array_get x12 0)),
        (Ojs.int_of_js (Ojs.array_get x12 1)))
 -let (_ : (string * int) to_js) =
 +let _ =
    fun (x13 : (string * int)) ->
      let (x14, x15) = x13 in
      let x16 = Ojs.array_make 2 in
      Ojs.array_set x16 0 (Ojs.string_to_js x14);
      Ojs.array_set x16 1 (Ojs.int_to_js x15);
      x16
```