### PR TITLE
[new release] postgresql (5.3.0)

### DIFF
--- a/packages/postgresql/postgresql.5.3.0/opam
+++ b/packages/postgresql/postgresql.5.3.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Bindings to the PostgreSQL library"
+description:
+  "Postgresql offers library functions for accessing PostgreSQL databases."
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "dune-compiledb"
+  "dune-configurator"
+  "conf-postgresql" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/postgresql-ocaml/releases/download/5.3.0/postgresql-5.3.0.tbz"
+  checksum: [
+    "sha256=0528a5b6c5d9f3f33edf170e39cc6ba18fdaf084bb8715e5b6f62a1b2192c0e4"
+    "sha512=cf50c316c799b9b089ab9b29cfeac3caf3eb36c1efd4fcc595730cc1f924b36e9e92affea2632664afa967334409326384e86ada6d1624f9aba650c50d56e98e"
+  ]
+}
+x-commit-hash: "88593b209d2e1da1e6d68bc6e8cc6d066a751483"


### PR DESCRIPTION
Bindings to the PostgreSQL library

- Project page: <a href="https://mmottl.github.io/postgresql-ocaml">https://mmottl.github.io/postgresql-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/postgresql-ocaml/api">https://mmottl.github.io/postgresql-ocaml/api</a>

##### CHANGES:

### Added

- `Connection` functor that allows for custom mutex implementations. This
  improves compatibility with effect-based concurrency frameworks and helps
  prevent deadlocks.
- Makefile target to generate `compile_commands.json` for improved LSP support
  in editors.
- Version discovery supports PostgreSQL beta/rc versions (via `pg_config` and
  `pkg-config`). Thanks to Antonio Nuno Monteiro for the patch.

### Changed

- Improved thread coordination during cancellation of operations.
- Removed the use of C stubs to check for a finished connection.
- Replaced custom resource management logic with `Fun.protect`.

Thanks to Christophe Raffalli for contributing solutions for the improved thread
coordination and for effect-based concurrency frameworks.
