### PR TITLE
ocp-index 1.3.4 breaks ocp-index-top

### DIFF
--- a/packages/ocp-index-top/ocp-index-top.0.5.0/opam
+++ b/packages/ocp-index-top/ocp-index-top.0.5.0/opam
@@ -15,7 +15,7 @@ depends: [
   "topkg" {build}
   "cppo" {build}
   "cppo_ocamlbuild" {build}
-  "ocp-index"
+  "ocp-index" {< "1.3.4"}
 ]
 synopsis: "Documentation in the OCaml toplevel"
 authors: "Reynir Björnsson <reynir@reynir.dk>"

--- a/packages/ocp-index-top/ocp-index-top.0.5.0/opam
+++ b/packages/ocp-index-top/ocp-index-top.0.5.0/opam
@@ -15,7 +15,7 @@ depends: [
   "topkg" {build}
   "cppo" {build}
   "cppo_ocamlbuild" {build}
-  "ocp-index" {< "1.3.4"}
+  "ocp-index" {>= "1.1.9" < "1.3.4"}
 ]
 synopsis: "Documentation in the OCaml toplevel"
 authors: "Reynir Björnsson <reynir@reynir.dk>"


### PR DESCRIPTION
OCamlPro/ocp-index@4abad8e
```
  # File "ocpIndexTop.cppo.ml", line 83, characters 21-26:
  # Error: This expression has type qualify:bool -> LibIndex.t
  #        but an expression was expected of type LibIndex.t
```
@AltGr Please consider bumping the version to 1.4 (if not 2.0).