### PR TITLE
Add a Windows MSys2 MinGW workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - windows-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,6 +16,7 @@ jobs:
           - windows-latest
         windows_env:
           - cygwin
+          - msys2
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout tree
@@ -37,6 +38,13 @@ jobs:
             D:\opamroot
           key: ${{ runner.os }}-${{ matrix.windows_env }}-opam-${{ hashFiles('install.ps1') }}
 
+      - name: Add MSys2 to PATH and install prerequisites
+        if: matrix.windows_env == 'msys2'
+        run: |
+          "C:\msys64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          C:\msys64\usr\bin\pacman.exe --noconfirm -Syuu  # Core update (in case any core packages are outdated)
+          C:\msys64\usr\bin\pacman.exe --noconfirm -Syuu m4 make mingw-w64-i686-gcc mingw-w64-x86_64-gcc rsync unzip
+
       - name: Install opam
         if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
@@ -49,7 +57,7 @@ jobs:
 
       - name: Init opam
         if: steps.cache-opam.outputs.cache-hit != 'true'
-        run: opam init --yes --no-setup .
+        run: opam init --yes --no-setup ${{ matrix.windows_env == 'msys2' && '--cygwin-local-install' || '' }} .
 
       - name: Restrict testing to available compilers
         if: steps.cache-opam.outputs.cache-hit != 'true'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -123,6 +123,6 @@ jobs:
             Write-Host
           }
           if ($failed) {
-            throw "build failed"
+            throw "One or more packages failed to build"
           }
           Exit

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -114,7 +114,7 @@ jobs:
             opam install --color=always --confirm-level=unsafe-yes "$pkg"
             Write-Host "::endgroup::"
             switch ($LASTEXITCODE) {
-              0 { Break }
+              0 { Write-Host "`e[1;32m$pkg installed successfully`e[0m."; Break }
               5 { Write-Host "$pkg is not installable. `e[1;33mSkip`e[0m."; Break } # TODO: Remove when https://github.com/ocaml/opam/issues/6017 is fixed
               20 { Write-Host "$pkg is not installable. `e[1;33mSkip`e[0m."; Break }
               31 { Write-Host "`e[1;31m$pkg failed to build`e[0m."; $failed = $true; Break }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,6 +13,8 @@ jobs:
       matrix:
         os:
           - windows-latest
+        windows_env:
+          - cygwin
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout tree
@@ -32,7 +34,7 @@ jobs:
           path: |
             D:\opam\bin
             D:\opamroot
-          key: ${{ runner.os }}-opam-${{ hashFiles('install.ps1') }}
+          key: ${{ runner.os }}-${{ matrix.windows_env }}-opam-${{ hashFiles('install.ps1') }}
 
       - name: Install opam
         if: steps.cache-opam.outputs.cache-hit != 'true'


### PR DESCRIPTION
This PR adds a GitHub actions workflow to test packages under Windows with MSys2 MinGW.
It replaces the first PR in https://github.com/ocaml/opam-repository/pull/28588.

Fixes https://github.com/ocaml/opam-repository/issues/27914

Ever since the first template PR #26072 we've worked with a package layout that integrates MinGW support 
for both MinGW installed via Cygwin as well as MinGW installed via MSys2.
We just haven't had CI support to help test such packages extensions. This PR adds that support.

MSys2 is Cygwin's cool young cousin (read: a fork): https://www.msys2.org/ :sunglasses: 
Generally MSys2 just seems a bit more up to date, for example:
- Cygwin's `freeglut` package is too old to include a `.pc` file for `pkg-config`/`pkgconf` whereas MSys2 has a newer release including a `.pc` file (spotted on https://github.com/ocaml/opam-repository/pull/27846)
- MSys2 has a https://packages.msys2.org/base/mingw-w64-oniguruma for `conf-oniguruma` needed transitively for `yocaml_markdown` but Cygwin offers no such MinGW package
- Cygwin offers `gtksourceview{2,3}` packages whereas MSys2 provides `gtksourceview{3,4,5}`

So for a relatively up-to-date MinGW packages, MSys2 is a good candidate.

This PR integrates into the existing PowerShell-job for Cygwin with relatively few changes.
As a curiosity, an MSys2 update needs to run twice in case of updates needed to a core package https://www.msys2.org/docs/ci/

In addition, I've also made a few minor adjustments:
- After a successful installation a line is printed informing users of it, thinking that UI-wise a red message printed on failure should have a corresponding green message printed on success (otherwise one has to know that `Testing conf-mingw-w64-gtksourceview3-i686.1` means passed - or unfold the triangle to realize it)
- With a message printed after each install candidate, the summary message `build failed` at the end (when there are installation failures) struck me as a bit too brief.