### PR TITLE
refl.0.4.1 is not compatible with OCaml 5.3

### DIFF
--- a/packages/refl/refl.0.4.1/opam
+++ b/packages/refl/refl.0.4.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/thierry-martinez/refl"
 doc: "https://github.com/thierry-martinez/refl"
 bug-reports: "https://github.com/thierry-martinez/refl"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3.0"}
   "dune" {>= "1.11.0"}
   "stdcompat" {>= "14"}
   "fix" {>= "20200131"}


### PR DESCRIPTION
This shows up in https://github.com/ocaml/opam-repository/pull/28357 as:
:x:  [pyast.0.1.0 (failed: refl.0.4.1 failed to build)](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/b4a21dfb8f36d076fcce7e0cf4a496bc55c525bd/variant/compilers,5.3,dune.3.20.0,revdeps,pyast.0.1.0)
:x: [pyast.0.1.1 (failed: refl.0.4.1 failed to build)](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/b4a21dfb8f36d076fcce7e0cf4a496bc55c525bd/variant/compilers,5.3,dune.3.20.0,revdeps,pyast.0.1.1)
:x: [pyast.0.2.0 (failed: refl.0.4.1 failed to build)](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/b4a21dfb8f36d076fcce7e0cf4a496bc55c525bd/variant/compilers,5.3,dune.3.20.0,revdeps,pyast.0.2.0)
:x: [refl.0.4.1 (failed: The value "Ppxlib.Pprintast.core_type" has type)](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/b4a21dfb8f36d076fcce7e0cf4a496bc55c525bd/variant/compilers,5.3,dune.3.20.0,revdeps,refl.0.4.1)

with the error message:
```
#=== ERROR while compiling refl.0.4.1 =========================================#
# context              2.3.0 | linux/x86_64 | ocaml-base-compiler.5.3.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/refl.0.4.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p refl -j 71 @install
# exit-code            1
# env-file             ~/.opam/log/refl-7-bed347.env
# output-file          ~/.opam/log/refl-7-bed347.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlc.opt -open Stdcompat -w +32+34-40 -g -bin-annot -bin-annot-occurrences -I ppx/.ppx_refl.objs/byte -I /home/opam/.opam/5.3/lib/findlib -I /home/opam/.opam/5.3/lib/fix -I /home/opam/.opam/5.3/lib/metapp -I /home/opam/.opam/5.3/lib/metapp/preutils -I /home/opam/.opam/5.3/lib/metapp/version_info -I /home/opam/.opam/5.3/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.3/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.3/lib/ocaml/compiler-libs -I /home/opam/.opam/5.3/lib/ppx_derivers -I /home/opam/.opam/5.3/lib/ppxlib -I /home/opam/.opam/5.3/lib/ppxlib/ast -I /home/opam/.opam/5.3/lib/ppxlib/astlib -I /home/opam/.opam/5.3/lib/ppxlib/print_diff -I /home/opam/.opam/5.3/lib/ppxlib/stdppx -I /home/opam/.opam/5.3/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.3/lib/sexplib0 -I /home/opam/.opam/5.3/lib/stdcompat -I /home/opam/.opam/5.3/lib/stdlib-shims -cmi-file ppx/.ppx_refl.objs/byte/ppx_refl.cmi -no-alias-deps -open Ppx_refl__ -o ppx/.ppx_refl.objs/byte/ppx_refl.cmo -c -impl ppx/ppx_refl.pp.ml)
# File "ppx/ppx_refl.ml", line 358, characters 48-74:
# 358 |         "Type variable expected but '%a' found" Ppxlib.Pprintast.core_type ty
#                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: The value "Ppxlib.Pprintast.core_type" has type
#          "Stdlib.Format.formatter ->
#          Astlib__.Ast_414.Parsetree.core_type -> unit"
#        but an expression was expected of type
#          "Format_doc.formatter -> 'a -> unit"
#        Type "Stdlib.Format.formatter" = "Stdlib__Format.formatter"
#        is not compatible with type "Format_doc.formatter"
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlopt.opt -open Stdcompat -w +32+34-40 -g -I ppx/.ppx_refl.objs/byte -I ppx/.ppx_refl.objs/native -I /home/opam/.opam/5.3/lib/findlib -I /home/opam/.opam/5.3/lib/fix -I /home/opam/.opam/5.3/lib/metapp -I /home/opam/.opam/5.3/lib/metapp/preutils -I /home/opam/.opam/5.3/lib/metapp/version_info -I /home/opam/.opam/5.3/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.3/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.3/lib/ocaml/compiler-libs -I /home/opam/.opam/5.3/lib/ppx_derivers -I /home/opam/.opam/5.3/lib/ppxlib -I /home/opam/.opam/5.3/lib/ppxlib/ast -I /home/opam/.opam/5.3/lib/ppxlib/astlib -I /home/opam/.opam/5.3/lib/ppxlib/print_diff -I /home/opam/.opam/5.3/lib/ppxlib/stdppx -I /home/opam/.opam/5.3/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.3/lib/sexplib0 -I /home/opam/.opam/5.3/lib/stdcompat -I /home/opam/.opam/5.3/lib/stdlib-shims -cmi-file ppx/.ppx_refl.objs/byte/ppx_refl.cmi -no-alias-deps -open Ppx_refl__ -o ppx/.ppx_refl.objs/native/ppx_refl.cmx -c -impl ppx/ppx_refl.pp.ml)
# File "ppx/ppx_refl.ml", line 358, characters 48-74:
# 358 |         "Type variable expected but '%a' found" Ppxlib.Pprintast.core_type ty
#                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: The value "Ppxlib.Pprintast.core_type" has type
#          "Stdlib.Format.formatter ->
#          Astlib__.Ast_414.Parsetree.core_type -> unit"
#        but an expression was expected of type
#          "Format_doc.formatter -> 'a -> unit"
#        Type "Stdlib.Format.formatter" = "Stdlib__Format.formatter"
#        is not compatible with type "Format_doc.formatter"
```

It is caused by https://github.com/ocaml/ocaml/pull/13169 changing the signature of `Location.raise_errorf` from
`?loc:t -> ?sub:msg list -> ('a, Format.formatter, unit, 'b) format4 -> 'a` to
`?loc:t -> ?sub:msg list -> ?footnote:delayed_msg -> ('a, Format_doc.formatter, unit, 'b) format4 -> 'a`
(note the switch from `Format.formatter` to `Format_doc.formatter` above)
which is used in https://github.com/ocamllibs/refl/blob/v0.4.1/ppx/ppx_refl.ml#L357