### PR TITLE
Package ninja_utils.1.0.0

### DIFF
--- a/packages/ninja_utils/ninja_utils.1.0.0/opam
+++ b/packages/ninja_utils/ninja_utils.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Small library used to generate Ninja build files"
+description:
+  "This library contains the implementations of utility functions used to generate Ninja build files -- see https://ninja-build.org. It's currently used by the Catala build system (see https://github.com/CatalaLang/catala/tree/master/build_system)"
+maintainer: ["contact@catala-lang.org"]
+authors: ["Emile Rolley"]
+license: "Apache-2.0"
+homepage: "https://github.com/CatalaLang/ninja_utils"
+bug-reports: "https://github.com/CatalaLang/ninja_utils/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.12.0"}
+  "re" {>= "1.10.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CatalaLang/ninja_utils.git"
+url {
+  src:
+    "https://github.com/CatalaLang/ninja_utils/archive/refs/tags/1.0.0.tar.gz"
+  checksum: [
+    "md5=e71fe8fc11e3a25d6b0b742105035766"
+    "sha512=6a3cd306742600eb5efc0b3bff8272a0948363ed1ff85ac76d45ebfafd0f188d86aea3103fa8cf72b6c4c97b9fbf19a27da1e3600273072f671e553b270698db"
+  ]
+}


### PR DESCRIPTION
### `ninja_utils.1.0.0`
Small library used to generate Ninja build files
This library contains the implementations of utility functions used to generate Ninja build files -- see https://ninja-build.org. It's currently used by the Catala build system (see https://github.com/CatalaLang/catala/tree/master/build_system)



---
* Homepage: https://github.com/CatalaLang/ninja_utils
* Source repo: git+https://github.com/CatalaLang/ninja_utils.git
* Bug tracker: https://github.com/CatalaLang/ninja_utils/issues

---
:camel: Pull-request generated by opam-publish v2.5.1