### PR TITLE
Add cmdliner.2.0.0 upper bounds for diffast-git-cli 0.1.1 and 0.2

### DIFF
--- a/packages/diffast-git-cli/diffast-git-cli.0.1.1/opam
+++ b/packages/diffast-git-cli/diffast-git-cli.0.1.1/opam
@@ -19,7 +19,7 @@ available: os != "win32" & opam-version >= "2.1"
 depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.17"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "mtime" {>= "2.0"}
   "fmt"
   "logs"

--- a/packages/diffast-git-cli/diffast-git-cli.0.2/opam
+++ b/packages/diffast-git-cli/diffast-git-cli.0.2/opam
@@ -19,7 +19,7 @@ available: os != "win32" & opam-version >= "2.1"
 depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.17"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "mtime" {>= "2.0"}
   "fmt"
   "logs"


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/28662
```
#=== ERROR while compiling diffast-git-cli.0.2 ================================#
# context              2.4.1 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/diffast-git-cli.0.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p diffast-git-cli -j 255 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/diffast-git-cli-7-a932ff.env
# output-file          ~/.opam/log/diffast-git-cli-7-a932ff.out
### output ###
# (cd _build/default/src/api/dev && /usr/bin/git describe --always --dirty) > _build/default/src/api/dev/v
# fatal: not a git repository (or any parent up to mount point /)
# Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -O3 -I src/git/cli/.git_diffast.eobjs/byte -I src/git/cli/.git_diffast.eobjs/native -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/asn1-combinators -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/awa -I /home/opam/.opam/4.14/lib/awa-mirage -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/base64/rfc2045 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bos -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/bytesrw -I /home/opam/.opam/4.14/lib/bytesrw/zlib -I /home/opam/.opam/4.14/lib/ca-certs-nss -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/carton -I /home/opam/.opam/4.14/lib/carton-git -I /home/opam/.opam/4.14/lib/carton-lwt -I /home/opam/.opam/4.14/lib/carton/thin -I /home/opam/.opam/4.14/lib/checkseum/c -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/cryptokit -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/csv -I /home/opam/.opam/4.14/lib/decompress/de -I /home/opam/.opam/4.14/lib/decompress/zl -I /home/opam/.opam/4.14/lib/diffast-api -I /home/opam/.opam/4.14/lib/diffast-core -I /home/opam/.opam/4.14/lib/diffast-git -I /home/opam/.opam/4.14/lib/diffast-misc -I /home/opam/.opam/4.14/lib/digestif/c -I /home/opam/.opam/4.14/lib/dns -I /home/opam/.opam/4.14/lib/dns-client -I /home/opam/.opam/4.14/lib/dns-client-mirage -I /home/opam/.opam/4.14/lib/dns/cache -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duff -I /home/opam/.opam/4.14/lib/dune-private-libs/dune-section -I /home/opam/.opam/4.14/lib/dune-private-libs/meta_parser -I /home/opam/.opam/4.14/lib/dune-site -I /home/opam/.opam/4.14/lib/dune-site/dynlink -I /home/opam/.opam/4.14/lib/dune-site/plugins -I /home/opam/.opam/4.14/lib/dune-site/private -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/emile -I /home/opam/.opam/4.14/lib/encore -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/faraday -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/fmt/cli -I /home/opam/.opam/4.14/lib/fmt/tty -I /home/opam/.opam/4.14/lib/fpath -I /home/opam/.opam/4.14/lib/gen -I /home/opam/.opam/4.14/lib/git -I /home/opam/.opam/4.14/lib/git-mirage/http -I /home/opam/.opam/4.14/lib/git-mirage/ssh -I /home/opam/.opam/4.14/lib/git-mirage/tcp -I /home/opam/.opam/4.14/lib/git-paf -I /home/opam/.opam/4.14/lib/git-unix -I /home/opam/.opam/4.14/lib/git/loose -I /home/opam/.opam/4.14/lib/git/loose-git -I /home/opam/.opam/4.14/lib/git/nss -I /home/opam/.opam/4.14/lib/git/nss/git -I /home/opam/.opam/4.14/lib/git/nss/hkt -I /home/opam/.opam/4.14/lib/git/nss/neg -I /home/opam/.opam/4.14/lib/git/nss/pck -I /home/opam/.opam/4.14/lib/git/nss/pkt-line -I /home/opam/.opam/4.14/lib/git/nss/sigs -I /home/opam/.opam/4.14/lib/git/nss/smart -I /home/opam/.opam/4.14/lib/git/nss/smart-flow -I /home/opam/.opam/4.14/lib/git/nss/unixiz -I /home/opam/.opam/4.14/lib/gmap -I /home/opam/.opam/4.14/lib/h1 -I /home/opam/.opam/4.14/lib/happy-eyeballs -I /home/opam/.opam/4.14/lib/happy-eyeballs-lwt -I /home/opam/.opam/4.14/lib/happy-eyeballs-mirage -I /home/opam/.opam/4.14/lib/httpun-types -I /home/opam/.opam/4.14/lib/hxd/core -I /home/opam/.opam/4.14/lib/hxd/string -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/kdf/hkdf -I /home/opam/.opam/4.14/lib/kdf/pbkdf -I /home/opam/.opam/4.14/lib/ke -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/logs/cli -I /home/opam/.opam/4.14/lib/logs/fmt -I /home/opam/.opam/4.14/lib/lru -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/markup -I /home/opam/.opam/4.14/lib/menhirLib -I /home/opam/.opam/4.14/lib/metrics -I /home/opam/.opam/4.14/lib/mimic -I /home/opam/.opam/4.14/lib/mimic-happy-eyeballs -I /home/opam/.opam/4.14/lib/mirage-crypto -I /home/opam/.opam/4.14/lib/mirage-crypto-ec -I /home/opam/.opam/4.14/lib/mirage-crypto-pk -I /home/opam/.opam/4.14/lib/mirage-crypto-rng -I /home/opam/.opam/4.14/lib/mirage-flow -I /home/opam/.opam/4.14/lib/mirage-kv -I /home/opam/.opam/4.14/lib/mirage-mtime/unix -I /home/opam/.opam/4.14/lib/mirage-ptime/unix -I /home/opam/.opam/4.14/lib/mirage-sleep/unix -I /home/opam/.opam/4.14/lib/mtime -I /home/opam/.opam/4.14/lib/mtime/clock -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocamlgraph -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/ohex -I /home/opam/.opam/4.14/lib/optint -I /home/opam/.opam/4.14/lib/paf -I /home/opam/.opam/4.14/lib/pecu -I /home/opam/.opam/4.14/lib/psq -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/ptime/clock -I /home/opam/.opam/4.14/lib/randomconv -I /home/opam/.opam/4.14/lib/rresult -I /home/opam/.opam/4.14/lib/sedlex -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/tcpip -I /home/opam/.opam/4.14/lib/tls -I /home/opam/.opam/4.14/lib/tls-mirage -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uuidm -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/vlt -I /home/opam/.opam/4.14/lib/x509 -I /home/opam/.opam/4.14/lib/zarith -intf-suffix .ml -no-alias-deps -o src/git/cli/.git_diffast.eobjs/native/dune__exe__Git_diffast.cmx -c -impl src/git/cli/git_diffast.pp.ml)
# File "src/git/cli/git_diffast.ml", line 376, characters 8-17:
# 376 |         args#repo $ sha1s)
#               ^^^^^^^^^
# Error: This expression has type string Cmdliner.Term.t
#        but an expression was expected of type Fpath.t Cmdliner.Term.t
#        Type string is not compatible with type Fpath.t 
```

and
```
#=== ERROR while compiling diffast-git-cli.0.1.1 ==============================#
# context              2.4.1 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/diffast-git-cli.0.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p diffast-git-cli -j 255 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/diffast-git-cli-7-774605.env
# output-file          ~/.opam/log/diffast-git-cli-7-774605.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -O3 -I src/git/cli/.git_diffast.eobjs/byte -I src/git/cli/.git_diffast.eobjs/native -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/asn1-combinators -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/awa -I /home/opam/.opam/4.14/lib/awa-mirage -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/base64/rfc2045 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bos -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/bytesrw -I /home/opam/.opam/4.14/lib/bytesrw/zlib -I /home/opam/.opam/4.14/lib/ca-certs-nss -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/carton -I /home/opam/.opam/4.14/lib/carton-git -I /home/opam/.opam/4.14/lib/carton-lwt -I /home/opam/.opam/4.14/lib/carton/thin -I /home/opam/.opam/4.14/lib/checkseum/c -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/cryptokit -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/csv -I /home/opam/.opam/4.14/lib/decompress/de -I /home/opam/.opam/4.14/lib/decompress/zl -I /home/opam/.opam/4.14/lib/diffast-api -I /home/opam/.opam/4.14/lib/diffast-core -I /home/opam/.opam/4.14/lib/diffast-git -I /home/opam/.opam/4.14/lib/diffast-misc -I /home/opam/.opam/4.14/lib/digestif/c -I /home/opam/.opam/4.14/lib/dns -I /home/opam/.opam/4.14/lib/dns-client -I /home/opam/.opam/4.14/lib/dns-client-mirage -I /home/opam/.opam/4.14/lib/dns/cache -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duff -I /home/opam/.opam/4.14/lib/dune-private-libs/dune-section -I /home/opam/.opam/4.14/lib/dune-private-libs/meta_parser -I /home/opam/.opam/4.14/lib/dune-site -I /home/opam/.opam/4.14/lib/dune-site/dynlink -I /home/opam/.opam/4.14/lib/dune-site/plugins -I /home/opam/.opam/4.14/lib/dune-site/private -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/emile -I /home/opam/.opam/4.14/lib/encore -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/faraday -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/fmt/cli -I /home/opam/.opam/4.14/lib/fmt/tty -I /home/opam/.opam/4.14/lib/fpath -I /home/opam/.opam/4.14/lib/gen -I /home/opam/.opam/4.14/lib/git -I /home/opam/.opam/4.14/lib/git-mirage/http -I /home/opam/.opam/4.14/lib/git-mirage/ssh -I /home/opam/.opam/4.14/lib/git-mirage/tcp -I /home/opam/.opam/4.14/lib/git-paf -I /home/opam/.opam/4.14/lib/git-unix -I /home/opam/.opam/4.14/lib/git/loose -I /home/opam/.opam/4.14/lib/git/loose-git -I /home/opam/.opam/4.14/lib/git/nss -I /home/opam/.opam/4.14/lib/git/nss/git -I /home/opam/.opam/4.14/lib/git/nss/hkt -I /home/opam/.opam/4.14/lib/git/nss/neg -I /home/opam/.opam/4.14/lib/git/nss/pck -I /home/opam/.opam/4.14/lib/git/nss/pkt-line -I /home/opam/.opam/4.14/lib/git/nss/sigs -I /home/opam/.opam/4.14/lib/git/nss/smart -I /home/opam/.opam/4.14/lib/git/nss/smart-flow -I /home/opam/.opam/4.14/lib/git/nss/unixiz -I /home/opam/.opam/4.14/lib/gmap -I /home/opam/.opam/4.14/lib/h1 -I /home/opam/.opam/4.14/lib/happy-eyeballs -I /home/opam/.opam/4.14/lib/happy-eyeballs-lwt -I /home/opam/.opam/4.14/lib/happy-eyeballs-mirage -I /home/opam/.opam/4.14/lib/httpun-types -I /home/opam/.opam/4.14/lib/hxd/core -I /home/opam/.opam/4.14/lib/hxd/string -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/kdf/hkdf -I /home/opam/.opam/4.14/lib/kdf/pbkdf -I /home/opam/.opam/4.14/lib/ke -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/logs/cli -I /home/opam/.opam/4.14/lib/logs/fmt -I /home/opam/.opam/4.14/lib/lru -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/markup -I /home/opam/.opam/4.14/lib/menhirLib -I /home/opam/.opam/4.14/lib/metrics -I /home/opam/.opam/4.14/lib/mimic -I /home/opam/.opam/4.14/lib/mimic-happy-eyeballs -I /home/opam/.opam/4.14/lib/mirage-crypto -I /home/opam/.opam/4.14/lib/mirage-crypto-ec -I /home/opam/.opam/4.14/lib/mirage-crypto-pk -I /home/opam/.opam/4.14/lib/mirage-crypto-rng -I /home/opam/.opam/4.14/lib/mirage-flow -I /home/opam/.opam/4.14/lib/mirage-kv -I /home/opam/.opam/4.14/lib/mirage-mtime/unix -I /home/opam/.opam/4.14/lib/mirage-ptime/unix -I /home/opam/.opam/4.14/lib/mirage-sleep/unix -I /home/opam/.opam/4.14/lib/mtime -I /home/opam/.opam/4.14/lib/mtime/clock -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocamlgraph -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/ohex -I /home/opam/.opam/4.14/lib/optint -I /home/opam/.opam/4.14/lib/paf -I /home/opam/.opam/4.14/lib/pecu -I /home/opam/.opam/4.14/lib/psq -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/ptime/clock -I /home/opam/.opam/4.14/lib/randomconv -I /home/opam/.opam/4.14/lib/rresult -I /home/opam/.opam/4.14/lib/sedlex -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/tcpip -I /home/opam/.opam/4.14/lib/tls -I /home/opam/.opam/4.14/lib/tls-mirage -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uuidm -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/vlt -I /home/opam/.opam/4.14/lib/x509 -I /home/opam/.opam/4.14/lib/zarith -intf-suffix .ml -no-alias-deps -o src/git/cli/.git_diffast.eobjs/native/dune__exe__Git_diffast.cmx -c -impl src/git/cli/git_diffast.pp.ml)
# File "src/git/cli/git_diffast.ml", line 376, characters 8-17:
# 376 |         args#repo $ sha1s)
#               ^^^^^^^^^
# Error: This expression has type string Cmdliner.Term.t
#        but an expression was expected of type Fpath.t Cmdliner.Term.t
#        Type string is not compatible with type Fpath.t 
```