### PR TITLE
Add: htmlit.0.2.0

### DIFF
--- a/packages/htmlit/htmlit.0.2.0/opam
+++ b/packages/htmlit/htmlit.0.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "HTML generation combinators for OCaml"
+description: """\
+Htmlit is an OCaml library providing simple but subtle combinators for
+generating HTML fragments and pages.
+
+Htmlit is distributed under the ISC license. It has no dependencies.
+
+Homepage: <https://erratique.ch/software/htmlit>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The htmlit programmers"
+license: "ISC"
+tags: ["web" "html" "org:erratique"]
+homepage: "https://erratique.ch/software/htmlit"
+doc: "https://erratique.ch/software/htmlit/doc"
+bug-reports: "https://github.com/dbuenzli/htmlit/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/htmlit.git"
+url {
+  src: "https://erratique.ch/software/htmlit/releases/htmlit-0.2.0.tbz"
+  checksum:
+    "sha512=f331ce05cd53c865356af4d133d6a37b25057526dd07a0eaea55dcfbef731587318d8b789792cf34a670efc7ee703d5ad23a89ab1c54f2740bba81c5cc826216"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `htmlit.0.2.0` [home](https://erratique.ch/software/htmlit), [doc](https://erratique.ch/software/htmlit/doc), [issues](https://github.com/dbuenzli/htmlit/issues)  
  *HTML generation combinators for OCaml*


---

#### `htmlit` v0.2.0 2025-07-25 Zagreb

- Add `At.{download,role,popover,popoveraction,popovertargetaction`}.

---

Use `b0 -- .opam publish htmlit.0.2.0` to update the pull request.