### PR TITLE
fix: Bump minimum ffmpeg version for Liquidsoap

### DIFF
--- a/packages/liquidsoap/liquidsoap.2.3.3/opam
+++ b/packages/liquidsoap/liquidsoap.2.3.3/opam
@@ -86,8 +86,8 @@ conflicts: [
   "dssi" {< "0.1.3"}
   "faad" {< "0.5.0"}
   "fdkaac" {< "0.3.1"}
-  "ffmpeg" {< "1.2.4"}
-  "ffmpeg-avutil" {< "1.2.4"}
+  "ffmpeg" {< "1.2.5"}
+  "ffmpeg-avutil" {< "1.2.5"}
   "flac" {< "1.0.0"}
   "frei0r" {< "0.1.0"}
   "inotify" {< "1.0"}


### PR DESCRIPTION
## Summary
This PR fixes the build issues encountered with the `liquidsoap=2.3.3` package by marking it's incompatibility with `ffmpeg<1.2.5`.

## Additional
Refs: https://github.com/savonet/liquidsoap/pull/4576