### PR TITLE
[new release] icalendar (0.1.13)

### DIFF
--- a/packages/icalendar/icalendar.0.1.13/opam
+++ b/packages/icalendar/icalendar.0.1.13/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/robur-coop/icalendar"
+bug-reports: "https://github.com/robur-coop/icalendar/issues"
+dev-repo: "git+https://github.com/robur-coop/icalendar.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://robur-coop.github.io/icalendar/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "1.3"}
+  "alcotest" {with-test}
+  "fmt"
+  "angstrom" {>= "0.14.0"}
+  "re" {>= "1.7.2"}
+  "uri"
+  "ptime"
+  "ppx_deriving"
+  "gmap" {>= "0.3.0"}
+]
+
+synopsis: "A library to parse and print the iCalendar (RFC 5545) format"
+description: """
+Parse and print .ics files as specified in RFC 5545.
+Supports recurrent events, but only to the day level of detail.
+Does not support vJournal components.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/icalendar/releases/download/v0.1.13/icalendar-0.1.13.tbz"
+  checksum: [
+    "sha256=249aed2390c673d97f861a6423bf1a14f7e9301f33ac41efb9e6761b228d3f01"
+    "sha512=d0e3a89d91c9b42d9a12103ba9a13008f99748e180ba7f8ca7e89646fc600d13140901fee79f8e5145bd46427affd592f39c4039f686203233180b43fb2455f7"
+  ]
+}
+x-commit-hash: "0ddfa52cdb291dede490358904fbb0f883af8f9f"


### PR DESCRIPTION
A library to parse and print the iCalendar (RFC 5545) format

- Project page: <a href="https://github.com/robur-coop/icalendar">https://github.com/robur-coop/icalendar</a>
- Documentation: <a href="https://robur-coop.github.io/icalendar/">https://robur-coop.github.io/icalendar/</a>

##### CHANGES:

* Support "summary" in all alarms (requested by @pdonadeo in robur-coop/icalendar#20 (SOGo),
  fixed robur-coop/icalendar#21 @hannesm)
