### PR TITLE
[new release] html_of_jsx (0.0.5)

### DIFF
--- a/packages/html_of_jsx/html_of_jsx.0.0.5/opam
+++ b/packages/html_of_jsx/html_of_jsx.0.0.5/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Render HTML with JSX"
+description:
+  "html_of_jsx is a JSX transformation that allows you to write HTML declaratively."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/davesnx/html_of_jsx"
+bug-reports: "https://github.com/davesnx/html_of_jsx/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "ppxlib" {>= "0.25.0"}
+  "alcotest" {with-test}
+  "benchmark" {with-test}
+  "reason" {>= "3.10.0" & with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {= "0.26.1" & (with-dev-setup | with-test)}
+  "ocaml-lsp-server" {with-dev-setup}
+  "tiny_httpd" {with-dev-setup}
+  "mlx" {with-dev-setup}
+  "ocamlformat-mlx" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/html_of_jsx.git"
+url {
+  src:
+    "https://github.com/davesnx/html_of_jsx/releases/download/0.0.5/html_of_jsx-0.0.5.tbz"
+  checksum: [
+    "sha256=53406f788909fdab597fe4b627a87b61543417e0bc1133a000629e12be444062"
+    "sha512=e2be5fa788c450b6ccbfef9390625b6abc26616b03fa111e3549f4d28a6410f2f8f27c63c91f6f93d5c1b00908480ed286d0bfe28c2c9d58d0cf829a8df66163"
+  ]
+}
+x-commit-hash: "f755078379953deda4ac13d0c756ec9db3d51772"


### PR DESCRIPTION
Render HTML with JSX

- Project page: <a href="https://github.com/davesnx/html_of_jsx">https://github.com/davesnx/html_of_jsx</a>

##### CHANGES:

## 0.0.5

- Make tests run in FreeBSD (https://github.com/davesnx/html_of_jsx/issues/22) (@davesnx)
- Fix: prefix with Stdlib all ppx generated code (https://github.com/davesnx/html_of_jsx/pull/23) (@tjdevries)
- Allow react attributes as props (via -react flag) (https://github.com/davesnx/html_of_jsx/pull#26) (@davesnx)
- Documentation: pushed old "features" document into the main index as seen https://davesnx.github.io/html_of_jsx/html_of_jsx/index.html

## 0.0.4

- [BREAKING] Handle HTML encoding for `'` (@davesnx)
- Handle HTML encoding for `"` (from `&davesnx/html_of_jsx#34;` to `&quot;`) (@davesnx)
- Improved performance of `JSX.render` (@davesnx)
- [BREAKING] Remove `Fragment` in favor of `JSX.list` (@davesnx)
- Remove unused `Component (unit -> element)` since it isn't needed (@davesnx)
- [BREAKING] Change attributes representation (@andreypopp)
- [BREAKING] Remove melange dependency (@andreypopp)
- [BREAKING] Lower the OCaml bound to 4.14 (@davesnx)
- Make lib wrapped (@andreypopp)

## 0.0.3

- [BREAKING] `Html_of_jsx.render` lives under `JSX.render` (removing the `Html_of_jsx` module entirely) (@lessp)
- [BREAKING] Module `Jsx` is turned into `JSX` (@lessp)
- [BREAKING] dune's library is now `html_of_jsx` instead of (`html_of_jsx.lib`) (@lessp)
- [BREAKING] `JSX.element` is opaque (can't see the type from outside), but we have a `JSX.Debug` module to inspect and re-construct `JSX.element` (cc @leostera) (@lessp)
- Improved performance of `JSX.render` (@lessp)
- add `hx-trigger` to htmx ppx davesnx/html_of_jsx#13 (@lessp)
- `htmlFor` -> `for_` (@lessp)
- Fix aria-autocomplete (@davesnx)

## 0.0.2

- Add `Jsx.unsafe` to allow unsafe HTML as children
- Fix HTML attributes formatting (charset, autocomplete, tabindex, inputmode, etc...)
- Enable HTMX attributes via `html_of_jsx.ppx -htmx`

## 0.0.1

- First working version of the ppx and library
- Supports most of features from [JSX](https://reasonml.github.io/docs/en/jsx) (uppercase components, fragments, optional attributes, punning)
- but with a few improvements (lowercase components, no need to add annotations)
- No React idioms (no `className`, no `htmlFor`, no `onChange`, etc...)
- Type-safe, validates attributes and their types ([it can be better thought](https://github.com/davesnx/html_of_jsx/issues/2))
- Minimal
  - `Html_of_jsx.render` to render an element to HTML
  - `Jsx.*` to construct DOM Elements and DOM nodes (`Jsx.text`, `Jsx.int`, `Jsx.null`, `Jsx.list`)
- Works with [Reason](https://reasonml.github.io) and [mlx](https://github.com/andreypopp/mlx)
- Supports some htmx under the ppx (`html_of_jsx.ppx -htmx`)
