### PR TITLE
[new release] html_of_jsx (0.0.6)

### DIFF
--- a/packages/html_of_jsx/html_of_jsx.0.0.6/opam
+++ b/packages/html_of_jsx/html_of_jsx.0.0.6/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Render HTML with JSX"
+description:
+  "html_of_jsx is a JSX transformation that allows you to write HTML declaratively."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/davesnx/html_of_jsx"
+bug-reports: "https://github.com/davesnx/html_of_jsx/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "ppxlib" {>= "0.25.0"}
+  "odoc" {with-doc}
+  "alcotest" {with-test}
+  "benchmark" {with-test}
+  "reason" {>= "3.10.0" & with-test}
+  "ocamlformat" {>= "0.26.1" & (with-dev-setup | with-test)}
+  "mlx" {with-test | with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "tiny_httpd" {with-dev-setup}
+  "ocamlformat-mlx" {>= "0.26.1" & (with-dev-setup)}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/html_of_jsx.git"
+url {
+  src:
+    "https://github.com/davesnx/html_of_jsx/releases/download/0.0.6/html_of_jsx-0.0.6.tbz"
+  checksum: [
+    "sha256=7f4aeaaa9df466b72ab2bf14bcc1b908789c67187781cb4c78ee5eb7d22697d8"
+    "sha512=31ef6fa8e80dac79d8806c08a64a5cb600f703309417bff917bfc8a6b72237383493eb3c13aade3059b17f0e3102aeba9cb358934c6f1541749ea9443037d791"
+  ]
+}
+x-commit-hash: "0d29b5518e7fc38f26e74d8aa0154b0a18991aa2"


### PR DESCRIPTION
Render HTML with JSX

- Project page: <a href="https://github.com/davesnx/html_of_jsx">https://github.com/davesnx/html_of_jsx</a>

##### CHANGES:

- Support OCaml 5.3 (https://github.com/davesnx/html_of_jsx/pull/29) (@davesnx)
