### PR TITLE
Package crs.0.0.20250914

### DIFF
--- a/packages/crs/crs.0.0.20250914/opam
+++ b/packages/crs/crs.0.0.20250914/opam
@@ -1,0 +1,95 @@
+opam-version: "2.0"
+synopsis: "A tool for managing code review comments embedded in source code"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/crs"
+doc: "https://mbarbin.github.io/crs/"
+bug-reports: "https://github.com/mbarbin/crs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "base" {>= "v0.17"}
+  "cmdlang" {>= "0.0.9"}
+  "file-rewriter" {>= "0.0.3"}
+  "fpath" {>= "0.7.3"}
+  "fpath-base" {>= "0.3.1"}
+  "loc" {>= "0.2.2"}
+  "pageantty" {>= "0.0.2"}
+  "pp" {>= "2.0.0"}
+  "pplumbing" {>= "0.0.14"}
+  "ppx_compare" {>= "v0.17"}
+  "ppx_deriving_yojson" {>= "3.9"}
+  "ppx_enumerate" {>= "v0.17"}
+  "ppx_hash" {>= "v0.17"}
+  "ppx_here" {>= "v0.17"}
+  "ppx_sexp_conv" {>= "v0.17"}
+  "ppx_sexp_value" {>= "v0.17"}
+  "ppxlib" {>= "0.33"}
+  "print-table" {>= "0.1.0"}
+  "re" {>= "1.12.0"}
+  "spawn" {>= "v0.17"}
+  "stdio" {>= "v0.17"}
+  "volgo" {>= "0.0.18"}
+  "volgo-base" {>= "0.0.18"}
+  "volgo-git-unix" {>= "0.0.18"}
+  "volgo-hg-unix" {>= "0.0.18"}
+  "yojson" {>= "2.1.1"}
+  "yojson-five" {>= "2.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/crs.git"
+description: """\
+
+The [crs] package provides libraries and a CLI to help manage code
+review comments embedded directly in source code using a specialized
+syntax.
+
+With [crs] you can locate, parse, and manipulate these comments
+easily, and perform tasks such as systematically updating comments
+across multiple files, changing their priority, marking them as
+resolved, modifying reporter or assignee information, and more.
+
+This tool can be used during development or integrated into your CI
+pipeline. For example, you can use [crs] to ensure no unresolved
+comments remain before merging a pull request or releasing a new
+version of your software.
+
+Beyond its standalone functionality, [crs] is intended to serve as a
+sharable building block for more comprehensive code review systems and
+collaborative workflows.
+
+The [crs] projects builds upon ideas from [iron], a code review system
+built by Jane Street and released as open source in 2016-2017. We
+deeply appreciate Jane Street’s willingness to share [iron], which has
+provided a valuable starting point for exploring and advancing these
+ideas.
+
+[iron]: https://github.com/janestreet/iron
+
+"""
+tags: [ "code-review" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/crs/releases/download/0.0.20250914/crs-0.0.20250914.tbz"
+  checksum: [
+    "sha256=dad0c46a83ef40da150d8b840b01c66af3b979dfa7c3e17c3edef38aa84b804f"
+    "sha512=d7a8b2a34f4a3ddda0eaaa3e4248ec2870f944a5d64782bd73b031637b01e94a378d7534b1c02da739f32343b342ed8e8bf491e6442a3bd7b0e748bd61c58770"
+  ]
+}
+x-commit-hash: "375804352246d79e23a8cba7dc63fd9fc174751d"


### PR DESCRIPTION
### `crs.0.0.20250914`
A tool for managing code review comments embedded in source code
The [crs] package provides libraries and a CLI to help manage code
review comments embedded directly in source code using a specialized
syntax.

With [crs] you can locate, parse, and manipulate these comments
easily, and perform tasks such as systematically updating comments
across multiple files, changing their priority, marking them as
resolved, modifying reporter or assignee information, and more.

This tool can be used during development or integrated into your CI
pipeline. For example, you can use [crs] to ensure no unresolved
comments remain before merging a pull request or releasing a new
version of your software.

Beyond its standalone functionality, [crs] is intended to serve as a
sharable building block for more comprehensive code review systems and
collaborative workflows.

The [crs] projects builds upon ideas from [iron], a code review system
built by Jane Street and released as open source in 2016-2017. We
deeply appreciate Jane Street’s willingness to share [iron], which has
provided a valuable starting point for exploring and advancing these
ideas.

[iron]: https://github.com/janestreet/iron



---
* Homepage: https://github.com/mbarbin/crs
* Source repo: git+https://github.com/mbarbin/crs.git
* Bug tracker: https://github.com/mbarbin/crs/issues

---
## 0.0.20250914 (2025-09-14)

### Changed

- Switch to `ppx_deriving_yojson` ([#86](https://github.com/mbarbin/crs/pull/86), @mbarbin).

### Fixed

- Prepare for compatibility with OCaml 5.4.0 ([#86](https://github.com/mbarbin/crs/pull/86), @mbarbin).

## 0.0.20250911 (2025-09-11)

### Added

- Add support for `.crs-ignore` files ([#77](https://github.com/mbarbin/crs/pull/77), [#78](https://github.com/mbarbin/crs/pull/78), @mbarbin).
- Add documentation about use with assistant agent ([#76](https://github.com/mbarbin/crs/pull/76), @mbarbin).

### Changed

- Upgrade `crs-config` to latest format ([#75](https://github.com/mbarbin/crs/pull/75), @mbarbin).

## 0.0.20250813 (2025-08-13)

### Added

- Add CRs Actions config reference including recent changes ([#74](https://github.com/mbarbin/crs/pull/74), @mbarbin).
- Add new documentation pages ([#70](https://github.com/mbarbin/crs/pull/70), [#71](https://github.com/mbarbin/crs/pull/71), [#72](https://github.com/mbarbin/crs/pull/72), @mbarbin).
- Add invalid CRs parser ([#65](https://github.com/mbarbin/crs/pull/65), @mbarbin).
- Add getters for cr comment content start offset and prefix ([#63](https://github.com/mbarbin/crs/pull/63), @mbarbin).
- Add more tests for invalid CRs ([#61](https://github.com/mbarbin/crs/pull/61), [#64](https://github.com/mbarbin/crs/pull/64), @mbarbin).

### Changed

- Some format changes to CRs Actions config ([#73](https://github.com/mbarbin/crs/pull/73), @mbarbin).
- Ignore CRs that are considered not-a-cr by the invalid CRs parser ([#66](https://github.com/mbarbin/crs/pull/66), @mbarbin).
- Install crs in the CI actions PATH and use shared crs actions ([#62](https://github.com/mbarbin/crs/pull/62), @mbarbin).
- Wrap CLI readme text using code margin ([#60](https://github.com/mbarbin/crs/pull/60), @mbarbin).
- Switch from `text-table` to upstream `print-table` lib ([#59](https://github.com/mbarbin/crs/pull/59), @mbarbin).
- Prepare review mode for requiring the pull-request base ([#57](https://github.com/mbarbin/crs/pull/57), @mbarbin).
- Rename review-mode "commit" => "revision" ([#57](https://github.com/mbarbin/crs/pull/57), @mbarbin).

### Fixed

- Fix GitHub annotations for empty locs and multiple lines messages ([#56](https://github.com/mbarbin/crs/pull/56), @mbarbin).
- Make `Header.priority` return `Now` on XCRs ([#55](https://github.com/mbarbin/crs/pull/55), @mbarbin).

### Removed

- Removed library `crs.text-table`. It was upstreamed ([#59](https://github.com/mbarbin/crs/pull/59), @mbarbin).


---
:camel: Pull-request generated by opam-publish v2.5.1