### PR TITLE
Add missing conf-npm to alcotest-js.1.9.1

### DIFF
--- a/packages/alcotest-js/alcotest-js.1.9.1/opam
+++ b/packages/alcotest-js/alcotest-js.1.9.1/opam
@@ -15,6 +15,7 @@ depends: [
   "js_of_ocaml-compiler" {>= "3.11.0"}
   "fmt" {with-test & >= "0.8.7"}
   "cmdliner" {with-test & >= "1.2.0"}
+  "conf-npm" {with-test}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/mirage/alcotest.git"


### PR DESCRIPTION
This PR adds a missing `conf-npm` to `alcotest-js.1.9.1` to avoid `Program node not found in the tree or in PATH`.

I can see @mseri added the same line for 1.9.0 in https://github.com/ocaml/opam-repository/pull/27617. It would probably be good to upstream.

This was missed in https://github.com/ocaml/opam-repository/pull/28629 and I see 72(!) occurrences of
```
alcotest-js.1.9.1
  tests (failed: Program node not found in the tree or in PATH)
```
in the still live https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/9ccf5c243215d84a1b06e9750cb040d14252b29d
from 6 days ago, so it seems like a premature merge @smorimoto :wink: 

I just spotted the error on https://github.com/ocaml/opam-repository/pull/28662 where it showed up again.