### PR TITLE
[new release] ocaml-llhttp (0.0.1)

### DIFF
--- a/packages/ocaml-llhttp/ocaml-llhttp.0.0.1/opam
+++ b/packages/ocaml-llhttp/ocaml-llhttp.0.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for llhttp"
+description: "OCaml bindings for llhttp"
+maintainer: ["Jonathan Cooper"]
+authors: ["Jonathan Cooper"]
+license: "MIT"
+homepage: "https://github.com/ReallySnazzy/ocaml-llhttp"
+doc: "https://url/to/documentation"
+bug-reports: "https://github.com/ReallySnazzy/ocaml-llhttp/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ReallySnazzy/ocaml-llhttp.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ReallySnazzy/ocaml-llhttp/releases/download/v0.0.1/ocaml-llhttp-0.0.1.tbz"
+  checksum: [
+    "sha256=e108e50802c39ae4d6527ed465d4d61d352a7f88e8bbc34c4f32b9672dcae103"
+    "sha512=cfa4a158a4fc08782b13aeb6e07e944cf48d2aefc5794c112ca3c7bb3cd4d25ccd7067275ee83b7a9f38e02ad3419a0fd3a2aac75fbb0f9f474e7f30c9bc6994"
+  ]
+}
+x-commit-hash: "4ffddf13d96958eea38876732bdb47cbcc330fee"


### PR DESCRIPTION
OCaml bindings for llhttp

- Project page: <a href="https://github.com/ReallySnazzy/ocaml-llhttp">https://github.com/ReallySnazzy/ocaml-llhttp</a>
- Documentation: <a href="https://url/to/documentation">https://url/to/documentation</a>

##### CHANGES:

- Initial version
- Basic workflow for callbacks into llhttp
