### PR TITLE
[new release] testo (4 packages) (0.2.0)

### DIFF
--- a/packages/testo-diff/testo-diff.0.1.0/opam
+++ b/packages/testo-diff/testo-diff.0.1.0/opam
@@ -40,3 +40,4 @@ url {
   ]
 }
 x-commit-hash: "76de74b853b5735d01c4903b4a45c1d44f0f470d"
+x-maintenance-intent: ["(latest)"]

--- a/packages/testo-diff/testo-diff.0.2.0/opam
+++ b/packages/testo-diff/testo-diff.0.2.0/opam
@@ -41,3 +41,4 @@ url {
   ]
 }
 x-commit-hash: "f03e691f9065b0c14af6a2622a8c6f3710510008"
+x-maintenance-intent: ["(latest)"]

--- a/packages/testo-lwt/testo-lwt.0.1.0/opam
+++ b/packages/testo-lwt/testo-lwt.0.1.0/opam
@@ -43,3 +43,4 @@ url {
   ]
 }
 x-commit-hash: "76de74b853b5735d01c4903b4a45c1d44f0f470d"
+x-maintenance-intent: ["(latest)"]

--- a/packages/testo-lwt/testo-lwt.0.2.0/opam
+++ b/packages/testo-lwt/testo-lwt.0.2.0/opam
@@ -43,3 +43,4 @@ url {
   ]
 }
 x-commit-hash: "f03e691f9065b0c14af6a2622a8c6f3710510008"
+x-maintenance-intent: ["(latest)"]

--- a/packages/testo-util/testo-util.0.1.0/opam
+++ b/packages/testo-util/testo-util.0.1.0/opam
@@ -38,3 +38,4 @@ url {
   ]
 }
 x-commit-hash: "76de74b853b5735d01c4903b4a45c1d44f0f470d"
+x-maintenance-intent: ["(latest)"]

--- a/packages/testo-util/testo-util.0.2.0/opam
+++ b/packages/testo-util/testo-util.0.2.0/opam
@@ -39,3 +39,4 @@ url {
   ]
 }
 x-commit-hash: "f03e691f9065b0c14af6a2622a8c6f3710510008"
+x-maintenance-intent: ["(latest)"]

--- a/packages/testo/testo.0.1.0/opam
+++ b/packages/testo/testo.0.1.0/opam
@@ -42,3 +42,4 @@ url {
   ]
 }
 x-commit-hash: "76de74b853b5735d01c4903b4a45c1d44f0f470d"
+x-maintenance-intent: ["(latest)"]

--- a/packages/testo/testo.0.2.0/opam
+++ b/packages/testo/testo.0.2.0/opam
@@ -42,3 +42,4 @@ url {
   ]
 }
 x-commit-hash: "f03e691f9065b0c14af6a2622a8c6f3710510008"
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
Test framework for OCaml

- Project page: <a href="https://github.com/semgrep/testo">https://github.com/semgrep/testo</a>

##### CHANGES:

* Fix: handle windows paths correctly CLI help output
  (https://github.com/semgrep/testo/pull/121)
* Fix: correct path masking on Windows paths
  (https://github.com/semgrep/testo/pull/121)
* Fix: prevent "Bad file descriptor" errors arising from output redirection on
  Windows (https://github.com/semgrep/testo/pull/121)
* Fix: handle temporary file deletion cleanly on windows
  (https://github.com/semgrep/testo/pull/119)
* Fix: don't set signals on Windows (https://github.com/semgrep/testo/pull/118).
* Add `Testo.with_chdir` (https://github.com/semgrep/testo/pull/104).
* Fix nonsensical diff formatting (https://github.com/semgrep/testo/pull/104).
* Fix: enable the approval of the output of a test that is expected to
  complete but produces the incorrect output. Running the `approve`
  subcommand on such a test now successfully changes its status from
  XFAIL to XPASS ([semgrep/testo#103](https://github.com/semgrep/testo/pull/103)).
* Allow multiple `-s` search queries in the same test command,
  allowing the selection of various tests by their name or hash
  ([semgrep/testo#110](https://github.com/semgrep/testo/pull/110)).
* Add a `--expert` option to hide the legend printed by `run` and
  `status` ([semgrep/testo#109](https://github.com/semgrep/testo/issues/109)).
* Add a `--autoclean` option to `run` and `status` subcommands to
  delete test snapshots that don't belong to any known test as it
  typically happens after tests are renamed
  ([semgrep/testo#126](https://github.com/semgrep/testo/pull/126)).
* Add support for timeouts
  ([semgrep/testo#127](https://github.com/semgrep/testo/issues/127)).
