### PR TITLE
[new release] mirage-kv-mem (4.0.1)

### DIFF
--- a/packages/mirage-kv-mem/mirage-kv-mem.4.0.1/opam
+++ b/packages/mirage-kv-mem/mirage-kv-mem.4.0.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/mirage/mirage-kv-mem"
+doc: "https://mirage.github.io/mirage-kv-mem/"
+bug-reports: "https://github.com/mirage/mirage-kv-mem/issues"
+dev-repo: "git+https://github.com/mirage/mirage-kv-mem.git"
+tags: [ "org:mirage" "org:robur" ]
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.3.0"}
+  "alcotest" {with-test}
+  "mirage-ptime" {>= "5.0.0"}
+  "mirage-kv" {>= "6.0.0"}
+  "fmt" {>= "0.9.0"}
+  "ptime" {>= "1.1.0"}
+  "optint" {>= "0.3.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+
+synopsis: "In-memory key value store for MirageOS"
+description: """
+Implements the mirage-kv interface, but does not provide a persistent data storage.
+Use for testing or amnesia.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-kv-mem/releases/download/v4.0.1/mirage-kv-mem-4.0.1.tbz"
+  checksum: [
+    "sha256=7b961185883728ee4bc059a2d49be7aa51779a878090e6be31f2903c8a9e5e51"
+    "sha512=0e3a4afc577ebf94acb4bf1f48682066522136d3986bc6b193efefb7ed1b1a3b47d33fa626fd5aea17c29ccfb640a40fd67c4a15c4ecdaacbdcde0c0d933dd0a"
+  ]
+}
+x-commit-hash: "db48b024d030ea7a874742403b570e5b4d3339c2"


### PR DESCRIPTION
In-memory key value store for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-kv-mem">https://github.com/mirage/mirage-kv-mem</a>
- Documentation: <a href="https://mirage.github.io/mirage-kv-mem/">https://mirage.github.io/mirage-kv-mem/</a>

##### CHANGES:

* Make listing tail-recursive (mirage/mirage-kv-mem#7 @Firobe @reynir)
* Add x-maintenance-intent opam field (@hannesm)
