### PR TITLE
Set a missing upper bound for owi's smtml dependency

### DIFF
--- a/packages/owi/owi.0.2/opam
+++ b/packages/owi/owi.0.2/opam
@@ -62,7 +62,7 @@ build: [
 dev-repo: "git+https://github.com/ocamlpro/owi.git"
 available: (arch = "x86_32" | arch = "x86_64" | arch = "arm64") & os != "win32"
 depexts: [
-  [ "llvm" "lld" "wabt"]  {os-family = "debian"}
+  [ "llvm" "lld" "wabt"]  {os-family = "debian" | os-family = "ubuntu"}
   [ "llvm" "wabt"]  {os-family = "homebrew"}
   [ "llvm" "lld" "wabt" ] {os-family = "arch"}
   [ "llvm" "lld" "wabt" ] {os-family = "fedora"}


### PR DESCRIPTION
Compiling owi.0.2 is failing on the CI with the following error:
```
#=== ERROR while compiling owi.0.2 ============================================#
# context              2.3.0 | linux/x86_64 | ocaml-base-compiler.5.3.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/owi.0.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p owi -j 255 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/owi-7-afb67f.env
# output-file          ~/.opam/log/owi-7-afb67f.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlc.opt -w +a-4-40-41-42-44-45-70-73 -warn-error +a -g -bin-annot -bin-annot-occurrences -I src/.owi.objs/byte -I src/.owi.objs/public_cmi -I /home/opam/.opam/5.3/lib/astring -I /home/opam/.opam/5.3/lib/base -I /home/opam/.opam/5.3/lib/base/base_internalhash_types -I /home/opam/.opam/5.3/lib/base/md5 -I /home/opam/.opam/5.3/lib/base/shadow_stdlib -I /home/opam/.opam/5.3/lib/base_bigstring -I /home/opam/.opam/5.3/lib/base_quickcheck -I /home/opam/.opam/5.3/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.3/lib/bin_prot -I /home/opam/.opam/5.3/lib/bin_prot/shape -I /home/opam/.opam/5.3/lib/bos -I /home/opam/.opam/5.3/lib/cmdliner -I /home/opam/.opam/5.3/lib/core -I /home/opam/.opam/5.3/lib/core/base_for_tests -I /home/opam/.opam/5.3/lib/core/command -I /home/opam/.opam/5.3/lib/core/filename_base -I /home/opam/.opam/5.3/lib/core/heap_block -I /home/opam/.opam/5.3/lib/core/univ_map -I /home/opam/.opam/5.3/lib/core/validate -I /home/opam/.opam/5.3/lib/digestif -I /home/opam/.opam/5.3/lib/dolmen -I /home/opam/.opam/5.3/lib/dolmen/ae -I /home/opam/.opam/5.3/lib/dolmen/class -I /home/opam/.opam/5.3/lib/dolmen/dimacs -I /home/opam/.opam/5.3/lib/dolmen/icnf -I /home/opam/.opam/5.3/lib/dolmen/intf -I /home/opam/.opam/5.3/lib/dolmen/line -I /home/opam/.opam/5.3/lib/dolmen/smtlib2 -I /home/opam/.opam/5.3/lib/dolmen/smtlib2/poly -I /home/opam/.opam/5.3/lib/dolmen/smtlib2/v6 -I /home/opam/.opam/5.3/lib/dolmen/smtlib2/v6_response -I /home/opam/.opam/5.3/lib/dolmen/smtlib2/v6_script -I /home/opam/.opam/5.3/lib/dolmen/std -I /home/opam/.opam/5.3/lib/dolmen/tptp -I /home/opam/.opam/5.3/lib/dolmen/tptp/v6_3_0 -I /home/opam/.opam/5.3/lib/dolmen/zf -I /home/opam/.opam/5.3/lib/dolmen_type -I /home/opam/.opam/5.3/lib/dune-private-libs/dune-section -I /home/opam/.opam/5.3/lib/dune-site -I /home/opam/.opam/5.3/lib/dune-site/private -I /home/opam/.opam/5.3/lib/eqaf -I /home/opam/.opam/5.3/lib/fieldslib -I /home/opam/.opam/5.3/lib/fmt -I /home/opam/.opam/5.3/lib/fpath -I /home/opam/.opam/5.3/lib/gel -I /home/opam/.opam/5.3/lib/gen -I /home/opam/.opam/5.3/lib/hc -I /home/opam/.opam/5.3/lib/hmap -I /home/opam/.opam/5.3/lib/int_repr -I /home/opam/.opam/5.3/lib/integers -I /home/opam/.opam/5.3/lib/jane-street-headers -I /home/opam/.opam/5.3/lib/jane_rope -I /home/opam/.opam/5.3/lib/logs -I /home/opam/.opam/5.3/lib/menhirLib -I /home/opam/.opam/5.3/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.3/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.3/lib/ocaml/compiler-libs -I /home/opam/.opam/5.3/lib/ocaml/runtime_events -I /home/opam/.opam/5.3/lib/ocaml/threads -I /home/opam/.opam/5.3/lib/ocaml/unix -I /home/opam/.opam/5.3/lib/ocaml_intrinsics -I /home/opam/.opam/5.3/lib/ocaml_intrinsics_kernel -I /home/opam/.opam/5.3/lib/parsexp -I /home/opam/.opam/5.3/lib/patricia-tree -I /home/opam/.opam/5.3/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_derivers -I /home/opam/.opam/5.3/lib/ppx_diff/diffable -I /home/opam/.opam/5.3/lib/ppx_diff/diffable_cinaps -I /home/opam/.opam/5.3/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_expect/config -I /home/opam/.opam/5.3/lib/ppx_expect/config_types -I /home/opam/.opam/5.3/lib/ppx_expect/make_corrected_file -I /home/opam/.opam/5.3/lib/ppx_expect/runtime -I /home/opam/.opam/5.3/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_inline_test/config -I /home/opam/.opam/5.3/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_log/syntax -I /home/opam/.opam/5.3/lib/ppx_log/types -I /home/opam/.opam/5.3/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.3/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.3/lib/ppx_stable_witness/runtime -I /home/opam/.opam/5.3/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/5.3/lib/ppx_string/runtime -I /home/opam/.opam/5.3/lib/ppxlib -I /home/opam/.opam/5.3/lib/ppxlib/ast -I /home/opam/.opam/5.3/lib/ppxlib/astlib -I /home/opam/.opam/5.3/lib/ppxlib/print_diff -I /home/opam/.opam/5.3/lib/ppxlib/stdppx -I /home/opam/.opam/5.3/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.3/lib/prelude -I /home/opam/.opam/5.3/lib/pyml -I /home/opam/.opam/5.3/lib/re2 -I /home/opam/.opam/5.3/lib/re2/c -I /home/opam/.opam/5.3/lib/regex_parser_intf -I /home/opam/.opam/5.3/lib/rresult -I /home/opam/.opam/5.3/lib/scfg -I /home/opam/.opam/5.3/lib/sedlex -I /home/opam/.opam/5.3/lib/seq -I /home/opam/.opam/5.3/lib/sexplib -I /home/opam/.opam/5.3/lib/sexplib0 -I /home/opam/.opam/5.3/lib/smtml -I /home/opam/.opam/5.3/lib/smtml/prelude -I /home/opam/.opam/5.3/lib/spelll -I /home/opam/.opam/5.3/lib/splittable_random -I /home/opam/.opam/5.3/lib/stdcompat -I /home/opam/.opam/5.3/lib/stdio -I /home/opam/.opam/5.3/lib/stdlib-shims -I /home/opam/.opam/5.3/lib/time_now -I /home/opam/.opam/5.3/lib/typerep -I /home/opam/.opam/5.3/lib/uutf -I /home/opam/.opam/5.3/lib/variantslib -I /home/opam/.opam/5.3/lib/xmlm -I /home/opam/.opam/5.3/lib/yojson -I /home/opam/.opam/5.3/lib/zarith -cmi-file src/.owi.objs/byte/owi__Symbolic_value.cmi -no-alias-deps -open Owi -o src/.owi.objs/byte/owi__Symbolic_value.cmo -c -impl src/symbolic/symbolic_value.pp.ml)
# File "src/symbolic/symbolic_value.ml", line 32, characters 50-53:
# 32 | let const_i32 (i : Int32.t) : int32 = value (Num (I32 i))
#                                                        ^^^
# Error: This variant expression is expected to have type "Smtml.Num.t"
#        There is no constructor "I32" within type "Smtml.Num.t"
# Hint: Did you mean "F32"?
```

This has been observed on #28397 (and the dune.3.20 pre-releases) as well as on #28399.

The reason is that smtml.0.7.0 changed the public interface in https://github.com/formalsec/smtml/pull/284
https://github.com/formalsec/smtml/blob/main/CHANGES.md#070---2025-05-07
```
### 0.7.0 - 2025-05-07
[...]
2025-05-07 Remove integer ADT from Num.t
[...]
```

This PR therefore sets smtml.0.7.0 as an upper bound.
(That one is also the earliest version not archived - but we can decide whether to restore a 0.6.x release separately)