### PR TITLE
Release ppxlib and ppxlib-tools 0.36.2

### DIFF
--- a/packages/ppxlib-tools/ppxlib-tools.0.36.2/opam
+++ b/packages/ppxlib-tools/ppxlib-tools.0.36.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Tools for PPX users and authors"
+description: """
+Set of helper tools for PPX users and authors.
+
+ppxlib-pp-ast: Command line tool to pretty print OCaml ASTs in a human readable
+format."""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0"}
+  "ppxlib" {= version}
+  "cmdliner" {>= "1.3.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.36.2/ppxlib-0.36.2.tbz"
+  checksum: [
+    "sha256=c8756007d8cac1379a8461146100c1d611c7df6ecc1a9a0aa9bddec0d6e4e71b"
+    "sha512=eedafd477493be365857dbfd3733abc4a50854cd94151ae8ebc150284a1ebe5252b1a11b62c756e8078e9397a1a2fd7f1946b40e225bf7084cd33bba7fba48c7"
+  ]
+}
+x-commit-hash: "1521e60f1e43d76ea573079c9dfe5f4736079fc6"

--- a/packages/ppxlib/ppxlib.0.36.2/opam
+++ b/packages/ppxlib/ppxlib.0.36.2/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "Standard infrastructure for ppx rewriters"
+description: """
+Ppxlib is the standard infrastructure for ppx rewriters
+and other programs that manipulate the in-memory representation of
+OCaml programs, a.k.a the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0" & < "5.4.0"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0" {>= "v0.12"}
+  "sexplib0" {with-test & >= "v0.15"}
+  "stdlib-shims"
+  "ocamlfind" {with-test}
+  "re" {with-test & >= "1.9.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "ocamlformat" {with-dev-setup & = "0.26.2"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-migrate-parsetree" {< "2.0.0"}
+  "ocaml-base-compiler" {= "5.1.0~alpha1"}
+  "ocaml-variants" {= "5.1.0~alpha1+options"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.36.2/ppxlib-0.36.2.tbz"
+  checksum: [
+    "sha256=c8756007d8cac1379a8461146100c1d611c7df6ecc1a9a0aa9bddec0d6e4e71b"
+    "sha512=eedafd477493be365857dbfd3733abc4a50854cd94151ae8ebc150284a1ebe5252b1a11b62c756e8078e9397a1a2fd7f1946b40e225bf7084cd33bba7fba48c7"
+  ]
+}
+x-commit-hash: "1521e60f1e43d76ea573079c9dfe5f4736079fc6"


### PR DESCRIPTION
As per usual, starting with a draft to see how revdeps look like.

This should be an improvement over the failed attempt at releasing 0.36.1 as users are less susceptible of producing nodes that will be incorrectly printed.

It is still possible to manually construct them but `Ast_builder` users should not have that problem anymore.

## Changes

- Make Ast_builder's default `value_binding` constructor generate the proper
  `pvb_constraint` from the pattern and expression arguments.
  (ocaml-ppx/ppxlib#589, @NathanReb)
- Fix pprintast to output correct syntax from `Ppat_constraint (pat, Ptyp_poly ...)`
  nodes until they are completely dropped. (ocaml-ppx/ppxlib#588, @NathanReb)