### PR TITLE
[new release] hxd (0.3.5)

### DIFF
--- a/packages/hxd/hxd.0.3.5/opam
+++ b/packages/hxd/hxd.0.3.5/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/hxd"
+bug-reports:  "https://github.com/dinosaure/hxd/issues"
+dev-repo:     "git+https://github.com/dinosaure/hxd.git"
+doc:          "https://dinosaure.github.io/hxd/"
+license:      "MIT"
+synopsis:     "Hexdump in OCaml"
+description: """Please, help me to debug ocaml-git
+"""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.7"}
+  "dune-configurator" {>= "2.7"}
+  "cmdliner"          {>= "1.1.0"}
+]
+
+depopts: [
+  "lwt"
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/dinosaure/hxd/releases/download/v0.3.5/hxd-0.3.5.tbz"
+  checksum: [
+    "sha256=135235f7c12b4fdfc2a6f764fd08e9ab7eb438856e02c6e668d73ba89ce77443"
+    "sha512=8b55c2f619d9df5db78990f9c52462416a6da71f36d570ea2ad1b640605132cbb4dd3df078f041d5fde721d61baa6d6efb9a0163f738efaf4a429660a3a665a6"
+  ]
+}
+x-commit-hash: "f660ca37e0440f5f46d5d8ae5652734c748b45c1"


### PR DESCRIPTION
Hexdump in OCaml

- Project page: <a href="https://github.com/dinosaure/hxd">https://github.com/dinosaure/hxd</a>
- Documentation: <a href="https://dinosaure.github.io/hxd/">https://dinosaure.github.io/hxd/</a>

##### CHANGES:

* Fix the compilation with `cmdliner.2.0.0` (@dinosaure, dinosaure/hxd#19)
