### PR TITLE
release camlp5 8.03.06 -- fixed (+tests) line directive support

### DIFF
--- a/packages/camlp5/camlp5.8.03.06/opam
+++ b/packages/camlp5/camlp5.8.03.06/opam
@@ -49,6 +49,7 @@ build: [
   [make "-j%{jobs}%" "DEBUG=-g" "all"]
   [make "-C" "testsuite" "clean" "all-tests"] { with-test }
   [make "-C" "test" "clean" "all"] { with-test & os != "macos" & os != "opensuse-tumbleweed" }
+  [make "-C" "mdx-tests" "clean" "all"] { with-test & os != "macos" & os != "opensuse-tumbleweed" }
 #  [make "-C" "scripts" "clean" "test"] { with-test }
 ]
 install: [make "install"]

--- a/packages/camlp5/camlp5.8.03.06/opam
+++ b/packages/camlp5/camlp5.8.03.06/opam
@@ -66,6 +66,6 @@ dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.03.06.tar.gz"
   checksum: [
-    "sha512=322ccb24a88d7cf0e219760fd33bccbc2ac1578eb934aabfaa05b0cfb66163269ea947509ec8279a414d5145faf8fa2b464da3749c700b460d855aabaf8e66d2"
+    "sha512=2110347f00ef4aa4377c74e2764a2fb2ac6ea2d0844fffd106bd1543d9c54f9cb0fdcbc70d49e517e83d30da3e22fd970aa55378a1ea9b70f217541d8a1ef5b0"
   ]
 }

--- a/packages/camlp5/camlp5.8.03.06/opam
+++ b/packages/camlp5/camlp5.8.03.06/opam
@@ -55,7 +55,7 @@ build: [
 install: [make "install"]
 conflicts: [
    "ocaml-option-bytecode-only"
-   "pa_ppx" { < "0.18" }
+   "pa_ppx" { < "0.19" }
    "p5scm" { <= "0.3.1" }
    "matita" { <= "0.99.5" }
    "lablgl" { <= "1.07" }

--- a/packages/camlp5/camlp5.8.03.06/opam
+++ b/packages/camlp5/camlp5.8.03.06/opam
@@ -1,0 +1,70 @@
+
+opam-version: "2.0"
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description: """
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel."""
+x-maintenance-intent: [ "(latest)" ]
+maintainer: ["Chet Murthy <chetsky@gmail.com>"]
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+license: "BSD-3-Clause"
+homepage: "https://camlp5.github.io"
+doc: "https://camlp5.github.io/doc/html"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+depends: [
+  "ocaml" {>= "4.10" & < "5.04.0" }
+  "ocamlfind"
+  "camlp-streams" { >= "5.0" }
+  "conf-perl"
+  "conf-bash"
+  "camlp5-buildscripts" { >= "0.06" }
+  "conf-diffutils" { with-test & (os-distribution = "alpine" | os-distribution = "freebsd") }
+  "re" { >= "1.11.0" }
+  "ounit2" { with-test }
+  "pcre2" { >= "8.0.3" }
+  "rresult"
+  "bos"
+  "fmt"
+  "mdx" {>= "2.3.0" & with-test}
+]
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man "-oversion" ocaml:version]
+  [make "-j%{jobs}%" "DEBUG=-g" "world.opt"]
+  [make "-j%{jobs}%" "DEBUG=-g" "all"]
+  [make "-C" "testsuite" "clean" "all-tests"] { with-test }
+  [make "-C" "test" "clean" "all"] { with-test & os != "macos" & os != "opensuse-tumbleweed" }
+#  [make "-C" "scripts" "clean" "test"] { with-test }
+]
+install: [make "install"]
+conflicts: [
+   "ocaml-option-bytecode-only"
+   "pa_ppx" { < "0.18" }
+   "p5scm" { <= "0.3.1" }
+   "matita" { <= "0.99.5" }
+   "lablgl" { <= "1.07" }
+   "frama-clang" { = "0.0.14" }
+]
+x-ci-accept-failures: [ "opensuse-tumbleweed" ]
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+url {
+  src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.03.06.tar.gz"
+  checksum: [
+    "sha512=322ccb24a88d7cf0e219760fd33bccbc2ac1578eb934aabfaa05b0cfb66163269ea947509ec8279a414d5145faf8fa2b464da3749c700b460d855aabaf8e66d2"
+  ]
+}

--- a/packages/camlp5/camlp5.8.03.06/opam
+++ b/packages/camlp5/camlp5.8.03.06/opam
@@ -49,7 +49,7 @@ build: [
   [make "-j%{jobs}%" "DEBUG=-g" "all"]
   [make "-C" "testsuite" "clean" "all-tests"] { with-test }
   [make "-C" "test" "clean" "all"] { with-test & os != "macos" & os != "opensuse-tumbleweed" }
-  [make "-C" "mdx-tests" "clean" "all"] { with-test & os != "macos" & os != "opensuse-tumbleweed" }
+  [make "-C" "mdx-tests" "clean" "all"] { with-test & os != "macos" & os != "opensuse-tumbleweed" & ocaml >= "4.14" }
 #  [make "-C" "scripts" "clean" "test"] { with-test }
 ]
 install: [make "install"]
@@ -66,6 +66,6 @@ dev-repo: "git+https://github.com/camlp5/camlp5.git"
 url {
   src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.03.06.tar.gz"
   checksum: [
-    "sha512=2110347f00ef4aa4377c74e2764a2fb2ac6ea2d0844fffd106bd1543d9c54f9cb0fdcbc70d49e517e83d30da3e22fd970aa55378a1ea9b70f217541d8a1ef5b0"
+    "sha512=86be96c26ba86f6c603944c75255de99a0a62ad850c8d68c3811125eddf9a976d9be1e0cb3eb95a01c1081b46c21b1442469bb241f76817fc5dad5165b0fd370"
   ]
 }

--- a/packages/camlp5/camlp5.8.03.06/opam
+++ b/packages/camlp5/camlp5.8.03.06/opam
@@ -55,7 +55,7 @@ build: [
 install: [make "install"]
 conflicts: [
    "ocaml-option-bytecode-only"
-   "pa_ppx" { < "0.19" }
+   "pa_ppx" { <= "0.19" }
    "p5scm" { <= "0.3.1" }
    "matita" { <= "0.99.5" }
    "lablgl" { <= "1.07" }


### PR DESCRIPTION
the previous version was incomplete, and I didn't add tests; now there are (I hope) extensive tests.