### PR TITLE
Package opam-publish.2.5.1

### DIFF
--- a/packages/opam-publish/opam-publish.2.5.1/opam
+++ b/packages/opam-publish/opam-publish.2.5.1/opam
@@ -31,10 +31,9 @@ flags: plugin
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/ocaml/opam-publish.git"
 url {
-  src:
-    "https://github.com/ocaml/opam-publish/releases/download/2.5.1/opam-publish-2.5.1.tar.gz"
+  src: "https://github.com/ocaml-opam/opam-publish/archive/master.tar.gz"
   checksum: [
-    "md5=faaca05485e10574959125f6ab2039ba"
-    "sha512=591c6372cb54833c2797575587503d912ba9710981d054aa48961267d5fd6dbad79581bc1fa860e3d9000ba687b4e5d7dd4aa737cf2d475bfcc574abd667ac33"
+    "md5=c39627bff74363b491343b18793e8f82"
+    "sha512=2b104d97eb0c3d9a1ea4fff7ac0db03277c38e84f93ab4b5f298690df9412232a14c6ca88f04154531abe5928565e666084df3efe66dbdbcaf7bf385952651a8"
   ]
 }


### PR DESCRIPTION
### `opam-publish.2.5.1`
A tool to ease contributions to opam repositories
opam-publish automates publishing packages to package repositories: it checks that the
opam file is complete using `opam lint`, verifies and adds the archive URL and its
checksum and files a GitHub pull request for merging it.



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v2.5.1