### PR TITLE
Mark the 5.4 preview packages unavailable

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.5.4.2~5.4preview/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.4.2~5.4preview/opam
@@ -14,8 +14,7 @@ depends: [
   "merlin-lib" {= version}
   "ocamlfind" {>= "1.6.0"}
 ]
-available: opam-version >= "2.1.0"
-flags: avoid-version
+available: false
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/merlin-lib/merlin-lib.5.4.2~5.4preview/opam
+++ b/packages/merlin-lib/merlin-lib.5.4.2~5.4preview/opam
@@ -18,8 +18,7 @@ depends: [
   "menhirLib" {dev & >= "20201216"}
   "menhirSdk" {dev & >= "20201216"}
 ]
-available: opam-version >= "2.1.0"
-flags: avoid-version
+available: false
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/merlin/merlin.5.4.2~5.4preview/opam
+++ b/packages/merlin/merlin.5.4.2~5.4preview/opam
@@ -20,8 +20,7 @@ depends: [
 conflicts: [
   "seq" {!= "base"}
 ]
-available: opam-version >= "2.1.0"
-flags: avoid-version
+available: false
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/ocaml-index/ocaml-index.5.4.2~5.4preview/opam
+++ b/packages/ocaml-index/ocaml-index.5.4.2~5.4preview/opam
@@ -13,8 +13,7 @@ depends: [
   "merlin-lib" {= version}
   "odoc" {with-doc}
 ]
-available: opam-version >= "2.1.0"
-flags: avoid-version
+available: false
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.22.1~5.4preview/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.22.1~5.4preview/opam
@@ -47,8 +47,7 @@ depends: [
   "merlin-lib" {>= "5.4" & < "6.0"}
   "ppx_yojson_conv" {with-dev-setup}
 ]
-available: opam-version >= "2.1.0"
-flags: avoid-version
+available: false
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]

--- a/packages/ppxlib/ppxlib.0.37.0~5.4preview/opam
+++ b/packages/ppxlib/ppxlib.0.37.0~5.4preview/opam
@@ -53,8 +53,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
 x-maintenance-intent: ["(latest)"]
-flags: avoid-version
-available: opam-version >= "2.1.0"
+available: false
 url {
   src: "https://github.com/ocaml-ppx/ppxlib/archive/757f6c284b1fe748d5027eef3bbef924b6bbd7ce.tar.gz"
   checksum: [


### PR DESCRIPTION
This should be safe to do now that they have all been officially released