### PR TITLE
[new release] dream-html (2 packages) (3.11.1)

### DIFF
--- a/packages/dream-html/dream-html.3.11.1/opam
+++ b/packages/dream-html/dream-html.3.11.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.14.0"}
+  "ppxlib" {>= "0.33.0" & < "1.0.0"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.11.1/dream-html-3.11.1.tbz"
+  checksum: [
+    "sha256=46740bc3e088406bbcf8f789ce9c8d7e4c4aaca608b85dca916b1fb380220fbe"
+    "sha512=504400f06e964b28cbefa2e06c8a29c7165a30ff48ff5790716baa27ef4949f424e979cd561c9b7c2ef0c9d8ff79d7d5e327ed4700bb04004dc8c327e4d481e4"
+  ]
+}
+x-commit-hash: "e164ee0ff59d4f5734b6458566872d55aabfd828"

--- a/packages/pure-html/pure-html.3.11.1/opam
+++ b/packages/pure-html/pure-html.3.11.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.11.1/dream-html-3.11.1.tbz"
+  checksum: [
+    "sha256=46740bc3e088406bbcf8f789ce9c8d7e4c4aaca608b85dca916b1fb380220fbe"
+    "sha512=504400f06e964b28cbefa2e06c8a29c7165a30ff48ff5790716baa27ef4949f424e979cd561c9b7c2ef0c9d8ff79d7d5e327ed4700bb04004dc8c327e4d481e4"
+  ]
+}
+x-commit-hash: "e164ee0ff59d4f5734b6458566872d55aabfd828"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

See https://github.com/yawaramin/dream-html/tags
