### PR TITLE
Add MinGW and MSys support for libao

### DIFF
--- a/packages/conf-ao/conf-ao.1/opam
+++ b/packages/conf-ao/conf-ao.1/opam
@@ -4,9 +4,17 @@ homepage: "https://www.xiph.org/ao/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "libao dev team"
 license: "GPL-2.0-only"
-build: ["pkg-config" "--exists" "ao"]
+build: [
+  ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
+     "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
+     "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution != "cygwin"}
+   "--print-errors" "--exists" "ao"]
+]
 depends: [
   "conf-pkg-config" {build}
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-ao-i686" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-ao-x86_64" {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [
   ["libao-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-mingw-w64-ao-i686/conf-mingw-w64-ao-i686.1/opam
+++ b/packages/conf-mingw-w64-ao-i686/conf-mingw-w64-ao-i686.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "libao for i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of libao for the mingw-w64 project is available"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: "libao dev team"
+license: "GPL-2.0-only"
+homepage: "https://www.xiph.org/ao/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32"
+build: ["pkgconf" "--personality=i686-w64-mingw32" "ao"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-i686" {build}
+]
+depexts: [
+  ["mingw64-i686-libao"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-i686-libao"] {os = "win32" & os-distribution = "msys2"}
+]

--- a/packages/conf-mingw-w64-ao-x86_64/conf-mingw-w64-ao-x86_64.1/opam
+++ b/packages/conf-mingw-w64-ao-x86_64/conf-mingw-w64-ao-x86_64.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "libao for x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of libao for the mingw-w64 project is available"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: "libao dev team"
+license: "GPL-2.0-only"
+homepage: "https://www.xiph.org/ao/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32"
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" "ao"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-x86_64" {build}
+]
+depexts: [
+  ["mingw64-x86_64-libao"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-x86_64-libao"] {os = "win32" & os-distribution = "msys2"}
+]


### PR DESCRIPTION
This PR adds MinGW and MSys support for `libao`. It is based on
- https://packages.msys2.org/base/mingw-w64-libao
- https://cygwin.com/packages/summary/mingw64-x86_64-libao.html
- https://cygwin.com/packages/summary/mingw64-i686-libao.html

The PR is modeled after https://github.com/ocaml/opam-repository/pull/26072 by @dra27 who wrote (I quote): :smiley: 
> I'm very happy to be pinged to review them

Polite ping to @gridbugs who struggled to get this working https://www.gridbugs.org/sound-on-ocaml-on-windows/ and thus may be interested in testing it... :crossed_fingers: 