### PR TITLE
[new release] mirage-net-xen (2.1.6)

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.2.1.6/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.2.1.6/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+license:       "ISC"
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "mirage-xen" {>= "7.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "shared-memory-ring" {>="3.0.0"}
+  "macaddr" {>= "5.2.0"}
+  "lwt-dllist"
+  "logs" {>= "0.5.0"}
+]
+conflicts: [
+    "result" {< "1.5"}
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v2.1.6/mirage-net-xen-2.1.6.tbz"
+  checksum: [
+    "sha256=a586f78599f355b54f4954a4210592c1406f1439fee3180582797e862e56e26d"
+    "sha512=5c6b9e3a563182a9872374d292d89220b7b48d13d82c4f566374b3c16a84d559cc88176576d24f7e2efaceb188bd4ff17395eba3d4f0d3fcc62e335cd15e0e92"
+  ]
+}
+x-commit-hash: "8f68b0b3de5c93f8bde679bc7a00d3810fad61f7"


### PR DESCRIPTION
Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol

- Project page: <a href="https://github.com/mirage/mirage-net-xen">https://github.com/mirage/mirage-net-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-xen/">https://mirage.github.io/mirage-net-xen/</a>

##### CHANGES:

* Pre-allocate 1MB for the RX ring in `connect`, and use and reuse these pages
  (mirage/mirage-net-xen#114 @palainp)
