### PR TITLE
Fix shuttle_http.0.11.0 and shuttle_websocket.0.11.0 404s

### DIFF
--- a/packages/shuttle_http/shuttle_http.0.11.0/opam
+++ b/packages/shuttle_http/shuttle_http.0.11.0/opam
@@ -38,7 +38,7 @@ build: [
 ]
 dev-repo: "git+https://git.sr.ht/~soni/shuttle_http"
 url {
-  src: "https://git.sr.ht/~soni/shuttle_http/archive/0.11.0.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/shuttle_http-0.11.0.tar.gz"
   checksum: [
     "md5=c18e89676a71564229afaf9d40a64ebb"
     "sha512=12d9dc7f6ab96147c14469bb48f56b5f528633d7925033aea99b303976868cc762919228057511a8d658c76496636c69f9e283c91d76eadbb7bd5443c492d939"

--- a/packages/shuttle_websocket/shuttle_websocket.0.11.0/opam
+++ b/packages/shuttle_websocket/shuttle_websocket.0.11.0/opam
@@ -30,7 +30,7 @@ build: [
 ]
 dev-repo: "git+https://git.sr.ht/~soni/shuttle_http"
 url {
-  src: "https://git.sr.ht/~soni/shuttle_http/archive/0.11.0.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/shuttle_http-0.11.0.tar.gz"
   checksum: [
     "md5=c18e89676a71564229afaf9d40a64ebb"
     "sha512=12d9dc7f6ab96147c14469bb48f56b5f528633d7925033aea99b303976868cc762919228057511a8d658c76496636c69f9e283c91d76eadbb7bd5443c492d939"


### PR DESCRIPTION
`shuttle_http` and `shuttle_websocket` seems to have been temporarily relocated to https://git.sr.ht/~soni/shuttle_http
for the 0.11.0 release, but now the URL gives a 404 on #28397, #28357 and earlier dune pre-releases, resulting in:

- :x: [shuttle_http.0.11.0 (failed: Failed to get sources of shuttle_http.0.11.0: curl error code 404)](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/13c7baba98a78bb5e39d3ae30e04f5d994db41c3/variant/compilers,4.14,dune-configurator.3.20.1,revdeps,shuttle_http.0.11.0)
- :x: [shuttle_websocket.0.11.0 (failed: Failed to get sources of shuttle_http.0.11.0, shuttle_websocket.0.11.0 (https://git.sr.ht/~soni/shuttle_http/archive/0.11.0.tar.gz): curl error code 404)](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/13c7baba98a78bb5e39d3ae30e04f5d994db41c3/variant/compilers,4.14,dune-configurator.3.20.1,revdeps,shuttle_websocket.0.11.0)

https://github.com/ocaml/opam-source-archives/pull/50 restored the (shared) tar-ball from cache, and this PR updates the `src` `url` to the newly restored location.
