### PR TITLE
fstar.2025.10.06

### DIFF
--- a/packages/fstar/fstar.2025.10.06/opam
+++ b/packages/fstar/fstar.2025.10.06/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "mtzguido@gmail.com"
+authors: [
+  "Nik Swamy <nswamy@microsoft.com>"
+  "Jonathan Protzenko <protz@microsoft.com>"
+  "Tahina Ramananandro <taramana@microsoft.com>"
+]
+homepage: "http://fstar-lang.org"
+license: "Apache-2.0"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "batteries"
+  "zarith" {>= "1.14"}
+  "stdint"
+  "yojson"
+  "dune" { >= "3.8.0"}
+  "memtrace" {>= "0.2.3"}
+  "menhirLib"
+  "menhir" {build & >= "20230415"}
+  "mtime" {>= "2.1.0"}
+  "pprint"
+  "sedlex" {>= "3.5" }
+  "ppxlib" {>= "0.36.0" }
+  "process"
+  "ppx_deriving" {build}
+  "ppx_deriving_yojson" {build}
+]
+depexts: ["coreutils"] {os = "macos" & os-distribution = "homebrew"}
+build: [
+  [make "-j" jobs "ADMIT=1"]
+]
+install: [
+  [make "PREFIX=%{prefix}%" "install"]
+]
+post-messages: [
+  """
+F* requires specific versions of Z3 to work correctly, and will refuse to run
+if the version string does not match. You should have z3-4.8.5 and z3-4.13.3
+in your $PATH. For details, see
+https://github.com/FStarLang/FStar/blob/master/INSTALL.md#runtime-dependency-particular-version-of-z3.
+""" {success}
+]
+dev-repo: "git+https://github.com/FStarLang/FStar"
+bug-reports: "https://github.com/FStarLang/FStar/issues"
+synopsis: "Verification system for effectful programs"
+url {
+  src: "https://github.com/FStarLang/FStar/archive/refs/tags/v2025.10.06.tar.gz"
+  checksum: [
+    "md5=4f3abf2798478703764c91cb77c00c43"
+    "sha512=feef67d947110865bdbb5fdc4777cc2120e994f750a8abcec76a6b10e1237438070bb99de3cd7a350225aec697a5b297dd4d5f145a47985e0e1e1fb6f5841dc2"
+  ]
+}


### PR DESCRIPTION
Hi! Just a new F*.

We recently noticed some failures due the newer ppxlib using a newer version of pprintast that prints "raw identifiers", which are not valid below OCaml 5.2.0. We added a workaround, hopefully the CI here passes on all versions!

(updated, the hash was wrong)