### PR TITLE
Missing v in decoders-jsonaf's jsonaf bound

### DIFF
--- a/packages/decoders-jsonaf/decoders-jsonaf.1.0.0/opam
+++ b/packages/decoders-jsonaf/decoders-jsonaf.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "3.1"}
   "ocaml" {>= "4.10.0"}
   "decoders" {= version}
-  "jsonaf" {>= "0.15.0"}
+  "jsonaf" {>= "v0.15.0"}
   "odoc" {with-doc}
   "ounit2" {with-test}
 ]


### PR DESCRIPTION
I just filed an upstream PR here: https://github.com/mattjbray/ocaml-decoders/pull/79