### PR TITLE
Add a `conf-binaryen` package

### DIFF
--- a/packages/conf-binaryen/conf-binaryen.1/opam
+++ b/packages/conf-binaryen/conf-binaryen.1/opam
@@ -16,7 +16,7 @@ depexts: [
   ["binaryen"] {os-family = "arch"}
   ["binaryen"] {os-family = "alpine"}
   ["binaryen"] {os-family = "rehl"}
-  ["binaryen"] {os-distribution = "opensuse-tumbleweed"}
+  ["binaryen"] {os-distribution = "opensuse-tumbleweed" | os-distribution = "opensuse-leap"}
   ["binaryen"] {os-family = "homebrew"}
   ["binaryen"] {os-family = "macports"}
   ["binaryen"] {os-distribution = "freebsd"}


### PR DESCRIPTION
This PR adds a `conf-binaryen` package. Most distributions nowadays seem to package a recent-enough version of `binaryen` for the needs of `wasm_of_ocaml`, so this PR is a first step to allow this use case.

This is joint work with @n-osborne.