### PR TITLE
[new release] h1 (2 packages) (1.1.0)

### DIFF
--- a/packages/git-paf/git-paf.3.18.0/opam
+++ b/packages/git-paf/git-paf.3.18.0/opam
@@ -23,7 +23,7 @@ depends: [
   "uri"
   "bigstringaf"
   "domain-name"
-  "h1"
+  "h1" {< "1.1.0"}
   "mirage-flow" {>= "4.0.0"}
   "tls-mirage" {>= "1.0.0"}
 ]

--- a/packages/h1-lwt-unix/h1-lwt-unix.1.1.0/opam
+++ b/packages/h1-lwt-unix/h1-lwt-unix.1.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+]
+license: "BSD-3-clause"
+homepage: "https://github.com/robur-coop/ocaml-h1"
+bug-reports: "https://github.com/robur-coop/ocaml-h1/issues"
+dev-repo: "git+https://github.com/robur-coop/ocaml-h1.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "faraday-lwt-unix"
+  "h1" {= version}
+  "dune" {>= "2.0.0"}
+  "lwt" {>= "2.4.7"}
+]
+synopsis: "Lwt support for ocaml-h1"
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-h1/releases/download/v1.1.0/h1-1.1.0.tbz"
+  checksum: [
+    "sha256=2d3067ed380163920149fbe9149d5bda630b4f45e3c10be793beea06a07c6d3c"
+    "sha512=d720e6fbc31f02045fe5a6fad34ec284ef3ae636a52c31f9eb6e4cc74e8fba9a3a91df0b738c8d0bb06e57119d0534d872f3f7ef873f441b4802cc96a98b9528"
+  ]
+}
+x-commit-hash: "96ff7b2cdcc5bb4f8f9783558eb61fd68a6fc514"

--- a/packages/h1/h1.1.0.0/opam
+++ b/packages/h1/h1.1.0.0/opam
@@ -24,7 +24,7 @@ depends: [
 synopsis:
   "A high-performance, memory-efficient, and scalable web server for OCaml"
 description: """
-http/af implements the HTTP 1.1 specification with respect to parsing,
+h1 implements the HTTP 1.1 specification with respect to parsing,
 serialization, and connection pipelining as a state machine that is agnostic to
 the underlying IO mechanism, and is therefore portable across many platform.
 It uses the Angstrom and Faraday libraries to implement the parsing and

--- a/packages/h1/h1.1.1.0/opam
+++ b/packages/h1/h1.1.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "alcotest" {with-test & >= "1.2.0"}
   "stdio" {with-test}
-  "base64"
+  "base64" {>= "3.5.0"}
   "bstr"
   "angstrom" {>= "0.14.0"}
   "faraday"  {>= "0.6.1"}

--- a/packages/h1/h1.1.1.0/opam
+++ b/packages/h1/h1.1.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/robur-coop/ocaml-h1"
+bug-reports: "https://github.com/robur-coop/ocaml-h1/issues"
+dev-repo: "git+https://github.com/robur-coop/ocaml-h1.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "alcotest" {with-test & >= "1.2.0"}
+  "stdio" {with-test}
+  "base64"
+  "bstr"
+  "angstrom" {>= "0.14.0"}
+  "faraday"  {>= "0.6.1"}
+  "httpun-types" {>= "0.1.0"}
+  "lwt" {with-test}
+]
+synopsis:
+  "A high-performance, memory-efficient, and scalable web server for OCaml"
+description: """
+h1 implements the HTTP 1.1 specification with respect to parsing,
+serialization, and connection pipelining as a state machine that is agnostic to
+the underlying IO mechanism, and is therefore portable across many platform.
+It uses the Angstrom and Faraday libraries to implement the parsing and
+serialization layers of the HTTP standard, hence the name."""
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-h1/releases/download/v1.1.0/h1-1.1.0.tbz"
+  checksum: [
+    "sha256=2d3067ed380163920149fbe9149d5bda630b4f45e3c10be793beea06a07c6d3c"
+    "sha512=d720e6fbc31f02045fe5a6fad34ec284ef3ae636a52c31f9eb6e4cc74e8fba9a3a91df0b738c8d0bb06e57119d0534d872f3f7ef873f441b4802cc96a98b9528"
+  ]
+}
+x-commit-hash: "96ff7b2cdcc5bb4f8f9783558eb61fd68a6fc514"


### PR DESCRIPTION
A high-performance, memory-efficient, and scalable web server for OCaml

- Project page: <a href="https://github.com/robur-coop/ocaml-h1">https://github.com/robur-coop/ocaml-h1</a>

##### CHANGES:

- Add the websocket implementation (@swrup, @dinosaure, robur-coop/ocaml-h1#8)
- Fix last references of http/af (@dinosaure, @vlog, robur-coop/ocaml-h1#13, robur-coop/ocaml-h1#14, robur-coop/ocaml-h1#16)
- Fix the upgrade support and allow multiple values (@dinosaure, robur-coop/ocaml-h1#15)
- Move to `bstr` (@swrup, robur-coop/ocaml-h1#11)
