### PR TITLE
[new release] mirage-mtime (5.1.0)

### DIFF
--- a/packages/mirage-mtime/mirage-mtime.5.1.0/opam
+++ b/packages/mirage-mtime/mirage-mtime.5.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "hannes@mehnert.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray" "Hannes Mehnert"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-mtime"
+doc: "https://mirage.github.io/mirage-mtime/"
+bug-reports: "https://github.com/mirage/mirage-mtime/issues"
+synopsis: "Libraries and module types for a monotonic clock"
+description: """
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirageos.org) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements a monotonic timesource since an arbitrary point.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "mtime" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-mtime.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-mtime/releases/download/v5.1.0/mirage-mtime-5.1.0.tbz"
+  checksum: [
+    "sha256=e5ffba272dd75c9e40ed8ccbbf87d9614345c3adb7bfe95dd170a3c6e367deae"
+    "sha512=9ac59431e7e2c38ea66eda555778c2f19ac86665bfa5729a8b991e359cb5c8650b77e715c2c429d94c3cd26a5977b7e55b36e704cf4cb9393c291178792680eb"
+  ]
+}
+x-commit-hash: "ab0f04a0720bd628f587d944f3e2f9c1c26cfef4"


### PR DESCRIPTION
Libraries and module types for a monotonic clock

- Project page: <a href="https://github.com/mirage/mirage-mtime">https://github.com/mirage/mirage-mtime</a>
- Documentation: <a href="https://mirage.github.io/mirage-mtime/">https://mirage.github.io/mirage-mtime/</a>

##### CHANGES:

* mirage-mtime.mock: add a `val Mirage_mtime_set.reset : unit -> unit` function,
  required by moby/vpnkit (mirage/mirage-mtime#2 @hannesm)
