### PR TITLE
[new release] hvsock (3.1.0)

### DIFF
--- a/packages/hvsock/hvsock.3.1.0/opam
+++ b/packages/hvsock/hvsock.3.1.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: [ "David Scott" "Rolf Neugebauer" "Anil Madhavapeddy" "Simon Ferquel"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-hvsock"
+dev-repo: "git+https://github.com/mirage/ocaml-hvsock.git"
+bug-reports: "https://github.com/mirage/ocaml-hvsock/issues"
+doc: "https://mirage.github.io/ocaml-hvsock"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "base-bytes"
+  "base-threads"
+  "base-unix"
+  "lwt" {>= "3.2.0"}
+  "logs"
+  "fmt"
+  "cmdliner" {>= "1.1"}
+  "sha"
+  "uri"
+  "base64" {>= "3.0.0"}
+  "uuidm"
+  "uutf"
+  "mirage-flow" {>= "5.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "duration"
+  "dune" {>= "1.2.0"}
+  "alcotest" {with-test & >= "0.4.0"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+]
+synopsis: "Bindings for Hyper-V AF_VSOCK"
+description: """
+[![Build Status (Linux)](https://travis-ci.org/mirage/ocaml-hvsock.svg)](https://travis-ci.org/mirage/ocaml-hvsock)
+[![Build status (Windows)](https://ci.appveyor.com/api/projects/status/974tsg317b4k8xra?svg=true)](https://ci.appveyor.com/project/mirage/ocaml-hvsock/branch/master)
+
+These bindings allow Host <-> VM communication on Hyper-V systems on both Linux
+and Windows.
+
+*Warning*: the `AF_HYPERV` patches for Linux are not yet merged and hence the
+definition of `AF_HYPERV` is not yet stable. If other address families are merged
+before this one then the value of `AF_HYPERV` will change!
+
+Please read [the API documentation](https://djs55.github.io/ocaml-hvsock/index.html)."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-hvsock/releases/download/3.1.0/hvsock-3.1.0.tbz"
+  checksum: [
+    "sha256=c3dc439a50b2b83dc584b20726a1311ca52187792613e9cf441c39da51ef7407"
+    "sha512=cd631f190c63dabd8151e51715d048c828aa9a8207661a6b06c5b7754de030ebec81f06d6c545afc3b7fc2637466ebe4ac5f205e4cbad672591f79f9c5366242"
+  ]
+}
+x-commit-hash: "9236656298b4044a636e1baf6b11d021a2ece634"

--- a/packages/hvsock/hvsock.3.1.0/opam
+++ b/packages/hvsock/hvsock.3.1.0/opam
@@ -50,7 +50,7 @@ and Windows.
 definition of `AF_HYPERV` is not yet stable. If other address families are merged
 before this one then the value of `AF_HYPERV` will change!
 
-Please read [the API documentation](https://djs55.github.io/ocaml-hvsock/index.html)."""
+Please read [the API documentation](https://mirage.github.io/ocaml-hvsock/index.html)."""
 url {
   src:
     "https://github.com/mirage/ocaml-hvsock/releases/download/3.1.0/hvsock-3.1.0.tbz"
@@ -60,3 +60,4 @@ url {
   ]
 }
 x-commit-hash: "9236656298b4044a636e1baf6b11d021a2ece634"
+x-maintenance-intent: [ "(latest)" ]


### PR DESCRIPTION
Bindings for Hyper-V AF_VSOCK

- Project page: <a href="https://github.com/mirage/ocaml-hvsock">https://github.com/mirage/ocaml-hvsock</a>
- Documentation: <a href="https://mirage.github.io/ocaml-hvsock">https://mirage.github.io/ocaml-hvsock</a>

##### CHANGES:

- Update to latest mirage-flow libraries (mirage/ocaml-hvsock#69 from @patricoferris)
- Remove Mirage_time.S (mirage/ocaml-hvsock#69 mirage/ocaml-hvsock#70 from @patricoferris @hannesm)
