### PR TITLE
Add conf-gtk3 support for Windows (MinGW and MSys2)

### DIFF
--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: "The GTK Toolkit"
 license: "LGPL-2.1-or-later"
-homepage: "https://developer.gnome.org/"
+homepage: "https://www.gtk.org/"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 build: [
   ["pkgconf" "--personality=i686-w64-mingw32" "--print-errors" "--exists" "gtk+-3.0"] {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}

--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -4,10 +4,15 @@ authors: "The GTK Toolkit"
 homepage: "https://developer.gnome.org/"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 build: [
-  ["pkgconf" "gtk+-3.0"] {os = "win32" & os-distribution != "cygwinports"}
+  ["pkgconf" "--personality=i686-w64-mingw32" "--print-errors" "--exists" "gtk+-3.0"] {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
+  ["pkgconf" "--personality=x86_64-w64-mingw32" "--print-errors" "--exists" "gtk+-3.0"] {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
   ["pkg-config" "--short-errors" "--print-errors" "--atleast-version" "3.18" "gtk+-3.0"] {os != "win32" | os-distribution != "cygwin"}
 ]
-depends: ["conf-pkg-config" {build}]
+depends: [
+  "conf-pkg-config" {build}
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk3-i686" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk3-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+]
 depexts: [
   ["libgtk-3-dev" "libexpat1-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["gtk+3" "expat"] {os-distribution = "homebrew" & os = "macos"}
@@ -19,7 +24,7 @@ depexts: [
   ["gtk3-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gtk3"] {os-family = "arch"}
   ["gtk3"] {os = "win32" & os-distribution = "cygwinports"}
-  ["libgtk3-devel"] {os = "win32" & os-distribution = "cygwin"}
+  ["libgtk3-devel"] {os = "cygwin"}
   ["gtk3"] {os = "freebsd"}
 ]
 post-messages: [

--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: "The GTK Toolkit"
+license: "LGPL-2.1-or-later"
 homepage: "https://developer.gnome.org/"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 build: [

--- a/packages/conf-mingw-w64-gtk3-i686/conf-mingw-w64-gtk3-i686.1/opam
+++ b/packages/conf-mingw-w64-gtk3-i686/conf-mingw-w64-gtk3-i686.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "GTK+ 3 for i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of GTK+ 3 for the mingw-w64 project is available"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: "The GTK Toolkit"
+license: "LGPL-2.1-or-later"
+homepage: "https://developer.gnome.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32"
+build: ["pkgconf" "--personality=i686-w64-mingw32" "gtk+-3.0"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-i686" {build}
+]
+depexts: [
+  ["mingw64-i686-gtk3"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-i686-gtk3"] {os = "win32" & os-distribution = "msys2"}
+]

--- a/packages/conf-mingw-w64-gtk3-x86_64/conf-mingw-w64-gtk3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gtk3-x86_64/conf-mingw-w64-gtk3-x86_64.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "GTK+ 3 for i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of GTK+ 3 for the mingw-w64 project is available"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: "The GTK Toolkit"
+license: "LGPL-2.1-or-later"
+homepage: "https://www.gtk.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32"
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" "gtk+-3.0"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-x86_64" {build}
+]
+depexts: [
+  ["mingw64-x86_64-gtk3"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-x86_64-gtk3"] {os = "win32" & os-distribution = "msys2"}
+]


### PR DESCRIPTION
This PR adds conf-gtk3 support for Windows, specifically on MinGW and MSys2.
It is again modeled after #26072 and uses the following packages:
- https://packages.msys2.org/base/mingw-w64-gtk3
- https://cygwin.com/packages/summary/mingw64-i686-gtk3.html
- https://cygwin.com/packages/summary/mingw64-x86_64-gtk3.html

I ended up getting a bit lost in all the `build` step nesting and hence just ended up writing them out, one after another :shrug: 

A bit of history of `gtk3` Windows support:
- #24432 first added Cygwin support, using `os-distribution = "cygwin"` for the depext
- #26130 later corrected it to use `os = "cygwin"`
- 3ec08b23ff and 10f9fad925 from #28011 adjusted it again, installing a Cygwin (not MinGW) package when matching the MinGW CI setup

CC @dra27 and @punchagan