### PR TITLE
opam-*: Add missing upper-bound constraints on cmdliner 2.0.0

### DIFF
--- a/packages/opam-client/opam-client.2.4.0/opam
+++ b/packages/opam-client/opam-client.2.4.0/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.10.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.4.0~alpha1/opam
+++ b/packages/opam-client/opam-client.2.4.0~alpha1/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.10.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.4.0~alpha2/opam
+++ b/packages/opam-client/opam-client.2.4.0~alpha2/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.10.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.4.0~beta1/opam
+++ b/packages/opam-client/opam-client.2.4.0~beta1/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.10.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.4.0~rc1/opam
+++ b/packages/opam-client/opam-client.2.4.0~rc1/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.10.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 conflicts: [

--- a/packages/opam-client/opam-client.2.4.1/opam
+++ b/packages/opam-client/opam-client.2.4.1/opam
@@ -27,7 +27,7 @@ depends: [
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
   "re" {>= "1.10.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 conflicts: [

--- a/packages/opam-depext/opam-depext.1.2.1-1/opam
+++ b/packages/opam-depext/opam-depext.1.2.1-1/opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/ocaml/opam-depext/issues"
 depends: [
   "ocaml" {>= "4.00"}
   "base-unix"
-  "cmdliner" {>= "0.9.8" & dev}
+  "cmdliner" {dev & >= "0.9.8" & < "2.0.0"}
   "ocamlfind" {dev}
 ]
 depopts: "ocaml-option-bytecode-only"

--- a/packages/opam-depext/opam-depext.1.2.1/opam
+++ b/packages/opam-depext/opam-depext.1.2.1/opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/ocaml/opam-depext/issues"
 depends: [
   "ocaml" {>= "4.00"}
   "base-unix"
-  "cmdliner" {>= "0.9.8" & dev}
+  "cmdliner" {dev & >= "0.9.8" & < "2.0.0"}
   "ocamlfind" {dev}
 ]
 available: opam-version >= "2.0.0~beta5" & os != "win32"

--- a/packages/opam-depext/opam-depext.1.2.3/opam
+++ b/packages/opam-depext/opam-depext.1.2.3/opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/ocaml/opam-depext/issues"
 depends: [
   "ocaml" {>= "4.00"}
   "base-unix"
-  "cmdliner" {>= "0.9.8" & dev}
+  "cmdliner" {dev & >= "0.9.8" & < "2.0.0"}
   "ocamlfind" {dev}
 ]
 available: opam-version >= "2.0.0~beta5" & os != "win32"

--- a/packages/opam-devel/opam-devel.2.0.0/opam
+++ b/packages/opam-devel/opam-devel.2.0.0/opam
@@ -23,7 +23,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= "2.0.0"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "jbuilder" {>= "1.0+beta20"}
 ]
 post-messages: [

--- a/packages/opam-devel/opam-devel.2.0.1/opam
+++ b/packages/opam-devel/opam-devel.2.0.1/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= "2.0.1"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "jbuilder" {>= "1.0+beta20"}
 ]
 build: [

--- a/packages/opam-devel/opam-devel.2.0.10/opam
+++ b/packages/opam-devel/opam-devel.2.0.10/opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= version}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.2.1"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.0.2/opam
+++ b/packages/opam-devel/opam-devel.2.0.2/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= "2.0.2"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-devel/opam-devel.2.0.3/opam
+++ b/packages/opam-devel/opam-devel.2.0.3/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= "2.0.3"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-devel/opam-devel.2.0.4/opam
+++ b/packages/opam-devel/opam-devel.2.0.4/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= "2.0.4"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-devel/opam-devel.2.0.5/opam
+++ b/packages/opam-devel/opam-devel.2.0.5/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= "2.0.5"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-devel/opam-devel.2.0.6/opam
+++ b/packages/opam-devel/opam-devel.2.0.6/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= "2.0.6"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-devel/opam-devel.2.0.7/opam
+++ b/packages/opam-devel/opam-devel.2.0.7/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-devel/opam-devel.2.0.8/opam
+++ b/packages/opam-devel/opam-devel.2.0.8/opam
@@ -21,7 +21,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= version}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [

--- a/packages/opam-devel/opam-devel.2.0.9/opam
+++ b/packages/opam-devel/opam-devel.2.0.9/opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= version}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.2.1"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.1.0/opam
+++ b/packages/opam-devel/opam-devel.2.1.0/opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.11.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.1.1/opam
+++ b/packages/opam-devel/opam-devel.2.1.1/opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.11.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.1.2/opam
+++ b/packages/opam-devel/opam-devel.2.1.2/opam
@@ -27,7 +27,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.11.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.1.3/opam
+++ b/packages/opam-devel/opam-devel.2.1.3/opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.11.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.1.4/opam
+++ b/packages/opam-devel/opam-devel.2.1.4/opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.11.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.1.5/opam
+++ b/packages/opam-devel/opam-devel.2.1.5/opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.11.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.1.6/opam
+++ b/packages/opam-devel/opam-devel.2.1.6/opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-client" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "1.11.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.2.0/opam
+++ b/packages/opam-devel/opam-devel.2.2.0/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-client" {= version}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.0.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.2.1/opam
+++ b/packages/opam-devel/opam-devel.2.2.1/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-client" {= version}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.0.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.3.0/opam
+++ b/packages/opam-devel/opam-devel.2.3.0/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-client" {= version}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.4.0/opam
+++ b/packages/opam-devel/opam-devel.2.4.0/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-client" {= version}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.4.0~alpha1/opam
+++ b/packages/opam-devel/opam-devel.2.4.0~alpha1/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-client" {= version}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.4.0~alpha2/opam
+++ b/packages/opam-devel/opam-devel.2.4.0~alpha2/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-client" {= version}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.4.0~beta1/opam
+++ b/packages/opam-devel/opam-devel.2.4.0~beta1/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-client" {= version}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.4.0~rc1/opam
+++ b/packages/opam-devel/opam-devel.2.4.0~rc1/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-client" {= version}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-devel/opam-devel.2.4.1/opam
+++ b/packages/opam-devel/opam-devel.2.4.1/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-client" {= version}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}

--- a/packages/opam-installer/opam-installer.2.4.0/opam
+++ b/packages/opam-installer/opam-installer.2.4.0/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 build: [

--- a/packages/opam-installer/opam-installer.2.4.0~alpha1/opam
+++ b/packages/opam-installer/opam-installer.2.4.0~alpha1/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 available: opam-version >= "2.1.0"

--- a/packages/opam-installer/opam-installer.2.4.0~alpha2/opam
+++ b/packages/opam-installer/opam-installer.2.4.0~alpha2/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 available: opam-version >= "2.1.0"

--- a/packages/opam-installer/opam-installer.2.4.0~beta1/opam
+++ b/packages/opam-installer/opam-installer.2.4.0~beta1/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 available: opam-version >= "2.1.0"

--- a/packages/opam-installer/opam-installer.2.4.0~rc1/opam
+++ b/packages/opam-installer/opam-installer.2.4.0~rc1/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 available: opam-version >= "2.1.0"

--- a/packages/opam-installer/opam-installer.2.4.1/opam
+++ b/packages/opam-installer/opam-installer.2.4.1/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "0.9.8" & < "2.0.0"}
   "dune" {>= "2.8.0"}
 ]
 build: [

--- a/packages/opam-lib/opam-lib.1.3.1/opam
+++ b/packages/opam-lib/opam-lib.1.3.1/opam
@@ -21,7 +21,7 @@ build: [
 depends: [
   "ocaml"
   "ocamlgraph" {< "2.0.0"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "dose3" {>= "5.0" & < "6.0"}
   "cudf"
   "re" {>= "1.2.0"}

--- a/packages/opam-publish/opam-publish.0.3.5/opam
+++ b/packages/opam-publish/opam-publish.0.3.5/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml"
   "opam-lib" {build & > "1.2.2"}
   "ocamlfind" {build}
-  "cmdliner" {build}
+  "cmdliner" {build & < "2.0.0"}
   ("ssl" | "tls" {< "1.0.0"})
   ("github" {build & >= "2.0.0" & < "3.0.0"} |
    "github-unix" {build & >= "3.0.0" & < "4.3.0"})

--- a/packages/opam-publish/opam-publish.2.0.0/opam
+++ b/packages/opam-publish/opam-publish.2.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "opam-format" {build & >= "2.0.0" & < "2.1"}
   "opam-state" {build & >= "2.0.0" & < "2.1"}
   "jbuilder" {>= "1.0+beta19"}
-  "cmdliner" {build}
+  "cmdliner" {build & < "2.0.0"}
   ("ssl" | "tls" {< "1.0.0"})
   ("github" {build & >= "2.0.0" & < "3.0.0"} |
    "github-unix" {build & >= "3.0.0" & < "4.3.0"})

--- a/packages/opam-publish/opam-publish.2.0.1/opam
+++ b/packages/opam-publish/opam-publish.2.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "opam-format" {build & >= "2.0.0" & < "2.1"}
   "opam-state" {build & >= "2.0.0" & < "2.1"}
   "jbuilder" {>= "1.0+beta19"}
-  "cmdliner" {build}
+  "cmdliner" {build & < "2.0.0"}
   "lwt_ssl"
   ("ssl" {build & = "0.5.5"} | "tls" {< "1.0.0"})
   ("github" {build & >= "2.0.0" & < "3.0.0"} |

--- a/packages/opam-publish/opam-publish.2.0.2/opam
+++ b/packages/opam-publish/opam-publish.2.0.2/opam
@@ -14,7 +14,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml-opam/opam-publish"
 bug-reports: "https://github.com/ocaml-opam/opam-publish/issues"
 depends: [
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.03.0"}

--- a/packages/opam-publish/opam-publish.2.0.3/opam
+++ b/packages/opam-publish/opam-publish.2.0.3/opam
@@ -11,7 +11,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocaml/opam-publish.git"
 build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.03.0"}

--- a/packages/opam-publish/opam-publish.2.1.0/opam
+++ b/packages/opam-publish/opam-publish.2.1.0/opam
@@ -11,7 +11,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocaml/opam-publish.git"
 build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.03.0"}

--- a/packages/opam-publish/opam-publish.2.2.0/opam
+++ b/packages/opam-publish/opam-publish.2.2.0/opam
@@ -14,7 +14,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/opam-publish"
 bug-reports: "https://github.com/ocaml/opam-publish/issues"
 depends: [
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.03.0"}

--- a/packages/opam-publish/opam-publish.2.3.0/opam
+++ b/packages/opam-publish/opam-publish.2.3.0/opam
@@ -14,7 +14,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/opam-publish"
 bug-reports: "https://github.com/ocaml/opam-publish/issues"
 depends: [
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.03.0"}

--- a/packages/opam-publish/opam-publish.2.3.1/opam
+++ b/packages/opam-publish/opam-publish.2.3.1/opam
@@ -14,7 +14,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/opam-publish"
 bug-reports: "https://github.com/ocaml/opam-publish/issues"
 depends: [
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.03.0"}

--- a/packages/opam-publish/opam-publish.2.4.0/opam
+++ b/packages/opam-publish/opam-publish.2.4.0/opam
@@ -14,7 +14,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/opam-publish"
 bug-reports: "https://github.com/ocaml/opam-publish/issues"
 depends: [
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.03.0"}

--- a/packages/opam-publish/opam-publish.2.5.0/opam
+++ b/packages/opam-publish/opam-publish.2.5.0/opam
@@ -14,7 +14,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/opam-publish"
 bug-reports: "https://github.com/ocaml/opam-publish/issues"
 depends: [
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.03.0"}

--- a/packages/opam-publish/opam-publish.2.5.1/opam
+++ b/packages/opam-publish/opam-publish.2.5.1/opam
@@ -14,7 +14,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/opam-publish"
 bug-reports: "https://github.com/ocaml/opam-publish/issues"
 depends: [
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.08.0"}

--- a/packages/opam-publish/opam-publish.2.6.0/opam
+++ b/packages/opam-publish/opam-publish.2.6.0/opam
@@ -14,7 +14,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/opam-publish"
 bug-reports: "https://github.com/ocaml/opam-publish/issues"
 depends: [
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.08.0"}


### PR DESCRIPTION
Cmdliner 2.0.0 breaks backward compatibility for opam and popular opam plugins and won't be able to upgrade (discussed in https://github.com/dbuenzli/cmdliner/issues/200), so i'm adding these constraints to avoid the breakage.

Required to be merged before https://github.com/ocaml/opam-repository/pull/28599