### PR TITLE
Package ldap.2.5.2

### DIFF
--- a/packages/ldap/ldap.2.5.2/opam
+++ b/packages/ldap/ldap.2.5.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Implementation of the Light Weight Directory Access Protocol"
+maintainer: "Kate <kit-ty-kate@exn.st>"
+authors: "Eric Stokes <letaris@me.com>"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+tags: "ldap"
+homepage: "https://github.com/kit-ty-kate/ocamldap"
+doc: "https://kit-ty-kate.github.io/ocamldap"
+bug-reports: "https://github.com/kit-ty-kate/ocamldap/issues"
+depends: [
+  "base64" {>= "3.0.0"}
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.03.0"}
+  "re" {>= "1.3.0"}
+  "camlp-streams" {>= "5.0.1"}
+  "ssl" {>= "0.5.3"}
+]
+conflicts: [
+  "ocamldap" {!= "transition"}
+]
+build: [
+  "dune"
+  "build"
+  "-p"
+  name
+  "-j"
+  jobs
+  "@install"
+  "@runtest" {with-test}
+]
+dev-repo: "git+https://github.com/kit-ty-kate/ocamldap.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/ocamldap/releases/download/2.5.2/ldap-2.5.2.tar.gz"
+  checksum: [
+    "md5=746db5d6239931ff7ceff7a75bc61315"
+    "sha512=8dcad3e5b86445c914ea6bb76e2a8fbf35deb674b226222a6482e3ffea0144b30f2e39bb2920b068b0c11f66a4bda3c12d5e1408e19739069ef066ce5b65980c"
+  ]
+}

--- a/packages/ldap/ldap.2.5.2/opam
+++ b/packages/ldap/ldap.2.5.2/opam
@@ -37,3 +37,4 @@ url {
     "sha512=8dcad3e5b86445c914ea6bb76e2a8fbf35deb674b226222a6482e3ffea0144b30f2e39bb2920b068b0c11f66a4bda3c12d5e1408e19739069ef066ce5b65980c"
   ]
 }
+x-maintenance-intent: "(latest)"


### PR DESCRIPTION
### `ldap.2.5.2`
Implementation of the Light Weight Directory Access Protocol



---
* Homepage: https://github.com/kit-ty-kate/ocamldap
* Source repo: git+https://github.com/kit-ty-kate/ocamldap.git
* Bug tracker: https://github.com/kit-ty-kate/ocamldap/issues

---
:camel: Pull-request generated by opam-publish v2.5.0