### PR TITLE
[new release] miou (0.5.0)

### DIFF
--- a/packages/miou/miou.0.5.0/opam
+++ b/packages/miou/miou.0.5.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/robur-coop/miou"
+bug-reports:  "https://github.com/robur-coop/miou/issues"
+dev-repo:     "git+https://github.com/robur-coop/miou.git"
+doc:          "https://docs.osau.re/miou/"
+license:      "MIT"
+synopsis:     "Composable concurrency primitives for OCaml"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"             {>= "5.0.0"}
+  "dune"              {>= "2.8.0"}
+  "dune-configurator"
+  "dscheck"           {with-test & >= "0.4.0"}
+  "digestif"          {with-test}
+  "happy-eyeballs"    {with-test & >= "0.6.0"}
+  "dns-client"        {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test}
+  "ipaddr"            {with-test}
+  "logs"              {with-test & >= "0.7.0"}
+  "dns"               {with-test}
+  "dns-client"        {with-test}
+  "mtime"             {with-test & >= "2.0.0"}
+  "ocamlformat"       {with-dev-setup & = "0.27.0"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/miou/releases/download/v0.5.0/miou-0.5.0.tbz"
+  checksum: [
+    "sha256=50aa6aa6767d3fe1875e35c69e4b1d92346a5f3a0349ac065f2efce6378c89c3"
+    "sha512=58736c04b4c5f11165fc04b7b1ffe7183852e994a3617cebc7ecaa6e88244b583712c3d04e5f82bc52241317b71c8c3262d188a6c8f398a3f7813c75a8fc52dd"
+  ]
+}
+x-commit-hash: "5311a91b2c4a8f49392c66109314e9bf0ddcb7d0"


### PR DESCRIPTION
Composable concurrency primitives for OCaml

- Project page: <a href="https://github.com/robur-coop/miou">https://github.com/robur-coop/miou</a>
- Documentation: <a href="https://docs.osau.re/miou/">https://docs.osau.re/miou/</a>

##### CHANGES:

- Use `poll(2)`/`ppoll(2)` instead of `select(3P)` (robur-coop/miou#75, @dinosaure, @haesbaert,
  @hannesm, @backtracking)

  `miou.unix` now uses the `poll(2)` or `ppoll(2)` function if available (the
  choice is determined at compilation). It replaces the use of `select(3P)` and
  improves performance. Miou no longer needs to build lists of file descriptors
  to observe, but instead manipulates a bitv and an array containing these file
  descriptors.

  The `bitv` implementation comes from the [bitv][bitv] library written by
  @backtracking, who kindly allowed us to relicense it under MIT.

  Finally, a special thanks to @haesbaert, who originally wrote
  [ocaml-iomux][iomux], which provides a portable implementation and an OCaml
  interface for using `poll(2)`/`ppoll(2)`.

  The use of `poll(2)`/`ppoll(2)` should improve performance, as noted in the
  PR, particularly with regard to our [httpcats][httpcats] HTTP server.

  It should be noted that `dune-configurator` has been added as a new dependency
  for Miou. However, support for `topkg`/`ocamlbuild` is still maintained (and
  it is possible to compile and install Miou with this build system).

- Synchronize `dom0` when one domain receive a signal (robur-coop/miou#78, @omegametabroccolo,
  @dinosaure, @reynir, partially fix robur-coop/miou#77)

- Add `Miou.Ownership.release` to disown and release a resource
  (@dinosaure, robur-coop/miou#79)
