### PR TITLE
Release 21.1 of stdcompat

### DIFF
--- a/packages/stdcompat/stdcompat.21.1/opam
+++ b/packages/stdcompat/stdcompat.21.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "Compatibility module for OCaml standard library"
+description:
+  "Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml."
+maintainer: "Sébastien Hinderer <sebastien.hinderer@inria.fr>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/ocamllibs/stdcompat"
+bug-reports: "https://github.com/ocamllibs/stdcompat/issues"
+depends: [
+  "ocaml" {>= "4.11" & < "5.4"}
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocamllibs/stdcompat.git"
+url {
+  src:
+    "https://github.com/ocamllibs/stdcompat/archive/refs/tags/21.1.tar.gz"
+  checksum: [
+    "sha512=b3d93d200aa57a193459c143fafa97b7e96cbed3043ef8c7a2bc359ed385ff7d1ec03561cdab1f28e80055dc1c0bd7647bba827c6300b85a1d1c66a539626189"
+  ]
+}


### PR DESCRIPTION
Fixes an issues with 21.0, namely that a legitimate source file was listed in .gitignore, which could and did create problems.