### PR TITLE
Add: uucd.17.0.0, uucp.17.0.0, uunf.17.0.0, uuseg.17.0.0

### DIFF
--- a/packages/uucd/uucd.17.0.0/opam
+++ b/packages/uucd/uucd.17.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Unicode character database decoder for OCaml"
+description: """\
+Uucd is an OCaml module to decode the data of the [Unicode character 
+database][1] from its XML [representation][2]. It provides high-level 
+(but not necessarily efficient) access to the data so that efficient 
+representations can be extracted.
+
+Uucd is made of a single module, depends on [Xmlm][xmlm] and is distributed
+under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr44/
+[2]: http://www.unicode.org/reports/tr42/
+[xmlm]: http://erratique.ch/software/xmlm 
+
+Home page: <http://erratique.ch/software/uucd>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uucd programmers"
+license: "ISC"
+tags: ["unicode" "database" "decoder" "org:erratique"]
+homepage: "https://erratique.ch/software/uucd"
+doc: "https://erratique.ch/software/uucd/doc/Uucd"
+bug-reports: "https://github.com/dbuenzli/uucd/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+  "xmlm"
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/uucd.git"
+url {
+  src: "https://erratique.ch/software/uucd/releases/uucd-17.0.0.tbz"
+  checksum:
+    "sha512=adcbf252bdb1851221b226b086f58d9c73b78ffa4fbfe02d98e8f8203e10d4f0d6d26f6a624a16cf9cff5f7043a26ebdf6fef5980ab7b24e48f35ff87a92f3a4"
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/uucp/uucp.17.0.0/opam
+++ b/packages/uucp/uucp.17.0.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Unicode character properties for OCaml"
+description: """\
+Uucp is an OCaml library providing efficient access to a selection of
+character properties of the [Unicode character database].
+
+Uucp is distributed under the ISC license. It has no dependency.
+
+Home page: <http://erratique.ch/software/uucp>
+
+[Unicode character database]: http://www.unicode.org/reports/tr44/"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uucp programmers"
+license: "ISC"
+tags: ["unicode" "text" "character" "org:erratique"]
+homepage: "https://erratique.ch/software/uucp"
+doc: "https://erratique.ch/software/uucp/doc/"
+bug-reports: "https://github.com/dbuenzli/uucp/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+  "uucd" {with-test & dev & >= "17.0.0" & < "18.0.0"}
+  "uunf" {with-test}
+]
+depopts: ["uunf" "cmdliner"]
+conflicts: [
+  "uunf" {< "17.0.0" | >= "18.0.0"}
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-uunf"
+  "%{uunf:installed}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+post-messages:
+  "If the build fails with \"ocamlopt.opt got signal and exited\", issue 'ulimit -s unlimited' and retry."
+    {failure & (arch = "ppc64" | arch = "arm64")}
+dev-repo: "git+https://erratique.ch/repos/uucp.git"
+url {
+  src: "https://erratique.ch/software/uucp/releases/uucp-17.0.0.tbz"
+  checksum:
+    "sha512=c2b5c883c2ed1ee8e7bc9102339dfbca5940e68cd2af59a10abc827fb64c91ad03f85cfc12d4c79605c10e9b3a90743267af8b069143fefeeff6658ec8ed843f"
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/uunf/uunf.17.0.0/opam
+++ b/packages/uunf/uunf.17.0.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Unicode text normalization for OCaml"
+description: """\
+Uunf is an OCaml library for normalizing Unicode text. It supports all
+Unicode [normalization forms]. The library is independent from any IO
+mechanism or Unicode text data structure and it can process text
+without a complete in-memory representation.
+
+Uunf is distributed under the ISC license. It has no dependency.
+
+[normalization forms]: http://www.unicode.org/reports/tr15/
+
+Homepage: <http://erratique.ch/software/uunf>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uunf programmers"
+license: "ISC"
+tags: ["unicode" "text" "normalization" "org:erratique"]
+homepage: "https://erratique.ch/software/uunf"
+doc: "https://erratique.ch/software/uunf/doc/Uunf"
+bug-reports: "https://github.com/dbuenzli/uunf/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+  "uucd" {dev & >= "17.0.0" & < "18.0.0"}
+]
+depopts: ["uutf" "cmdliner"]
+conflicts: [
+  "uutf" {< "1.0.0"}
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-uutf"
+  "%{uutf:installed}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+post-messages:
+  "If the build fails with \"ocamlopt.opt got signal and exited\", issue 'ulimit -s unlimited' and retry."
+    {failure & (arch = "ppc64" | arch = "arm64")}
+dev-repo: "git+https://erratique.ch/repos/uunf.git"
+url {
+  src: "https://erratique.ch/software/uunf/releases/uunf-17.0.0.tbz"
+  checksum:
+    "sha512=1ec4d7229bb473ab2dd146ec732c8c70f357f73211e71d32625cd2410a35766e684bbeb1bd4e186b7403d4af8d597d46b7ccf58b23ae95aac32a96c0b4321691"
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/uuseg/uuseg.17.0.0/opam
+++ b/packages/uuseg/uuseg.17.0.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Unicode text segmentation for OCaml"
+description: """\
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the [Unicode
+line breaking algorithm][2] to detect line break opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg is distributed under the ISC license. It depends on [Uucp].
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/
+[Uucp]: http://erratique.ch/software/uucp
+
+Homepage: <http://erratique.ch/software/uuseg>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uuseg programmers"
+license: "ISC"
+tags: ["unicode" "text" "segmentation" "org:erratique"]
+homepage: "https://erratique.ch/software/uuseg"
+doc: "https://erratique.ch/software/uuseg/doc/"
+bug-reports: "https://github.com/dbuenzli/uuseg/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+  "uucp" {>= "17.0.0" & < "18.0.0"}
+]
+depopts: ["uutf" "cmdliner"]
+conflicts: [
+  "uutf" {< "1.0.0"}
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-uutf"
+  "%{uutf:installed}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/uuseg.git"
+url {
+  src: "https://erratique.ch/software/uuseg/releases/uuseg-17.0.0.tbz"
+  checksum:
+    "sha512=8d81ca0a57516b94c66a0da256f3455ba26b0875ca9e354a665ec30223c9216be57abdd52c39c8c384fe127df8060c18ff07d92d4d9f53892bc4ed20699df3ef"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `uucd.17.0.0` [home](https://erratique.ch/software/uucd), [doc](https://erratique.ch/software/uucd/doc/Uucd), [issues](https://github.com/dbuenzli/uucd/issues)  
  *Unicode character database decoder for OCaml*
* Add: `uucp.17.0.0` [home](https://erratique.ch/software/uucp), [doc](https://erratique.ch/software/uucp/doc/), [issues](https://github.com/dbuenzli/uucp/issues)  
  *Unicode character properties for OCaml*
* Add: `uunf.17.0.0` [home](https://erratique.ch/software/uunf), [doc](https://erratique.ch/software/uunf/doc/Uunf), [issues](https://github.com/dbuenzli/uunf/issues)  
  *Unicode text normalization for OCaml*
* Add: `uuseg.17.0.0` [home](https://erratique.ch/software/uuseg), [doc](https://erratique.ch/software/uuseg/doc/), [issues](https://github.com/dbuenzli/uuseg/issues)  
  *Unicode text segmentation for OCaml*


---

#### `uucd` v17.0.0 2025-09-11 Zagreb

- Support for Unicode 17.0.0

---

#### `uucp` v17.0.0 2025-09-11 Zagreb

- Unicode 17.0.0 support.

---

#### `uunf` v17.0.0 2025-09-11 Zagreb

- Unicode 17.0.0 support.

---

#### `uuseg` v17.0.0 2025-09-11 Zagreb

- Unicode 17.0.0 support.
- Add `Uuseg.equal` thanks to @lord for suggesting.

---

Use `b0 -- .opam publish uucd.17.0.0 uucp.17.0.0 uunf.17.0.0 uuseg.17.0.0` to update the pull request.