### PR TITLE
Add an ocaml 5.4 upper bound on qcheck-ounit.0.25

### DIFF
--- a/packages/qcheck-ounit/qcheck-ounit.0.25/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.25/opam
@@ -18,7 +18,7 @@ depends: [
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "5.4"}
 ]
 dev-repo: "git+https://github.com/c-cube/qcheck.git"
 url {


### PR DESCRIPTION
qcheck-ounit 0.18-0.25 will fail its test run on OCaml 5.4.0 https://github.com/c-cube/qcheck/pull/346 due to a difference in the number of spaces printed:
```diff
File "example/ounit/QCheck_ounit_test.expected", line 1, characters 0-0:
diff --git a/_build/default/example/ounit/QCheck_ounit_test.expected b/_build/default/example/ounit/QCheck_ounit_test.output
index a95398e..7ecae3f 100644
--- a/_build/default/example/ounit/QCheck_ounit_test.expected
+++ b/_build/default/example/ounit/QCheck_ounit_test.output
@@ -55,7 +55,7 @@ Error: tests:1:fail_sort_id (in the log).
 
 
 test `fail_sort_id` failed on ≥ 1 cases: [1; 0] (after 16 shrink steps)
-                                           
+                                         
 
 ------------------------------------------------------------------------------
 Ran: 8 tests in: <nondet> seconds.

```
This is fixed in the newly released qcheck-ounit 0.26.

This PR therefore sets an OCaml upper bound for 0.25 to limit the red CI lights.
Versions 0.18-0.24 are also affected but have been archived from the opam repo.