### PR TITLE
[new release] mirage (2 packages) (4.10.0)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.4.10.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.4.10.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+available: opam-version >= "2.1.0"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.9.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "4.0.0"}
+  "ipaddr" {>= "5.5.0"}
+  "cmdliner" {>= "1.2.0"}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "ppxlib" {= "0.29.0"} #0.29.0 provides a vendored ppx_sexp_conv
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.10.0/mirage-4.10.0.tbz"
+  checksum: [
+    "sha256=795cc176ffbc67363d4c4ef69354aced9681c0b1e24bf93f0a270975ee0b608b"
+    "sha512=96a2fb3971613b146371a02af1ce59c73ca86dd1f42c0c47334bfbabe7d5f4cffb080c2c585e2e21fe3d33133bbe86b703cb9d276dd86ce3a90a544f03293af5"
+  ]
+}
+x-commit-hash: "c54f3d38235e6e2382b34f847cc87ef9e49e04e4"

--- a/packages/mirage/mirage.4.10.0/opam
+++ b/packages/mirage/mirage.4.10.0/opam
@@ -19,6 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.13.0"}
+  "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
   "cmdliner" {>= "1.2.0"}

--- a/packages/mirage/mirage.4.10.0/opam
+++ b/packages/mirage/mirage.4.10.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+available: opam-version >= "2.1.0"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.9.0"}
+  "astring"
+  "cmdliner" {>= "1.2.0"}
+  "cmdliner" {with-test & >= "1.3.0"}
+  "emile" {>= "1.1"}
+  "fmt" {>= "0.8.7"}
+  "ipaddr" {>= "5.0.0"}
+  "bos"
+  "fpath"
+  "rresult" {>= "0.7.0"}
+  "uri" {>= "4.2.0"}
+  "logs" {>= "0.7.0"}
+  "opam-monorepo" {>= "0.4.0"}
+  "alcotest" {with-test}
+  "mirage-runtime" {with-test & = version}
+  "dune" {with-test & != "3.20.0" & != "3.20.1"}
+]
+
+conflicts: [ "jbuilder" {with-test} ]
+
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.10.0/mirage-4.10.0.tbz"
+  checksum: [
+    "sha256=795cc176ffbc67363d4c4ef69354aced9681c0b1e24bf93f0a270975ee0b608b"
+    "sha512=96a2fb3971613b146371a02af1ce59c73ca86dd1f42c0c47334bfbabe7d5f4cffb080c2c585e2e21fe3d33133bbe86b703cb9d276dd86ce3a90a544f03293af5"
+  ]
+}
+x-commit-hash: "c54f3d38235e6e2382b34f847cc87ef9e49e04e4"

--- a/packages/mirage/mirage.4.10.0/opam
+++ b/packages/mirage/mirage.4.10.0/opam
@@ -22,8 +22,8 @@ depends: [
   "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
-  "cmdliner" {>= "1.2.0"}
-  "cmdliner" {with-test & >= "1.3.0"}
+  "cmdliner" {>= "1.2.0" & < "2.0.0"}
+  "cmdliner" {with-test & >= "1.3.0" & < "2.0.0"}
   "emile" {>= "1.1"}
   "fmt" {>= "0.8.7"}
   "ipaddr" {>= "5.0.0"}


### PR DESCRIPTION
The MirageOS library operating system

- Project page: <a href="https://github.com/mirage/mirage">https://github.com/mirage/mirage</a>
- Documentation: <a href="https://mirage.github.io/mirage/">https://mirage.github.io/mirage/</a>

##### CHANGES:

- Add unikraft targets (mirage/mirage#1607 @fabbing @shym)
- Add a `?local_libs` parameter to allow local dune libs
  (mirage/mirage#1609 @omegametabroccolo)
- Add a `--name` argument to each unikernel (`Mirage_runtime.name ()`),
  remove `monitor_hostname` (mirage/mirage#1611 @hannesm)
- Use Git_net instead of Git_mirage (mirage/mirage#1606 @dinosaure)
- Fix Mirage_runtime documentation headers, use correct Stop special comment
  (mirage/mirage#1605 @reynir)
- Exclude buggy dune versions from testing (mirage/mirage#1609 @reynir)
- Remove unused exports about ip stacks, ipv4_config, ipv6_config,
  socket_tcpv4v6, and socket_udpv4v6 (mirage/mirage#1612 @hannesm)
