### PR TITLE
[deprecated] fswatch and conf-fswatch

### DIFF
--- a/packages/conf-fswatch/conf-fswatch.11-0.1.0/opam
+++ b/packages/conf-fswatch/conf-fswatch.11-0.1.0/opam
@@ -20,7 +20,9 @@ depexts: [
 synopsis: "Virtual package relying on libfswatch installation"
 description: "This package can install only if the libfswatch is available on the system"
 
-flags: [conf]
+messages: ["WARNING! The fswatch library is deprecated!"]
+
+flags: [conf deprecated]
 extra-source "test.c" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-fswatch/test.c"

--- a/packages/conf-fswatch/conf-fswatch.11-0.1.3/opam
+++ b/packages/conf-fswatch/conf-fswatch.11-0.1.3/opam
@@ -13,7 +13,6 @@ build: [
 
 depexts: [
   ["libfswatch-dev"] {os-family = "debian"}
-  ["fswatch"] {os-family = "ubuntu"}
   ["fswatch-devel"] {os-distribution  = "fedora"}
   ["fswatch"] {os-distribution = "arch"}
   ["sys-fs/fswatch"] {os-distribution = "gentoo"}
@@ -24,7 +23,9 @@ depexts: [
 synopsis: "Virtual package relying on libfswatch installation"
 description: "This package can install only if the libfswatch is available on the system"
 
-flags: [conf]
+messages: ["WARNING! The fswatch library is deprecated!"]
+
+flags: [conf deprecated]
 extra-source "test.c" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-fswatch/test.c"

--- a/packages/fswatch/fswatch.11-0.1.0/opam
+++ b/packages/fswatch/fswatch.11-0.1.0/opam
@@ -17,6 +17,9 @@ depends: [
 synopsis: "Bindings for libfswatch -- file change monitor"
 description: """fswatch is a file change monitor that receives notifications when the contents of the specified files or directories are modified."""
 
+messages: ["WARNING! The fswatch library is deprecated!"]
+flags: [deprecated]
+
 url {
   src: "https://github.com/kandu/ocaml-fswatch/archive/11-0.1.0.tar.gz"
   checksum: [

--- a/packages/fswatch/fswatch.11-0.1.1/opam
+++ b/packages/fswatch/fswatch.11-0.1.1/opam
@@ -17,6 +17,9 @@ depends: [
 synopsis: "Bindings for libfswatch -- file change monitor"
 description: """fswatch is a file change monitor that receives notifications when the contents of the specified files or directories are modified."""
 
+messages: ["WARNING! The fswatch library is deprecated!"]
+flags: [deprecated]
+
 url {
   src: "https://github.com/kandu/ocaml-fswatch/archive/11-0.1.1.tar.gz"
   checksum: [

--- a/packages/fswatch/fswatch.11-0.1.3/opam
+++ b/packages/fswatch/fswatch.11-0.1.3/opam
@@ -23,6 +23,9 @@ depends: [
   "dune" {>= "1.4"}
 ]
 
+messages: ["WARNING! The fswatch library is deprecated!"]
+flags: [deprecated]
+
 synopsis: "Bindings for libfswatch -- file change monitor"
 description: """fswatch is a file change monitor that receives notifications when the contents of the specified files or directories are modified."""
 

--- a/packages/fswatch/fswatch.11-0.1.4/opam
+++ b/packages/fswatch/fswatch.11-0.1.4/opam
@@ -26,6 +26,9 @@ depends: [
 synopsis: "Bindings for libfswatch -- file change monitor"
 description: """fswatch is a file change monitor that receives notifications when the contents of the specified files or directories are modified."""
 
+messages: ["WARNING! The fswatch library is deprecated!"]
+flags: [deprecated]
+
 url {
   src: "https://github.com/kandu/ocaml-fswatch/archive/11-0.1.4.tar.gz"
   checksum: [

--- a/packages/fswatch/fswatch.11-0.1.5/opam
+++ b/packages/fswatch/fswatch.11-0.1.5/opam
@@ -26,6 +26,9 @@ depends: [
 synopsis: "Bindings for libfswatch -- file change monitor"
 description: """fswatch is a file change monitor that receives notifications when the contents of the specified files or directories are modified."""
 
+messages: ["WARNING! The fswatch library is deprecated!"]
+flags: [deprecated]
+
 url {
   src: "https://github.com/kandu/ocaml-fswatch/archive/11-0.1.5.tar.gz"
   checksum: [

--- a/packages/fswatch/fswatch.11-0.1.6/opam
+++ b/packages/fswatch/fswatch.11-0.1.6/opam
@@ -26,6 +26,9 @@ depends: [
 synopsis: "Bindings for libfswatch -- file change monitor"
 description: """fswatch is a file change monitor that receives notifications when the contents of the specified files or directories are modified."""
 
+messages: ["WARNING! The fswatch library is deprecated!"]
+flags: [deprecated]
+
 url {
   src: "https://github.com/kandu/ocaml-fswatch/archive/11-0.1.6.tar.gz"
   checksum: [


### PR DESCRIPTION
This PR flags fswatch and conf-fswatch packages as deprecated.

The motivation is base on the discussion here https://github.com/ocaml/opam-repository/issues/22256