### PR TITLE
Package josecaml.0.1.0

### DIFF
--- a/packages/josecaml/josecaml.0.1.0/opam
+++ b/packages/josecaml/josecaml.0.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+homepage: "https://github.com/nsklyarov/josecaml"
+bug-reports: "https://github.com/nsklyarov/josecaml/issues"
+dev-repo: "git+https://github.com/nsklyarov/josecaml.git"
+synopsis: "Minimal JWT implementation in OCaml"
+description: """
+josecaml is a lightweight, dependency-minimal library for JSON Web Token (JWT) encoding and decoding in OCaml.
+It currently supports HMAC-SHA256 (HS256) with base64url encoding.
+"""
+maintainer: "nsklyarov.work@gmail.com"
+authors: "Nikita Sklyarov"
+license: "MIT"
+depends: [
+  "ocaml"    {>= "4.14.0"}
+  "dune"     {>= "3.5"}
+  "base64"   {>= "3.5.0"}
+  "digestif" {>= "1.1.0"}
+  "cstruct"  {>= "6.0.0"}
+  "yojson"   {>= "2.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/nsklyarov/josecaml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=7e10f6ae6b19a82c2dcda2b5bc742794"
+    "sha512=cfee46721bc414e12fc094fef6df64251cb5b195b76ae9559ba8a6c80e31d570c8f27da16f3ae479595048b52e5e71ab26d06bc9419dd45ab60ad4169dcbacf4"
+  ]
+}


### PR DESCRIPTION
### `josecaml.0.1.0`
Minimal JWT implementation in OCaml
josecaml is a lightweight, dependency-minimal library for JSON Web Token (JWT) encoding and decoding in OCaml.
It currently supports HMAC-SHA256 (HS256) with base64url encoding.



---
* Homepage: https://github.com/nsklyarov/josecaml
* Source repo: git+https://github.com/nsklyarov/josecaml.git
* Bug tracker: https://github.com/nsklyarov/josecaml/issues

---
:camel: Pull-request generated by opam-publish v2.5.1