### PR TITLE
Package rocq-rouche-capelli.0.1.0

### DIFF
--- a/packages/rocq-rouche-capelli/rocq-rouche-capelli.0.1.0/opam
+++ b/packages/rocq-rouche-capelli/rocq-rouche-capelli.0.1.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "A proof for the Rouché–Capelli theorem by rocq-math-comp"
+description: """
+This package provides a formal proof of the Rouché–Capelli theorem (also known as
+the Kronecker–Capelli theorem) using the Rocq Prover and the Mathematical Components
+library. The theorem provides necessary and sufficient conditions for a system of
+linear equations to have solutions, stating that a system is consistent if and only
+if the rank of its coefficient matrix equals the rank of its augmented matrix.
+"""
+maintainer: "Chenghui Weng <144981080+weng-chenghui@users.noreply.github.com>"
+authors: [
+  "Cheng-Hui Weng"
+  "Reynald Affeldt"
+  "Jacques Garrigue"
+  "Takafumi Saikawa"
+]
+license: "MIT"
+homepage: "https://github.com/weng-chenghui/rocq-rouche-capelli"
+bug-reports: "https://github.com/weng-chenghui/rocq-rouche-capelli/issues"
+dev-repo: "git+https://github.com/weng-chenghui/rocq-rouche-capelli.git"
+tags: [
+  "category:Mathematics/Algebra"
+  "keyword:linear algebra"
+  "keyword:matrix"
+  "keyword:rank"
+  "logpath:RoucheCapelli"
+]
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "rocq-core" {= "9.0.0"}
+  "coq-mathcomp-ssreflect" {= "2.4.0"}
+  "coq-mathcomp-algebra" {= "2.4.0"}
+  "coq-mathcomp-field" {= "2.4.0"}
+  "coq-mathcomp-fingroup" {= "2.4.0"}
+  "coq-mathcomp-finmap" {>= "2.1.0"}
+  "coq-mathcomp-solvable" {= "2.4.0"}
+  "coq-mathcomp-classical" {= "1.13.0"}
+]
+build: [
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile.coq"]
+  ["%{make}%" "-f" "Makefile.coq" "-j%{jobs}%"]
+]
+install: [
+  ["%{make}%" "-f" "Makefile.coq" "install"]
+]
+url {
+  src:
+    "https://github.com/weng-chenghui/rocq-rouche-capelli/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=4a1ae9eb8160ec1b5ccf7979bb4152a0"
+    "sha512=9d8fde0cbd0334855ae50136ead2e09f2d49d36e5085e3deb39c824384a7c95bb9eb4153ec4f9d41bc1a8712decbff5b5286ce5c1daef260fec34e75e49c32e3"
+  ]
+}


### PR DESCRIPTION
### `rocq-rouche-capelli.0.1.0`
A proof for the Rouché–Capelli theorem by rocq-math-comp
This package provides a formal proof of the Rouché–Capelli theorem (also known as
the Kronecker–Capelli theorem) using the Rocq Prover and the Mathematical Components
library. The theorem provides necessary and sufficient conditions for a system of
linear equations to have solutions, stating that a system is consistent if and only
if the rank of its coefficient matrix equals the rank of its augmented matrix.



---
* Homepage: https://github.com/weng-chenghui/rocq-rouche-capelli
* Source repo: git+https://github.com/weng-chenghui/rocq-rouche-capelli.git
* Bug tracker: https://github.com/weng-chenghui/rocq-rouche-capelli/issues

---
:camel: Pull-request generated by opam-publish v2.6.0