### PR TITLE
[new release] postgresql (5.3.1)

### DIFF
--- a/packages/postgresql/postgresql.5.3.1/opam
+++ b/packages/postgresql/postgresql.5.3.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Bindings to the PostgreSQL library"
+description:
+  "Postgresql offers library functions for accessing PostgreSQL databases."
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "dune-compiledb"
+  "dune-configurator"
+  "conf-postgresql" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/postgresql-ocaml/releases/download/5.3.1/postgresql-5.3.1.tbz"
+  checksum: [
+    "sha256=72f89fcd70642fd6a4655af27f75336ae924706f3f57f0e0f975cf99b3555678"
+    "sha512=33916e27a653437de82558d26ac1327ad5a9f33f380a3831ceb5b1b2aae8ccf9f133d5409c36a86c8858a652d9e36ec832c4a12162bcf4d3f04a288da312e346"
+  ]
+}
+x-commit-hash: "6c11a17ff96ce556a4c8349bd8f446937ff352e6"


### PR DESCRIPTION
Bindings to the PostgreSQL library

- Project page: <a href="https://mmottl.github.io/postgresql-ocaml">https://mmottl.github.io/postgresql-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/postgresql-ocaml/api">https://mmottl.github.io/postgresql-ocaml/api</a>

##### CHANGES:

### Fixed

- `getvalue` and `get_escaped_value` now return `Postgresql.null` for SQL NULL
  values, matching the documentation. Thanks to Christophe Raffalli for the
  patch.

### Changed

- Applied OCaml/C formatting and added an ocamlformat pre-commit hook.
