### PR TITLE
[new release] doi2bib (2 packages) (0.7.7)

### DIFF
--- a/packages/bibfmt/bibfmt.0.7.7/opam
+++ b/packages/bibfmt/bibfmt.0.7.7/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "CLI tool to pretty-print bibtex files"
+maintainer: ["marcello.seri@gmail.com"]
+authors: ["Marcello Seri"]
+license: "MIT"
+homepage: "https://github.com/mseri/doi2bib"
+bug-reports: "https://github.com/mseri/doi2bib/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.14.0"}
+  "cmdliner" {>= "1.1.0"}
+  "re" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mseri/doi2bib.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mseri/doi2bib/releases/download/0.7.7/doi2bib-0.7.7.tbz"
+  checksum: [
+    "sha256=667d14ba4d0fe8aea933187645368db40b7d16ebcd407a8e8c7991530f7913fd"
+    "sha512=524e6b62c3ebc40476af208cc94c9ba252dcf1c96a1900a5298f452b3e3e945dad3eb8bafab0486aa59d2aefad8b77f8653c76df3a690a938b437ec96c4e7df6"
+  ]
+}
+x-commit-hash: "689df3f461aaf7f805708de12ff342c2dfff43cf"

--- a/packages/doi2bib/doi2bib.0.7.7/opam
+++ b/packages/doi2bib/doi2bib.0.7.7/opam
@@ -15,7 +15,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+#    "@runtest" {with-test} # tests require network
     "@doc" {with-doc}
   ]
 ]

--- a/packages/doi2bib/doi2bib.0.7.7/opam
+++ b/packages/doi2bib/doi2bib.0.7.7/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "CLI tool to get bibtex entries from DOI/arXiv/PubMed IDs"
+maintainer: ["marcello.seri@gmail.com"]
+authors: ["Marcello Seri"]
+license: "MIT"
+homepage: "https://github.com/mseri/doi2bib"
+bug-reports: "https://github.com/mseri/doi2bib/issues"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mseri/doi2bib.git"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08"}
+  "bibfmt" {= version}
+  "astring" {>= "0.8.0"}
+  "cohttp-lwt-unix" {>= "2.5.0"}
+  "cmdliner" {>= "1.1.0"}
+  "clz" {>= "0.1.0"}
+  "ezxmlm" {>= "1.1.0"}
+  "lwt" {>= "5.5.0"}
+  "bigstringaf" {>= "0.2.0"}
+  ("tls" {>= "0.12.0" & < "0.16"} | "tls-lwt")
+  "re" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mseri/doi2bib/releases/download/0.7.7/doi2bib-0.7.7.tbz"
+  checksum: [
+    "sha256=667d14ba4d0fe8aea933187645368db40b7d16ebcd407a8e8c7991530f7913fd"
+    "sha512=524e6b62c3ebc40476af208cc94c9ba252dcf1c96a1900a5298f452b3e3e945dad3eb8bafab0486aa59d2aefad8b77f8653c76df3a690a938b437ec96c4e7df6"
+  ]
+}
+x-commit-hash: "689df3f461aaf7f805708de12ff342c2dfff43cf"


### PR DESCRIPTION
CHANGES:

- bibfmt and doi2bib drop the month field in bibtex. It is useless and the way DOI API reports it is also incompatible with many bibtex configurations.
- doi2bib: fix for changes in PubMed API
- bibfmt: add support for field entries capitalization and stricter parsing. Now, by default, field names are always upper cased.
- doi2bib: make the parser fails if there are duplicate fields in a bibtex entry.