### PR TITLE
[new release] albatross (2.5.0)

### DIFF
--- a/packages/albatross/albatross.2.5.0/opam
+++ b/packages/albatross/albatross.2.5.0/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/robur-coop/albatross"
+dev-repo: "git+https://github.com/robur-coop/albatross.git"
+bug-reports: "https://github.com/robur-coop/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "2.7.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "conf-libev"
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "5.3.0"}
+  "logs"
+  "bos" {>= "0.2.0"}
+  "ptime" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "1.0.0"}
+  "tls" {>= "1.0.2"}
+  "tls-lwt" {>= "1.0.2"}
+  "asn1-combinators" {>= "0.3.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "metrics" {>= "0.5.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "ohex" {>= "0.2.0"}
+  "http-lwt-client" {>= "0.3.0"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.4.0"}
+  "cachet" {>= "0.0.2"}
+  "fpath" {>= "0.7.3"}
+  "logs-syslog" {>= "0.4.1"}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+available: os != "openbsd"
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/albatross/releases/download/v2.5.0/albatross-2.5.0.tbz"
+  checksum: [
+    "sha256=d23caa29583412078b1e067572fd3adade3329d92f94d0448de8f62403abb745"
+    "sha512=79820b0a1482d56e3618615c21c31930d25f3b582c203d617b7681b45ebeeccc8a58bd73244870c1298cf190daec2f5154a98f105b1d49e0a02e6b7050641087"
+  ]
+}
+x-commit-hash: "0c982ec9cec5a273ede028927770d26b6dd1c80e"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/robur-coop/albatross">https://github.com/robur-coop/albatross</a>

##### CHANGES:

* Console: fix an out of memory issue (reading lines) reported by @edwintorok,
  now only the first 512 bytes of each line is displayed, the rest is dropped
* Update: accept old_unikernel_info{2,3} replies (robur-coop/albatross#210 @hannesm)
* Streaming unikernels and block devices:
  Instead of providing unikernel images and block device data as a big blob in
  memory (or the certificate), these commands now work in streaming mode:
   - TLS endpoint upon receiving a Unikernel_{force_}create if the image is the
     empty string, it reads data on the TLS flow (everything chunked with a 4
     byte length prefix, until a 0 chunk is received) robur-coop/albatross#211 @reynir @hannesm
   - Block_set as well carries the data as a stream on the communication channel
     - please note this is carried forward from the TLS endpoint to albatrossd
   - Block_dump delivers the block data as a stream
     (of `Block_data of string option)
  robur-coop/albatross#216 @hannesm @reynir @dinosaure
* Support metris 0.5 (robur-coop/albatross#220 @hannesm)
* Update Nix flake (robur-coop/albatross#218 @Julow)
