### PR TITLE
Update oqamldebug.0.9.5 dependencies

### DIFF
--- a/packages/oqamldebug/oqamldebug.0.9.5/opam
+++ b/packages/oqamldebug/oqamldebug.0.9.5/opam
@@ -10,9 +10,6 @@ build: [
   [ make ]
   [ "strip" "oqamldebug" ]
 ]
-depexts: [
-  ["qt4-qmake" "libqt4-dev"] {os-family = "debian"}
-]
 synopsis: "Graphical front-end to ocamldebug"
 description: """
 Features:
@@ -33,7 +30,7 @@ On debian install simply qt4-dev package..
 
 On MacOS it is necessary to set QMAKESPEC as follow to install the package
 export QMAKESPEC=macx-g++"""
-depends: ["ocaml"]
+depends: ["ocaml" "conf-qt"]
 url {
   src:
     "https://github.com/ocaml/opam-source-archives/raw/main/oqamldebug-0.9.5.tar.gz"


### PR DESCRIPTION
This package does not build due to the deprecated dependency `qt4-make`.

Removed direct external dependency on `qt4-make`, in favour of depending upon `conf-qt`, which uses `qt5-make`.