### PR TITLE
Package ppx_expect.v0.16.2

### DIFF
--- a/packages/ppx_expect/ppx_expect.v0.16.2/opam
+++ b/packages/ppx_expect/ppx_expect.v0.16.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_expect"
+bug-reports: "https://github.com/janestreet/ppx_expect/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_expect.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_expect/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"           {>= "4.14.0"}
+  "base"            {>= "v0.16" & < "v0.17"}
+  "ppx_here"        {>= "v0.16" & < "v0.17"}
+  "ppx_inline_test" {>= "v0.16" & < "v0.17"}
+  "stdio"           {>= "v0.16" & < "v0.17"}
+  "dune"            {>= "2.0.0"}
+  "ppxlib"          {>= "0.28.0"}
+  "re"              {>= "1.8.0"}
+]
+conflicts: [
+  "js_of_ocaml-compiler" {< "5.8"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Cram like framework for OCaml"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_expect/archive/refs/tags/v0.16.2.tar.gz"
+  checksum: [
+    "md5=99759b6592f5f3e6207af78884b1f3e5"
+    "sha512=1f1adf2bea04da27e6a2b1b3d2fe07773aed7043f83008018e724fc2c0334ac0e3c962f43fca53394e7954f40083539ad5108ac5aa945d2d6b65f99c7a4ee513"
+  ]
+}


### PR DESCRIPTION
### `ppx_expect.v0.16.2`
Cram like framework for OCaml
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_expect
* Source repo: git+https://github.com/janestreet/ppx_expect.git
* Bug tracker: https://github.com/janestreet/ppx_expect/issues

---
:camel: Pull-request generated by opam-publish v2.5.1