### PR TITLE
Set an upper bound of dream-httpaf for dream.1.0.0~alpha5-7

### DIFF
--- a/packages/dream/dream.1.0.0~alpha5/opam
+++ b/packages/dream/dream.1.0.0~alpha5/opam
@@ -53,7 +53,7 @@ depends: [
   "conf-libev" {os != "win32"}
   "cstruct" {>= "6.0.0"}
   "digestif" {>= "0.7"}  # to_raw_string.
-  "dream-httpaf" {>= "1.0.0~alpha2"}
+  "dream-httpaf" {>= "1.0.0~alpha2" & < "1.0.0~alpha4"}
   "dream-pure" {>= "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}  # --instrument-with.
   "fmt" {>= "0.8.7"}  # `Italic.

--- a/packages/dream/dream.1.0.0~alpha6/opam
+++ b/packages/dream/dream.1.0.0~alpha6/opam
@@ -53,7 +53,7 @@ depends: [
   ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
   "cstruct" {>= "6.0.0"}
   "digestif" {>= "0.7"}  # to_raw_string.
-  "dream-httpaf" {>= "1.0.0~alpha2"}
+  "dream-httpaf" {>= "1.0.0~alpha2" & < "1.0.0~alpha4"}
   "dream-pure" {>= "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}  # --instrument-with.
   "fmt" {>= "0.8.7"}  # `Italic.

--- a/packages/dream/dream.1.0.0~alpha7/opam
+++ b/packages/dream/dream.1.0.0~alpha7/opam
@@ -55,7 +55,7 @@ depends: [
   ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
   "cstruct" {>= "6.0.0"}
   "digestif" {>= "0.7"}  # to_raw_string.
-  "dream-httpaf" {>= "1.0.0~alpha2"}
+  "dream-httpaf" {>= "1.0.0~alpha2" & < "1.0.0~alpha4"}
   "dream-pure" {>= "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}  # --instrument-with.
   "fmt" {>= "0.8.7"}  # `Italic.


### PR DESCRIPTION
This PR sets upper bounds for `dream-httpaf` in `dream.1.0.0~alpha5-7`
as using `dream-httpaf.1.0.0~alpha4` causes a compilation failure.
We've previously set lower bounds for it in #27034.

This was spotted in https://github.com/ocaml/opam-repository/pull/28267
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/d0ec749105986928c2134f9046e9b9382af0aafe
causing
```
[ERROR] The compilation of dream.1.0.0~alpha7 failed at "dune build -p dream -j 71".

#=== ERROR while compiling dream.1.0.0~alpha7 =================================#
# context              2.3.0 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/dream.1.0.0~alpha7
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p dream -j 71
# exit-code            1
# env-file             ~/.opam/log/dream-7-00e69c.env
# output-file          ~/.opam/log/dream-7-00e69c.out
### output ###
# File "src/http/dune", line 21, characters 2-32:
# 21 |   dream-httpaf.dream-websocketaf
#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Library "dream-httpaf.dream-websocketaf" not found.
# -> required by library "dream.http" in _build/default/src/http
# -> required by _build/default/META.dream
# -> required by _build/install/default/lib/dream/META
# -> required by _build/default/dream.install
# -> required by alias install
```

To clear up numbering: `dream-httpaf.1.0.0~alpha4` was released with `dream.1.0.0~alpha8` in 0750dded83.
The opam file for `dream-httpaf` explicitly says `"This package does not have a stable API."` and the release https://github.com/aantron/dream/releases/tag/1.0.0-alpha8 mentions
`Replace vendored http/af stack with depending on httpun from opam`

Hopefully this will eliminate a few more CI red lights... :crossed_fingers: 