### PR TITLE
Add opam-state < 2.4 upper bounds to odep and opam-0install

### DIFF
--- a/packages/odep/odep.0.2.0/opam
+++ b/packages/odep/odep.0.2.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.13"}
   "parsexp"
   "opam-core" {>= "2.1.0"}
-  "opam-state" {>= "2.1.0" & (< "2.2.0~beta3" | >= "2.2.0")}
+  "opam-state" {>= "2.1.0" & (< "2.2.0~beta3" | >= "2.2.0") & < "2.4"}
   "opam-format"
   "ocamlfind" {>= "1.8.1"}
   "cmdliner" {>= "1.1.0"}

--- a/packages/odep/odep.0.2.1/opam
+++ b/packages/odep/odep.0.2.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.13"}
   "parsexp"
   "opam-core" {>= "2.1.0"}
-  "opam-state" {>= "2.1.0" & (< "2.2.0~beta3" | >= "2.2.0")}
+  "opam-state" {>= "2.1.0" & (< "2.2.0~beta3" | >= "2.2.0") & < "2.4"}
   "opam-format"
   "ocamlfind" {>= "1.8.1"}
   "cmdliner" {>= "1.1.0"}

--- a/packages/opam-0install/opam-0install.0.4.2/opam
+++ b/packages/opam-0install/opam-0install.0.4.2/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "2.7"}
   "fmt"
   "cmdliner" {< "2.0.0"}
-  "opam-state" {>= "2.1.0~rc" & (< "2.2.0~beta3" | >= "2.2.0")}
+  "opam-state" {>= "2.1.0~rc" & (< "2.2.0~beta3" | >= "2.2.0") & < "2.4"}
   "ocaml" {>= "4.08.0"}
   "0install-solver"
   "opam-file-format" {>= "2.1.1"}

--- a/packages/opam-0install/opam-0install.0.4.3/opam
+++ b/packages/opam-0install/opam-0install.0.4.3/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "2.7"}
   "fmt" {>= "0.8.7"}
   "cmdliner" {>= "1.1.0" & < "2.0.0"}
-  "opam-state" {>= "2.1.0~rc" & (< "2.2.0~beta3" | >= "2.2.0")}
+  "opam-state" {>= "2.1.0~rc" & (< "2.2.0~beta3" | >= "2.2.0") & < "2.4"}
   "ocaml" {>= "4.08.0"}
   "0install-solver"
   "opam-file-format" {>= "2.1.1"}

--- a/packages/opam-0install/opam-0install.0.4.4/opam
+++ b/packages/opam-0install/opam-0install.0.4.4/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "2.7"}
   "fmt" {>= "0.8.7"}
   "cmdliner" {>= "1.1.0" & < "2.0.0"}
-  "opam-state" {>= "2.1.0~rc"}
+  "opam-state" {>= "2.1.0~rc" & < "2.4"}
   "ocaml" {>= "4.10.0"}
   "0install-solver"
   "opam-file-format" {>= "2.1.1"}

--- a/packages/opam-0install/opam-0install.0.5/opam
+++ b/packages/opam-0install/opam-0install.0.5/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "2.7"}
   "fmt" {>= "0.8.7"}
   "cmdliner" {>= "1.1.0" & < "2.0.0"}
-  "opam-state" {>= "2.2.1"}
+  "opam-state" {>= "2.2.1" & < "2.4"}
   "opam-format" {>= "2.2.1"}
   "ocaml" {>= "4.10.0"}
   "0install-solver"


### PR DESCRIPTION
opam-state 2.4 makes the `lock_kind` argument of `OpamStateConfig` mandatory (instead of optional). These packages are missing the argument, which causes a partial application warning and neither therefore works.
Upstream fixes for the packages are at https://github.com/sim642/odep/commit/eb2969f04acb59084abbf6640895716ee18c3451 and https://github.com/ocaml-opam/opam-0install-solver/pull/63.