### PR TITLE
utop is not compatible with OCaml 5.4 (uses compiler-libs)

### DIFF
--- a/packages/utop/utop.2.15.0-1/opam
+++ b/packages/utop/utop.2.15.0-1/opam
@@ -10,7 +10,7 @@ doc: "https://ocaml-community.github.io/utop/"
 bug-reports: "https://github.com/ocaml-community/utop/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.11.0" & < "5.4"}
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}

--- a/packages/utop/utop.2.15.0/opam
+++ b/packages/utop/utop.2.15.0/opam
@@ -10,7 +10,7 @@ doc: "https://ocaml-community.github.io/utop/"
 bug-reports: "https://github.com/ocaml-community/utop/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.11.0" & < "5.4"}
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}


### PR DESCRIPTION
```
#=== ERROR while compiling utop.2.15.0-1 ======================================#
# context              2.4.0~rc1 | linux/x86_64 | ocaml-base-compiler.5.4.0~alpha1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.4/.opam-switch/build/utop.2.15.0-1
# command              ~/.opam/5.4/bin/dune build -p utop -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/utop-14-a01e1d.env
# output-file          ~/.opam/log/utop-14-a01e1d.out
### output ###
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/lib/.uTop.objs/byte -I /home/opam/.opam/5.4/lib/bytes -I /home/opam/.opam/5.4/lib/findlib -I /home/opam/.opam/5.4/lib/lambda-term -I /home/opam/.opam/5.4/lib/logs -I /home/opam/.opam/5.4/lib/logs/lwt -I /home/opam/.opam/5.4/lib/lwt -I /home/opam/.opam/5.4/lib/lwt/unix -I /home/opam/.opam/5.4/lib/lwt_react -I /home/opam/.opam/5.4/lib/mew -I /home/opam/.opam/5.4/lib/mew_vi -I /home/opam/.opam/5.4/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4/lib/ocaml/threads -I /home/opam/.opam/5.4/lib/ocaml/unix -I /home/opam/.opam/5.4/lib/ocplib-endian -I /home/opam/.opam/5.4/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.4/lib/react -I /home/opam/.opam/5.4/lib/result -I /home/opam/.opam/5.4/lib/trie -I /home/opam/.opam/5.4/lib/uchar -I /home/opam/.opam/5.4/lib/uucp -I /home/opam/.opam/5.4/lib/uuseg -I /home/opam/.opam/5.4/lib/uutf -I /home/opam/.opam/5.4/lib/xdg -I /home/opam/.opam/5.4/lib/zed -intf-suffix .ml -no-alias-deps -o src/lib/.uTop.objs/byte/uTop.cmo -c -impl src/lib/uTop.pp.ml)
# File "src/lib/uTop.ml", lines 199-202, characters 22-3:
# Error: Some record fields are undefined: out_width
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/lib/.uTop.objs/byte -I /home/opam/.opam/5.4/lib/bytes -I /home/opam/.opam/5.4/lib/findlib -I /home/opam/.opam/5.4/lib/lambda-term -I /home/opam/.opam/5.4/lib/logs -I /home/opam/.opam/5.4/lib/logs/lwt -I /home/opam/.opam/5.4/lib/lwt -I /home/opam/.opam/5.4/lib/lwt/unix -I /home/opam/.opam/5.4/lib/lwt_react -I /home/opam/.opam/5.4/lib/mew -I /home/opam/.opam/5.4/lib/mew_vi -I /home/opam/.opam/5.4/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4/lib/ocaml/threads -I /home/opam/.opam/5.4/lib/ocaml/unix -I /home/opam/.opam/5.4/lib/ocplib-endian -I /home/opam/.opam/5.4/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.4/lib/react -I /home/opam/.opam/5.4/lib/result -I /home/opam/.opam/5.4/lib/trie -I /home/opam/.opam/5.4/lib/uchar -I /home/opam/.opam/5.4/lib/uucp -I /home/opam/.opam/5.4/lib/uuseg -I /home/opam/.opam/5.4/lib/uutf -I /home/opam/.opam/5.4/lib/xdg -I /home/opam/.opam/5.4/lib/zed -intf-suffix .ml -no-alias-deps -o src/lib/.uTop.objs/byte/uTop_complete.cmo -c -impl src/lib/uTop_complete.pp.ml)
# File "src/lib/uTop_complete.ml", line 33, characters 52-55:
# Error: The value acc has type Longident.t
#        but an expression was expected of type Longident.t Location.loc
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/lib/.uTop.objs/byte -I /home/opam/.opam/5.4/lib/bytes -I /home/opam/.opam/5.4/lib/findlib -I /home/opam/.opam/5.4/lib/lambda-term -I /home/opam/.opam/5.4/lib/logs -I /home/opam/.opam/5.4/lib/logs/lwt -I /home/opam/.opam/5.4/lib/lwt -I /home/opam/.opam/5.4/lib/lwt/unix -I /home/opam/.opam/5.4/lib/lwt_react -I /home/opam/.opam/5.4/lib/mew -I /home/opam/.opam/5.4/lib/mew_vi -I /home/opam/.opam/5.4/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4/lib/ocaml/threads -I /home/opam/.opam/5.4/lib/ocaml/unix -I /home/opam/.opam/5.4/lib/ocplib-endian -I /home/opam/.opam/5.4/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.4/lib/react -I /home/opam/.opam/5.4/lib/result -I /home/opam/.opam/5.4/lib/trie -I /home/opam/.opam/5.4/lib/uchar -I /home/opam/.opam/5.4/lib/uucp -I /home/opam/.opam/5.4/lib/uuseg -I /home/opam/.opam/5.4/lib/uutf -I /home/opam/.opam/5.4/lib/xdg -I /home/opam/.opam/5.4/lib/zed -intf-suffix .ml -no-alias-deps -o src/lib/.uTop.objs/byte/uTop_main.cmo -c -impl src/lib/uTop_main.pp.ml)
# File "src/lib/uTop_main.ml", line 313, characters 41-45:
# Error: The value comp has type string but an expression was expected of type
#          string Location.loc
```
Reported upstream in https://github.com/ocaml-community/utop/issues/504