### PR TITLE
Packages ppx_js_style.v0.17.1 and ppx_yojson_conv.v0.17.1

### DIFF
--- a/packages/ppx_js_style/ppx_js_style.v0.17.1/opam
+++ b/packages/ppx_js_style/ppx_js_style.v0.17.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_js_style"
+bug-reports: "https://github.com/janestreet/ppx_js_style/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_js_style.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_js_style/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"    {>= "5.3.0"}
+  "base"     {>= "v0.17" & < "v0.18"}
+  "dune"     {>= "3.11.0"}
+  "octavius"
+  "ppxlib"   {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Code style checker for Jane Street Packages"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+
+This packages is a no-op ppx rewriter. It is used as a 'lint' tool to
+enforce some coding conventions across all Jane Street packages.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_js_style/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=4bf6d0da9a4dcb81ad1b59690e6a5df4"
+    "sha512=7df4fb48935eaa505be37689cf01c2ae87ede67847e7574357d291a6d1a03fda4da589d9b6d2233992fbf8aaad5e2ad07e197b1e6aa6a92622347aa552fb7fcf"
+  ]
+}

--- a/packages/ppx_yojson_conv/ppx_yojson_conv.v0.17.1/opam
+++ b/packages/ppx_yojson_conv/ppx_yojson_conv.v0.17.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_yojson_conv"
+bug-reports: "https://github.com/janestreet/ppx_yojson_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_yojson_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_yojson_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"               {>= "5.3.0"}
+  "base"                {>= "v0.17" & < "v0.18"}
+  "ppx_js_style"        {>= "v0.17" & < "v0.18"}
+  "ppx_yojson_conv_lib" {>= "v0.17" & < "v0.18"}
+  "dune"                {>= "3.11.0"}
+  "ppxlib"              {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "[@@deriving] plugin to generate Yojson conversion functions"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_yojson_conv/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=ae68824365ee93ba5761c73a9ac26749"
+    "sha512=9fd8673d68791de18ed9fbb705ed441fa4cc7e5085000d99c4dd3d0b5ff488c833ca7fdf9952ab02dde2b3272df41440ad373dd89e2ff3f6e226eccd8fad81d2"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `ppx_js_style.v0.17.1`: Code style checker for Jane Street Packages
- `ppx_yojson_conv.v0.17.1`: [@@deriving] plugin to generate Yojson conversion functions



---

---
:camel: Pull-request generated by opam-publish v2.5.1