### PR TITLE
retry release 8.03.06: fixed and unit-tested line-directive support

### DIFF
--- a/packages/camlp5/camlp5.8.03.06/opam
+++ b/packages/camlp5/camlp5.8.03.06/opam
@@ -1,0 +1,71 @@
+
+opam-version: "2.0"
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description: """
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel."""
+x-maintenance-intent: [ "(latest)" ]
+maintainer: ["Chet Murthy <chetsky@gmail.com>"]
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+license: "BSD-3-Clause"
+homepage: "https://camlp5.github.io"
+doc: "https://camlp5.github.io/doc/html"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+depends: [
+  "ocaml" {>= "4.10" & < "5.04.0" }
+  "ocamlfind"
+  "camlp-streams" { >= "5.0" }
+  "conf-perl"
+  "conf-bash"
+  "camlp5-buildscripts" { >= "0.06" }
+  "conf-diffutils" { with-test & (os-distribution = "alpine" | os-distribution = "freebsd") }
+  "re" { >= "1.11.0" }
+  "ounit2" { with-test }
+  "pcre2" { >= "8.0.3" }
+  "rresult"
+  "bos"
+  "fmt"
+  "mdx" {>= "2.3.0" & with-test}
+]
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man "-oversion" ocaml:version]
+  [make "-j%{jobs}%" "DEBUG=-g" "world.opt"]
+  [make "-j%{jobs}%" "DEBUG=-g" "all"]
+  [make "-C" "testsuite" "clean" "all-tests"] { with-test }
+  [make "-C" "test" "clean" "all"] { with-test & os != "macos" & os != "opensuse-tumbleweed" }
+  [make "-C" "mdx-tests" "clean" "all"] { with-test & os != "macos" & os != "opensuse-tumbleweed" }
+#  [make "-C" "scripts" "clean" "test"] { with-test }
+]
+install: [make "install"]
+conflicts: [
+   "ocaml-option-bytecode-only"
+   "pa_ppx" { <= "0.19" }
+   "p5scm" { <= "0.3.1" }
+   "matita" { <= "0.99.5" }
+   "lablgl" { <= "1.07" }
+   "frama-clang" { = "0.0.14" }
+]
+x-ci-accept-failures: [ "opensuse-tumbleweed" ]
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+url {
+  src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.03.06.tar.gz"
+  checksum: [
+    "sha512=eb4b665e5e3360320a1d87e458385bf521bcb1a0f569637e6f9436aedd027fb264ad4c2b6b60f77aa32ea3c2670827573b6a02acf1ee3258a4734012647803fd"
+  ]
+}


### PR DESCRIPTION
now supports line directives in both original and revised syntax.

unit-tests using ocaml-mdx.

To allow ocaml-mdx to work for revised syntax, I added ";;" as a terminator for toplevel phrases, but only for toplevel phrases.