### PR TITLE
[new release] doi2bib (2 packages) (0.7.9)

### DIFF
--- a/packages/bibfmt/bibfmt.0.7.9/opam
+++ b/packages/bibfmt/bibfmt.0.7.9/opam
@@ -22,7 +22,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+#    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/doi2bib/doi2bib.0.7.9/opam
+++ b/packages/doi2bib/doi2bib.0.7.9/opam
@@ -15,7 +15,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+#    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
CHANGES:

- bibfmt: added --quiet flag to suppress all output except errors.
- bibfmt: added --force flag to ignore parsing errors and output only successfully parsed entries.
- bibfmt: refactored deduplication functions - moved all deduplication logic (deduplicate_entries, resolve_conflicts, merge_entries_non_interactive) from library to bibdedup CLI tool. The library now provides only the core find_duplicate_groups function for programmatic use.