### PR TITLE
Add: bytesrw.0.2.0

### DIFF
--- a/packages/bytesrw/bytesrw.0.2.0/opam
+++ b/packages/bytesrw/bytesrw.0.2.0/opam
@@ -1,0 +1,82 @@
+opam-version: "2.0"
+synopsis: "Composable byte stream readers and writers for OCaml"
+description: """\
+Bytesrw extends the OCaml `Bytes` module with composable, memory
+efficient, byte stream readers and writers compatible with effect
+based concurrency.
+
+Except for byte slice life-times, these abstractions intentionally
+separate away ressource management and the specifics of reading and
+writing bytes.
+
+Bytesrw distributed under the ISC license. It has no dependencies.
+
+Optional support for compressed and hashed bytes depend, at your wish, on 
+the C [`zlib`], [`libzstd`], [`blake3`], [`libmd`], [`xxhash`] and
+libraries.
+
+[`blake3`]: https://blake3.io
+[`libzstd`]: http://zstd.net
+[`libmd`]: https://www.hadrons.org/software/libmd/
+[`xxhash`]: https://xxhash.com/
+[`zlib`]: https://zlib.net
+
+Homepage: <https://erratique.ch/software/bytesrw/>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The bytesrw programmers"
+license: "ISC"
+tags: [
+  "bytes"
+  "streaming"
+  "zstd"
+  "zlib"
+  "gzip"
+  "deflate"
+  "sha1"
+  "sha2"
+  "compression"
+  "hashing"
+  "utf"
+  "xxhash"
+  "blake3"
+  "org:erratique"
+]
+homepage: "https://erratique.ch/software/bytesrw"
+doc: "https://erratique.ch/software/bytesrw/doc"
+bug-reports: "https://github.com/dbuenzli/bytesrw/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+]
+depopts: [
+  "conf-xxhash" "conf-zlib" "conf-zstd" "conf-libmd" "conf-libblake3"
+]
+conflicts: [
+  "conf-zstd" {< "1.3.8"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-conf-libblake3"
+  "%{conf-libblake3:installed}%"
+  "--with-conf-libmd"
+  "%{conf-libmd:installed}%"
+  "--with-conf-xxhash"
+  "%{conf-xxhash:installed}%"
+  "--with-conf-zlib"
+  "%{conf-zlib:installed}%"
+  "--with-conf-zstd"
+  "%{conf-zstd:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/bytesrw.git"
+url {
+  src: "https://erratique.ch/software/bytesrw/releases/bytesrw-0.2.0.tbz"
+  checksum:
+    "sha512=e3f07dbd808e152cd4b2ea5c2fa3863d4b72f7f97cfa3cd7493a3725c84f39d882042388ee47c9d6acfd30a650c21db429c8264db3d7466cad6e580308b5a2d2"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `bytesrw.0.2.0` [home](https://erratique.ch/software/bytesrw), [doc](https://erratique.ch/software/bytesrw/doc), [issues](https://github.com/dbuenzli/bytesrw/issues)  
  *Composable byte stream readers and writers for OCaml*


---

#### `bytesrw` v0.2.0 2025-07-25 Zagreb

- Fix `Bytesrw_xxhash.Xxh64.{to_hex,pp}`. Leading zeros
  were not being printed ([#5](https://github.com/dbuenzli/bytesrw/issues/5)).
- Change unuseful signature of `Slice.break`: do not return 
  `None` if any of `Slice.take` or `Slice.drop` does. Simply
  return the result of both operations.
- Fix wrong bound checks in `Slice.{sub,make}[_or_eod]`. The functions
  now behave like `Bytes.sub` as far as indexing is allowed. Thanks
  to Adrián Montesinos González for the report and suggesting the fix ([#4](https://github.com/dbuenzli/bytesrw/issues/4)).
- `bytesrw.*` libraries are made to export `bytesrw`.

---

Use `b0 -- .opam publish bytesrw.0.2.0` to update the pull request.