### PR TITLE
[new release] gmp (6.3.0)

### DIFF
--- a/packages/gmp/gmp.6.3.0/opam
+++ b/packages/gmp/gmp.6.3.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Lucas Pluvinage <lucas@tarides.com>"
+license: ["LGPL-3.0-only" "LGPL-2.0-only"]
+authors: "Torbjörn Granlund and contributors"
+homepage: "https://github.com/mirage/ocaml-gmp"
+bug-reports: "https://github.com/mirage/ocaml-gmp/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-gmp.git"
+substs: [ "src/build.sh" ]
+build: [
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.6"}
+  "conf-m4"
+]
+depexts: [
+  [ "xz" ] {os = "macos" & os-distribution = "homebrew"}
+]
+conflicts: [
+  "ocaml-solo5" {< "0.8.3"}
+]
+synopsis: "The GNU Multiple Precision Arithmetic Library"
+description: """Dune packaging of the GMP library, suitable for 
+cross-compilation."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-gmp/releases/download/6.3.0/gmp-6.3.0.tbz"
+  checksum: [
+    "sha256=eaa668ebbe1319673ad385b52a9a35d7ee31a8ad67f7677461893e373aeb4b95"
+    "sha512=f604c08ff981ac9d67fecde26c652422b66dbd14ed87de40c0db03da87e05ef4c18f041f2bd636f183328ff9e8e823c18f7e32a105a6c7dd21fb16325b5e9037"
+  ]
+}
+x-commit-hash: "8322b0657cbb5381281fa1faf73db7ef5a769f21"


### PR DESCRIPTION
The GNU Multiple Precision Arithmetic Library

- Project page: <a href="https://github.com/mirage/ocaml-gmp">https://github.com/mirage/ocaml-gmp</a>

##### CHANGES:

- Upgrade to GMP 6.3.0 and add a patch for GCC 15 (@dinosaure, mirage/ocaml-gmp#25)
- Fix the CI (@dinosaure, mirage/ocaml-gmp#26)
