### PR TITLE
Add: brr.0.0.8

### DIFF
--- a/packages/brr/brr.0.0.8/opam
+++ b/packages/brr/brr.0.0.8/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Browser programming toolkit for OCaml"
+description: """\
+Brr is a toolkit for programming browsers in OCaml with the
+[`js_of_ocaml`][jsoo] compiler. It provides:
+
+* Interfaces to a selection of browser APIs.
+* An OCaml console developer tool for live interaction 
+  with programs running in web pages.
+* A JavaScript FFI for idiomatic OCaml programming.
+
+Brr is distributed under the ISC license. It depends on the
+`js_of_ocaml` compiler and runtime – but not on its libraries or
+syntax extension.
+
+[jsoo]: https://ocsigen.org/js_of_ocaml
+
+Homepage: <https://erratique.ch/software/brr>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The brr programmers"
+license: ["ISC" "BSD-3-Clause"]
+tags: ["reactive" "declarative" "frp" "front-end" "browser" "org:erratique"]
+homepage: "https://erratique.ch/software/brr"
+doc: "https://erratique.ch/software/brr/doc/"
+bug-reports: "https://github.com/dbuenzli/brr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+  "js_of_ocaml-compiler" {>= "6.0.1"}
+  "js_of_ocaml-toplevel" {>= "6.0.1"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/brr.git"
+url {
+  src: "https://erratique.ch/software/brr/releases/brr-0.0.8.tbz"
+  checksum:
+    "sha512=49e7bfbad2ea6a0139354e4a33c59c8a113c4c1e20a4f629bc5cad24aa801e474b4af10ce35adbda5d23dd294d1de5efa5b10bb3030d03f4758459977250a0f6"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `brr.0.0.8` [home](https://erratique.ch/software/brr), [doc](https://erratique.ch/software/brr/doc/), [issues](https://github.com/dbuenzli/brr/issues)  
  *Browser programming toolkit for OCaml*


---

#### `brr` v0.0.8 2025-07-25 Zagreb

- Add `Brr_css.{Highlight,HighlightRegistry,Css}` a binding to the
  CSS Custom Highlight API.
- Add `Brr.Range` a binding to `Range` objects.
- Add `Brr.Regexp` a binding to `RegExp` objects.
- Add `El.text_content` a binding to `Node.textContent`.
- Add `El.Prop.hidden` binding the `hidden` property.
- Add more arguments to `El.scroll_into_view`.
  Thanks to Paul-Elliot Anglès d'Auriac for the patch ([#70](https://github.com/dbuenzli/brr/issues/70)).
- Add `El.Style.zoom` property.
  Thanks to Paul-Elliot Anglès d'Auriac for the patch ([#74](https://github.com/dbuenzli/brr/issues/74)).
- Add `El.offset_{h,w,top,left,parent}`.
  Thanks to Paul-Elliot Anglès d'Auriac for the patch ([#76](https://github.com/dbuenzli/brr/issues/76)).
- Add `Window.parent`.
  Thanks to Paul-Elliot Anglès d'Auriac for the patch ([#73](https://github.com/dbuenzli/brr/issues/73)).
- Add `Window.inner_{width,height}`.
  Thanks to Paul-Elliot Anglès d'Auriac for the patch ([#75](https://github.com/dbuenzli/brr/issues/75)).
- Add `Canvas.attrs_create` which fixes the shadowing issue by
  the `Canvas.attrs` getter that prevented from creating these values.
  Thanks to Tim Ats for reporting and @naora for fixing ([#63](https://github.com/dbuenzli/brr/issues/63), [#79](https://github.com/dbuenzli/brr/issues/79)).
- Add `` `Type_error `` case to `Jv.Error.enum`.

- Fix callbacks in `Brr_io.Geolocalation`. Thanks to Jérôme Vouillon ([#80](https://github.com/dbuenzli/brr/issues/80)).
- Fix `At.wrap` attribute, it was defined as `value`.
  Thanks to Brendan Zabarauskas for the patch ([#66](https://github.com/dbuenzli/brr/issues/66)).
- Fix `Result_syntax.(and*)`. Thanks to Jérôme Vouillon.
- Fix `Service_worker.{script_url,state}`. Thanks to Jérôme Vouillon.
- Fix typo in binding of `Tarray.sub`. Thanks to Jérôme Vouillon.
- Fix typo in binding of `Fetch.Ev.preload_response`. Thanks to Jérôme Vouillon.
- Fix wrong default value for `name` in `Crypto_algo.Aes_gcm_params.v`
  to `AES-GCM`. Thanks to @EruEri for the patch ([#65](https://github.com/dbuenzli/brr/issues/65)).

---

Use `b0 -- .opam publish brr.0.0.8` to update the pull request.