### PR TITLE
Add `ppxlib` `with-test` bounds for `ppx_rapper_lwt` and `ppx_rapper_async`

### DIFF
--- a/packages/ppx_rapper_async/ppx_rapper_async.3.0.0/opam
+++ b/packages/ppx_rapper_async/ppx_rapper_async.3.0.0/opam
@@ -10,6 +10,7 @@ depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.07"}
   "ppx_rapper" {= version}
+  "ppxlib" {with-test & < "0.31.0"}
   "caqti-async"
   "async"
 ]

--- a/packages/ppx_rapper_async/ppx_rapper_async.3.1.0/opam
+++ b/packages/ppx_rapper_async/ppx_rapper_async.3.1.0/opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.07"}
   "ppx_rapper" {= version}
+  "ppxlib" {with-test & < "0.31.0"}
   "caqti-async"
   "async"
 ]

--- a/packages/ppx_rapper_lwt/ppx_rapper_lwt.3.0.0/opam
+++ b/packages/ppx_rapper_lwt/ppx_rapper_lwt.3.0.0/opam
@@ -10,6 +10,7 @@ depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.07"}
   "ppx_rapper" {= version}
+  "ppxlib" {with-test & < "0.31.0"}
   "caqti-lwt"
   "lwt"
   "caqti-type-calendar" {with-test}

--- a/packages/ppx_rapper_lwt/ppx_rapper_lwt.3.1.0/opam
+++ b/packages/ppx_rapper_lwt/ppx_rapper_lwt.3.1.0/opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.07"}
   "ppx_rapper" {= version}
+  "ppxlib" {with-test & < "0.31.0"}
   "caqti-lwt"
   "lwt"
   "caqti-type-calendar" {with-test}


### PR DESCRIPTION
This is causing a ton of red CI lights on https://github.com/ocaml/opam-repository/pull/28357, e.g.,
  :x: [ppx_rapper_async.3.0.0 (failed: The compilation of ppx_rapper_async.3.0.0 failed at "dune build -p ppx_rapper_async -j 255 @install @runtest".)](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/b4a21dfb8f36d076fcce7e0cf4a496bc55c525bd/variant/compilers,4.14,dune-configurator.3.20.0,revdeps,ppx_rapper_async.3.0.0)
  :x: [ppx_rapper_async.3.1.0 (failed: The compilation of ppx_rapper_async.3.1.0 failed at "dune build -p ppx_rapper_async -j 255 @install @runtest".)](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/b4a21dfb8f36d076fcce7e0cf4a496bc55c525bd/variant/compilers,4.14,dune-configurator.3.20.0,revdeps,ppx_rapper_async.3.1.0)
  :x: [ppx_rapper_lwt.3.0.0 (failed: The compilation of ppx_rapper_lwt.3.0.0 failed at "dune build -p ppx_rapper_lwt -j 255 @install @runtest".)](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/b4a21dfb8f36d076fcce7e0cf4a496bc55c525bd/variant/compilers,4.14,dune-configurator.3.20.0,revdeps,ppx_rapper_lwt.3.0.0)
  :x: [ppx_rapper_lwt.3.1.0 (failed: The compilation of ppx_rapper_lwt.3.1.0 failed at "dune build -p ppx_rapper_lwt -j 255 @install @runtest".)](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/b4a21dfb8f36d076fcce7e0cf4a496bc55c525bd/variant/compilers,4.14,dune-configurator.3.20.0,revdeps,ppx_rapper_lwt.3.1.0)
...

It is caused by simple expect test differences when using newer `ppxlib`s:
```
#=== ERROR while compiling ppx_rapper_lwt.3.1.0 ===============================#
# context              2.3.0 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/ppx_rapper_lwt.3.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ppx_rapper_lwt -j 255 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/ppx_rapper_lwt-7-5f02e8.env
# output-file          ~/.opam/log/ppx_rapper_lwt-7-5f02e8.out
### output ###
# File "test/ppx/test.expected.ml", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/ppx/test.expected.ml _build/default/test/ppx/test.actual.ml
# diff --git a/_build/default/test/ppx/test.expected.ml b/_build/default/test/ppx/test.actual.ml
# index 974f691..f843df6 100644
# --- a/_build/default/test/ppx/test.expected.ml
# +++ b/_build/default/test/ppx/test.actual.ml
# @@ -220,7 +220,8 @@ let list =
#                       [@ocaml.warning "-33"]) item pack) Dynparam.empty elems in
#            let query =
#              Caqti_request.Infix.(->?) ~oneshot:true
# -              (let open Caqti_type in tup2 bool packed_list_type)
# +              ((let open Caqti_type in tup2 bool packed_list_type)
# +              [@ocaml.warning "-33"])
#                ((let open Caqti_type in
#                    tup2 int (tup2 string (tup2 bool (option string))))
#                [@ocaml.warning "-33"]) sql in
# @@ -256,8 +257,9 @@ let collect_list =
#                     Dynparam.add ((let open Caqti_type in int)
#                       [@ocaml.warning "-33"]) item pack) Dynparam.empty elems in
#            let query =
# -            Caqti_request.Infix.( ->* ) ~oneshot:true packed_list_type
# -              ((let open Caqti_type in string)[@ocaml.warning "-33"]) sql in
# +            Caqti_request.Infix.( ->* ) ~oneshot:true ((packed_list_type)
# +              [@ocaml.warning "-33"]) ((let open Caqti_type in string)
# +              [@ocaml.warning "-33"]) sql in
#            Db.collect_list query versions in
#    wrapped
#  module Suit : Ppx_rapper_runtime.CUSTOM =
```

a54638e028  from https://github.com/ocaml/opam-repository/pull/24497 added similar `with-test` bounds for the `ppx_rapper` sister package.
These don't apply to `ppx_rapper_lwt` and `ppx_rapper_async` though.
I've confirmed locally that installing these 4 `--with-test` with `ppx.0.31.0` (or later) triggers expect test failures.