### PR TITLE
Frama c.31.0 plugins MetAcsl and Frama-Clang

### DIFF
--- a/packages/frama-c-metacsl/frama-c-metacsl.0.9/opam
+++ b/packages/frama-c-metacsl/frama-c-metacsl.0.9/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "MetAcsl plugin of Frama-C for writing pervasives properties"
+description: """\
+MetAcsl let users write properties that need to be checked at particular
+contexts (e.g. each time a location is written to inside a given set
+of functions). It will then generate all the corresponding ACSL
+annotations, leaving it to analysis plug-ins (e.g. WP) to prove the
+resulting clauses."""
+maintainer: "Virgile.Prevosto@cea.fr"
+authors: ["Virgile Robles" "Téo Bernier" "Nikolai Kosmatov"]
+license: "LGPL-2.1-only"
+tags: [
+  "program verification"
+  "formal specification"
+  "C"
+  "plugins"
+  "ACSL"
+  "MetACSL"
+]
+homepage: "https://frama-c.com/"
+bug-reports: "https://git.frama-c.com/pub/meta/-/issues"
+depends: [
+  "ocaml" {>= "4.13.1"}
+  "dune" {>= "3.13" & != "3.13.0"}
+  "frama-c" {>= "31.0~" & < "32.0~"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "conf-swi-prolog"
+  "why3" {>= "1.3.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+messages:
+  "Note that if you wish to use the deduction features of MetAcsl, you must install the conf-swi-prolog package (and swi-prolog itself)"
+    {!conf-swi-prolog:installed}
+dev-repo: "git+https://git.frama-c.com/pub/meta.git"
+url {
+  src: "https://git.frama-c.com/pub/meta/-/archive/0.9/meta-0.9.tar.bz2"
+  checksum: [
+    "md5=ab56559d1670d0d5ceade62cf2f74a91"
+    "sha512=0d18c0e436941ffb3de60c762a990180c6f1efb8b3350c35ab77444167a4fff888afe8350b2cd914e40ce593fb8bd90e0b6c128c1088fbb939a87cc86488ca4f"
+  ]
+}

--- a/packages/frama-clang/frama-clang.0.0.18/opam
+++ b/packages/frama-clang/frama-clang.0.0.18/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Frama-C plug-in based on Clang for parsing C++ files"
+description:
+  "This Frama-C plug-in parse C++ files that may contain ACSL++ annotations."
+maintainer: "Virgile.Prevosto@cea.fr"
+authors: "Virgile Prevosto"
+license: "LGPL-2.1-only"
+tags: ["formal specification" "C++" "plugins" "ACSL" "ACSL++"]
+homepage: "https://frama-c.com/frama-clang.html"
+bug-reports: "https://git.frama-c.com/pub/frama-clang/-/issues"
+depends: [
+  "dune" {>= "3.13" & != "3.13.0"}
+  "frama-c" {>= "31.0~" & < "32.0~"}
+  "zarith" {>= "1.5"}
+  "camlp5"
+  "camlp-streams"
+  "conf-llvm" {>= "11.0.0" & < "20"}
+  "conf-libclang" {>= "11.0.0" & < "20"}
+  "conf-clang"
+  "conf-cmake"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/frama-clang.git"
+url {
+  src:
+    "https://git.frama-c.com/pub/frama-clang/-/archive/0.0.18/frama-clang-0.0.18.tar.bz2"
+  checksum: [
+    "md5=f83ac85f2272c3bbb8d4800b41048c8d"
+    "sha512=f4f5d7a231e2d231f0144adb745a9920d8f1fc0716c13d0817f668678dbc164c697821f6d387f4478e77b0ef62db7ca874bb192a041bd3403274c67eb37c9f0c"
+  ]
+}
+x-ci-accept-failures: ["debian-11" "ubuntu-20.04"]


### PR DESCRIPTION
This PR adds packages for the new versions of frama-c-metacsl and frama-clang compatible with Frama-C 31.0 released in June