### PR TITLE
[new release] mirage-sleep (4.1.0)

### DIFF
--- a/packages/mirage-sleep/mirage-sleep.4.1.0/opam
+++ b/packages/mirage-sleep/mirage-sleep.4.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "hannes@mehnert.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-sleep"
+doc: "https://mirage.github.io/mirage-sleep/"
+bug-reports: "https://github.com/mirage/mirage-sleep/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "lwt" {>= "4.0.0"}
+  "duration"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-sleep.git"
+synopsis: "Sleep operation for MirageOS"
+description: """
+Mirage_sleep defines the single function `ns`.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-sleep/releases/download/v4.1.0/mirage-sleep-4.1.0.tbz"
+  checksum: [
+    "sha256=0a81e5e0b8066c00ed0ef59bdead2ef1a321da31d3f46bede3bbe4d0fce9d9bb"
+    "sha512=30b163bb6bf12d6e14463a286d1eafdc983ef7c687628147b0c42eea042ac490465934cd1bfd7ef6814a8bbcc9cacc9d536c858c2604d3d2ac0ed3fcf97c734d"
+  ]
+}
+x-commit-hash: "1d5a6743751401479c91dcb34345016a69a8a188"


### PR DESCRIPTION
Sleep operation for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-sleep">https://github.com/mirage/mirage-sleep</a>
- Documentation: <a href="https://mirage.github.io/mirage-sleep/">https://mirage.github.io/mirage-sleep/</a>

##### CHANGES:

* Add support for unikraft (mirage/mirage-sleep#1 @shym @fabbing @Firobe)
