### PR TITLE
[new release] coq-lsp (0.2.4+9.1)

### DIFF
--- a/packages/coq-lsp/coq-lsp.0.2.4+9.1/opam
+++ b/packages/coq-lsp/coq-lsp.0.2.4+9.1/opam
@@ -1,0 +1,80 @@
+synopsis: "Language Server Protocol native server for Coq"
+description:
+"""
+Language Server Protocol native server for Coq
+"""
+opam-version: "2.0"
+maintainer: "e@x80.org"
+bug-reports: "https://github.com/ejgallego/coq-lsp/issues"
+homepage: "https://github.com/ejgallego/coq-lsp"
+dev-repo: "git+https://github.com/ejgallego/coq-lsp.git"
+authors: [
+  "Emilio Jesús Gallego Arias <e@x80.org>"
+  "Ali Caglayan <alizter@gmail.com>"
+  "Shachar Itzhaky <shachari@cs.technion.ac.il>"
+  "Ramkumar Ramachandra <r@artagnon.com>"
+]
+license: "LGPL-2.1-or-later"
+doc: "https://ejgallego.github.io/coq-lsp/"
+
+depends: [
+
+  ("ocaml" {>= "5.0"} | ("ocaml" {<= "5.0"} & "memprof-limits" { >= "0.2.1" } ))
+
+  "dune"         { >= "3.13.0" } # Version interval [3.8-3.12] was
+                                 # broken for composed builds with Coq
+
+  # lsp dependencies
+  "cmdliner"     { >= "1.1.0" }
+  "yojson"       { >= "1.7.0" }
+  "uri"          { >= "4.2.0" }
+  "dune-build-info" { >= "3.2.0" }
+
+  # coq-layout-printer
+  "tyxml"        { >= "4.5.0" }
+
+  # for waterproof json parser
+  "menhir"       { >= "20220210" }
+
+  # unit testing
+  "ppx_inline_test"     { >= "v0.15.0" }
+
+  # This is now a hard dep due to API changes in 1.9.7
+  "ocamlfind" { >= "1.9.8" }
+
+  # Rocq
+  "rocq-core"          { >= "9.1" < "9.2"  }
+  "rocq-stdlib"        { >= "9" & with-test }
+
+  # serlib deps
+  "ppx_deriving"        { >= "5.2"                 }
+  "ppx_deriving_yojson" { >= "3.7.0"               }
+  "ppx_import"          { >= "1.11.0"              }
+  "sexplib"             { >= "v0.15.0" & < "v0.18" }
+  "ppx_sexp_conv"       { >= "v0.15.0" & < "v0.18" }
+  "ppx_compare"         { >= "v0.15.0" & < "v0.18" }
+  "ppx_hash"            { >= "v0.15.0" & < "v0.18" }
+]
+
+# older results get in mess with ppx_deriving, we cannot control how
+# it gets pulled, often in min-bound rev-dep, so we conflict with it
+conflicts: [ "result" { < "1.5" } ]
+
+depopts: ["lwt" "logs"]
+
+build: [
+  [ "rm" "-rf" "vendor" ]
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [ [ "dune" "runtest" "-p" name "-j" jobs ] ]
+
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-lsp/releases/download/0.2.4%2B9.1/coq-lsp-0.2.4.9.1.tbz"
+  checksum: [
+    "sha256=667908bdd88f0bb1b75d2fa76a483006d600c9422a2a15297a172e62c0415cad"
+    "sha512=42f8e5ad308702f77c9dc40243acd2e656b16bdb94c302306dbb87387cc36941deccd5f52c18d1a045467030ddf86528b22819522a647eee5b9e1ac25f4a9560"
+  ]
+}
+x-commit-hash: "3a749b285f42de753123b0df8fff600442372d61"


### PR DESCRIPTION
Language Server Protocol native server for Coq

- Project page: <a href="https://github.com/ejgallego/coq-lsp">https://github.com/ejgallego/coq-lsp</a>
- Documentation: <a href="https://ejgallego.github.io/coq-lsp/">https://ejgallego.github.io/coq-lsp/</a>

##### CHANGES:

------------------------------

 - [js] [deps] Bump to findlib 1.9.8, use vanilla API for loading and
   remove our own local wrapper (@ejgallego, ejgallego/coq-lsp#975).
 - [petanque] New `petanque/ast` and `petanque/ast_at_pos`
   (@ejgallego, @JulesViennotFranca, ejgallego/coq-lsp#980)
 - [serlib] Support for generic Ast analyzers. This opens the door to
   many feature requests such as syntax coloring, dependency
   extraction, etc... (@ejgallego, @JulesViennotFranca, ejgallego/coq-lsp#981)
 - [fleche] Support "rocq" markdown delimiters in .mv files
   (@ejgallego, ejgallego/coq-lsp#987)
 - [workspace] Support _RocqProject (@ejgallego, ejgallego/coq-lsp#988, fixes ejgallego/coq-lsp#934)
 - [lsp] [getDocument] Allow to get goals in one shot. We also
   refactor the response type to accommodate different
   meta-data. Note: (!) breaking change. (@ejgallego, ejgallego/coq-lsp#985, fixes
   ejgallego/coq-lsp#862, thanks to the Alectryon team)
 - [lsp] Better error handling in URI parsing (@ejgallego, ejgallego/coq-lsp#994, thanks to
   Adrien from Zulip)
 - [lsp] Better protocol-level handling for our non-standard `Lang.Point`
   and `Lang.Diagnostic` types, via global flags that allow us to
   choose the input/output representation for non-standard field such
   as [Point.offset]. This ensures that leaks of these non-standard
   fields are rarer. (@ejgallego, ejgallego/coq-lsp#995, cc ejgallego/coq-lsp#279, cc ejgallego/coq-lsp#2, thanks to
   Adrien from Zulip)
 - [lsp] [completion] Rework completion configuration into a
   `coq-lsp.completion` json object. The `unicode_completion` setting
   is now deprecated, and has been replaced by
   `completion.unicode.enable` (@ejgallego, ejgallego/coq-lsp#993)
 - [lsp] [completion] [vscode] Unicode completion commit characters
   are now configurable via the server setting variable
   `completion.unicode.commit_chars`. (@Durbatuluk1701, ejgallego/coq-lsp#993)
 - [goals] [config] New (global) option for goal display method
   `proof/goals`: `messages_follow_goal`. If `true`, `proof/goals`
   will show errors and messages for the same sentence goals are
   shown; if `false`, it will always show errors and messages for the
   specified `position`, if there is a Rocq sentence at hand
   (@jpoiret, @ejgallego, ejgallego/coq-lsp#999, fixes: ejgallego/coq-lsp#941)
 - [coq] Install full state before parsing. Before we did only
   `Pcoq.unfreeze` but that is not enough, in particular the call to
   `get_default_proof_mode` will not be correct (@ejgallego, @pimotte,
   ejgallego/coq-lsp#1011, fixes ejgallego/coq-lsp#656)
 - [misc] Don't depend on Jane Street's base (@patrick-nicodemus
   @ejgallego, ejgallego/coq-lsp#1004)
 - [wasm worker] Add WebAssembly based worker based on waCoq. This is
   now the default for the .vsix binary build. For now, we include
   Rocq's Stdlib and Waterproof (@corwin-of-amber, @ejgallego,
   @pimotte, ejgallego/coq-lsp#1008, cc ejgallego/coq-lsp#833, fixes ejgallego/coq-lsp#907, fixes ejgallego/coq-lsp#908, fixes ejgallego/coq-lsp#913)
 - [opam] Added `x-maintenance-intent` intent field. (@ejgallego,
   ejgallego/coq-lsp#1020)
 - [lsp] [didOpen] `languageId` now takes priority over uri extension
   in LSP `didOpen`. (@ejgallego, ejgallego/coq-lsp#1021, fixes ejgallego/coq-lsp#1005)
 - [coq] incorporate experimental `coq-layout-engine` printer, both in
   client and server parts (@ejgallego, ejgallego/coq-lsp#668, see also ejgallego/coq-lsp#72 and
   https://github.com/jscoq/jscoq/pull/282 )
 - [lsp] [code] New notification `$/coq/executionInformation` which
   will signal clients when rocq-lsp does intent to start to execute a
   sentence. Experimentally, this is used to provide a red glow on
   long-running commands in coq-lsp/VSCode, to provide better user
   feedback on long-running commands (@ejgallego, suggested by
   @jpoiret, ejgallego/coq-lsp#1002)
 - [lsp] [outline] Support `Notation`, `Ltac` and `Ltac Notation` in
   outline entries (@ejgallego, ejgallego/coq-lsp#1025, fixes ejgallego/coq-lsp#632)
