### PR TITLE
clangml and pyml are not compatible with stdcompat >= 21

### DIFF
--- a/packages/clangml/clangml.4.0.0/opam
+++ b/packages/clangml/clangml.4.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build & >= "1.8.0"}
   "dune" {>= "1.10.0"}
   "ppxlib" {>= "0.6.0" & < "0.9.0"}
-  "stdcompat" {>= "10"}
+  "stdcompat" {>= "10" & < "21"}
   "ppx_show" {>= "0.1.0"}
   "ppx_compare" {>= "v0.12.0"}
   "override" {>= "0.1.0"}

--- a/packages/clangml/clangml.4.0.1/opam
+++ b/packages/clangml/clangml.4.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "conf-zlib"
   "dune" {>= "1.10.0"}
   "ppxlib" {>= "0.9.0" & < "0.14.0"}
-  "stdcompat" {>= "10"}
+  "stdcompat" {>= "10" & < "21"}
   "override" {>= "0.1.0"}
   "ppx_deriving" {>= "4.3"}
   "ocaml" {>= "4.04.0"}

--- a/packages/clangml/clangml.4.1.0/opam
+++ b/packages/clangml/clangml.4.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "1.11.0"}
-  "stdcompat" {>= "13"}
+  "stdcompat" {>= "13" & < "21"}
   "ocaml" {>= "4.03.0" & < "4.12.0"}
   "ocamlfind" {build & >= "1.8.0"}
   "ocamlcodoc" {with-test & >= "1.0.1"}

--- a/packages/clangml/clangml.4.2.0/opam
+++ b/packages/clangml/clangml.4.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "1.11.0"}
-  "stdcompat" {>= "13"}
+  "stdcompat" {>= "13" & < "21"}
   "ocaml" {>= "4.03.0" & < "4.12.0"}
   "ocamlfind" {build & >= "1.8.0"}
   "ocamlcodoc" {with-test & >= "1.0.1"}

--- a/packages/clangml/clangml.4.3.0/opam
+++ b/packages/clangml/clangml.4.3.0/opam
@@ -14,7 +14,7 @@ depends: [
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "1.11.0"}
-  "stdcompat" {>= "13"}
+  "stdcompat" {>= "13" & < "21"}
   "ocaml" {>= "4.08.0" & < "4.12.0"}
   "ocamlfind" {build & >= "1.8.0"}
   "ocamlcodoc" {with-test & >= "1.0.1"}

--- a/packages/clangml/clangml.4.4.0/opam
+++ b/packages/clangml/clangml.4.4.0/opam
@@ -14,7 +14,7 @@ depends: [
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "1.11.0"}
-  "stdcompat" {>= "13"}
+  "stdcompat" {>= "13" & < "21"}
   "ocaml" {>= "4.08.0"}
   "ocamlfind" {build & >= "1.8.0"}
   "ocamlcodoc" {with-test & >= "1.0.1"}

--- a/packages/clangml/clangml.4.5.0/opam
+++ b/packages/clangml/clangml.4.5.0/opam
@@ -14,7 +14,7 @@ depends: [
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "1.11.0"}
-  "stdcompat" {>= "13"}
+  "stdcompat" {>= "13" & < "21"}
   "ocaml" {>= "4.08.0" & < "5.0"}
   "ocamlfind" {build & >= "1.8.0"}
   "ocamlcodoc" {with-test & >= "1.0.1"}

--- a/packages/clangml/clangml.4.6.0/opam
+++ b/packages/clangml/clangml.4.6.0/opam
@@ -14,7 +14,7 @@ depends: [
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "1.11.0"}
-  "stdcompat" {>= "13"}
+  "stdcompat" {>= "13" & < "21"}
   "ocaml" {>= "4.08.0" & < "5.0"}
   "ocamlfind" {build & >= "1.8.0"}
   "ocamlcodoc" {with-test & >= "1.0.1"}

--- a/packages/clangml/clangml.4.7.0/opam
+++ b/packages/clangml/clangml.4.7.0/opam
@@ -15,7 +15,7 @@ depends: [
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "1.11.0"}
-  "stdcompat" {>= "19"}
+  "stdcompat" {>= "19" & < "21"}
   "ocaml" {>= "4.08.0"}
   "ocamlfind" {build & >= "1.8.0"}
   "ocamlcodoc" {with-test & >= "1.0.1"}

--- a/packages/clangml/clangml.4.8.0/opam
+++ b/packages/clangml/clangml.4.8.0/opam
@@ -16,7 +16,7 @@ depends: [
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "3.0"}
-  "stdcompat" {>= "19"}
+  "stdcompat" {>= "19" & < "21"}
   "ocaml" {>= "4.08.0"}
   "ocamlfind" {build & >= "1.8.0"}
   "ocamlcodoc" {with-test & >= "1.0.1"}

--- a/packages/pyml/pyml.20190626/opam
+++ b/packages/pyml/pyml.20190626/opam
@@ -12,7 +12,7 @@ description: "OCaml bindings for Python 2 and Python 3"
 depends: [
   "ocaml" {>= "3.12.1" & < "4.10.0"}
   "ocamlfind" {build}
-  "stdcompat" {>= "11"}
+  "stdcompat" {>= "11" & < "21"}
   "num"
 ]
 depopts: ["utop"]

--- a/packages/pyml/pyml.20200115/opam
+++ b/packages/pyml/pyml.20200115/opam
@@ -12,7 +12,7 @@ description: "OCaml bindings for Python 2 and Python 3"
 depends: [
   "ocaml" {>= "3.12.1" & < "4.11.0"}
   "ocamlfind" {build}
-  "stdcompat" {>= "11"}
+  "stdcompat" {>= "11" & < "21"}
 ]
 depopts: ["utop"]
 url {

--- a/packages/pyml/pyml.20200222/opam
+++ b/packages/pyml/pyml.20200222/opam
@@ -12,7 +12,7 @@ description: "OCaml bindings for Python 2 and Python 3"
 depends: [
   "ocaml" {>= "3.12.1" & < "4.12.0"}
   "ocamlfind" {build}
-  "stdcompat" {>= "13"}
+  "stdcompat" {>= "13" & < "21"}
 ]
 depopts: ["utop"]
 url {

--- a/packages/pyml/pyml.20200518/opam
+++ b/packages/pyml/pyml.20200518/opam
@@ -13,7 +13,7 @@ description: "OCaml bindings for Python 2 and Python 3"
 depends: [
   "ocaml" {>= "3.12.1" & < "5.0"}
   "ocamlfind" {build}
-  "stdcompat" {>= "13"}
+  "stdcompat" {>= "13" & < "21"}
   "conf-python-3-dev" {with-test}
 ]
 depopts: ["utop"]

--- a/packages/pyml/pyml.20210226/opam
+++ b/packages/pyml/pyml.20210226/opam
@@ -13,7 +13,7 @@ description: "OCaml bindings for Python 2 and Python 3"
 depends: [
   "ocaml" {>= "3.12.1" & < "5.0"}
   "ocamlfind" {build}
-  "stdcompat" {>= "13"}
+  "stdcompat" {>= "13" & < "21"}
   "conf-python-3-dev" {with-test}
 ]
 depopts: ["utop"]

--- a/packages/pyml/pyml.20210924/opam
+++ b/packages/pyml/pyml.20210924/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "3.12.1" & < "5.0"}
   "dune" {>= "2.8.0"}
   "ocamlfind" {build}
-  "stdcompat" {>= "17"}
+  "stdcompat" {>= "17" & < "21"}
   "conf-python-3-dev" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/pyml/pyml.20211015/opam
+++ b/packages/pyml/pyml.20211015/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "3.12.1" & < "5.0"}
   "dune" {>= "2.8.0"}
   "ocamlfind" {build}
-  "stdcompat" {>= "17"}
+  "stdcompat" {>= "17" & < "21"}
   "conf-python-3-dev" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/pyml/pyml.20220322/opam
+++ b/packages/pyml/pyml.20220322/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "3.12.1" & < "5.0"}
   "dune" {>= "2.8.0"}
   "ocamlfind" {build}
-  "stdcompat" {>= "18"}
+  "stdcompat" {>= "18" & < "21"}
   "conf-python-3-dev" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/pyml/pyml.20220325/opam
+++ b/packages/pyml/pyml.20220325/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "3.12.1" & < "5.0"}
   "dune" {>= "2.8.0"}
   "ocamlfind" {build}
-  "stdcompat" {>= "18"}
+  "stdcompat" {>= "18" & < "21"}
   "conf-python-3-dev" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/pyml/pyml.20220615/opam
+++ b/packages/pyml/pyml.20220615/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "3.12.1" & < "5.0"}
   "dune" {>= "2.8.0"}
   "ocamlfind" {build}
-  "stdcompat" {>= "18"}
+  "stdcompat" {>= "18" & < "21"}
   "conf-python-3-dev" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/pyml/pyml.20220905/opam
+++ b/packages/pyml/pyml.20220905/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "3.12.1"}
   "dune" {>= "2.8.0"}
   "ocamlfind" {build}
-  "stdcompat" {>= "18"}
+  "stdcompat" {>= "18" & < "21"}
   "conf-python-3-dev" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/pyml/pyml.20231101/opam
+++ b/packages/pyml/pyml.20231101/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "3.12.1"}
   "dune" {>= "2.8.0"}
   "ocamlfind" {build}
-  "stdcompat" {>= "19"}
+  "stdcompat" {>= "19" & < "21"}
   "conf-python-3-dev" {with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Seen on https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/2816ad4dba16196f57cd1f9363ca75af4a4fa046 from PR #28305

The new stdcompat does no longer ship the headers: `fatal error: stdcompat.h: No such file or directory`