### PR TITLE
[new release] postgresql (5.3.2)

### DIFF
--- a/packages/postgresql/postgresql.5.3.2/opam
+++ b/packages/postgresql/postgresql.5.3.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Bindings to the PostgreSQL library"
+description:
+  "Postgresql offers library functions for accessing PostgreSQL databases."
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "dune-compiledb"
+  "dune-configurator"
+  "conf-postgresql" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/postgresql-ocaml/releases/download/5.3.2/postgresql-5.3.2.tbz"
+  checksum: [
+    "sha256=1c47d22772f8938ff23d7350575d88ff2a3cf0d1f3988162f7bb807bccb157af"
+    "sha512=9f0ba45e066e7cdbc6429eede7a76955bd924a46db33c0a81dd2eb6a2cb3700a678355235b7891b17baaf227c6f32ad558c6bdac4e61923f13e227fae4e5afe2"
+  ]
+}
+x-commit-hash: "eea20fde9aad7d66c9255ac65873302942ede946"


### PR DESCRIPTION
Bindings to the PostgreSQL library

- Project page: <a href="https://mmottl.github.io/postgresql-ocaml">https://mmottl.github.io/postgresql-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/postgresql-ocaml/api">https://mmottl.github.io/postgresql-ocaml/api</a>

##### CHANGES:

### Fixed

- Enable binary results for parameterless queries by calling `PQsendQueryParams`
  when `binary_result` is requested (instead of `PQsendQuery`). Thanks to Alain
  Frisch for the patch.
