### PR TITLE
[new release] eio (5 packages) (1.3)

### DIFF
--- a/packages/eio/eio.1.3/opam
+++ b/packages/eio/eio.1.3/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "5.2.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "hmap" {>= "0.8.1"}
+  "domain-local-await" {>= "0.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "2.0.0"}
+  "mdx" {>= "2.4.1" & with-test}
+  "dscheck" {>= "0.1.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "seq" {< "0.3"}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+x-extra-doc-deps: [
+  "eio_main" {= version}
+  "bigstring"
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.3/eio-1.3.tbz"
+  checksum: [
+    "sha256=8ed5c13e6689f31c85dca5f12762d84b8cc0042a7b07d3e464df6eb4b72b3dfc"
+    "sha512=46e8f817f32c3316e7f35835a136ad177a295b3306351eb2efa2386482b0169a5b19ed2925b32da2a1f10d40f083fe3d588dd401908f9fec6e4a44cd68535204"
+  ]
+}
+x-commit-hash: "37d6e67f7e25b43e4a66574ed98838c79f1a21b4"

--- a/packages/eio_linux/eio_linux.1.3/opam
+++ b/packages/eio_linux/eio_linux.1.3/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An Eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "eio" {= version}
+  "mdx" {>= "2.4.1" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "0.9"}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+available: [os = "linux"]
+x-extra-doc-deps: [
+  "eio_main" {= version}
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.3/eio-1.3.tbz"
+  checksum: [
+    "sha256=8ed5c13e6689f31c85dca5f12762d84b8cc0042a7b07d3e464df6eb4b72b3dfc"
+    "sha512=46e8f817f32c3316e7f35835a136ad177a295b3306351eb2efa2386482b0169a5b19ed2925b32da2a1f10d40f083fe3d588dd401908f9fec6e4a44cd68535204"
+  ]
+}
+x-commit-hash: "37d6e67f7e25b43e4a66574ed98838c79f1a21b4"

--- a/packages/eio_main/eio_main.1.3/opam
+++ b/packages/eio_main/eio_main.1.3/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "mdx" {>= "2.4.1" & with-test}
+  "kcas" {>= "0.3.0" & with-test}
+  "yojson" {>= "2.0.2" & with-test}
+  "eio_linux"
+    {= version & os = "linux" &
+     (os-distribution != "centos" | os-version > "7")}
+  "eio_posix" {= version & os != "win32"}
+  "eio_windows" {= version & os = "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+x-ci-accept-failures: ["macos-homebrew"]
+x-extra-doc-deps: [
+  "eio_main" {= version}
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.3/eio-1.3.tbz"
+  checksum: [
+    "sha256=8ed5c13e6689f31c85dca5f12762d84b8cc0042a7b07d3e464df6eb4b72b3dfc"
+    "sha512=46e8f817f32c3316e7f35835a136ad177a295b3306351eb2efa2386482b0169a5b19ed2925b32da2a1f10d40f083fe3d588dd401908f9fec6e4a44cd68535204"
+  ]
+}
+x-commit-hash: "37d6e67f7e25b43e4a66574ed98838c79f1a21b4"

--- a/packages/eio_posix/eio_posix.1.3/opam
+++ b/packages/eio_posix/eio_posix.1.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for POSIX systems"
+description: "An Eio implementation for most Unix-like platforms"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "iomux" {>= "0.2"}
+  "mdx" {>= "2.4.1" & with-test}
+  "conf-bash" {with-test}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+x-extra-doc-deps: [
+  "eio_main" {= version}
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.3/eio-1.3.tbz"
+  checksum: [
+    "sha256=8ed5c13e6689f31c85dca5f12762d84b8cc0042a7b07d3e464df6eb4b72b3dfc"
+    "sha512=46e8f817f32c3316e7f35835a136ad177a295b3306351eb2efa2386482b0169a5b19ed2925b32da2a1f10d40f083fe3d588dd401908f9fec6e4a44cd68535204"
+  ]
+}
+x-commit-hash: "37d6e67f7e25b43e4a66574ed98838c79f1a21b4"

--- a/packages/eio_windows/eio_windows.1.3/opam
+++ b/packages/eio_windows/eio_windows.1.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Windows"
+description: "An Eio implementation using OCaml's Unix.select"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "fmt" {>= "0.8.9"}
+  "kcas" {>= "0.3.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+available: [os = "win32"]
+x-extra-doc-deps: [
+  "eio_main" {= version}
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.3/eio-1.3.tbz"
+  checksum: [
+    "sha256=8ed5c13e6689f31c85dca5f12762d84b8cc0042a7b07d3e464df6eb4b72b3dfc"
+    "sha512=46e8f817f32c3316e7f35835a136ad177a295b3306351eb2efa2386482b0169a5b19ed2925b32da2a1f10d40f083fe3d588dd401908f9fec6e4a44cd68535204"
+  ]
+}
+x-commit-hash: "37d6e67f7e25b43e4a66574ed98838c79f1a21b4"


### PR DESCRIPTION
Effect-based direct-style IO API for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/eio">https://github.com/ocaml-multicore/eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/eio/">https://ocaml-multicore.github.io/eio/</a>

##### CHANGES:

Bug fixes:

- posix: ensure `spawn_unix` wraps errors when calling `openat` (@dijkstracula ocaml-multicore/eio#809).

- Use `O_RESOLVE_BENEATH` on FreeBSD (@talex5 ocaml-multicore/eio#810, reported by @dijkstracula).
  FreeBSD needs `-D__BSD_VISIBLE` to be able to see this.
  Fixed the CI bug this revealed, which had started also affecting macos.

- Ignore `ECONNRESET` on close (@talex5 ocaml-multicore/eio#787).
  FreeBSD returns `ECONNRESET` in certain (unclear) circumstances, but it does still close the FD successfully.
  If you care about this case, you should probably use `shutdown` instead and check for it there.
  Python and Ruby at least both explicitly check for and ignore this error too.

- On Windows, fix stdin broken-pipe and blocked domains (@bdodrem @talex5 ocaml-multicore/eio#795).
  - Ensure blocking FDs are ready before trying to use them.
  - Replace `eio_windows_cstruct_stubs.c` by Unix functions added in OCaml 5.2,
    which correctly handle Window's strange use of `EPIPE`.

Documentation:

- Documentation fixes (@jonludlam ocaml-multicore/eio#813).

- Minor documentation improvements (@talex5 ocaml-multicore/eio#794).

Build fixes:

- Disable `dune subst` (@talex5 ocaml-multicore/eio#789).
