### PR TITLE
[new release] alcotest (5 packages) (1.9.1)

### DIFF
--- a/packages/alcotest-async/alcotest-async.1.9.1/opam
+++ b/packages/alcotest-async/alcotest-async.1.9.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Async-based helpers for Alcotest"
+description: "Async-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "re" {with-test}
+  "fmt" {with-test}
+  "cmdliner" {with-test & >= "1.2.0"}
+  "core" {>= "v0.16.0"}
+  "core_unix" {>= "v0.16.0"}
+  "base"
+  "async_kernel"
+  "ocaml" {>= "4.14.0"}
+  "alcotest" {= version}
+  "async" {>= "v0.16.0"}
+  "async_unix" {>= "v0.16.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.9.1/alcotest-1.9.1.tbz"
+  checksum: [
+    "sha256=1e29c3b41d4329062105b723dfda3aff86b8cef5e7c7500d0e491fc5fd78e482"
+    "sha512=c49d402fa636dcf11f81917610dd1d2eca8606c8919aede4db23710d071f6046a8f93c78de9fbfee26637a53ca67f71fad500bfa2478b7f0f059608a492dd0a5"
+  ]
+}
+x-commit-hash: "7db64e91b159ce60937d2ff647208eb25fe37610"

--- a/packages/alcotest-js/alcotest-js.1.9.1/opam
+++ b/packages/alcotest-js/alcotest-js.1.9.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Virtual package containing optional JavaScript dependencies for Alcotest"
+description:
+  "Virtual package containing optional JavaScript dependencies for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "alcotest" {= version}
+  "js_of_ocaml-compiler" {>= "3.11.0"}
+  "fmt" {with-test & >= "0.8.7"}
+  "cmdliner" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@runtest-js" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.9.1/alcotest-1.9.1.tbz"
+  checksum: [
+    "sha256=1e29c3b41d4329062105b723dfda3aff86b8cef5e7c7500d0e491fc5fd78e482"
+    "sha512=c49d402fa636dcf11f81917610dd1d2eca8606c8919aede4db23710d071f6046a8f93c78de9fbfee26637a53ca67f71fad500bfa2478b7f0f059608a492dd0a5"
+  ]
+}
+x-commit-hash: "7db64e91b159ce60937d2ff647208eb25fe37610"

--- a/packages/alcotest-lwt/alcotest-lwt.1.9.1/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.1.9.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Lwt-based helpers for Alcotest"
+description: "Lwt-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "re" {with-test}
+  "cmdliner" {with-test & >= "1.2.0"}
+  "fmt"
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {= version}
+  "lwt"
+  "logs"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.9.1/alcotest-1.9.1.tbz"
+  checksum: [
+    "sha256=1e29c3b41d4329062105b723dfda3aff86b8cef5e7c7500d0e491fc5fd78e482"
+    "sha512=c49d402fa636dcf11f81917610dd1d2eca8606c8919aede4db23710d071f6046a8f93c78de9fbfee26637a53ca67f71fad500bfa2478b7f0f059608a492dd0a5"
+  ]
+}
+x-commit-hash: "7db64e91b159ce60937d2ff647208eb25fe37610"

--- a/packages/alcotest-mirage/alcotest-mirage.1.9.1/opam
+++ b/packages/alcotest-mirage/alcotest-mirage.1.9.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Mirage implementation for Alcotest"
+description: "Mirage implementation for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "re" {with-test}
+  "cmdliner" {with-test & >= "1.2.0"}
+  "fmt"
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {= version}
+  "mirage-clock" {>= "2.0.0"}
+  "duration"
+  "lwt"
+  "logs"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.9.1/alcotest-1.9.1.tbz"
+  checksum: [
+    "sha256=1e29c3b41d4329062105b723dfda3aff86b8cef5e7c7500d0e491fc5fd78e482"
+    "sha512=c49d402fa636dcf11f81917610dd1d2eca8606c8919aede4db23710d071f6046a8f93c78de9fbfee26637a53ca67f71fad500bfa2478b7f0f059608a492dd0a5"
+  ]
+}
+x-commit-hash: "7db64e91b159ce60937d2ff647208eb25fe37610"

--- a/packages/alcotest/alcotest.1.9.1/opam
+++ b/packages/alcotest/alcotest.1.9.1/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "Alcotest is a lightweight and colourful test framework"
+description: """
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "cmdliner" {>= "1.2.0"}
+  "re" {>= "1.7.2"}
+  "stdlib-shims"
+  "uutf" {>= "1.0.1"}
+  "ocaml-syntax-shims"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "js_of_ocaml-compiler" {< "5.8"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.9.1/alcotest-1.9.1.tbz"
+  checksum: [
+    "sha256=1e29c3b41d4329062105b723dfda3aff86b8cef5e7c7500d0e491fc5fd78e482"
+    "sha512=c49d402fa636dcf11f81917610dd1d2eca8606c8919aede4db23710d071f6046a8f93c78de9fbfee26637a53ca67f71fad500bfa2478b7f0f059608a492dd0a5"
+  ]
+}
+x-commit-hash: "7db64e91b159ce60937d2ff647208eb25fe37610"


### PR DESCRIPTION
Alcotest is a lightweight and colourful test framework

- Project page: <a href="https://github.com/mirage/alcotest">https://github.com/mirage/alcotest</a>
- Documentation: <a href="https://mirage.github.io/alcotest">https://mirage.github.io/alcotest</a>

##### CHANGES:

- Remove bad test with `cmdliner` to be compatible with `cmdliner.2.0.0` (@MisterDA, mirage/alcotest#424)
