### PR TITLE
[new release] ansifmt (1.0.0-pre2)

### DIFF
--- a/packages/ansifmt/ansifmt.1.0.0-pre2/opam
+++ b/packages/ansifmt/ansifmt.1.0.0-pre2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A simple, lightweight library for ANSI styling"
+description: "A simple, lightweight library for ANSI styling."
+maintainer: ["lexa <contact@qexat.com>"]
+authors: ["lexa <contact@qexat.com>"]
+license: "MIT"
+tags: ["ansi" "formatting" "styling" "pretty-printing" "terminal"]
+homepage: "https://github.com/qexat/ansifmt"
+bug-reports: "https://github.com/qexat/ansifmt/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.1"}
+  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test}
+  "re" {= "1.12.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/qexat/ansifmt.git"
+url {
+  src:
+    "https://github.com/qexat/ansifmt/releases/download/1.0.0-pre2/ansifmt-1.0.0-pre2.tbz"
+  checksum: [
+    "sha256=2587f45a2854a760140e98bdf131c1aae9aa2f2f44b474c0e11ed521dab5e3cf"
+    "sha512=95ae665b49c19f42b3d39a48ea34c9cf08b8ca004e8ebe439287b3fac8ad7a99e8ff5259eb236a8da9ca2a2dd7f3ad77202f246fb76ebc9a3de02c7127dff877"
+  ]
+}
+x-commit-hash: "0287128f57c2efef5491e39a939e40e6040c743d"


### PR DESCRIPTION
A simple, lightweight library for ANSI styling

- Project page: <a href="https://github.com/qexat/ansifmt">https://github.com/qexat/ansifmt</a>

##### CHANGES:

**1.0.0 is a complete rewrite of ansifmt**.

At this stage, ansifmt has been fully rewritten. It now includes a test suite. This version is entirely incompatible with ansifmt 0.3.0 and older. Notably, some of its features were purposefully lost in this rewrite.
Users should expect a new library on top of this one to replace them in the future.

## Changes

- `ansifmt` is now split in two modules: `Ansi`, which provides APIs for escape sequences (in `Ansi`), attributes as a low-level representation (in `Ansi.Attribute`) and terminal-compatible colors (in `Ansi.Color`), and `Fmt`, which provides a pretty-printable string API built on top of `Ansi`.
- The `Color` API has been simplified. Colors can now be constructed using built-in integers ; they will be normalized-on-demand. `Advanced` is now called `Basic`. `Minimal` has been dropped as it is already covered by `Basic`, assuming that modern terminal emulators support 8-bit colors.
- The `Styling` API (now called `Ansi`) has been tremendously simplified and is now based on a choice type instead of a record type.
- `parse_hex` is now `of_hex_repr`.
- Luminance calculation now linearizes properly the color.

## Features

- A new `Fmt` API is available, which allows to construct strings with specific parts stylized using `Ansi`. This includes a convenient function, `Fmt.print`, to print in the terminal, stripping escape sequences when the output channel is not a TTY (by default -- this is configurable).
- Color parsing now supports deserialization of strings of the form `rgb(r, g, b)`.
- `Ansi`, `Attributes`, `Color` and `Fmt` objects are serializable.
- `Ansi` objects are now deserializable.

## Removed

- The `Formatting` API has been fully dropped. We estimate that `ansifmt` is not the right place to put this in. Instead, we are working on another library, built on top of `ansifmt`, that will provide these features in an improved manner.
- The `IO` API has been removed following `Formatting`.

## Performance

No benchmark has been done, so this should be taken with a grain of salt, but it is likely that the new version exhibits better performance, due to simplification of implementation and lightening of the library overall.
