### PR TITLE
fix(z3): use multiple jobs for build

### DIFF
--- a/packages/z3/z3.4.15.2/opam
+++ b/packages/z3/z3.4.15.2/opam
@@ -17,16 +17,16 @@ build: [
     CPPFLAGS="-I/usr/local/opt/llvm/include $CPPFLAGS"
     export PATH LDFLAGS CPPFLAGS
     python3 scripts/mk_make.py --ml
-    make -C build 
-  """] {os-distribution = "homebrew" & arch = "x86_64"}
+    make -C build -j %{jobs}%"""
+  ] {os-distribution = "homebrew" & arch = "x86_64"}
   [ "sh" "-c" """#!/bin/sh
     PATH=/opt/homebrew/opt/llvm/bin:$PATH
     LDFLAGS="-L/opt/homebrew/opt/llvm/lib $LDFLAGS"
     CPPFLAGS="-I/opt/homebrew/opt/llvm/include $CPPFLAGS"
     export PATH LDFLAGS CPPFLAGS
     python3 scripts/mk_make.py --ml
-    make -C build
-  """] {os-distribution = "homebrew" & arch = "arm64"}
+    make -C build -j %{jobs}%"""
+  ] {os-distribution = "homebrew" & arch = "arm64"}
 ]
 
 install: [


### PR DESCRIPTION
The homebrew builds of `z3` did not use multiple jobs.
I do not know if this is accidental, but it made the build quite slow. Locally this seems to work fine, will let CI judge further.