### PR TITLE
[new release] mirage-monitoring (0.0.8)

### DIFF
--- a/packages/mirage-monitoring/mirage-monitoring.0.0.8/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.8/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mirage-monitoring"
+doc: "https://robur-coop.github.io/mirage-monitoring"
+dev-repo: "git+https://github.com/robur-coop/mirage-monitoring.git"
+bug-reports: "https://github.com/robur-coop/mirage-monitoring/issues"
+license: "AGPL-3.0-only"
+
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune"
+  "logs" {>= "0.6.3"}
+  "metrics" {>= "0.5.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "mirage-sleep" {>= "4.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-runtime" {>= "4.5.0"}
+  "memtrace-mirage" {>= "0.2.1.2.3"}
+  "cmdliner" {>= "2.0.0"}
+]
+conflicts: [
+  "mirage-solo5" {< "0.9.2"}
+  "mirage-xen" {< "8.0.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Monitoring of MirageOS unikernels"
+description: """
+Reporting metrics to Influx, Telegraf. Dynamic adjusting log level and metrics
+sources, memprof profiling.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/mirage-monitoring/releases/download/v0.0.8/mirage-monitoring-0.0.8.tbz"
+  checksum: [
+    "sha256=0ba82c65c554463e6fe91c169b8d38ec5c11a0a2d558bf72023f25808499622e"
+    "sha512=8053ad15c3334fa61399c0335e64899b00ce7c3dde4bec7891c02f972c9143b181d7c9a2201ef74942a357b1c04a134e5bf60cfa531a397cf661cc8e9d6c2c04"
+  ]
+}
+x-commit-hash: "2df3c24a996b3a875d22ddfd2df587b842858d2f"


### PR DESCRIPTION
Monitoring of MirageOS unikernels

- Project page: <a href="https://github.com/robur-coop/mirage-monitoring">https://github.com/robur-coop/mirage-monitoring</a>
- Documentation: <a href="https://robur-coop.github.io/mirage-monitoring">https://robur-coop.github.io/mirage-monitoring</a>

##### CHANGES:

* Update to cmdliner 2.0.0 API (!3 @hannesm)
