### PR TITLE
ocamlformat-mlx 0.2{6,7} need upper bound on cmdliner

### DIFF
--- a/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.26.2.0/opam
+++ b/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.26.2.0/opam
@@ -19,6 +19,7 @@ depends: [
   "alcotest" {with-test & >= "1.3.0"}
   "base" {>= "v0.12.0"}
   "dune" {>= "2.8"}
+  "cmdliner" {< "2.0.0"}
   "dune-build-info"
   "either"
   "fix"

--- a/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.27.0.1/opam
+++ b/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.27.0.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08" & < "5.4"}
   "alcotest" {with-test & >= "1.3.0"}
   "base" {>= "v0.12.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8"}
   "dune-build-info"
   "either"

--- a/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.27.0/opam
+++ b/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.27.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08" & < "5.3"}
   "alcotest" {with-test & >= "1.3.0"}
   "base" {>= "v0.12.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "dune" {>= "2.8"}
   "dune-build-info"
   "either"


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/28665