### PR TITLE
js_of_ocaml-compiler: remove the cmdliner upper bound

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.1.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.1.0/opam
@@ -17,7 +17,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "menhir"
   "menhirLib"
   "menhirSdk"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.0.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.0.1/opam
@@ -17,7 +17,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "menhir"
   "menhirLib"
   "menhirSdk"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.1.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.1.0/opam
@@ -17,7 +17,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "2.3"}
   "menhir"
   "menhirLib"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.1.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.1.1/opam
@@ -17,7 +17,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "2.3"}
   "menhir"
   "menhirLib"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.2.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.2.0/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "2.3"}
   "menhir"
   "menhirLib"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.3.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.3.0/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "2.3"}
   "menhir"
   "menhirLib"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.4.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.4.0/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "2.3"}
   "menhir"
   "menhirLib"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.5.2/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.5.2/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "2.3"}
   "menhir"
   "menhirLib"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.6.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.6.0/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "2.3"}
   "menhir"
   "menhirLib"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.7.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.7.0/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "2.3"}
   "menhir"
   "menhirLib"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.7.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.7.1/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "2.3"}
   "menhir"
   "menhirLib"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.7.2/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.7.2/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "2.3"}
   "menhir"
   "menhirLib"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.8.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.8.1/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "2.3"}
   "menhir"
   "menhirLib"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.8.2/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.8.2/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "2.3"}
   "menhir"
   "menhirLib"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.9.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.9.0/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "3.3"}
   "qcheck" {with-test}
   "menhir"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.9.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.9.1/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "3.3"}
   "qcheck" {with-test}
   "menhir"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.0.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.0.1/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.15.0" & < "0.36.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "3.3"}
   "qcheck" {with-test}
   "menhir"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.1.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.1.0/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.35"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "3.3"}
   "qcheck" {with-test}
   "menhir"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.1.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.1.1/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.35"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "3.3"}
   "qcheck" {with-test}
   "menhir"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.2.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.2.0/opam
@@ -18,7 +18,6 @@ depends: [
   "ppxlib" {>= "0.35"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "cmdliner" {with-test & < "2.0.0"}
   "sedlex" {>= "3.3"}
   "qcheck" {with-test}
   "menhir"


### PR DESCRIPTION
partially reverts 0033ee9f2f9ce46bfdc877b137783379093ee177 #28603 #28599 https://discuss.ocaml.org/t/ann-cmdliner-2-0-0/17324/15