### PR TITLE
Add: cmdliner.2.0.0

### DIFF
--- a/packages/cmdliner/cmdliner.2.0.0/opam
+++ b/packages/cmdliner/cmdliner.2.0.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Declarative definition of command line interfaces for OCaml"
+description: """\
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles command line completion, syntax errors,
+help messages and UNIX man page generation. It supports programs with
+single or multiple commands and respects most of the [POSIX] and [GNU]
+conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+Homepage: <http://erratique.ch/software/cmdliner>
+
+[POSIX]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[GNU]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The cmdliner programmers"
+license: "ISC"
+tags: ["cli" "system" "declarative" "org:erratique"]
+homepage: "https://erratique.ch/software/cmdliner"
+doc: "https://erratique.ch/software/cmdliner/doc"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+]
+build: [make "all" "PREFIX=%{prefix}%"]
+install: [
+  [
+    make
+    "install"
+    "BINDIR=%{_:bin}%"
+    "LIBDIR=%{_:lib}%"
+    "DOCDIR=%{_:doc}%"
+    "SHAREDIR=%{share}%"
+    "MANDIR=%{man}%"
+  ]
+  [
+    make
+    "install-doc"
+    "LIBDIR=%{_:lib}%"
+    "DOCDIR=%{_:doc}%"
+    "SHAREDIR=%{share}%"
+    "MANDIR=%{man}%"
+  ]
+]
+dev-repo: "git+https://erratique.ch/repos/cmdliner.git"
+url {
+  src: "https://erratique.ch/software/cmdliner/releases/cmdliner-2.0.0.tbz"
+  checksum:
+    "sha512=6d7d63ed04e4deff414eccd61c185d33a58a2de94fb9b624bf4c8b611d6d7b8f346740e57639822705012edab2a56c9a4ebbf1b1ce4d39c6144755a650cfc2e8"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `cmdliner.2.0.0` [home](https://erratique.ch/software/cmdliner), [doc](https://erratique.ch/software/cmdliner/doc), [issues](https://github.com/dbuenzli/cmdliner/issues)  
  *Declarative definition of command line interfaces for OCaml*


---

#### `cmdliner` v2.0.0 2025-09-26 Zagreb

### End-user visible changes

- **IMPORTANT** Cmdliner no longer allows command names, option names,
  and `Arg.enum` values to be specified by a prefix if the prefix is
  unambiguous. See [#200](https://github.com/dbuenzli/cmdliner/issues/200) for the rationale. To quickly salvage scripts
  that may be relying on the old behaviour, it can be restored by
  setting the environment variable `CMDLINER_LEGACY_PREFIXES=true`.
  However the scripts should be fixed: this escape hatch will be
  removed in the future.

- Pager. If set, respect the user's `LESS` environment variable
  (otherwise the default `LESS=FRX` is left unchanged).  Note however
  that you likely need at least `R` specified if you define it
  yourself, otherwise the manpage may look garbled ([#191](https://github.com/dbuenzli/cmdliner/issues/191)). Thanks to
  Yukai Chou for suggesting.

- Fix lack of output whenever `PAGER` or `MANPAGER` is set but empty;
  fallback to pager discovery ([#194](https://github.com/dbuenzli/cmdliner/issues/194)). For example this prevented to
  see manpages in `emacs`'s compilation mode which unhelpfully
  hardcodes `PAGER=""`.

- Fix synopsis rendering of required optional arguments ([#203](https://github.com/dbuenzli/cmdliner/issues/203)).

- Output error messages on `stderr` with styled text ([#144](https://github.com/dbuenzli/cmdliner/issues/144)). Quoted
  and typewriter text is in bold. Variables are written as
  underlines. Key words of error messages are in red.

- Output error messages after the usage line and remove the `Try with
  $(tool) --help for more information` message. Instead we explicitly
  indicate the `--help` option in the usage line. Having the error message
  at the end makes it easier to spot.

- Make `--help` request work in any context, except after `--` or on
  the arguments after an unknown command error in which case that
  error is reported (less confusing). Since the option has an optional
  argument value, one had to be carefull that it would not pickup the
  next argument and try to parse it according to `FMT`. This is no
  longer the case. If the argument fails to parse `--help=auto` is
  assumed. ([#201](https://github.com/dbuenzli/cmdliner/issues/201)).
  
- Deprecation messages are now prepended to the doc strings in the manpage.

### API changes

- Reserve the `--__complete` option for library use.

- Documentation language, `$(cmd)`, `$(cmd.name)` and `$(tool)` can be
  used and should be prefered over of `$(iname)`, `$(tname)` and
  `$(mname)`. `$(cmd.parent)` is added to refer to a command's parent
  or itself at the root.

- Make `Cmdliner.Arg.conv` abstract.  Thanks to Andrey Popp for
  the patch ([#206](https://github.com/dbuenzli/cmdliner/issues/206)).

- Thanks to the previous point, use the `docv` parameter of argument
  converters can now be used to define the default value used by `docv` in
  `Arg.info`. See `Arg.Conv.docv`.

- Add `Manpage.section_name` type alias ([#202](https://github.com/dbuenzli/cmdliner/issues/202)).

- Add `Cmd.make` which should be preferred to `Cmd.v` (The `M.v` notation is
  nice for simulating literals, not for heavy constructor).

- Add `Cmd.Env.info_var`. To get back the environment variable name
  from a variable info.

- Add optional `doc_envs` argument to `Arg.info` for adding the given
  environment variables info to the command in which the argument is used.
  Sometimes more than one variable make sense and the `env` argument is
  not directly used.

- Add `Arg.Completion` a module to define argument completion 
  strategies ([#1](https://github.com/dbuenzli/cmdliner/issues/1), [#187](https://github.com/dbuenzli/cmdliner/issues/187)). 
  
- Add `Arg.Conv` module to define converters. This should be used in
  new code. 

- Add `Arg.{file,dir,}path` string converters equiped with appropriate
  file system completions.

- Add `docv` optional parameter to `Arg.enum`.

- Add `Term.env` which provides access to the environment access 
  function provided to evaluation functions.

- Clarify the semantics of the `deprecated` argument of
  `Cmdliner.Cmd.info`, `Cmdliner.Arg.info` and
  `Cmdliner.Cmd.Env.info`. First, the language markup is now supported
  therein. Second the message is no longer only used to warn about
  usage it is now also prepended to the doc string of the entity.

- Use `Arg.conv`'s `docv` property in the documentation of arguments
  whenever `Arg.info`'s `docv` is unspecified ([#207](https://github.com/dbuenzli/cmdliner/issues/207)).

- Do not check file existence for `-` in `Arg.file` or
  `Arg.non_dir_file` values. This is supposed to mean `stdin` or
  `stdout` ([#208](https://github.com/dbuenzli/cmdliner/issues/208)).

- Fix manpage rendering performing direct calls to `Sys.getenv` in
  `Cmd.eval*` functions instead of calling the `env` argument as
  advertised in the docs. Incidentally add an `env` optional argument
  to `Manpage.print` ([#209](https://github.com/dbuenzli/cmdliner/issues/209)).

- Deprecate. `Arg.{printer,conv_docv,conv_parser,
  conv_printer,parser_of_kind_of_string,conv,conv'}`. These will
  likely never be removed but they should no longer be used for 
  new code. Use `Arg.Conv`. 

- Remove deprecated `Arg.{converter,parser,pconv}` ([#206](https://github.com/dbuenzli/cmdliner/issues/206)).
- Remove deprecated `Arg.{env,env_var}` ([#206](https://github.com/dbuenzli/cmdliner/issues/206)).
- Remove deprecated `Term.{pure,man_format}` ([#206](https://github.com/dbuenzli/cmdliner/issues/206)).
- Remove deprecated `Term` evaluation interface ([#206](https://github.com/dbuenzli/cmdliner/issues/206)).

### Other

- Install a `cmdliner` tool to help with manpage and completion script
  installation. See the command line interface manual of the library
  for more information ([#187](https://github.com/dbuenzli/cmdliner/issues/187), [#227](https://github.com/dbuenzli/cmdliner/issues/227), [#228](https://github.com/dbuenzli/cmdliner/issues/228)).

- Install all source files for `odoc` and goto definition editor
  functionality. Thanks to Emile Trotignon and Paul-Elliot Anglès
  d'Auriac for noticing and suggesting ([#225](https://github.com/dbuenzli/cmdliner/issues/225)).

- Added a proper test suite to the library to check for regressions.
  Replaces most of the test executables that had to be run and inspected
  manually ([#205](https://github.com/dbuenzli/cmdliner/issues/205)).

---

Use `b0 -- .opam publish cmdliner.2.0.0` to update the pull request.