### PR TITLE
maintainer contact for ocaml-sdl2

### DIFF
--- a/packages/ocamlsdl2/ocamlsdl2.0.04/opam
+++ b/packages/ocamlsdl2/ocamlsdl2.0.04/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "monnier.florent@gmail.com"
+maintainer: "https://github.com/fccm/OCamlSDL2/issues"
 authors: [
   "Florent Monnier"
   "Piotr Mardziel"

--- a/packages/ocamlsdl2/ocamlsdl2.0.04/opam
+++ b/packages/ocamlsdl2/ocamlsdl2.0.04/opam
@@ -6,7 +6,7 @@ authors: [
   "David Cadé"
   "Guillaume Munch-Maccagnoni"
 ]
-license: "restrictionless Zlib"
+license: "Zlib OR any-OSI"
 homepage: "https://github.com/fccm/OCamlSDL2"
 bug-reports: "https://github.com/fccm/OCamlSDL2/issues"
 dev-repo: "git+https://github.com/fccm/OCamlSDL2.git"


### PR DESCRIPTION
Fixed the contact-link about the maintainer, for problem(s) with this set of bindings.