### PR TITLE
[new release] dune (15 packages) (3.20.0)

### DIFF
--- a/packages/chrome-trace/chrome-trace.3.20.0/opam
+++ b/packages/chrome-trace/chrome-trace.3.20.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Chrome trace event generation library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.20.0/dune-3.20.0.tbz"
+  checksum: [
+    "sha256=767999da81e528484139ecfe927288ffe521ac2467462a40d6a760ed789ba086"
+    "sha512=18f6a293cb5d4423a3bf69ce9559b40e7075e49b13c79166f2aacfa55cbc2609e20938bad889b43df0d5a3396ea034e405631d3757da6164c51be375e5751632"
+  ]
+}
+x-commit-hash: "3bd6fcbde34880a6c120848b41b68e9d4292266d"

--- a/packages/dune-action-plugin/dune-action-plugin.3.20.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.20.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "dune-glob" {= version}
+  "csexp" {>= "1.5.0"}
+  "ppx_expect" {with-test}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "dune-rpc" {= version}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.20.0/dune-3.20.0.tbz"
+  checksum: [
+    "sha256=767999da81e528484139ecfe927288ffe521ac2467462a40d6a760ed789ba086"
+    "sha512=18f6a293cb5d4423a3bf69ce9559b40e7075e49b13c79166f2aacfa55cbc2609e20938bad889b43df0d5a3396ea034e405631d3757da6164c51be375e5751632"
+  ]
+}
+x-commit-hash: "3bd6fcbde34880a6c120848b41b68e9d4292266d"

--- a/packages/dune-build-info/dune-build-info.3.20.0/opam
+++ b/packages/dune-build-info/dune-build-info.3.20.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Embed build information inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.20.0/dune-3.20.0.tbz"
+  checksum: [
+    "sha256=767999da81e528484139ecfe927288ffe521ac2467462a40d6a760ed789ba086"
+    "sha512=18f6a293cb5d4423a3bf69ce9559b40e7075e49b13c79166f2aacfa55cbc2609e20938bad889b43df0d5a3396ea034e405631d3757da6164c51be375e5751632"
+  ]
+}
+x-commit-hash: "3bd6fcbde34880a6c120848b41b68e9d4292266d"

--- a/packages/dune-configurator/dune-configurator.3.20.0/opam
+++ b/packages/dune-configurator/dune-configurator.3.20.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.20.0/dune-3.20.0.tbz"
+  checksum: [
+    "sha256=767999da81e528484139ecfe927288ffe521ac2467462a40d6a760ed789ba086"
+    "sha512=18f6a293cb5d4423a3bf69ce9559b40e7075e49b13c79166f2aacfa55cbc2609e20938bad889b43df0d5a3396ea034e405631d3757da6164c51be375e5751632"
+  ]
+}
+x-commit-hash: "3bd6fcbde34880a6c120848b41b68e9d4292266d"

--- a/packages/dune-glob/dune-glob.3.20.0/opam
+++ b/packages/dune-glob/dune-glob.3.20.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "stdune" {= version}
+  "dyn"
+  "ordering"
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.20.0/dune-3.20.0.tbz"
+  checksum: [
+    "sha256=767999da81e528484139ecfe927288ffe521ac2467462a40d6a760ed789ba086"
+    "sha512=18f6a293cb5d4423a3bf69ce9559b40e7075e49b13c79166f2aacfa55cbc2609e20938bad889b43df0d5a3396ea034e405631d3757da6164c51be375e5751632"
+  ]
+}
+x-commit-hash: "3bd6fcbde34880a6c120848b41b68e9d4292266d"

--- a/packages/dune-private-libs/dune-private-libs.3.20.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.3.20.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "csexp" {>= "1.5.0"}
+  "pp" {>= "1.1.0"}
+  "dyn" {= version}
+  "stdune" {= version}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.20.0/dune-3.20.0.tbz"
+  checksum: [
+    "sha256=767999da81e528484139ecfe927288ffe521ac2467462a40d6a760ed789ba086"
+    "sha512=18f6a293cb5d4423a3bf69ce9559b40e7075e49b13c79166f2aacfa55cbc2609e20938bad889b43df0d5a3396ea034e405631d3757da6164c51be375e5751632"
+  ]
+}
+x-commit-hash: "3bd6fcbde34880a6c120848b41b68e9d4292266d"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.20.0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.20.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc and Lwt"
+description: "Specialization of dune-rpc to Lwt"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "dune-rpc" {= version}
+  "csexp" {>= "1.5.0"}
+  "lwt" {>= "5.6.0"}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.20.0/dune-3.20.0.tbz"
+  checksum: [
+    "sha256=767999da81e528484139ecfe927288ffe521ac2467462a40d6a760ed789ba086"
+    "sha512=18f6a293cb5d4423a3bf69ce9559b40e7075e49b13c79166f2aacfa55cbc2609e20938bad889b43df0d5a3396ea034e405631d3757da6164c51be375e5751632"
+  ]
+}
+x-commit-hash: "3bd6fcbde34880a6c120848b41b68e9d4292266d"

--- a/packages/dune-rpc/dune-rpc.3.20.0/opam
+++ b/packages/dune-rpc/dune-rpc.3.20.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocamlc-loc"
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.20.0/dune-3.20.0.tbz"
+  checksum: [
+    "sha256=767999da81e528484139ecfe927288ffe521ac2467462a40d6a760ed789ba086"
+    "sha512=18f6a293cb5d4423a3bf69ce9559b40e7075e49b13c79166f2aacfa55cbc2609e20938bad889b43df0d5a3396ea034e405631d3757da6164c51be375e5751632"
+  ]
+}
+x-commit-hash: "3bd6fcbde34880a6c120848b41b68e9d4292266d"

--- a/packages/dune-site/dune-site.3.20.0/opam
+++ b/packages/dune-site/dune-site.3.20.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Embed locations information inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.20.0/dune-3.20.0.tbz"
+  checksum: [
+    "sha256=767999da81e528484139ecfe927288ffe521ac2467462a40d6a760ed789ba086"
+    "sha512=18f6a293cb5d4423a3bf69ce9559b40e7075e49b13c79166f2aacfa55cbc2609e20938bad889b43df0d5a3396ea034e405631d3757da6164c51be375e5751632"
+  ]
+}
+x-commit-hash: "3bd6fcbde34880a6c120848b41b68e9d4292266d"

--- a/packages/dune/dune.3.20.0/opam
+++ b/packages/dune/dune.3.20.0/opam
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+Dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+Dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+Dune is composable; supporting multi-package development by simply
+dropping multiple repositories into the same directory.
+
+Dune also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "2.0.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  "ocaml" {>= "4.08"}
+  "base-unix"
+  "base-threads"
+  "lwt" { with-dev-setup & os != "win32" }
+  "cinaps" { with-dev-setup }
+  "csexp" { with-dev-setup & >= "1.3.0" }
+  "js_of_ocaml" { with-dev-setup & >= "6.1.0" & os != "win32" }
+  "js_of_ocaml-compiler" { with-dev-setup & >= "6.1.0" & os != "win32" }
+  "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
+  "menhir" { with-dev-setup & os != "win32" }
+  "ocamlfind" { with-dev-setup & os != "win32" }
+  "odoc" { with-dev-setup & >= "2.4.0" & os != "win32" }
+  "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
+  "spawn" { with-dev-setup }
+  "ppx_inline_test" { with-dev-setup & os != "win32" }
+  "ppxlib" { with-dev-setup & >= "0.35.0" & os != "win32" }
+  "ctypes" { with-dev-setup & os != "win32" }
+  "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
+  "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.20.0/dune-3.20.0.tbz"
+  checksum: [
+    "sha256=767999da81e528484139ecfe927288ffe521ac2467462a40d6a760ed789ba086"
+    "sha512=18f6a293cb5d4423a3bf69ce9559b40e7075e49b13c79166f2aacfa55cbc2609e20938bad889b43df0d5a3396ea034e405631d3757da6164c51be375e5751632"
+  ]
+}
+x-commit-hash: "3bd6fcbde34880a6c120848b41b68e9d4292266d"

--- a/packages/dyn/dyn.3.20.0/opam
+++ b/packages/dyn/dyn.3.20.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.08.0"}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.20.0/dune-3.20.0.tbz"
+  checksum: [
+    "sha256=767999da81e528484139ecfe927288ffe521ac2467462a40d6a760ed789ba086"
+    "sha512=18f6a293cb5d4423a3bf69ce9559b40e7075e49b13c79166f2aacfa55cbc2609e20938bad889b43df0d5a3396ea034e405631d3757da6164c51be375e5751632"
+  ]
+}
+x-commit-hash: "3bd6fcbde34880a6c120848b41b68e9d4292266d"

--- a/packages/ocamlc-loc/ocamlc-loc.3.20.0/opam
+++ b/packages/ocamlc-loc/ocamlc-loc.3.20.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Parse ocaml compiler output into structured form"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.08.0"}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-lsp-server" {< "1.15.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.20.0/dune-3.20.0.tbz"
+  checksum: [
+    "sha256=767999da81e528484139ecfe927288ffe521ac2467462a40d6a760ed789ba086"
+    "sha512=18f6a293cb5d4423a3bf69ce9559b40e7075e49b13c79166f2aacfa55cbc2609e20938bad889b43df0d5a3396ea034e405631d3757da6164c51be375e5751632"
+  ]
+}
+x-commit-hash: "3bd6fcbde34880a6c120848b41b68e9d4292266d"

--- a/packages/ordering/ordering.3.20.0/opam
+++ b/packages/ordering/ordering.3.20.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.20.0/dune-3.20.0.tbz"
+  checksum: [
+    "sha256=767999da81e528484139ecfe927288ffe521ac2467462a40d6a760ed789ba086"
+    "sha512=18f6a293cb5d4423a3bf69ce9559b40e7075e49b13c79166f2aacfa55cbc2609e20938bad889b43df0d5a3396ea034e405631d3757da6164c51be375e5751632"
+  ]
+}
+x-commit-hash: "3bd6fcbde34880a6c120848b41b68e9d4292266d"

--- a/packages/stdune/stdune.3.20.0/opam
+++ b/packages/stdune/stdune.3.20.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "dyn" {= version}
+  "ordering" {= version}
+  "pp" {>= "2.0.0"}
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.20.0/dune-3.20.0.tbz"
+  checksum: [
+    "sha256=767999da81e528484139ecfe927288ffe521ac2467462a40d6a760ed789ba086"
+    "sha512=18f6a293cb5d4423a3bf69ce9559b40e7075e49b13c79166f2aacfa55cbc2609e20938bad889b43df0d5a3396ea034e405631d3757da6164c51be375e5751632"
+  ]
+}
+x-commit-hash: "3bd6fcbde34880a6c120848b41b68e9d4292266d"

--- a/packages/xdg/xdg.3.20.0/opam
+++ b/packages/xdg/xdg.3.20.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.20.0/dune-3.20.0.tbz"
+  checksum: [
+    "sha256=767999da81e528484139ecfe927288ffe521ac2467462a40d6a760ed789ba086"
+    "sha512=18f6a293cb5d4423a3bf69ce9559b40e7075e49b13c79166f2aacfa55cbc2609e20938bad889b43df0d5a3396ea034e405631d3757da6164c51be375e5751632"
+  ]
+}
+x-commit-hash: "3bd6fcbde34880a6c120848b41b68e9d4292266d"


### PR DESCRIPTION
Fast, portable, and opinionated build system

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

### Fixed

- Stop re-running cram tests after promotion when it's not necessary (ocaml/dune#11994,
  @rgrinberg)

- fix: `$ dune subst` should not fail when adding the version field in opam
  files (ocaml/dune#11801, fixes ocaml/dune#11045, @btjorge)

- Kill all processes in the process group after the main process has
  terminated; in particular this avoids background processes in cram tests to
  stick around after the test finished (ocaml/dune#11841, fixes ocaml/dune#11820, @Alizter,
  @Leonidas-from-XIV)

### Added

- `(tests)` stanzas now generate aliases with the test name. To run
  `(test (name a))` you can do `dune build @runtest-a`. (ocaml/dune#11558, grants part of ocaml/dune#10239,
  @Alizter)

- Inline test libraries now produce aliases `runtest-name_of_lib`
  allowing users to run specific inline tests as `dune build
  @runtest-name_of_lib`. (ocaml/dune#11109, partially fixes ocaml/dune#10239, @Alizter)

- feature: `$ dune subst` use version from `dune-project` when no version
  control repository has been detected (ocaml/dune#11801, @btjorge)

- Allow `dune exec` to run concurrently with another instance of dune in watch
  mode (ocaml/dune#11840, @gridbugs)

- Introduce `%{os}`, `%{os_version}`, `%{os_distribution}`, and `%{os_family}`
  percent forms. These have the same values as their opam counterparts.
  (ocaml/dune#11863, @rgrinberg)

- Introduce option `(implicit_transitive_deps false-if-hidden-includes-supported)`
  that is equivalent to `(implicit_transitive_deps false)` when `-H` is
  supported by the compiler (OCaml >= 5.2) and equivalent to
  `(implicit_transitive_deps true)` otherwise. (ocaml/dune#11866, fixes ocaml/dune#11212, @nojb)

- Add `dune describe location` for printing the path to the executable that
  would be run (ocaml/dune#11905, @gridbugs)

- `dune runtest` can now understand absolute paths as well as run tests in
  specific build contexts (ocaml/dune#11936, @Alizter).

- Added 'empty' alias which contains no targets. (ocaml/dune#11556 ocaml/dune#11952 ocaml/dune#11955 ocaml/dune#11956,
  grants ocaml/dune#4161, @Alizter and @rgrinberg)

- Allow `dune promote` to properly run while a watch mode server is running
  (ocaml/dune#12010, @ElectreAAS)

- Add `--alias` and `--alias-rec` flags as an alternative to the `@@` and `@`
  syntax in the command line (ocaml/dune#12043, fixes ocaml/dune#5775, @rgrinberg)

- Added a `(timeout <float>)` field to the `(cram)` stanza to specify per-test
  time limits. Tests exceeding the timeout are terminated with an error.
  (ocaml/dune#12041, @Alizter)

### Changed

- Format long lists in s-expressions to fill the line instead of
  formatting them in a vertical way (ocaml/dune#10892, fixes ocaml/dune#10860, @nojb)

- Switch from MD5 to BLAKE3 for digesting targets and rules. BLAKE3 is both more
  performant and difficult to break than MD5 (ocaml/dune#11735, @rgrinberg, @Alizter)

- Print a warning when `dune build` runs over RPC (ocaml/dune#11833, @gridbugs)

- Stop emitting empty module group wrapper `.js` file in `melange.emit`
  (ocaml/dune#11987, fixes ocaml/dune#11986, @anmonteiro)
