### PR TITLE
[new release] miou (0.4.0)

### DIFF
--- a/packages/miou/miou.0.4.0/opam
+++ b/packages/miou/miou.0.4.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/robur-coop/miou"
+bug-reports:  "https://github.com/robur-coop/miou/issues"
+dev-repo:     "git+https://github.com/robur-coop/miou.git"
+doc:          "https://docs.osau.re/miou/"
+license:      "MIT"
+synopsis:     "Composable concurrency primitives for OCaml"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"             {>= "5.0.0"}
+  "dune"              {>= "2.8.0"}
+  "dscheck"           {with-test & >= "0.4.0"}
+  "digestif"          {with-test}
+  "happy-eyeballs"    {with-test & >= "0.6.0"}
+  "dns-client"        {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test}
+  "ipaddr"            {with-test}
+  "logs"              {with-test & >= "0.7.0"}
+  "dns"               {with-test}
+  "dns-client"        {with-test}
+  "mtime"             {with-test & >= "2.0.0"}
+  "ocamlformat"       {with-dev-setup & = "0.27.0"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/miou/releases/download/v0.4.0/miou-0.4.0.tbz"
+  checksum: [
+    "sha256=d9ae52113d923f2425a1375c594f4accf61171780af1ef211dbbba38ff51dacf"
+    "sha512=f114d1d4b1ff0c7bbe74adbb2fa65a7343064a14ea252b8ae5dbd98c209b3c1d56f2e360422ea8e5cd2656a6f50cb10ae262b0c4e6681724803dd6e8eb1d1653"
+  ]
+}
+x-commit-hash: "2918f34c566be9bd6c36c228cb63472db3503a74"


### PR DESCRIPTION
Composable concurrency primitives for OCaml

- Project page: <a href="https://github.com/robur-coop/miou">https://github.com/robur-coop/miou</a>
- Documentation: <a href="https://docs.osau.re/miou/">https://docs.osau.re/miou/</a>

##### CHANGES:

- Fix the suspension mechanism and allow the user to pass a function which will
  be executed when the suspension is confirmed by Miou (@dinosaure, robur-coop/miou#58)
- Clean-up correctly cancelled syscalls (@dinosaure, robur-coop/miou#59)
- Fix the number of orphans we count (@dinosaure, robur-coop/miou#60)
- Do some micro-optimisations when we use only one core (@dinosaure, robur-coop/miou#61)
- Add tests about `waitpid` and document it (@dinosaure, @mbarbin, robur-coop/miou#64, robur-coop/miou#66)
- Explain into the documentation the Miou behavior about exceptions
  (@kit-ty-kate, @dinosaure, robur-coop/miou#67)
- Update the README.md and add a CODE_OF_CONDUCT.md (@dinosaure, robur-coop/miou#68)
- Fix our tests on Windows (@dinosaure, robur-coop/miou#69)
