### PR TITLE
[new release] chamelon (2 packages) (0.2.0)

### DIFF
--- a/packages/chamelon-unix/chamelon-unix.0.2.0/opam
+++ b/packages/chamelon-unix/chamelon-unix.0.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "alcotest" {>= "1.5.0" & with-test}
   "alcotest-lwt" {>= "1.5.0" & with-test}
   "mirage-block-combinators" {>= "3.0.0" & with-test}
-  "mirage-crypto-rng" {>= "0.10.6" & with-test}
+  "mirage-crypto-rng" {>= "1.2.0" & with-test}
   "bos" {>= "0.2.0"}
   "chamelon" {= version}
   "cmdliner" {>= "1.1.0"}

--- a/packages/chamelon-unix/chamelon-unix.0.2.0/opam
+++ b/packages/chamelon-unix/chamelon-unix.0.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: [ "yomimono <maintenance@identity-function.com>" ]
+authors: [ "yomimono <maintenance@identity-function.com>" ]
+homepage: "https://github.com/yomimono/chamelon"
+bug-reports: "https://github.com/yomimono/chamelon/issues"
+dev-repo: "git+https://github.com/yomimono/chamelon.git"
+license: "ISC"
+synopsis: "Command-line Unix utilities for chamelon filesystems"
+
+build: [
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.9.0"}
+  "alcotest" {>= "1.5.0" & with-test}
+  "alcotest-lwt" {>= "1.5.0" & with-test}
+  "mirage-block-combinators" {>= "3.0.0" & with-test}
+  "mirage-crypto-rng" {>= "0.10.6" & with-test}
+  "bos" {>= "0.2.0"}
+  "chamelon" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "logs" {>= "0.6.0"}
+  "lwt" {>= "5.3.0"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-block-unix" {>= "2.13.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-clock-unix" {>= "4.0.0"}
+  "mirage-kv" {>= "4.0.1"}
+  "mirage-logs" {>= "1.2.0"}
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/yomimono/chamelon/releases/download/v0.2.0/chamelon-0.2.0.tbz"
+  checksum: [
+    "sha256=877315069d15a15a00ed5e80c7ea28fb67329dc08c4decd8689b86f7c61097b7"
+    "sha512=9168eb9e4c0afe2d6b95d32be6c12cb44b5d070df8af2bfb6edb2234371ff7d034c24cebc8714dcf603a4519dc308851928559194bcd7417b270d32930c42461"
+  ]
+}
+x-commit-hash: "e736f42eed26054aefaec0a36ee6e0d9041f8015"

--- a/packages/chamelon/chamelon.0.2.0/opam
+++ b/packages/chamelon/chamelon.0.2.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: [ "yomimono <maintenance@identity-function.com>" ]
+authors: [ "yomimono <maintenance@identity-function.com>" ]
+homepage: "https://github.com/yomimono/chamelon"
+bug-reports: "https://github.com/yomimono/chamelon/issues"
+dev-repo: "git+https://github.com/yomimono/chamelon.git"
+license: "ISC"
+synopsis: "Subset of littlefs filesystem fulfilling MirageOS KV"
+description: """
+Chamelon implements a subset of the littlefs filesystem,
+which was originally designed for microcontroller use.  It exposes
+an interface matching the Mirage_kv.RW module type and operates
+on top of a block device matching Mirage_block.S .
+
+It is extremely not POSIX."""
+
+build: [
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.9.0"}
+  "crowbar" {>= "0.2.1" & with-test}
+  "fpath" {>= "0.7.3" & with-test}
+  "alcotest" {>= "1.5.0" & with-test}
+  "alcotest-lwt" {>= "1.5.0" & with-test}
+  "mirage-block-combinators" {>= "3.0.0" & with-test}
+  "mirage-block-unix" {>= "2.13.0" & with-test}
+  "mirage-ptime" {>= "5.0.0"}
+  "mirage-crypto-rng" {>= "1.2.0" & with-test}
+  "bechamel" {>= "0.2.0" & with-test}
+  "bechamel-js" {>= "0.2.0" & with-test}
+  "checkseum" {>= "0.3.2"}
+  "cstruct" {>= "6.0.0"}
+  "digestif" {>= "1.0.0"}
+  "fmt" {>= "0.8.7"}
+  "logs" {>= "0.6.0"}
+  "lwt" {>= "5.3.0"}
+  "ptime" {>= "0.8.6"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-kv" {>= "6.0.1"}
+  "mirage-logs" {>= "1.2.0"}
+  "ppx_cstruct"
+  "optint" {>= "0.0.4"}
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/yomimono/chamelon/releases/download/v0.2.0/chamelon-0.2.0.tbz"
+  checksum: [
+    "sha256=877315069d15a15a00ed5e80c7ea28fb67329dc08c4decd8689b86f7c61097b7"
+    "sha512=9168eb9e4c0afe2d6b95d32be6c12cb44b5d070df8af2bfb6edb2234371ff7d034c24cebc8714dcf603a4519dc308851928559194bcd7417b270d32930c42461"
+  ]
+}
+x-commit-hash: "e736f42eed26054aefaec0a36ee6e0d9041f8015"

--- a/packages/chamelon/chamelon.0.2.0/opam
+++ b/packages/chamelon/chamelon.0.2.0/opam
@@ -28,6 +28,7 @@ depends: [
   "alcotest-lwt" {>= "1.5.0" & with-test}
   "mirage-block-combinators" {>= "3.0.0" & with-test}
   "mirage-block-unix" {>= "2.13.0" & with-test}
+  "mirage-clock-unix" {>= "4.0.0" & with-test}
   "mirage-ptime" {>= "5.0.0"}
   "mirage-crypto-rng" {>= "1.2.0" & with-test}
   "bechamel" {>= "0.2.0" & with-test}


### PR DESCRIPTION
Subset of littlefs filesystem fulfilling MirageOS KV

- Project page: <a href="https://github.com/yomimono/chamelon">https://github.com/yomimono/chamelon</a>

##### CHANGES:

* improvement: use the new-to-chamelon `Float.log2` for skip-list math (@yomimono)
* improvement: actually implement Kv.allocate and Kv.rename (@yomimono)
* improvement: `chamelon.exe` now provides `chamelon parse`, which outputs a block-by-block parse attempt to stderr. Many types now also have `pp`s to support this. This tool does not distinguish between metadata and data blocks, which makes it primarily useful for debugging rather than recovery. (@yomimono)
* bugfix: fix many places where tags weren't checked for the 'tag deleted' field (@yomimono)
* bugfix: fix potential data loss bug when keys are overwritten and the new entry is the first in a newly-split block (reported by independently by @palainp and then by @armael and @gasche with tests and a great writeup, fix by @yomimono)
* bugfix: fix incorrect `No_space` when re-mounting a filesystem where many blocks are already used, but nowhere near all of them (reported by @reynir with tests, fix by @yomimono)
* bugfix: fix confusion about superblock entry bearing the name `littlefs` (@yomimono)
* bugfix: check block revision counts with sequence math, as in the spec (@yomimono)
* maintenance: break dependency cycle between Tag and Entry (@emillon)
* maintenance: adapt to mirage-kv 6.0.1 type signatures (@hannesm, @palainp)
* maintenance: various opam updates for the modern age (@hannesm)
* tests: add a lot of tests (@reynir, @gasche, @armael, @yomimono)
* miscellaneous: break some logic into `fs_internal.ml`, a precursor to a more general reorganization to get error-prone low-level operations out of `kv` and `fs` (@yomimono)
