### PR TITLE
Update oqamldebug to qt5-qmake

### DIFF
--- a/packages/oqamldebug/oqamldebug.0.9.5/opam
+++ b/packages/oqamldebug/oqamldebug.0.9.5/opam
@@ -11,7 +11,7 @@ build: [
   [ "strip" "oqamldebug" ]
 ]
 depexts: [
-  ["qt4-qmake" "libqt4-dev"] {os-family = "debian"}
+  ["qt5-qmake" "qtbase5-dev"] {os-family = "debian"}
 ]
 synopsis: "Graphical front-end to ocamldebug"
 description: """


### PR DESCRIPTION
qt4-qmake is no longer in the Debian repository and has been replaced with qt5-qmake.