### PR TITLE
[new release] goblint-cil (2.0.8)

### DIFF
--- a/packages/goblint-cil/goblint-cil.2.0.8/opam
+++ b/packages/goblint-cil/goblint-cil.2.0.8/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+synopsis:
+  "A front-end for the C programming language that facilitates program analysis and transformation"
+description: """
+This is a fork of the 'cil' package used for 'goblint'. Major changes include:
+* Support for C99 and C11.
+* Compatibility with modern OCaml versions.
+* Use Zarith instead of Num and use that for integer constants.
+* Improved locations with columns and spans.
+* Removal of unmaintained extensions and MSVC support.
+* Use dune instead of make and ocamlbuild.
+* Many bug fixes."""
+maintainer: [
+  "Michael Schwarz <michael.schwarz93@gmail.com>"
+  "Simmo Saan <simmo.saan@gmail.com>"
+]
+authors: [
+  "George Necula"
+  "Scott McPeak"
+  "Westley Weimer"
+  "Gabriel Kerneis"
+  "Ralf Vogler"
+  "Michael Schwarz"
+  "Simmo Saan"
+]
+license: "BSD-3-Clause"
+homepage: "https://github.com/goblint/cil"
+bug-reports: "https://github.com/goblint/cil/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "ocamlfind" {with-test}
+  "zarith"
+  "hevea" {with-doc}
+  "dune" {>= "2.7"}
+  "dune-configurator"
+  "odoc" {with-doc}
+  "stdlib-shims"
+  "ppx_deriving_yojson" {>= "3.2"}
+  "yojson"
+  "conf-perl"
+  "cppo"
+  "conf-gcc"
+]
+conflicts: ["cil"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/goblint/cil.git"
+depexts: [
+  ["perl-ExtUtils-MakeMaker"] {os-distribution = "centos" | os-family = "fedora" | os-distribution = "ol"}
+  ["perl-FindBin"] {os-family = "fedora"}
+  ["build-base"] {os-distribution = "alpine"}
+]
+available: arch = "x86_64" | arch = "arm64"
+x-ci-accept-failures: [
+  "freebsd" # installed cilly binary is not found for some reason (https://github.com/ocaml/opam-repository/pull/24812#issuecomment-1819231335)
+]
+url {
+  src:
+    "https://github.com/goblint/cil/releases/download/2.0.8/goblint-cil-2.0.8.tbz"
+  checksum: [
+    "sha256=b09009442e27c51e61653ca0104069097bfcb7943457478fd5a153cdda9cbc09"
+    "sha512=0f89d8920a35daa9213d7c407d1e1d89d820df9d6da1878335209e166aad68b2a377134ab08bb74499b40d13a7b758959b225b01e067d6e609da5295913e2af7"
+  ]
+}
+x-commit-hash: "d1da1ba071b7060b7b9c533853a3c56e82e762ba"


### PR DESCRIPTION
A front-end for the C programming language that facilitates program analysis and transformation

- Project page: <a href="https://github.com/goblint/cil">https://github.com/goblint/cil</a>

##### CHANGES:

* Fix 32bit `Machdep` generation on 64bit host (goblint/cil#195).
