### PR TITLE
Package mlgpx.1.0.0

### DIFF
--- a/packages/mlgpx/mlgpx.1.0.0/opam
+++ b/packages/mlgpx/mlgpx.1.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Library and CLI for parsing and generating GPS Exchange (GPX) formats"
+description:
+  "mlgpx is a streaming GPX (GPS Exchange Format) library for OCaml. It provides a portable core library using the xmlm streaming XML parser, with a separate Unix layer for file I/O operations. The library supports the complete GPX 1.1 specification including waypoints, routes, tracks, and metadata with strong type safety and validation."
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy"
+license: "ISC"
+homepage: "https://tangled.sh/@anil.recoil.org/ocaml-gpx"
+bug-reports: "https://tangled.sh/@anil.recoil.org/ocaml-gpx/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.18"}
+  "xmlm"
+  "ptime"
+  "eio"
+  "ppx_expect"
+  "alcotest"
+  "eio_main"
+  "cmdliner"
+  "fmt"
+  "logs"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://www.cl.cam.ac.uk/~avsm2/distrib/mlgpx-1.0.0.tbz"
+  checksum: [
+    "md5=5342bb7e601273245a9fe263e5a08770"
+    "sha512=cd73b16e988b3ed3cc427a6c6c6d6c9c745adb1eb7efaae3c34e8d006e9c03d9f9d2616cd4118564bd9873903969d3e4053b585e79dbd3e3e7d0f541e2faac83"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `mlgpx.1.0.0`
Library and CLI for parsing and generating GPS Exchange (GPX) formats
mlgpx is a streaming GPX (GPS Exchange Format) library for OCaml. It provides a portable core library using the xmlm streaming XML parser, with a separate Unix layer for file I/O operations. The library supports the complete GPX 1.1 specification including waypoints, routes, tracks, and metadata with strong type safety and validation.



---
* Homepage: https://tangled.sh/@anil.recoil.org/ocaml-gpx
* Bug tracker: https://tangled.sh/@anil.recoil.org/ocaml-gpx/issues

---
:camel: Pull-request generated by opam-publish v2.5.1