### PR TITLE
Add an OCaml 5.4 preview for ocamlformat

### DIFF
--- a/packages/ocamlformat-lib/ocamlformat-lib.0.27.0.1~5.4preview/opam
+++ b/packages/ocamlformat-lib/ocamlformat-lib.0.27.0.1~5.4preview/opam
@@ -63,5 +63,6 @@ url {
     "https://github.com/ocaml-ppx/ocamlformat/archive/1851bc47e2ba3ff79b66f967986a853c23bed445.tar.gz"
   checksum: [
     "md5=8c28d4ca2d66969e0a37dbb587bdc9b1"
+    "sha256=72fc8ff7638d86c7e002efc233ade5f39fe6ee1ab679c5db4e6709dc60a98eeb"
   ]
 }

--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.27.0.1~5.4preview/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.27.0.1~5.4preview/opam
@@ -45,5 +45,6 @@ url {
     "https://github.com/ocaml-ppx/ocamlformat/archive/1851bc47e2ba3ff79b66f967986a853c23bed445.tar.gz"
   checksum: [
     "md5=8c28d4ca2d66969e0a37dbb587bdc9b1"
+    "sha256=72fc8ff7638d86c7e002efc233ade5f39fe6ee1ab679c5db4e6709dc60a98eeb"
   ]
 }

--- a/packages/ocamlformat/ocamlformat.0.27.0.1~5.4preview/opam
+++ b/packages/ocamlformat/ocamlformat.0.27.0.1~5.4preview/opam
@@ -54,5 +54,6 @@ url {
     "https://github.com/ocaml-ppx/ocamlformat/archive/1851bc47e2ba3ff79b66f967986a853c23bed445.tar.gz"
   checksum: [
     "md5=8c28d4ca2d66969e0a37dbb587bdc9b1"
+    "sha256=72fc8ff7638d86c7e002efc233ade5f39fe6ee1ab679c5db4e6709dc60a98eeb"
   ]
 }


### PR DESCRIPTION
cc @Julow 

To give the ocamlformat maintainer more time to do a proper release of ocamlformat i'm proposing to add this preview package (same deal as with the ppxlib and merlin preview packages)

Note: I've used the older version that has been available in opam-alpha-repository for a while out of caution.