### PR TITLE
Add OpenSuse support for `conf-mpfr-paths`

### DIFF
--- a/packages/conf-mpfr-paths/conf-mpfr-paths.1/opam
+++ b/packages/conf-mpfr-paths/conf-mpfr-paths.1/opam
@@ -38,7 +38,7 @@ depexts: [
   ["mpfr"] {os = "openbsd"}
   ["mpfr"] {os-family = "arch"}
   ["mpfr-dev"] {os-family = "alpine"}
-  ["mpfr-devel"] {os-family = "suse"}
+  ["mpfr-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["mpfr"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 available: [


### PR DESCRIPTION
Spotted in #28224 where `apronext` is now failing `conf-mpfr-paths` now that `conf-gmp-paths` was fixed in #28231:
```
#=== ERROR while compiling conf-mpfr-paths.1 ==================================#
# context              2.3.0 | linux/x86_64 | ocaml-base-compiler.5.3.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/conf-mpfr-paths.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build sh /home/opam/.opam/5.3/lib/ez-conf-lib/ez-conf-lib mpfr mpfr.h test-mpfr.c CPPFLAGS+=-I/usr/include LDFLAGS+=-L/usr/lib64 LIBS+=-lgmp --package-name conf-mpfr-paths -- /usr/local
# exit-code            1
# env-file             ~/.opam/log/conf-mpfr-paths-7-0e450a.env
# output-file          ~/.opam/log/conf-mpfr-paths-7-0e450a.out
### output ###
# checking compilation with gcc -O2 -fno-strict-aliasing -fwrapv  -pthread   -D_FILE_OFFSET_BITS=64 : working
# looking for mpfr without prefix
# include mpfr.h: not found
# looking for mpfr in prefix /usr/local
# looking for mpfr in prefix /usr
# looking for mpfr in prefix /usr/local
# library mpfr not found
# mpfr not found; pass further possible prefixes     	 after '--' on the command line
```