### PR TITLE
OCaml 5.4 reference manual: update for the new chapter on debuggers

### DIFF
--- a/packages/ocaml-manual/ocaml-manual.5.4.0-1/opam
+++ b/packages/ocaml-manual/ocaml-manual.5.4.0-1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "Xavier Leroy"
+           "Damien Doligez"
+           "Alain Frisch"
+           "Jacques Garrigue"
+           "Didier Rémy"
+           "Jérôme Vouillon" ]
+homepage: "http://ocaml.org/"
+doc: "https://ocaml.org/manual/"
+license: "CC-BY-SA-4.0"
+dev-repo: "git+https://github.com/ocaml/ocaml.git"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+install: ["cp" "-R" "." _:doc]
+synopsis: "The OCaml system manual"
+depends: [
+  "ocaml" {= "5.4.0"}
+]
+url {
+  src: "http://caml.inria.fr/distrib/ocaml-5.4/ocaml-5.4-refman-html-1.tar.gz"
+  checksum: "sha256=295acd6d95bc5c6f844692b856a7b3e53b23301ab3fabca3ab46ac77fc236484"
+}


### PR DESCRIPTION
This PR adds an amended `ocaml-manual.5.4.0-1` package which points toward the amended version of the OCaml reference manual which contains the new chapter on native debuggers; which was added late in the release cycle and that I had forgotten to backport to the 5.4 manual before the release.