### PR TITLE
Package opam-publish.2.7.0

### DIFF
--- a/packages/opam-publish/opam-publish.2.7.0/opam
+++ b/packages/opam-publish/opam-publish.2.7.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A tool to ease contributions to opam repositories"
+description: """\
+opam-publish automates publishing packages to package repositories: it checks that the
+opam file is complete using `opam lint`, verifies and adds the archive URL and its
+checksum and files a GitHub pull request for merging it."""
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+depends: [
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
+  "dune" {>= "1.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "ocaml" {>= "4.08.0"}
+  "opam-core" {>= "2.2.0"}
+  "opam-format" {>= "2.2.0"}
+  "opam-state" {>= "2.2.0"}
+  "github" {>= "4.3.2"}
+  "github-unix" {>= "4.3.2"}
+]
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+url {
+  src:
+    "https://github.com/ocaml/opam-publish/releases/download/2.7.0/opam-publish-2.7.0.tar.gz"
+  checksum: [
+    "md5=65775620ef78d8f11ec3fbddd26ff5dd"
+    "sha512=4dca6f1f2e41c2be4d43ee7dde053287230cadd7f13fb90361b69744155e30eadc093f44ce1cdec2e22bd16238d10106f33271d193b5c2d32801669645d0ff93"
+  ]
+}


### PR DESCRIPTION
### `opam-publish.2.7.0`
A tool to ease contributions to opam repositories
opam-publish automates publishing packages to package repositories: it checks that the
opam file is complete using `opam lint`, verifies and adds the archive URL and its
checksum and files a GitHub pull request for merging it.



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v2.7.0