### PR TITLE
Upper bound yojson version in linol package

### DIFF
--- a/packages/linol/linol.0.10/opam
+++ b/packages/linol/linol.0.10/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/c-cube/linol"
 bug-reports: "https://github.com/c-cube/linol/issues"
 depends: [
   "dune" {>= "2.0"}
-  "yojson" {>= "1.6"}
+  "yojson" {>= "1.6" & < "3.0.0"}
   "logs"
   "trace" {>= "0.4"}
   "ocaml" {>= "4.14"}


### PR DESCRIPTION
Spotted in #28437:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/c56e58d25e43ce7dd35f9942ad32b42e22d608c9/variant/compilers,5.3,dune.3.20.2,revdeps,linol.0.10
```
# File "vendor/lsp/cancel_request.ml", line 7, characters 48-70:
# 7 |   | `Assoc fields -> Json.field_exn fields "id" Jsonrpc.Id.t_of_yojson
#                                                     ^^^^^^^^^^^^^^^^^^^^^^
# Error: The value "Jsonrpc.Id.t_of_yojson" has type
#          "Linol_jsonrpc.Jsonrpc.Json.t -> Linol_jsonrpc.Jsonrpc.Id.t"
#        but an expression was expected of type "Yojson.Safe.t -> 'a"
#        Type
#          "Linol_jsonrpc.Jsonrpc.Json.t" =
#            "[ `Assoc of (string * Linol_jsonrpc.Jsonrpc.Json.t) list
#            | `Bool of bool
#            | `Float of float
#            | `Int of int
#            | `Intlit of string
#            | `List of Linol_jsonrpc.Jsonrpc.Json.t list
#            | `Null
#            | `String of string
#            | `Tuple of Linol_jsonrpc.Jsonrpc.Json.t list
#            | `Variant of string * Linol_jsonrpc.Jsonrpc.Json.t option ]"
#        is not compatible with type
#          "Yojson.Safe.t" =
#            "[ `Assoc of (string * Yojson.Safe.t) list
#            | `Bool of bool
#            | `Float of float
#            | `Int of int
#            | `Intlit of string
#            | `List of Yojson.Safe.t list
#            | `Null
#            | `String of string ]"
#        The second variant type does not allow tag(s) "`Tuple", "`Variant"
```

caused by https://github.com/ocaml-community/yojson/blob/3.0.0/CHANGES.md
```
- Removed support for Tuple and Variant in JSON. It was a non-standard extension that was rarely used, so this simplifies the Yojson types and the parser more standard-conforming
```
This PR therefore sets an upper bound of yojson.3.0.0 in linol.0.10