### PR TITLE
[new release] progress (2 packages) (0.5.0)

### DIFF
--- a/packages/progress/progress.0.5.0/opam
+++ b/packages/progress/progress.0.5.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/CraigFe/progress"
 doc: "https://CraigFe.github.io/progress/"
 bug-reports: "https://github.com/CraigFe/progress/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "3.20.0"}
   "ocaml" {>= "4.08.0"}
   ("ocaml" {>= "5.2.0"} | ("ocaml" {< "5.2.0"} & "vector"))
   "terminal" {= version}

--- a/packages/progress/progress.0.5.0/opam
+++ b/packages/progress/progress.0.5.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "User-definable progress bars"
+description: """
+A progress bar library for OCaml, featuring a DSL for declaratively specifying
+progress bar formats. Supports rendering multiple progress bars simultaneously."""
+maintainer: ["Craig Ferguson <me@craigfe.io>"]
+authors: ["Craig Ferguson <me@craigfe.io>"]
+license: "MIT"
+homepage: "https://github.com/CraigFe/progress"
+doc: "https://CraigFe.github.io/progress/"
+bug-reports: "https://github.com/CraigFe/progress/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  ("ocaml" {>= "5.2.0"} | ("ocaml" {< "5.2.0"} & "vector"))
+  "terminal" {= version}
+  "fmt" {>= "0.8.5"}
+  "logs" {>= "0.7.0"}
+  "mtime" {>= "2.0.0"}
+  "uucp" {>= "2.0.0"}
+  "uutf" {>= "1.0.0"}
+  "optint" {>= "0.1.0"}
+  "alcotest" {with-test & >= "1.4.0"}
+  "astring" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CraigFe/progress.git"
+url {
+  src:
+    "https://github.com/craigfe/progress/releases/download/0.5.0/progress-0.5.0.tbz"
+  checksum: [
+    "sha256=7f87f0597363928c45ba859ae5a1430f6aa3c29e251ff1a53cf786ed0e045961"
+    "sha512=45dee4fe2ae0b7fc3ca675f6e854d738873eb608ef9155ea5d7edac4639c183ae1f512847a1b43bdfc1f4c459e7d5b44d03ee809455797e680f890b33d531367"
+  ]
+}
+x-commit-hash: "0c83d49dff81ffd3dab80ed123d526841e3ca5fe"

--- a/packages/progress/progress.0.5.0/opam
+++ b/packages/progress/progress.0.5.0/opam
@@ -48,3 +48,4 @@ url {
   ]
 }
 x-commit-hash: "0c83d49dff81ffd3dab80ed123d526841e3ca5fe"
+x-maintenance-intent: [ "(latest)" ]

--- a/packages/terminal/terminal.0.5.0/opam
+++ b/packages/terminal/terminal.0.5.0/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/CraigFe/progress"
 doc: "https://CraigFe.github.io/progress/"
 bug-reports: "https://github.com/CraigFe/progress/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "3.20.0"}
   "ocaml" {>= "4.03.0"}
   "uucp" {>= "2.0.0"}
   "uutf" {>= "1.0.0"}

--- a/packages/terminal/terminal.0.5.0/opam
+++ b/packages/terminal/terminal.0.5.0/opam
@@ -43,3 +43,4 @@ url {
   ]
 }
 x-commit-hash: "0c83d49dff81ffd3dab80ed123d526841e3ca5fe"
+x-maintenance-intent: [ "(latest)" ]

--- a/packages/terminal/terminal.0.5.0/opam
+++ b/packages/terminal/terminal.0.5.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Basic utilities for interacting with terminals"
+description: "Basic utilities for interacting with terminals"
+maintainer: ["Craig Ferguson <me@craigfe.io>"]
+authors: ["Craig Ferguson <me@craigfe.io>"]
+license: "MIT"
+homepage: "https://github.com/CraigFe/progress"
+doc: "https://CraigFe.github.io/progress/"
+bug-reports: "https://github.com/CraigFe/progress/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.03.0"}
+  "uucp" {>= "2.0.0"}
+  "uutf" {>= "1.0.0"}
+  "stdlib-shims"
+  "alcotest" {with-test & >= "1.4.0"}
+  "fmt" {with-test}
+  "astring" {with-test}
+  "mtime" {with-test & >= "2.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CraigFe/progress.git"
+url {
+  src:
+    "https://github.com/craigfe/progress/releases/download/0.5.0/progress-0.5.0.tbz"
+  checksum: [
+    "sha256=7f87f0597363928c45ba859ae5a1430f6aa3c29e251ff1a53cf786ed0e045961"
+    "sha512=45dee4fe2ae0b7fc3ca675f6e854d738873eb608ef9155ea5d7edac4639c183ae1f512847a1b43bdfc1f4c459e7d5b44d03ee809455797e680f890b33d531367"
+  ]
+}
+x-commit-hash: "0c83d49dff81ffd3dab80ed123d526841e3ca5fe"


### PR DESCRIPTION
User-definable progress bars

- Project page: <a href="https://github.com/CraigFe/progress">https://github.com/CraigFe/progress</a>
- Documentation: <a href="https://CraigFe.github.io/progress/">https://CraigFe.github.io/progress/</a>

##### CHANGES:

- Update to `ocamlformat.0.27.0` (@dinosaure, CraigFe/progress#49)
- Fix on `Line.eta` (@gasche, CraigFe/progress#48)
- Remove the `Vector` module and use the `Dynarray` module when it's available

  **breaking change**: `progress` provides a new sub-library `progress.vector`
  which, depending on the OCaml version, corresponds to the `vector` opam
  package for OCaml < 5.2.0 or `Stdlib.Dynarray` for OCaml >= 5.2.0. It unlocks
  the ability to link `progress` with some projects which define their own
  `Vector` module.
