### PR TITLE
[new release] charrua (4 packages) (2.1.0)

### DIFF
--- a/packages/charrua-client/charrua-client.2.1.0/opam
+++ b/packages/charrua-client/charrua-client.2.1.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "DHCP client implementation"
+description: """\
+charrua-client is a DHCP client powered by [charrua](https://github.com/mirage/charrua).
+
+The base library exposes a simple state machine in `Dhcp_client`
+for use in acquiring a DHCP lease."""
+maintainer: "Mindy Preston"
+authors: "Mindy Preston"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/charrua"
+doc: "https://docs.mirage.io"
+bug-reports: "https://github.com/mirage/charrua/issues"
+depends: [
+  "dune" {>= "1.4.0"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {with-test}
+  "cstruct-unix" {with-test}
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
+  "charrua-server" {= version & with-test}
+  "charrua" {= version}
+  "cstruct" {>= "6.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "mirage-mtime" {>= "4.0.0"}
+  "mirage-sleep" {>= "4.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "randomconv" {>= "0.2.0"}
+  "duration"
+  "logs"
+  "fmt"
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "tcpip" {>= "9.0.0"}
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/charrua.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v2.1.0/charrua-2.1.0.tbz"
+  checksum: [
+    "sha256=53a6be65499aa901b5db6a3c0494c21b5bc3fe2098c6e56826d3b55c49ed2b99"
+    "sha512=37d171014c755f7fc2465fd0124f5a80cb377c3a493883a38afdd2e583bf2022bec410842e5c7425b7945c3be408a55e9153a498c0f5f211dd1baa2c44fd5d6f"
+  ]
+}
+x-commit-hash: "bc5a7670423a2ceb0deb3aaecb7399236bf881d8"

--- a/packages/charrua-server/charrua-server.2.1.0/opam
+++ b/packages/charrua-server/charrua-server.2.1.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "DHCP server"
+description: """\
+Charrua-server consists of a single `Dhcp_server` module used for constructing DHCP
+servers.
+
+[dhcp](https://github.com/mirage/mirage-skeleton/tree/master/applications/dhcp)
+is a Mirage DHCP unikernel server based on charrua, included as a part of the MirageOS unikernel example and starting-point repository.
+
+#### Features
+
+* `Dhcp_server` supports a stripped down ISC dhcpd.conf, so you can probably just
+  use your old `dhcpd.conf`. It also supports manual configuration building in
+  OCaml.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in OCaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America."""
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+doc: "https://mirage.github.io/charrua/"
+bug-reports: "https://github.com/mirage/charrua/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.4.0"}
+  "menhir" {build & >= "20181006"}
+  "charrua" {= version}
+  "cstruct" {>= "6.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "cstruct-unix" {with-test}
+  "tcpip" {>= "9.0.0" & with-test}
+  "alcotest" {with-test & >= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/charrua.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v2.1.0/charrua-2.1.0.tbz"
+  checksum: [
+    "sha256=53a6be65499aa901b5db6a3c0494c21b5bc3fe2098c6e56826d3b55c49ed2b99"
+    "sha512=37d171014c755f7fc2465fd0124f5a80cb377c3a493883a38afdd2e583bf2022bec410842e5c7425b7945c3be408a55e9153a498c0f5f211dd1baa2c44fd5d6f"
+  ]
+}
+x-commit-hash: "bc5a7670423a2ceb0deb3aaecb7399236bf881d8"

--- a/packages/charrua-unix/charrua-unix.2.1.0/opam
+++ b/packages/charrua-unix/charrua-unix.2.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Unix DHCP daemon"
+description: """\
+charrua-unix is an _ISC-licensed_ Unix DHCP daemon based on
+[charrua](http://www.github.com/mirage/charrua)."""
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+bug-reports: "https://github.com/mirage/charrua/issues"
+depends: [
+  "dune" {>= "1.4.0"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "3.0.0"}
+  "lwt_log"
+  "charrua" {= version}
+  "charrua-server" {= version}
+  "cstruct-unix"
+  "cmdliner" {>= "1.1.0"}
+  "rawlink-lwt" {>= "2.0"}
+  "tuntap" {>= "2.0.0"}
+  "mtime" {>= "2.0.0"}
+  "duration"
+  "cstruct-lwt" {>= "6.0.0"}
+  "ipaddr" {>= "5.1.0"}
+  "tcpip" {>= "9.0.0"}
+  "fmt" {>= "0.9.0"}
+  "logs" {>= "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/charrua.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v2.1.0/charrua-2.1.0.tbz"
+  checksum: [
+    "sha256=53a6be65499aa901b5db6a3c0494c21b5bc3fe2098c6e56826d3b55c49ed2b99"
+    "sha512=37d171014c755f7fc2465fd0124f5a80cb377c3a493883a38afdd2e583bf2022bec410842e5c7425b7945c3be408a55e9153a498c0f5f211dd1baa2c44fd5d6f"
+  ]
+}
+x-commit-hash: "bc5a7670423a2ceb0deb3aaecb7399236bf881d8"

--- a/packages/charrua/charrua.2.1.0/opam
+++ b/packages/charrua/charrua.2.1.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+bug-reports: "https://github.com/mirage/charrua/issues"
+dev-repo: "git+https://github.com/mirage/charrua.git"
+doc: "https://mirage.github.io/charrua/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"         {>= "4.13.0"}
+  "dune"          {>= "1.4.0"}
+  "cstruct"       {>= "6.0.0"}
+  "ipaddr"        {>= "5.0.0"}
+  "macaddr"       {>= "4.0.0"}
+  "ethernet"      {>= "3.0.0"}
+  "tcpip"         {>= "9.0.0"}
+  "ohex"          {>= "0.2.0"}
+  "fmt"           {>= "0.9.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "DHCP wire frame encoder and decoder"
+description: """
+Charrua consists a single modules, `Dhcp_wire` responsible for parsing and
+constructing DHCP messages
+
+You can browse the API for [charrua](http://www.github.com/mirage/charrua) at
+https://mirage.github.io/charrua/
+
+#### Features
+
+* `Dhcp_wire` provides marshalling and unmarshalling utilities for DHCP.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in OCaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v2.1.0/charrua-2.1.0.tbz"
+  checksum: [
+    "sha256=53a6be65499aa901b5db6a3c0494c21b5bc3fe2098c6e56826d3b55c49ed2b99"
+    "sha512=37d171014c755f7fc2465fd0124f5a80cb377c3a493883a38afdd2e583bf2022bec410842e5c7425b7945c3be408a55e9153a498c0f5f211dd1baa2c44fd5d6f"
+  ]
+}
+x-commit-hash: "bc5a7670423a2ceb0deb3aaecb7399236bf881d8"


### PR DESCRIPTION
DHCP wire frame encoder and decoder

- Project page: <a href="https://github.com/mirage/charrua">https://github.com/mirage/charrua</a>
- Documentation: <a href="https://mirage.github.io/charrua/">https://mirage.github.io/charrua/</a>

##### CHANGES:

* Add support for client FQDN (RFC 4702) (mirage/charrua#133 @hannesm)
* Client: allow cidr, gateway, no_init being passed to connect. If passed,
  no DHCP requests will be done. This enables MirageOS unikernels where the
  decision whether to do DHCP or not is done at runtime (mirage/charrua#135 @hannesm)
* Client: pass options to be embedded in the DHCP request (mirage/charrua#135 @hannesm)
* server: extend Update and Reply with lease and DHCP options (mirage/charrua#135 @hannesm)
