### PR TITLE
[new release] bitwuzla-cxx (0.8.2)

### DIFF
--- a/packages/bitwuzla-cxx/bitwuzla-cxx.0.8.2/opam
+++ b/packages/bitwuzla-cxx/bitwuzla-cxx.0.8.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "SMT solver for AUFBVFP (C++ API)"
+description: """
+
+OCaml binding for the SMT solver Bitwuzla C++ API.
+
+Bitwuzla is a Satisfiability Modulo Theories (SMT) solver for the theories of fixed-size bit-vectors, arrays and uninterpreted functions and their combinations. Its name is derived from an Austrian dialect expression that can be translated as “someone who tinkers with bits”."""
+maintainer: ["Frédéric Recoules <frederic.recoules@cea.fr>"]
+authors: ["Frédéric Recoules"]
+license: "MIT"
+tags: ["SMT solver" "AUFBVFP"]
+homepage: "https://bitwuzla.github.io"
+doc: "https://bitwuzla.github.io/docs/ocaml/"
+bug-reports: "https://github.com/bitwuzla/ocaml-bitwuzla/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.12"}
+  "conf-git" {build}
+  "conf-gcc" {build}
+  "conf-g++" {build}
+  "zarith"
+  "ppx_inline_test" {with-test & >= "v0.13"}
+  "ppx_expect" {with-test & >= "v0.13"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
+available: [ arch != "arm32" & (os = "linux" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) | os = "macos" & os-distribution = "homebrew") ]
+url {
+  src:
+    "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/0.8.2/bitwuzla-cxx-0.8.2.tbz"
+  checksum: [
+    "sha256=983723b0d0440c4880d058c9ef2c3cda23335ac35cec212c6be72bd1e3a408ae"
+    "sha512=be0025bf261e096566e67ec414bf14ddf41b3b52499a25959a12e89d424a6d091e6399b23ef725a4cadeec4b376cd95f4c9463664523c5cd747a21229df2f02d"
+  ]
+}
+x-commit-hash: "9d1a67cc743e8f0f3ae5c2b563c370dcece988a1"


### PR DESCRIPTION
SMT solver for AUFBVFP (C++ API)

- Project page: <a href="https://bitwuzla.github.io">https://bitwuzla.github.io</a>
- Documentation: <a href="https://bitwuzla.github.io/docs/ocaml/">https://bitwuzla.github.io/docs/ocaml/</a>

##### CHANGES:

Update [Bitwuzla](https://github.com/bitwuzla/bitwuzla/releases/tag/0.8.2) sources.

Vendor submodules:
- [Cadical](https://github.com/arminbiere/cadical) tag:rel-2.1.2
- [CryptoMiniSat](https://github.com/msoos/cryptominisat) tag:5.11.21
- [Kissat](https://github.com/arminbiere/kissat) tag:rel-4.0.1
- [Bitwuzla](https://github.com/bitwuzla/bitwuzla) tag:0.8.2
