### PR TITLE
[new release] slipshow (0.6.0): The King's Slipshow

### DIFF
--- a/packages/slipshow/slipshow.0.6.0/opam
+++ b/packages/slipshow/slipshow.0.6.0/opam
@@ -24,7 +24,7 @@ depends: [
   "fmt"
   "logs"
   "fsevents-lwt"
-  "js_of_ocaml-compiler"
+  "js_of_ocaml-compiler" {>= "6.0.1"}
   "js_of_ocaml-lwt"
   "magic-mime"
   "dream" {>= "1.0.0~alpha5"}

--- a/packages/slipshow/slipshow.0.6.0/opam
+++ b/packages/slipshow/slipshow.0.6.0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis: "A compiler from markdown to slipshow"
+description:
+  "Slipshow is an engine to write slips, a concept evolved from slides."
+maintainer: ["Paul-Elliot"]
+authors: ["Paul-Elliot"]
+license: ["GPL-3.0-or-later" "ISC" "BSD-3-Clause" "Apache-2.0" "OFL-1.1"]
+tags: ["slipshow" "presentation" "slideshow" "beamer"]
+homepage: "https://github.com/panglesd/slipshow"
+doc: "https://slipshow.readthedocs.io"
+bug-reports: "https://github.com/panglesd/slipshow/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.6"}
+  "crunch" {with-dev-setup}
+  "lambdasoup" {with-test}
+  "cmdliner" {>= "1.3.0"}
+  "base64"
+  "bos"
+  "lwt"
+  "inotify" {os = "linux"}
+  "cf-lwt" {>= "0.4"}
+  "astring"
+  "fmt"
+  "logs"
+  "fsevents-lwt"
+  "js_of_ocaml-compiler"
+  "js_of_ocaml-lwt"
+  "magic-mime"
+  "dream" {>= "1.0.0~alpha5"}
+  "fpath"
+  "ppx_blob" {>= "0.8.0"}
+  "sexplib"
+  "ppx_sexp_conv"
+  "odoc" {with-doc}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/panglesd/slipshow.git"
+# We avoid 32 bits arcitecture because our usage of ppx_blob generates strings
+# whose size exceed the maximum size in 32 bits OCaml...
+available: arch != "arm32" & arch != "x86_32"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/panglesd/slipshow/releases/download/v0.5.0/slipshow-0.5.0.tbz"
+  checksum: [
+    "sha256=175bb890a7ea6c6ceae04087b1af03c65f457d877e845e1a24aded4852b0d12e"
+    "sha512=67bbcde432af9894e971d63d4caaf46d648098a4d1a26337f4e85561848150a02687573e023fb5575444541314794b7e65da5bbb6171094070e80c2876dcabfd"
+  ]
+}
+x-commit-hash: "09bfdaec42587be139fc5843d3907fd96d3ba28a"

--- a/packages/slipshow/slipshow.0.6.0/opam
+++ b/packages/slipshow/slipshow.0.6.0/opam
@@ -56,7 +56,7 @@ available: arch != "arm32" & arch != "x86_32"
 x-maintenance-intent: [ "(latest)" ]
 url {
   src:
-    "https://github.com/panglesd/slipshow/releases/download/v0.5.0/slipshow-0.5.0.tbz"
+    "https://github.com/panglesd/slipshow/releases/download/v0.6.0/slipshow-0.6.0.tbz"
   checksum: [
     "sha256=175bb890a7ea6c6ceae04087b1af03c65f457d877e845e1a24aded4852b0d12e"
     "sha512=67bbcde432af9894e971d63d4caaf46d648098a4d1a26337f4e85561848150a02687573e023fb5575444541314794b7e65da5bbb6171094070e80c2876dcabfd"


### PR DESCRIPTION
See the [release announcement](https://github.com/panglesd/slipshow/releases/tag/v0.6.0) for a funny gif.

CHANGES:

### Engine

- Add a speaker view, opened with `s`. (panglesd/slipshow#147)
- Fix `Z` and `X` not working (panglesd/slipshow#147)
- On step change, move back to the position we left (panglesd/slipshow#148)

### Language

- Add a `speaker-note` action. (panglesd/slipshow#147)