### PR TITLE
Package coq-waterproof.3.0.0+8.20

### DIFF
--- a/packages/coq-waterproof/coq-waterproof.3.0.0+8.20/opam
+++ b/packages/coq-waterproof/coq-waterproof.3.0.0+8.20/opam
@@ -24,7 +24,7 @@ bug-reports: "https://github.com/impermeable/coq-waterproof/issues"
 depends: [
   "ocaml" {>= "4.09.0"}
   "coq" {>= "8.20" & < "8.21" | = "dev"}
-  "dune" {>= "3.6"}
+  "dune" {>= "3.8"}
 ]
 
 build: [
@@ -32,6 +32,8 @@ build: [
 ]
 
 available: (arch != "s390x") & (arch != "ppc64") & (os != "win32")
+
+conflicts: [ "ocaml-option-bytecode-only" ]
 
 tags: [
   "keyword:mathematics education"


### PR DESCRIPTION
### `coq-waterproof.3.0.0+8.20`
Coq proofs in a style that resembles non-mechanized mathematical proofs
The Waterproof plugin for the Coq proof assistant allows you to write Coq proofs in a style that resembles handwritten mathematical proofs, designed to help university students with learning how to prove mathematical statements.



---
* Homepage: https://github.com/impermeable/coq-waterproof
* Source repo: git+https://github.com/impermeable/coq-waterproof.git
* Bug tracker: https://github.com/impermeable/coq-waterproof/issues

---
:camel: Pull-request generated by opam-publish v2.2.0