### PR TITLE
OCaml 5.3 and dune.3.12.1 conflict too

### DIFF
--- a/packages/dune/dune.3.12.1/opam
+++ b/packages/dune/dune.3.12.1/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "5.4"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.3"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]


### PR DESCRIPTION
https://github.com/ocaml/opam-repository/pull/28536 revealed a missing upper bound:
```
#=== ERROR while compiling dune.3.12.1 ========================================#
# context              2.4.1 | linux/x86_64 | ocaml-base-compiler.5.3.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/dune.3.12.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml boot/bootstrap.ml -j 255
# exit-code            2
# env-file             ~/.opam/log/dune-7-cf4a18.env
# output-file          ~/.opam/log/dune-7-cf4a18.out
### output ###
# ocamlc -output-complete-exe -w -24 -g -o .duneboot.exe -I boot -I +unix unix.cma boot/libs.ml boot/duneboot.ml
# ./.duneboot.exe -j 255
# cd _boot && /home/opam/.opam/5.3/bin/ocamlopt.opt -c -g -I +unix -I +threads dune_digest_stubs.c
# In file included from /home/opam/.opam/5.3/lib/ocaml/caml/io.h:28,
#                  from /home/opam/.opam/5.3/lib/ocaml/caml/md5.h:24,
#                  from src/dune_digest/dune_digest_stubs.c:10:
# /home/opam/.opam/5.3/lib/ocaml/caml/platform.h: In function 'caml_plat_latch_is_released':
# /home/opam/.opam/5.3/lib/ocaml/caml/platform.h:222:10: error: implicit declaration of function 'atomic_load_acquire' [-Wimplicit-function-declaration]
#   222 |   return atomic_load_acquire(&latch->value) == Latch_released;
#       |          ^~~~~~~~~~~~~~~~~~~
# /home/opam/.opam/5.3/lib/ocaml/caml/platform.h: In function 'caml_plat_latch_set':
# /home/opam/.opam/5.3/lib/ocaml/caml/platform.h:230:3: error: implicit declaration of function 'atomic_store_release'; did you mean 'atomic_store_explicit'? [-Wimplicit-function-declaration]
#   230 |   atomic_store_release(&latch->value, Latch_unreleased);
#       |   ^~~~~~~~~~~~~~~~~~~~
#       |   atomic_store_explicit
# 
```

This is an unfortunate interaction between OCaml 5.3 and dune.3.12.1 which was fixed upstream in https://github.com/ocaml/dune/pull/9733

On the opam-repo similar 5.3 bounds were added
- for dune.3.12.2 in 9ee8695a33 from #27304
- for dune.3.10.0 in 48010ffa79 from #28092
