### PR TITLE
[new release] icalendar (0.1.12)

### DIFF
--- a/packages/icalendar/icalendar.0.1.12/opam
+++ b/packages/icalendar/icalendar.0.1.12/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/robur-coop/icalendar"
+bug-reports: "https://github.com/robur-coop/icalendar/issues"
+dev-repo: "git+https://github.com/robur-coop/icalendar.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://robur-coop.github.io/icalendar/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "1.3"}
+  "alcotest" {with-test}
+  "fmt"
+  "angstrom" {>= "0.14.0"}
+  "re" {>= "1.7.2"}
+  "uri"
+  "ptime"
+  "ppx_deriving"
+  "gmap" {>= "0.3.0"}
+]
+
+synopsis: "A library to parse and print the iCalendar (RFC 5545) format"
+description: """
+Parse and print .ics files as specified in RFC 5545.
+Supports recurrent events, but only to the day level of detail.
+Does not support vJournal components.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/icalendar/releases/download/v0.1.12/icalendar-0.1.12.tbz"
+  checksum: [
+    "sha256=f17f78bd084d1bbe8021a6b6fff16a568c26c0dc80333176f33fe6da246cd54a"
+    "sha512=edf7371febe51340e4b38f19dcb2bde19c5ec595a65907c61583865c3f6ea01085b59b807ca4d8f31c8110eb4d2c210aa4379aad997eb8dfec348ba0f488b6be"
+  ]
+}
+x-commit-hash: "c566ab67729df18d483b10d2253c87d8246173be"


### PR DESCRIPTION
A library to parse and print the iCalendar (RFC 5545) format

- Project page: <a href="https://github.com/robur-coop/icalendar">https://github.com/robur-coop/icalendar</a>
- Documentation: <a href="https://robur-coop.github.io/icalendar/">https://robur-coop.github.io/icalendar/</a>

##### CHANGES:

* vjournal support (robur-coop/icalendar#19 by @RyanGibb, fixes robur-coop/icalendar#18)
