### PR TITLE
[new release] passage (0.1.7)

### DIFF
--- a/packages/passage/passage.0.1.7/opam
+++ b/packages/passage/passage.0.1.7/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Passage - used to store and manage access to shared secrets"
+description: "Passage - used to store and manage access to shared secrets"
+maintainer: ["Ahrefs Pte Ltd <github@ahrefs.com>"]
+authors: ["Ahrefs Pte Ltd <github@ahrefs.com>"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/passage"
+bug-reports: "https://github.com/ahrefs/passage/issues"
+depends: [
+  "cmdliner" {>= "1.1.0"}
+  "ocaml" {>= "4.14"}
+  "conf-age"
+  "dune" {>= "3.9"}
+  "devkit" {>= "1.20240429"}
+  "extunix"
+  "fileutils"
+  "fpath"
+  "lwt"
+  "lwt_ppx"
+  "menhir" {>= "20231231"}
+  "ppx_expect"
+  "ocamlformat" {with-dev-setup & = "0.26.2"}
+  "qrc"
+  "re2"
+  "sedlex"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/passage.git"
+available: os != "win32"
+x-ci-accept-failures: [
+  "alpine-3.20"
+  "archlinux"
+  "debian-11"
+  "fedora-39"
+  "fedora-40"
+  "opensuse-15.6"
+  "opensuse-tumbleweed"
+]
+url {
+  src:
+    "https://github.com/ahrefs/passage/releases/download/0.1.7/passage-0.1.7.tbz"
+  checksum: [
+    "sha256=d8d25d205c85f2cf6d122ce913405eee7f117b51d18861f0acb5351b5bf608c4"
+    "sha512=0cb84765c09ec5e02f571959b3bbd6586b6a54e0d821953451f75dd8fcc3a69aec81c86df54b356e5c98a329ae385c6c42cf6a1adad86b2270c3f392c85354f7"
+  ]
+}
+x-commit-hash: "93805be3c93445ad517e1bf8042fb7e016e50882"


### PR DESCRIPTION
Passage - used to store and manage access to shared secrets

- Project page: <a href="https://github.com/ahrefs/passage">https://github.com/ahrefs/passage</a>

##### CHANGES:

- Add --comment flag to the create command
- Add edit-comments command
- Show recipients in "user is not recipient" error
- Add add-who and rm-who commands
- Add groups suggestions to recipients suggestions
- Add `my` command
- Add better handling of bad setup for get and ls
- Improve error handling and message for missing setup
- Better error message when passage isn't setup
- Update Makefile
- Improve README and run linting
- Catch `realpath` error and raise friendlier exception
- Update bash completions
- Add zsh completions
