### PR TITLE
notty is not compatible with OCaml 5.4

### DIFF
--- a/packages/notty/notty.0.2.3/opam
+++ b/packages/notty/notty.0.2.3/opam
@@ -14,7 +14,7 @@ description:
 build: [ [ "dune" "subst" ] {dev}
          [ "dune" "build" "-p" name "-j" jobs ] ]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "dune" {>= "1.7"}
   "cppo" {build & >= "1.1.0"}
   "uutf" {>= "1.0.0"}


### PR DESCRIPTION
A field in Format.formatter_out_functions was added
```
#=== ERROR while compiling notty.0.2.3 ========================================#
# context              2.4.0~rc1 | linux/x86_64 | ocaml-base-compiler.5.4.0~alpha1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.4/.opam-switch/build/notty.0.2.3
# command              ~/.opam/5.4/bin/dune build -p notty -j 1
# exit-code            1
# env-file             ~/.opam/log/notty-14-670c4a.env
# output-file          ~/.opam/log/notty-14-670c4a.out
### output ###
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/.notty.objs/byte -I src/.notty.objs/public_cmi -I /home/opam/.opam/5.4/lib/uutf -intf-suffix .ml -no-alias-deps -o src/.notty.objs/byte/notty.cmo -c -impl src/notty.ml)
# File "src/notty.ml", lines 386-396, characters 43-7:
# 386 | ...........................................{
# 387 |           out_flush = (fun () ->
# 388 |             img := !img <-> !line; line := empty; attr := [])
# 389 |         ; out_newline = (fun () ->
# 390 |             img := !img <-> !line; line := void 0 1)
# ...
# 393 |         (* Not entirely clear; either or both could be void: *)
# 394 |         ; out_spaces = (fun w -> line := !line <|> char (top_a attr) ' ' w 1)
# 395 |         ; out_indent = (fun w -> line := !line <|> char (top_a attr) ' ' w 1)
# 396 |       }...
# Error: Some record fields are undefined: out_width
```
Reported upstream in https://github.com/pqwy/notty/issues/57