### PR TITLE
Add a yojson upper bound for morbig.0.11.0

### DIFF
--- a/packages/morbig/morbig.0.11.0/opam
+++ b/packages/morbig/morbig.0.11.0/opam
@@ -28,7 +28,7 @@ depends: [
   "odoc"                 {with-doc}
   "ppx_deriving_yojson"
   "visitors"             {>= "20200207"}
-  "yojson"               {>= "1.6.0"}
+  "yojson"               {>= "1.6.0" & < "3.0.0"}
   "conf-jq" {with-test}
 ]
 


### PR DESCRIPTION
Spotted on https://github.com/ocaml/opam-repository/pull/28693

```
#=== ERROR while compiling morbig.0.11.0 ======================================#
# context              2.4.1 | linux/x86_64 | ocaml-base-compiler.5.3.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/morbig.0.11.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make build
# exit-code            2
# env-file             ~/.opam/log/morbig-7-5c3543.env
# output-file          ~/.opam/log/morbig-7-5c3543.out
### output ###
# if command -v ocamlopt >/dev/null; then cp src/c/dune.native src/c/dune; fi
# dune build @install
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlc.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -w -3 -g -bin-annot -bin-annot-occurrences -I src/.morbig.objs/byte -I /home/opam/.opam/5.3/lib/menhirLib -I /home/opam/.opam/5.3/lib/ocaml/str -I /home/opam/.opam/5.3/lib/ppx_deriving/runtime -I /home/opam/.opam/5.3/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.3/lib/result -I /home/opam/.opam/5.3/lib/visitors/runtime -I /home/opam/.opam/5.3/lib/yojson -cmi-file src/.morbig.objs/byte/morbig__JsonHelpers.cmi -no-alias-deps -opaque -open Morbig__ -o src/.morbig.objs/byte/morbig__JsonHelpers.cmo -c -impl src/jsonHelpers.pp.ml)
# File "src/jsonHelpers.ml", line 34, characters 65-66:
# 34 |   |> (if simplified then json_filter_positions else function x-> x)
#                                                                       ^
# Error: The value "x" has type "Yojson.Safe.t"
#        but an expression was expected of type
#          "[> `Assoc of (string * 'a) list
#           | `Bool of bool
#           | `Float of float
#           | `Int of int
#           | `Intlit of string
#           | `List of 'a list
#           | `Null
#           | `String of string
#           | `Tuple of 'a list
#           | `Variant of 'b * 'a option ]
#          as 'a"
#        The first variant type does not allow tag(s) "`Tuple", "`Variant"
```

2.2.2 interface: https://github.com/ocaml-community/yojson/blob/2.2.2/lib/type.ml  (incl. `Tuple` and `Variant`)
3.0.0 interface: https://github.com/ocaml-community/yojson/blob/3.0.0/lib/type.ml  (excl. `Tuple` and `Variant`)