### PR TITLE
Packages hardcaml.v0.17.1, ppx_derive_at_runtime.v0.17.1, ppx_hardcaml.v0.17.1, ppx_jsonaf_conv.v0.17.1, ppx_pattern_bind.v0.17.1, ppx_quick_test.v0.17.1, ppx_typed_fields.v0.17.1 and streamable.v0.17.1

### DIFF
--- a/packages/hardcaml/hardcaml.v0.17.1/opam
+++ b/packages/hardcaml/hardcaml.v0.17.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/hardcaml"
+bug-reports: "https://github.com/janestreet/hardcaml/issues"
+dev-repo: "git+https://github.com/janestreet/hardcaml.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/hardcaml/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"         {>= "5.3.0"}
+  "base"          {>= "v0.17" & < "v0.18"}
+  "bin_prot"      {>= "v0.17" & < "v0.18"}
+  "core_kernel"   {>= "v0.17" & < "v0.18"}
+  "ppx_jane"      {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
+  "stdio"         {>= "v0.17" & < "v0.18"}
+  "dune"          {>= "3.11.0"}
+  "ppxlib"        {>= "0.36.0"}
+  "zarith"        {>= "1.11"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "RTL Hardware Design in OCaml"
+description: "
+Hardcaml is an embedded DSL for designing and simulating hardware in OCaml.
+Generic hardware designs are easily expressed using features such as higher
+order functions, lists, maps etc.  A built in simulator allows designs to
+be simulated within Hardcaml.  Designs are converted to either Verilog or
+VHDL to interact with standard back end tooling.
+"
+url {
+  src:
+    "https://github.com/janestreet/hardcaml/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=7435ee8610c2205c5f912b4bf09163b0"
+    "sha512=38d7cf428bd3491024212e52776ac582183d7b5f6a494589a3697d9a213fa18347d6eeea23327859c340b0cb3b967c08cd21a8a7f8d15cf2de20e5598cb8456d"
+  ]
+}

--- a/packages/ppx_derive_at_runtime/ppx_derive_at_runtime.v0.17.1/opam
+++ b/packages/ppx_derive_at_runtime/ppx_derive_at_runtime.v0.17.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_derive_at_runtime"
+bug-reports: "https://github.com/janestreet/ppx_derive_at_runtime/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_derive_at_runtime.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_derive_at_runtime/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"                    {>= "5.3.0"}
+  "base"                     {>= "v0.17" & < "v0.18"}
+  "expect_test_helpers_core" {>= "v0.17" & < "v0.18"}
+  "ppx_jane"                 {>= "v0.17" & < "v0.18"}
+  "dune"                     {>= "3.11.0"}
+  "ppxlib"                   {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Define a new ppx deriver by naming a runtime module."
+description: "
+
+Allows specifying new ppx derivers much more easily than writing
+a ppx by hand. For example, to get `[@@deriving foo]`, you only have to
+specify a module path such as `My_library.Foo`.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_derive_at_runtime/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=8abae25696a31ba88a12e046c1d671ed"
+    "sha512=a998d1bd85f1d2c76ffe4fddd56ff7f2f995cbd44bbd44263c331dd272cf4d9ac69dd9a4dbb45fe9d526e97456090108c901b6d393d186adce50d92f6488447d"
+  ]
+}

--- a/packages/ppx_hardcaml/ppx_hardcaml.v0.17.1/opam
+++ b/packages/ppx_hardcaml/ppx_hardcaml.v0.17.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_hardcaml"
+bug-reports: "https://github.com/janestreet/ppx_hardcaml/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_hardcaml.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_hardcaml/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"    {>= "5.3.0"}
+  "base"     {>= "v0.17" & < "v0.18"}
+  "hardcaml" {>= "v0.17" & < "v0.18"}
+  "ppx_jane" {>= "v0.17" & < "v0.18"}
+  "dune"     {>= "3.11.0"}
+  "ppxlib"   {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Rewrite OCaml records for use as Hardcaml Interfaces"
+description: "
+An interface in Hardcaml is an OCaml record with special attributes including
+a bit width and RTL netlist name.  Input and output ports of a hardware design
+can then be accessed through the OCaml record.  This allows easier management
+of bundles of ports when working with the Simulator, Netlist generation or
+hierarchical designs.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_hardcaml/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=74cb19720c582bd5c4559aba77807024"
+    "sha512=5179b3741e94cf603fc8907b9946a1021979463262e7ab7cbe83df0f320ed2f2bfa8d8aef5ed53f10f9fcd64aaad5f618b26ef16ecabe7bdb358cc9ff01317d7"
+  ]
+}

--- a/packages/ppx_jsonaf_conv/ppx_jsonaf_conv.v0.17.1/opam
+++ b/packages/ppx_jsonaf_conv/ppx_jsonaf_conv.v0.17.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_jsonaf_conv"
+bug-reports: "https://github.com/janestreet/ppx_jsonaf_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_jsonaf_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_jsonaf_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"    {>= "5.3.0"}
+  "base"     {>= "v0.17" & < "v0.18"}
+  "jsonaf"   {>= "v0.17" & < "v0.18"}
+  "ppx_jane" {>= "v0.17" & < "v0.18"}
+  "dune"     {>= "3.11.0"}
+  "ppxlib"   {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "[@@deriving] plugin to generate Jsonaf conversion functions"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_jsonaf_conv/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=2e9916fed20953aee759623b21502293"
+    "sha512=6ab435f0bd47a829d75471e7c8bec7b1db68d074ea806805854cdf25c76d4aa89a294163fbdbf8451e5a61d48cf26489cf7f94fece8d59e76dde954ecee269e9"
+  ]
+}

--- a/packages/ppx_pattern_bind/ppx_pattern_bind.v0.17.1/opam
+++ b/packages/ppx_pattern_bind/ppx_pattern_bind.v0.17.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_pattern_bind"
+bug-reports: "https://github.com/janestreet/ppx_pattern_bind/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_pattern_bind.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_pattern_bind/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"   {>= "5.3.0"}
+  "base"    {>= "v0.17" & < "v0.18"}
+  "ppx_let" {>= "v0.17" & < "v0.18"}
+  "dune"    {>= "3.11.0"}
+  "ppxlib"  {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "A ppx for writing fast incremental bind nodes in a pattern match"
+description: "
+A ppx rewriter that is intended for use with Incremental. It makes it
+easier to write incremental computations using pattern-matching in a
+way that causes incremental nodes to fire as little as possible.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_pattern_bind/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=42d58abff78cb01b61a32e5faa2c3632"
+    "sha512=c50a8f84507cdd18980cf0c9d36c1fa0b8032534f184f453c40b27e1b125abc541746e143ba4ff30c632b1c3bb7789c568177b81fd56dc1136a0464d86f83040"
+  ]
+}

--- a/packages/ppx_quick_test/ppx_quick_test.v0.17.1/opam
+++ b/packages/ppx_quick_test/ppx_quick_test.v0.17.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_quick_test"
+bug-reports: "https://github.com/janestreet/ppx_quick_test/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_quick_test.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_quick_test/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"                    {>= "5.3.0"}
+  "async"                    {>= "v0.17" & < "v0.18"}
+  "async_kernel"             {>= "v0.17" & < "v0.18"}
+  "base"                     {>= "v0.17" & < "v0.18"}
+  "base_quickcheck"          {>= "v0.17" & < "v0.18"}
+  "core"                     {>= "v0.17" & < "v0.18"}
+  "core_kernel"              {>= "v0.17" & < "v0.18"}
+  "expect_test_helpers_core" {>= "v0.17" & < "v0.18"}
+  "ppx_expect"               {>= "v0.17" & < "v0.18"}
+  "ppx_here"                 {>= "v0.17" & < "v0.18"}
+  "ppx_jane"                 {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv"            {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_message"         {>= "v0.17" & < "v0.18"}
+  "dune"                     {>= "3.11.0"}
+  "ppxlib"                   {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Spiritual equivalent of let%expect_test, but for property based tests as an ergonomic wrapper to write quickcheck tests."
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_quick_test/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=d6f4ee666c0f68d41bd21ba5629a8ce0"
+    "sha512=40367c43059e3b25cc82673e30989d86522967107d6ae3f89233500193c9a9df205c9d697f45b9d7b2a70acb55691365bcc9d2c284a5089b98fd6de7032c71fe"
+  ]
+}

--- a/packages/ppx_typed_fields/ppx_typed_fields.v0.17.1/opam
+++ b/packages/ppx_typed_fields/ppx_typed_fields.v0.17.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_typed_fields"
+bug-reports: "https://github.com/janestreet/ppx_typed_fields/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_typed_fields.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_typed_fields/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"         {>= "5.3.0"}
+  "base"          {>= "v0.17" & < "v0.18"}
+  "core"          {>= "v0.17" & < "v0.18"}
+  "ppx_compare"   {>= "v0.17" & < "v0.18"}
+  "ppx_enumerate" {>= "v0.17" & < "v0.18"}
+  "ppx_jane"      {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
+  "ppx_string"    {>= "v0.17" & < "v0.18"}
+  "sexplib"       {>= "v0.17" & < "v0.18"}
+  "sexplib0"      {>= "v0.17" & < "v0.18"}
+  "dune"          {>= "3.11.0"}
+  "ppxlib"        {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "GADT-based field accessors and utilities"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_typed_fields/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=4b6d77bf987a7f857fd6d302425e8648"
+    "sha512=5e2d97f8f2b87ba1972214d2f5af9fd63a47929d0e7aca8e7718c1f8eb8880a3b0ebe6e55d4523c84a4e9b973f8fe7a8d246a1120cb7ea08adab5f7034a64c9f"
+  ]
+}

--- a/packages/streamable/streamable.v0.17.1/opam
+++ b/packages/streamable/streamable.v0.17.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/streamable"
+bug-reports: "https://github.com/janestreet/streamable/issues"
+dev-repo: "git+https://github.com/janestreet/streamable.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/streamable/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"            {>= "5.3.0"}
+  "async_kernel"     {>= "v0.17" & < "v0.18"}
+  "async_rpc_kernel" {>= "v0.17" & < "v0.18"}
+  "base"             {>= "v0.17" & < "v0.18"}
+  "core"             {>= "v0.17" & < "v0.18"}
+  "core_kernel"      {>= "v0.17" & < "v0.18"}
+  "ppx_jane"         {>= "v0.17" & < "v0.18"}
+  "dune"             {>= "3.11.0"}
+  "ppxlib"           {>= "0.36.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "A collection of types suitable for incremental serialization."
+description: "
+A collection of types suitable for incremental serialization.
+"
+url {
+  src:
+    "https://github.com/janestreet/streamable/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=f8ef1a28079f4e6e6617ba2cfa51bc4e"
+    "sha512=2f56d8b10032756c3190b0e68094f0c89f96f9f3fc39d5a8c62f340abe837c7ba1c75f99c914213cbb6376dc6f3abac689110d18af226998bba4484dd9ff3c47"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `hardcaml.v0.17.1`: RTL Hardware Design in OCaml
- `ppx_derive_at_runtime.v0.17.1`: Define a new ppx deriver by naming a runtime module.
- `ppx_hardcaml.v0.17.1`: Rewrite OCaml records for use as Hardcaml Interfaces
- `ppx_jsonaf_conv.v0.17.1`: [@@deriving] plugin to generate Jsonaf conversion functions
- `ppx_pattern_bind.v0.17.1`: A ppx for writing fast incremental bind nodes in a pattern match
- `ppx_quick_test.v0.17.1`: Spiritual equivalent of let%expect_test, but for property based tests as an ergonomic wrapper to write quickcheck tests.
- `ppx_typed_fields.v0.17.1`: GADT-based field accessors and utilities
- `streamable.v0.17.1`: A collection of types suitable for incremental serialization.



---

---
:camel: Pull-request generated by opam-publish v2.5.1