### PR TITLE
2 packages from kit-ty-kate/opam-build at 0.2.6

### DIFF
--- a/packages/opam-build/opam-build.0.2.6/opam
+++ b/packages/opam-build/opam-build.0.2.6/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to build projects"
+maintainer: "Kate <kit-ty-kate@exn.st>"
+authors: "Kate <kit-ty-kate@exn.st>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.4" & < "2.5"}
+  "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
+]
+available: opam-version >= "2.4" & opam-version < "2.5"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.2.6/opam-build-0.2.6.tar.gz"
+  checksum: [
+    "md5=dcbc907ae739d526fb1fb04ce1c72067"
+    "sha512=e8f553a69bef8435f649c29e8ad195ec381363c57580843d395ea3a7f774166f77dd8313da45a37e521e0888d2149a8f2f2982d229a45b2255d5fab0d591f9a1"
+  ]
+}

--- a/packages/opam-test/opam-test.0.2.6/opam
+++ b/packages/opam-test/opam-test.0.2.6/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to test projects"
+maintainer: "Kate <kit-ty-kate@exn.st>"
+authors: "Kate <kit-ty-kate@exn.st>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.4" & < "2.5"}
+  "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
+]
+available: opam-version >= "2.4" & opam-version < "2.5"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.2.6/opam-build-0.2.6.tar.gz"
+  checksum: [
+    "md5=dcbc907ae739d526fb1fb04ce1c72067"
+    "sha512=e8f553a69bef8435f649c29e8ad195ec381363c57580843d395ea3a7f774166f77dd8313da45a37e521e0888d2149a8f2f2982d229a45b2255d5fab0d591f9a1"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `opam-build.0.2.6`: An opam plugin to build projects
- `opam-test.0.2.6`: An opam plugin to test projects



---
* Homepage: https://github.com/kit-ty-kate/opam-build
* Source repo: git+https://github.com/kit-ty-kate/opam-build.git
* Bug tracker: https://github.com/kit-ty-kate/opam-build/issues

---
:camel: Pull-request generated by opam-publish v2.5.0