### PR TITLE
Release merlin v5.6-503 and ocaml-lsp 1.23.1

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.5.6-503/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.6-503/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" }
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.6-503/merlin-5.6-503.tbz"
+  checksum: [
+    "sha256=b0dcad092aaaf7a23f65ab9a089e8761bd665cc72357909e0ac6c2182f4fc2d4"
+    "sha512=9987baf2b2e82bab4c90a328bfcba9945e797e0f3d947156f04435ee84b49542844b379e35a79027c3ffe81f4b7a8f1c60803233999b4c039d4598033371880d"
+  ]
+}
+x-commit-hash: "ced228ec336b6d1996322f472145c26d69e785af"

--- a/packages/jsonrpc/jsonrpc.1.23.1/opam
+++ b/packages/jsonrpc/jsonrpc.1.23.1/opam
@@ -19,7 +19,7 @@ homepage: "https://github.com/ocaml/ocaml-lsp"
 bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
   "dune" {>= "3.0"}
-  "yojson"
+  "yojson" {>= "2.0"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]

--- a/packages/jsonrpc/jsonrpc.1.23.1/opam
+++ b/packages/jsonrpc/jsonrpc.1.23.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implementation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson"
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.23.1/lsp-1.23.1.tbz"
+  checksum: [
+    "sha256=c747e394026639ea204467e859de93ea8e9958dbf44f780dcb2a1897c56d7571"
+    "sha512=958a3012d4876ed3ba0be2913f0de09946e719d342110256d7eb73280e0c42d71f38fc321dffc7d5a82b9266ee023fda1d93e6d3fdec70aec53d78d28d96e6da"
+  ]
+}
+x-commit-hash: "e29fa980f762d1adecd77e0cdbbafa8386788999"

--- a/packages/lsp/lsp.1.23.1/opam
+++ b/packages/lsp/lsp.1.23.1/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "jsonrpc" {= version}
+  "yojson"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "cinaps" {with-test}
+  "ppx_expect" {>= "v0.17.0" & with-test}
+  "uutf" {>= "1.0.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.14"}
+  "ppx_yojson_conv" {with-dev-setup}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.23.1/lsp-1.23.1.tbz"
+  checksum: [
+    "sha256=c747e394026639ea204467e859de93ea8e9958dbf44f780dcb2a1897c56d7571"
+    "sha512=958a3012d4876ed3ba0be2913f0de09946e719d342110256d7eb73280e0c42d71f38fc321dffc7d5a82b9266ee023fda1d93e6d3fdec70aec53d78d28d96e6da"
+  ]
+}
+x-commit-hash: "e29fa980f762d1adecd77e0cdbbafa8386788999"

--- a/packages/merlin-lib/merlin-lib.5.6-503/opam
+++ b/packages/merlin-lib/merlin-lib.5.6-503/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="5.3" & <"5.4"}
+  "dune" {>= "3.0.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test & >= "1.3.0" }
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.6-503/merlin-5.6-503.tbz"
+  checksum: [
+    "sha256=b0dcad092aaaf7a23f65ab9a089e8761bd665cc72357909e0ac6c2182f4fc2d4"
+    "sha512=9987baf2b2e82bab4c90a328bfcba9945e797e0f3d947156f04435ee84b49542844b379e35a79027c3ffe81f4b7a8f1c60803233999b4c039d4598033371880d"
+  ]
+}
+x-commit-hash: "ced228ec336b6d1996322f472145c26d69e785af"

--- a/packages/merlin/merlin.5.6-503/opam
+++ b/packages/merlin/merlin.5.6-503/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {= version}
+  "ocaml-index" {>= "1.0" & post}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.6-503/merlin-5.6-503.tbz"
+  checksum: [
+    "sha256=b0dcad092aaaf7a23f65ab9a089e8761bd665cc72357909e0ac6c2182f4fc2d4"
+    "sha512=9987baf2b2e82bab4c90a328bfcba9945e797e0f3d947156f04435ee84b49542844b379e35a79027c3ffe81f4b7a8f1c60803233999b4c039d4598033371880d"
+  ]
+}
+x-commit-hash: "ced228ec336b6d1996322f472145c26d69e785af"

--- a/packages/ocaml-index/ocaml-index.5.6-503/opam
+++ b/packages/ocaml-index/ocaml-index.5.6-503/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A tool that indexes value usages from cmt files"
+description:
+  "ocaml-index should integrate with the build system to index codebase and allow tools such as Merlin to perform project-wide occurrences queries."
+maintainer: ["ulysse@tarides.com"]
+authors: ["ulysse@tarides.com"]
+license: "MIT"
+homepage: "https://github.com/ocaml/merlin/ocaml-index"
+bug-reports: "https://github.com/ocaml/merlin/issues"
+x-maintenance-intent: ["(latest)"]
+depends: [
+  "dune" {>= "3.0.0"}
+  "ocaml" {>= "5.3"}
+  "merlin-lib" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.6-503/merlin-5.6-503.tbz"
+  checksum: [
+    "sha256=b0dcad092aaaf7a23f65ab9a089e8761bd665cc72357909e0ac6c2182f4fc2d4"
+    "sha512=9987baf2b2e82bab4c90a328bfcba9945e797e0f3d947156f04435ee84b49542844b379e35a79027c3ffe81f4b7a8f1c60803233999b4c039d4598033371880d"
+  ]
+}
+x-commit-hash: "ced228ec336b6d1996322f472145c26d69e785af"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.23.1/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.23.1/opam
@@ -45,6 +45,7 @@ depends: [
   "ocamlformat-rpc-lib" {>= "0.21.0"}
   "odoc" {with-doc}
   "merlin-lib" {>= "5.5" & < "5.7"}
+  "ocaml-index" {>= "5.5" & < "5.7" & post}
   "ppx_yojson_conv" {with-dev-setup}
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.23.1/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.23.1/opam
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson"
+  "base" {>= "v0.16.0"}
+  "lsp" {= version}
+  "jsonrpc" {= version}
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc" {>= "3.4.0"}
+  "chrome-trace" {>= "3.3.0"}
+  "dyn"
+  "stdune"
+  "fiber" {>= "3.1.1" & < "4.0.0"}
+  "ocaml" {>= "5.3" & < "5.4"}
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "astring"
+  "camlp-streams"
+  "ppx_expect" {>= "v0.17.0" & with-test}
+  "ocamlformat" {with-test & = "0.27.0"}
+  "ocamlc-loc" {>= "3.7.0"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "merlin-lib" {>= "5.5" & < "5.7"}
+  "ppx_yojson_conv" {with-dev-setup}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.23.1/lsp-1.23.1.tbz"
+  checksum: [
+    "sha256=c747e394026639ea204467e859de93ea8e9958dbf44f780dcb2a1897c56d7571"
+    "sha512=958a3012d4876ed3ba0be2913f0de09946e719d342110256d7eb73280e0c42d71f38fc321dffc7d5a82b9266ee023fda1d93e6d3fdec70aec53d78d28d96e6da"
+  ]
+}
+x-commit-hash: "e29fa980f762d1adecd77e0cdbbafa8386788999"


### PR DESCRIPTION
# Merlin changes:

Tue Jun 24 17:10:42 CEST 2025

  + merlin binary
    - Add `locate-types` command (https://github.com/ocaml/merlin/pull/1951)
  + merlin library
    - Fix `merlin_reader` for OpenBSD (https://github.com/ocaml/merlin/pull/1956)
    - Improve recovery of mutually recursive definitions (https://github.com/ocaml/merlin/pull/1962, https://github.com/ocaml/merlin/pull/1963, fixes https://github.com/ocaml/merlin/issues/1953)
  + vim plugin
    - Fix error when `:MerlinOccurrencesProjectWide` fails to gather code previews (https://github.com/ocaml/merlin/pull/1970)
    - Add more short-paths tests cases (https://github.com/ocaml/merlin/pull/1904)

# OCaml LSP changes:

## Fixes

- Fix hover on method calls not showing the type. (https://github.com/ocaml/ocaml-lsp/pull/1553, fixes https://github.com/ocaml/ocaml-lsp/issues/1552)
- Fix error on opening `.mll` files (https://github.com/ocaml/ocaml-lsp/pull/1557)
- Ensure compatibility with both yojson 2.0 and 3.0. (https://github.com/ocaml/ocaml-lsp/pull/1534)