### PR TITLE
2 packages from OCamlPro/ocp-index at 1.4.0

### DIFF
--- a/packages/ocp-browser/ocp-browser.1.4.0/opam
+++ b/packages/ocp-browser/ocp-browser.1.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis:
+  "Console browser for the documentation of installed OCaml libraries"
+description: """\
+ocp-browser is a ncurses-like interface that allows to easily browse the
+interfaces and documentation of all installed OCaml modules."""
+maintainer: "louis.gesbert@ocamlpro.com"
+authors: ["Louis Gesbert" "Gabriel Radanne"]
+license: "GPL-3.0-only"
+tags: ["org:ocamlpro" "org:typerex"]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.0"}
+  "ocp-index" {= version}
+  "cmdliner" {>= "1.3.0"}
+  "lambda-term" {>= "3.3.0"}
+  "zed" {>= "2.0.0"}
+  "odoc" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
+url {
+  src: "https://github.com/OCamlPro/ocp-index/archive/refs/tags/1.4.0.tar.gz"
+  checksum: [
+    "md5=7224ae09fd740ce7ab7b059666e08e4b"
+    "sha512=92e6c32ae1b953ae0928e48e09dc3238a43b87165130ec85f9e73c71ea6ce38f51bc3e39768bae0eb76d06a945767a4dcbabd3a111ccf45f37b182aa16b304ad"
+  ]
+}

--- a/packages/ocp-index/ocp-index.1.4.0/opam
+++ b/packages/ocp-index/ocp-index.1.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Lightweight completion and documentation browsing for OCaml libraries"
+description: """\
+This package includes
+* The `ocp-index` library and command-line tool
+* `ocp-grep`, a tool that finds uses of a given (qualified) identifier in a source tree
+* bindings for emacs and vim (sublime text also [available](https://github.com/whitequark/sublime-ocp-index/))
+
+To automatically configure your editors, install this with package `user-setup`."""
+maintainer: "louis.gesbert@ocamlpro.com"
+authors: ["Louis Gesbert" "Gabriel Radanne" "Kate Deplaix"]
+license: ["LGPL-2.1-only WITH OCaml-LGPL-linking-exception" "GPL-3.0-only"]
+tags: ["org:ocamlpro" "org:typerex"]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.0"}
+  "ocp-indent" {>= "1.4.2"}
+  "re" {>= "1.9.0"}
+  "cmdliner" {>= "1.3.0"}
+  "odoc" {with-doc}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+post-messages:
+  """\
+This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path "%{prefix}%/share/emacs/site-lisp")
+  (require 'ocp-index)
+
+* for Vim, add the following line to ~/.vimrc:
+  set rtp+=%{share}%/ocp-index/vim"""
+    {success & !user-setup:installed}
+dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
+url {
+  src: "https://github.com/OCamlPro/ocp-index/archive/refs/tags/1.4.0.tar.gz"
+  checksum: [
+    "md5=7224ae09fd740ce7ab7b059666e08e4b"
+    "sha512=92e6c32ae1b953ae0928e48e09dc3238a43b87165130ec85f9e73c71ea6ce38f51bc3e39768bae0eb76d06a945767a4dcbabd3a111ccf45f37b182aa16b304ad"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `ocp-browser.1.4.0`: Console browser for the documentation of installed OCaml libraries
- `ocp-index.1.4.0`: Lightweight completion and documentation browsing for OCaml libraries



---
* Homepage: http://www.typerex.org/ocp-index.html
* Source repo: git+https://github.com/OCamlPro/ocp-index.git
* Bug tracker: https://github.com/OCamlPro/ocp-index/issues

---
:camel: Pull-request generated by opam-publish v2.5.0