### PR TITLE
4 packages from mirage/ocaml-github at 4.5.0

### DIFF
--- a/packages/github-data/github-data.4.5.0/opam
+++ b/packages/github-data/github-data.4.5.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "GitHub APIv3 data library"
+description: """\
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/rest/)
+(JSON).  This package installs the data conversion library."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+license: "MIT"
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "yojson" {>= "1.7.0"}
+  "atdgen" {>= "2.0.0"}
+  "atdgen-runtime" {>= "2.0.0"}
+]
+conflicts: [
+  "github" {!= version}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.5.0/github-4.5.0.tar.gz"
+  checksum: [
+    "md5=b04f1921b3692a8d748f65df6562d144"
+    "sha512=0ae1592429050bc690c91d2b5544f77b9ac2248d21a6f896525bfab698c24fd32397bba58b5ee766cd6203433e4bbba6da12770e31a44dd12b64bb683bc4b005"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/github-jsoo/github-jsoo.4.5.0/opam
+++ b/packages/github-jsoo/github-jsoo.4.5.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "GitHub APIv3 JavaScript library"
+description: """\
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/rest/)
+(JSON). This library installs the JavaScript version, which uses [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+license: "MIT"
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "github" {= version}
+  "cohttp" {>= "4.0.0"}
+  "cohttp-lwt-jsoo" {>= "4.0.0"}
+  "js_of_ocaml-lwt" {>= "3.4.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.5.0/github-4.5.0.tar.gz"
+  checksum: [
+    "md5=b04f1921b3692a8d748f65df6562d144"
+    "sha512=0ae1592429050bc690c91d2b5544f77b9ac2248d21a6f896525bfab698c24fd32397bba58b5ee766cd6203433e4bbba6da12770e31a44dd12b64bb683bc4b005"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/github-unix/github-unix.4.5.0/opam
+++ b/packages/github-unix/github-unix.4.5.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "GitHub APIv3 Unix library"
+description: """\
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/rest/)
+(JSON).  This package installs the Unix (Lwt) version."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+license: "MIT"
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "github" {= version}
+  "cohttp" {>= "4.0.0"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "stringext"
+  "cmdliner" {>= "1.1.0"}
+  "base-unix"
+  "lwt"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.5.0/github-4.5.0.tar.gz"
+  checksum: [
+    "md5=b04f1921b3692a8d748f65df6562d144"
+    "sha512=0ae1592429050bc690c91d2b5544f77b9ac2248d21a6f896525bfab698c24fd32397bba58b5ee766cd6203433e4bbba6da12770e31a44dd12b64bb683bc4b005"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/github/github.4.5.0/opam
+++ b/packages/github/github.4.5.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "GitHub APIv3 OCaml library"
+description: """\
+This library provides an OCaml interface to the
+[GitHub APIv3](https://docs.github.com/rest/) (JSON).
+
+It is compatible with [MirageOS](https://mirage.io) and also compiles to pure
+JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+license: "MIT"
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "uri" {>= "1.9.0"}
+  "cohttp" {>= "4.0.0"}
+  "lwt" {>= "2.4.4"}
+  "cohttp-lwt" {>= "4.0.0"}
+  "github-data" {= version}
+  "yojson" {>= "1.7.0"}
+  "stringext"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.5.0/github-4.5.0.tar.gz"
+  checksum: [
+    "md5=b04f1921b3692a8d748f65df6562d144"
+    "sha512=0ae1592429050bc690c91d2b5544f77b9ac2248d21a6f896525bfab698c24fd32397bba58b5ee766cd6203433e4bbba6da12770e31a44dd12b64bb683bc4b005"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `github.4.5.0`: GitHub APIv3 OCaml library
- `github-data.4.5.0`: GitHub APIv3 data library
- `github-jsoo.4.5.0`: GitHub APIv3 JavaScript library
- `github-unix.4.5.0`: GitHub APIv3 Unix library



---
* Homepage: https://github.com/mirage/ocaml-github
* Source repo: git+https://github.com/mirage/ocaml-github.git
* Bug tracker: https://github.com/mirage/ocaml-github/issues

---
:camel: Pull-request generated by opam-publish v2.5.1