### PR TITLE
Add an ocaml upper bound to boltzgen 0.9, 0.9.2, 0.9.3

### DIFF
--- a/packages/boltzgen/boltzgen.0.9.2/opam
+++ b/packages/boltzgen/boltzgen.0.9.2/opam
@@ -9,7 +9,7 @@ homepage: "https://git.lacl.fr/barbot/boltzgen"
 bug-reports: "https://git.lacl.fr/barbot/boltzgen/-/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3.0"}
   "ocaml-compiler-libs"
   "cmdliner" {< "2.0.0"}
   "base-unix"

--- a/packages/boltzgen/boltzgen.0.9.3/opam
+++ b/packages/boltzgen/boltzgen.0.9.3/opam
@@ -9,7 +9,7 @@ homepage: "https://git.lacl.fr/barbot/boltzgen"
 bug-reports: "https://git.lacl.fr/barbot/boltzgen/-/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.3.0"}
   "ocaml-compiler-libs"
   "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "base-unix"

--- a/packages/boltzgen/boltzgen.0.9/opam
+++ b/packages/boltzgen/boltzgen.0.9/opam
@@ -9,7 +9,7 @@ homepage: "https://git.lacl.fr/barbot/boltzgen"
 bug-reports: "https://git.lacl.fr/barbot/boltzgen/-/issues"
 depends: [
   "dune" {>= "2.6"}
-  "ocaml" {>= "4.08.1"}
+  "ocaml" {>= "4.08.1" & < "5.3.0"}
   "ocaml-compiler-libs"
   "cmdliner" {< "2.0.0"}
 ]


### PR DESCRIPTION
Also spotted on [#28437](https://github.com/ocaml/opam-repository/pull/28437):
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/c56e58d25e43ce7dd35f9942ad32b42e22d608c9/variant/compilers,5.3,dune.3.20.2,revdeps,boltzgen.0.9.3
```
#=== ERROR while compiling boltzgen.0.9.3 =====================================#
# context              2.3.0 | linux/x86_64 | ocaml-base-compiler.5.3.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/boltzgen.0.9.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p boltzgen -j 255 @install
# exit-code            1
# env-file             ~/.opam/log/boltzgen-7-b4095b.env
# output-file          ~/.opam/log/boltzgen-7-b4095b.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I .boltzgen_runtime.objs/byte -I /home/opam/.opam/5.3/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.3/lib/ocaml/compiler-libs -I /home/opam/.opam/5.3/lib/ocaml/unix -cmi-file .boltzgen_runtime.objs/byte/boltzgen_runtime__Parse_from_compiler.cmi -no-alias-deps -open Boltzgen_runtime -o .boltzgen_runtime.objs/byte/boltzgen_runtime__Parse_from_compiler.cmo -c -impl parse_from_compiler.ml)
# File "parse_from_compiler.ml", line 32, characters 8-23:
# 32 |         Pprintast.tyvar var var
#              ^^^^^^^^^^^^^^^
# Error: The value "Pprintast.tyvar" has type "Format.formatter -> string -> unit"
#        but an expression was expected of type
#          "Format_doc.formatter -> 'a -> unit"
#        Type "Format.formatter" is not compatible with type "Format_doc.formatter"
```
This is caused by https://github.com/ocaml/ocaml/blob/5.3/Changes
```
- #13169, #13311: Introduce a document data type for compiler messages
  rather than relying on `Format.formatter -> unit` closures.
  (Florian Angeletti, review by Gabriel Scherer)
```
from https://github.com/ocaml/ocaml/pull/13169 in ocaml 5.3