### PR TITLE
Add conf-gtk2 support for windows (MinGW, MSys2, and Cygwin)

### DIFF
--- a/packages/conf-gtk2/conf-gtk2.1/opam
+++ b/packages/conf-gtk2/conf-gtk2.1/opam
@@ -27,6 +27,7 @@ depexts: [
   ["gtk2"] {os-family = "arch"}
   ["gtk2"] {os-distribution = "nixos"}
   ["gtk2.0"] {os = "win32" & os-distribution = "cygwinports"}
+  ["libgtk2.0-devel"] {os = "cygwin"}
   ["gtk+" "expat"] {os-distribution = "homebrew" & os = "macos"}
   ["gtk2"] {os = "freebsd"}
 ]

--- a/packages/conf-gtk2/conf-gtk2.1/opam
+++ b/packages/conf-gtk2/conf-gtk2.1/opam
@@ -4,9 +4,17 @@ homepage: "https://gtk.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["The GNOME Project"]
 license: "LGPL-2.1-or-later"
-build: ["pkg-config" "--exists" "gtk+-2.0"]
+build: [
+  ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
+      "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
+      "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution != "cygwin"}
+   "--exists" "gtk+-2.0"]
+]
 depends: [
   "conf-pkg-config" {build}
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk2-i686" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk2-x86_64" {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [
   ["libgtk2.0-dev" "libexpat1-dev"] {os-family = "debian"}

--- a/packages/conf-mingw-w64-gtk2-i686/conf-mingw-w64-gtk2-i686.1/opam
+++ b/packages/conf-mingw-w64-gtk2-i686/conf-mingw-w64-gtk2-i686.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "gtk2 for i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of gtk2 for the mingw-w64 project is available"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["The GNOME Project"]
+license: "LGPL-2.1-or-later"
+homepage: "https://gtk.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32"
+build: ["pkgconf" "--personality=i686-w64-mingw32" "gtk+-2.0"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-i686" {build}
+]
+depexts: [
+  ["mingw64-i686-gtk2.0"] {os = "win32" & os-distribution = "cygwin"}
+  # 32-bit gtk2 not available on MSys2
+]

--- a/packages/conf-mingw-w64-gtk2-x86_64/conf-mingw-w64-gtk2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gtk2-x86_64/conf-mingw-w64-gtk2-x86_64.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "gtk2 for i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of gtk2 for the mingw-w64 project is available"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["The GNOME Project"]
+license: "LGPL-2.1-or-later"
+homepage: "https://gtk.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32"
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" "gtk+-2.0"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-x86_64" {build}
+]
+depexts: [
+  ["mingw64-x86_64-gtk2.0"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-x86_64-gtk2"] {os = "win32" & os-distribution = "msys2"}
+]


### PR DESCRIPTION
This PR adds MinGW and MSys support for `conf-gtk2`. It is again modeled after #26072 by @dra27 and based on the following packages:
- https://cygwin.com/packages/summary/mingw64-i686-gtk2.0.html
- https://cygwin.com/packages/summary/mingw64-x86_64-gtk2.0.html
- https://packages.msys2.org/base/mingw-w64-gtk2

I couldn't find a 32-bit gtk2 package for MSys2 though :shrug: 

While at it, the second commit also adds "regular Cygwin" support by installing https://cygwin.com/packages/summary/libgtk2.0-devel.html

These correspond to lines 1, 2, and 4 from the Windows table at the bottom of this wiki page:
https://github.com/ocaml/opam-repository/wiki/Depexts-os-distribution---os-family-values