### PR TITLE
Add dune-project equivalent to x-maintenance-intent

### DIFF
--- a/governance/policies/archiving.md
+++ b/governance/policies/archiving.md
@@ -100,6 +100,8 @@ When it has been decided that a set of package versions (aka "versions") should 
         - `["(none)"]` the maintainer will not maintain any version
         - `["1.3"]` the maintainer will maintain the latest  version of "1.3.Z"
         - `["2.(latest)"]` the maintainer will maintain the latest minor version specifically of version "2" of the package
+    - `dune-project` uses [`maintenance_intent`](https://dune.readthedocs.io/en/latest/reference/dune-project/maintenance_intent.html). Example:
+        - `(package ... (maintenance_intent "(latest)") ...)`
 - `x-maintained`:
     - Allowed values: `true` and `false`
     - Meaning:


### PR DESCRIPTION
I was sent here from https://github.com/ocaml/opam-repository/pull/28504#issuecomment-3284278212 and it took me a while to find a way to do this from a `dune-project` file. I hope this will save others time.

This kind of tip might go better into a howto-style guide such as "how to create complete opam files for public release from a dune project?" is there is one (?).

Edit: there is already https://dune.readthedocs.io/en/latest/howto/opam-file-generation.html
Feel free to scrap this PR.