### PR TITLE
[new release] odoc (5 packages) (3.1.0)

### DIFF
--- a/packages/odoc-driver/odoc-driver.3.1.0/opam
+++ b/packages/odoc-driver/odoc-driver.3.1.0/opam
@@ -1,0 +1,75 @@
+opam-version: "2.0"
+homepage: "https://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+maintainer: [
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+]
+authors: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Leo White <leo@lpw25.net>"
+  "Lubega Simon <lubegasimon73@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+  "Thomas Refis <trefis@janestreet.com>"
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml Documentation Generator - Driver"
+description: """
+The driver is a sample implementation of a tool to drive odoc to generate
+documentation for installed packages.
+"""
+
+
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "odoc" {= version}
+  "dune" {>= "3.18.0"}
+  "odoc-md"
+  "bos"
+  "fpath" {>= "0.7.3"}
+  "yojson" {>= "2.0.0"}
+  "ocamlfind"
+  "opam-format" {>= "2.1.0"}
+  "logs"
+  "eio_main"
+  "eio" {>= "1.0"}
+  "progress"
+  "cmdliner" {>= "1.3.0"}
+  "sexplib"
+  "ppx_sexp_conv"
+  "sherlodoc"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: ["(latest)"]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/3.1.0/odoc-3.1.0.tbz"
+  checksum: [
+    "sha256=355b3cfff4934903cbaed8b51ce35e333e8609932d230294200a9f2d42ffa914"
+    "sha512=f78318d0a16164a9cd16ee02f611c2e00d32b772fe38e992d6db6ec94b1c00cd9c377fbfe64031b8f245e57b2f3aac9364108327e7f1693533ddcff94c476e05"
+  ]
+}
+x-commit-hash: "dbe1333c687102e1a9a1cbe59d63b8f69e6b1af0"

--- a/packages/odoc-md/odoc-md.3.1.0/opam
+++ b/packages/odoc-md/odoc-md.3.1.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+homepage: "https://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+maintainer: [
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+]
+authors: [
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+  "Jon Ludlam <jon@recoil.org>"
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml Documentation Generator - Markdown support"
+description: """
+Odoc-md is part of the odoc suite of tools for generating documentation for OCaml packages.
+
+This package provides support for generating documentation from Markdown files.
+"""
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "odoc" {= version}
+  "dune" {>= "3.18.0"}
+  "cmdliner" {>= "1.3.0"}
+  "cmarkit"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: ["(latest)"]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/3.1.0/odoc-3.1.0.tbz"
+  checksum: [
+    "sha256=355b3cfff4934903cbaed8b51ce35e333e8609932d230294200a9f2d42ffa914"
+    "sha512=f78318d0a16164a9cd16ee02f611c2e00d32b772fe38e992d6db6ec94b1c00cd9c377fbfe64031b8f245e57b2f3aac9364108327e7f1693533ddcff94c476e05"
+  ]
+}
+x-commit-hash: "dbe1333c687102e1a9a1cbe59d63b8f69e6b1af0"
+

--- a/packages/odoc-parser/odoc-parser.3.1.0/opam
+++ b/packages/odoc-parser/odoc-parser.3.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Parser for ocaml documentation comments"
+description: """
+Odoc_parser is a library for parsing the contents of OCaml documentation
+comments, formatted using 'odoc' syntax, an extension of the language
+understood by ocamldoc."""
+maintainer: ["Jon Ludlam <jon@recoil.org>"]
+authors: ["Anton Bachin <antonbachin@yahoo.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml/odoc"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+doc: "https://ocaml.github.io/odoc/odoc_parser"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.08.0" & < "5.5"}
+  "astring"
+  "camlp-streams"
+  "ppx_expect" {with-test}
+  "sexplib0" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    # Tests are not all associated with a package and would be run if using the
+    # default '@runtest'.
+    "@src/parser/runtest" {with-test}
+  ]
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/3.1.0/odoc-3.1.0.tbz"
+  checksum: [
+    "sha256=355b3cfff4934903cbaed8b51ce35e333e8609932d230294200a9f2d42ffa914"
+    "sha512=f78318d0a16164a9cd16ee02f611c2e00d32b772fe38e992d6db6ec94b1c00cd9c377fbfe64031b8f245e57b2f3aac9364108327e7f1693533ddcff94c476e05"
+  ]
+}
+x-commit-hash: "dbe1333c687102e1a9a1cbe59d63b8f69e6b1af0"
+

--- a/packages/odoc/odoc.3.1.0/opam
+++ b/packages/odoc/odoc.3.1.0/opam
@@ -1,0 +1,89 @@
+opam-version: "2.0"
+homepage: "https://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+maintainer: [
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+]
+authors: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Leo White <leo@lpw25.net>"
+  "Lubega Simon <lubegasimon73@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+  "Thomas Refis <trefis@janestreet.com>"
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml Documentation Generator"
+description: """
+**odoc** is a powerful and flexible documentation generator for OCaml. It reads *doc comments*, demarcated by `(** ... *)`, and transforms them into a variety of output formats, including HTML, LaTeX, and man pages.
+
+- **Output Formats:** Odoc generates HTML for web browsing, LaTeX for PDF generation, and man pages for use on Unix-like systems.
+- **Cross-References:** odoc uses the `ocamldoc` markup, which allows to create links for functions, types, modules, and documentation pages.
+- **Link to Source Code:** Documentation generated includes links to the source code of functions, providing an easy way to navigate from the docs to the actual implementation.
+- **Code Highlighting:** odoc automatically highlights syntax in code snippets for different languages.
+
+odoc is part of the [OCaml Platform](https://ocaml.org/docs/platform), the recommended set of tools for OCaml.
+"""
+
+
+depends: [
+  "odoc-parser" {= version}
+  "astring"
+  "cmdliner" {>= "1.3.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "3.18.0"}
+  "fpath" {>= "0.7.3"}
+  "ocaml" {>= "4.08.0" & < "5.5"}
+  "tyxml" {>= "4.4.0"}
+  "fmt"
+  "crunch" {>= "1.4.1"}
+  "ocamlfind" {with-test}
+  "yojson" {>= "2.1.0" & with-test}
+  "sexplib0" {with-test}
+  "conf-jq" {with-test}
+  "ppx_expect" {with-test}
+  "bos" {with-test}
+  "bisect_ppx" {with-test & > "2.5.0"}
+]
+
+conflicts: [ "ocaml-option-bytecode-only" ]
+
+x-extra-doc-deps: [
+  "odoc-driver" {= version}
+  "sherlodoc" {= version}
+  "odig"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/3.1.0/odoc-3.1.0.tbz"
+  checksum: [
+    "sha256=355b3cfff4934903cbaed8b51ce35e333e8609932d230294200a9f2d42ffa914"
+    "sha512=f78318d0a16164a9cd16ee02f611c2e00d32b772fe38e992d6db6ec94b1c00cd9c377fbfe64031b8f245e57b2f3aac9364108327e7f1693533ddcff94c476e05"
+  ]
+}
+x-commit-hash: "dbe1333c687102e1a9a1cbe59d63b8f69e6b1af0"

--- a/packages/sherlodoc/sherlodoc.3.1.0/opam
+++ b/packages/sherlodoc/sherlodoc.3.1.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Search engine for OCaml documentation"
+maintainer: ["art.wendling@gmail.com"]
+authors: ["Arthur Wendling" "Emile Trotignon"]
+license: "MIT"
+homepage: "https://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.0.8"}
+  "odoc" {= version}
+  "base64" {>= "3.5.1"}
+  "bigstringaf" {>= "0.9.1"}
+  "js_of_ocaml" {>= "5.6.0"}
+  "brr" {>= "0.0.6"}
+  "cmdliner" {>= "1.3.0"}
+  "decompress" {>= "1.5.3"}
+  "fpath" {>= "0.7.3"}
+  "lwt" {>= "5.7.0"}
+  "menhir" {>= "20230608"}
+  "ppx_blob" {>= "0.9.0"}
+  "tyxml" {>= "4.6.0"}
+  "result" {>= "1.5"}
+  "odig" {with-test}
+  "alcotest" {with-test}
+]
+depopts: [
+  "ancient" {>= "0.9.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@sherlodoc/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/3.1.0/odoc-3.1.0.tbz"
+  checksum: [
+    "sha256=355b3cfff4934903cbaed8b51ce35e333e8609932d230294200a9f2d42ffa914"
+    "sha512=f78318d0a16164a9cd16ee02f611c2e00d32b772fe38e992d6db6ec94b1c00cd9c377fbfe64031b8f245e57b2f3aac9364108327e7f1693533ddcff94c476e05"
+  ]
+}
+x-commit-hash: "dbe1333c687102e1a9a1cbe59d63b8f69e6b1af0"


### PR DESCRIPTION
CHANGES:

- Exposed sherlodoc libraries for use in other projects (@jonludlam, ocaml/odoc#1349)
- OCaml 5.4.0 support (@Octachron, ocaml/odoc#1355)
- New arguments to LaTeX generator, --shorten-beyond-depth and --remove-functor-arg-link (@Octachron, ocaml/odoc#1337)
- New experimental markdown generator (@davesnx, ocaml/odoc#1341)

- Remove cmdliner compatibility layer, no longer needed (@dbuenzli, ocaml/odoc#1328)
- Drop support for OCaml < 4.08 (@jonludlam, ocaml/odoc#1300)
- Allow referencing libraries from package added in `odoc-config.sexp` (@panglesd, ocaml/odoc#1343)
- Use full path in heading labels in LaTeX backend (@octachron, ocaml/odoc#1332)
- Separate page from anchor in LaTeX labels to prevent collisions (@Octachron, ocaml/odoc#1337)

- Fix bug in parsing META files when there are no dependencies (@jonludlam, ocaml/odoc#1352)
- Fix ocaml/odoc#1335 - incorrect rendering when on medium screen size with no global sidebar (@lukemaurer, ocaml/odoc#1361)
- Fixed generation of occurrences for docs CI (@jonludlam, ocaml/odoc#1362)
- Partial fix for ocaml/odoc#1369 - ensure that we never create a link to a hidden page (@jonludlam, ocaml/odoc#1370)