### PR TITLE
Extend conf-gmp-paths to support OpenSuse

### DIFF
--- a/packages/conf-gmp-paths/conf-gmp-paths.1/opam
+++ b/packages/conf-gmp-paths/conf-gmp-paths.1/opam
@@ -33,7 +33,7 @@ depexts: [
   ["gmp"] {os = "openbsd"}
   ["gmp"] {os = "freebsd"}
   ["gmp-dev"] {os-distribution = "alpine"}
-  ["gmp-devel"] {os-family = "suse"}
+  ["gmp-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gmp"] {os = "win32" & os-distribution = "cygwinports"}
   ["gmp"] {os-distribution = "nixos"}
 ]


### PR DESCRIPTION
Spotted as `apronext` failures on opensuse-tumbleweed as part of #28224:
```
#=== ERROR while compiling conf-gmp-paths.1 ===================================#
# context              2.3.0 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/conf-gmp-paths.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build sh /home/opam/.opam/4.14/lib/ez-conf-lib/ez-conf-lib gmp gmp.h test-gmp.c --package-name conf-gmp-paths -- /usr/local
# exit-code            1
# env-file             ~/.opam/log/conf-gmp-paths-7-fc9a11.env
# output-file          ~/.opam/log/conf-gmp-paths-7-fc9a11.out
### output ###
# checking compilation with gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC  -D_FILE_OFFSET_BITS=64 : working
# looking for gmp without prefix
# include gmp.h: not found
# looking for gmp in prefix /usr/local
# looking for gmp in prefix /usr
# looking for gmp in prefix /usr/local
# library gmp not found
# gmp not found; pass further possible prefixes     	 after '--' on the command line
```

This makes the line identical to the corresponding suse-line in packages/conf-gmp/conf-gmp.5/opam.