### PR TITLE
[new release] yocaml (13 packages) (2.4.1)

### DIFF
--- a/packages/yocaml/yocaml.2.4.1/opam
+++ b/packages/yocaml/yocaml.2.4.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Core engine of the YOCaml Static Site Generator"
+description: "YOCaml is a build system dedicated to generate static document"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "logs" {>= "0.7.0"}
+  "odoc" {with-doc}
+  "sherlodoc" {with-doc}
+  "fmt" {with-test}
+  "alcotest" {with-test & >= "1.3.0"}
+  "qcheck" {with-test}
+  "qcheck-alcotest" {with-test}
+  "ppx_expect"
+  "mdx" {with-test & = "2.5.0"}
+  "ocamlformat" {with-dev-setup}
+  "ocp-indent" {with-dev-setup}
+  "merlin" {with-dev-setup}
+  "utop" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.4.1/yocaml-2.4.1.tbz"
+  checksum: [
+    "sha256=cfc7c139116d6881b1d0bc7af706b8f8ceb6cd1f5be67d621944388731ab9d6c"
+    "sha512=9d1a075a6a9d3c8bae9ae4e389ada0a5b7818b3993ef9dd45af65070434b86bb56c349db5d0149134d449495415c28e2bfca993a20d5e4b7d16263f7231334c3"
+  ]
+}
+x-commit-hash: "ef29ff2653ba072f045d3bc422bf57eb70990af9"

--- a/packages/yocaml_cmarkit/yocaml_cmarkit.2.4.1/opam
+++ b/packages/yocaml_cmarkit/yocaml_cmarkit.2.4.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Yocaml plugin for using Markdown (via Cmarkit package) as a Markup language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "cmarkit"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.4.1/yocaml-2.4.1.tbz"
+  checksum: [
+    "sha256=cfc7c139116d6881b1d0bc7af706b8f8ceb6cd1f5be67d621944388731ab9d6c"
+    "sha512=9d1a075a6a9d3c8bae9ae4e389ada0a5b7818b3993ef9dd45af65070434b86bb56c349db5d0149134d449495415c28e2bfca993a20d5e4b7d16263f7231334c3"
+  ]
+}
+x-commit-hash: "ef29ff2653ba072f045d3bc422bf57eb70990af9"

--- a/packages/yocaml_eio/yocaml_eio.2.4.1/opam
+++ b/packages/yocaml_eio/yocaml_eio.2.4.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "The Eio runtime YOCaml"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.5.0"}
+  "yocaml" {= version}
+  "yocaml_runtime" {= version}
+  "eio" {>= "1.1"}
+  "eio_main" {>= "1.1"}
+  "cohttp-eio" {>= "6.0.0~beta2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.4.1/yocaml-2.4.1.tbz"
+  checksum: [
+    "sha256=cfc7c139116d6881b1d0bc7af706b8f8ceb6cd1f5be67d621944388731ab9d6c"
+    "sha512=9d1a075a6a9d3c8bae9ae4e389ada0a5b7818b3993ef9dd45af65070434b86bb56c349db5d0149134d449495415c28e2bfca993a20d5e4b7d16263f7231334c3"
+  ]
+}
+x-commit-hash: "ef29ff2653ba072f045d3bc422bf57eb70990af9"

--- a/packages/yocaml_git/yocaml_git.2.4.1/opam
+++ b/packages/yocaml_git/yocaml_git.2.4.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis:
+  "Yocaml plugins for generating Yocaml program into a Git repository"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "lwt" {>= "5.7.0"}
+  "mimic" {>= "0.0.9"}
+  "cstruct" {>= "6.2.0"}
+  "git-kv" {>= "0.2.0"}
+  "git-net" {>= "0.2.0"}
+  "mirage-clock" {>= "4.2.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "yocaml" {= version}
+  "yocaml_runtime" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.4.1/yocaml-2.4.1.tbz"
+  checksum: [
+    "sha256=cfc7c139116d6881b1d0bc7af706b8f8ceb6cd1f5be67d621944388731ab9d6c"
+    "sha512=9d1a075a6a9d3c8bae9ae4e389ada0a5b7818b3993ef9dd45af65070434b86bb56c349db5d0149134d449495415c28e2bfca993a20d5e4b7d16263f7231334c3"
+  ]
+}
+x-commit-hash: "ef29ff2653ba072f045d3bc422bf57eb70990af9"

--- a/packages/yocaml_jingoo/yocaml_jingoo.2.4.1/opam
+++ b/packages/yocaml_jingoo/yocaml_jingoo.2.4.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for using Jingoo as a template language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "jingoo" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.4.1/yocaml-2.4.1.tbz"
+  checksum: [
+    "sha256=cfc7c139116d6881b1d0bc7af706b8f8ceb6cd1f5be67d621944388731ab9d6c"
+    "sha512=9d1a075a6a9d3c8bae9ae4e389ada0a5b7818b3993ef9dd45af65070434b86bb56c349db5d0149134d449495415c28e2bfca993a20d5e4b7d16263f7231334c3"
+  ]
+}
+x-commit-hash: "ef29ff2653ba072f045d3bc422bf57eb70990af9"

--- a/packages/yocaml_markdown/yocaml_markdown.2.4.1/opam
+++ b/packages/yocaml_markdown/yocaml_markdown.2.4.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "The recommended plugin for processing Markdown documents (based on Cmarkit)"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "cmarkit"
+  "hilite" {>= "0.5.0"}
+  "textmate-language"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.4.1/yocaml-2.4.1.tbz"
+  checksum: [
+    "sha256=cfc7c139116d6881b1d0bc7af706b8f8ceb6cd1f5be67d621944388731ab9d6c"
+    "sha512=9d1a075a6a9d3c8bae9ae4e389ada0a5b7818b3993ef9dd45af65070434b86bb56c349db5d0149134d449495415c28e2bfca993a20d5e4b7d16263f7231334c3"
+  ]
+}
+x-commit-hash: "ef29ff2653ba072f045d3bc422bf57eb70990af9"

--- a/packages/yocaml_mustache/yocaml_mustache.2.4.1/opam
+++ b/packages/yocaml_mustache/yocaml_mustache.2.4.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for using Mustache as a template language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "mustache" {= "3.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.4.1/yocaml-2.4.1.tbz"
+  checksum: [
+    "sha256=cfc7c139116d6881b1d0bc7af706b8f8ceb6cd1f5be67d621944388731ab9d6c"
+    "sha512=9d1a075a6a9d3c8bae9ae4e389ada0a5b7818b3993ef9dd45af65070434b86bb56c349db5d0149134d449495415c28e2bfca993a20d5e4b7d16263f7231334c3"
+  ]
+}
+x-commit-hash: "ef29ff2653ba072f045d3bc422bf57eb70990af9"

--- a/packages/yocaml_omd/yocaml_omd.2.4.1/opam
+++ b/packages/yocaml_omd/yocaml_omd.2.4.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Yocaml plugin for using Markdown (via OMD package) as a Markup language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "omd" {>= "2.0.0~alpha4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.4.1/yocaml-2.4.1.tbz"
+  checksum: [
+    "sha256=cfc7c139116d6881b1d0bc7af706b8f8ceb6cd1f5be67d621944388731ab9d6c"
+    "sha512=9d1a075a6a9d3c8bae9ae4e389ada0a5b7818b3993ef9dd45af65070434b86bb56c349db5d0149134d449495415c28e2bfca993a20d5e4b7d16263f7231334c3"
+  ]
+}
+x-commit-hash: "ef29ff2653ba072f045d3bc422bf57eb70990af9"

--- a/packages/yocaml_otoml/yocaml_otoml.2.4.1/opam
+++ b/packages/yocaml_otoml/yocaml_otoml.2.4.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for dealing with TOML as metadata provider"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "otoml" {>= "1.0.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.4.1/yocaml-2.4.1.tbz"
+  checksum: [
+    "sha256=cfc7c139116d6881b1d0bc7af706b8f8ceb6cd1f5be67d621944388731ab9d6c"
+    "sha512=9d1a075a6a9d3c8bae9ae4e389ada0a5b7818b3993ef9dd45af65070434b86bb56c349db5d0149134d449495415c28e2bfca993a20d5e4b7d16263f7231334c3"
+  ]
+}
+x-commit-hash: "ef29ff2653ba072f045d3bc422bf57eb70990af9"

--- a/packages/yocaml_runtime/yocaml_runtime.2.4.1/opam
+++ b/packages/yocaml_runtime/yocaml_runtime.2.4.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Tool for describing runtimes (using Logs and Digestif)"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & = "2.5.0"}
+  "yocaml" {= version}
+  "cohttp" {>= "5.3.11"}
+  "magic-mime" {>= "1.3.1"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.9.0"}
+  "digestif" {>= "1.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.4.1/yocaml-2.4.1.tbz"
+  checksum: [
+    "sha256=cfc7c139116d6881b1d0bc7af706b8f8ceb6cd1f5be67d621944388731ab9d6c"
+    "sha512=9d1a075a6a9d3c8bae9ae4e389ada0a5b7818b3993ef9dd45af65070434b86bb56c349db5d0149134d449495415c28e2bfca993a20d5e4b7d16263f7231334c3"
+  ]
+}
+x-commit-hash: "ef29ff2653ba072f045d3bc422bf57eb70990af9"

--- a/packages/yocaml_syndication/yocaml_syndication.2.4.1/opam
+++ b/packages/yocaml_syndication/yocaml_syndication.2.4.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for dealing with RSS and Atom feed"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "yocaml" {= version}
+  "fmt" {with-test}
+  "alcotest" {with-test & >= "1.3.0"}
+  "qcheck" {with-test}
+  "qcheck-alcotest" {with-test}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.4.1/yocaml-2.4.1.tbz"
+  checksum: [
+    "sha256=cfc7c139116d6881b1d0bc7af706b8f8ceb6cd1f5be67d621944388731ab9d6c"
+    "sha512=9d1a075a6a9d3c8bae9ae4e389ada0a5b7818b3993ef9dd45af65070434b86bb56c349db5d0149134d449495415c28e2bfca993a20d5e4b7d16263f7231334c3"
+  ]
+}
+x-commit-hash: "ef29ff2653ba072f045d3bc422bf57eb70990af9"

--- a/packages/yocaml_unix/yocaml_unix.2.4.1/opam
+++ b/packages/yocaml_unix/yocaml_unix.2.4.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "The Unix runtime for YOCaml"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "httpcats" {>= "0.0.1"}
+  "yocaml" {= version}
+  "yocaml_runtime" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.4.1/yocaml-2.4.1.tbz"
+  checksum: [
+    "sha256=cfc7c139116d6881b1d0bc7af706b8f8ceb6cd1f5be67d621944388731ab9d6c"
+    "sha512=9d1a075a6a9d3c8bae9ae4e389ada0a5b7818b3993ef9dd45af65070434b86bb56c349db5d0149134d449495415c28e2bfca993a20d5e4b7d16263f7231334c3"
+  ]
+}
+x-commit-hash: "ef29ff2653ba072f045d3bc422bf57eb70990af9"

--- a/packages/yocaml_yaml/yocaml_yaml.2.4.1/opam
+++ b/packages/yocaml_yaml/yocaml_yaml.2.4.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for dealing with Yaml as metadata provider"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "yaml" {>= "3.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v2.4.1/yocaml-2.4.1.tbz"
+  checksum: [
+    "sha256=cfc7c139116d6881b1d0bc7af706b8f8ceb6cd1f5be67d621944388731ab9d6c"
+    "sha512=9d1a075a6a9d3c8bae9ae4e389ada0a5b7818b3993ef9dd45af65070434b86bb56c349db5d0149134d449495415c28e2bfca993a20d5e4b7d16263f7231334c3"
+  ]
+}
+x-commit-hash: "ef29ff2653ba072f045d3bc422bf57eb70990af9"


### PR DESCRIPTION
Core engine of the YOCaml Static Site Generator

- Project page: <a href="https://github.com/xhtmlboi/yocaml">https://github.com/xhtmlboi/yocaml</a>

##### CHANGES:

#### Yocaml

- Add `Toc.traverse` for building your own TOC string [gr-im](https://github.com/gr-im)

#### Yocaml_markdown

- Reintroduce the package to have a strong way to deal with Markdown and Syntax Highlighting (It probably made `yocaml_omd` and `yocaml_cmarkit` obsolete) [gr-im](https://github.com/gr-im)

#### Yocaml_cmarkit

- Add a regular function to compute TOC [gr-im](https://github.com/gr-im)
