### PR TITLE
[new release] wayland (2.2)

### DIFF
--- a/packages/wayland/wayland.2.2/opam
+++ b/packages/wayland/wayland.2.2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Pure OCaml Wayland protocol library"
+description:
+  "Wayland is a communications protocol intended for use between processes on a single computer. It is mainly used by graphical applications (clients) to talk to display servers, but nothing about the protocol is specific to graphics and it could be used for other things. This library can be used to write Wayland clients, servers and proxies."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "Apache-2.0 AND LicenseRef-various-licenses-for-the-schema-files"
+homepage: "https://github.com/talex5/ocaml-wayland"
+doc: "https://talex5.github.io/ocaml-wayland/"
+bug-reports: "https://github.com/talex5/ocaml-wayland/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "ocaml" {>= "5.0"}
+  "xmlm" {>= "1.3.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cstruct" {>= "6.0.0"}
+  "eio" {>= "0.12"}
+  "eio_main" {>= "0.12" & with-test}
+  "cmdliner" {>= "1.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/talex5/ocaml-wayland.git"
+url {
+  src:
+    "https://github.com/talex5/ocaml-wayland/releases/download/v2.2/wayland-2.2.tbz"
+  checksum: [
+    "sha256=0f882060a4cfe9424ed397676b8e2aaa931d84610beb29cb2ec9c355d1819625"
+    "sha512=847781a3d274da7463ad1a2e46bada3663b8dee08fa576ad787e7ba35cb0f39a3e1a0e6e9729db2f643885a35ae32ece0358c5897d31b68907cad44f1b26af31"
+  ]
+}
+x-commit-hash: "ed3e9d06da9abf7837d48de25dbe29df262800cd"


### PR DESCRIPTION
Pure OCaml Wayland protocol library

- Project page: <a href="https://github.com/talex5/ocaml-wayland">https://github.com/talex5/ocaml-wayland</a>
- Documentation: <a href="https://talex5.github.io/ocaml-wayland/">https://talex5.github.io/ocaml-wayland/</a>

##### CHANGES:

- Add cursor-shape-v1 and tablet-v2 protocols (@talex5 talex5/ocaml-wayland#51).

- Add viewporter protocol (@talex5 talex5/ocaml-wayland#50).

- Suppress `unused-type-declaration` in generated code, for OCaml 5.4.
