### PR TITLE
Avoid conf-gmp-powm-sec.1 too

### DIFF
--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.1/opam
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.1/opam
@@ -18,7 +18,7 @@ description: """
 This package can only install if the GMP lib is installed on the system and
 corresponds to a version that has the mpz_powm_sec function."""
 authors: "Etienne Millon <etienne@cryptosense.com>"
-flags: conf
+flags: [conf avoid-version]
 extra-source "test.c" {
   src:
     "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-gmp-powm-sec/test.c.1"


### PR DESCRIPTION
Similarly to https://github.com/ocaml/opam-repository/pull/28540
gcc-14's  implicit-function-declaration error is causing `conf-gmp-powm-sec.1` to fail during a lower bound search
https://gcc.gnu.org/gcc-14/porting_to.html

Seen on https://github.com/ocaml/opam-repository/pull/28539
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/838b60f55ba5673b90bb32ff755274fcd893caca/variant/compilers,4.14,proton.1.0.16,lower-bounds
```
#=== ERROR while compiling conf-gmp-powm-sec.1 ================================#
# context              2.4.1 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/conf-gmp-powm-sec.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build sh -exc cc -c $CFLAGS -I/usr/local/include test.c
# exit-code            1
# env-file             ~/.opam/log/conf-gmp-powm-sec-7-13ea75.env
# output-file          ~/.opam/log/conf-gmp-powm-sec-7-13ea75.out
### output ###
# + cc -c -I/usr/local/include test.c
# test.c: In function 'test':
# test.c:10:9: error: implicit declaration of function '__gmp_init'; did you mean '__gmpf_init'? [-Wimplicit-function-declaration]
#    10 |         __gmp_init();
#       |         ^~~~~~~~~~
#       |         __gmpf_init
```