### PR TITLE
mrmime 0.5.0 doesn't work nicely with cmdliner 2.0.0

### DIFF
--- a/packages/mrmime/mrmime.0.5.0/opam
+++ b/packages/mrmime/mrmime.0.5.0/opam
@@ -34,7 +34,7 @@ depends: [
   "bigarray-compat"
   "bigarray-overlap" {>= "0.2.0"}
   "angstrom"         {>= "0.14.0"}
-  "cmdliner"
+  "cmdliner"         {< "2.0.0"}
   "fpath"
   "hxd"
   "mirage-crypto-rng" {< "1.0.0"}


### PR DESCRIPTION
```
- (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I corpus/.generate.eobjs/byte -I /home/opam/.opam/4.14/lib/afl-persistent -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/base64/rfc2045 -I /home/opam/.opam/4.14/lib/bigarray-compat -I /home/opam/.opam/4.14/lib/bigarray-overlap -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/coin -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/emile -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/eqaf/bigstring -I /home/opam/.opam/4.14/lib/eqaf/cstruct -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/fmt/cli -I /home/opam/.opam/4.14/lib/fmt/tty -I /home/opam/.opam/4.14/lib/fpath -I /home/opam/.opam/4.14/lib/hxd/core -I /home/opam/.opam/4.14/lib/hxd/string -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ke -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/logs/cli -I /home/opam/.opam/4.14/lib/logs/fmt -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/mirage-crypto -I /home/opam/.opam/4.14/lib/mirage-crypto-rng -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/pecu -I /home/opam/.opam/4.14/lib/prettym -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/rosetta -I /home/opam/.opam/4.14/lib/rresult -I /home/opam/.opam/4.14/lib/unstrctrd -I /home/opam/.opam/4.14/lib/unstrctrd/parser -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/uuuu -I /home/opam/.opam/4.14/lib/yuscii -I lib/.mrmime.objs/byte -no-alias-deps -open Dune__exe -o corpus/.generate.eobjs/byte/dune__exe__Generate.cmo -c -impl corpus/generate.ml)
- File "corpus/generate.ml", line 107, characters 12-23:
- 107 |   let env = Arg.env_var "BLAZE_LOGS" in
-                   ^^^^^^^^^^^
- Error: Unbound value Arg.env_var
[ERROR] The compilation of mrmime.0.5.0 failed at "dune build -p mrmime -j 255".
```

newer mrmime versions are fine