### PR TITLE
Add macOS CI accept-failures for pyparsing package

### DIFF
--- a/packages/conf-python3-pyparsing/conf-python3-pyparsing.1/opam
+++ b/packages/conf-python3-pyparsing/conf-python3-pyparsing.1/opam
@@ -21,7 +21,7 @@ depexts: [
   ["py39-pyparsing"] {os = "freebsd"}
 ]
 
-available: os != "macos"
+x-ci-accept-failures: ["macos-homebrew"]
 synopsis: "Virtual package relying on PyParsing"
 description:
   "This package can only install if the PyParsing python3 library is installed on the system."


### PR DESCRIPTION
In light of the [corresponding discussion](https://discuss.ocaml.org/t/managing-external-dependencies-on-macos/17357/2) on discourse.

`pyparsing` is installable on macOS, just not through homebrew.

Thanks,

tiferrei