### PR TITLE
Package opam-publish.2.6.0

### DIFF
--- a/packages/opam-publish/opam-publish.2.6.0/opam
+++ b/packages/opam-publish/opam-publish.2.6.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A tool to ease contributions to opam repositories"
+description: """\
+opam-publish automates publishing packages to package repositories: it checks that the
+opam file is complete using `opam lint`, verifies and adds the archive URL and its
+checksum and files a GitHub pull request for merging it."""
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+depends: [
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "1.0"}
+  "lwt_ssl"
+  "ocaml" {>= "4.08.0"}
+  "opam-core" {>= "2.2.0"}
+  "opam-format" {>= "2.2.0"}
+  "opam-state" {>= "2.2.0"}
+  "github" {>= "4.3.2"}
+  "github-unix" {>= "4.3.2"}
+]
+conflicts: [
+  "ssl" {= "0.5.6"}
+]
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+url {
+  src:
+    "https://github.com/ocaml/opam-publish/releases/download/2.6.0/opam-publish-2.6.0.tar.gz"
+  checksum: [
+    "md5=bcf1663ca507d6c70bc50deb61e5cef5"
+    "sha512=e0c547356f1e8138db775217cb6a479ec7a383f9fd67b46328eab8a859bc4dbe790387e68b7b4ff6bc16bca01f104d8e588170c28032c4aea6d3728ca2919949"
+  ]
+}


### PR DESCRIPTION
### `opam-publish.2.6.0`
A tool to ease contributions to opam repositories
opam-publish automates publishing packages to package repositories: it checks that the
opam file is complete using `opam lint`, verifies and adds the archive URL and its
checksum and files a GitHub pull request for merging it.



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v2.5.0