### PR TITLE
conf-vips: add conf-vips for mosaique

### DIFF
--- a/packages/conf-vips/conf-vips.1/opam
+++ b/packages/conf-vips/conf-vips.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libvips-dev"] {os-family = "debian"}
   ["libvips-dev"] {os-family = "ubuntu"}
   ["vips-devel"] {os-family = "fedora"}
-  ["vips-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["libvips-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["vips-dev"] {os-distribution = "alpine"}
   ["vips"] {os-distribution = "nixos"}
   ["libvips"] {os-distribution = "arch"}


### PR DESCRIPTION
adding conf-vips for [mosaique](https://github.com/ocaml/opam-repository/pull/28632).
I checked for [all distribution](https://pkgs.org/search/?q=vips). But maybe a double check is worth it.

I removed windows because I dont know how it works. So I wasn't confident enougth to let it there.
I also removed centos. It seems that it doesn't have vips.