### PR TITLE
[new release] ocaml-sat-solvers (0.8)

### DIFF
--- a/packages/ocaml-sat-solvers/ocaml-sat-solvers.0.8/opam
+++ b/packages/ocaml-sat-solvers/ocaml-sat-solvers.0.8/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "An abstraction layer for integrating SAT Solvers into OCaml"
+description: "An abstraction layer for integrating SAT Solvers into OCaml."
+maintainer: ["Oliver Friedmann" "Martin Lange"]
+authors: ["Oliver Friedmann" "Martin Lange"]
+license: "BSD-3-clause"
+homepage: "https://github.com/tcsprojects/ocaml-sat-solvers"
+bug-reports: "https://github.com/tcsprojects/ocaml-sat-solvers/issues"
+depends: [
+  "ocaml" {>= "4.8"}
+  "dune" {>= "3.10"}
+  "minisat" {>= "0.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tcsprojects/ocaml-sat-solvers.git"
+url {
+  src:
+    "https://github.com/tcsprojects/ocaml-sat-solvers/releases/download/v0.8/ocaml-sat-solvers-0.8.tbz"
+  checksum: [
+    "sha256=d5e5f3b98eabaeb8dd106fd79e425ee28f7301c52f7d35453b5f99233720a4e5"
+    "sha512=caa023cfd102edf0b36d36a9ac2e8a8154491ec68973cae00e8fb4ea19cb22b02634119a5c92110ce03cfea196771afe987f734f7efd7eb0bc21fd96855935fc"
+  ]
+}
+x-commit-hash: "02642910431245dcdcb79facc327d0b622cfebff"


### PR DESCRIPTION
An abstraction layer for integrating SAT Solvers into OCaml

- Project page: <a href="https://github.com/tcsprojects/ocaml-sat-solvers">https://github.com/tcsprojects/ocaml-sat-solvers</a>

##### CHANGES:

- Change from OASIS to DUNE
- Change from OCAML 4 to OCAML 5
