### PR TITLE
13 packages from gitlab.com/api/v4/projects/60486861/packages/generic/src/2.4.2.14/MlFront.tar.gz

### DIFF
--- a/packages/MlFront_Cache/MlFront_Cache.2.4.2/opam
+++ b/packages/MlFront_Cache/MlFront_Cache.2.4.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Caching for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "bos" {>= "0.2.1"}
+  "fmt" {>= "0.9.0"}
+  "fpath" {>= "0.7.3"}
+  "mirage-crypto-rng" {>= "2.0.0"}
+  "sqlite3" {>= "5.2.0"}
+  "uuidm" {>= "0.9.8"}
+  "MlFront_Core" {= version}
+  "MlFront_Errors" {= version}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.4.2.14/MlFront.tar.gz"
+  checksum: [
+    "md5=2eb38d7e0e29841b8c0f5ab1449a2b90"
+    "sha512=f09047c3ec865d75dece80a167b7d7a4bf9372756b966efb92aa3ee4bc054bf647620792dfc82301709077dbe1100be992528bbe4986f608fcce94faa24c186a"
+  ]
+}

--- a/packages/MlFront_Cli/MlFront_Cli.2.4.2/opam
+++ b/packages/MlFront_Cli/MlFront_Cli.2.4.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Command line interfaces for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.4.2.14/MlFront.tar.gz"
+  checksum: [
+    "md5=2eb38d7e0e29841b8c0f5ab1449a2b90"
+    "sha512=f09047c3ec865d75dece80a167b7d7a4bf9372756b966efb92aa3ee4bc054bf647620792dfc82301709077dbe1100be992528bbe4986f608fcce94faa24c186a"
+  ]
+}

--- a/packages/MlFront_Codept/MlFront_Codept.2.4.2/opam
+++ b/packages/MlFront_Codept/MlFront_Codept.2.4.2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Utilities built on top of codept_lib"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "bos" {>= "0.2.1"}
+  "codept-lib" {>= "0.12.0"}
+  "ezjsonm" {>= "1.3.0"}
+  "fmt" {>= "0.9.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "6.0.2"}
+  "stringext" {>= "1.6.0"}
+  "MlFront_Core" {= version}
+  "MlFront_Config" {= version}
+  "MlFront_Errors" {= version}
+  "containers-data" {with-test & >= "3.13.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+pin-depends: [
+  "codept-lib.0.12.0"
+  "git+https://github.com/Octachron/codept.git#f7168fbeefa5776448d95a62b0c5a4a196845851"
+]
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.4.2.14/MlFront.tar.gz"
+  checksum: [
+    "md5=2eb38d7e0e29841b8c0f5ab1449a2b90"
+    "sha512=f09047c3ec865d75dece80a167b7d7a4bf9372756b966efb92aa3ee4bc054bf647620792dfc82301709077dbe1100be992528bbe4986f608fcce94faa24c186a"
+  ]
+}

--- a/packages/MlFront_Config/MlFront_Config.2.4.2/opam
+++ b/packages/MlFront_Config/MlFront_Config.2.4.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Configuration for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "cppo" {>= "1.6.8"}
+  "MlFront_Core" {= version}
+  "ppxlib" {with-test & >= "0.30.0"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.4.2.14/MlFront.tar.gz"
+  checksum: [
+    "md5=2eb38d7e0e29841b8c0f5ab1449a2b90"
+    "sha512=f09047c3ec865d75dece80a167b7d7a4bf9372756b966efb92aa3ee4bc054bf647620792dfc82301709077dbe1100be992528bbe4986f608fcce94faa24c186a"
+  ]
+}

--- a/packages/MlFront_Core/MlFront_Core.2.4.2/opam
+++ b/packages/MlFront_Core/MlFront_Core.2.4.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Module and library identification for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "digestif" {>= "1.1.4"}
+  "stringext" {>= "1.6.0"}
+  "crowbar" {with-test & >= "0.2.1"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.4.2.14/MlFront.tar.gz"
+  checksum: [
+    "md5=2eb38d7e0e29841b8c0f5ab1449a2b90"
+    "sha512=f09047c3ec865d75dece80a167b7d7a4bf9372756b966efb92aa3ee4bc054bf647620792dfc82301709077dbe1100be992528bbe4986f608fcce94faa24c186a"
+  ]
+}

--- a/packages/MlFront_Errors/MlFront_Errors.2.4.2/opam
+++ b/packages/MlFront_Errors/MlFront_Errors.2.4.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Error handling for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "fmt" {>= "0.9.0"}
+  "logs" {>= "0.7.0"}
+  "stringext" {>= "1.6.0"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.4.2.14/MlFront.tar.gz"
+  checksum: [
+    "md5=2eb38d7e0e29841b8c0f5ab1449a2b90"
+    "sha512=f09047c3ec865d75dece80a167b7d7a4bf9372756b966efb92aa3ee4bc054bf647620792dfc82301709077dbe1100be992528bbe4986f608fcce94faa24c186a"
+  ]
+}

--- a/packages/MlFront_Exec/MlFront_Exec.2.4.2/opam
+++ b/packages/MlFront_Exec/MlFront_Exec.2.4.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Executes reproducible units of work called thunks"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "MlFront_Signify" {= version}
+  "MlFront_Thunk" {= version}
+  "MlFront_ZipFile" {= version}
+  "pbrt"
+  "ptime" {>= "1.1.0"}
+  "ppx_deriving" {>= "6.0.2"}
+  "xdg" {>= "3.12.1"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "ocaml-protoc" {with-test & >= "3.1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.4.2.14/MlFront.tar.gz"
+  checksum: [
+    "md5=2eb38d7e0e29841b8c0f5ab1449a2b90"
+    "sha512=f09047c3ec865d75dece80a167b7d7a4bf9372756b966efb92aa3ee4bc054bf647620792dfc82301709077dbe1100be992528bbe4986f608fcce94faa24c186a"
+  ]
+}

--- a/packages/MlFront_Logs/MlFront_Logs.2.4.2/opam
+++ b/packages/MlFront_Logs/MlFront_Logs.2.4.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Logging for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "MlFront_Cli" {= version}
+  "cmdliner" {>= "1.2.0"}
+  "fmt" {>= "0.9.0"}
+  "logs" {>= "0.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.4.2.14/MlFront.tar.gz"
+  checksum: [
+    "md5=2eb38d7e0e29841b8c0f5ab1449a2b90"
+    "sha512=f09047c3ec865d75dece80a167b7d7a4bf9372756b966efb92aa3ee4bc054bf647620792dfc82301709077dbe1100be992528bbe4986f608fcce94faa24c186a"
+  ]
+}

--- a/packages/MlFront_Manip/MlFront_Manip.2.4.2/opam
+++ b/packages/MlFront_Manip/MlFront_Manip.2.4.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Binary manipulation tools for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "tezt" {with-test & >= "4.1.0"}
+  "ppxlib" {with-test & >= "0.30.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.4.2.14/MlFront.tar.gz"
+  checksum: [
+    "md5=2eb38d7e0e29841b8c0f5ab1449a2b90"
+    "sha512=f09047c3ec865d75dece80a167b7d7a4bf9372756b966efb92aa3ee4bc054bf647620792dfc82301709077dbe1100be992528bbe4986f608fcce94faa24c186a"
+  ]
+}

--- a/packages/MlFront_Signify/MlFront_Signify.2.4.2/opam
+++ b/packages/MlFront_Signify/MlFront_Signify.2.4.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "OpenBSD compatible signify for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "mirage-crypto-rng" {>= "2.0.0"}
+  "stringext" {with-test & >= "1.6.0"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.4.2.14/MlFront.tar.gz"
+  checksum: [
+    "md5=2eb38d7e0e29841b8c0f5ab1449a2b90"
+    "sha512=f09047c3ec865d75dece80a167b7d7a4bf9372756b966efb92aa3ee4bc054bf647620792dfc82301709077dbe1100be992528bbe4986f608fcce94faa24c186a"
+  ]
+}

--- a/packages/MlFront_Thunk/MlFront_Thunk.2.4.2/opam
+++ b/packages/MlFront_Thunk/MlFront_Thunk.2.4.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Describes and runs reproducible units of work called thunks"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "MlFront_Core" {= version}
+  "fmlib_parse" {>= "0.5.11"}
+  "fmlib_pretty" {>= "0.5.11"}
+  "digestif" {>= "1.1.4"}
+  "jsont" {>= "0.1.1"}
+  "yojson" {>= "2.1.2"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.4.2.14/MlFront.tar.gz"
+  checksum: [
+    "md5=2eb38d7e0e29841b8c0f5ab1449a2b90"
+    "sha512=f09047c3ec865d75dece80a167b7d7a4bf9372756b966efb92aa3ee4bc054bf647620792dfc82301709077dbe1100be992528bbe4986f608fcce94faa24c186a"
+  ]
+}

--- a/packages/MlFront_Tools/MlFront_Tools.2.4.2/opam
+++ b/packages/MlFront_Tools/MlFront_Tools.2.4.2/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Command line interfaces for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14.0"}
+  "bos" {>= "0.2.1"}
+  "cmdliner" {>= "1.2.0"}
+  "crunch" {>= "3.3.1"}
+  "fmt" {>= "0.9.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "stringext" {>= "1.6.0"}
+  "diskuvbox" {with-test & >= "0.2.0"}
+  "ezjsonm" {>= "1.3.0"}
+  "menhir" {>= "20180523"}
+  "containers-data" {with-test & >= "3.13.1"}
+  "digestif" {>= "1.1.4"}
+  "crowbar" {with-test & >= "0.2.1"}
+  "re" {with-test & >= "1.11.0"}
+  "stringext" {with-test & >= "1.6.0"}
+  "tezt" {with-test & >= "4.1.0"}
+  "ppxlib" {with-test & >= "0.30.0"}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "sh"
+    "ci/build-cli.sh"
+    "-t" {with-test}
+    "-d" {with-doc}
+    "-a"
+    "windows_unknown" {os = "win32"}
+    "unix_unknown" {!(os = "win32")}
+  ]
+  ["install" "MlFront_Tools.install.win32" "MlFront_Tools.install"]
+    {os = "win32"}
+  ["install" "MlFront_Tools.install.unix" "MlFront_Tools.install"]
+    {!(os = "win32")}
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.4.2.14/MlFront.tar.gz"
+  checksum: [
+    "md5=2eb38d7e0e29841b8c0f5ab1449a2b90"
+    "sha512=f09047c3ec865d75dece80a167b7d7a4bf9372756b966efb92aa3ee4bc054bf647620792dfc82301709077dbe1100be992528bbe4986f608fcce94faa24c186a"
+  ]
+}

--- a/packages/MlFront_ZipFile/MlFront_ZipFile.2.4.2/opam
+++ b/packages/MlFront_ZipFile/MlFront_ZipFile.2.4.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Zip files for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://diskuv.com/mlfront/overview-1/"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "re" {>= "1.11.0"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/60486861/packages/generic/src/2.4.2.14/MlFront.tar.gz"
+  checksum: [
+    "md5=2eb38d7e0e29841b8c0f5ab1449a2b90"
+    "sha512=f09047c3ec865d75dece80a167b7d7a4bf9372756b966efb92aa3ee4bc054bf647620792dfc82301709077dbe1100be992528bbe4986f608fcce94faa24c186a"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`MlFront_Cache.2.4.2`: Caching for MlFront
-`MlFront_Cli.2.4.2`: Command line interfaces for MlFront
-`MlFront_Codept.2.4.2`: Utilities built on top of codept_lib
-`MlFront_Config.2.4.2`: Configuration for MlFront
-`MlFront_Core.2.4.2`: Module and library identification for MlFront
-`MlFront_Errors.2.4.2`: Error handling for MlFront
-`MlFront_Exec.2.4.2`: Executes reproducible units of work called thunks
-`MlFront_Logs.2.4.2`: Logging for MlFront
-`MlFront_Manip.2.4.2`: Binary manipulation tools for MlFront
-`MlFront_Signify.2.4.2`: OpenBSD compatible signify for MlFront
-`MlFront_Thunk.2.4.2`: Describes and runs reproducible units of work called thunks
-`MlFront_Tools.2.4.2`: Command line interfaces for MlFront
-`MlFront_ZipFile.2.4.2`: Zip files for MlFront



---
* Homepage: https://diskuv.com/mlfront/overview-1/
* Source repo: git+https://gitlab.com/dkml/build-tools/MlFront.git
* Bug tracker: https://gitlab.com/dkml/build-tools/MlFront/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0