### PR TITLE
Package ppx_deriving.6.1.1

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.6.1.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.6.1.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Type-driven code generation for OCaml"
+description: """\
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks."""
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: "whitequark <whitequark@whitequark.org>"
+license: "MIT"
+tags: "syntax"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6.3"}
+  "cppo" {>= "1.1.0" & build}
+  "ocamlfind"
+  "ppx_derivers"
+  "ppxlib" {>= "0.36.0"}
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_deriving/releases/download/v6.1.1/ppx_deriving-6.1.1.tar.gz"
+  checksum: [
+    "md5=3208e6028fbb5a417f751d3529eae031"
+    "sha512=9d64fd1a7c908e70ac11164db6732d69e74eac28c29ba6d76d40711554615c0af5a8c491eb6f05181b99294b50fc2c50b454b6d75d022db9d33133188d071102"
+  ]
+}


### PR DESCRIPTION
### `ppx_deriving.6.1.1`
Type-driven code generation for OCaml
ppx_deriving provides common infrastructure for generating
code based on type definitions, and a set of useful plugins
for common tasks.



---
* Homepage: https://github.com/ocaml-ppx/ppx_deriving
* Source repo: git+https://github.com/ocaml-ppx/ppx_deriving.git
* Bug tracker: https://github.com/ocaml-ppx/ppx_deriving/issues

---
:camel: Pull-request generated by opam-publish v2.5.0