### PR TITLE
[new release] runtime_events_tools (2 packages) (0.5.3)

### DIFF
--- a/packages/runtime_events_tools/runtime_events_tools.0.5.3/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.5.3/opam
@@ -33,6 +33,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/tarides/runtime_events_tools.git"
+x-maintenance-intent: ["(latest)"]
 available: os != "win32"
 url {
   src:

--- a/packages/runtime_events_tools/runtime_events_tools.0.5.3/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.5.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Tools for the runtime events tracing system in OCaml"
+description: "Various tools for the runtime events tracing system in OCaml"
+maintainer: ["Sadiq Jaffer" "KC Sivaramakrishnan" "Sudha Parimala"]
+authors: ["Sadiq Jaffer"]
+license: "ISC"
+homepage: "https://github.com/tarides/runtime_events_tools"
+bug-reports: "https://github.com/tarides/runtime_events_tools/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.0.0~"}
+  "hdr_histogram"
+  "cmdliner" {>= "1.1.0"}
+  "trace-fuchsia" {>= "0.10"}
+  "trace" {>= "0.10"}
+  "menhir" {with-test}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
+  "alcotest" {with-test & >= "1.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/runtime_events_tools.git"
+available: os != "win32"
+url {
+  src:
+    "https://github.com/tarides/runtime_events_tools/releases/download/0.5.3/runtime_events_tools-0.5.3.tbz"
+  checksum: [
+    "sha256=38a314c841710f5a4faf2d7b25adf4cb9106b7d48a0384baedcf80f60a0db189"
+    "sha512=cee61789a4c842e038da04155f24b567d9ae069fe4be11cea8c1396898069c69a7366ed18cc4adcfa3675177bcf227b8ec44e8712371d64324aa6c190c0fe41d"
+  ]
+}
+x-commit-hash: "d80d578c2f3d2ce5589eeb7d226087983661506e"

--- a/packages/runtime_events_tools_bare/runtime_events_tools_bare.0.5.3/opam
+++ b/packages/runtime_events_tools_bare/runtime_events_tools_bare.0.5.3/opam
@@ -28,6 +28,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/tarides/runtime_events_tools.git"
+x-maintenance-intent: ["(latest)"]
 available: os != "win32"
 url {
   src:

--- a/packages/runtime_events_tools_bare/runtime_events_tools_bare.0.5.3/opam
+++ b/packages/runtime_events_tools_bare/runtime_events_tools_bare.0.5.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Tools for the runtime events tracing system in OCaml"
+description:
+  "Various tools for the runtime events tracing system in OCaml: minimal dependencies"
+maintainer: ["Sadiq Jaffer" "KC Sivaramakrishnan" "Sudha Parimala"]
+authors: ["Sadiq Jaffer"]
+license: "ISC"
+homepage: "https://github.com/tarides/runtime_events_tools"
+bug-reports: "https://github.com/tarides/runtime_events_tools/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.0.0~"}
+  "cmdliner" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/runtime_events_tools.git"
+available: os != "win32"
+url {
+  src:
+    "https://github.com/tarides/runtime_events_tools/releases/download/0.5.3/runtime_events_tools-0.5.3.tbz"
+  checksum: [
+    "sha256=38a314c841710f5a4faf2d7b25adf4cb9106b7d48a0384baedcf80f60a0db189"
+    "sha512=cee61789a4c842e038da04155f24b567d9ae069fe4be11cea8c1396898069c69a7366ed18cc4adcfa3675177bcf227b8ec44e8712371d64324aa6c190c0fe41d"
+  ]
+}
+x-commit-hash: "d80d578c2f3d2ce5589eeb7d226087983661506e"


### PR DESCRIPTION
Tools for the runtime events tracing system in OCaml

- Project page: <a href="https://github.com/tarides/runtime_events_tools">https://github.com/tarides/runtime_events_tools</a>

##### CHANGES:

* Use trace instead of tracing (tarides/runtime_events_tools#57 tarides/runtime_events_tools#59, @patricoferris @tmcgilchrist)
* Add an option to control sleep interval between calls to read_poll (tarides/runtime_events_tools#60, @tomjridge @tmcgilchrist)
