### PR TITLE
[new release] utop (2.16.0)

### DIFF
--- a/packages/utop/utop.2.16.0/opam
+++ b/packages/utop/utop.2.16.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Universal toplevel for OCaml"
+description:
+  "utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for OCaml. It can run in a terminal or in Emacs. It supports line edition, history, real-time and context sensitive completion, colors, and more. It integrates with the Tuareg mode in Emacs."
+maintainer: ["Florian Angeletti <octa@polychoron.fr>"]
+authors: ["Jérémie Dimino"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/utop"
+doc: "https://ocaml-community.github.io/utop/"
+bug-reports: "https://github.com/ocaml-community/utop/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.11.0"}
+  "base-unix"
+  "base-threads"
+  "ocamlfind" {>= "1.7.2"}
+  "lambda-term" {>= "3.1.0" & < "4.0"}
+  "logs"
+  "lwt"
+  "lwt_react"
+  "zed" {>= "3.2.0"}
+  "react" {>= "1.0.0"}
+  "cppo" {>= "1.1.2"}
+  "alcotest" {with-test}
+  "xdg" {>= "3.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-community/utop.git"
+url {
+  src:
+    "https://github.com/ocaml-community/utop/releases/download/2.16.0/utop-2.16.0.tbz"
+  checksum: [
+    "sha256=0b9f79135d2132fb211cbe889941cfd0d54cc7bb8062b8a0443e38c540b8c763"
+    "sha512=073d67d898ac1b579aac050e8c88a229d67a13e9c85f1d835023a46750cdf4b2f2180d1ea70005e9e0366721503d0ba2b9c326deddfb43426d87481e461cd45e"
+  ]
+}
+x-commit-hash: "bd6a1546e5c73c7a626e456fac5e81027106e4d6"


### PR DESCRIPTION
CHANGES:
---------------
* Add support for OCaml 5.4 
* restore backtrace 
* support camlp$n preprocessor
* utop configuration and state files (utoprc, utop-history) are now always in the relevant
  utop subdirectory
* fix emacs completion for qualified paths (Module.M.some_name) (
* implicit bindings for emacs mode 
