### PR TITLE
[new release] ocaml-llhttp (0.0.4)

### DIFF
--- a/packages/ocaml-llhttp/ocaml-llhttp.0.0.4/opam
+++ b/packages/ocaml-llhttp/ocaml-llhttp.0.0.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for llhttp"
+description: "OCaml bindings for llhttp"
+maintainer: ["Jonathan Cooper"]
+authors: ["Jonathan Cooper"]
+license: "MIT"
+homepage: "https://github.com/ReallySnazzy/ocaml-llhttp"
+bug-reports: "https://github.com/ReallySnazzy/ocaml-llhttp/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml"
+  "ctypes"
+  "ctypes-foreign"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ReallySnazzy/ocaml-llhttp.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ReallySnazzy/ocaml-llhttp/releases/download/v0.0.4/ocaml-llhttp-0.0.4.tbz"
+  checksum: [
+    "sha256=d2bc3b336cd19ec3076b457e036072f8150685b9b93982ec58ca3758f9f97f1d"
+    "sha512=9469c03d121f0fc1b98a048633a7a73a9d8133ed56a24b7e6c549d0ba07ed3f278ccc33266c19e5498eae7ba1255f3f8dc0c5a137563b7662f91d7cc65d58c32"
+  ]
+}
+x-commit-hash: "036dd79df3e7209ad3f5fa59f03fa8e63377afc3"


### PR DESCRIPTION
OCaml bindings for llhttp

- Project page: <a href="https://github.com/ReallySnazzy/ocaml-llhttp">https://github.com/ReallySnazzy/ocaml-llhttp</a>

##### CHANGES:

- Include all changes missed in last version for dune-release
