### PR TITLE
Release of Solo5 0.9.3

### DIFF
--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.9.3/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.9.3/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["env" "TARGET_CC=aarch64-linux-gnu-gcc" "TARGET_LD=aarch64-linux-gnu-ld" "TARGET_OBJCOPY=aarch64-linux-gnu-objcopy" "./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install-toolchain"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+  "solo5" {= version}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["gcc-aarch64-linux-gnu"] {os-family = "debian"}
+]
+available: [
+  (arch != "arm64") &
+  (os = "linux" & os-family = "debian")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to cross-build
+MirageOS unikernels for the aarch64 architecture.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.9.3/solo5-v0.9.3.tar.gz"
+  checksum: "sha512=e8eed5c0be0d5ee5f528ac91874363f4fded71618ed19bdbd354d303ed7fdc73394fd2531ccb780c579fa789e13181205d062e34c6e82916b072936ebaadf9dd"
+}

--- a/packages/solo5/solo5.0.9.3/opam
+++ b/packages/solo5/solo5.0.9.3/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.7.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+  "solo5-bindings-xen"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+x-ci-accept-failures: [ "centos-7" ]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the host system.
+"""
+x-maintenance-intent: [ "(latest)" ]
+x-ci-accept-failures: [ "opensuse-15.6" ] # too old GCC compiler (OpenSUSE uses GCC 7 and we require GCC 10)
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.9.3/solo5-v0.9.3.tar.gz"
+  checksum: "sha512=e8eed5c0be0d5ee5f528ac91874363f4fded71618ed19bdbd354d303ed7fdc73394fd2531ccb780c579fa789e13181205d062e34c6e82916b072936ebaadf9dd"
+}


### PR DESCRIPTION
- Fix `test_ssp` on OpenBSD (@omegametabroccolo, solo5/solo5#599)
- Fix build of hvt on aarch64 (solo5/solo5#601, @cmainas)
- Adapt OpenBSD hvt tender with the new `vmm(4)` (@omegametabroccolo, @hannesm, solo5/solo5#600)