### PR TITLE
z3.4.15.2: parallelize homebrew build

### DIFF
--- a/packages/z3/z3.4.15.2/opam
+++ b/packages/z3/z3.4.15.2/opam
@@ -17,7 +17,7 @@ build: [
     CPPFLAGS="-I/usr/local/opt/llvm/include $CPPFLAGS"
     export PATH LDFLAGS CPPFLAGS
     python3 scripts/mk_make.py --ml
-    make -C build 
+    make -C build -j %{jobs}%
   """] {os-distribution = "homebrew" & arch = "x86_64"}
   [ "sh" "-c" """#!/bin/sh
     PATH=/opt/homebrew/opt/llvm/bin:$PATH
@@ -25,7 +25,7 @@ build: [
     CPPFLAGS="-I/opt/homebrew/opt/llvm/include $CPPFLAGS"
     export PATH LDFLAGS CPPFLAGS
     python3 scripts/mk_make.py --ml
-    make -C build
+    make -C build -j %{jobs}%
   """] {os-distribution = "homebrew" & arch = "arm64"}
 ]
 


### PR DESCRIPTION
The Linux build is parallelized, but the Homebrew one isn't, making it really slow. Add `-j %{jobs}%` to parallelize.
