### PR TITLE
[new release] albatross (2.6.0)

### DIFF
--- a/packages/albatross/albatross.2.6.0/opam
+++ b/packages/albatross/albatross.2.6.0/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/robur-coop/albatross"
+dev-repo: "git+https://github.com/robur-coop/albatross.git"
+bug-reports: "https://github.com/robur-coop/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "2.7.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "conf-libev"
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "5.3.0"}
+  "logs"
+  "bos" {>= "0.2.0"}
+  "ptime" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "1.0.0"}
+  "tls" {>= "1.0.2"}
+  "tls-lwt" {>= "1.0.2"}
+  "asn1-combinators" {>= "0.3.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "metrics" {>= "0.5.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "ohex" {>= "0.2.0"}
+  "http-lwt-client" {>= "0.3.0"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.4.0"}
+  "cachet" {>= "0.0.2"}
+  "fpath" {>= "0.7.3"}
+  "logs-syslog" {>= "0.4.1"}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+available: os != "openbsd"
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/albatross/releases/download/v2.6.0/albatross-2.6.0.tbz"
+  checksum: [
+    "sha256=95335cd203ba8f4b47a0fa2135ae2adc677c5a09a9e85bf729800eeb78f79de6"
+    "sha512=5661030612576a2941f57935cf9ceaf04b859e58cd6e70cc1372a9491b85ddaa17e3773c27df5c072fc166533f66ee0663fd52b2e1c4451f1e119dda26ebbac9"
+  ]
+}
+x-commit-hash: "8fefc74e38cfe11d701a56c8d46d5c2ace3ad800"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/robur-coop/albatross">https://github.com/robur-coop/albatross</a>

##### CHANGES:

* Add "--name=UNIKERNEL NAME" to every unikernel - and if it fails to start
  with error code 64, restart without the additional parameter. This is in
  sync with mirage 4.10 which adds a "--name" argument to every unikernel
  (robur-coop/albatross#229 @hannesm)
* Add a "startup" to unikernel configuration to control startup order
  (fixes robur-coop/albatross#53, robur-coop/albatross#225 @hannesm)
* BUGFIX: vmmd: decompress the unikernel image in restart before checking
  resources (fixes robur-coop/albatross#209, robur-coop/albatross#228 @hannesm)
* BREAKING albatrossd, albatross-influx: add a "--no-drop-path" flag to use the
  full name (including path) for reporting (both for --name and for influx
  reporting). Previously, a "--drop-label" flag was available. The default is
  to drop the path. (robur-coop/albatross#229 @hannesm)
* client: add support for '-' for remote destination to output the certificate
  (robur-coop/albatross#227 @hannesm)
* BREAKING remove support for old commands (robur-coop/albatross#226 @hannesm)
  - wire version 3 and wire version 4 (version 5 introduced in 1.5.0, May 2022)
  - old_console_subscribe and utc_console_data (2.1.0, Jul 2024)
  - old_unikernel_info1, old_unikernel_get (1.1.0, Jan 2021)
  - old_unikernel_info2 (2.1.0, Dec 2023)
  - old unikernel_create and force_create (1.0.0, Mar 2020)
  - old unikernel_create and force_create (1.1.0, Jan 2021)
