### PR TITLE
[new release] omni-irc, omni-irc-sig, omni-irc-conn, omni-irc-engine, omni-irc-io-tcp, omni-irc-io-tls, omni-irc-io-unixsock, omni-irc-ui, omni-irc-ui-notty and omni-irc-client (0.1.8)

### DIFF
--- a/packages/omni-irc-client/omni-irc-client.0.1.8/opam
+++ b/packages/omni-irc-client/omni-irc-client.0.1.8/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: simple raw client (TCP<->AF_UNIX bridge + optional UI)"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "yojson"
+  "omni-irc-sig"
+  "omni-irc-conn"
+  "omni-irc-io-unixsock" {"os" != "win32"}
+  "omni-irc-io-tcp"
+  "omni-irc-io-tls"
+  "omni-irc-ui"
+  "omni-irc-ui-notty" {"os" != "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.8/omni-irc-0.1.8.tbz"
+  checksum: [
+    "sha256=ae6eeb040ec04288c9708295827aa58e846140b4812d20c88acfae52d76c7163"
+    "sha512=51d6e8f51eafe105765771f6e013bc3bb57e7dd87f2750df44bb509d4f3e53d6133b185eb18b8be1a6e6660e65875671672a84663e4aadf8be67bd66434d4f78"
+  ]
+}
+x-commit-hash: "afd897d5b9f5f7053f034cc51868418d6a2980ff"

--- a/packages/omni-irc-conn/omni-irc-conn.0.1.8/opam
+++ b/packages/omni-irc-conn/omni-irc-conn.0.1.8/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: transport connector (functor over IO)"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "omni-irc-sig"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.8/omni-irc-0.1.8.tbz"
+  checksum: [
+    "sha256=ae6eeb040ec04288c9708295827aa58e846140b4812d20c88acfae52d76c7163"
+    "sha512=51d6e8f51eafe105765771f6e013bc3bb57e7dd87f2750df44bb509d4f3e53d6133b185eb18b8be1a6e6660e65875671672a84663e4aadf8be67bd66434d4f78"
+  ]
+}
+x-commit-hash: "afd897d5b9f5f7053f034cc51868418d6a2980ff"

--- a/packages/omni-irc-engine/omni-irc-engine.0.1.8/opam
+++ b/packages/omni-irc-engine/omni-irc-engine.0.1.8/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: event engine (dispatcher + core handlers)"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.8/omni-irc-0.1.8.tbz"
+  checksum: [
+    "sha256=ae6eeb040ec04288c9708295827aa58e846140b4812d20c88acfae52d76c7163"
+    "sha512=51d6e8f51eafe105765771f6e013bc3bb57e7dd87f2750df44bb509d4f3e53d6133b185eb18b8be1a6e6660e65875671672a84663e4aadf8be67bd66434d4f78"
+  ]
+}
+x-commit-hash: "afd897d5b9f5f7053f034cc51868418d6a2980ff"

--- a/packages/omni-irc-io-tcp/omni-irc-io-tcp.0.1.8/opam
+++ b/packages/omni-irc-io-tcp/omni-irc-io-tcp.0.1.8/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: TCP IO"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "omni-irc-sig"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.8/omni-irc-0.1.8.tbz"
+  checksum: [
+    "sha256=ae6eeb040ec04288c9708295827aa58e846140b4812d20c88acfae52d76c7163"
+    "sha512=51d6e8f51eafe105765771f6e013bc3bb57e7dd87f2750df44bb509d4f3e53d6133b185eb18b8be1a6e6660e65875671672a84663e4aadf8be67bd66434d4f78"
+  ]
+}
+x-commit-hash: "afd897d5b9f5f7053f034cc51868418d6a2980ff"

--- a/packages/omni-irc-io-tls/omni-irc-io-tls.0.1.8/opam
+++ b/packages/omni-irc-io-tls/omni-irc-io-tls.0.1.8/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: TLS IO"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "tls-lwt" {"os" != "win32"}
+  "x509" {"os" != "win32"}
+  "ca-certs" {"os" != "win32"}
+  "domain-name" {"os" != "win32"}
+  "cstruct" {"os" != "win32"}
+  "omni-irc-sig"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.8/omni-irc-0.1.8.tbz"
+  checksum: [
+    "sha256=ae6eeb040ec04288c9708295827aa58e846140b4812d20c88acfae52d76c7163"
+    "sha512=51d6e8f51eafe105765771f6e013bc3bb57e7dd87f2750df44bb509d4f3e53d6133b185eb18b8be1a6e6660e65875671672a84663e4aadf8be67bd66434d4f78"
+  ]
+}
+x-commit-hash: "afd897d5b9f5f7053f034cc51868418d6a2980ff"

--- a/packages/omni-irc-io-unixsock/omni-irc-io-unixsock.0.1.8/opam
+++ b/packages/omni-irc-io-unixsock/omni-irc-io-unixsock.0.1.8/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: single-consumer AF_UNIX bridge"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "omni-irc-sig"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.8/omni-irc-0.1.8.tbz"
+  checksum: [
+    "sha256=ae6eeb040ec04288c9708295827aa58e846140b4812d20c88acfae52d76c7163"
+    "sha512=51d6e8f51eafe105765771f6e013bc3bb57e7dd87f2750df44bb509d4f3e53d6133b185eb18b8be1a6e6660e65875671672a84663e4aadf8be67bd66434d4f78"
+  ]
+}
+x-commit-hash: "afd897d5b9f5f7053f034cc51868418d6a2980ff"

--- a/packages/omni-irc-sig/omni-irc-sig.0.1.8/opam
+++ b/packages/omni-irc-sig/omni-irc-sig.0.1.8/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: tiny IO signature"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.8/omni-irc-0.1.8.tbz"
+  checksum: [
+    "sha256=ae6eeb040ec04288c9708295827aa58e846140b4812d20c88acfae52d76c7163"
+    "sha512=51d6e8f51eafe105765771f6e013bc3bb57e7dd87f2750df44bb509d4f3e53d6133b185eb18b8be1a6e6660e65875671672a84663e4aadf8be67bd66434d4f78"
+  ]
+}
+x-commit-hash: "afd897d5b9f5f7053f034cc51868418d6a2980ff"

--- a/packages/omni-irc-ui-notty/omni-irc-ui-notty.0.1.8/opam
+++ b/packages/omni-irc-ui-notty/omni-irc-ui-notty.0.1.8/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: Notty-Lwt User Interface"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "notty" {"os" != "win32"}
+  "yojson" {"os" != "win32"}
+  "omni-irc-ui"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.8/omni-irc-0.1.8.tbz"
+  checksum: [
+    "sha256=ae6eeb040ec04288c9708295827aa58e846140b4812d20c88acfae52d76c7163"
+    "sha512=51d6e8f51eafe105765771f6e013bc3bb57e7dd87f2750df44bb509d4f3e53d6133b185eb18b8be1a6e6660e65875671672a84663e4aadf8be67bd66434d4f78"
+  ]
+}
+x-commit-hash: "afd897d5b9f5f7053f034cc51868418d6a2980ff"

--- a/packages/omni-irc-ui/omni-irc-ui.0.1.8/opam
+++ b/packages/omni-irc-ui/omni-irc-ui.0.1.8/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: contracts for UI modules"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.8/omni-irc-0.1.8.tbz"
+  checksum: [
+    "sha256=ae6eeb040ec04288c9708295827aa58e846140b4812d20c88acfae52d76c7163"
+    "sha512=51d6e8f51eafe105765771f6e013bc3bb57e7dd87f2750df44bb509d4f3e53d6133b185eb18b8be1a6e6660e65875671672a84663e4aadf8be67bd66434d4f78"
+  ]
+}
+x-commit-hash: "afd897d5b9f5f7053f034cc51868418d6a2980ff"

--- a/packages/omni-irc/omni-irc.0.1.8/opam
+++ b/packages/omni-irc/omni-irc.0.1.8/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: meta package for the monorepo"
+description:
+  "Meta package for the Omni-IRC libraries. Install the specific subpackages: omni-irc-sig, omni-irc-conn, omni-irc-engine, omni-irc-io-{tcp,tls,unixsock}, omni-irc-ui, omni-irc-ui-notty (and optionally omni-irc-client)."
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "5.0"}
+  "omni-irc-sig"
+  "omni-irc-conn"
+  "omni-irc-engine"
+  "omni-irc-io-tcp"
+  "omni-irc-io-tls"
+  "omni-irc-io-unixsock" {"os" != "win32"}
+  "omni-irc-io-unixsock"
+  "omni-irc-ui"
+  "omni-irc-ui-notty" {"os" != "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.8/omni-irc-0.1.8.tbz"
+  checksum: [
+    "sha256=ae6eeb040ec04288c9708295827aa58e846140b4812d20c88acfae52d76c7163"
+    "sha512=51d6e8f51eafe105765771f6e013bc3bb57e7dd87f2750df44bb509d4f3e53d6133b185eb18b8be1a6e6660e65875671672a84663e4aadf8be67bd66434d4f78"
+  ]
+}
+x-commit-hash: "afd897d5b9f5f7053f034cc51868418d6a2980ff"


### PR DESCRIPTION
Omni IRC: meta package for the monorepo

- Project page: <a href="https://github.com/jesse-greathouse/omni-irc">https://github.com/jesse-greathouse/omni-irc</a>
- Documentation: <a href="https://github.com/jesse-greathouse/omni-irc#readme">https://github.com/jesse-greathouse/omni-irc#readme</a>

##### CHANGES:

- Initial public multi-package release of Omni-IRC libraries.
- Packages: omni-irc-sig, omni-irc-conn, omni-irc-engine, omni-irc-io-{tcp,tls,unixsock},
  omni-irc-ui, omni-irc-ui-notty, omni-irc-client (example CLI).
