### PR TITLE
memtrace.0.1 also doesn't work with OCaml5

### DIFF
--- a/packages/memtrace/memtrace.0.1/opam
+++ b/packages/memtrace/memtrace.0.1/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/janestreet/memtrace"
 bug-reports: "https://github.com/janestreet/memtrace/issues"
 depends: [
   "dune" {>= "2.3"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.11.0" & < "5.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
An upper bound was added for `memtrace.0.1.1` and upwards in #21297.

I just saw `memtrace.0.1` triggering and failing on 5.3 on #28276 with the same error:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/1543bda091d998b92bcf85fe4dd4ec84534a224d/variant/compilers,5.3,dune.3.20.0~alpha1,revdeps,memtrace.0.1
```
#=== ERROR while compiling memtrace.0.1 =======================================#
# context              2.3.0 | linux/x86_64 | ocaml-base-compiler.5.3.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/memtrace.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p memtrace -j 255 @install
# exit-code            1
# env-file             ~/.opam/log/memtrace-7-57e3d7.env
# output-file          ~/.opam/log/memtrace-7-57e3d7.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlopt.opt -w -40 -g -I src/.memtrace.objs/byte -I src/.memtrace.objs/native -I /home/opam/.opam/5.3/lib/ocaml/threads -I /home/opam/.opam/5.3/lib/ocaml/unix -cmi-file src/.memtrace.objs/byte/memtrace__Trace.cmi -no-alias-deps -open Memtrace__ -o src/.memtrace.objs/native/memtrace__Trace.cmx -c -impl src/trace.ml)
# File "src/trace.ml", lines 346-352, characters 16-4:
# 346 | ................Hashtbl.MakeSeeded (struct
# 347 |   type t = int
# 348 |   let hash _seed (id : t) =
# 349 |     let h = id * 189696287 in
# 350 |     h lxor (h lsr 23)
# 351 |   let equal (a : t) (b : t) = a = b
# 352 | end)
# Error: Modules do not match:
#        sig
#          type t = int
#          val hash : 'a -> t -> int
#          val equal : t -> t -> bool
#        end
#      is not included in Hashtbl.SeededHashedType
#      The value "seeded_hash" is required but not provided
#      File "hashtbl.mli", line 440, characters 4-36: Expected declaration
```