### PR TITLE
Fix Cygwin cairo support and add MinGW cairo support

### DIFF
--- a/packages/conf-cairo/conf-cairo.1/opam
+++ b/packages/conf-cairo/conf-cairo.1/opam
@@ -4,13 +4,18 @@ homepage: "http://cairographics.org/"
 authors: ["Keith Packard" "Carl Worth" "Behdad Esfahbod"]
 license: ["LGPL-2.1-only" "MPL-1.1"]
 build: [
+  ["pkgconf" "--personality=i686-w64-mingw32" "cairo"] {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
+  ["pkgconf" "--personality=x86_64-w64-mingw32" "cairo"] {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
   ["pkg-config" "cairo"] {os != "macos" & os != "win32"}
-  ["pkgconf" "--cflags" "cairo"] {os = "win32" & os-distribution != "msys2"}
   ["sh" "-exc"
    "export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/; pkg-config --libs cairo"]
    {os = "macos" & os-distribution = "homebrew"}
 ]
-depends: ["conf-pkg-config" {>= "3" & build}]
+depends: [
+  "conf-pkg-config" {>= "3" & build}
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-cairo-i686" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-cairo-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+]
 depexts: [
   ["libcairo2-dev"] {os-family = "debian"}
   ["libcairo2-dev"] {os-family = "ubuntu"}
@@ -25,7 +30,7 @@ depexts: [
   ["cairo"] {os-family = "arch"}
   ["cairo"] {os = "macos" & os-distribution = "homebrew"}
   ["cairo"] {os = "win32" & os-distribution = "cygwinports"}
-  ["libcairo-devel"] {os = "win32" & os-distribution = "cygwin"}
+  ["libcairo-devel"] {os = "cygwin"}
 ]
 synopsis: "Virtual package relying on a Cairo system installation"
 description:

--- a/packages/conf-mingw-w64-cairo-i686/conf-mingw-w64-cairo-i686.1/opam
+++ b/packages/conf-mingw-w64-cairo-i686/conf-mingw-w64-cairo-i686.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "Provides cairo for i686 mingw-w64 (32-bit x86)"
+description: "Ensure that the i686 version of cairo for the mingw-w64 project is available"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Keith Packard" "Carl Worth" "Behdad Esfahbod"]
+license: ["LGPL-2.1-only" "MPL-1.1"]
+homepage: "http://cairographics.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32"
+build: ["pkgconf" "--personality=i686-w64-mingw32" "cairo"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-i686" {build}
+]
+depexts: [
+  ["mingw64-i686-cairo"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-i686-cairo"] {os = "win32" & os-distribution = "msys2"}
+]

--- a/packages/conf-mingw-w64-cairo-x86_64/conf-mingw-w64-cairo-x86_64.1/opam
+++ b/packages/conf-mingw-w64-cairo-x86_64/conf-mingw-w64-cairo-x86_64.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "Provides cairo for x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensure that the x86_64 version of cairo for the mingw-w64 project is available"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Keith Packard" "Carl Worth" "Behdad Esfahbod"]
+license: ["LGPL-2.1-only" "MPL-1.1"]
+homepage: "http://cairographics.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32"
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" "cairo"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-x86_64" {build}
+]
+depexts: [
+  ["mingw64-x86_64-cairo"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-x86_64-cairo"] {os = "win32" & os-distribution = "msys2"}
+]


### PR DESCRIPTION
This PR
- fixes the existing Cygwin cairo support and
- adds MinGW cairo support, modeled after the template PR https://github.com/ocaml/opam-repository/pull/26072

Previously, the `conf-cairo`-file would install a Cygwin package https://cygwin.com/packages/summary/libcairo-devel.html (and thus depending on cygwin1.dll) rather than a MinGW package, allowing us to build standalone, native Windows executables.

Recall: Windows is supported in multiple forms (also summarized in our wiki-page: https://github.com/ocaml/opam-repository/wiki/Depexts-os-distribution---os-family-values):
- MinGW - which allows to produce native Windows executables and can be installed either through
  - Cygwin (`os = "win32" & os-distribution = "cygwin"`) or
  - MSys2 (`os = "win32" & os-distribution = "msys2"`)
- Cygwin (`os = "cygwin" & os-distribution = "cygwin"`) which produces executables that require Cygwin
- cygwinports (`os = "win32" & os-distribution = "cygwinports"`) is the old, now discontinued approach based on a dedicated Windows opam-repo
- ...

Previously, CI would be green since the Cygwin package exists and installs cleanly - when matching the Cygwin-hosted MinGW environment we currently test in the GitHub actions CI workflow. The CI didn't catch the subtle, unwanted cygwin1.dll dependency introduced though... :shrug: 

The MinGW packages installed are
- https://cygwin.com/packages/summary/mingw64-x86_64-cairo.html
- https://cygwin.com/packages/summary/mingw64-i686-cairo.html
- https://packages.msys2.org/base/mingw-w64-cairo

and the Cygwin package in question is
- https://cygwin.com/packages/summary/libcairo-devel.html

We don't have CI support for testing pure Cygwin (non-MinGW) ATM, but as in the previous PRs I've tested the two others with a self PR: https://github.com/jmid/opam-repository/pull/13