### PR TITLE
ocamlformat is not compatible with OCaml 5.4

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.26.2/opam
+++ b/packages/ocamlformat/ocamlformat.0.26.2/opam
@@ -22,7 +22,7 @@ authors: [
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.4"}
   "cmdliner" {with-test = "false" & >= "1.1.0" | with-test & >= "1.2.0"}
   "dune" {>= "2.8"}
   "ocamlformat-lib" {= version}

--- a/packages/ocamlformat/ocamlformat.0.27.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.27.0/opam
@@ -22,7 +22,7 @@ authors: [
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.4"}
   "cmdliner" {with-test = "false" & >= "1.1.0" | with-test & >= "1.2.0"}
   "csexp" {>= "1.4.0"}
   "dune" {>= "2.8"}


### PR DESCRIPTION
A field in Format.formatter_out_functions was added
```
#=== ERROR while compiling ocamlformat.0.27.0 =================================#
# context              2.4.0~rc1 | linux/x86_64 | ocaml-base-compiler.5.4.0~alpha1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.4/.opam-switch/build/ocamlformat.0.27.0
# command              ~/.opam/5.4/bin/dune build -p ocamlformat -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/ocamlformat-14-b9f5a0.env
# output-file          ~/.opam/log/ocamlformat-14-b9f5a0.out
### output ###
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w -40 -noassert -open Ocamlformat_ocaml_common -open Ocamlformat_stdlib -g -bin-annot -bin-annot-occurrences -I lib/bin_conf/.bin_conf.objs/byte -I /home/opam/.opam/5.4/lib/astring -I /home/opam/.opam/5.4/lib/base -I /home/opam/.opam/5.4/lib/base/base_internalhash_types -I /home/opam/.opam/5.4/lib/base/shadow_stdlib -I /home/opam/.opam/5.4/lib/bytes -I /home/opam/.opam/5.4/lib/camlp-streams -I /home/opam/.opam/5.4/lib/cmdliner -I /home/opam/.opam/5.4/lib/dune-build-info -I /home/opam/.opam/5.4/lib/either -I /home/opam/.opam/5.4/lib/fpath -I /home/opam/.opam/5.4/lib/menhirLib -I /home/opam/.opam/5.4/lib/ocaml-version -I /home/opam/.opam/5.4/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4/lib/ocaml_intrinsics_kernel -I /home/opam/.opam/5.4/lib/ocamlformat-lib -I /home/opam/.opam/5.4/lib/ocamlformat-lib/format_ -I /home/opam/.opam/5.4/lib/ocamlformat-lib/ocaml_common -I /home/opam/.opam/5.4/lib/ocamlformat-lib/ocamlformat_stdlib -I /home/opam/.opam/5.4/lib/ocamlformat-lib/odoc_parser -I /home/opam/.opam/5.4/lib/ocamlformat-lib/parser_extended -I /home/opam/.opam/5.4/lib/ocamlformat-lib/parser_shims -I /home/opam/.opam/5.4/lib/ocamlformat-lib/parser_standard -I /home/opam/.opam/5.4/lib/ocamlformat-lib/stdlib_shims -I /home/opam/.opam/5.4/lib/ocp-indent/lexer -I /home/opam/.opam/5.4/lib/ocp-indent/lib -I /home/opam/.opam/5.4/lib/ocp-indent/utils -I /home/opam/.opam/5.4/lib/re -I /home/opam/.opam/5.4/lib/seq -I /home/opam/.opam/5.4/lib/sexplib0 -I /home/opam/.opam/5.4/lib/stdio -I /home/opam/.opam/5.4/lib/uucp -I /home/opam/.opam/5.4/lib/uuseg -intf-suffix .ml -no-alias-deps -open Bin_conf__ -o lib/bin_conf/.bin_conf.objs/byte/bin_conf.cmo -c -impl lib/bin_conf/Bin_conf.ml)
# File "lib/bin_conf/Bin_conf.ml", lines 526-530, characters 6-35:
# 526 | ......{ out_string= (fun _ _ _ -> ())
# 527 |       ; out_flush= (fun () -> ())
# 528 |       ; out_newline= (fun () -> ())
# 529 |       ; out_spaces= (fun _ -> ())
# 530 |       ; out_indent= (fun _ -> ()) }..
# Error: Some record fields are undefined: out_width
```
Reported upstream in https://github.com/ocaml-ppx/ocamlformat/issues/2688