### PR TITLE
Add MinGW support for conf-gtksourceview3

### DIFF
--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
@@ -4,8 +4,16 @@ authors: "The gtksourceview programmers"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://projects.gnome.org/gtksourceview/"
 license: "LGPL-2.1-or-later"
-build: [["pkg-config" "--short-errors" "--print-errors" "gtksourceview-3.0"]]
-depends: ["conf-pkg-config" {build}]
+build: [
+  ["pkgconf" "--personality=i686-w64-mingw32" "--short-errors" "--print-errors" "gtksourceview-3.0"] {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
+  ["pkgconf" "--personality=x86_64-w64-mingw32" "--short-errors" "--print-errors" "gtksourceview-3.0"] {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
+  ["pkg-config" "--short-errors" "--print-errors" "gtksourceview-3.0"] {os != "win32" | os-distribution != "cygwin"}
+]
+depends: [
+  "conf-pkg-config" {build}
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtksourceview3-i686" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtksourceview3-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+]
 depexts: [
   ["gtksourceview-dev"] {os-distribution = "alpine"}
   ["gtksourceview3"] {os-distribution = "arch"}

--- a/packages/conf-mingw-w64-gtksourceview3-i686/conf-mingw-w64-gtksourceview3-i686.1/opam
+++ b/packages/conf-mingw-w64-gtksourceview3-i686/conf-mingw-w64-gtksourceview3-i686.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "Provides gtksourceview3 for i686 mingw-w64 (32-bit x86)"
+description: "Ensure that the i686 version of gtksourceview3 for the mingw-w64 project is available"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: "The gtksourceview programmers"
+license: "LGPL-2.1-or-later"
+homepage: "https://projects.gnome.org/gtksourceview/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32"
+build: ["pkgconf" "--personality=i686-w64-mingw32" "gtksourceview-3.0"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-i686" {build}
+]
+depexts: [
+  ["mingw64-i686-gtksourceview3.0"] {os = "win32" & os-distribution = "cygwin"}
+  # no i686 package available at https://packages.msys2.org/base/mingw-w64-gtksourceview3
+]

--- a/packages/conf-mingw-w64-gtksourceview3-x86_64/conf-mingw-w64-gtksourceview3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gtksourceview3-x86_64/conf-mingw-w64-gtksourceview3-x86_64.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "Provides gtksourceview3 for x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensure that the x86_64 version of gtksourceview3 for the mingw-w64 project is available"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: "The gtksourceview programmers"
+license: "LGPL-2.1-or-later"
+homepage: "https://projects.gnome.org/gtksourceview/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32"
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" "gtksourceview-3.0"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-x86_64" {build}
+]
+depexts: [
+  ["mingw64-x86_64-gtksourceview3.0"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-x86_64-gtksourceview3"] {os = "win32" & os-distribution = "msys2"}
+]


### PR DESCRIPTION
This adds Windows MinGW support for `conf-gtksourceview3`.
I spotted this failing to install recently on https://github.com/ocaml/opam-repository/pull/28275

The PR is based on the template PR #26072
and the `conf-mingw` packages have (again) been generated semi-automatically.

Support is based on the following packages:
- https://cygwin.com/packages/summary/mingw64-x86_64-gtksourceview3.0.html
- https://cygwin.com/packages/summary/mingw64-i686-gtksourceview3.0.html
- https://packages.msys2.org/base/mingw-w64-gtksourceview3

Note: the latter has no i686 (32-bit) package supported.

I've tested this on both Cygwin-MinGW and Msys2-MinGW with a self-PR here: https://github.com/jmid/opam-repository/pull/17  (where 5/6 pass with only the MSys2 i686 installation fails for the above reason)
