### PR TITLE
[new release] ocaml-llhttp (0.0.1)

### DIFF
--- a/packages/ocaml-llhttp/ocaml-llhttp.0.0.1/opam
+++ b/packages/ocaml-llhttp/ocaml-llhttp.0.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for llhttp"
+description: "OCaml bindings for llhttp"
+maintainer: ["Jonathan Cooper"]
+authors: ["Jonathan Cooper"]
+license: "MIT"
+homepage: "https://github.com/ReallySnazzy/ocaml-llhttp"
+doc: "https://github.com/ReallySnazzy/ocaml-llhttp/blob/master/README.md"
+bug-reports: "https://github.com/ReallySnazzy/ocaml-llhttp/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ReallySnazzy/ocaml-llhttp.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ReallySnazzy/ocaml-llhttp/releases/download/v0.0.1/ocaml-llhttp-0.0.1.tbz"
+  checksum: [
+    "sha256=7c2b7fcea8b2d39de24a1da387592d741e3c83b44bf6c1af488a3d94b5f46561"
+    "sha512=469d7c2293346fb06bd03b5f57a5cba85c71c410a86bf7eedc94f501eeb2ac1805b3fb7a4d64106cb7c40de807c4b856053160f7e89bc0a73f9742430b4520b6"
+  ]
+}
+x-commit-hash: "8f0a563e7d258f2ab7cba3f07ed1073c6fb945fa"


### PR DESCRIPTION
OCaml bindings for llhttp

- Project page: <a href="https://github.com/ReallySnazzy/ocaml-llhttp">https://github.com/ReallySnazzy/ocaml-llhttp</a>
- Documentation: <a href="https://github.com/ReallySnazzy/ocaml-llhttp/blob/master/README.md">https://github.com/ReallySnazzy/ocaml-llhttp/blob/master/README.md</a>

##### CHANGES:

- Initial version
- Basic workflow for callbacks into llhttp
