### PR TITLE
2 packages from xguerin/bitstring at 5.0.0

### DIFF
--- a/packages/bitstring/bitstring.5.0.0/opam
+++ b/packages/bitstring/bitstring.5.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Bitstrings and bitstring matching for OCaml"
+description: """\
+The ocaml-bitstring project adds Erlang-style bitstrings and matching over bitstrings as a syntax extension and library for OCaml. 
+You can use this module to both parse and generate binary formats, files and protocols. 
+Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful."""
+maintainer: "Xavier R. Guérin <xguerin@users.noreply.github.com>"
+authors: ["Richard W.M. Jones" "Xavier R. Guérin"]
+license: "LGPL-2.0-or-later"
+homepage: "https://github.com/xguerin/bitstring"
+bug-reports: "https://github.com/xguerin/bitstring/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "5.2.0"}
+  "stdlib-shims" {>= "0.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xguerin/bitstring.git"
+url {
+  src: "https://github.com/xguerin/bitstring/archive/refs/tags/v5.0.0.tar.gz"
+  checksum: [
+    "md5=bfd69bdcfe25b4c77b31a899595d730a"
+    "sha512=a74d5ac05b547d186b0fe2b58314a424e6953ef2704503a960fb05f74895309fc99624b138fd99eda9109895cba453ce52c13f3a6eb0294cdefb1afad39aa67d"
+  ]
+}

--- a/packages/ppx_bitstring/ppx_bitstring.5.0.0/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.5.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Bitstrings and bitstring matching for OCaml - PPX extension"
+description: """\
+The ocaml-bitstring project adds Erlang-style bitstrings and matching over bitstrings as a syntax extension and library for OCaml. 
+You can use this module to both parse and generate binary formats, files and protocols. 
+Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful."""
+maintainer: "Xavier R. Guérin <xguerin@users.noreply.github.com>"
+authors: ["Richard W.M. Jones" "Xavier R. Guérin"]
+license: "LGPL-2.0-or-later"
+homepage: "https://github.com/xguerin/bitstring"
+bug-reports: "https://github.com/xguerin/bitstring/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "5.2.0"}
+  "bitstring" {>= "5.0.0"}
+  "ocaml" {with-test & >= "5.2.0"}
+  "ppxlib" {>= "0.36.0"}
+  "ounit" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xguerin/bitstring.git"
+url {
+  src: "https://github.com/xguerin/bitstring/archive/refs/tags/v5.0.0.tar.gz"
+  checksum: [
+    "md5=bfd69bdcfe25b4c77b31a899595d730a"
+    "sha512=a74d5ac05b547d186b0fe2b58314a424e6953ef2704503a960fb05f74895309fc99624b138fd99eda9109895cba453ce52c13f3a6eb0294cdefb1afad39aa67d"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `bitstring.5.0.0`: Bitstrings and bitstring matching for OCaml
- `ppx_bitstring.5.0.0`: Bitstrings and bitstring matching for OCaml - PPX extension



---
* Homepage: https://github.com/xguerin/bitstring
* Source repo: git+https://github.com/xguerin/bitstring.git
* Bug tracker: https://github.com/xguerin/bitstring/issues

---
:camel: Pull-request generated by opam-publish v2.5.1