### PR TITLE
[new release] ppx_import (1.12.0)

### DIFF
--- a/packages/ppx_import/ppx_import.1.12.0/opam
+++ b/packages/ppx_import/ppx_import.1.12.0/opam
@@ -14,7 +14,7 @@ depends: [
 | ("ocaml"                   {>= "4.10.0"}
    "ppx_sexp_conv" {with-test & >= "v0.13.0"})
   "dune"                    {              >= "1.11.0"  }
-  "ppxlib"                  {              >= "0.26.0"  }
+  "ppxlib"                  {              >= "0.34.0"  }
   "ounit"                   { with-test                 }
   "ppx_deriving"            { with-test  & >= "4.2.1"   }
 ]


### PR DESCRIPTION
A syntax extension for importing declarations from interface files

- Project page: <a href="https://github.com/ocaml-ppx/ppx_import">https://github.com/ocaml-ppx/ppx_import</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_import/">https://ocaml-ppx.github.io/ppx_import/</a>

##### CHANGES:

  * Support for OCaml 5.4 (ocaml-ppx/ppx_import#100, @octachron, backport ocaml-ppx/ppx_import#104, @egallego)
  * Support for OCaml 4.5, 4.6, and 4.7 has been removed (ocaml-ppx/ppx_import#104, @egallego)
