### PR TITLE
Add: fmt.0.11.0

### DIFF
--- a/packages/fmt/fmt.0.11.0/opam
+++ b/packages/fmt/fmt.0.11.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "OCaml Format pretty-printer combinators"
+description: """\
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
+library that allows to setup formatters for terminal color output
+depends on the Unix library. The optional `Fmt_cli` library that
+provides command line support for Fmt depends on [`cmdliner`].
+
+Fmt is distributed under the ISC license.
+
+Home page: <http://erratique.ch/software/fmt>
+
+[`cmdliner`]: http://erratique.ch/software/cmdliner"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The fmt programmers"
+license: "ISC"
+tags: ["string" "format" "pretty-print" "org:erratique"]
+homepage: "https://erratique.ch/software/fmt"
+doc: "https://erratique.ch/software/fmt/doc/"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+]
+depopts: ["base-unix" "cmdliner"]
+conflicts: [
+  "cmdliner" {< "1.3.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-base-unix"
+  "%{base-unix:installed}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/fmt.git"
+url {
+  src: "https://erratique.ch/software/fmt/releases/fmt-0.11.0.tbz"
+  checksum:
+    "sha512=3f40155fc6a7315202e410585964307d63416c8001fd243667ed9d8d1a02b67deecacb25e9c2feb409c537bbdfb7817d91168de4ddd643532ff51d6c1c696a4a"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `fmt.0.11.0` [home](https://erratique.ch/software/fmt), [doc](https://erratique.ch/software/fmt/doc/), [issues](https://github.com/dbuenzli/fmt/issues)  
  *OCaml Format pretty-printer combinators*


---

#### `fmt` v0.11.0 2025-07-25 Zagreb

* Add `Fmt.{cardinal,ordinal}` to format english 
  plurals. Thanks to Brian Ward for suggesting ([#64](https://github.com/dbuenzli/fmt/issues/64)).
* Export `fmt` from `fmt.tty` and `fmt.cli` libraries.

---

Use `b0 -- .opam publish fmt.0.11.0` to update the pull request.