### PR TITLE
remove "lablgl" from conflicts lines, since it seems like it builds

### DIFF
--- a/packages/camlp5/camlp5.8.03.00/opam
+++ b/packages/camlp5/camlp5.8.03.00/opam
@@ -55,7 +55,6 @@ conflicts: [
    "pa_ppx" { < "0.15" }
    "p5scm" { <= "0.3.1" }
    "matita" { <= "0.99.5" }
-   "lablgl" { <= "1.07" }
 ]
 x-ci-accept-failures: [ "opensuse-tumbleweed" ]
 dev-repo: "git+https://github.com/camlp5/camlp5.git"

--- a/packages/camlp5/camlp5.8.03.04/opam
+++ b/packages/camlp5/camlp5.8.03.04/opam
@@ -56,7 +56,6 @@ conflicts: [
    "pa_ppx" { < "0.18" }
    "p5scm" { <= "0.3.1" }
    "matita" { <= "0.99.5" }
-   "lablgl" { <= "1.07" }
    "frama-clang" { = "0.0.14" }
 ]
 x-ci-accept-failures: [ "opensuse-tumbleweed" ]

--- a/packages/camlp5/camlp5.8.03.05/opam
+++ b/packages/camlp5/camlp5.8.03.05/opam
@@ -56,7 +56,6 @@ conflicts: [
    "pa_ppx" { < "0.18" }
    "p5scm" { <= "0.3.1" }
    "matita" { <= "0.99.5" }
-   "lablgl" { <= "1.07" }
    "frama-clang" { = "0.0.14" }
 ]
 x-ci-accept-failures: [ "opensuse-tumbleweed" ]

--- a/packages/camlp5/camlp5.8.03.06/opam
+++ b/packages/camlp5/camlp5.8.03.06/opam
@@ -58,7 +58,6 @@ conflicts: [
    "pa_ppx" { <= "0.19" }
    "p5scm" { <= "0.3.1" }
    "matita" { <= "0.99.5" }
-   "lablgl" { <= "1.07" }
    "frama-clang" { = "0.0.14" }
 ]
 x-ci-accept-failures: [ "opensuse-tumbleweed" ]


### PR DESCRIPTION
remove "lablgl" from conflicts lines, since it seems like it builds fine with camlp5.  Not sure why it was in conflicts.