### PR TITLE
Fix broken hashes for Claudius

### DIFF
--- a/packages/claudius/claudius.1.1.1/opam
+++ b/packages/claudius/claudius.1.1.1/opam
@@ -52,7 +52,7 @@ url {
     src:
       "https://github.com/claudiusFX/Claudius/archive/refs/tags/1.1.1.tar.gz"
     checksum: [
-      "sha256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      "sha512=cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+      "sha256=61576bb6f2b4d7d3e8cc4d4b037f12b800dbabe8816272ddaff15fd0f255002f"
+      "sha512=2f843fe03ce18fafa4dd9b4c3ae771a775c00b2981b7d9d2d6cfeaed7d58a908bfe0aa314528ab40bc4ae2fe44d46261fd7487e4b9ffc0a28a8f0012d64c1fad"
     ]
 }


### PR DESCRIPTION
This was missed in the original PR due to the first commit "passing" CI (everything fails on opam CI AFAICT, but it had been reviewed by a reviewer and passed), but then a request for an extra opam flag came in and another one and in that review process it was missed that the SHAsums had been broken. You can see the failure here:

https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/df209fe7c7fe89a6b482dbd3002485b1befe4827

But because CI is always red and there was a manual thumbs up to the first commit, this got missed.