### PR TITLE
[new release] omni-irc (10 packages) (0.1.10)

### DIFF
--- a/packages/omni-irc-client/omni-irc-client.0.1.10/opam
+++ b/packages/omni-irc-client/omni-irc-client.0.1.10/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: simple raw client (TCP<->AF_UNIX bridge + optional UI)"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "yojson"
+  "omni-irc-sig"
+  "omni-irc-conn"
+  "omni-irc-engine"
+  "omni-irc-io-tcp"
+  "omni-irc-io-tls" {"os" != "win32"}
+  "omni-irc-io-unixsock" {"os" != "win32"}
+  "omni-irc-ui"
+  "omni-irc-ui-notty" {"os" != "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/0.1.10/omni-irc-0.1.10.tbz"
+  checksum: [
+    "sha256=21756f8fbb99ac82b6ef66c658509b965020a0913eac67d5612b98d61b9ad419"
+    "sha512=7493fce1721d6d8c467e8e28157a2cc5f95474379d55643abc823aed34d68c951fa63af5b205ba7f50adc7cd37211a6db89867768bd5ee0de72420786133b538"
+  ]
+}
+x-commit-hash: "fa1c961b06d4d50a02b1667f7c96f4881dbb8ee1"

--- a/packages/omni-irc-conn/omni-irc-conn.0.1.10/opam
+++ b/packages/omni-irc-conn/omni-irc-conn.0.1.10/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: transport connector (functor over IO)"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "omni-irc-sig"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/0.1.10/omni-irc-0.1.10.tbz"
+  checksum: [
+    "sha256=21756f8fbb99ac82b6ef66c658509b965020a0913eac67d5612b98d61b9ad419"
+    "sha512=7493fce1721d6d8c467e8e28157a2cc5f95474379d55643abc823aed34d68c951fa63af5b205ba7f50adc7cd37211a6db89867768bd5ee0de72420786133b538"
+  ]
+}
+x-commit-hash: "fa1c961b06d4d50a02b1667f7c96f4881dbb8ee1"

--- a/packages/omni-irc-engine/omni-irc-engine.0.1.10/opam
+++ b/packages/omni-irc-engine/omni-irc-engine.0.1.10/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: event engine (dispatcher + core handlers)"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/0.1.10/omni-irc-0.1.10.tbz"
+  checksum: [
+    "sha256=21756f8fbb99ac82b6ef66c658509b965020a0913eac67d5612b98d61b9ad419"
+    "sha512=7493fce1721d6d8c467e8e28157a2cc5f95474379d55643abc823aed34d68c951fa63af5b205ba7f50adc7cd37211a6db89867768bd5ee0de72420786133b538"
+  ]
+}
+x-commit-hash: "fa1c961b06d4d50a02b1667f7c96f4881dbb8ee1"

--- a/packages/omni-irc-io-tcp/omni-irc-io-tcp.0.1.10/opam
+++ b/packages/omni-irc-io-tcp/omni-irc-io-tcp.0.1.10/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: TCP IO"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "omni-irc-sig"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/0.1.10/omni-irc-0.1.10.tbz"
+  checksum: [
+    "sha256=21756f8fbb99ac82b6ef66c658509b965020a0913eac67d5612b98d61b9ad419"
+    "sha512=7493fce1721d6d8c467e8e28157a2cc5f95474379d55643abc823aed34d68c951fa63af5b205ba7f50adc7cd37211a6db89867768bd5ee0de72420786133b538"
+  ]
+}
+x-commit-hash: "fa1c961b06d4d50a02b1667f7c96f4881dbb8ee1"

--- a/packages/omni-irc-io-tls/omni-irc-io-tls.0.1.10/opam
+++ b/packages/omni-irc-io-tls/omni-irc-io-tls.0.1.10/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: TLS IO"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "tls-lwt" {"os" != "win32"}
+  "x509" {"os" != "win32"}
+  "ca-certs" {"os" != "win32"}
+  "domain-name" {"os" != "win32"}
+  "cstruct" {"os" != "win32"}
+  "omni-irc-sig"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/0.1.10/omni-irc-0.1.10.tbz"
+  checksum: [
+    "sha256=21756f8fbb99ac82b6ef66c658509b965020a0913eac67d5612b98d61b9ad419"
+    "sha512=7493fce1721d6d8c467e8e28157a2cc5f95474379d55643abc823aed34d68c951fa63af5b205ba7f50adc7cd37211a6db89867768bd5ee0de72420786133b538"
+  ]
+}
+x-commit-hash: "fa1c961b06d4d50a02b1667f7c96f4881dbb8ee1"

--- a/packages/omni-irc-io-unixsock/omni-irc-io-unixsock.0.1.10/opam
+++ b/packages/omni-irc-io-unixsock/omni-irc-io-unixsock.0.1.10/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: single-consumer AF_UNIX bridge"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "omni-irc-sig"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/0.1.10/omni-irc-0.1.10.tbz"
+  checksum: [
+    "sha256=21756f8fbb99ac82b6ef66c658509b965020a0913eac67d5612b98d61b9ad419"
+    "sha512=7493fce1721d6d8c467e8e28157a2cc5f95474379d55643abc823aed34d68c951fa63af5b205ba7f50adc7cd37211a6db89867768bd5ee0de72420786133b538"
+  ]
+}
+x-commit-hash: "fa1c961b06d4d50a02b1667f7c96f4881dbb8ee1"

--- a/packages/omni-irc-sig/omni-irc-sig.0.1.10/opam
+++ b/packages/omni-irc-sig/omni-irc-sig.0.1.10/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: tiny IO signature"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/0.1.10/omni-irc-0.1.10.tbz"
+  checksum: [
+    "sha256=21756f8fbb99ac82b6ef66c658509b965020a0913eac67d5612b98d61b9ad419"
+    "sha512=7493fce1721d6d8c467e8e28157a2cc5f95474379d55643abc823aed34d68c951fa63af5b205ba7f50adc7cd37211a6db89867768bd5ee0de72420786133b538"
+  ]
+}
+x-commit-hash: "fa1c961b06d4d50a02b1667f7c96f4881dbb8ee1"

--- a/packages/omni-irc-ui-notty/omni-irc-ui-notty.0.1.10/opam
+++ b/packages/omni-irc-ui-notty/omni-irc-ui-notty.0.1.10/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: Notty-Lwt User Interface"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "notty" {"os" != "win32"}
+  "yojson" {"os" != "win32"}
+  "omni-irc-ui"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+available: [ os != "win32" ]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/0.1.10/omni-irc-0.1.10.tbz"
+  checksum: [
+    "sha256=21756f8fbb99ac82b6ef66c658509b965020a0913eac67d5612b98d61b9ad419"
+    "sha512=7493fce1721d6d8c467e8e28157a2cc5f95474379d55643abc823aed34d68c951fa63af5b205ba7f50adc7cd37211a6db89867768bd5ee0de72420786133b538"
+  ]
+}
+x-commit-hash: "fa1c961b06d4d50a02b1667f7c96f4881dbb8ee1"

--- a/packages/omni-irc-ui/omni-irc-ui.0.1.10/opam
+++ b/packages/omni-irc-ui/omni-irc-ui.0.1.10/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: contracts for UI modules"
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "lwt"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/0.1.10/omni-irc-0.1.10.tbz"
+  checksum: [
+    "sha256=21756f8fbb99ac82b6ef66c658509b965020a0913eac67d5612b98d61b9ad419"
+    "sha512=7493fce1721d6d8c467e8e28157a2cc5f95474379d55643abc823aed34d68c951fa63af5b205ba7f50adc7cd37211a6db89867768bd5ee0de72420786133b538"
+  ]
+}
+x-commit-hash: "fa1c961b06d4d50a02b1667f7c96f4881dbb8ee1"

--- a/packages/omni-irc/omni-irc.0.1.10/opam
+++ b/packages/omni-irc/omni-irc.0.1.10/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Omni IRC: meta package for the monorepo"
+description:
+  "Meta package for the Omni-IRC libraries. Install the specific subpackages: omni-irc-sig, omni-irc-conn, omni-irc-engine, omni-irc-io-{tcp,tls,unixsock}, omni-irc-ui, omni-irc-ui-notty (and optionally omni-irc-client)."
+maintainer: ["Jesse Greathouse <jesse.greathouse@gmail.com>"]
+authors: ["Jesse Greathouse"]
+license: "LicenseRef-OmniIRC-ViewOnly-1.0"
+homepage: "https://github.com/jesse-greathouse/omni-irc"
+doc: "https://github.com/jesse-greathouse/omni-irc#readme"
+bug-reports: "https://github.com/jesse-greathouse/omni-irc/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "5.0"}
+  "omni-irc-sig"
+  "omni-irc-conn"
+  "omni-irc-engine"
+  "omni-irc-io-tcp"
+  "omni-irc-io-tls" {"os" != "win32"}
+  "omni-irc-io-unixsock" {"os" != "win32"}
+  "omni-irc-ui"
+  "omni-irc-ui-notty" {"os" != "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jesse-greathouse/omni-irc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/jesse-greathouse/omni-irc/releases/download/0.1.10/omni-irc-0.1.10.tbz"
+  checksum: [
+    "sha256=21756f8fbb99ac82b6ef66c658509b965020a0913eac67d5612b98d61b9ad419"
+    "sha512=7493fce1721d6d8c467e8e28157a2cc5f95474379d55643abc823aed34d68c951fa63af5b205ba7f50adc7cd37211a6db89867768bd5ee0de72420786133b538"
+  ]
+}
+x-commit-hash: "fa1c961b06d4d50a02b1667f7c96f4881dbb8ee1"


### PR DESCRIPTION
CHANGES:

- Initial public multi-package release of Omni-IRC libraries.
- Packages: omni-irc-sig, omni-irc-conn, omni-irc-engine, omni-irc-io-{tcp,tls,unixsock}, omni-irc-ui, omni-irc-ui-notty, omni-irc-client (example CLI).