### PR TITLE
Package coq-waterproof.3.0.0+9.0

### DIFF
--- a/packages/coq-waterproof/coq-waterproof.3.0.0+9.0/opam
+++ b/packages/coq-waterproof/coq-waterproof.3.0.0+9.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "Jim Portegies <j.w.portegies@tue.nl>"
+authors: [
+  "Jelle Wemmenhove"
+  "Pim Otte"
+  "Balthazar Pathiachvili"
+  "Cosmin Manea"
+  "Lulof Pirée"
+  "Adrian Vrămuleţ"
+  "Tudor Voicu"
+  "Jim Portegies <j.w.portegies@tue.nl>"
+]
+
+synopsis: "Coq proofs in a style that resembles non-mechanized mathematical proofs"
+description: """
+The Waterproof plugin for the Coq proof assistant allows you to write Coq proofs in a style that resembles handwritten mathematical proofs, designed to help university students with learning how to prove mathematical statements.
+"""
+
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/impermeable/coq-waterproof"
+dev-repo: "git+https://github.com/impermeable/coq-waterproof.git"
+bug-reports: "https://github.com/impermeable/coq-waterproof/issues"
+
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "rocq-prover" {>= "9.0" & < "9.1" | = "dev"}
+  "coq" {>= "9.0" & < "9.1" | = "dev"}
+  "dune" {>= "3.8"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install"]
+]
+
+available: (arch != "s390x") & (arch != "ppc64")
+
+tags: [
+  "keyword:mathematics education"
+  "category:Mathematics/Education"
+  "date:2023-11-04"
+  "logpath:Waterproof"
+]
+url {
+  src:
+    "https://github.com/impermeable/coq-waterproof/archive/refs/tags/3.0.0+9.0.tar.gz"
+  checksum: [
+    "md5=c7cd0b7e7b58dcd1dfc09564f44bef85"
+    "sha512=4d23ebf53fd47ca2e3d0d2b0c1ce042ccd0a1ad2c6bcdccb3d402336f3d3957ea1fb469b749ac1b635a0f480a7c94ba65f820a940543276631ffb478be2ff4f4"
+  ]
+}


### PR DESCRIPTION
### `coq-waterproof.3.0.0+9.0`
Coq proofs in a style that resembles non-mechanized mathematical proofs
The Waterproof plugin for the Coq proof assistant allows you to write Coq proofs in a style that resembles handwritten mathematical proofs, designed to help university students with learning how to prove mathematical statements.



---
* Homepage: https://github.com/impermeable/coq-waterproof
* Source repo: git+https://github.com/impermeable/coq-waterproof.git
* Bug tracker: https://github.com/impermeable/coq-waterproof/issues

---
:camel: Pull-request generated by opam-publish v2.2.0