### PR TITLE
[new release] conf-libev 4-13

### DIFF
--- a/packages/conf-libev/conf-libev.4-13/opam
+++ b/packages/conf-libev/conf-libev.4-13/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "http://software.schmorp.de/pkg/libev.html"
+authors: "Marc Lehmann"
+license: "BSD-2-Clause"
+build: [["sh" "./build.sh"]]
+depends: [
+  "ocaml" {>= "3.11.0"}
+]
+depexts: [
+  ["libev-dev"] {os-family = "debian"}
+  ["libev-dev"] {os-family = "ubuntu"}
+  ["libev"] {os = "macos" & os-distribution = "homebrew"}
+  ["libev-dev"] {os-family = "alpine"}
+  ["libev"] {os-family = "arch"}
+  ["libev-devel"] {os-family = "fedora"}
+  ["libev-devel"] {os-distribution = "rhel"}
+  ["libev-devel"] {os-distribution = "centos"}
+  ["libev-devel"] {os-distribution = "ol" & os-version >= "8"}
+  ["libev-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["libev"] {os = "freebsd"}
+  ["libev"] {os = "openbsd"}
+  ["libev"] {os = "netbsd"}
+  ["libev"] {os-distribution = "nixos"}
+]
+synopsis: "High-performance event loop/event model with lots of features"
+description: """
+Libev is modelled (very loosely) after libevent and the Event perl
+module, but is faster, scales better and is more correct, and also more
+featureful. And also smaller. Yay."""
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+available: os != "win32"
+flags: conf
+extra-source "discover.ml" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-libev/discover.ml.4-13"
+  checksum: [
+    "sha256=569e94c09c4722989c3acb0f6b709a5dd6218f79175268c7f40f4bd26abd4fc2"
+    "md5=0c92517ce8da8366129ee2fff4035951"
+  ]
+}
+extra-source "build.sh" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-libev/build.sh"
+  checksum: [
+    "sha256=4825462f8f84312caf9a2c797bbd24abc776d8a343de5561330314d846e5cf61"
+    "md5=f37b5eb73ebeb177dff1cd8bb2f38c4e"
+  ]
+}


### PR DESCRIPTION
add support for netbsd and pkgsrc bootstrapped systems

this PR works in pairs with https://github.com/ocaml/opam-source-archives/pull/51 which is a new discover.ml routine supporting netbsd and pkgsrc bootstrapped system. As that PR was merged, it's time to get this PR submitted.