### PR TITLE
9 packages from mbarbin/vcs at 0.0.21

### DIFF
--- a/packages/volgo-base/volgo-base.0.0.21/opam
+++ b/packages/volgo-base/volgo-base.0.0.21/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis: "An Extension of volgo.Vcs to use with Base"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "base" {>= "v0.17"}
+  "fpath" {>= "0.7.3"}
+  "fpath-base" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "ppx_compare" {>= "v0.17"}
+  "ppx_enumerate" {>= "v0.17"}
+  "ppx_hash" {>= "v0.17"}
+  "ppx_here" {>= "v0.17"}
+  "ppx_let" {>= "v0.17"}
+  "ppx_sexp_conv" {>= "v0.17"}
+  "ppx_sexp_value" {>= "v0.17"}
+  "ppxlib" {>= "0.33"}
+  "volgo" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[Volgo_base] is a library that extends the [Vcs] library with
+additional modules and functionalities to improve compatibility with
+programs using [base].
+
+For example, it adds [Comparable.S] to all container key modules so
+that they can be used with [base]-style containers such as [Map] and
+[Hashtbl].
+
+It also exports a module [Vcs.Or_error] to make it easy to use [Vcs]
+with the [Or_error] monad.
+
+The library is designed to be used as a drop-in replacement for [Vcs].
+To achieve this, it includes a single module named [Vcs] which must be
+set up to shadow the regular [Vcs] module.
+
+[base]: https://github.com/janestreet/base
+
+"""
+tags: [ "git" "vcs" "base" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.21/volgo-0.0.21.tbz"
+  checksum: [
+    "sha256=b34a73addb7bbcad6ae8276903fb5ca5b7c7d810c911931e770eaff229bb3140"
+    "sha512=1dacbd771bdd8e43ddfd901f70e803b77b48f811f3b50a90e1aafadfa6be874b5b75049b9185cb07f1555dd1d1aa67d0fe1e16ef3c7c32ba6be47d058e597e80"
+  ]
+}
+x-commit-hash: "7b2d3b3fb82d01c1916d6bd8c8047d0b5f3a3e36"

--- a/packages/volgo-git-backend/volgo-git-backend.0.0.21/opam
+++ b/packages/volgo-git-backend/volgo-git-backend.0.0.21/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "An IO-free library that parses the output of Git commands"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "astring" {>= "0.8.5"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "sexplib0" {>= "v0.16"}
+  "volgo" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo] is a set of OCaml libraries for interacting with Git
+repositories. It provides a type-safe and direct-style API to
+programmatically perform Git operations, ranging from creating commits
+and branches to loading and navigating commit graphs in memory,
+computing diffs between revisions, and more.
+
+[Volgo_git_backend] is not meant to be used directly by a user. Rather
+it is a helper library for building Git CLI backends for [volgo]. Given
+the ability to run a [git] process, this library knows which commands
+to run, how to parse their output, and how to interpret their exit
+codes to turn them into typed results.
+
+"""
+tags: [ "cli" "git" "vcs" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.21/volgo-0.0.21.tbz"
+  checksum: [
+    "sha256=b34a73addb7bbcad6ae8276903fb5ca5b7c7d810c911931e770eaff229bb3140"
+    "sha512=1dacbd771bdd8e43ddfd901f70e803b77b48f811f3b50a90e1aafadfa6be874b5b75049b9185cb07f1555dd1d1aa67d0fe1e16ef3c7c32ba6be47d058e597e80"
+  ]
+}
+x-commit-hash: "7b2d3b3fb82d01c1916d6bd8c8047d0b5f3a3e36"

--- a/packages/volgo-git-eio/volgo-git-eio.0.0.21/opam
+++ b/packages/volgo-git-eio/volgo-git-eio.0.0.21/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "A Git backend for Vcs based on Volgo_git_backend for Eio programs"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "conf-git" {with-test}
+  "eio" {>= "1.0"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "sexplib0" {>= "v0.17"}
+  "volgo" {= version}
+  "volgo-git-backend" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo] is a set of OCaml libraries for interacting with Git
+repositories. It provides a type-safe and direct-style API to
+programmatically perform Git operations, ranging from creating
+commits and branches to loading and navigating commit graphs in
+memory, computing diffs between revisions, and more.
+
+[Volgo_git_eio] implements a Git backend for [volgo] based on [eio].
+It runs the [git] CLI as a subprocess in a non-blocking fashion.
+
+[eio]: https://github.com/ocaml-multicore/eio
+
+"""
+tags: [ "eio" "git" "vcs" "non-blocking-io" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.21/volgo-0.0.21.tbz"
+  checksum: [
+    "sha256=b34a73addb7bbcad6ae8276903fb5ca5b7c7d810c911931e770eaff229bb3140"
+    "sha512=1dacbd771bdd8e43ddfd901f70e803b77b48f811f3b50a90e1aafadfa6be874b5b75049b9185cb07f1555dd1d1aa67d0fe1e16ef3c7c32ba6be47d058e597e80"
+  ]
+}
+x-commit-hash: "7b2d3b3fb82d01c1916d6bd8c8047d0b5f3a3e36"

--- a/packages/volgo-git-unix/volgo-git-unix.0.0.21/opam
+++ b/packages/volgo-git-unix/volgo-git-unix.0.0.21/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis:
+  "A Git backend for Vcs based on Volgo_git_backend and the Unix library"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "conf-git" {with-test}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "sexplib0" {>= "v0.16"}
+  "spawn" {>= "v0.16"}
+  "volgo" {= version}
+  "volgo-git-backend" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo] is a set of OCaml libraries for interacting with Git
+repositories. It provides a type-safe and direct-style API to
+programmatically perform Git operations, ranging from creating
+commits and branches to loading and navigating commit graphs in
+memory, computing diffs between revisions, and more.
+
+[Volgo_git_unix] implements a Git backend for [volgo] based on the
+OCaml standard library. It runs the [git] CLI as a subprocess in a
+blocking fashion, similar to the Stdlib's [Unix] module.
+
+"""
+tags: [ "git" "vcs" "blocking-io" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.21/volgo-0.0.21.tbz"
+  checksum: [
+    "sha256=b34a73addb7bbcad6ae8276903fb5ca5b7c7d810c911931e770eaff229bb3140"
+    "sha512=1dacbd771bdd8e43ddfd901f70e803b77b48f811f3b50a90e1aafadfa6be874b5b75049b9185cb07f1555dd1d1aa67d0fe1e16ef3c7c32ba6be47d058e597e80"
+  ]
+}
+x-commit-hash: "7b2d3b3fb82d01c1916d6bd8c8047d0b5f3a3e36"

--- a/packages/volgo-hg-backend/volgo-hg-backend.0.0.21/opam
+++ b/packages/volgo-hg-backend/volgo-hg-backend.0.0.21/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "An IO-free library that parses the output of Mercurial commands"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "astring" {>= "0.8.5"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "sexplib0" {>= "v0.16"}
+  "volgo" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo] is a set of OCaml libraries for interacting with Git
+repositories. It provides a type-safe and direct-style API to
+programmatically perform Git operations, ranging from creating commits
+and branches to loading and navigating commit graphs in memory,
+computing diffs between revisions, and more.
+
+[Volgo_hg_backend] is not meant to be used directly by a user. Rather
+it is a helper library for building Mercurial CLI backends for
+[volgo]. Given the ability to run a [hg] process, this library knows
+which commands to run, how to parse their output, and how to
+interpret their exit codes to turn them into typed results.
+
+"""
+tags: [ "cli" "git" "mercurial" "vcs" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.21/volgo-0.0.21.tbz"
+  checksum: [
+    "sha256=b34a73addb7bbcad6ae8276903fb5ca5b7c7d810c911931e770eaff229bb3140"
+    "sha512=1dacbd771bdd8e43ddfd901f70e803b77b48f811f3b50a90e1aafadfa6be874b5b75049b9185cb07f1555dd1d1aa67d0fe1e16ef3c7c32ba6be47d058e597e80"
+  ]
+}
+x-commit-hash: "7b2d3b3fb82d01c1916d6bd8c8047d0b5f3a3e36"

--- a/packages/volgo-hg-eio/volgo-hg-eio.0.0.21/opam
+++ b/packages/volgo-hg-eio/volgo-hg-eio.0.0.21/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis:
+  "A Mercurial backend for Vcs based on Volgo_hg_backend for Eio programs"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "conf-hg" {with-test}
+  "eio" {>= "1.0"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "sexplib0" {>= "v0.17"}
+  "volgo" {= version}
+  "volgo-git-eio" {= version}
+  "volgo-hg-backend" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo] is a set of OCaml libraries for interacting with Git
+repositories. It provides a type-safe and direct-style API to
+programmatically perform Git operations, ranging from creating
+commits and branches to loading and navigating commit graphs in
+memory, computing diffs between revisions, and more.
+
+[Volgo_hg_eio] implements a Mercurial backend for [volgo] based on
+[eio]. It runs the [hg] CLI as a subprocess in a non-blocking
+fashion.
+
+"""
+tags: [ "eio" "git" "mercurial" "vcs" "non-blocking-io" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.21/volgo-0.0.21.tbz"
+  checksum: [
+    "sha256=b34a73addb7bbcad6ae8276903fb5ca5b7c7d810c911931e770eaff229bb3140"
+    "sha512=1dacbd771bdd8e43ddfd901f70e803b77b48f811f3b50a90e1aafadfa6be874b5b75049b9185cb07f1555dd1d1aa67d0fe1e16ef3c7c32ba6be47d058e597e80"
+  ]
+}
+x-commit-hash: "7b2d3b3fb82d01c1916d6bd8c8047d0b5f3a3e36"

--- a/packages/volgo-hg-unix/volgo-hg-unix.0.0.21/opam
+++ b/packages/volgo-hg-unix/volgo-hg-unix.0.0.21/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis:
+  "A Mercurial backend for Vcs based on Volgo_hg_backend and the Unix library"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "conf-hg" {with-test}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "sexplib0" {>= "v0.16"}
+  "volgo" {= version}
+  "volgo-git-unix" {= version}
+  "volgo-hg-backend" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo] is a set of OCaml libraries for interacting with Git
+repositories. It provides a type-safe and direct-style API to
+programmatically perform Git operations, ranging from creating
+commits and branches to loading and navigating commit graphs in
+memory, computing diffs between revisions, and more.
+
+[Volgo_hg_unix] implements a Mercurial backend for [volgo] based on
+the OCaml standard library. It runs the [hg] CLI as a subprocess in
+a blocking fashion, similar to the Stdlib's [Unix] module.
+
+"""
+tags: [ "git" "mercurial" "vcs" "blocking-io" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.21/volgo-0.0.21.tbz"
+  checksum: [
+    "sha256=b34a73addb7bbcad6ae8276903fb5ca5b7c7d810c911931e770eaff229bb3140"
+    "sha512=1dacbd771bdd8e43ddfd901f70e803b77b48f811f3b50a90e1aafadfa6be874b5b75049b9185cb07f1555dd1d1aa67d0fe1e16ef3c7c32ba6be47d058e597e80"
+  ]
+}
+x-commit-hash: "7b2d3b3fb82d01c1916d6bd8c8047d0b5f3a3e36"

--- a/packages/volgo-vcs/volgo-vcs.0.0.21/opam
+++ b/packages/volgo-vcs/volgo-vcs.0.0.21/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis:
+  "A command line tool for vcs operations based on the volgo libraries"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "cmdlang" {>= "0.0.9"}
+  "conf-git" {with-test}
+  "conf-hg" {with-test}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "sexplib0" {>= "v0.16"}
+  "volgo" {= version}
+  "volgo-git-backend" {= version}
+  "volgo-git-unix" {= version}
+  "volgo-hg-backend" {= version}
+  "volgo-hg-unix" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo-vcs] is a package from the [volgo] project that provides a
+command-line interface called [volgo-vcs]. This CLI is implemented
+on top of the other packages from the project.
+
+It allows users to run exploratory tests using the [volgo] interfaces
+and the Git backends available on actual repositories, directly from
+the command line.
+
+This tool can be helpful for reproducing issues with the library or
+getting familiar with some functionality of the project in an
+interactive fashion using real live data.
+
+"""
+tags: [ "cli" "git" "vcs" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.21/volgo-0.0.21.tbz"
+  checksum: [
+    "sha256=b34a73addb7bbcad6ae8276903fb5ca5b7c7d810c911931e770eaff229bb3140"
+    "sha512=1dacbd771bdd8e43ddfd901f70e803b77b48f811f3b50a90e1aafadfa6be874b5b75049b9185cb07f1555dd1d1aa67d0fe1e16ef3c7c32ba6be47d058e597e80"
+  ]
+}
+x-commit-hash: "7b2d3b3fb82d01c1916d6bd8c8047d0b5f3a3e36"

--- a/packages/volgo/volgo.0.0.21/opam
+++ b/packages/volgo/volgo.0.0.21/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "A Versatile OCaml Library for Git Operations"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/vcs"
+doc: "https://mbarbin.github.io/vcs/"
+bug-reports: "https://github.com/mbarbin/vcs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "astring" {>= "0.8.5"}
+  "bitv" {>= "2.1"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "sexplib0" {>= "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/vcs.git"
+description: """\
+
+[volgo] is a set of OCaml libraries for interacting with Git
+repositories. It provides a type-safe and direct-style API to
+programmatically perform Git operations, ranging from creating
+commits and branches to loading and navigating commit graphs in
+memory, computing diffs between revisions, and more.
+
+[Vcs] is the user-facing OCaml module for the project and
+dynamically dispatches its implementation at runtime.
+
+"""
+tags: [ "git" "vcs" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/vcs/releases/download/0.0.21/volgo-0.0.21.tbz"
+  checksum: [
+    "sha256=b34a73addb7bbcad6ae8276903fb5ca5b7c7d810c911931e770eaff229bb3140"
+    "sha512=1dacbd771bdd8e43ddfd901f70e803b77b48f811f3b50a90e1aafadfa6be874b5b75049b9185cb07f1555dd1d1aa67d0fe1e16ef3c7c32ba6be47d058e597e80"
+  ]
+}
+x-commit-hash: "7b2d3b3fb82d01c1916d6bd8c8047d0b5f3a3e36"


### PR DESCRIPTION
This pull-request concerns:
- `volgo.0.0.21`: A Versatile OCaml Library for Git Operations
- `volgo-base.0.0.21`: An Extension of volgo.Vcs to use with Base
- `volgo-git-backend.0.0.21`: An IO-free library that parses the output of Git commands
- `volgo-git-eio.0.0.21`: A Git backend for Vcs based on Volgo_git_backend for Eio programs
- `volgo-git-unix.0.0.21`: A Git backend for Vcs based on Volgo_git_backend and the Unix library
- `volgo-hg-backend.0.0.21`: An IO-free library that parses the output of Mercurial commands
- `volgo-hg-eio.0.0.21`: A Mercurial backend for Vcs based on Volgo_hg_backend for Eio programs
- `volgo-hg-unix.0.0.21`: A Mercurial backend for Vcs based on Volgo_hg_backend and the Unix library
- `volgo-vcs.0.0.21`: A command line tool for vcs operations based on the volgo libraries



---
* Homepage: https://github.com/mbarbin/vcs
* Source repo: git+https://github.com/mbarbin/vcs.git
* Bug tracker: https://github.com/mbarbin/vcs/issues

---
## 0.0.21 (2025-08-27)

### Changed

- Replace naive bit_vector module by bitv ([#96](https://github.com/mbarbin/vcs/pull/96), @mbarbin).

## 0.0.20 (2025-08-14)

### Changed

- Removed some build dependencies from kernel parts ([#92](https://github.com/mbarbin/vcs/pull/92), [#93](https://github.com/mbarbin/vcs/pull/93), [#94](https://github.com/mbarbin/vcs/pull/94), [#95](https://github.com/mbarbin/vcs/pull/95), @mbarbin).
- Update CRs Actions workflows ([#90](https://github.com/mbarbin/vcs/pull/90), [#91](https://github.com/mbarbin/vcs/pull/91), @mbarbin).

## 0.0.19 (2025-07-22)

### Added

- Add function `Vcs.current_branch_opt` ([#87](https://github.com/mbarbin/vcs/pull/87), @mbarbin).

### Changed

- Make `current_branch` in the backend return an option ([#87](https://github.com/mbarbin/vcs/pull/87), @mbarbin).

### Fixed

- Improve handling of diff when filenames have curly-braces ([#89](https://github.com/mbarbin/vcs/pull/89), @mbarbin).
- Handle file type changes in `name-status` diff computation ([#88](https://github.com/mbarbin/vcs/pull/88), @mbarbin).
- Allow char '#' in branch names ([#88](https://github.com/mbarbin/vcs/pull/88), @mbarbin).


---
:camel: Pull-request generated by opam-publish v2.5.1