### PR TITLE
[new release] hilite (0.5.0)

### DIFF
--- a/packages/hilite/hilite.0.5.0/opam
+++ b/packages/hilite/hilite.0.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Build time syntax highlighting"
+description:
+  "A library for adding syntax highlighting to OCaml-related code and outputing to HTML"
+maintainer: ["patrick@sirref.org"]
+authors: ["Patrick Ferris"]
+license: "ISC"
+tags: ["syntax" "highlighting"]
+homepage: "https://github.com/patricoferris/hilite"
+bug-reports: "https://github.com/patricoferris/hilite/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "mdx" {>= "2.4.1" & with-test}
+  "cmarkit" {>= "0.3.0" & with-test}
+  "textmate-language" {>= "0.3.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/patricoferris/hilite.git"
+url {
+  src:
+    "https://github.com/patricoferris/hilite/releases/download/v0.5.0/hilite-0.5.0.tbz"
+  checksum: [
+    "sha256=550c01abe4a95808553693499dcb75ef87bd86127db8f3db1f94a81689e13a15"
+    "sha512=b42375e1dd288fc3795c570be2b94486aa91c499c5b6a2cff936d530d6864b57f0269deb73a7f333339e41e89b4cd0452655ff7c40f58360cea13efaee645115"
+  ]
+}
+x-commit-hash: "529cb756b05dd15793c181304f438ba1aa48f12a"


### PR DESCRIPTION
Build time syntax highlighting

- Project page: <a href="https://github.com/patricoferris/hilite">https://github.com/patricoferris/hilite</a>

##### CHANGES:

- Allow users to supply their own grammars and bypass the built-in ones (patricoferris/hilite#19, @patricoferris)
- Separate markdown package into an optional `hilite.markdown` package (patricoferris/hilite#18, @patricoferris)
