### PR TITLE
ber-metaocaml: enable availability on macOS arm64

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.3.0+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0+BER/opam
@@ -76,4 +76,4 @@ depopts: [
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]
-available: !(os = "macos" & arch = "arm64") & os != "win32" & arch != "arm32" & arch != "x86_32"
+available: os != "win32" & arch != "arm32" & arch != "x86_32"


### PR DESCRIPTION
This PR updates the `available:` constraint for ber-metaocaml(`ocaml-variants.5.3.0+BER`).

**Before:**
```opam
available: !(os = "macos" & arch = "arm64") & os != "win32" & arch != "arm32" & arch != "x86_32"
```

**After:**

```opam
available: os != "win32" & arch != "arm32" & arch != "x86_32"
```

This change makes `ber-metaocaml` available on macOS with Apple Silicon (arm64).
The package now builds and runs correctly in that environment.

* Tested on: macOS 15 (Sequoia), arm64 (Apple M1).

No other metadata changes.