### PR TITLE
Package vsrocq-language-server.2.3.1

### DIFF
--- a/packages/vsrocq-language-server/vsrocq-language-server.2.3.1/opam
+++ b/packages/vsrocq-language-server/vsrocq-language-server.2.3.1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/rocq-prover/vsrocq"
+bug-reports: "https://github.com/rocq-prover/vsrocq/issues"
+dev-repo: "git+https://github.com/rocq-prover/vsrocq"
+
+build: [
+  [make "dune-files"]
+  [
+    "etc/rocq-wrap-coqc.sh" {!coq-core:installed}
+    "dune" "build" "-p" name "-j" jobs 
+  ]
+]
+depends: [
+  "ocaml" { >= "4.14" }
+  "dune" { >= "3.5" }
+  ("coq-core" { ((>= "8.18" < "8.21") | (= "dev")) }
+  | "rocq-core" { ((>= "9.0+rc1" < "9.2~") | (= "dev")) })
+  ("coq-stdlib" { ((>= "8.18" < "8.21") | (= "dev")) }
+  | "rocq-stdlib" { ((>= "9.0+rc1" < "9.2~") | (= "dev")) })
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "ppx_optcomp"
+  "result" { >= "1.5" }
+  "lsp" { >= "1.15"}
+  "sel" {>= "0.6.0"}
+]
+conflicts: [
+    "vscoq-language-server" {< "2.7~"}
+]
+synopsis: "VSRocq language server"
+available: arch != "arm32" & arch != "x86_32"
+description: """
+LSP based language server for Rocq and its VSRocq user interface
+"""
+url {
+  src:
+    "https://github.com/rocq-prover/vsrocq/releases/download/v2.3.1/vsrocq-language-server-2.3.1.tar.gz"
+  checksum: [
+    "md5=521c971030f0cf552a2566b08b7b57f7"
+    "sha512=ef1ddf8a84db5557023a3f128b9fbde5e7fe910d1c6dc8d8c7b55b71636e7deddbf2675516120320de39c25ae39463b9fab1ddaa8217c097f405501e36361f28"
+  ]
+}


### PR DESCRIPTION
### `vsrocq-language-server.2.3.1`
VSRocq language server
LSP based language server for Rocq and its VSRocq user interface



---
* Homepage: https://github.com/rocq-prover/vsrocq
* Source repo: git+https://github.com/rocq-prover/vsrocq
* Bug tracker: https://github.com/rocq-prover/vsrocq/issues

---
:camel: Pull-request generated by opam-publish v2.5.0