### PR TITLE
[new release] iomux (0.4)

### DIFF
--- a/packages/iomux/iomux.0.4/opam
+++ b/packages/iomux/iomux.0.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "IO Multiplexer bindings"
+description:
+  "Low level bindings for Unix IO Multiplexers (poll/ppoll/kevent/epoll)"
+maintainer: ["OCaml Multicore Team"]
+authors: ["Christiano Haesbaert"]
+license: "ISC"
+tags: ["io" "multiplexing" "poll" "ppoll" "epoll" "kevent" "kqueue"]
+homepage: "https://github.com/ocaml-multicore/ocaml-iomux"
+doc: "https://ocaml-multicore.github.io/ocaml-iomux"
+bug-reports: "https://github.com/ocaml-multicore/ocaml-iomux/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.19"}
+  "dune-configurator"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/ocaml-iomux.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml-multicore/ocaml-iomux/releases/download/v0.4/iomux-0.4.tbz"
+  checksum: [
+    "sha256=1e393fae559476848c5c70525076b11070e806a549eebae084b046a9772bab35"
+    "sha512=352c7d92cbc6048cbac2d0b94d1b4e8e81dc20ff2482cad6ed4fc352ac77fcbafb6a6bebb6206967e6a2e215c8b221d38c3ea33cb842153a7e2662bd5780d4b4"
+  ]
+}
+x-commit-hash: "c2c89ea0198e8119f75766359211d5a3d961535a"


### PR DESCRIPTION
IO Multiplexer bindings

- Project page: <a href="https://github.com/ocaml-multicore/ocaml-iomux">https://github.com/ocaml-multicore/ocaml-iomux</a>
- Documentation: <a href="https://ocaml-multicore.github.io/ocaml-iomux">https://ocaml-multicore.github.io/ocaml-iomux</a>

##### CHANGES:

* Clamp max open files to 2^19, as macOS sometimes returns
  2^32-1 (ocaml-multicore/ocaml-iomux#7 @avsm).
* Upgrade to dune 3.19 and move to ocaml-multicore organisation (@avsm).
