### PR TITLE
[base v0.15.1] Move patch URL to opam-repository-archive due to flaky checksum

### DIFF
--- a/packages/base/base.v0.15.1/opam
+++ b/packages/base/base.v0.15.1/opam
@@ -37,7 +37,7 @@ checksum: "sha256=755e303171ea267e3ba5af7aa8ea27537f3394d97c77d340b10f806d6ef61a
 patches: ["fix-mpopcnt.patch" { arch="arm64" & os="macos"} ]
 extra-source "fix-mpopcnt.patch" {
   src:
-    "https://patch-diff.githubusercontent.com/raw/janestreet/base/pull/184.diff"
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/base/base-pr-184.diff"
   checksum: [
     "sha256=0fa6c87a379b3b35ffe3db3c8e1674dbc70cef91b5b457a35ed6d758a8f9ca80"
   ]


### PR DESCRIPTION
Fixes #28675