### PR TITLE
mdx is not compatible with OCaml 5.4 (uses compiler-libs)

### DIFF
--- a/packages/mdx/mdx.2.5.0/opam
+++ b/packages/mdx/mdx.2.5.0/opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/realworldocaml/mdx"
 bug-reports: "https://github.com/realworldocaml/mdx/issues"
 depends: [
   "dune" {>= "3.5"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "ocamlfind"
   "fmt" {>= "0.8.7"}
   "cppo" {build & >= "1.1.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling mdx.2.5.0 ==========================================#
# context              2.4.0~rc1 | linux/x86_64 | ocaml-base-compiler.5.4.0~alpha1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.4/.opam-switch/build/mdx.2.5.0
# command              ~/.opam/5.4/bin/dune build -p mdx -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/mdx-14-ac8cb6.env
# output-file          ~/.opam/log/mdx-14-ac8cb6.out
### output ###
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I lib/top/.mdx_top.objs/byte -I /home/opam/.opam/5.4/lib/astring -I /home/opam/.opam/5.4/lib/camlp-streams -I /home/opam/.opam/5.4/lib/csexp -I /home/opam/.opam/5.4/lib/findlib -I /home/opam/.opam/5.4/lib/fmt -I /home/opam/.opam/5.4/lib/logs -I /home/opam/.opam/5.4/lib/ocaml-version -I /home/opam/.opam/5.4/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4/lib/ocaml/str -I /home/opam/.opam/5.4/lib/ocaml/threads -I /home/opam/.opam/5.4/lib/ocaml/unix -I /home/opam/.opam/5.4/lib/re -I /home/opam/.opam/5.4/lib/result -I /home/opam/.opam/5.4/lib/seq -I lib/.mdx.objs/byte -I vendor/odoc-parser/src/.odoc_parser.objs/byte -no-alias-deps -open Mdx_top__ -o lib/top/.mdx_top.objs/byte/mdx_top__Compat_top.cmi -c -intf lib/top/compat_top.pp.mli)
# File "lib/top/compat_top.mli", line 11, characters 40-69:
# Error: Unbound type constructor Types.constructor_description
```
Reported upstream in https://github.com/realworldocaml/mdx/issues/469