### PR TITLE
Improve packaging of Rocq 9.0.

### DIFF
--- a/packages/coq/coq.9.0.0/opam
+++ b/packages/coq/coq.9.0.0/opam
@@ -7,10 +7,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.8"}
-  "rocq-prover" {= version}
   "coq-core" {= version}
   "coq-stdlib" {= "9.0.0"}
   "coqide-server" {= version}
-  "odoc" {with-doc}
 ]

--- a/packages/rocq-prover/rocq-prover.9.0.0/opam
+++ b/packages/rocq-prover/rocq-prover.9.0.0/opam
@@ -20,12 +20,7 @@ homepage: "https://rocq-prover.org"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.8"}
-  "rocq-core" {= version}
+  "rocq-core"
   "rocq-stdlib"
-  "ounit2" {with-test}
-  "conf-python-3" {with-test}
-  "conf-time" {with-test}
-  "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/coq/coq.git"

--- a/packages/rocq-stdlib/rocq-stdlib.9.0.0/opam
+++ b/packages/rocq-stdlib/rocq-stdlib.9.0.0/opam
@@ -22,7 +22,7 @@ doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/stdlib/issues"
 depends: [
   "rocq-runtime"
-  "rocq-core" {>= "9.0" & < "9.1~"}
+  "rocq-core" {>= "9.0"}
 ]
 dev-repo: "git+https://github.com/coq/stdlib.git"
 build: [


### PR DESCRIPTION
1. Remove spurious dependencies from packages without any build instructions.

2. Remove the "rocq-prover" dependency from "coq" as "rocq-prover" is only meant to be installed by end users. Other packages should depend on either "rocq-runtime" or "rocq-core".

3. Remove some explicit versioning from "rocq-prover" as this virtual package will not change in the foreseeable future, so no need to release a new version every time.

4. Remove the upper bound from the "rocq-core" dependency of "rocq-stdlib" in order to ease the release of Rocq 9.1.