### PR TITLE
Add: tgls.0.9.1

### DIFF
--- a/packages/tgls/tgls.0.9.1/opam
+++ b/packages/tgls/tgls.0.9.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Thin bindings to OpenGL {3,4} and OpenGL ES {2,3} for OCaml"
+description: """\
+Tgls is a set of independent OCaml libraries providing thin bindings
+to OpenGL libraries. It has support for core OpenGL 3.{2,3} and
+4.{0,1,2,3,4} and OpenGL ES 2 and 3.{0,1,2}.
+
+Tgls depends on [ocaml-ctypes][ctypes] and the C OpenGL library of your
+platform. It is distributed under the ISC license.
+          
+[ctypes]: https://github.com/ocamllabs/ocaml-ctypes
+
+Home page: <http://erratique.ch/software/tgls>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The tgls programmers"
+license: "ISC"
+tags: ["bindings" "opengl" "opengl-es" "graphics" "org:erratique"]
+homepage: "https://erratique.ch/software/tgls"
+doc: "https://erratique.ch/software/tgls/doc/"
+bug-reports: "https://github.com/dbuenzli/tgls/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "ctypes" {>= "0.21.1"}
+  "ctypes-foreign" {>= "0.21.1"}
+  "xmlm" {dev}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/tgls.git"
+url {
+  src: "https://erratique.ch/software/tgls/releases/tgls-0.9.1.tbz"
+  checksum:
+    "sha512=c39cf8e74d438b6c258a493277d7fc4d5d65fbaa2974d7f4cf03308c7693a88043d86caa9a76d43e734d4afbdb8da6d03238f898f28d5b49ff9e1efa96efff64"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `tgls.0.9.1` [home](https://erratique.ch/software/tgls), [doc](https://erratique.ch/software/tgls/doc/), [issues](https://github.com/dbuenzli/tgls/issues)  
  *Thin bindings to OpenGL {3,4} and OpenGL ES {2,3} for OCaml*


---

#### `tgls` v0.9.1 2025-07-23 Zagreb

- Each library has now its own `tgl_stub.c` nop stub needed to
  correctly generate the `.so` files. In turn this makes `tgls`
  compatible with `topkg` >= 1.1.0.

---

Use `b0 -- .opam publish tgls.0.9.1` to update the pull request.