### PR TITLE
[new release] mirage-net-xen (2.1.7)

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.2.1.7/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.2.1.7/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+license:       "ISC"
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "mirage-xen" {>= "7.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "shared-memory-ring" {>="3.0.0"}
+  "macaddr" {>= "5.2.0"}
+  "lwt-dllist"
+  "logs" {>= "0.5.0"}
+]
+conflicts: [
+    "result" {< "1.5"}
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v2.1.7/mirage-net-xen-2.1.7.tbz"
+  checksum: [
+    "sha256=6e314790e9052f072d152df65d708e0baa67db5c62d5df252577588fac71bc28"
+    "sha512=936ba507cbfe0a639b20e14b6d769e5754cbb04b5697fce51e05fb66d85d37127a498f0e7d4f294af87a7d5b148082c2fadfe2045f01b6f65d1453414fe31557"
+  ]
+}
+x-commit-hash: "509eb9ebc37d682ab2869b6e35cac19b236483eb"


### PR DESCRIPTION
Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol

- Project page: <a href="https://github.com/mirage/mirage-net-xen">https://github.com/mirage/mirage-net-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-xen/">https://mirage.github.io/mirage-net-xen/</a>

##### CHANGES:

* read MTU from xenstore instead of using a hardcoded 1500 (mirage/mirage-net-xen#115 @hannesm,
  reviewed by @palainp)
