### PR TITLE
[new release] fd-send-recv (2.0.3)

### DIFF
--- a/packages/fd-send-recv/fd-send-recv.2.0.3/opam
+++ b/packages/fd-send-recv/fd-send-recv.2.0.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "xen-api@lists.xensource.com"
+authors: [
+  "David Scott"
+  "David Sheets"
+  "Euan Harris"
+  "Vincent Bernardoff"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/ocaml-fd-send-recv"
+bug-reports: "https://github.com/xapi-project/ocaml-fd-send-recv/issues"
+dev-repo: "git+https://github.com/xapi-project/ocaml-fd-send-recv.git"
+doc: "https://github.com/xapi-project/ocaml-fd-send-recv/blob/master/lib/fd_send_recv.mli"
+x-maintenance-intent: ["(latest)"]
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "1.4"}
+  "odoc" {with-doc}
+]
+synopsis:
+  "Bindings for sendmsg/recvmsg that allow Unix.file_descrs to be sent and received over Unix domain sockets"
+url {
+  src:
+    "https://github.com/xapi-project/ocaml-fd-send-recv/releases/download/v2.0.3/fd-send-recv-2.0.3.tbz"
+  checksum: [
+    "sha256=34970f254a14885daaabb98f5410160530aa6e994747ad1eab99ec4f61dc9934"
+    "sha512=c50d836212d9b0e05ffa9fe83dc208929b7aab3c88340f0d7ea7a13bec802bdb15d4279c9dc146bb0b6b59d9baf7db7802d57cd35f3ecda6c2ee053c6b3c69c7"
+  ]
+}
+x-commit-hash: "7ae08696ef551829e6a5554c4b36f77e929f44f9"


### PR DESCRIPTION
Bindings for sendmsg/recvmsg that allow Unix.file_descrs to be sent and received over Unix domain sockets

- Project page: <a href="https://github.com/xapi-project/ocaml-fd-send-recv">https://github.com/xapi-project/ocaml-fd-send-recv</a>
- Documentation: <a href="https://github.com/xapi-project/ocaml-fd-send-recv/blob/master/lib/fd_send_recv.mli">https://github.com/xapi-project/ocaml-fd-send-recv/blob/master/lib/fd_send_recv.mli</a>

##### CHANGES:

- Make library compatible with 4.x again
