### PR TITLE
Fix ocaml-base-compiler.5.3.0+ for MSVC

### DIFF
--- a/packages/ocaml-option-no-compression/ocaml-option-no-compression.1/opam
+++ b/packages/ocaml-option-no-compression/ocaml-option-no-compression.1/opam
@@ -8,7 +8,12 @@ homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "CC0-1.0+"
 depends: [
-  "ocaml-variants" {post & >= "5.1.0~"}
+  "ocaml-variants" {post & >= "5.1.0~"} |
+  # The MSVC port OCaml doesn't support compression and for equivalence with the
+  # handling of ocaml-option-bytecode-only pulls in ocaml-option-no-compression.
+  # As with ocaml-option-bytecode-only, this is a temporary fix until
+  # ocaml-option- / base- is sorted out properly.
+  ("ocaml-base-compiler" {post & >= "5.1.0~"} & "host-system-msvc" {post})
 ]
 maintainer: "David Allsopp <david@tarides.com>"
 flags: compiler

--- a/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
+++ b/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
@@ -27,7 +27,8 @@ conflicts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-no-flat-float-array"
-  "ocaml-option-no-compression"
+  # See constraint in ocaml-option-no-compression
+  "ocaml-option-no-compression" {os != "win32"}
   "ocaml-option-spacetime"
   "ocaml-option-static"
   "ocaml-option-nnp"


### PR DESCRIPTION
Slip-up when the `ocaml-compiler` package was added - it has to cater for both ocaml-variants and ocaml-base-compiler and wasn't doing that correctly for ocaml-base-compiler.5.3.0 (and any later packages) when installing `system-msvc`.

The change in ocaml-options-vanilla.1 _only_ affects Windows. The change in in `ocaml-option-no-compression` expressly allows `ocaml-compiler` to pull in `ocaml-option-no-compression` only when building for MSVC.

It's a similar wart to the handling of `ocaml-option-bytecode-only` - this PR at least makes the warts consistent.