### PR TITLE
[new release] mirage-mtime (5.2.0)

### DIFF
--- a/packages/mirage-mtime/mirage-mtime.5.2.0/opam
+++ b/packages/mirage-mtime/mirage-mtime.5.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "hannes@mehnert.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray" "Hannes Mehnert"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-mtime"
+doc: "https://mirage.github.io/mirage-mtime/"
+bug-reports: "https://github.com/mirage/mirage-mtime/issues"
+synopsis: "Libraries and module types for a monotonic clock"
+description: """
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirageos.org) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements a monotonic timesource since an arbitrary point.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "mtime" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-mtime.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-mtime/releases/download/v5.2.0/mirage-mtime-5.2.0.tbz"
+  checksum: [
+    "sha256=91a04352a405d5215e724bbce624675fd8e2d7c4e36d3225cf806546e44089bf"
+    "sha512=5ffc9570c2d939d3deee1ca0b12ba49c9332ec141bf847edd7c4c8fbe274bf1f4a4ac5b74a7acdb30d1cbf81783bd71b66e83cfa7af1a7e80a1406edafcec110"
+  ]
+}
+x-commit-hash: "4fc4a1b5c5f60c62772f59d1fd6f6968ef8e30d2"


### PR DESCRIPTION
Libraries and module types for a monotonic clock

- Project page: <a href="https://github.com/mirage/mirage-mtime">https://github.com/mirage/mirage-mtime</a>
- Documentation: <a href="https://mirage.github.io/mirage-mtime/">https://mirage.github.io/mirage-mtime/</a>

##### CHANGES:

* Add support for unikraft (mirage/mirage-mtime#1 @shym @fabbing @Firobe)
