### PR TITLE
Add MinGW support for freetype

### DIFF
--- a/packages/conf-freetype/conf-freetype.1/opam
+++ b/packages/conf-freetype/conf-freetype.1/opam
@@ -4,8 +4,16 @@ authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
 homepage: "http://www.freetype.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-1.0-or-later"
-build: [["pkg-config" "freetype2"]]
-depends: ["conf-pkg-config" {build}]
+build: [
+  ["pkgconf" "--personality=i686-w64-mingw32" "freetype2"] {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
+  ["pkgconf" "--personality=x86_64-w64-mingw32" "freetype2"] {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
+  ["pkg-config" "freetype2"] {os != "win32" | os-distribution != "cygwin"}
+]
+depends: [
+  "conf-pkg-config" {build}
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-freetype-i686" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-freetype-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+]
 depexts: [
   ["libfreetype6-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["freetype-dev"] {os-family = "alpine"}

--- a/packages/conf-mingw-w64-freetype-i686/conf-mingw-w64-freetype-i686.1/opam
+++ b/packages/conf-mingw-w64-freetype-i686/conf-mingw-w64-freetype-i686.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "Provides freetype for i686 mingw-w64 (32-bit x86)"
+description: "Ensure that the i686 version of freetype for the mingw-w64 project is available"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+license: "GPL-1.0-or-later"
+homepage: "http://www.freetype.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32"
+build: ["pkgconf" "--personality=i686-w64-mingw32" "freetype2"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-i686" {build}
+]
+depexts: [
+  ["mingw64-i686-freetype2"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-i686-freetype"] {os = "win32" & os-distribution = "msys2"}
+]

--- a/packages/conf-mingw-w64-freetype-x86_64/conf-mingw-w64-freetype-x86_64.1/opam
+++ b/packages/conf-mingw-w64-freetype-x86_64/conf-mingw-w64-freetype-x86_64.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "Provides freetype for x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensure that the x86_64 version of freetype for the mingw-w64 project is available"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+license: "GPL-1.0-or-later"
+homepage: "http://www.freetype.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32"
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" "freetype2"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-x86_64" {build}
+]
+depexts: [
+  ["mingw64-x86_64-freetype2"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-x86_64-freetype"] {os = "win32" & os-distribution = "msys2"}
+]


### PR DESCRIPTION
This add MinGW support for `conf-freetype`, also following the template PR https://github.com/ocaml/opam-repository/pull/26072.

The MinGW packages installed are:
- https://cygwin.com/packages/summary/mingw64-i686-freetype2.html
- https://cygwin.com/packages/summary/mingw64-x86_64-freetype2.html
- https://packages.msys2.org/base/mingw-w64-freetype

The most interesting here is they all offer `freetype2.pc` for `pkg-config` to query, despite the different freetype/freetype2 naming. For the `conf-mingw`-packages I am naming them as the original `conf-freetype`, for internal opam-repo consistency.


The self-PR testing the two MinGW modes is here: https://github.com/jmid/opam-repository/pull/14