### PR TITLE
Tezt/Bam: Remove unecessary dependency

### DIFF
--- a/packages/tezt-bam/tezt-bam.0.4/opam
+++ b/packages/tezt-bam/tezt-bam.0.4/opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "3.7" & >= "3.7"}
   "tezt" {>= "4.0"}
   "bam"
-  "bam-ppx"
+  "bam-ppx" {with-test}
   "mtime" {>= "2.0"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
`bam-ppx` is only useful for tests.