### PR TITLE
[new release] uring (2.7.0)

### DIFF
--- a/packages/uring/uring.2.7.0/opam
+++ b/packages/uring/uring.2.7.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Linux io_uring"
+description:
+  "Bindings to the Linux io_uring kernel IO interfaces. See https://github.com/ocaml-multicore/eio for a higher-level API using this."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Sadiq Jaffer" "Thomas Leonard"]
+homepage: "https://github.com/ocaml-multicore/ocaml-uring"
+doc: "https://ocaml-multicore.github.io/ocaml-uring/"
+bug-reports: "https://github.com/ocaml-multicore/ocaml-uring/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "cstruct" {>= "6.0.1"}
+  "ocaml" {>= "4.12.0"}
+  "dune-configurator"
+  "lwt" {with-test & >= "5.0.0"}
+  "bechamel" {>= "0.1.0" & with-test}
+  "logs" {with-test & >= "0.5.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "fmt" {>= "0.8.10"}
+  "optint" {>= "0.1.0"}
+  "mdx" {>= "2.1.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/ocaml-uring.git"
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+]
+available: [os = "linux"]
+license: ["ISC" "MIT"]
+x-ci-accept-failures: [
+  "centos-7" # default C compiler does not support stdatomic.h
+  "oraclelinux-7" # default C compiler does not support stdatomic.h
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/ocaml-uring/releases/download/v2.7.0/uring-2.7.0.tbz"
+  checksum: [
+    "sha256=99e3e2ebf4d7b7182d2d82f21d101d9d17207a574256051a3d8f8c6574b30ba5"
+    "sha512=ecb74cc98fa86bc43abfb72f582006956d603c1dc588a3729e89beebbb97c5386c2d6db19c207db409f92cb37442e356c740dd5393c2246ee70559c5d181eff1"
+  ]
+}
+x-commit-hash: "7988852a13646acc7646aea74909b147bf8923dd"


### PR DESCRIPTION
OCaml bindings for Linux io_uring

- Project page: <a href="https://github.com/ocaml-multicore/ocaml-uring">https://github.com/ocaml-multicore/ocaml-uring</a>
- Documentation: <a href="https://ocaml-multicore.github.io/ocaml-uring/">https://ocaml-multicore.github.io/ocaml-uring/</a>

##### CHANGES:

- Fix use-after-free data race in CQE handlers (@avsm ocaml-multicore/ocaml-uring#124, reported ocaml-multicore/ocaml-uring#123 by @polytypic).

- Add socket bind and listen operations (@avsm ocaml-multicore/ocaml-uring#118).

- Update liburing to 2.7 (@avsm ocaml-multicore/ocaml-uring#118).

- Add `Uring.Setup_flags` module (@talex5 ocaml-multicore/ocaml-uring#122).

- Clean up configurator code and update primitives.h (@talex5 ocaml-multicore/ocaml-uring#121).

- Add `mkdirat` operation (@patricoferris ocaml-multicore/ocaml-uring#120).
