### PR TITLE
stdune < 3.19.0 is not compatible with OCaml 5.4

### DIFF
--- a/packages/stdune/stdune.3.0.2/opam
+++ b/packages/stdune/stdune.3.0.2/opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "dyn" {= version}
   "ordering" {= version}
   "pp" {>= "1.1.0" & < "2.0.0"}

--- a/packages/stdune/stdune.3.0.3/opam
+++ b/packages/stdune/stdune.3.0.3/opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "dyn" {= version}
   "ordering" {= version}
   "pp" {>= "1.1.0" & < "2.0.0"}

--- a/packages/stdune/stdune.3.1.0/opam
+++ b/packages/stdune/stdune.3.1.0/opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "dyn" {= version}
   "ordering" {= version}
   "pp" {>= "1.1.0" & < "2.0.0"}

--- a/packages/stdune/stdune.3.1.1/opam
+++ b/packages/stdune/stdune.3.1.1/opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "dyn" {= version}
   "ordering" {= version}
   "pp" {>= "1.1.0" & < "2.0.0"}

--- a/packages/stdune/stdune.3.15.3/opam
+++ b/packages/stdune/stdune.3.15.3/opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.12"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "base-unix"
   "dyn" {= version}
   "ordering" {= version}

--- a/packages/stdune/stdune.3.17.2/opam
+++ b/packages/stdune/stdune.3.17.2/opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.12"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "base-unix"
   "dyn" {= version}
   "ordering" {= version}

--- a/packages/stdune/stdune.3.2.0/opam
+++ b/packages/stdune/stdune.3.2.0/opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "dyn" {= version}
   "ordering" {= version}
   "pp" {>= "1.1.0" & < "2.0.0"}

--- a/packages/stdune/stdune.3.3.0/opam
+++ b/packages/stdune/stdune.3.3.0/opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.3"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "base-unix"
   "dyn" {= version}
   "ordering" {= version}

--- a/packages/stdune/stdune.3.3.1/opam
+++ b/packages/stdune/stdune.3.3.1/opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.3"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "base-unix"
   "dyn" {= version}
   "ordering" {= version}

--- a/packages/stdune/stdune.3.4.0/opam
+++ b/packages/stdune/stdune.3.4.0/opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.3"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "base-unix"
   "dyn" {= version}
   "ordering" {= version}

--- a/packages/stdune/stdune.3.4.1/opam
+++ b/packages/stdune/stdune.3.4.1/opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.3"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "base-unix"
   "dyn" {= version}
   "ordering" {= version}

--- a/packages/stdune/stdune.3.5.0/opam
+++ b/packages/stdune/stdune.3.5.0/opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.3"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "base-unix"
   "dyn" {= version}
   "ordering" {= version}

--- a/packages/stdune/stdune.3.6.0/opam
+++ b/packages/stdune/stdune.3.6.0/opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.5"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "base-unix"
   "dyn" {= version}
   "ordering" {= version}

--- a/packages/stdune/stdune.3.6.1/opam
+++ b/packages/stdune/stdune.3.6.1/opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.5"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "base-unix"
   "dyn" {= version}
   "ordering" {= version}

--- a/packages/stdune/stdune.3.6.2/opam
+++ b/packages/stdune/stdune.3.6.2/opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.5"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "base-unix"
   "dyn" {= version}
   "ordering" {= version}


### PR DESCRIPTION
expected sigwinch to not be present in Sys
```
#=== ERROR while compiling stdune.3.17.2 ======================================#
# context              2.4.0~rc1 | linux/x86_64 | ocaml-base-compiler.5.4.0~alpha1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.4/.opam-switch/build/stdune.3.17.2
# command              ~/.opam/5.4/bin/dune build -p stdune -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/stdune-14-e46559.env
# output-file          ~/.opam/log/stdune-14-e46559.out
### output ###
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w -40 -alert -unstable -g -bin-annot -bin-annot-occurrences -I otherlibs/stdune/src/.stdune.objs/byte -I /home/opam/.opam/5.4/lib/csexp -I /home/opam/.opam/5.4/lib/dyn -I /home/opam/.opam/5.4/lib/ocaml/unix -I /home/opam/.opam/5.4/lib/ordering -I /home/opam/.opam/5.4/lib/pp -I otherlibs/stdune/dune_filesystem_stubs/.dune_filesystem_stubs.objs/byte -intf-suffix .ml -no-alias-deps -open Stdune__ -o otherlibs/stdune/src/.stdune.objs/byte/stdune__Signal.cmo -c -impl otherlibs/stdune/src/signal.ml)
# File "otherlibs/stdune/src/signal.ml", line 65, characters 11-19:
# 65 |   ; Winch, sigwinch ()
#                 ^^^^^^^^
# Error: This expression has type int
#        This is not a function; it cannot be applied.
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlopt.opt -w -40 -alert -unstable -g -I otherlibs/stdune/src/.stdune.objs/byte -I otherlibs/stdune/src/.stdune.objs/native -I /home/opam/.opam/5.4/lib/csexp -I /home/opam/.opam/5.4/lib/dyn -I /home/opam/.opam/5.4/lib/ocaml/unix -I /home/opam/.opam/5.4/lib/ordering -I /home/opam/.opam/5.4/lib/pp -I otherlibs/stdune/dune_filesystem_stubs/.dune_filesystem_stubs.objs/byte -I otherlibs/stdune/dune_filesystem_stubs/.dune_filesystem_stubs.objs/native -intf-suffix .ml -no-alias-deps -open Stdune__ -o otherlibs/stdune/src/.stdune.objs/native/stdune__Signal.cmx -c -impl otherlibs/stdune/src/signal.ml)
# File "otherlibs/stdune/src/signal.ml", line 65, characters 11-19:
# 65 |   ; Winch, sigwinch ()
#                 ^^^^^^^^
# Error: This expression has type int
#        This is not a function; it cannot be applied.
```
This was fixed in 3.19.0