### PR TITLE
Package coq-waterproof.3.0.0+8.17

### DIFF
--- a/packages/coq-waterproof/coq-waterproof.3.0.0+8.17/opam
+++ b/packages/coq-waterproof/coq-waterproof.3.0.0+8.17/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Jim Portegies <j.w.portegies@tue.nl>"
+authors: [
+  "Jelle Wemmenhove"
+  "Pim Otte"
+  "Balthazar Pathiachvili"
+  "Cosmin Manea"
+  "Lulof Pirée"
+  "Adrian Vrămuleţ"
+  "Tudor Voicu"
+  "Jim Portegies <j.w.portegies@tue.nl>"
+]
+
+synopsis: "Coq proofs in a style that resembles non-mechanized mathematical proofs"
+description: """
+The Waterproof plugin for the Coq proof assistant allows you to write Coq proofs in a style that resembles handwritten mathematical proofs, designed to help university students with learning how to prove mathematical statements.
+"""
+
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/impermeable/coq-waterproof"
+dev-repo: "git+https://github.com/impermeable/coq-waterproof.git"
+bug-reports: "https://github.com/impermeable/coq-waterproof/issues"
+
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "coq" {>= "8.17" & < "8.18"}
+  "dune" {>= "3.6."}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install"]
+]
+
+available: (arch != "s390x") & (arch != "ppc64") & (os != "win32")
+
+tags: [
+  "keyword:mathematics education"
+  "category:Mathematics/Education"
+  "date:2023-11-04"
+  "logpath:Waterproof"
+]
+url {
+  src:
+    "https://github.com/impermeable/coq-waterproof/archive/refs/tags/3.0.0+8.17.tar.gz"
+  checksum: [
+    "md5=0d402d92c1d3309dcb01fcbdb7f72c37"
+    "sha512=7a82041ef05b3edd0fbe2f63507a7ce7d910f6bf3f2a5d615b0c6f55986fd60ae2d5006983929d08a63a3a2c917801709aa4a47d2c1161a2d72d223081d341a9"
+  ]
+}

--- a/packages/coq-waterproof/coq-waterproof.3.0.0+8.17/opam
+++ b/packages/coq-waterproof/coq-waterproof.3.0.0+8.17/opam
@@ -33,7 +33,7 @@ build: [
 
 available: (arch != "s390x") & (arch != "ppc64") & (os != "win32")
 
-conflicts: [ "ocaml-option-bytecode-only" {arch = "arm32" | arch = "x86_32"} ]
+conflicts: [ "ocaml-option-bytecode-only" ]
 
 tags: [
   "keyword:mathematics education"

--- a/packages/coq-waterproof/coq-waterproof.3.0.0+8.17/opam
+++ b/packages/coq-waterproof/coq-waterproof.3.0.0+8.17/opam
@@ -24,7 +24,7 @@ bug-reports: "https://github.com/impermeable/coq-waterproof/issues"
 depends: [
   "ocaml" {>= "4.09.0"}
   "coq" {>= "8.17" & < "8.18"}
-  "dune" {>= "3.6."}
+  "dune" {>= "3.8."}
 ]
 
 build: [

--- a/packages/coq-waterproof/coq-waterproof.3.0.0+8.17/opam
+++ b/packages/coq-waterproof/coq-waterproof.3.0.0+8.17/opam
@@ -24,7 +24,7 @@ bug-reports: "https://github.com/impermeable/coq-waterproof/issues"
 depends: [
   "ocaml" {>= "4.09.0"}
   "coq" {>= "8.17" & < "8.18"}
-  "dune" {>= "3.8."}
+  "dune" {>= "3.8"}
 ]
 
 build: [

--- a/packages/coq-waterproof/coq-waterproof.3.0.0+8.17/opam
+++ b/packages/coq-waterproof/coq-waterproof.3.0.0+8.17/opam
@@ -33,6 +33,8 @@ build: [
 
 available: (arch != "s390x") & (arch != "ppc64") & (os != "win32")
 
+conflicts: [ "ocaml-option-bytecode-only" {arch = "arm32" | arch = "x86_32"} ]
+
 tags: [
   "keyword:mathematics education"
   "category:Mathematics/Education"


### PR DESCRIPTION
### `coq-waterproof.3.0.0+8.17`
Coq proofs in a style that resembles non-mechanized mathematical proofs
The Waterproof plugin for the Coq proof assistant allows you to write Coq proofs in a style that resembles handwritten mathematical proofs, designed to help university students with learning how to prove mathematical statements.



---
* Homepage: https://github.com/impermeable/coq-waterproof
* Source repo: git+https://github.com/impermeable/coq-waterproof.git
* Bug tracker: https://github.com/impermeable/coq-waterproof/issues

---
:camel: Pull-request generated by opam-publish v2.2.0