### PR TITLE
[new release] html_of_jsx (0.3.0-beta.13)

### DIFF
--- a/packages/html_of_jsx/html_of_jsx.0.3.0-beta.13/opam
+++ b/packages/html_of_jsx/html_of_jsx.0.3.0-beta.13/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Render HTML with JSX"
+description:
+  "html_of_jsx is a JSX transformation that allows you to write HTML declaratively."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/davesnx/html_of_jsx"
+bug-reports: "https://github.com/davesnx/html_of_jsx/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "ppxlib" {>= "0.25.0"}
+  "odoc" {with-doc}
+  "alcotest" {with-test}
+  "benchmark" {with-test}
+  "reason" {>= "3.10.0" & with-test}
+  "ocamlformat" {>= "0.26.1" & (with-dev-setup | with-test)}
+  "mlx" {with-test | with-dev-setup}
+  "dune-release" {with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "tiny_httpd" {with-dev-setup}
+  "ocamlformat-mlx" {>= "0.26.1" & (with-dev-setup)}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/html_of_jsx.git"
+url {
+  src:
+    "https://github.com/davesnx/html_of_jsx/releases/download/0.3.0-beta.13/html_of_jsx-0.3.0-beta.13.tbz"
+  checksum: [
+    "sha256=c7a6fe3bcd0c4d4eabbdbcc68b3bf63b63fe1fdd774217662ffa9fd2e8daecfb"
+    "sha512=509612edaaaf93f406ccb634e527cc4b676477d04a149f62bd818a729c84a2badc49ae10dece70cd5456726933c3b2014126beabe5e7d29592ab4b9293bc21cf"
+  ]
+}
+x-commit-hash: "01183b93ea398ce3b7c23c991993c708ad832452"


### PR DESCRIPTION
Render HTML with JSX

- Project page: <a href="https://github.com/davesnx/html_of_jsx">https://github.com/davesnx/html_of_jsx</a>

##### CHANGES:

## 0.0.5

- Make tests run in FreeBSD (https://github.com/davesnx/html_of_jsx/issues/22) (@davesnx)
- Fix: prefix with Stdlib all ppx generated code (https://github.com/davesnx/html_of_jsx/pull/23) (@tjdevries)
- Allow react attributes as props (via -react flag) (https://github.com/davesnx/html_of_jsx/pull#26) (@davesnx)
- Documentation: pushed old "features" document into the main index as seen https://davesnx.github.io/html_of_jsx/html_of_jsx/index.html

## 0.0.4

- [BREAKING] Handle HTML encoding for `'` (@davesnx)
- Handle HTML encoding for `"` (from `&davesnx/html_of_jsx#34;` to `&quot;`) (@davesnx)
- Improved performance of `JSX.render` (@davesnx)
- [BREAKING] Remove `Fragment` in favor of `JSX.list` (@davesnx)
- Remove unused `Component (unit -> element)` since it isn't needed (@davesnx)
- [BREAKING] Change attributes representation (@andreypopp)
- [BREAKING] Remove melange dependency (@andreypopp)
- [BREAKING] Lower the OCaml bound to 4.14 (@davesnx)
- Make lib wrapped (@andreypopp)

## 0.0.3

- [BREAKING] `Html_of_jsx.render` lives under `JSX.render` (removing the `Html_of_jsx` module entirely) (@lessp)
- [BREAKING] Module `Jsx` is turned into `JSX` (@lessp)
- [BREAKING] dune's library is now `html_of_jsx` instead of (`html_of_jsx.lib`) (@lessp)
- [BREAKING] `JSX.element` is opaque (can't see the type from outside), but we have a `JSX.Debug` module to inspect and re-construct `JSX.element` (cc @leostera) (@lessp)
- Improved performance of `JSX.render` (@lessp)
- add `hx-trigger` to htmx ppx davesnx/html_of_jsx#13 (@lessp)
- `htmlFor` -> `for_` (@lessp)
- Fix aria-autocomplete (@davesnx)

## 0.0.2

- Add `Jsx.unsafe` to allow unsafe HTML as children
- Fix HTML attributes formatting (charset, autocomplete, tabindex, inputmode, etc...)
- Enable HTMX attributes via `html_of_jsx.ppx -htmx`

## 0.0.1

- First working version of the ppx and library
- Supports most of features from [JSX](https://reasonml.github.io/docs/en/jsx) (uppercase components, fragments, optional attributes, punning)
- but with a few improvements (lowercase components, no need to add annotations)
- No React idioms (no `className`, no `htmlFor`, no `onChange`, etc...)
- Type-safe, validates attributes and their types ([it can be better thought](https://github.com/davesnx/html_of_jsx/issues/2))
- Minimal
  - `Html_of_jsx.render` to render an element to HTML
  - `Jsx.*` to construct DOM Elements and DOM nodes (`Jsx.text`, `Jsx.int`, `Jsx.null`, `Jsx.list`)
- Works with [Reason](https://reasonml.github.io) and [mlx](https://github.com/andreypopp/mlx)
- Supports some htmx under the ppx (`html_of_jsx.ppx -htmx`)
