### PR TITLE
[new release] knights_tour (0.0.6)

### DIFF
--- a/packages/knights_tour/knights_tour.0.0.6/opam
+++ b/packages/knights_tour/knights_tour.0.0.6/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Solves the 'Knights Tour' and various 'Poyomino' puzzles"
+description:
+  "See https://en.wikipedia.org/wiki/Knight%27s_tour or https://en.wikipedia.org/wiki/Polyomino"
+maintainer: ["kris.de.volder@gmail.com"]
+authors: ["Kris De Volder"]
+license: "MIT"
+homepage: "https://github.com/kdvolder/knights_tour"
+bug-reports: "https://github.com/kdvolder/knights_tour/issues"
+depends: [
+  "dune" {>= "3.1"}
+  "ocaml" {>= "5.1.0"}
+  "graphics"
+  "stdio"
+  "ppx_inline_test"
+  "ppx_expect"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/kdvolder/knights_tour.git"
+doc: "https://kdvolder.github.io/knights_tour/"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/kdvolder/knights_tour/releases/download/v0.0.6/knights_tour-0.0.6.tbz"
+  checksum: [
+    "sha256=770624ae4e35d5a58188a1f25e16730d186df8bc4397827fe9a798ea5ca574e3"
+    "sha512=b6c7b2473ddf321afaac6b668f9c6820fb8cc872abc494b69edfdff4101c6b660645837b04801e2917c38dd9f19f79bb0a7b029d59a58ddf1e3a235659bab099"
+  ]
+}
+x-commit-hash: "8fb65ed3855616e501ab91c7b54b46e3795edaee"


### PR DESCRIPTION
Solves the 'Knights Tour' and various 'Poyomino' puzzles

- Project page: <a href="https://github.com/kdvolder/knights_tour">https://github.com/kdvolder/knights_tour</a>
- Documentation: <a href="https://kdvolder.github.io/knights_tour/">https://kdvolder.github.io/knights_tour/</a>

##### CHANGES:

- Added a new `collections` library with modules: `Clist`, `Dlist`, `Treequence`, `Persist`, and utilities. `Dlist` and `Treequence` now implement the same interface for flexible queue/stack usage.
- Introduced a stochastic estimator for searchspace exploration. This allows estimating characteristics of the searchspace,
  such as the number of decision nodes, solutions, and failing nodes, by random sampling.
- Added a new UI (`solve_file_ui`) with a React client and Express server for real-time monitoring, stats, and heatmap visualization.
- Improved `solve_file`:
	- Added `--graphics` commandline option.
	- Now adapts to OS memory availability, dynamically adjusting breadth limit to avoid running out of memory.
	- Refactored argument parsing and code structure.
- Major improvements and refactoring in `searchspace`:
	- Added `stochastic_estimator` module.
	- Improved modularization and code reuse.
- Enhanced pentominos and knights_tour modules:
	- New and improved board, pointSet, puzzle, and cache implementations.
	- Better modularization for code reuse.
- Documentation updates and improved docs structure.
- Various bug fixes, code cleanups, and performance tweaks throughout the codebase.
