### PR TITLE
Package notty-community.0.2.4

### DIFF
--- a/packages/notty-community/notty-community.0.2.4/opam
+++ b/packages/notty-community/notty-community.0.2.4/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Declaring terminals"
+description: """\
+Notty is a declarative terminal library for OCaml structured around a notion
+of composable images. It tries to abstract away the basic terminal
+programming model, providing something simpler and more expressive.
+
+This is a branch from the original notty, maintained by the community."""
+maintainer: [
+  "Ali Caglayan <alizter@gmail.com>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "Romain Calascibetta <romain.calascibetta@gmail.com>"
+]
+authors: "David Kaloper <dk505@cam.ac.uk>"
+license: "ISC"
+homepage: "https://github.com/ocaml-community/notty-community"
+bug-reports: "https://github.com/ocaml-community/notty-community/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "cppo" {build & >= "1.1.0"}
+  "uutf" {>= "1.0.0"}
+  "uucp" {with-dev-setup}
+  "lwt" {with-test}
+  "odoc" {with-doc}
+]
+depopts: ["lwt"]
+conflicts: [
+  "lwt" {< "2.6.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-community/notty-community.git"
+url {
+  src:
+    "https://github.com/ocaml-community/notty-community/releases/download/v0.2.4/notty-community-0.2.4.tar.gz"
+  checksum: [
+    "md5=b8cb51edb37d28d9d53e98ac52848677"
+    "sha512=8922a190a412790285603ba7ab37f9f58202d9406ebc9e6d3329189eac7fda5c25316264c27b6f7decb8f25f0d78801873b9f16c40e90f020e2c06ab9d058686"
+  ]
+}


### PR DESCRIPTION
### `notty-community.0.2.4`
Declaring terminals
Notty is a declarative terminal library for OCaml structured around a notion
of composable images. It tries to abstract away the basic terminal
programming model, providing something simpler and more expressive.

This is a branch from the original notty, maintained by the community.



---
* Homepage: https://github.com/ocaml-community/notty-community
* Source repo: git+https://github.com/ocaml-community/notty-community.git
* Bug tracker: https://github.com/ocaml-community/notty-community/issues

---
:camel: Pull-request generated by opam-publish v2.7.0