### PR TITLE
[new release] httpcats (0.1.0)

### DIFF
--- a/packages/httpcats/httpcats.0.1.0/opam
+++ b/packages/httpcats/httpcats.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/httpcats"
+dev-repo: "git+https://github.com/robur-coop/httpcats.git"
+bug-reports: "https://github.com/robur-coop/httpcats/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.8.0"}
+  "logs" {with-test}
+  "miou" {>= "0.4.0"}
+  "fmt" {>= "0.9.0" & with-test}
+  "h2" {>= "0.13.0"}
+  "h1" {>= "1.1.0"}
+  "ca-certs"
+  "bstr"
+  "tls-miou-unix" {>= "1.0.1"}
+  "dns-client-miou-unix" {>= "9.0.0"}
+  "happy-eyeballs-miou-unix"
+  "mirage-crypto-rng-miou-unix" {with-test & >= "1.1.0"}
+  "alcotest" {>= "1.8.0" & with-test}
+  "digestif" {with-test & >= "1.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "A simple HTTP client using h1, h2, and miou"
+available: [ arch != "x86_32" ]
+url {
+  src:
+    "https://github.com/robur-coop/httpcats/releases/download/v0.1.0/httpcats-0.1.0.tbz"
+  checksum: [
+    "sha256=c58f1a030833feccf91f91d688659a95357da5f43fe3c2c98d7b44284d962f49"
+    "sha512=ab4c4259f6f1047713cee9265981e173a542834b91dadbf9445855a60a50e80482caffb4247e1f12f2e646690e996e5e7dd04ebec473b6911f51ff1de8ddd8fc"
+  ]
+}
+x-commit-hash: "b2fdc95557f2b077dfd3ba751a0979d0604fe148"


### PR DESCRIPTION
A simple HTTP client using h1, h2, and miou

- Project page: <a href="https://github.com/robur-coop/httpcats">https://github.com/robur-coop/httpcats</a>

##### CHANGES:

- Add the support of websocket (@swrup & @dinosaure)
- Improve the `Httpcats.request` and handle cookies and redirections well
  (@dinosaure)
- Improve the runtime implement to process an HTTP communication (with http/1.1
  & h2) (@dinosaure)
- Improve the documentation (@dinosaure)

This changelog does not contain PRs referring to additions to httpcats, as they
were produced with a quick iteration to finalise the release of httpcats.0.1.0.
