### PR TITLE
Package catala.1.0.0~alpha

### DIFF
--- a/packages/catala/catala.1.0.0~alpha/opam
+++ b/packages/catala/catala.1.0.0~alpha/opam
@@ -1,0 +1,86 @@
+opam-version: "2.0"
+synopsis:
+  "Compiler and library for the literate programming language for tax code specification"
+description:
+  "Catala is a domain-specific language for deriving faithful-by-construction algorithms from legislative texts. See https://catala-lang.org for more information"
+maintainer: "contact@catala-lang.org"
+authors: [
+  "Vincent Botbol"
+  "Nicolas Chataing"
+  "Alain Delaët-Tixeuil"
+  "Louis Gesbert"
+  "Aymeric Fromherz"
+  "Denis Merigoux"
+  "Raphaël Monat"
+  "Romain Primet"
+  "Emile Rolley"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/CatalaLang/catala"
+bug-reports: "https://github.com/CatalaLang/catala/issues"
+depends: [
+  "ocolor" {>= "1.3.0"}
+  "bindlib" {>= "6.0"}
+  "cmdliner" {>= "1.1.0"}
+  "cppo" {>= "1"}
+  "dates_calc" {>= "0.0.7"}
+  "dune" {>= "3.13"}
+  "js_of_ocaml-ppx" {= "4.1.0"}
+  "menhir" {>= "20200211"}
+  "menhirLib" {>= "20200211"}
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {!= "1.9.5"}
+  "ocamlgraph" {>= "1.8.8"}
+  "re" {>= "1.11"}
+  "sedlex" {>= "3.2"}
+  "uucp" {>= "10"}
+  "ubase" {>= "0.05"}
+  "zarith" {>= "1.12"}
+  "zarith_stubs_js" {>= "v0.14.1"}
+  "yojson" {>= "2.1.0"}
+  "crunch" {>= "3.0.0"}
+  "alcotest" {>= "1.5.0"}
+  "ninja_utils" {= "0.9.0"}
+  "odoc" {with-doc}
+  "ocamlformat" {cataladevmode & = "0.26.0"}
+  "obelisk" {cataladevmode}
+  "conf-npm" {cataladevmode}
+  "conf-python-3-dev" {cataladevmode}
+  "conf-openjdk" {cataladevmode}
+  "cpdf" {cataladevmode}
+  "conf-pandoc" {cataladevmode}
+  "z3" {catalaz3mode}
+  "conf-ninja"
+  "otoml" {>= "1.0"}
+]
+depopts: ["z3"]
+conflicts: [
+  "z3" {< "4.8.11"}
+  "base" {>= "v0.16.0"}
+]
+build: [
+  "dune"
+  "build"
+  "-p"
+  name
+  "-j"
+  jobs
+  "@install"
+  "@runtest" {with-test}
+  "@doc" {with-doc}
+]
+depexts: [
+  ["groff"] {with-doc}
+  ["python3-pip"] {cataladevmode & os-family = "debian"}
+  ["py3-pip" "py3-pygments"] {cataladevmode & os-distribution = "alpine"}
+  ["python-pygments"] {cataladevmode & os-family = "arch"}
+]
+dev-repo: "git+https://github.com/CatalaLang/catala"
+url {
+  src:
+    "https://github.com/CatalaLang/catala/archive/refs/tags/1.0.0-alpha.tar.gz"
+  checksum: [
+    "md5=2615968670ac21b1d00386a9b04b3843"
+    "sha512=eff292fdd75012f26ce7b17020f5a8374eef37cd4dd6ba60338dfbe89fbcad3443d1b409e44c182b740da9f58dff7e76dcb8ddefe47f9b2b160666d1c6930143"
+  ]
+}


### PR DESCRIPTION
### `catala.1.0.0~alpha`
Compiler and library for the literate programming language for tax code specification
Catala is a domain-specific language for deriving faithful-by-construction algorithms from legislative texts. See https://catala-lang.org for more information



---
* Homepage: https://github.com/CatalaLang/catala
* Source repo: git+https://github.com/CatalaLang/catala
* Bug tracker: https://github.com/CatalaLang/catala/issues

---
:camel: Pull-request generated by opam-publish v2.5.1