### PR TITLE
mark conf-gmp.1 as avoid version

### DIFF
--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -27,7 +27,7 @@ synopsis: "Virtual package relying on a GMP lib system installation"
 description:
   "This package can only install if the GMP lib is installed on the system."
 authors: "nbraud"
-flags: conf
+flags: [conf avoid-version]
 extra-source "test.c" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-gmp/test.c.1"


### PR DESCRIPTION
```
=== ERROR while compiling conf-gmp.1 =========================================#
 […]
== output ==
 + cc -c -I/usr/local/include test.c test.c: In function 'test': test.c:7:9: error: implicit declaration of function '__gmp_init'; did you mean '__gmpf_init'? [-Wimplicit-function-declaration]
     7 |         __gmp_init();
       |         ^~~~~~~~~~
       |         __gmpf_init
```

as seen in https://github.com/ocaml/opam-repository/pull/28538