### PR TITLE
Add a Windows MSys2 MinGW workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -117,7 +117,7 @@ jobs:
             Write-Host
           }
           if ($failed) {
-            throw "build failed"
+            throw "One or more packages failed to build"
           }
           Exit
 
@@ -235,5 +235,5 @@ jobs:
             esac
           done
           if [ "$failed" = true ] ; then
-            echo "build failed" && exit 1
+            echo "One or more packages failed to build" && exit 1
           fi


### PR DESCRIPTION
This PR adds a GitHub actions workflow to test packages under Windows with MSys2 MinGW.

Fixes https://github.com/ocaml/opam-repository/issues/27914

Ever since the first template PR #26072 we've worked with a package layout that integrates MinGW support 
for both MinGW installed via Cygwin as well as MinGW installed via MSys2.
We just haven't had CI support to help test such packages extensions. This PR adds that support.

MSys2 is Cygwin's cool young cousin (read: a fork): https://www.msys2.org/ :sunglasses: 
Generally MSys2 just seems a bit more up to date, for example:
- Cygwin's `freeglut` package is too old to include a `.pc` file for `pkg-config`/`pkgconf` whereas MSys2 has a newer release including a `.pc` file (spotted on https://github.com/ocaml/opam-repository/pull/27846)
- MSys2 has a https://packages.msys2.org/base/mingw-w64-oniguruma for `conf-oniguruma` needed transitively for `yocaml_markdown` but Cygwin offers no such MinGW package
- Cygwin offers `gtksourceview{2,3}` packages whereas MSys2 provides `gtksourceview{3,4,5}`

So for a relatively up-to-date MinGW packages, MSys2 is a good candidate.

In the PR I've ended up building on https://github.com/msys2/setup-msys2 and formulated it as a rough bash-mirror of the existing PowerShell-job for Cygwin. There's a bit of redundancy to doing it this way and I actually first tried a merged design. This however lead to
- some Cygwin / MSys2 specific steps in between, thus not being as clean as I had hoped
- an issue with illegal escape codes causing compilation errors after cache restoration

Compared to the existing Cygwin MinGW job, I've also made a few minor adjustments:
- After a successful installation a line is printed informing users of it, thinking that UI-wise a red message printed on failure should have a corresponding green message printed on success (otherwise one has to know that `Testing conf-mingw-w64-gtksourceview3-i686.1` means passed - or unfold the triangle to realize it)
- With a message printed after each install candidate, `build failed` at the end (when there are installation failures) struck me as a bit too brief.

A run of both workflow jobs can be seen on this self-PR: https://github.com/jmid/opam-repository/pull/17
(modulo the final `build failed` message adjustment mentioned above)