### PR TITLE
ppx_import is not compatible with OCaml 5.4 (uses compiler-libs)

### DIFF
--- a/packages/ppx_import/ppx_import.1.11.0/opam
+++ b/packages/ppx_import/ppx_import.1.11.0/opam
@@ -10,9 +10,8 @@ dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
 tags: [ "syntax" ]
 
 depends: [
-   "ocaml"                   {>= "4.05.0" &  < "4.10.0"  }
-| ("ocaml"                   {>= "4.10.0"}
-   "ppx_sexp_conv" {with-test & >= "v0.13.0"})
+   "ocaml" {>= "4.05.0" & < "4.10.0"} |
+("ocaml" {>= "4.10.0" & < "5.4"} & "ppx_sexp_conv" {with-test & >= "v0.13.0"})
   "dune"                    {              >= "1.11.0"  }
   "ppxlib"                  {              >= "0.26.0"  }
   "ounit"                   { with-test                 }

--- a/packages/ppx_import/ppx_import.1.7.1/opam
+++ b/packages/ppx_import/ppx_import.1.7.1/opam
@@ -11,7 +11,7 @@ dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
 tags: [ "syntax" ]
 
 depends: [
-  "ocaml"                   {              >= "4.04.2" }
+  "ocaml" {>= "4.04.2" & < "5.4"}
   "dune"                    {              >= "1.2.0"  }
   "ppxlib"                  {              >= "0.3.1"  }
   "ppx_tools_versioned"     {              >= "5.2.2"  }

--- a/packages/ppx_import/ppx_import.1.8.0/opam
+++ b/packages/ppx_import/ppx_import.1.8.0/opam
@@ -10,7 +10,7 @@ dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
 tags: [ "syntax" ]
 
 depends: [
-  "ocaml"                   {              >= "4.04.2" }
+  "ocaml" {>= "4.04.2" & < "5.4"}
   "dune"                    {              >= "1.2.0"  }
   "ppx_tools_versioned"     {              >= "5.4.0"  }
   "ocaml-migrate-parsetree" {              >= "1.7.0"  }

--- a/packages/ppx_import/ppx_import.1.9.1/opam
+++ b/packages/ppx_import/ppx_import.1.9.1/opam
@@ -10,7 +10,7 @@ dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
 tags: [ "syntax" ]
 
 depends: [
-  "ocaml"                   {              >= "4.05.0"  }
+  "ocaml" {>= "4.05.0" & < "5.4"}
   "dune"                    {              >= "1.11.0"  }
   "ppxlib"                  {              >= "0.24.0"  & < "0.26.0" }
   "ounit"                   { with-test                 }


### PR DESCRIPTION
```
#=== ERROR while compiling ppx_import.1.11.0 ==================================#
# context              2.4.0~rc1 | linux/x86_64 | ocaml-base-compiler.5.4.0~alpha1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.4/.opam-switch/build/ppx_import.1.11.0
# command              ~/.opam/5.4/bin/dune build -p ppx_import -j 1
# exit-code            1
# env-file             ~/.opam/log/ppx_import-14-42a25b.env
# output-file          ~/.opam/log/ppx_import-14-42a25b.out
### output ###
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/.ppx_import.objs/byte -I /home/opam/.opam/5.4/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.4/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.4/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4/lib/ppx_derivers -I /home/opam/.opam/5.4/lib/ppxlib -I /home/opam/.opam/5.4/lib/ppxlib/ast -I /home/opam/.opam/5.4/lib/ppxlib/astlib -I /home/opam/.opam/5.4/lib/ppxlib/print_diff -I /home/opam/.opam/5.4/lib/ppxlib/stdppx -I /home/opam/.opam/5.4/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.4/lib/sexplib0 -I /home/opam/.opam/5.4/lib/stdlib-shims -no-alias-deps -open Ppx_import__ -o src/.ppx_import.objs/byte/ppx_import.cmo -c -impl src/ppx_import.pp.ml)
# File "src/ppx_import.ml", line 34, characters 40-43:
# 34 |     | Longident.Ldot (lid, id) -> print lid ("." :: id :: acc)
#                                              ^^^
# Error: The value lid has type Longident.t Location.loc
#        but an expression was expected of type Longident.t
```
reported upstream in https://github.com/ocaml-ppx/ppx_import/issues/99