### PR TITLE
2 packages from mbarbin/dunolint at 0.0.20250804

### DIFF
--- a/packages/dunolint-lib/dunolint-lib.0.0.20250804/opam
+++ b/packages/dunolint-lib/dunolint-lib.0.0.20250804/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "A library to create dunolint configs"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/dunolint"
+doc: "https://mbarbin.github.io/dunolint/"
+bug-reports: "https://github.com/mbarbin/dunolint/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "base" {>= "v0.16"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "ppx_compare" {>= "v0.16"}
+  "ppx_enumerate" {>= "v0.16"}
+  "ppx_sexp_conv" {>= "v0.16"}
+  "ppxlib" {>= "0.35.0"}
+  "re" {>= "1.8.0"}
+  "sexplib0" {>= "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/dunolint.git"
+description: """\
+
+[dunolint] is a set of OCaml libraries and a cli tool to lint and help
+manage files in (large) dune projects.
+
+[dunolint-lib] is the package you need as a user to define a dunolint
+config, without pulling all the dependencies required by the linter
+engine and command line.
+
+It defines a configuration language in which you can express linting
+invariants for your projects. The tool will enforce these invariants,
+applying global and systematic changes automatically when able, and
+help with general ergonomics questions.
+
+For example: "I want for all libs in this subdirectory to enable
+`bisect_ppx`, please go patch my dune files". Or, "I would like all
+libraries that verify this particular predicate to supply the ppx flag
+`-unused-code-warnings=force`", and more.
+
+You can setup [dunolint] as part of your CI checks to help enforcing
+properties and linting checks going forward.
+
+"""
+tags: [ "dune" "linter" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/dunolint/releases/download/0.0.20250804/dunolint-0.0.20250804.tbz"
+  checksum: [
+    "sha256=e4ca7c98db73dd9ab2ae8cba37ee0645f580267484e9893dbce6e28f4f2f0170"
+    "sha512=7ca658fb96139a0c41724355ac6aaf83d75468c7df14569b8f6090711f73a8fb2408ed1145384e756418682f0fa660a915842fd2b3f8b42e5ed4990e795b384e"
+  ]
+}
+x-commit-hash: "f5a9df101023cb391b1f1e1d579852ad205b13c2"

--- a/packages/dunolint/dunolint.0.0.20250804/opam
+++ b/packages/dunolint/dunolint.0.0.20250804/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+synopsis: "A linter for build files in dune projects"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/dunolint"
+doc: "https://mbarbin.github.io/dunolint/"
+bug-reports: "https://github.com/mbarbin/dunolint/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.3"}
+  "base" {>= "v0.17"}
+  "cmdlang" {>= "0.0.9"}
+  "dunolint-lib" {= version}
+  "file-rewriter" {>= "0.0.3"}
+  "fmt" {>= "0.9.0"}
+  "fpath" {>= "0.7.3"}
+  "fpath-base" {>= "0.3.1"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "loc" {>= "0.2.2"}
+  "logs" {>= "0.7.0"}
+  "pageantty" {>= "0.0.2"}
+  "parsexp" {>= "v0.17"}
+  "patdiff" {>= "v0.17"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "ppx_compare" {>= "v0.17"}
+  "ppx_enumerate" {>= "v0.17"}
+  "ppx_hash" {>= "v0.17"}
+  "ppx_here" {>= "v0.17"}
+  "ppx_let" {>= "v0.17"}
+  "ppx_sexp_conv" {>= "v0.17"}
+  "ppx_sexp_value" {>= "v0.17"}
+  "ppxlib" {>= "0.35.0"}
+  "sexplib0" {>= "v0.17"}
+  "sexps-rewriter" {>= "0.0.3"}
+  "stdio" {>= "v0.17"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/dunolint.git"
+description: """\
+
+[dunolint] is a set of OCaml libraries and a cli tool to lint and help
+manage files in (large) dune projects.
+
+[dunolint] is the package that implements the linter engine for
+dunolint configs as well as the [dunolint] command line tool.
+
+You may install it to get the [dunolint] cli, and/or if you want to
+use the linting libraries to write custom rewriters and linters.
+
+"""
+tags: [ "dune" "linter" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/dunolint/releases/download/0.0.20250804/dunolint-0.0.20250804.tbz"
+  checksum: [
+    "sha256=e4ca7c98db73dd9ab2ae8cba37ee0645f580267484e9893dbce6e28f4f2f0170"
+    "sha512=7ca658fb96139a0c41724355ac6aaf83d75468c7df14569b8f6090711f73a8fb2408ed1145384e756418682f0fa660a915842fd2b3f8b42e5ed4990e795b384e"
+  ]
+}
+x-commit-hash: "f5a9df101023cb391b1f1e1d579852ad205b13c2"


### PR DESCRIPTION
This pull-request concerns:
- `dunolint.0.0.20250804`: A linter for build files in dune projects
- `dunolint-lib.0.0.20250804`: A library to create dunolint configs



---
* Homepage: https://github.com/mbarbin/dunolint
* Source repo: git+https://github.com/mbarbin/dunolint.git
* Bug tracker: https://github.com/mbarbin/dunolint/issues

---
## 0.0.20250804 (2025-08-04)

### Added

- Made all names in dunolint lib export `Comparable.S` ([#84](https://github.com/mbarbin/dunolint/pull/84), @mbarbin).

### Changed

- Move sections handling logic into helper module ([#85](https://github.com/mbarbin/dunolint/pull/85), @mbarbin).
- Move comment handling logic into helper module ([#84](https://github.com/mbarbin/dunolint/pull/84), @mbarbin).

### Fixed

- Entries `pps` are now sorted by sections when separated by comments ([#86](https://github.com/mbarbin/dunolint/pull/86), @mbarbin, reported and suggested by @raphael-proust).

## 0.0.20250730 (2025-07-30)

### Added

- Improve canonical order of libraries to open via flags ([#83](https://github.com/mbarbin/dunolint/pull/83), @mbarbin).
- Add support for ordered-set and use it in library.modes ([#81](https://github.com/mbarbin/dunolint/pull/81), @mbarbin).
- Enable CRs workflows (experimental) ([#76](https://github.com/mbarbin/dunolint/pull/76), [#78](https://github.com/mbarbin/dunolint/pull/78), @mbarbin).
- Add tests ([#67](https://github.com/mbarbin/dunolint/pull/67), [#68](https://github.com/mbarbin/dunolint/pull/68), @mbarbin).

### Changed

- Improved testing coverage ([#80](https://github.com/mbarbin/dunolint/pull/80), @mbarbin).
- Small refactors, tweaks & code improvement ([#77](https://github.com/mbarbin/dunolint/pull/77), [#79](https://github.com/mbarbin/dunolint/pull/79), @mbarbin).
- Use `Git_pager` from opam package `pageantty` instead of vendoring it ([#73](https://github.com/mbarbin/dunolint/pull/73), @mbarbin).
- Refactor enforce functions to ease further testing ([#72](https://github.com/mbarbin/dunolint/pull/72), @mbarbin).
- Support building dunolint-lib with OCaml 4.14 ([#65](https://github.com/mbarbin/dunolint/pull/65), @mbarbin).
- Updated git-pager and err dependencies ([#63](https://github.com/mbarbin/dunolint/pull/63), [#64](https://github.com/mbarbin/dunolint/pull/64), @mbarbin).

### Fixed

- Fix unexpected rewrites on duped flags in libs ([#82](https://github.com/mbarbin/dunolint/pull/82), @mbarbin).
- Fix some cram test failures shown by ocaml-ci ([#75](https://github.com/mbarbin/dunolint/pull/75), @mbarbin).
- Fix disabling of color when `--color=never` is supplied ([#70](https://github.com/mbarbin/dunolint/pull/70), @mbarbin).
- Fix doc location for installation guide ([#69](https://github.com/mbarbin/dunolint/pull/69), @mbarbin).
- Fix git pager clean termination when displayed diff exceeds 1 page ([#61](https://github.com/mbarbin/dunolint/pull/61), @mbarbin).

### Removed

- Replace library `equals MODES` by `has_modes` construct ([#81](https://github.com/mbarbin/dunolint/pull/81), @mbarbin).

## 0.0.20250403 (2025-04-03)

### Added

- Added command `tools lint-file` to ease editor integration ([#39](https://github.com/mbarbin/dunolint/pull/39), [#40](https://github.com/mbarbin/dunolint/pull/40), [#46](https://github.com/mbarbin/dunolint/pull/46), @mbarbin, requested by and with help from @arvidj).
- Added support for `library.modes` ([#23](https://github.com/mbarbin/dunolint/pull/23), [#27](https://github.com/mbarbin/dunolint/pull/27), @mbarbin, requested by @raphael-proust)
- Document release process and current state ([#25](https://github.com/mbarbin/dunolint/pull/25), @mbarbin).
- Added coverage and regression tests ([#18](https://github.com/mbarbin/dunolint/pull/18), [#19](https://github.com/mbarbin/dunolint/pull/19), [#30](https://github.com/mbarbin/dunolint/pull/30), [#33](https://github.com/mbarbin/dunolint/pull/33), [#34](https://github.com/mbarbin/dunolint/pull/34), [#48](https://github.com/mbarbin/dunolint/pull/48), @mbarbin).

### Changed

- Reduce dependencies of config library ([#49](https://github.com/mbarbin/dunolint/pull/49), [#51](https://github.com/mbarbin/dunolint/pull/51), @mbarbin).
- Enabled setup-ocaml's *dune-cache* in CI ([#52](https://github.com/mbarbin/dunolint/pull/52), @mbarbin).
- Upgrade Docusaurus to latest available ([#24](https://github.com/mbarbin/dunolint/pull/24), @mbarbin).

### Fixed

- Add missing `melange` library mode ([#43](https://github.com/mbarbin/dunolint/pull/43), [#44](https://github.com/mbarbin/dunolint/pull/44), @mbarbin, reported by @arvidj).
- Fixes for `odoc.3.0.0` ([#28](https://github.com/mbarbin/dunolint/pull/28), [#32](https://github.com/mbarbin/dunolint/pull/32), @mbarbin, with help from @jonludlam)

### Removed

- Disabled failing macos build from CI for now ([#20](https://github.com/mbarbin/dunolint/pull/20), @mbarbin).

## 0.0.20250315 (2025-03-15)

### Added

- Prepare to include more ci workflows incrementally in the future ([#16](https://github.com/mbarbin/dunolint/pull/16), @mbarbin).

### Changed

- Dependencies in `libraries` are now sorted by sections when separated by comments ([#12](https://github.com/mbarbin/dunolint/pull/12), [#14](https://github.com/mbarbin/dunolint/pull/14), @mbarbin, reported and suggested by @raphael-proust).


---
:camel: Pull-request generated by opam-publish v2.5.1