### PR TITLE
[new release] omni-irc (10 packages) (0.1.9)

### DIFF
--- a/packages/omni-irc-client/omni-irc-client.0.1.9/opam
+++ b/packages/omni-irc-client/omni-irc-client.0.1.9/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: simple raw client (TCP<->AF_UNIX bridge + optional UI)"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "yojson"
+  "omni-irc-sig"
+  "omni-irc-conn"
+  "omni-irc-io-tcp"
+  "omni-irc-io-tls" {"os" != "win32"}
+  "omni-irc-io-unixsock" {"os" != "win32"}
+  "omni-irc-ui"
+  "omni-irc-ui-notty" {"os" != "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.9/omni-irc-0.1.9.tbz"
+  checksum: [
+    "sha256=f393d3696328d33fdf925efc794ae4a2b2a677545e6d7978dbc423b6a44c446f"
+    "sha512=c6c4e4fda597b1bb648124862c2f6fbf282045425ce58ff198eeba80536bc5ba9f657405571f440f84fad28c9d1fdd371c638eae8f955294dd6b43bd907bae32"
+  ]
+}
+x-commit-hash: "e5ede7bab6c81b6a7b0b8e632be9fd9b9a3076be"

--- a/packages/omni-irc-conn/omni-irc-conn.0.1.9/opam
+++ b/packages/omni-irc-conn/omni-irc-conn.0.1.9/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: transport connector (functor over IO)"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "omni-irc-sig"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.9/omni-irc-0.1.9.tbz"
+  checksum: [
+    "sha256=f393d3696328d33fdf925efc794ae4a2b2a677545e6d7978dbc423b6a44c446f"
+    "sha512=c6c4e4fda597b1bb648124862c2f6fbf282045425ce58ff198eeba80536bc5ba9f657405571f440f84fad28c9d1fdd371c638eae8f955294dd6b43bd907bae32"
+  ]
+}
+x-commit-hash: "e5ede7bab6c81b6a7b0b8e632be9fd9b9a3076be"

--- a/packages/omni-irc-engine/omni-irc-engine.0.1.9/opam
+++ b/packages/omni-irc-engine/omni-irc-engine.0.1.9/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: event engine (dispatcher + core handlers)"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.9/omni-irc-0.1.9.tbz"
+  checksum: [
+    "sha256=f393d3696328d33fdf925efc794ae4a2b2a677545e6d7978dbc423b6a44c446f"
+    "sha512=c6c4e4fda597b1bb648124862c2f6fbf282045425ce58ff198eeba80536bc5ba9f657405571f440f84fad28c9d1fdd371c638eae8f955294dd6b43bd907bae32"
+  ]
+}
+x-commit-hash: "e5ede7bab6c81b6a7b0b8e632be9fd9b9a3076be"

--- a/packages/omni-irc-io-tcp/omni-irc-io-tcp.0.1.9/opam
+++ b/packages/omni-irc-io-tcp/omni-irc-io-tcp.0.1.9/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: TCP IO"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "omni-irc-sig"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.9/omni-irc-0.1.9.tbz"
+  checksum: [
+    "sha256=f393d3696328d33fdf925efc794ae4a2b2a677545e6d7978dbc423b6a44c446f"
+    "sha512=c6c4e4fda597b1bb648124862c2f6fbf282045425ce58ff198eeba80536bc5ba9f657405571f440f84fad28c9d1fdd371c638eae8f955294dd6b43bd907bae32"
+  ]
+}
+x-commit-hash: "e5ede7bab6c81b6a7b0b8e632be9fd9b9a3076be"

--- a/packages/omni-irc-io-tls/omni-irc-io-tls.0.1.9/opam
+++ b/packages/omni-irc-io-tls/omni-irc-io-tls.0.1.9/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: TLS IO"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "tls-lwt" {"os" != "win32"}
+  "x509" {"os" != "win32"}
+  "ca-certs" {"os" != "win32"}
+  "domain-name" {"os" != "win32"}
+  "cstruct" {"os" != "win32"}
+  "omni-irc-sig"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.9/omni-irc-0.1.9.tbz"
+  checksum: [
+    "sha256=f393d3696328d33fdf925efc794ae4a2b2a677545e6d7978dbc423b6a44c446f"
+    "sha512=c6c4e4fda597b1bb648124862c2f6fbf282045425ce58ff198eeba80536bc5ba9f657405571f440f84fad28c9d1fdd371c638eae8f955294dd6b43bd907bae32"
+  ]
+}
+x-commit-hash: "e5ede7bab6c81b6a7b0b8e632be9fd9b9a3076be"

--- a/packages/omni-irc-io-unixsock/omni-irc-io-unixsock.0.1.9/opam
+++ b/packages/omni-irc-io-unixsock/omni-irc-io-unixsock.0.1.9/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: single-consumer AF_UNIX bridge"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "omni-irc-sig"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.9/omni-irc-0.1.9.tbz"
+  checksum: [
+    "sha256=f393d3696328d33fdf925efc794ae4a2b2a677545e6d7978dbc423b6a44c446f"
+    "sha512=c6c4e4fda597b1bb648124862c2f6fbf282045425ce58ff198eeba80536bc5ba9f657405571f440f84fad28c9d1fdd371c638eae8f955294dd6b43bd907bae32"
+  ]
+}
+x-commit-hash: "e5ede7bab6c81b6a7b0b8e632be9fd9b9a3076be"

--- a/packages/omni-irc-sig/omni-irc-sig.0.1.9/opam
+++ b/packages/omni-irc-sig/omni-irc-sig.0.1.9/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: tiny IO signature"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.9/omni-irc-0.1.9.tbz"
+  checksum: [
+    "sha256=f393d3696328d33fdf925efc794ae4a2b2a677545e6d7978dbc423b6a44c446f"
+    "sha512=c6c4e4fda597b1bb648124862c2f6fbf282045425ce58ff198eeba80536bc5ba9f657405571f440f84fad28c9d1fdd371c638eae8f955294dd6b43bd907bae32"
+  ]
+}
+x-commit-hash: "e5ede7bab6c81b6a7b0b8e632be9fd9b9a3076be"

--- a/packages/omni-irc-ui-notty/omni-irc-ui-notty.0.1.9/opam
+++ b/packages/omni-irc-ui-notty/omni-irc-ui-notty.0.1.9/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: Notty-Lwt User Interface"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "notty" {"os" != "win32"}
+  "yojson" {"os" != "win32"}
+  "omni-irc-ui"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.9/omni-irc-0.1.9.tbz"
+  checksum: [
+    "sha256=f393d3696328d33fdf925efc794ae4a2b2a677545e6d7978dbc423b6a44c446f"
+    "sha512=c6c4e4fda597b1bb648124862c2f6fbf282045425ce58ff198eeba80536bc5ba9f657405571f440f84fad28c9d1fdd371c638eae8f955294dd6b43bd907bae32"
+  ]
+}
+x-commit-hash: "e5ede7bab6c81b6a7b0b8e632be9fd9b9a3076be"

--- a/packages/omni-irc-ui/omni-irc-ui.0.1.9/opam
+++ b/packages/omni-irc-ui/omni-irc-ui.0.1.9/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: contracts for UI modules"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.9/omni-irc-0.1.9.tbz"
+  checksum: [
+    "sha256=f393d3696328d33fdf925efc794ae4a2b2a677545e6d7978dbc423b6a44c446f"
+    "sha512=c6c4e4fda597b1bb648124862c2f6fbf282045425ce58ff198eeba80536bc5ba9f657405571f440f84fad28c9d1fdd371c638eae8f955294dd6b43bd907bae32"
+  ]
+}
+x-commit-hash: "e5ede7bab6c81b6a7b0b8e632be9fd9b9a3076be"

--- a/packages/omni-irc/omni-irc.0.1.9/opam
+++ b/packages/omni-irc/omni-irc.0.1.9/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: meta package for the monorepo"
+description:
+  "Meta package for the Omni-IRC libraries. Install the specific subpackages: omni-irc-sig, omni-irc-conn, omni-irc-engine, omni-irc-io-{tcp,tls,unixsock}, omni-irc-ui, omni-irc-ui-notty (and optionally omni-irc-client)."
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "5.0"}
+  "omni-irc-sig"
+  "omni-irc-conn"
+  "omni-irc-engine"
+  "omni-irc-io-tcp"
+  "omni-irc-io-tls" {"os" != "win32"}
+  "omni-irc-io-unixsock" {"os" != "win32"}
+  "omni-irc-ui"
+  "omni-irc-ui-notty" {"os" != "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/v0.1.9/omni-irc-0.1.9.tbz"
+  checksum: [
+    "sha256=f393d3696328d33fdf925efc794ae4a2b2a677545e6d7978dbc423b6a44c446f"
+    "sha512=c6c4e4fda597b1bb648124862c2f6fbf282045425ce58ff198eeba80536bc5ba9f657405571f440f84fad28c9d1fdd371c638eae8f955294dd6b43bd907bae32"
+  ]
+}
+x-commit-hash: "e5ede7bab6c81b6a7b0b8e632be9fd9b9a3076be"


### PR DESCRIPTION
Omni IRC: meta package for the monorepo

- Project page: <a href="https://github.com/jesse-greathouse/omni-irc">https://github.com/jesse-greathouse/omni-irc</a>
- Documentation: <a href="https://github.com/jesse-greathouse/omni-irc#readme">https://github.com/jesse-greathouse/omni-irc#readme</a>

##### CHANGES:

- Initial public multi-package release of Omni-IRC libraries.
- Packages: omni-irc-sig, omni-irc-conn, omni-irc-engine, omni-irc-io-{tcp,tls,unixsock},
  omni-irc-ui, omni-irc-ui-notty, omni-irc-client (example CLI).
