### PR TITLE
release pa_ppx 0.20 for compat with camlp5 8.03.06

### DIFF
--- a/packages/pa_ppx/pa_ppx.0.20/opam
+++ b/packages/pa_ppx/pa_ppx.0.20/opam
@@ -1,0 +1,78 @@
+
+synopsis: "PPX Rewriters for Ocaml, written using Camlp5"
+description:
+"""
+This is a collection of PPX rewriters, re-implementing those based on ppxlib
+and other libraries, but instead based on Camlp5.  Included is also a collection
+of support libraries for writing new PPX rewriters.  Included are:
+
+pa_assert: ppx_assert
+pa_ppx.deriving, pa_ppx.deriving_plugins (enum, eq, fold, iter, make, map, ord, sexp, show, yojson):
+  ppx_deriving, plugins, ppx_sexp_conv, ppx_deriving_yojson
+pa_ppx.expect_test: ppx_expect_test
+pa_ppx.here: ppx_here
+pa_ppx.import: ppx_import
+pa_ppx.inline_test: ppx_inline_test
+
+pa_ppx.undo_deriving: pa_ppx.deriving expands [@@deriving ...] into code; this rewriter undoes that.
+pa_ppx.unmatched_vala: expands to match-cases (support library for camlp5-based PPX rewriters)
+pa_ppx.hashrecons: support for writing AST rewriters that automatically fills in hash-consing boilerplate
+pa_dock: implements doc-comment extraction for camlp5 preprocessors
+
+Many of the reimplementations in fact offer significant enhanced
+function, described in the pa_ppx documentation.  In addition, there
+is an extensive test-suite, much of it slightly modified versions of
+the tests for the respective PPX rewriters.
+
+"""
+opam-version: "2.0"
+x-maintenance-intent: [ "(latest)" ]
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx.git"
+doc: "https://github.com/camlp5/pa_ppx/doc"
+x-ci-accept-failures: [ "opensuse-tumbleweed" ]
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "5.4.0" }
+  "conf-perl"
+  "camlp5-buildscripts" { >= "0.03" }
+  "camlp5"      { >= "8.03.06" }
+  "not-ocamlfind" { >= "0.10" }
+  "pcre2"
+  "result" { >= "1.5" }
+  "yojson" { >= "1.7.0" }
+  "yojson" { with-test & >= "3.0.0" }
+  "sexplib0"
+  "bos" { >= "0.2.0" }
+  "fmt"
+  "uint" { >= "2.0.1" }
+  "ounit"
+  "mdx" {>= "2.3.0" & with-test}
+  "cppo"
+  "sexplib" { >= "v0.14.0" }
+  "ppx_import" { with-test & >= "1.7.1"  & <= "1.11.0" }
+  "ppx_deriving" { with-test & >= "6.0.2" }
+  "ppx_deriving_yojson" { with-test & >= "3.10.0" }
+  "ppx_here" { with-test & >= "v0.13.0" }
+  "ppx_sexp_conv" { with-test & >= "v0.13.0" }
+#  "expect_test_helpers" { with-test & >= "v0.13.0" }
+]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
+build: [
+  [make "get-generated"]
+  [make "-j%{jobs}%" "DEBUG=-g" "sys"]
+  [make "DEBUG=-g" "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx/archive/refs/tags/0.20.tar.gz"
+  checksum: [
+    "sha512=ff58c156d84c682c720c4b3eb7b3fc2c226750458f328cc03eb4f541c1e4a82303deae864a015e2a353350010c277466f2c7a36eb46e78d616d24e71ca695f58"
+  ]
+}


### PR DESCRIPTION
As with pa_ppx 0.19, tests can only run with ocaml 5.3.0, b/c pa_ppx tests need both modern ppx_deriving_yojson -and- ppx_sexp_conv.  They depend on ppxlib, and ... it's hard to get them at modern versions, with backlevel OCaml versions.