### PR TITLE
3 packages from mbarbin/dunolint at 0.0.20251006

### DIFF
--- a/packages/dunolint-lib-base/dunolint-lib-base.0.0.20251006/opam
+++ b/packages/dunolint-lib-base/dunolint-lib-base.0.0.20251006/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "An extension of dunolint-lib for use with Base"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/dunolint"
+doc: "https://mbarbin.github.io/dunolint/"
+bug-reports: "https://github.com/mbarbin/dunolint/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "base" {>= "v0.16"}
+  "dunolint-lib" {= version}
+  "fpath" {>= "0.7.3"}
+  "fpath-base" {>= "0.3.1"}
+  "ppx_compare" {>= "v0.16"}
+  "ppx_enumerate" {>= "v0.16"}
+  "ppx_sexp_conv" {>= "v0.16"}
+  "ppxlib" {>= "0.35.0"}
+  "re" {>= "1.8.0"}
+  "sexplib0" {>= "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/dunolint.git"
+url {
+  src:
+    "https://github.com/mbarbin/dunolint/releases/download/0.0.20251006/dunolint-0.0.20251006.tbz"
+  checksum: [
+    "sha256=1b064927c9e1ef5352a1886ae34a206fef0ce6a913c19a77b0162acc108e0e50"
+    "sha512=6cbc08ba318bef6584d15a4491e3dde1bf436109ce0f8b7c400a9f91bbcee64c5785bc924df11eafe98243ec2f188a7f92c58c5062729f3e2af1e9977f1a5e67"
+  ]
+}
+x-commit-hash: "b44dbf6bcf9923cb75c169d8e1f59ad4629f72e4"

--- a/packages/dunolint-lib/dunolint-lib.0.0.20251006/opam
+++ b/packages/dunolint-lib/dunolint-lib.0.0.20251006/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+synopsis: "A library to create dunolint configs"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/dunolint"
+doc: "https://mbarbin.github.io/dunolint/"
+bug-reports: "https://github.com/mbarbin/dunolint/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "re" {>= "1.8.0"}
+  "sexplib0" {>= "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/dunolint.git"
+description: """\
+
+[dunolint] is a set of OCaml libraries and a cli tool to lint and help
+manage files in (large) dune projects.
+
+[dunolint-lib] is the package you need as a user to define a dunolint
+config, without pulling all the dependencies required by the linter
+engine and command line.
+
+It defines a configuration language in which you can express linting
+invariants for your projects. The tool will enforce these invariants,
+applying global and systematic changes automatically when able, and
+help with general ergonomics questions.
+
+For example: "I want for all libs in this subdirectory to enable
+`bisect_ppx`, please go patch my dune files". Or, "I would like all
+libraries that verify this particular predicate to supply the ppx flag
+`-unused-code-warnings=force`", and more.
+
+You can setup [dunolint] as part of your CI checks to help enforcing
+properties and linting checks going forward.
+
+"""
+tags: [ "dune" "linter" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/dunolint/releases/download/0.0.20251006/dunolint-0.0.20251006.tbz"
+  checksum: [
+    "sha256=1b064927c9e1ef5352a1886ae34a206fef0ce6a913c19a77b0162acc108e0e50"
+    "sha512=6cbc08ba318bef6584d15a4491e3dde1bf436109ce0f8b7c400a9f91bbcee64c5785bc924df11eafe98243ec2f188a7f92c58c5062729f3e2af1e9977f1a5e67"
+  ]
+}
+x-commit-hash: "b44dbf6bcf9923cb75c169d8e1f59ad4629f72e4"

--- a/packages/dunolint/dunolint.0.0.20251006/opam
+++ b/packages/dunolint/dunolint.0.0.20251006/opam
@@ -1,0 +1,87 @@
+opam-version: "2.0"
+synopsis: "A linter for build files in dune projects"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/dunolint"
+doc: "https://mbarbin.github.io/dunolint/"
+bug-reports: "https://github.com/mbarbin/dunolint/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.3"}
+  "base" {>= "v0.17"}
+  "cmdlang" {>= "0.0.9"}
+  "cmdlang-cmdliner-err-runner" {>= "0.0.16"}
+  "dunolint-lib" {= version}
+  "dunolint-lib-base" {= version}
+  "file-rewriter" {>= "0.0.3"}
+  "fmt" {>= "0.9.0"}
+  "fpath" {>= "0.7.3"}
+  "fpath-base" {>= "0.3.1"}
+  "fpath-sexp0" {>= "0.3.1"}
+  "loc" {>= "0.2.2"}
+  "logs" {>= "0.7.0"}
+  "pageantty" {>= "0.0.2"}
+  "parsexp" {>= "v0.17"}
+  "patdiff" {>= "v0.17"}
+  "pp" {>= "2.0.0"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-log" {>= "0.0.16"}
+  "pplumbing-log-cli" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
+  "ppx_compare" {>= "v0.17"}
+  "ppx_enumerate" {>= "v0.17"}
+  "ppx_hash" {>= "v0.17"}
+  "ppx_here" {>= "v0.17"}
+  "ppx_let" {>= "v0.17"}
+  "ppx_sexp_conv" {>= "v0.17"}
+  "ppx_sexp_value" {>= "v0.17"}
+  "ppxlib" {>= "0.35.0"}
+  "re" {>= "1.8.0"}
+  "sexplib0" {>= "v0.17"}
+  "sexps-rewriter" {>= "0.0.3"}
+  "stdio" {>= "v0.17"}
+  "volgo" {>= "0.0.21"}
+  "volgo-base" {>= "0.0.21"}
+  "volgo-git-unix" {>= "0.0.21"}
+  "volgo-hg-unix" {>= "0.0.21"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/dunolint.git"
+description: """\
+
+[dunolint] is a set of OCaml libraries and a cli tool to lint and help
+manage files in (large) dune projects.
+
+[dunolint] is the package that implements the linter engine for
+dunolint configs as well as the [dunolint] command line tool.
+
+You may install it to get the [dunolint] cli, and/or if you want to
+use the linting libraries to write custom rewriters and linters.
+
+"""
+tags: [ "dune" "linter" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/dunolint/releases/download/0.0.20251006/dunolint-0.0.20251006.tbz"
+  checksum: [
+    "sha256=1b064927c9e1ef5352a1886ae34a206fef0ce6a913c19a77b0162acc108e0e50"
+    "sha512=6cbc08ba318bef6584d15a4491e3dde1bf436109ce0f8b7c400a9f91bbcee64c5785bc924df11eafe98243ec2f188a7f92c58c5062729f3e2af1e9977f1a5e67"
+  ]
+}
+x-commit-hash: "b44dbf6bcf9923cb75c169d8e1f59ad4629f72e4"


### PR DESCRIPTION
This pull-request concerns:
- `dunolint.0.0.20251006`: A linter for build files in dune projects
- `dunolint-lib.0.0.20251006`: A library to create dunolint configs
- `dunolint-lib-base.0.0.20251006`: An extension of dunolint-lib for use with Base



---
* Homepage: https://github.com/mbarbin/dunolint
* Source repo: git+https://github.com/mbarbin/dunolint.git
* Bug tracker: https://github.com/mbarbin/dunolint/issues

---
## 0.0.20251006 (2025-10-06)

### Added

- Added 'Config Autoloading' documentation page ([#129](https://github.com/mbarbin/dunolint/pull/129), @mbarbin).
- Add test for config cache ([#128](https://github.com/mbarbin/dunolint/pull/128), @mbarbin).
- Implement dunolint config files autoloading ([#127](https://github.com/mbarbin/dunolint/pull/127), @mbarbin).
- Added 'First Run Through' tutorial ([#115](https://github.com/mbarbin/dunolint/pull/115), @mbarbin).
- Added 'Quick Start' tutorial ([#106](https://github.com/mbarbin/dunolint/pull/106), @mbarbin).

### Changed

- Always include default skip paths in config ([#125](https://github.com/mbarbin/dunolint/pull/125), @mbarbin).
- Refactors to prepare config autoloading ([#121](https://github.com/mbarbin/dunolint/pull/121), [#122](https://github.com/mbarbin/dunolint/pull/122), [#123](https://github.com/mbarbin/dunolint/pull/123), [#124](https://github.com/mbarbin/dunolint/pull/124), [#126](https://github.com/mbarbin/dunolint/pull/126), @mbarbin).
- Make dunolint aware of and use dune workspaces ([#113](https://github.com/mbarbin/dunolint/pull/113), @mbarbin)
- Remove support for `--enforce` in lint-file tool ([#118](https://github.com/mbarbin/dunolint/pull/118), @mbarbin).
- Update doc for `(lang dunolint 1.0)` ([#110](https://github.com/mbarbin/dunolint/pull/110), @mbarbin).
- Upgrade to recent `pplumbing` repackaging ([#109](https://github.com/mbarbin/dunolint/pull/109), @mbarbin).
- Upgrade `crs` actions ([#108](https://github.com/mbarbin/dunolint/pull/108), @mbarbin).

### Fixed

- Fix workspace root detection in dune test envs ([#120](https://github.com/mbarbin/dunolint/pull/120), @mbarbin).
- Fix parsing errors of dune version in dune-project ([#112](https://github.com/mbarbin/dunolint/pull/112), @mbarbin).

## 0.0.20250910-1 (2025-09-10)

### Fixed

- Missing opam dependency `dunolint-lib-base` (@mbarbin).

## 0.0.20250910 (2025-09-10)

### Added

- Support new `(lang dunolint 1.0)` config stanzas format for `dunolint` files ([#105](https://github.com/mbarbin/dunolint/pull/105), @mbarbin).
- New lib `dunolint-lib-base` to extend `dunolint-lib` for base users ([#99](https://github.com/mbarbin/dunolint/pull/99), @mbarbin).

### Changed

- Now autoload config files if present at "$PWD/dunolint" ([#103](https://github.com/mbarbin/dunolint/pull/103), [#104](https://github.com/mbarbin/dunolint/pull/104), @mbarbin).
- Move the dunolint config at the root of the repo ([#102](https://github.com/mbarbin/dunolint/pull/102), @mbarbin).
- Change dune-lang sexps to be atoms (e.g. "3.19") instead of tuples ([#101](https://github.com/mbarbin/dunolint/pull/101), @mbarbin).
- Remove base and ppx dependencies from `dunolint-lib` ([#99](https://github.com/mbarbin/dunolint/pull/99), @mbarbin).
- Always use versioned sexp for config ([#98](https://github.com/mbarbin/dunolint/pull/98), @mbarbin).

### Fixed

- Improve location and messages for sexp loading errors ([#100](https://github.com/mbarbin/dunolint/pull/100), @mbarbin).
- Config loading errors are no longer internal errors and now reported with locations when able ([#97](https://github.com/mbarbin/dunolint/pull/97), @mbarbin).

## 0.0.20250907 (2025-09-07)

### Added

- Added dependency to `volgo-vcs` in preparation for future features ([#89](https://github.com/mbarbin/dunolint/pull/89), @mbarbin).
- Supports linting the dune lang version in dune-project files ([#93](https://github.com/mbarbin/dunolint/pull/93), @mbarbin).
- Supports implicit trans deps `false-if-hidden-includes-supported` value ([#92](https://github.com/mbarbin/dunolint/pull/92), @mbarbin).

### Changed

- Prepare transition to versioned API and config format ([#96](https://github.com/mbarbin/dunolint/pull/96), @mbarbin).
- Upgrade docusaurus dependencies to current latest ([#94](https://github.com/mbarbin/dunolint/pull/94), @mbarbin).
- Changes `(implicit_transitive_deps _)` config value from bool to variant ([#92](https://github.com/mbarbin/dunolint/pull/92), @mbarbin).
- Improved testing coverage ([#90](https://github.com/mbarbin/dunolint/pull/90), [#91](https://github.com/mbarbin/dunolint/pull/91), @mbarbin).

### Fixed

- Correctly propagate `skip_subtree` when returned from rules ([#90](https://github.com/mbarbin/dunolint/pull/90), @mbarbin).


---
:camel: Pull-request generated by opam-publish v2.6.0