### PR TITLE
[new release] opam-check-npm-deps (4.0.1)

### DIFF
--- a/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
@@ -50,3 +50,4 @@ url {
   ]
 }
 x-commit-hash: "1978cca0ea36d79f5f05a5c3b80f930f4922921e"
+x-maintenance-intent: [ "(latest)" ]

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.1.0.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/jchavarri/opam-check-npm-deps"
 bug-reports: "https://github.com/jchavarri/opam-check-npm-deps/issues"
 depends: [
   "ocaml" {>= "4.14.0"}
-  "reason" {>= "3.8.1" & < "4.0.0"}
+  "reason" {>= "3.8.1" & < "3.16.0"}
   "dune" {>= "3.8"}
   "opam-client" {>= "2.1.3" & < "2.2"}
   "mccs" {>= "1.1+14"}
@@ -21,7 +21,7 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_expect"
   "ppx_inline_test"
-  "ppx_let"
+  "ppx_let" { < "v0.17.1" }
   "ppx_sexp_conv"
   "odoc" {with-doc}
 ]

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.2.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.2.0.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/jchavarri/opam-check-npm-deps"
 bug-reports: "https://github.com/jchavarri/opam-check-npm-deps/issues"
 depends: [
   "ocaml" {>= "4.14.0"}
-  "reason" {>= "3.8.1"}
+  "reason" {>= "3.8.1" & < "3.16.0"}
   "dune" {>= "3.8"}
   "opam-client" {>= "2.2" & < "2.3"}
   "mccs" {>= "1.1+14"}
@@ -21,7 +21,7 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_expect"
   "ppx_inline_test"
-  "ppx_let"
+  "ppx_let" { < "v0.17.1" }
   "ppx_sexp_conv"
   "odoc" {with-doc}
 ]

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.2.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.2.0.0/opam
@@ -50,3 +50,4 @@ url {
   ]
 }
 x-commit-hash: "dffa1f2c9e787420e71dc6507e825305c4ac8e1d"
+x-maintenance-intent: [ "(latest)" ]

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.3.0.1/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.3.0.1/opam
@@ -51,3 +51,4 @@ url {
   ]
 }
 x-commit-hash: "30909d3f6122a261fbc85049f04adec7a647438b"
+x-maintenance-intent: [ "(latest)" ]

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.3.0.1/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.3.0.1/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/ahrefs/opam-check-npm-deps"
 bug-reports: "https://github.com/ahrefs/opam-check-npm-deps/issues"
 depends: [
   "ocaml" {>= "4.14.0"}
-  "reason" {>= "3.8.1"}
+  "reason" {>= "3.8.1" & < "3.16.0"}
   "dune" {>= "3.8"}
   "opam-client" {>= "2.3" & < "2.4"}
   "mccs" {>= "1.1+14"}
@@ -22,7 +22,7 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_expect"
   "ppx_inline_test"
-  "ppx_let"
+  "ppx_let" { < "v0.17.1" }
   "ppx_sexp_conv"
   "odoc" {with-doc}
 ]

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.4.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.4.0.0/opam
@@ -51,3 +51,4 @@ url {
   ]
 }
 x-commit-hash: "96f9bcfcf42bf6e3da045425cbf718c240f6ef33"
+x-maintenance-intent: [ "(latest)" ]

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.4.0.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.4.0.0/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/ahrefs/opam-check-npm-deps"
 bug-reports: "https://github.com/ahrefs/opam-check-npm-deps/issues"
 depends: [
   "ocaml" {>= "4.14.0"}
-  "reason" {>= "3.8.1"}
+  "reason" {>= "3.8.1" & < "3.16.0"}
   "dune" {>= "3.8"}
   "opam-client" {>= "2.4" & < "2.5"}
   "mccs" {>= "1.1+14"}
@@ -22,7 +22,7 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_expect"
   "ppx_inline_test"
-  "ppx_let"
+  "ppx_let" { < "v0.17.1" }
   "ppx_sexp_conv"
   "odoc" {with-doc}
 ]

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.4.0.1/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.4.0.1/opam
@@ -51,3 +51,4 @@ url {
   ]
 }
 x-commit-hash: "f1ebc47aaadb44148f99bd3020ebbf450b2edccf"
+x-maintenance-intent: [ "(latest)" ]

--- a/packages/opam-check-npm-deps/opam-check-npm-deps.4.0.1/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.4.0.1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis:
+  "An opam plugin to check for npm depexts inside the node_modules folder"
+description:
+  "Provides the `opam check-npm-deps` command, which given an opam switch, gathers all the depexts belonging to the npm platform and their version constraints, and checks the `node_modules` folder to see if the constraints are satisfied."
+maintainer: ["Javier Chávarri <javier.chavarri@ahrefs.com>"]
+authors: ["Javier Chávarri <javier.chavarri@ahrefs.com>"]
+tags: ["melange" "org:ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/opam-check-npm-deps"
+bug-reports: "https://github.com/ahrefs/opam-check-npm-deps/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "reason" {>= "3.8.1"}
+  "dune" {>= "3.8"}
+  "opam-client" {>= "2.4" & < "2.5"}
+  "mccs" {>= "1.1+14"}
+  "angstrom" {>= "0.15.0"}
+  "fmt" {>= "0.9.0"}
+  "bos"
+  "lwt_ppx"
+  "ppx_deriving_yojson"
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_let"
+  "ppx_sexp_conv"
+  "odoc" {with-doc}
+]
+available: opam-version >= "2.4" & opam-version < "2.5"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/opam-check-npm-deps.git"
+flags: plugin
+url {
+  src:
+    "https://github.com/ahrefs/opam-check-npm-deps/releases/download/4.0.1/opam-check-npm-deps-4.0.1.tbz"
+  checksum: [
+    "sha256=7fc43abbc83d4077528c40857ac75b9ea3f0379d666aac3c2555152926b21130"
+    "sha512=47fdcbf455fa75b857831a505f42d2f37231b37eee3d44368e30a7cfca7b01a51e28375494cbdefc0a849556aad1418e80d1a33c84725be992bdd33ac36b31b4"
+  ]
+}
+x-commit-hash: "f1ebc47aaadb44148f99bd3020ebbf450b2edccf"


### PR DESCRIPTION
An opam plugin to check for npm depexts inside the node_modules folder

- Project page: <a href="https://github.com/ahrefs/opam-check-npm-deps">https://github.com/ahrefs/opam-check-npm-deps</a>

##### CHANGES:

- Fix syntax error after reason/ppx_let upstream changes.
