### PR TITLE
Add missing `re` lower bound in `opam-compiler` 0.1.0 and 0.1.1

### DIFF
--- a/packages/opam-compiler/opam-compiler.0.1.0/opam
+++ b/packages/opam-compiler/opam-compiler.0.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "cmdliner" {< "1.1.0"}
   "github-unix"
   "lwt_ssl"
-  "re"
+  "re" {>= "1.5.0"}
   "lwt" {< "5.7.0"}
   "alcotest" {>= "1.2.0" & with-test}
 ]

--- a/packages/opam-compiler/opam-compiler.0.1.1/opam
+++ b/packages/opam-compiler/opam-compiler.0.1.1/opam
@@ -14,7 +14,7 @@ depends: [
   "cmdliner" {< "1.1.0"}
   "github-unix"
   "lwt_ssl"
-  "re"
+  "re" {>= "1.5.0"}
   "lwt" {< "5.7.0"}
   "alcotest" {>= "1.2.0" & with-test}
 ]


### PR DESCRIPTION
Spotted in #28374.

Since the 0.1.0 release it has had an `Re.Group` in the first line of the import interface:
https://github.com/ocaml-opam/opam-compiler/blob/0.1.0/lib/import.mli

I can see cbb85ac0fd added the bound for 0.2.0 as part of the release in https://github.com/ocaml/opam-repository/pull/25096.