### PR TITLE
qcheck-lin.0.8 is incompatible with ocaml.5.5

### DIFF
--- a/packages/qcheck-lin/qcheck-lin.0.8/opam
+++ b/packages/qcheck-lin/qcheck-lin.0.8/opam
@@ -21,7 +21,7 @@ homepage: "https://github.com/ocaml-multicore/multicoretests"
 bug-reports: "https://github.com/ocaml-multicore/multicoretests/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.12"}
+  "ocaml" {>= "4.12" & < "5.5"}
   "qcheck-core" {>= "0.25"}
   "qcheck-multicoretests-util" {= version}
   "odoc" {with-doc}


### PR DESCRIPTION
qcheck-lin.0.8 is incompatible with ocaml.5.5 and will fail with it: https://github.com/ocaml-multicore/multicoretests/issues/559

The 0.9 release in https://github.com/ocaml/opam-repository/pull/28270 contains a 5.5-compatible fix.
This PR thus adds an ocaml upper bound while I remember.

For more information see:
https://github.com/ocaml/ocaml/issues/14081
https://github.com/ocaml/ocaml/pull/13712
https://github.com/ocaml/ocaml/pull/13994