### PR TITLE
6 packages from mbarbin/pplumbing at 0.0.16

### DIFF
--- a/packages/cmdlang-cmdliner-err-runner/cmdlang-cmdliner-err-runner.0.0.16/opam
+++ b/packages/cmdlang-cmdliner-err-runner/cmdlang-cmdliner-err-runner.0.0.16/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "Cmdlang runner for programs using [Err] with a cmdliner backend"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/pplumbing"
+doc: "https://mbarbin.github.io/pplumbing/"
+bug-reports: "https://github.com/mbarbin/pplumbing/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "cmdlang" {>= "0.0.9"}
+  "cmdlang-to-cmdliner" {>= "0.0.9"}
+  "cmdliner" {>= "1.3.0"}
+  "pplumbing-err" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/pplumbing.git"
+description: """\
+
+[pplumbing] defines a set of utility libraries to use with [pp].
+It is compatible with [logs] and inspired by design choices used
+by [dune] for user messages.
+
+These libraries are meant to combine nicely into a small ecosystem
+of useful helpers to build CLIs in OCaml.
+
+[Cmdlang_cmdliner_err_runner] is a library for running command line
+programs specified with [cmdlang] with [cmdliner] as a backend and
+making opinionated choices, assuming your dependencies are using
+[Err].
+
+[cmdlang]: https://github.com/mbarbin/cmdlang
+[cmdliner]: https://github.com/dbuenzli/cmdliner
+[dune]: https://github.com/ocaml/dune
+[logs]: https://github.com/dbuenzli/logs
+[pp]: https://github.com/ocaml-dune/pp
+
+"""
+tags: [ "cli" "cmdlang" "logs" "pp" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/pplumbing/releases/download/0.0.16/pplumbing-0.0.16.tbz"
+  checksum: [
+    "sha256=8ae0c09fec9088bc7af60582717a9e9d8bb7703e2fbf0a1b90b82e5962ed7039"
+    "sha512=ddd1d5a3d47e7c5ebfb2898f0810156dfca4e10df500ce8f39238cfe02b51fd12ea6d7796914bd02e9ad8e615da1ed7067c9f712bdbbfb884cab08d57bba3564"
+  ]
+}
+x-commit-hash: "e12fafd3db63ab91e6b0a710f0adb0ede271e6fc"

--- a/packages/pplumbing-err/pplumbing-err.0.0.16/opam
+++ b/packages/pplumbing-err/pplumbing-err.0.0.16/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Report located errors and warnings to the user with [pp]"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/pplumbing"
+doc: "https://mbarbin.github.io/pplumbing/"
+bug-reports: "https://github.com/mbarbin/pplumbing/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "loc" {>= "0.2.2"}
+  "parsexp" {>= "v0.16"}
+  "pp" {>= "2.0.0"}
+  "pplumbing-pp-tty" {= version}
+  "sexplib0" {>= "v0.16"}
+  "stdune" {>= "3.17"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/pplumbing.git"
+description: """\
+
+[pplumbing] defines a set of utility libraries to use with [pp].
+It is compatible with [logs] and inspired by design choices used
+by [dune] for user messages.
+
+These libraries are meant to combine nicely into a small ecosystem
+of useful helpers to build CLIs in OCaml.
+
+[Err] is an abstraction to report located errors and warnings to
+the user.
+
+[dune]: https://github.com/ocaml/dune
+[pp]: https://github.com/ocaml-dune/pp
+
+"""
+tags: [ "cli" "pp" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/pplumbing/releases/download/0.0.16/pplumbing-0.0.16.tbz"
+  checksum: [
+    "sha256=8ae0c09fec9088bc7af60582717a9e9d8bb7703e2fbf0a1b90b82e5962ed7039"
+    "sha512=ddd1d5a3d47e7c5ebfb2898f0810156dfca4e10df500ce8f39238cfe02b51fd12ea6d7796914bd02e9ad8e615da1ed7067c9f712bdbbfb884cab08d57bba3564"
+  ]
+}
+x-commit-hash: "e12fafd3db63ab91e6b0a710f0adb0ede271e6fc"

--- a/packages/pplumbing-log-cli/pplumbing-log-cli.0.0.16/opam
+++ b/packages/pplumbing-log-cli/pplumbing-log-cli.0.0.16/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis:
+  "Command line helpers to configure the [err], [logs] and [fmt] libraries"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/pplumbing"
+doc: "https://mbarbin.github.io/pplumbing/"
+bug-reports: "https://github.com/mbarbin/pplumbing/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "cmdlang" {>= "0.0.9"}
+  "fmt" {>= "0.9.0"}
+  "logs" {>= "0.7.0"}
+  "pp" {>= "2.0.0"}
+  "pplumbing-err" {= version}
+  "pplumbing-log" {= version}
+  "pplumbing-pp-tty" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/pplumbing.git"
+description: """\
+
+[pplumbing] defines a set of utility libraries to use with [pp].
+It is compatible with [logs] and inspired by design choices used
+by [dune] for user messages.
+
+These libraries are meant to combine nicely into a small ecosystem
+of useful helpers to build CLIs in OCaml.
+
+[Pplumbing_log_cli] contains functions to work with [Err] on the
+side of end programs (such as a command line tool). It defines
+[cmdlang] command line helpers to configure the [Err] library,
+while taking care of setting the [logs] and [fmt] style rendering.
+
+[cmdlang]: https://github.com/mbarbin/cmdlang
+[dune]: https://github.com/ocaml/dune
+[fmt]: https://github.com/dbuenzli/fmt
+[logs]: https://github.com/dbuenzli/logs
+[pp]: https://github.com/ocaml-dune/pp
+
+"""
+tags: [ "cli" "cmdlang" "logs" "pp" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/pplumbing/releases/download/0.0.16/pplumbing-0.0.16.tbz"
+  checksum: [
+    "sha256=8ae0c09fec9088bc7af60582717a9e9d8bb7703e2fbf0a1b90b82e5962ed7039"
+    "sha512=ddd1d5a3d47e7c5ebfb2898f0810156dfca4e10df500ce8f39238cfe02b51fd12ea6d7796914bd02e9ad8e615da1ed7067c9f712bdbbfb884cab08d57bba3564"
+  ]
+}
+x-commit-hash: "e12fafd3db63ab91e6b0a710f0adb0ede271e6fc"

--- a/packages/pplumbing-log/pplumbing-log.0.0.16/opam
+++ b/packages/pplumbing-log/pplumbing-log.0.0.16/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "An interface to [logs] using [Pp_tty] rather than [Format]"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/pplumbing"
+doc: "https://mbarbin.github.io/pplumbing/"
+bug-reports: "https://github.com/mbarbin/pplumbing/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "logs" {>= "0.7.0"}
+  "pp" {>= "2.0.0"}
+  "pplumbing-pp-tty" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/pplumbing.git"
+description: """\
+
+[pplumbing] defines a set of utility libraries to use with [pp].
+It is compatible with [logs] and inspired by design choices used
+by [dune] for user messages.
+
+These libraries are meant to combine nicely into a small ecosystem
+of useful helpers to build CLIs in OCaml.
+
+[Pplumbing_log] is an interface to [logs] using [Pp_tty] rather
+than [Format].
+
+[dune]: https://github.com/ocaml/dune
+[logs]: https://github.com/dbuenzli/logs
+[pp]: https://github.com/ocaml-dune/pp
+
+"""
+tags: [ "cli" "logs" "pp" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/pplumbing/releases/download/0.0.16/pplumbing-0.0.16.tbz"
+  checksum: [
+    "sha256=8ae0c09fec9088bc7af60582717a9e9d8bb7703e2fbf0a1b90b82e5962ed7039"
+    "sha512=ddd1d5a3d47e7c5ebfb2898f0810156dfca4e10df500ce8f39238cfe02b51fd12ea6d7796914bd02e9ad8e615da1ed7067c9f712bdbbfb884cab08d57bba3564"
+  ]
+}
+x-commit-hash: "e12fafd3db63ab91e6b0a710f0adb0ede271e6fc"

--- a/packages/pplumbing-pp-tty/pplumbing-pp-tty.0.0.16/opam
+++ b/packages/pplumbing-pp-tty/pplumbing-pp-tty.0.0.16/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Build pretty printed documents for the user with [pp]"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/pplumbing"
+doc: "https://mbarbin.github.io/pplumbing/"
+bug-reports: "https://github.com/mbarbin/pplumbing/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "loc" {>= "0.2.2"}
+  "pp" {>= "2.0.0"}
+  "stdune" {>= "3.17"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/pplumbing.git"
+description: """\
+
+[pplumbing] defines a set of utility libraries to use with [pp].
+It is compatible with [logs] and inspired by design choices used
+by [dune] for user messages.
+
+These libraries are meant to combine nicely into a small ecosystem
+of useful helpers to build CLIs in OCaml.
+
+[pplumbing_pp_tty] extends [pp] to build colored documents in
+the user's terminal using ansi escape codes.
+
+[dune]: https://github.com/ocaml/dune
+[pp]: https://github.com/ocaml-dune/pp
+
+"""
+tags: [ "cli" "pp" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/pplumbing/releases/download/0.0.16/pplumbing-0.0.16.tbz"
+  checksum: [
+    "sha256=8ae0c09fec9088bc7af60582717a9e9d8bb7703e2fbf0a1b90b82e5962ed7039"
+    "sha512=ddd1d5a3d47e7c5ebfb2898f0810156dfca4e10df500ce8f39238cfe02b51fd12ea6d7796914bd02e9ad8e615da1ed7067c9f712bdbbfb884cab08d57bba3564"
+  ]
+}
+x-commit-hash: "e12fafd3db63ab91e6b0a710f0adb0ede271e6fc"

--- a/packages/pplumbing/pplumbing.0.0.16/opam
+++ b/packages/pplumbing/pplumbing.0.0.16/opam
@@ -1,0 +1,80 @@
+opam-version: "2.0"
+synopsis: "Utility libraries to use with [pp]"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/pplumbing"
+doc: "https://mbarbin.github.io/pplumbing/"
+bug-reports: "https://github.com/mbarbin/pplumbing/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "cmdlang-cmdliner-err-runner" {= version}
+  "cmdlang-to-cmdliner" {>= "0.0.9"}
+  "pplumbing-err" {= version}
+  "pplumbing-log" {= version}
+  "pplumbing-log-cli" {= version}
+  "pplumbing-pp-tty" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/pplumbing.git"
+description: """\
+
+[pplumbing] defines a set of utility libraries to use with [pp].
+It is compatible with [logs] and inspired by design choices used
+by [dune] for user messages.
+
+These libraries are meant to combine nicely into a small ecosystem
+of useful helpers to build CLIs in OCaml.
+
+- [Pp_tty] extends [pp] to build colored documents in the user's
+  terminal using ansi escape codes.
+
+- [Err] is an abstraction to report located errors and warnings to
+  the user.
+
+- [Log] is an interface to [logs] using [Pp_tty] rather than [Format].
+
+- [Log_cli] contains functions to work with [Err] on the side of end
+  programs (such as a command line tool). It defines command line
+  helpers to configure the [Err] library, while taking care of setting
+  the [logs] and [fmt] style rendering.
+
+- [Cmdlang_cmdliner_runner] is a library for running command line
+  programs specified with [cmdlang] with [cmdliner] as a backend and
+  making opinionated choices, assuming your dependencies are using
+  [Err].
+
+[cmdlang]: https://github.com/mbarbin/cmdlang
+[cmdliner]: https://github.com/dbuenzli/cmdliner
+[dune]: https://github.com/ocaml/dune
+[fmt]: https://github.com/dbuenzli/fmt
+[logs]: https://github.com/dbuenzli/logs
+[pp]: https://github.com/ocaml-dune/pp
+
+"""
+tags: [ "cli" "cmdlang" "logs" "pp" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/pplumbing/releases/download/0.0.16/pplumbing-0.0.16.tbz"
+  checksum: [
+    "sha256=8ae0c09fec9088bc7af60582717a9e9d8bb7703e2fbf0a1b90b82e5962ed7039"
+    "sha512=ddd1d5a3d47e7c5ebfb2898f0810156dfca4e10df500ce8f39238cfe02b51fd12ea6d7796914bd02e9ad8e615da1ed7067c9f712bdbbfb884cab08d57bba3564"
+  ]
+}
+x-commit-hash: "e12fafd3db63ab91e6b0a710f0adb0ede271e6fc"


### PR DESCRIPTION
This pull-request concerns:
- `cmdlang-cmdliner-err-runner.0.0.16`: Cmdlang runner for programs using [Err] with a cmdliner backend
- `pplumbing.0.0.16`: Utility libraries to use with [pp]
- `pplumbing-err.0.0.16`: Report located errors and warnings to the user with [pp]
- `pplumbing-log.0.0.16`: An interface to [logs] using [Pp_tty] rather than [Format]
- `pplumbing-log-cli.0.0.16`: Command line helpers to configure the [err], [logs] and [fmt] libraries
- `pplumbing-pp-tty.0.0.16`: Build pretty printed documents for the user with [pp]



---
* Homepage: https://github.com/mbarbin/pplumbing
* Source repo: git+https://github.com/mbarbin/pplumbing.git
* Bug tracker: https://github.com/mbarbin/pplumbing/issues

---
## 0.0.16 (2025-09-21)

### Changed

- Split remaining pakages to isolate dependencies ([#25](https://github.com/mbarbin/pplumbing/pull/25), @mbarbin).

## 0.0.15 (2025-09-19)

### Added

- Add a cmdlang runner based on climate for programs using `Err` ([#22](https://github.com/mbarbin/pplumbing/pull/22), @mbarbin).

### Changed

- Improve names `cmdlang-{backend}-err-runner` for cmd runners ([#23](https://github.com/mbarbin/pplumbing/pull/23), @mbarbin).
- Split pakages to isolate dependencies ([#18](https://github.com/mbarbin/pplumbing/pull/18), [#19](https://github.com/mbarbin/pplumbing/pull/19), [#20](https://github.com/mbarbin/pplumbing/pull/20), [#21](https://github.com/mbarbin/pplumbing/pull/21), @mbarbin).


---
:camel: Pull-request generated by opam-publish v2.6.0