### PR TITLE
Add macOS CI accept-failures for tomli package

### DIFF
--- a/packages/conf-python3-tomli/conf-python3-tomli.1/opam
+++ b/packages/conf-python3-tomli/conf-python3-tomli.1/opam
@@ -21,7 +21,7 @@ depexts: [
   ["py39-tomli"] {os = "freebsd"}
 ]
 
-available: os != "macos"
+x-ci-accept-failures: ["macos-homebrew"]
 synopsis: "Virtual package relying on Tomli"
 description:
   "This package can only install if the Tomli python3 library is installed on the system."


### PR DESCRIPTION
As #28666, this also applies to `tomli`.