### PR TITLE
[new release] logs-async (2 packages) (1.4)

### DIFF
--- a/packages/logs-async-reporter/logs-async-reporter.1.4/opam
+++ b/packages/logs-async-reporter/logs-async-reporter.1.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Logs reporter compatible with Async"
+description: "Logs reporter that will play nice with Async's runtime."
+maintainer: ["Vincent Bernardoff <vb@luminar.eu.org>"]
+authors: ["Vincent Bernardoff <vb@luminar.eu.org>"]
+license: "ISC"
+tags: ["async" "logs"]
+homepage: "https://github.com/vbmithr/logs-async"
+doc: "https://vbmithr.github.io/logs-async"
+bug-reports: "https://github.com/vbmithr/logs-async/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.10"}
+  "logs" {>= "0.9.0"}
+  "fmt" {>= "0.9.0"}
+  "core" {>= "v0.17"}
+  "async" {>= "v0.17"}
+  "zstandard" {>= "v0.17"}
+  "yojson" {>= "2.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/vbmithr/logs-async.git"
+url {
+  src:
+    "https://github.com/vbmithr/logs-async/releases/download/1.4/logs-async-1.4.tbz"
+  checksum: [
+    "sha256=e76db142b2a8dd9b72dbcde22d1f92be3c6a3f89c5fecfb8ef49934b5f5d551b"
+    "sha512=92b679ddc6769600547d7539aab7362c0f468aa73b3ae57f2965f0f06c0c2c504158a2057fc20a09a9182d683852b91ffe91e9c88dfd4bb06a06f2321e01bf63"
+  ]
+}
+x-commit-hash: "3e1e23290d5da022f4f83047a9de349add4b16e9"

--- a/packages/logs-async/logs-async.1.4/opam
+++ b/packages/logs-async/logs-async.1.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Jane Street Async logging with Logs"
+description: """
+This is analogous to the Logs_lwt module in the logs package.
+The log functions of this module return Async threads that proceed only
+when the log operation is over, as defined by the current
+Logs.reporter."""
+maintainer: ["Vincent Bernardoff <vb@luminar.eu.org>"]
+authors: ["Vincent Bernardoff <vb@luminar.eu.org>"]
+license: "ISC"
+tags: ["async" "logs"]
+homepage: "https://github.com/vbmithr/logs-async"
+doc: "https://vbmithr.github.io/logs-async"
+bug-reports: "https://github.com/vbmithr/logs-async/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.10"}
+  "logs" {>= "0.9.0"}
+  "async_kernel" {>= "v0.17"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/vbmithr/logs-async.git"
+url {
+  src:
+    "https://github.com/vbmithr/logs-async/releases/download/1.4/logs-async-1.4.tbz"
+  checksum: [
+    "sha256=e76db142b2a8dd9b72dbcde22d1f92be3c6a3f89c5fecfb8ef49934b5f5d551b"
+    "sha512=92b679ddc6769600547d7539aab7362c0f468aa73b3ae57f2965f0f06c0c2c504158a2057fc20a09a9182d683852b91ffe91e9c88dfd4bb06a06f2321e01bf63"
+  ]
+}
+x-commit-hash: "3e1e23290d5da022f4f83047a9de349add4b16e9"


### PR DESCRIPTION
Jane Street Async logging with Logs

- Project page: <a href="https://github.com/vbmithr/logs-async">https://github.com/vbmithr/logs-async</a>
- Documentation: <a href="https://vbmithr.github.io/logs-async">https://vbmithr.github.io/logs-async</a>

##### CHANGES:

- Use latest dune-project format and opam file autogeneration
- ocamlformat Janestreet style formatting
- Remove OVH logger
