### PR TITLE
Package print-table.0.1.0

### DIFF
--- a/packages/print-table/print-table.0.1.0/opam
+++ b/packages/print-table/print-table.0.1.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Simple Unicode/ANSI and Markdown text table rendering"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "ISC"
+homepage: "https://github.com/mbarbin/print-table"
+doc: "https://mbarbin.github.io/print-table/"
+bug-reports: "https://github.com/mbarbin/print-table/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/print-table.git"
+description: """\
+
+print-table provides a minimal library for rendering text tables
+with Unicode box-drawing characters and optional ANSI colors, or as
+GitHub-flavored Markdown.
+
+The API is straightforward and declarative, designed for readable
+tables in command-line tools, tests, and tutorials.
+
+This library has taken some inspiration from 2 existing and more
+feature-complete libraries, which we link to here for more advanced
+usages: see [printbox] and [ascii_table].
+
+[printbox]: https://github.com/c-cube/printbox
+[ascii_table]: https://github.com/janestreet/textutils
+
+"""
+tags: [ "table" "markdown" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/print-table/releases/download/0.1.0/print-table-0.1.0.tbz"
+  checksum: [
+    "sha256=88189431c9f7c4bd81f55993cacd61971552648a9c9acf37153de14ad6e394e4"
+    "sha512=c69fc30a774e43dfac4c0e87be3245da8f2d7ee4fef52d1e55ca53fd8c039e317ed7caafeded2713dc42a706213f7af124b34a34d0bced417528c51bbda89105"
+  ]
+}
+x-commit-hash: "6aab08416eca9905e5bc16aa5437c7d7486463e9"


### PR DESCRIPTION
### `print-table.0.1.0`
Simple Unicode/ANSI and Markdown text table rendering
print-table provides a minimal library for rendering text tables
with Unicode box-drawing characters and optional ANSI colors, or as
GitHub-flavored Markdown.

The API is straightforward and declarative, designed for readable
tables in command-line tools, tests, and tutorials.

This library has taken some inspiration from 2 existing and more
feature-complete libraries, which we link to here for more advanced
usages: see [printbox] and [ascii_table].

[printbox]: https://github.com/c-cube/printbox
[ascii_table]: https://github.com/janestreet/textutils



---
* Homepage: https://github.com/mbarbin/print-table
* Source repo: git+https://github.com/mbarbin/print-table.git
* Bug tracker: https://github.com/mbarbin/print-table/issues

---
Initial release.

- Simple builder interface.
- Text printer using Unicode/ANSI.
- GitHub Flavored Markdown printer.


---
:camel: Pull-request generated by opam-publish v2.5.1