### PR TITLE
Add upper bound on ppxlib.0.36.2 for ppx_yojson tests

### DIFF
--- a/packages/ppx_yojson/ppx_yojson.1.3.0/opam
+++ b/packages/ppx_yojson/ppx_yojson.1.3.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "alcotest" {with-test}
   "ppxlib" {>= "0.18.0"}
-  "ppxlib" {with-test & >= "0.26.0"}
+  "ppxlib" {with-test & >= "0.26.0" & < "0.36.2"}
   "ezjsonm" {with-test}
   "yojson" {with-test & >= "1.6.0"}
   "odoc" {with-doc}


### PR DESCRIPTION
`ppx_yojson` tests do not pass when using ppxlib.0.36.2 or higher, due to a slight change in the source output.

See #28686 and #28610. 