### PR TITLE
core_unix can be installed on Alpine <3.21

### DIFF
--- a/packages/core_unix/core_unix.v0.15.2/opam
+++ b/packages/core_unix/core_unix.v0.15.2/opam
@@ -29,7 +29,7 @@ description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
 "
 depexts: ["linux-headers"] {os-family = "alpine"}
-available: [ !(os = "freebsd" & os-version >= "14") & os-distribution != "alpine" ]
+available: [ !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") ]
 url {
 src: "https://github.com/janestreet/core_unix/archive/refs/tags/v0.15.2.tar.gz"
 checksum: "sha256=486d0e954603960fa081b3fd23e3cc3e50ac0892544acd35f9c2919c4bf5f67b"

--- a/packages/core_unix/core_unix.v0.16.0/opam
+++ b/packages/core_unix/core_unix.v0.16.0/opam
@@ -29,7 +29,7 @@ synopsis: "Unix-specific portions of Core"
 description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
 "
-available: [ !(os = "freebsd" & os-version >= "14") & os-distribution != "alpine" ]
+available: [ !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") ]
 url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/core_unix-v0.16.0.tar.gz"
 checksum: "sha256=4f70a9d3a761799d00c0a207942b4abd9f1a144bbcb19df98021d9fb7bfa9e5f"

--- a/packages/core_unix/core_unix.v0.17.0/opam
+++ b/packages/core_unix/core_unix.v0.17.0/opam
@@ -25,7 +25,7 @@ depends: [
   "dune"                     {>= "3.11.0"}
   "spawn"                    {>= "v0.15"}
 ]
-available: [ (arch = "x86_64" | arch = "arm64") & !(os = "freebsd" & os-version >= "14") & os-distribution != "alpine"]
+available: [ (arch = "x86_64" | arch = "arm64") & !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") ]
 synopsis: "Unix-specific portions of Core"
 description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].

--- a/packages/core_unix/core_unix.v0.17.1/opam
+++ b/packages/core_unix/core_unix.v0.17.1/opam
@@ -25,7 +25,7 @@ depends: [
   "dune"                     {>= "3.11.0"}
   "spawn"                    {>= "v0.15"}
 ]
-available: arch != "arm32" & arch != "x86_32" & arch != "ppc64" & arch != "s390x" & os-distribution != "alpine"
+available: arch != "arm32" & arch != "x86_32" & arch != "ppc64" & arch != "s390x" & (os-distribution != "alpine" | os-version < "3.21")
 synopsis: "Unix-specific portions of Core"
 description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].


### PR DESCRIPTION
Fixes #28283 

I tested `core_unix` versions `v0.15.0`, `v0.15.1`, `v0.15.2`, `v0.16.0`, `v0.17.0`, and `v0.17.1` on Alpine 3.20 and 3.21 to validate my changes.