### PR TITLE
Bug correction in dokeysto.4.0.2 impacting three packages

### DIFF
--- a/packages/dokeysto/dokeysto.4.0.2/opam
+++ b/packages/dokeysto/dokeysto.4.0.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/dokeysto"
+bug-reports: "https://github.com/UnixJunkie/dokeysto/issues"
+dev-repo: "git+https://github.com/UnixJunkie/dokeysto.git"
+license: "LGPL-2.1-only"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "exec" "-p" name "-j" jobs "src/test.exe"] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "base-bytes"
+  "base-unix"
+  "extunix"
+]
+synopsis: "The dumb OCaml key-value store"
+description: """Persistent hash table (i.e. in a file on disk)."""
+url {
+  src: "https://github.com/UnixJunkie/dokeysto/archive/v4.0.2.tar.gz"
+  checksum: [
+    "sha256=9742813145638dc1c70a53386a2998af7c1d8763335d26a3fd95239946a5aa28"
+    "md5=83b123fde068a8eb3d4a61920d2ed34a"
+  ]
+}

--- a/packages/dokeysto/dokeysto.4.0.2/opam
+++ b/packages/dokeysto/dokeysto.4.0.2/opam
@@ -18,6 +18,7 @@ depends: [
 ]
 synopsis: "The dumb OCaml key-value store"
 description: """Persistent hash table (i.e. in a file on disk)."""
+x-maintenance-intent: ["(latest)"]
 url {
   src: "https://github.com/UnixJunkie/dokeysto/archive/v4.0.2.tar.gz"
   checksum: [

--- a/packages/dokeysto_camltc/dokeysto_camltc.4.0.2/opam
+++ b/packages/dokeysto_camltc/dokeysto_camltc.4.0.2/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/UnixJunkie/dokeysto.git"
 license: "LGPL-2.1-only"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "exec" "-p" name "-j" jobs "src/test_camltc.exe"] {with-test}
+  ["dune" "exec" "-p" name "-j" jobs "src/test_camltc.exe"] {with-test & arch != "x86_32"}
 ]
 depends: [
   "ocaml"
@@ -15,8 +15,10 @@ depends: [
   "dokeysto" {>= "4.0.2"}
   "camltc" {>= "0.9.8"}
 ]
+available: os != "win32"
 synopsis: "The dumb OCaml key-value store w/ tokyocabinet backend"
 description: "dokeysto with tokyocabinet backend (camltc package in opam)"
+x-maintenance-intent: ["(latest)"]
 url {
   src: "https://github.com/UnixJunkie/dokeysto/archive/v4.0.2.tar.gz"
   checksum: [

--- a/packages/dokeysto_camltc/dokeysto_camltc.4.0.2/opam
+++ b/packages/dokeysto_camltc/dokeysto_camltc.4.0.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/dokeysto"
+bug-reports: "https://github.com/UnixJunkie/dokeysto/issues"
+dev-repo: "git+https://github.com/UnixJunkie/dokeysto.git"
+license: "LGPL-2.1-only"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "exec" "-p" name "-j" jobs "src/test_camltc.exe"] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "dokeysto" {>= "4.0.2"}
+  "camltc" {>= "0.9.8"}
+]
+synopsis: "The dumb OCaml key-value store w/ tokyocabinet backend"
+description: "dokeysto with tokyocabinet backend (camltc package in opam)"
+url {
+  src: "https://github.com/UnixJunkie/dokeysto/archive/v4.0.2.tar.gz"
+  checksum: [
+    "sha256=9742813145638dc1c70a53386a2998af7c1d8763335d26a3fd95239946a5aa28"
+    "md5=83b123fde068a8eb3d4a61920d2ed34a"
+  ]
+}

--- a/packages/dokeysto_lz4/dokeysto_lz4.4.0.2/opam
+++ b/packages/dokeysto_lz4/dokeysto_lz4.4.0.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/dokeysto"
+bug-reports: "https://github.com/UnixJunkie/dokeysto/issues"
+dev-repo: "git+https://github.com/UnixJunkie/dokeysto.git"
+license: "LGPL-2.1-only"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "exec" "-p" name "-j" jobs "src/test_lz4.exe"] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "dokeysto" {>= "4.0.2"}
+  "minicli" {>= "5.0.0"}
+  "lz4"
+]
+synopsis: "The dumb OCaml key-value store w/ LZ4 compression"
+description:
+  "dokeysto with on-the-fly compression/decompression of values via LZ4"
+url {
+  src: "https://github.com/UnixJunkie/dokeysto/archive/v4.0.2.tar.gz"
+  checksum: [
+    "sha256=9742813145638dc1c70a53386a2998af7c1d8763335d26a3fd95239946a5aa28"
+    "md5=83b123fde068a8eb3d4a61920d2ed34a"
+  ]
+}

--- a/packages/dokeysto_lz4/dokeysto_lz4.4.0.2/opam
+++ b/packages/dokeysto_lz4/dokeysto_lz4.4.0.2/opam
@@ -19,6 +19,7 @@ depends: [
 synopsis: "The dumb OCaml key-value store w/ LZ4 compression"
 description:
   "dokeysto with on-the-fly compression/decompression of values via LZ4"
+x-maintenance-intent: ["(latest)"]
 url {
   src: "https://github.com/UnixJunkie/dokeysto/archive/v4.0.2.tar.gz"
   checksum: [


### PR DESCRIPTION
dokeysto, dokeysto_camltc, dokeysto_lz4

Any software relying on dokeysto should use this new version (4.0.2).

Really stupid use of Unix.read somewhere replaced by a really_read function (like Stdlib.really_input but for Unix file descriptors).
