### PR TITLE
Fix bad checksums in osh and opam-custom-install

### DIFF
--- a/packages/opam-custom-install/opam-custom-install.0.1/opam
+++ b/packages/opam-custom-install/opam-custom-install.0.1/opam
@@ -18,7 +18,7 @@ flags: plugin
 authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 url {
   src:
-    "https://gitlab.ocamlpro.com/louis/opam-custom-install/-/archive/0.1/opam-custom-install-0.1.tar.gz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/opam-custom-install-0.1.tar.gz"
   checksum: [
     "md5=10b50105cc11e93efb9654c73e0db3f1"
     "sha512=87638e6da2963d7892f2b386a333f65ed769169267f9a6919dfa2a359b260c47a399969bb49f7948776553eb53f6159dabc4e160a90691cdc73b9861d5458eab"

--- a/packages/opam-custom-install/opam-custom-install.0.2/opam
+++ b/packages/opam-custom-install/opam-custom-install.0.2/opam
@@ -18,7 +18,7 @@ flags: plugin
 authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 url {
   src:
-    "https://gitlab.ocamlpro.com/louis/opam-custom-install/-/archive/0.2/opam-custom-install-0.2.tar.gz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/opam-custom-install-0.2.tar.gz"
   checksum: [
     "md5=82f4b7100bfee1744a3982cccbab5d20"
     "sha512=76a09a4a12905016f28661c1e2ada8407c9e2f21aee423ea46fb1ba90171c411831496e4126606486be61a042167c4067bca13e0ad4a7dbe850f8a71721aa874"

--- a/packages/osh/osh.0.1/opam
+++ b/packages/osh/osh.0.1/opam
@@ -36,7 +36,7 @@ build: [
 ]
 dev-repo: "git+https://gitlab.ocamlpro.com/OCamlPro/osh.git"
 url {
-  src: "https://gitlab.ocamlpro.com/OCamlPro/osh/-/archive/0.1/osh-0.1.tar.bz2"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/osh-0.1.tar.bz2"
   checksum: [
     "sha256=c5c6509d36e50715bb0bb90d54375a2fc618a7010c8c79c4663d8ffd5b5fde22"
     "sha512=cceaa356636ba8ca75e855c5f580e44d43e5cdf8cccf10293fcdad14bedffb35587896f55867f73bbd1c7804d229b9d8d2422eb3165eb8ff5d38064deb0b7d6c"


### PR DESCRIPTION
Spotted in ocaml/opam-repository#28302 and reported in ocaml/opam-repository#28278 this points the sources of `osh-0.1.tar.bz2` and `opam-custom-install-0.{1,2}.tar.gz` to the opam-source-archives where they were just added in https://github.com/ocaml/opam-source-archives/pull/49.

Hopefully this will remove a few more CI red lights... :slightly_smiling_face: :crossed_fingers: 