### PR TITLE
Package why3find.1.2.0

### DIFF
--- a/packages/why3find/why3find.1.2.0/opam
+++ b/packages/why3find/why3find.1.2.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "A Why3 Package Manager"
+description:
+  "The why3find utility is designed for managing packages for why3 developpers and associated OCaml extracted code."
+maintainer: ["benjamin.jorge@cea.fr" "loic.correnson@cea.fr"]
+authors: [
+  "Loïc Correnson <loic.correnson@cea.fr>"
+  "Benjamin Jorge <benjamin.jorge@cea.fr>"
+]
+license: "LGPL-2.1-only"
+tags: "why3"
+homepage: "https://git.frama-c.com/pub/why3find"
+doc: "https://git.frama-c.com/pub/why3find"
+bug-reports: "https://git.frama-c.com/pub/why3find/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "dune-site" {>= "3.12"}
+  "why3" {>= "1.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "yojson" {>= "1.7.0"}
+  "terminal_size" {>= "0.2.0"}
+  "zmq" {with-test}
+  "alt-ergo" {with-test & = "2.4.2"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "zmq" {>= "5.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/why3find.git"
+url {
+  src:
+    "https://git.frama-c.com/-/project/1056/uploads/043312a7a70961338479016ac535c706/why3find-1.2.0.tbz"
+  checksum: [
+    "md5=9ce13cca7ffe4bdb006f87293b36343f"
+    "sha512=eb43bba6ff4ba6d29c4a2122a789c55b8a980b11e3fdca97d026099d6fbd8d942ce0fcedddc0c525b8cda733887f6a45ee4db253e862454da5b5ff2a1a139974"
+  ]
+}


### PR DESCRIPTION
### `why3find.1.2.0`
A Why3 Package Manager
The why3find utility is designed for managing packages for why3 developpers and associated OCaml extracted code.



---
* Homepage: https://git.frama-c.com/pub/why3find
* Source repo: git+https://git.frama-c.com/pub/why3find.git
* Bug tracker: https://git.frama-c.com/pub/why3find/issues

---
:camel: Pull-request generated by opam-publish v2.5.1