### PR TITLE
Add: down.0.4.0

### DIFF
--- a/packages/down/down.0.4.0/opam
+++ b/packages/down/down.0.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "An OCaml toplevel (REPL) upgrade"
+description: """\
+Down is an unintrusive user experience upgrade for the `ocaml`
+toplevel (REPL). 
+
+Simply load the zero dependency `Down` library in the `ocaml` toplevel
+and you get line edition, history, session support and identifier
+completion and documentation (courtesy of [`ocp-index`][ocp-index]).
+
+Add this to your `~/.ocamlinit`:
+
+    #use "down.top"
+
+![tty](doc/tty.png)
+
+Down is distributed under the ISC license.
+
+Homepage: http://erratique.ch/software/down
+
+[ocp-index]: https://github.com/OCamlPro/ocp-index"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The down programmers"
+license: "ISC"
+tags: ["dev" "toplevel" "repl" "org:erratique"]
+homepage: "https://erratique.ch/software/down"
+doc: "https://erratique.ch/software/down/doc/"
+bug-reports: "https://github.com/dbuenzli/down/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+  "uucp" {dev}
+]
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%" "--lib-dir" "%{lib}%"
+]
+dev-repo: "git+https://erratique.ch/repos/down.git"
+url {
+  src: "https://erratique.ch/software/down/releases/down-0.4.0.tbz"
+  checksum:
+    "sha512=2fc5ff1d236cebf0ad99b5230c5136600c640412276c98aa9a6faab09e311d7467456ca39b49de954b9b7efdad62b3ca1bb8033797bc088ce283c9880756979f"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `down.0.4.0` [home](https://erratique.ch/software/down), [doc](https://erratique.ch/software/down/doc/), [issues](https://github.com/dbuenzli/down/issues)  
  *An OCaml toplevel (REPL) upgrade*


---

#### `down` v0.4.0 2025-07-29 Zagreb

- Restore (and improve) support for `ocamlnat`.  It's now possible to
  use `#use "down.top"` regardless. So if you don't have fancy stuff
  in your `.config/ocaml/init.ml` it will work equally with `ocaml`
  and `ocamlnat`. 
  
  Incidentally we no longer need to detect the presence of `ocamlnat`
  which solves [#33](https://github.com/dbuenzli/down/issues/33) (Thanks to Jacques-Henri Jourdan for the report).

- opam packaging: no longer install `down.top` in `ocaml`'s library
  directoy. `OCAML_TOPLEVEL_PATH` is supported since 4.08 and `opam
  env` now sets it correctly. With that the file we install the
  `toplevel` library directory should be enough for `#use "down.top"`
  to work.

- Fix incorrect permission when creating directories ([#36](https://github.com/dbuenzli/down/issues/36), v0.3.0
  regression). Thanks to Juneyoung Lee for the report and Nicolás
  Ojeda Bär for the analysis.

- Escape `%%LIBDIR%%` substitution in order to deal with spaces ([#38](https://github.com/dbuenzli/down/issues/38),
  [#41](https://github.com/dbuenzli/down/issues/41)). Thanks to Nicolás Ojeda Bär and Antonin Décimo for reporting.

- Update TTY width data to Unicode 16.0.0

---

Use `b0 -- .opam publish down.0.4.0` to update the pull request.