### PR TITLE
sherlodoc: restrict to cmdliner < 2.0.0

### DIFF
--- a/packages/sherlodoc/sherlodoc.3.1.0/opam
+++ b/packages/sherlodoc/sherlodoc.3.1.0/opam
@@ -15,6 +15,7 @@ depends: [
   "js_of_ocaml" {>= "5.6.0"}
   "brr" {>= "0.0.6"}
   "cmdliner" {>= "1.3.0"}
+  "cmdliner" {with-test & < "2.0.0"}
   "decompress" {>= "1.5.3"}
   "fpath" {>= "0.7.3"}
   "lwt" {>= "5.7.0"}


### PR DESCRIPTION
```
- File "sherlodoc/test/cram/link_in_docstring.t/run.t", line 1, characters 0-0:
- /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/sherlodoc/test/cram/link_in_docstring.t/run.t _build/default/sherlodoc/test/cram/link_in_docstring.t/run.t.corrected
- diff --git a/_build/default/sherlodoc/test/cram/link_in_docstring.t/run.t b/_build/default/sherlodoc/test/cram/link_in_docstring.t/run.t.corrected
- index 365f686..d4e9ebf 100644
- --- a/_build/default/sherlodoc/test/cram/link_in_docstring.t/run.t
- +++ b/_build/default/sherlodoc/test/cram/link_in_docstring.t/run.t.corrected
- @@ -5,8 +5,10 @@
-    $ export SHERLODOC_FORMAT=marshal
-    $ sherlodoc index $(find . -name '*.odocl')
-    $ sherlodoc search --print-docstring "foo"
- -  val A.foo : int
- -  <div><p>This is a docstring with a <span>link</span></p></div>
- +  Usage: sherlodoc search [--help] [OPTION]… [QUERY]
- +  sherlodoc: unknown option '--print-docstring'
- +  [124]
-    $ sherlodoc search --print-docstring "bar"
- -  val A.bar : int
- -  <div><p>This is a docstring with a ref to <span><code>foo</code></span></p></div>
- +  Usage: sherlodoc search [--help] [OPTION]… [QUERY]
- +  sherlodoc: unknown option '--print-docstring'
- +  [124]
```

//cc @art-w 