### PR TITLE
GHA: Handle symlinks on MSys2

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,6 +7,7 @@ on:
 env:
   OPAMROOT: D:\opamroot
   OPAMSOLVERTIMEOUT: 120
+  MSYS: winsymlinks:native
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Symlinks on MSys2 has a Cygwin-incompatible mode enabled by default https://www.msys2.org/docs/symlinks/
which I missed as part of https://github.com/ocaml/opam-repository/pull/28598. This means that MSys2 workflows may sometimes fail (and bail out) with `Unexpected error 40`, thus diverging in behaviour from the Cygwin-MinGW equivalent.

By setting an MSYS2 environment variable we reestablish Cygwin equivalent symlinks.

Here's an example from #28603:
https://github.com/ocaml/opam-repository/actions/runs/18063307516/job/51402636900
```
  #=== ERROR while fetching sources for msat.0.7 ================================#
  OpamSolution.Fetch_fail("\027[33m#\027[0m \027[33mpath\027[0m        D:\\a\\opam-repository\\opam-repository\n\027[33m#\027[0m \027[33mcommand\027[0m     C:\\msys64\\usr\\bin\\tar.exe xfz /c/Users/runneradmin/AppData/Local/Temp/opam-9176-3883ba/msat-0.7.tar.gz -C /c/Users/runneradmin/AppData/Local/Temp/opam-9176-fd15ed\n\027[33m#\027[0m \027[33mexit-code\027[0m   2\n\027[33m#\027[0m \027[33menv-file\027[0m    D:\\opamroot\\log\\log-9176-ace46f.env\n\027[33m#\027[0m \027[33moutput-file\027[0m D:\\opamroot\\log\\log-9176-ace46f.out\n\027[33m### output ###\n\027[0m\027[33m# \027[0m/usr/bin/tar: mSAT-0.7/src/util/log.ml: Cannot create symlink to 'log_real.ml': No such file or directory\n\027[33m# \027[0m/usr/bin/tar: Exiting with failure status due to previous errors\n")
  
  
  <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
  +- The following actions failed
  | - fetch msat 0.7
  +- 
  +- The following changes have been performed (the rest was aborted)
  | - remove    base-domains                  base
  | - remove    base-effects                  base
[...]
  | - install   uutf                          1.0.4
  | - install   zarith                        1.14
  +- 
  # To update the current shell environment, run: (& opam env) -split '\r?\n' | ForEach-Object { Invoke-Expression $_ }
  
  The former state can be restored with:
      D:\opam\bin\opam.exe switch import "D:\\opamroot\\default\\.opam-switch\\backup\\state-20250927182221.export"
Exception: D:\a\_temp\b156124b-2a73-4afe-a7ea-828ef3c2b964.ps1:14
Line |
  14 |      default { throw "Unexpected error $_" }
     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Unexpected error 40
```

Here's a self-PR confirming that with the fix the two MinGW workflows now work the same: https://github.com/jmid/opam-repository/pull/19
(they both fail with `archsat.1.1 failed to build` and no more `Unexpected error 40`)  :sweat_smile: 

Thanks to @dra27 for help figuring this one out :pray: 