### PR TITLE
[new release] sail (13 packages) (0.20)

### DIFF
--- a/packages/libsail/libsail.0.20/opam
+++ b/packages/libsail/libsail.0.20/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis:
+  "Sail is a language for describing the instruction semantics of processors"
+description: """
+Sail is a language for describing the instruction-set
+architecture (ISA) semantics of processors. Sail aims to provide a
+engineer-friendly, vendor-pseudocode-like language for describing
+instruction semantics. It is essentially a first-order imperative
+language, but with lightweight dependent typing for numeric types and
+bitvector lengths, which are automatically checked using Z3. It has
+been used for several papers, available from
+http://www.cl.cam.ac.uk/~pes20/sail/.
+"""
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "dune-site" {>= "3.0.2"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "menhir" {>= "20240715" & build}
+  "ott" {>= "0.28" & build}
+  "lem" {>= "2018-12-14"}
+  "linksem" {>= "0.3"}
+  "conf-gmp"
+  "yojson" {>= "1.6.0"}
+  "pprint" {>= "20220103"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20/sail-0.20.tbz"
+  checksum: [
+    "sha256=59399896d0ab364b7f39e493efd675c4c0b660380dd87c4b2773eb13b93e47d3"
+    "sha512=87f73f2863eb2d8b7733024becb301dd4375ba0fbf2599024758c6a333fcd71db0ed497fb43905cfa75f80b54aab5acf5dbeffd37313a9df23213a50d346b69e"
+  ]
+}
+x-commit-hash: "edddfd7c210a6a46092de28337c6e2e50af1d0da"

--- a/packages/sail/sail.0.20/opam
+++ b/packages/sail/sail.0.20/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis:
+  "Sail is a language for describing the instruction semantics of processors"
+description: """
+Sail is a language for describing the instruction-set
+architecture (ISA) semantics of processors. Sail aims to provide a
+engineer-friendly, vendor-pseudocode-like language for describing
+instruction semantics. It is essentially a first-order imperative
+language, but with lightweight dependent typing for numeric types and
+bitvector lengths, which are automatically checked using Z3. It has
+been used for several papers, available from
+http://www.cl.cam.ac.uk/~pes20/sail/.
+"""
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "libsail" {= version}
+  "sail_manifest" {= version & build}
+  "sail_ocaml_backend" {= version & post}
+  "sail_c_backend" {= version & post}
+  "sail_smt_backend" {= version & post}
+  "sail_sv_backend" {= version & post}
+  "sail_lem_backend" {= version & post}
+  "sail_coq_backend" {= version & post}
+  "sail_lean_backend" {= version & post}
+  "sail_latex_backend" {= version & post}
+  "sail_doc_backend" {= version & post}
+  "sail_output" {= version & post}
+  "linenoise" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+substs: [ "src/bin/manifest.ml" ]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20/sail-0.20.tbz"
+  checksum: [
+    "sha256=59399896d0ab364b7f39e493efd675c4c0b660380dd87c4b2773eb13b93e47d3"
+    "sha512=87f73f2863eb2d8b7733024becb301dd4375ba0fbf2599024758c6a333fcd71db0ed497fb43905cfa75f80b54aab5acf5dbeffd37313a9df23213a50d346b69e"
+  ]
+}
+x-commit-hash: "edddfd7c210a6a46092de28337c6e2e50af1d0da"

--- a/packages/sail_c_backend/sail_c_backend.0.20/opam
+++ b/packages/sail_c_backend/sail_c_backend.0.20/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to C translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20/sail-0.20.tbz"
+  checksum: [
+    "sha256=59399896d0ab364b7f39e493efd675c4c0b660380dd87c4b2773eb13b93e47d3"
+    "sha512=87f73f2863eb2d8b7733024becb301dd4375ba0fbf2599024758c6a333fcd71db0ed497fb43905cfa75f80b54aab5acf5dbeffd37313a9df23213a50d346b69e"
+  ]
+}
+x-commit-hash: "edddfd7c210a6a46092de28337c6e2e50af1d0da"

--- a/packages/sail_coq_backend/sail_coq_backend.0.20/opam
+++ b/packages/sail_coq_backend/sail_coq_backend.0.20/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Coq translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20/sail-0.20.tbz"
+  checksum: [
+    "sha256=59399896d0ab364b7f39e493efd675c4c0b660380dd87c4b2773eb13b93e47d3"
+    "sha512=87f73f2863eb2d8b7733024becb301dd4375ba0fbf2599024758c6a333fcd71db0ed497fb43905cfa75f80b54aab5acf5dbeffd37313a9df23213a50d346b69e"
+  ]
+}
+x-commit-hash: "edddfd7c210a6a46092de28337c6e2e50af1d0da"

--- a/packages/sail_doc_backend/sail_doc_backend.0.20/opam
+++ b/packages/sail_doc_backend/sail_doc_backend.0.20/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Sail documentation generator"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "libsail" {= version}
+  "base64" {>= "3.1.0"}
+  "omd" {>= "1.3.1" & < "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20/sail-0.20.tbz"
+  checksum: [
+    "sha256=59399896d0ab364b7f39e493efd675c4c0b660380dd87c4b2773eb13b93e47d3"
+    "sha512=87f73f2863eb2d8b7733024becb301dd4375ba0fbf2599024758c6a333fcd71db0ed497fb43905cfa75f80b54aab5acf5dbeffd37313a9df23213a50d346b69e"
+  ]
+}
+x-commit-hash: "edddfd7c210a6a46092de28337c6e2e50af1d0da"

--- a/packages/sail_latex_backend/sail_latex_backend.0.20/opam
+++ b/packages/sail_latex_backend/sail_latex_backend.0.20/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to LaTeX formatting"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "libsail" {= version}
+  "omd" {>= "1.3.1" & < "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20/sail-0.20.tbz"
+  checksum: [
+    "sha256=59399896d0ab364b7f39e493efd675c4c0b660380dd87c4b2773eb13b93e47d3"
+    "sha512=87f73f2863eb2d8b7733024becb301dd4375ba0fbf2599024758c6a333fcd71db0ed497fb43905cfa75f80b54aab5acf5dbeffd37313a9df23213a50d346b69e"
+  ]
+}
+x-commit-hash: "edddfd7c210a6a46092de28337c6e2e50af1d0da"

--- a/packages/sail_lean_backend/sail_lean_backend.0.20/opam
+++ b/packages/sail_lean_backend/sail_lean_backend.0.20/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Lean translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20/sail-0.20.tbz"
+  checksum: [
+    "sha256=59399896d0ab364b7f39e493efd675c4c0b660380dd87c4b2773eb13b93e47d3"
+    "sha512=87f73f2863eb2d8b7733024becb301dd4375ba0fbf2599024758c6a333fcd71db0ed497fb43905cfa75f80b54aab5acf5dbeffd37313a9df23213a50d346b69e"
+  ]
+}
+x-commit-hash: "edddfd7c210a6a46092de28337c6e2e50af1d0da"

--- a/packages/sail_lem_backend/sail_lem_backend.0.20/opam
+++ b/packages/sail_lem_backend/sail_lem_backend.0.20/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Lem translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20/sail-0.20.tbz"
+  checksum: [
+    "sha256=59399896d0ab364b7f39e493efd675c4c0b660380dd87c4b2773eb13b93e47d3"
+    "sha512=87f73f2863eb2d8b7733024becb301dd4375ba0fbf2599024758c6a333fcd71db0ed497fb43905cfa75f80b54aab5acf5dbeffd37313a9df23213a50d346b69e"
+  ]
+}
+x-commit-hash: "edddfd7c210a6a46092de28337c6e2e50af1d0da"

--- a/packages/sail_manifest/sail_manifest.0.20/opam
+++ b/packages/sail_manifest/sail_manifest.0.20/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Helper tool for compiling Sail"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "4.08.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20/sail-0.20.tbz"
+  checksum: [
+    "sha256=59399896d0ab364b7f39e493efd675c4c0b660380dd87c4b2773eb13b93e47d3"
+    "sha512=87f73f2863eb2d8b7733024becb301dd4375ba0fbf2599024758c6a333fcd71db0ed497fb43905cfa75f80b54aab5acf5dbeffd37313a9df23213a50d346b69e"
+  ]
+}
+x-commit-hash: "edddfd7c210a6a46092de28337c6e2e50af1d0da"

--- a/packages/sail_ocaml_backend/sail_ocaml_backend.0.20/opam
+++ b/packages/sail_ocaml_backend/sail_ocaml_backend.0.20/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to OCaml translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "libsail" {= version}
+  "base64" {>= "3.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20/sail-0.20.tbz"
+  checksum: [
+    "sha256=59399896d0ab364b7f39e493efd675c4c0b660380dd87c4b2773eb13b93e47d3"
+    "sha512=87f73f2863eb2d8b7733024becb301dd4375ba0fbf2599024758c6a333fcd71db0ed497fb43905cfa75f80b54aab5acf5dbeffd37313a9df23213a50d346b69e"
+  ]
+}
+x-commit-hash: "edddfd7c210a6a46092de28337c6e2e50af1d0da"

--- a/packages/sail_output/sail_output.0.20/opam
+++ b/packages/sail_output/sail_output.0.20/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Example Sail output plugin"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20/sail-0.20.tbz"
+  checksum: [
+    "sha256=59399896d0ab364b7f39e493efd675c4c0b660380dd87c4b2773eb13b93e47d3"
+    "sha512=87f73f2863eb2d8b7733024becb301dd4375ba0fbf2599024758c6a333fcd71db0ed497fb43905cfa75f80b54aab5acf5dbeffd37313a9df23213a50d346b69e"
+  ]
+}
+x-commit-hash: "edddfd7c210a6a46092de28337c6e2e50af1d0da"

--- a/packages/sail_smt_backend/sail_smt_backend.0.20/opam
+++ b/packages/sail_smt_backend/sail_smt_backend.0.20/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to SMT translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20/sail-0.20.tbz"
+  checksum: [
+    "sha256=59399896d0ab364b7f39e493efd675c4c0b660380dd87c4b2773eb13b93e47d3"
+    "sha512=87f73f2863eb2d8b7733024becb301dd4375ba0fbf2599024758c6a333fcd71db0ed497fb43905cfa75f80b54aab5acf5dbeffd37313a9df23213a50d346b69e"
+  ]
+}
+x-commit-hash: "edddfd7c210a6a46092de28337c6e2e50af1d0da"

--- a/packages/sail_sv_backend/sail_sv_backend.0.20/opam
+++ b/packages/sail_sv_backend/sail_sv_backend.0.20/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Systemverilog translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20/sail-0.20.tbz"
+  checksum: [
+    "sha256=59399896d0ab364b7f39e493efd675c4c0b660380dd87c4b2773eb13b93e47d3"
+    "sha512=87f73f2863eb2d8b7733024becb301dd4375ba0fbf2599024758c6a333fcd71db0ed497fb43905cfa75f80b54aab5acf5dbeffd37313a9df23213a50d346b69e"
+  ]
+}
+x-commit-hash: "edddfd7c210a6a46092de28337c6e2e50af1d0da"


### PR DESCRIPTION
Sail is a language for describing the instruction semantics of processors

- Project page: <a href="https://github.com/rems-project/sail">https://github.com/rems-project/sail</a>

##### CHANGES:

In addition to bug-fixes and smaller improvements, the following
changes and improvements have been made to the language:

##### Rocq Semantics

The core stepwise semantics of Sail that are currently used by the
interactive REPL and during optimisation passes like constant-folding
are now implemented in Rocq and extracted to OCaml.

##### Improved C++ support

New C++ `--cpp` backend that is a variant of the Sail C backend. It
wraps the generated model in a struct, so when using C++ multiple
instances can be created.
PR: https://github.com/rems-project/sail/pull/1437

As part of the above work, Sail always generates a separate header
file for C or C++, meaning the `--c-generate-header` option is
redundant and deprecated.

The `--c-static` option has been removed.

Small fixes to the parsing of `-` and foreach loops. Slightly breaking
as `from`, `to`, and `downto` are now treated as proper keywords and
cannot be used as identifiers.

##### Other changes

Arguments can now be passed via the `SAIL_FLAGS` environment variable,
or via `SAIL_ENCODED_FLAGS`.
PR: https://github.com/rems-project/sail/pull/1374
