### PR TITLE
Zarith_stubs_js missing v bounds

### DIFF
--- a/packages/bls12-381/bls12-381.20.1/opam
+++ b/packages/bls12-381/bls12-381.20.1/opam
@@ -11,7 +11,7 @@ depends: [
   "integers"
   "integers_stubs_js"
   "zarith" { >= "1.13" & < "1.14" }
-  "zarith_stubs_js" { >= "0.16.1" }
+  "zarith_stubs_js" { >= "v0.16.1" }
   "hex" { >= "1.3.0" }
   "tezt" { with-test & >= "4.0.0" & < "5.0.0" }
   "octez-alcotezt" { with-test & = version }

--- a/packages/catala/catala.0.3.0/opam
+++ b/packages/catala/catala.0.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "cmdliner" {>= "1.0.4" & < "1.1.0"}
   "re" {>= "1.9.0"}
   "zarith" {>= "1.10"}
-  "zarith_stubs_js" {>= "0.14.0"}
+  "zarith_stubs_js" {>= "v0.14.0"}
   "dune" {>= "2.2"}
   "ocamlgraph" {>= "1.8.8"}
   "calendar" {>= "2.04"}

--- a/packages/octez-libs/octez-libs.20.1/opam
+++ b/packages/octez-libs/octez-libs.20.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ppx_expect"
   "hex" { >= "1.3.0" }
   "zarith" { >= "1.13" & < "1.14" }
-  "zarith_stubs_js" { >= "0.16.1" }
+  "zarith_stubs_js" { >= "v0.16.1" }
   "aches" { >= "1.0.0" }
   "seqes" { >= "0.2" }
   "lwt-canceler" { >= "0.3" & < "0.4" }

--- a/packages/octez-proto-libs/octez-proto-libs.20.1/opam
+++ b/packages/octez-proto-libs/octez-proto-libs.20.1/opam
@@ -13,7 +13,7 @@ depends: [
   "data-encoding" { >= "1.0.1" & < "1.1" }
   "bls12-381" { = version }
   "zarith" { >= "1.13" & < "1.14" }
-  "zarith_stubs_js" { >= "0.16.1" }
+  "zarith_stubs_js" { >= "v0.16.1" }
   "class_group_vdf" { >= "0.0.4" }
   "aches" { >= "1.0.0" }
   "aches-lwt" { >= "1.0.0" }

--- a/packages/salto-analyzer/salto-analyzer.0.1/opam
+++ b/packages/salto-analyzer/salto-analyzer.0.1/opam
@@ -32,7 +32,7 @@ depends: [
   "js_of_ocaml" {>= "5.4.0" & <= "5.9.1"}
   "js_of_ocaml-ppx" {build & >= "5.4.0"}
   "js_of_ocaml-tyxml" {>= "5.4.0"}
-  "zarith_stubs_js" {>= "0.16.1"}
+  "zarith_stubs_js" {>= "v0.16.1"}
   "csexp" {>= "1.5.2"}
   "ez_dune_describe" {>= "0.1"}
   "odoc" {with-doc}


### PR DESCRIPTION
This PR adds a bunch more of missing `v` bounds for `zarith_stubs_js `in
- salto-analyzer
- octez-libs and octez-proto-libs
- bls12-381
- catala (for the older 0.3.0 release)