### PR TITLE
[new release] pcre (8.0.5)

### DIFF
--- a/packages/pcre/pcre.8.0.5/opam
+++ b/packages/pcre/pcre.8.0.5/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Bindings to the Perl Compatibility Regular Expressions library"
+description: """
+pcre-ocaml offers library functions for string pattern matching and
+substitution, similar to the functionality offered by the Perl language."""
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: ["Markus Mottl <markus.mottl@gmail.com>"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/pcre-ocaml"
+doc: "https://mmottl.github.io/pcre-ocaml/api"
+bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "dune-compiledb"
+  "dune-configurator"
+  "conf-libpcre" {build}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/pcre-ocaml/releases/download/8.0.5/pcre-8.0.5.tbz"
+  checksum: [
+    "sha256=ed9bcf88d781767ad6a7c0480aff09d5889f2fc500dda0d1620a1786d4e44490"
+    "sha512=3b221f39641864d16ee72ab80cc984eb8cd3b4bad0caa649e4fe0b89eb04e5d05ed3986135826761773fbbd83f87b28acc4f329bb0242790a2c1ea18602857a1"
+  ]
+}
+x-commit-hash: "c27dd679148a84f7931096ba525fc7cdd8c26e2b"


### PR DESCRIPTION
Bindings to the Perl Compatibility Regular Expressions library

- Project page: <a href="https://mmottl.github.io/pcre-ocaml">https://mmottl.github.io/pcre-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/pcre-ocaml/api">https://mmottl.github.io/pcre-ocaml/api</a>

##### CHANGES:

### Fixed

- Fix crash introduced in PR mmottl/pcre-ocaml#35. Thanks to Nathan Taylor for the contribution.

### Added

- Makefile target to generate `compile_commands.json` for improved LSP support
  in editors.
