### PR TITLE
Add Arch support for conf-gmp

### DIFF
--- a/packages/conf-gmp/conf-gmp.5/opam
+++ b/packages/conf-gmp/conf-gmp.5/opam
@@ -31,6 +31,7 @@ depexts: [
   ["gmp" "gmp-devel"] {os-distribution = "ol"}
   ["gmp"] {os = "openbsd"}
   ["gmp"] {os = "freebsd"}
+  ["gmp"] {os-distribution = "arch"}
   ["gmp-dev"] {os-distribution = "alpine"}
   ["gmp-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["gmp"] {os = "win32" & os-distribution = "cygwinports"}


### PR DESCRIPTION
Spotted on https://github.com/ocaml/opam-repository/pull/28419.

Based on https://archlinux.pkgs.org/rolling/archlinux-core-x86_64/gmp-6.3.0-2-x86_64.pkg.tar.zst.html