### PR TITLE
opam-*.2.4.1: removing mistakenly added avoid-version flag

### DIFF
--- a/packages/opam-client/opam-client.2.4.1/opam
+++ b/packages/opam-client/opam-client.2.4.1/opam
@@ -34,8 +34,6 @@ conflicts: [
   "extlib" {< "1.7.8"}
   "extlib-compat"
 ]
-available: opam-version >= "2.1.0"
-flags: avoid-version
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/opam-core/opam-core.2.4.1/opam
+++ b/packages/opam-core/opam-core.2.4.1/opam
@@ -41,8 +41,6 @@ depends: [
     "conf-msvc64" {os = "win32" & os-distribution != "cygwinports"}))
 ]
 conflicts: ["extlib-compat"]
-available: opam-version >= "2.1.0"
-flags: avoid-version
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/opam-devel/opam-devel.2.4.1/opam
+++ b/packages/opam-devel/opam-devel.2.4.1/opam
@@ -28,8 +28,6 @@ depends: [
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}
 ]
-available: opam-version >= "2.1.0"
-flags: avoid-version
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]

--- a/packages/opam-format/opam-format.2.4.1/opam
+++ b/packages/opam-format/opam-format.2.4.1/opam
@@ -26,8 +26,6 @@ depends: [
   "re" {>= "1.9.0"}
   "dune" {>= "2.8.0"}
 ]
-available: opam-version >= "2.1.0"
-flags: avoid-version
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/opam-installer/opam-installer.2.4.1/opam
+++ b/packages/opam-installer/opam-installer.2.4.1/opam
@@ -28,8 +28,6 @@ depends: [
   "cmdliner" {>= "0.9.8"}
   "dune" {>= "2.8.0"}
 ]
-available: opam-version >= "2.1.0"
-flags: avoid-version
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/opam-repository/opam-repository.2.4.1/opam
+++ b/packages/opam-repository/opam-repository.2.4.1/opam
@@ -26,8 +26,6 @@ depends: [
   "patch" {>= "3.0.0~alpha1"}
   "dune" {>= "2.8.0"}
 ]
-available: opam-version >= "2.1.0"
-flags: avoid-version
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/opam-solver/opam-solver.2.4.1/opam
+++ b/packages/opam-solver/opam-solver.2.4.1/opam
@@ -34,8 +34,6 @@ depopts: ["z3"]
 conflicts: [
   "z3" {< "4.8.4"}
 ]
-available: opam-version >= "2.1.0"
-flags: avoid-version
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/opam-state/opam-state.2.4.1/opam
+++ b/packages/opam-state/opam-state.2.4.1/opam
@@ -27,8 +27,6 @@ depends: [
   "spdx_licenses" {>= "1.0.0"}
   "dune" {>= "2.8.0"}
 ]
-available: opam-version >= "2.1.0"
-flags: avoid-version
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam-repository/issues/28293