### PR TITLE
[new release] mirage-ptime (5.1.0)

### DIFF
--- a/packages/mirage-ptime/mirage-ptime.5.1.0/opam
+++ b/packages/mirage-ptime/mirage-ptime.5.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "hannes@mehnert.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray" "Hannes Mehnert"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-ptime"
+doc: "https://mirage.github.io/mirage-ptime/"
+bug-reports: "https://github.com/mirage/mirage-ptime/issues"
+synopsis: "Libraries and module types for portable clocks"
+description: """
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirageos.org) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements a POSIX clock which counts time since the Unix epoch.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "ptime" {>= "1.1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-ptime.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-ptime/releases/download/v5.1.0/mirage-ptime-5.1.0.tbz"
+  checksum: [
+    "sha256=e9b3db31365e1a895130c3789e6adcf996771ea8e7016b63e15ecbe1f38a29f6"
+    "sha512=276a61bfcf7a025a3a6269b52f85ed158f9600385e1c2c2cf21d74985924bb013e703b804e7b15b7249708ef0cdee3c7c0da3cdf20b858a2b1d0da65829ed113"
+  ]
+}
+x-commit-hash: "d2336b223b830c415947c7c4196f2a80fff87dce"


### PR DESCRIPTION
Libraries and module types for portable clocks

- Project page: <a href="https://github.com/mirage/mirage-ptime">https://github.com/mirage/mirage-ptime</a>
- Documentation: <a href="https://mirage.github.io/mirage-ptime/">https://mirage.github.io/mirage-ptime/</a>

##### CHANGES:

* Add support for unikraft (mirage/mirage-ptime#1 @shym @Firobe @fabbing)
