### PR TITLE
Revert "conf-ninja: Use the upstream implementation on Alpine instead of samurai"

### DIFF
--- a/packages/conf-ninja/conf-ninja.1/opam
+++ b/packages/conf-ninja/conf-ninja.1/opam
@@ -5,7 +5,8 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Apache-2.0"
 build: ["ninja" "--version"]
 depexts: [
-  ["ninja-build"] {os-family = "debian" | os-family = "ubuntu" | os-family = "fedora" | os-distribution = "ol" | os-family = "alpine"}
+  ["ninja-build"] {os-family = "debian" | os-family = "ubuntu" | os-family = "fedora" | os-distribution = "ol"}
+  ["samurai"] {os-distribution = "alpine"}
   ["ninja"] {os-family = "arch" | os-family = "suse" | os-family = "opensuse" | os-family = "bsd"}
   ["ninja"] {os = "macos" & ( os-distribution = "homebrew" | os-distribution = "macports" )}
 ]


### PR DESCRIPTION
Reverts ocaml/opam-repository#28365

Per https://github.com/ocaml/opam-repository/pull/28723#issuecomment-3415700048