### PR TITLE
[new release] slipshow (0.4.1: The slides strike back)

### DIFF
--- a/packages/slipshow/slipshow.0.4.1/opam
+++ b/packages/slipshow/slipshow.0.4.1/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "A compiler from markdown to slipshow"
+description:
+  "Slipshow is an engine to write slips, a concept evolved from slides."
+maintainer: ["Paul-Elliot"]
+authors: ["Paul-Elliot"]
+license: ["GPL-3.0-or-later" "ISC" "BSD-3-Clause" "Apache-2.0" "OFL-1.1"]
+tags: ["slipshow" "presentation" "slideshow" "beamer"]
+homepage: "https://github.com/panglesd/slipshow"
+doc: "https://slipshow.readthedocs.io"
+bug-reports: "https://github.com/panglesd/slipshow/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.6"}
+  "crunch" {with-dev-setup}
+  "cmdliner" {>= "1.3.0"}
+  "base64"
+  "bos"
+  "lwt"
+  "inotify" {os = "linux"}
+  "cf-lwt" {>= "0.4"}
+  "astring"
+  "fmt"
+  "logs"
+  "fsevents-lwt"
+  "js_of_ocaml-compiler"
+  "js_of_ocaml-lwt"
+  "magic-mime"
+  "dream" {>= "1.0.0~alpha5"}
+  "fpath"
+  "ppx_blob" {>= "0.8.0"}
+  "sexplib"
+  "ppx_sexp_conv"
+  "odoc" {with-doc}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/panglesd/slipshow.git"
+# We avoid 32 bits arcitecture because our usage of ppx_blob generates strings
+# whose size exceed the maximum size in 32 bits OCaml...
+available: arch != "arm32" & arch != "x86_32"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/panglesd/slipshow/releases/download/v0.4.1/slipshow-0.4.1.tbz"
+  checksum: [
+    "sha256=7bd7621134711c6e45c527986b6fc9f1584f0f77c397f6d9bda84ee6e8e26ea2"
+    "sha512=e74f7557f110d838f56184a4d500bbaa8e44b6c64253fa3a05728c7305052cde72e0c90299e59fdd9a5f754f25014d4dd21d99b9f63fbde536e6cf5e224cb9fc"
+  ]
+}
+x-commit-hash: "f97d735af17fe82fc53fe3951b00a415433ec8cf"


### PR DESCRIPTION
See the [release](https://github.com/panglesd/slipshow/releases/tag/v0.4.1) [announcement](https://github.com/panglesd/slipshow/releases/tag/v0.4.0)!


CHANGES:

# 0.4.1

### Engine

- Fix pauses hiding the UI

# 0.4.0

### Compiler

- Fix `children:` not working sometimes (panglesd/slipshow#135)
- Add `--toplevel-attributes` to control the attributes on the toplevel container (panglesd/slipshow#137)

### Engine

- Render slide titles as slide titles (panglesd/slipshow#137)

### Language

- Add arguments to actions (panglesd/slipshow#135)
- Add frontmatter (panglesd/slipshow#137)

### Internal

- Add compatibility with latest version of Cmdliner (panglesd/slipshow#135)
- Fix `"` sometimes being present in Cmarkit, removing the need for ~~hacks~~ workarounds. (panglesd/slipshow#135)