### PR TITLE
Add an lwt_ppx upper bound for dream.1.0.0~alpha{1,2,3}

### DIFF
--- a/packages/dream/dream.1.0.0~alpha1/opam
+++ b/packages/dream/dream.1.0.0~alpha1/opam
@@ -57,7 +57,7 @@ depends: [
   "graphql-lwt"
   "hmap"
   "lwt"
-  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ppx" {>= "1.2.2" & <= "5.9.1"}
   "lwt_ssl"
   "ssl" {>= "0.5.8"}
   "logs" {>= "0.5.0"}

--- a/packages/dream/dream.1.0.0~alpha2/opam
+++ b/packages/dream/dream.1.0.0~alpha2/opam
@@ -58,7 +58,7 @@ depends: [
   "graphql-lwt"
   "hmap"
   "lwt"
-  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ppx" {>= "1.2.2" & <= "5.9.1"}
   "lwt_ssl"
   "ssl" {>= "0.5.8"}
   "logs" {>= "0.5.0"}

--- a/packages/dream/dream.1.0.0~alpha3/opam
+++ b/packages/dream/dream.1.0.0~alpha3/opam
@@ -58,7 +58,7 @@ depends: [
   "graphql_parser"
   "graphql-lwt"
   "lwt"
-  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ppx" {>= "1.2.2" & <= "5.9.1"}
   "lwt_ssl"
   "logs" {>= "0.5.0"}
   "magic-mime"


### PR DESCRIPTION
I've been seeing older dream alpha releases triggering red CI lights, most recently on #28508 - and before then on #28437 which adds needless noise:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/6ee86a28bc1c817f5249bbf9ffd7e607e26a9ea0/variant/compilers,4.14,menhirLib.20250912,revdeps,dream.1.0.0~alpha1
```
# File "src/middleware/content_length.ml", line 32, characters 42-62:
# 32 |     let%lwt (response : Dream.response) = next_handler request in
#                                                ^^^^^^^^^^^^^^^^^^^^
# Error: This expression has type
#          Dream.response = Dream.outgoing Dream__pure__Inmost.message
#        but an expression was expected of type 'a Lwt.t
```

I am able to reproduce this locally with `lwt_ppx.5.9.2` (pulling in `ppxlib.0.36.0`), while  `lwt_ppx.5.9.1` (with `ppxlib.0.35.0`) works. This PR therefore adds an upper bound of `lwt_ppx.5.9.1` for `dream.1.0.0~alpha{1,2,3}`.