### PR TITLE
Add: topkg.1.1.0, topkg-care.1.1.0

### DIFF
--- a/packages/topkg-care/topkg-care.1.1.0/opam
+++ b/packages/topkg-care/topkg-care.1.1.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "The transitory OCaml software packager"
+description: """\
+**Warning** Topkg is in maintenance mode and should not longer be used.
+
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution, creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml opam repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-format`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser
+
+Home page: <http://erratique.ch/software/topkg>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The topkg programmers"
+license: "ISC"
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+homepage: "https://erratique.ch/software/topkg"
+doc: "https://erratique.ch/software/topkg/doc"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build & >= "1.6.1"}
+  "ocamlbuild"
+  "topkg" {= version}
+  "fmt" {>= "0.9.0"}
+  "logs"
+  "bos" {>= "0.2.1"}
+  "cmdliner" {>= "1.3.0"}
+  "webbrowser"
+  "opam-format" {>= "2.0.0"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/topkg.git"
+url {
+  src: "https://erratique.ch/software/topkg/releases/topkg-1.1.0.tbz"
+  checksum:
+    "sha512=34d22ae5b6bd166dd4a601a7d12d89c336684b3c56d7c7f481b40837eab263616cc3a6e6f63602f3d4a7d53c911967bf261de6c1ac205341b98a9838e5ea7aeb"
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/topkg/topkg.1.1.0/opam
+++ b/packages/topkg/topkg.1.1.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "The transitory OCaml software packager"
+description: """\
+**Warning** Topkg is in maintenance mode and should not longer be used.
+
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution, creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml opam repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-format`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser
+
+Home page: <http://erratique.ch/software/topkg>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The topkg programmers"
+license: "ISC"
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+homepage: "https://erratique.ch/software/topkg"
+doc: "https://erratique.ch/software/topkg/doc"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build & >= "1.6.1"}
+  "ocamlbuild"
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/topkg.git"
+url {
+  src: "https://erratique.ch/software/topkg/releases/topkg-1.1.0.tbz"
+  checksum:
+    "sha512=34d22ae5b6bd166dd4a601a7d12d89c336684b3c56d7c7f481b40837eab263616cc3a6e6f63602f3d4a7d53c911967bf261de6c1ac205341b98a9838e5ea7aeb"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `topkg.1.1.0` [home](https://erratique.ch/software/topkg), [doc](https://erratique.ch/software/topkg/doc), [issues](https://github.com/dbuenzli/topkg/issues)  
  *The transitory OCaml software packager*
* Add: `topkg-care.1.1.0` [home](https://erratique.ch/software/topkg), [doc](https://erratique.ch/software/topkg/doc), [issues](https://github.com/dbuenzli/topkg/issues)  
  *The transitory OCaml software packager*


---

#### `topkg-care`, `topkg` v1.1.0 2025-07-23 Zagreb

- Change the default of `Topkg.Conf.debugger_support` from `false` to
  `true`. This enables the install of `.ml` and `.cmt` files by
  default which is expected for a good experience on `ocaml.org`.  The
  previous behaviour can be recovered by setting
  `TOPKG_CONF_DEBUGGER_SUPPORT=false` in your environment ([#143](https://github.com/dbuenzli/topkg/issues/143)).

- Fix install of hidden library modules when `Topkg.Conf.debugger_support` is
  `true`:
  1. When the hidden module has an `.mli`, the `.cmi` files was being installed
     instead of the `.cmti` and the `.mli` was missing ([#143](https://github.com/dbuenzli/topkg/issues/143)).
  2. When the hidden module had no `.mli` the installation would fail
     by requiring one.

---

Use `b0 -- .opam publish topkg.1.1.0 topkg-care.1.1.0` to update the pull request.