### PR TITLE
5 packages from mbarbin/cmdlang at 0.0.10

### DIFF
--- a/packages/cmdlang-stdlib-runner/cmdlang-stdlib-runner.0.0.10/opam
+++ b/packages/cmdlang-stdlib-runner/cmdlang-stdlib-runner.0.0.10/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "A basic execution runner for cmdlang based on stdlib.arg"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "cmdlang" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+description: """\
+
+[Cmdlang_stdlib_runner] is an execution engine for running command
+line programs specified with [cmdlang].
+
+It has no dependencies other than [cmdlang] and is implemented using
+the [Arg] module from the OCaml standard library.
+
+This package may be useful as a lightweight alternative to translating
+cmdlang parsers to more feature-rich libraries such as [cmdliner],
+[climate], or [core.command].
+
+"""
+tags: [ "cli" "cmdlang" "stdlib.arg" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.10/cmdlang-0.0.10.tbz"
+  checksum: [
+    "sha256=ca68da238799022810373d060bbd528d1de7687e8f8b4a89450c0bb33a41897d"
+    "sha512=7e223e3b02da4132f3638c83cad2b0b5bd3f672d777ad09a1d956db6bbed8d93b6125d754fcc0d970b16ac8150be08f9c3ae6a066868e2128351f9e049fefe53"
+  ]
+}
+x-commit-hash: "f32ae474676a018bf428b466f5edf0d76d738b01"

--- a/packages/cmdlang-to-base/cmdlang-to-base.0.0.10/opam
+++ b/packages/cmdlang-to-base/cmdlang-to-base.0.0.10/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Convert cmdlang Parsers to core.command"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "base" {>= "v0.17"}
+  "cmdlang" {= version}
+  "core" {>= "v0.17"}
+  "ppx_compare" {>= "v0.17"}
+  "ppx_enumerate" {>= "v0.17"}
+  "ppx_let" {>= "v0.17"}
+  "ppx_sexp_conv" {>= "v0.17"}
+  "ppx_sexp_value" {>= "v0.17"}
+  "ppxlib" {>= "0.33"}
+  "stdio" {>= "v0.17"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+description: """\
+
+[Cmdlang_to_base] allows translating command line programs specified
+with [cmdlang] into [core.command] commands suitable for execution.
+
+[core.command]: https://github.com/janestreet/core
+
+"""
+tags: [ "cli" "cmdlang" "core.command" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.10/cmdlang-0.0.10.tbz"
+  checksum: [
+    "sha256=ca68da238799022810373d060bbd528d1de7687e8f8b4a89450c0bb33a41897d"
+    "sha512=7e223e3b02da4132f3638c83cad2b0b5bd3f672d777ad09a1d956db6bbed8d93b6125d754fcc0d970b16ac8150be08f9c3ae6a066868e2128351f9e049fefe53"
+  ]
+}
+x-commit-hash: "f32ae474676a018bf428b466f5edf0d76d738b01"

--- a/packages/cmdlang-to-climate/cmdlang-to-climate.0.0.10/opam
+++ b/packages/cmdlang-to-climate/cmdlang-to-climate.0.0.10/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Convert cmdlang Parsers to climate"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "climate" {>= "0.8.0"}
+  "cmdlang" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+description: """\
+
+[Cmdlang_to_climate] allows translating command line programs
+specified with [cmdlang] into [climate] commands suitable for
+execution.
+
+[climate]: https://github.com/gridbugs/climate
+
+"""
+tags: [ "cli" "cmdlang" "climate" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.10/cmdlang-0.0.10.tbz"
+  checksum: [
+    "sha256=ca68da238799022810373d060bbd528d1de7687e8f8b4a89450c0bb33a41897d"
+    "sha512=7e223e3b02da4132f3638c83cad2b0b5bd3f672d777ad09a1d956db6bbed8d93b6125d754fcc0d970b16ac8150be08f9c3ae6a066868e2128351f9e049fefe53"
+  ]
+}
+x-commit-hash: "f32ae474676a018bf428b466f5edf0d76d738b01"

--- a/packages/cmdlang-to-cmdliner/cmdlang-to-cmdliner.0.0.10/opam
+++ b/packages/cmdlang-to-cmdliner/cmdlang-to-cmdliner.0.0.10/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Convert cmdlang Parsers to cmdliner"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "cmdlang" {= version}
+  "cmdliner" {>= "1.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+description: """\
+
+[Cmdlang_to_cmdliner] allows translating command line programs
+specified with [cmdlang] into [cmdliner] commands suitable for
+execution.
+
+[cmdliner]: https://github.com/dbuenzli/cmdliner
+
+"""
+tags: [ "cli" "cmdlang" "cmdliner" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.10/cmdlang-0.0.10.tbz"
+  checksum: [
+    "sha256=ca68da238799022810373d060bbd528d1de7687e8f8b4a89450c0bb33a41897d"
+    "sha512=7e223e3b02da4132f3638c83cad2b0b5bd3f672d777ad09a1d956db6bbed8d93b6125d754fcc0d970b16ac8150be08f9c3ae6a066868e2128351f9e049fefe53"
+  ]
+}
+x-commit-hash: "f32ae474676a018bf428b466f5edf0d76d738b01"

--- a/packages/cmdlang/cmdlang.0.0.10/opam
+++ b/packages/cmdlang/cmdlang.0.0.10/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Declarative Command-line Parsing for OCaml"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+description: """\
+
+Cmdlang is a library for creating command-line parsers in OCaml.
+Implemented as an OCaml EDSL, its declarative specification language
+lives at the intersection of other well-established similar libraries.
+
+Cmdlang doesn't include an execution engine. Instead, Cmdlang parsers
+are automatically translated to [cmdliner], [core.command], or
+[climate] commands for execution.
+
+[cmdliner]: https://github.com/dbuenzli/cmdliner
+[climate]: https://github.com/gridbugs/climate
+[core.command]: https://github.com/janestreet/core
+
+"""
+tags: [ "cli" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.10/cmdlang-0.0.10.tbz"
+  checksum: [
+    "sha256=ca68da238799022810373d060bbd528d1de7687e8f8b4a89450c0bb33a41897d"
+    "sha512=7e223e3b02da4132f3638c83cad2b0b5bd3f672d777ad09a1d956db6bbed8d93b6125d754fcc0d970b16ac8150be08f9c3ae6a066868e2128351f9e049fefe53"
+  ]
+}
+x-commit-hash: "f32ae474676a018bf428b466f5edf0d76d738b01"


### PR DESCRIPTION
This pull-request concerns:
- `cmdlang.0.0.10`: Declarative Command-line Parsing for OCaml
- `cmdlang-stdlib-runner.0.0.10`: A basic execution runner for cmdlang based on stdlib.arg
- `cmdlang-to-base.0.0.10`: Convert cmdlang Parsers to core.command
- `cmdlang-to-climate.0.0.10`: Convert cmdlang Parsers to climate
- `cmdlang-to-cmdliner.0.0.10`: Convert cmdlang Parsers to cmdliner



---
* Homepage: https://github.com/mbarbin/cmdlang
* Source repo: git+https://github.com/mbarbin/cmdlang.git
* Bug tracker: https://github.com/mbarbin/cmdlang/issues

---
## 0.0.10 (2025-09-19)

### Added

- Test behavior when a group is called with an invalid subcommand ([#26](https://github.com/mbarbin/cmdlang/pull/26), @mbarbin).

### Changed

- Add `Param.create'` using `of_string/to_string` API for Param ([#31](https://github.com/mbarbin/cmdlang/pull/31), @mbarbin).
- Change `Param.conv` internal AST representation to `of_string/to_string` ([#31](https://github.com/mbarbin/cmdlang/pull/31), @mbarbin).
- Upgrade to `climate.0.8.0` ([#28](https://github.com/mbarbin/cmdlang/pull/28), @mbarbin).
- More consistent cli commands and args doc strings ([#27](https://github.com/mbarbin/cmdlang/pull/27), @mbarbin).
- Upgrade `climate` and now requires `>= 0.5.0` ([#25](https://github.com/mbarbin/cmdlang/pull/25), @mbarbin).


---
:camel: Pull-request generated by opam-publish v2.6.0