### PR TITLE
Package mel-bastet.1.0.0

### DIFF
--- a/packages/mel-bastet/mel-bastet.1.0.0/opam
+++ b/packages/mel-bastet/mel-bastet.1.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A Melange-focused fork of Bastet for category theory and abstract algebra"
+maintainer: ["john@haley.io"]
+authors: ["John Haley"]
+license: "BSD-3-Clause"
+tags: ["category theory" "abstract algebra" "algebra" "cats"]
+homepage: "https://github.com/johnhaley81/mel-bastet"
+doc: "https://johnhaley81.github.io/mel-bastet"
+bug-reports: "https://github.com/johnhaley81/mel-bastet/issues"
+depends: [
+  "ocaml" {>= "5.3.0"}
+  "dune" {>= "3.19"}
+  "melange" {>= "5.1.0"}
+  "alcotest" {>= "1.9.0" & with-test}
+  "qcheck" {>= "0.25" & with-test}
+  "qcheck-core" {>= "0.25" & with-test} 
+  "qcheck-alcotest" {>= "0.25" & with-test}
+  "fmt" {>= "0.10.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/johnhaley81/mel-bastet.git"
+url {
+  src:
+    "https://github.com/johnhaley81/mel-bastet/archive/refs/tags/v1.0.0.tar.gz"
+  checksum: [
+    "md5=6f64c325f481da4361ef216709440203"
+    "sha512=d5c9b7cf6cdaab5997a41cbeaa3fafad31c2a2b3f2b87c4345e5a11b55e0e6bfb9bc8f1253b081118e5e45cd5e9a641a407923039b057f336f6468cbd3f4641f"
+  ]
+}


### PR DESCRIPTION
### `mel-bastet.1.0.0`
A Melange-focused fork of Bastet for category theory and abstract algebra



---
* Homepage: https://github.com/johnhaley81/mel-bastet
* Source repo: git+https://github.com/johnhaley81/mel-bastet.git
* Bug tracker: https://github.com/johnhaley81/mel-bastet/issues

---
:camel: Pull-request generated by opam-publish v2.5.1