### PR TITLE
bibtex2html depends upon conf-autoconf

### DIFF
--- a/packages/bibtex2html/bibtex2html.1.99-1/opam
+++ b/packages/bibtex2html/bibtex2html.1.99-1/opam
@@ -15,6 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "hevea"
+  "conf-autoconf"
 ]
 install: [make "install"]
 synopsis: "BibTeX to HTML translator"


### PR DESCRIPTION
`bibtex2html` depends upon `autoconf`, but does not explicitly list `conf-autoconf` as a dependency. This causes a build failure when `autoconf` is not present on the system by other means.