### PR TITLE
Set a ppxlib upper bound for mutaml

### DIFF
--- a/packages/mutaml/mutaml.0.3/opam
+++ b/packages/mutaml/mutaml.0.3/opam
@@ -19,6 +19,7 @@ depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.12.0"}
   "ppxlib" {>= "0.28.0"}
+  "ppxlib" {with-test & <= "0.33.0"}
   "ppx_yojson_conv" {>= "v0.14.0"}
   "stdlib-random"
   "conf-timeout"


### PR DESCRIPTION
Spotted on https://github.com/ocaml/opam-repository/pull/28302: `mutaml` will fail an installation `--with-test` on ppxlib 0.34 and above:
```
#=== ERROR while compiling mutaml.0.3 =========================================#
# context              2.3.0 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/mutaml.0.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p mutaml -j 255 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/mutaml-6-bc66eb.env
# output-file          ~/.opam/log/mutaml-6-bc66eb.out
### output ###
# (cd _build/default/examples/testproj-1-module && ./ounittest.exe)
# ....
# Ran: 4 tests in: 0.11 seconds.
# OK
# (cd _build/default/examples/testproj-2-modules/test && ./ounittest.exe)
# ..
# Ran: 2 tests in: 0.11 seconds.
# OK
# File "test/negative-tests/ppx-negtests.t", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/negative-tests/ppx-negtests.t _build/default/test/negative-tests/ppx-negtests.t.corrected
# diff --git a/_build/default/test/negative-tests/ppx-negtests.t b/_build/default/test/negative-tests/ppx-negtests.t.corrected
# index 2e7b62b..54c0b5e 100644
# --- a/_build/default/test/negative-tests/ppx-negtests.t
# +++ b/_build/default/test/negative-tests/ppx-negtests.t.corrected
# @@ -257,6 +257,9 @@ Instrument and check that it was received
#      -styler                     Code styler
#      -output-metadata FILE       Where to store the output metadata
#      -corrected-suffix SUFFIX    Suffix to append to corrected files
# +    -keywords <version+list>    Set keywords according to the version+list specification. Allows using a set of keywords different from the one of the current compiler for backward compatibility.
# +    --keywords <version+list>   Same as -keywords
# +    --use-compiler-pp Force     migrating the AST back to the compiler's version before printing it as source code using the compiler's Pprintast utilities.
#      -loc-filename <string>      File name to use in locations
#      -reserve-namespace <string> Mark the given namespace as reserved
#      -no-check                   Disable checks (unsafe)
```

This is not a serious error though - just a diff caused by additional options added to ppxlib.0.34 (and above), which shouldn't otherwise prevent using the package with never `ppxlib`s.
This PR therefore sets an upper `ppxlib` bound when running `with-test` ~~using the old Boolean trick of 
encoding an implication `with-test => bound` as `not with-test \/ bound`~~.
This should hopefully take care of one more red CI light... :slightly_smiling_face: :crossed_fingers: 