### PR TITLE
Make opam library packages require a stable version of patch

### DIFF
--- a/packages/opam-core/opam-core.2.4.0/opam
+++ b/packages/opam-core/opam-core.2.4.0/opam
@@ -29,7 +29,7 @@ depends: [
   "sha" {>= "1.13"}
   "jsonm"
   "swhid_core"
-  "patch" {>= "3.0.0~alpha2"}
+  "patch" {>= "3.0.0"}
   "uutf"
   (("host-system-mingw" {os = "win32" & os-distribution != "cygwinports"} &
     "conf-mingw-w64-gcc-i686"

--- a/packages/opam-core/opam-core.2.4.0~alpha2/opam
+++ b/packages/opam-core/opam-core.2.4.0~alpha2/opam
@@ -29,7 +29,7 @@ depends: [
   "sha" {>= "1.13"}
   "jsonm"
   "swhid_core"
-  "patch" {>= "3.0.0~alpha2"}
+  "patch" {>= "3.0.0"}
   "uutf"
   (("host-system-mingw" {os = "win32" & os-distribution != "cygwinports"} &
     "conf-mingw-w64-gcc-i686"

--- a/packages/opam-core/opam-core.2.4.0~beta1/opam
+++ b/packages/opam-core/opam-core.2.4.0~beta1/opam
@@ -29,7 +29,7 @@ depends: [
   "sha" {>= "1.13"}
   "jsonm"
   "swhid_core"
-  "patch" {>= "3.0.0~alpha2"}
+  "patch" {>= "3.0.0"}
   "uutf"
   (("host-system-mingw" {os = "win32" & os-distribution != "cygwinports"} &
     "conf-mingw-w64-gcc-i686"

--- a/packages/opam-core/opam-core.2.4.0~rc1/opam
+++ b/packages/opam-core/opam-core.2.4.0~rc1/opam
@@ -29,7 +29,7 @@ depends: [
   "sha" {>= "1.13"}
   "jsonm"
   "swhid_core"
-  "patch" {>= "3.0.0~alpha2"}
+  "patch" {>= "3.0.0"}
   "uutf"
   (("host-system-mingw" {os = "win32" & os-distribution != "cygwinports"} &
     "conf-mingw-w64-gcc-i686"

--- a/packages/opam-core/opam-core.2.4.1/opam
+++ b/packages/opam-core/opam-core.2.4.1/opam
@@ -29,7 +29,7 @@ depends: [
   "sha" {>= "1.13"}
   "jsonm"
   "swhid_core"
-  "patch" {>= "3.0.0~alpha2"}
+  "patch" {>= "3.0.0"}
   "uutf"
   (("host-system-mingw" {os = "win32" & os-distribution != "cygwinports"} &
     "conf-mingw-w64-gcc-i686"

--- a/packages/opam-repository/opam-repository.2.4.0/opam
+++ b/packages/opam-repository/opam-repository.2.4.0/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "patch" {>= "3.0.0~alpha1"}
+  "patch" {>= "3.0.0"}
   "dune" {>= "2.8.0"}
 ]
 build: [

--- a/packages/opam-repository/opam-repository.2.4.0~alpha2/opam
+++ b/packages/opam-repository/opam-repository.2.4.0~alpha2/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "patch" {>= "3.0.0~alpha1"}
+  "patch" {>= "3.0.0"}
   "dune" {>= "2.8.0"}
 ]
 available: opam-version >= "2.1.0"

--- a/packages/opam-repository/opam-repository.2.4.0~beta1/opam
+++ b/packages/opam-repository/opam-repository.2.4.0~beta1/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "patch" {>= "3.0.0~alpha1"}
+  "patch" {>= "3.0.0"}
   "dune" {>= "2.8.0"}
 ]
 available: opam-version >= "2.1.0"

--- a/packages/opam-repository/opam-repository.2.4.0~rc1/opam
+++ b/packages/opam-repository/opam-repository.2.4.0~rc1/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "patch" {>= "3.0.0~alpha1"}
+  "patch" {>= "3.0.0"}
   "dune" {>= "2.8.0"}
 ]
 available: opam-version >= "2.1.0"

--- a/packages/opam-repository/opam-repository.2.4.1/opam
+++ b/packages/opam-repository/opam-repository.2.4.1/opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "patch" {>= "3.0.0~alpha1"}
+  "patch" {>= "3.0.0"}
   "dune" {>= "2.8.0"}
 ]
 build: [


### PR DESCRIPTION
Fix of an issue seen on IRC.

In case people use `opam-devel` and happened to have a pre-release version of `patch`, this would create issues that can break `opam update` in some cases.

The interface of `patch` and list of dependencies after `3.0.0~alpha2` stayed the same so this is safe to use everywhere.

Port of https://github.com/ocaml/opam/pull/6663