### PR TITLE
repo: Set archive-mirrors to opam.ocaml.org's cache

### DIFF
--- a/repo
+++ b/repo
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 browse: "https://opam.ocaml.org/pkg/"
 upstream: "https://github.com/ocaml/opam-repository/tree/master/"
+archive-mirrors: "https://opam.ocaml.org/cache"
 announce: [
 """
 [WARNING] opam is out-of-date. Please consider updating it (https://opam.ocaml.org/doc/Install.html)


### PR DESCRIPTION
This makes it so that people using the git repository directly will now download archives through the official mirror first, unless they have set their own mirror using opam option --global archive-mirrors+="url-to-your-mirror", in which case opam.ocaml.org will only be used as fallback.

To merge only after https://github.com/ocaml-opam/opam2web/pull/247 and after the minor issues listed in https://github.com/ocaml/opam/issues/6642 have been discussed.

See [this discuss post](https://discuss.ocaml.org/t/opinion-is-it-time-to-stop-testing-with-opam-2-2/16723/3) for background context