### PR TITLE
Add: jsont.0.2.0

### DIFF
--- a/packages/jsont/jsont.0.2.0/opam
+++ b/packages/jsont/jsont.0.2.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Declarative JSON data manipulation for OCaml"
+description: """\
+Jsont is an OCaml library for declarative JSON data manipulation. It
+provides:
+
+- Combinators for describing JSON data using the OCaml values of your
+  choice. The descriptions can be used by generic functions to
+  decode, encode, query and update JSON data without having to
+  construct a generic JSON representation.
+- A JSON codec with optional text location tracking and layout
+  preservation. The codec is compatible with effect-based concurrency.
+
+The descriptions are independent from the codec and can be used by
+third-party processors or codecs.
+
+Jsont is distributed under the ISC license. It has no dependencies.
+The codec is optional and depends on the [`bytesrw`] library. The JavaScript
+support is optional and depends on the [`brr`] library.
+
+Homepage: <https://erratique.ch/software/jsont/>
+
+[`bytesrw`]: https://erratique.ch/software/bytesrw
+[`brr`]: https://erratique.ch/software/brr"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The jsont programmers"
+license: "ISC"
+tags: ["json" "codec" "org:erratique"]
+homepage: "https://erratique.ch/software/jsont"
+doc: "https://erratique.ch/software/jsont/doc"
+bug-reports: "https://github.com/dbuenzli/jsont/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+  "b0" {dev & with-test}
+]
+depopts: ["cmdliner" "brr" "bytesrw"]
+conflicts: [
+  "cmdliner" {< "1.3.0"}
+  "brr" {< "0.0.6"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+  "--with-bytesrw"
+  "%{bytesrw:installed}%"
+  "--with-brr"
+  "%{brr:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/jsont.git"
+url {
+  src: "https://erratique.ch/software/jsont/releases/jsont-0.2.0.tbz"
+  checksum:
+    "sha512=6206f73a66cb170b560a72e58f70b9fb2c20397b9ab819dceba49b6602b9b79e47ba307e6910e61ca4694555c66fdcd7a17490afb99548e8f43845a5a88913e7"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `jsont.0.2.0` [home](https://erratique.ch/software/jsont), [doc](https://erratique.ch/software/jsont/doc), [issues](https://github.com/dbuenzli/jsont/issues)  
  *Declarative JSON data manipulation for OCaml*


---

#### `jsont` v0.2.0 2025-07-25 Zagreb

- Fix `Jsont_bytesrw.{encode,encode'}`. Do not write the `eod` slice if
  `eod:false` is specified. Thanks to Benjamin Nguyen-Van-Yen for
  the report and the fix ([#8](https://github.com/dbuenzli/jsont/issues/8)).
- Fix `Jsont.zero` failing encodes rather than encoding `null` as
  advertised. Thanks to Adrián Montesinos González for the report ([#6](https://github.com/dbuenzli/jsont/issues/6)).
- Add `Jsont.Error.expected` to help format error messages.
- Add `Jsont.with_doc` to update kind and doc strings of existing JSON
  types.
- Add `Jsont.Object.Case.{tag,map_tag}` to access a case and case map tags.
- Fix `META` file. Really export all requires and
  remove uneeded `bytesrw` dependency from `jsont` library.

---

Use `b0 -- .opam publish jsont.0.2.0` to update the pull request.