### PR TITLE
[new release] fadecider (0.7)

### DIFF
--- a/packages/fadecider/fadecider.0.7/opam
+++ b/packages/fadecider/fadecider.0.7/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "A package for deciding universality and subsumption of omega automata using Ramsey-based methods"
+description:
+  "A package for deciding universality and subsumption of omega automata using Ramsey-based methods."
+maintainer: ["Oliver Friedmann" "Felix Klaedtke" "Martin Lange"]
+authors: ["Oliver Friedmann" "Felix Klaedtke" "Martin Lange"]
+license: "BSD-3-clause"
+homepage: "https://github.com/tcsprojects/fadecider"
+bug-reports: "https://github.com/tcsprojects/fadecider/issues"
+depends: [
+  "ocaml" {>= "4.8"}
+  "dune" {>= "3.18"}
+  "tcs-lib" {>= "0.6"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tcsprojects/fadecider.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/tcsprojects/fadecider/releases/download/v0.7/fadecider-0.7.tbz"
+  checksum: [
+    "sha256=7a27293d686ddd068a7247693ca8f48b524041ae6b6e9e40438571213bc3728b"
+    "sha512=020e418ec241463287b9d56c2a1b840a5f2f68892b703fe17427669be32225c8760751f588e5991cbffc96e9cd09204d4ecb77dfdcb0f6216b200419ded5a6ae"
+  ]
+}
+x-commit-hash: "3532b4901da9fb5882d2922a52b7512b7c6dbac5"


### PR DESCRIPTION
A package for deciding universality and subsumption of omega automata using Ramsey-based methods

- Project page: <a href="https://github.com/tcsprojects/fadecider">https://github.com/tcsprojects/fadecider</a>

##### CHANGES:

- Change from OASIS to DUNE
- Change from OCAML 4 to OCAML 5
