### PR TITLE
Restore `--strict` operation

### DIFF
--- a/packages/catala/catala.1.0.0~alpha/opam
+++ b/packages/catala/catala.1.0.0~alpha/opam
@@ -42,14 +42,14 @@ depends: [
   "alcotest" {>= "1.5.0"}
   "ninja_utils" {= "0.9.0"}
   "odoc" {with-doc}
-  "ocamlformat" {cataladevmode & = "0.26.0"}
-  "obelisk" {cataladevmode}
-  "conf-npm" {cataladevmode}
-  "conf-python-3-dev" {cataladevmode}
-  "conf-openjdk" {cataladevmode}
-  "cpdf" {cataladevmode}
-  "conf-pandoc" {cataladevmode}
-  "z3" {catalaz3mode}
+  "ocamlformat" {?cataladevmode & cataladevmode & = "0.26.0"}
+  "obelisk" {?cataladevmode & cataladevmode}
+  "conf-npm" {?cataladevmode & cataladevmode}
+  "conf-python-3-dev" {?cataladevmode & cataladevmode}
+  "conf-openjdk" {?cataladevmode & cataladevmode}
+  "cpdf" {?cataladevmode & cataladevmode}
+  "conf-pandoc" {?cataladevmode & cataladevmode}
+  "z3" {?catalaz3mode & catalaz3mode}
   "conf-ninja"
   "otoml" {>= "1.0"}
 ]
@@ -71,9 +71,9 @@ build: [
 ]
 depexts: [
   ["groff"] {with-doc}
-  ["python3-pip"] {cataladevmode & os-family = "debian"}
-  ["py3-pip" "py3-pygments"] {cataladevmode & os-distribution = "alpine"}
-  ["python-pygments"] {cataladevmode & os-family = "arch"}
+  ["python3-pip"] {?cataladevmode & cataladevmode & os-family = "debian"}
+  ["py3-pip" "py3-pygments"] {?cataladevmode & cataladevmode & os-distribution = "alpine"}
+  ["python-pygments"] {?cataladevmode & cataladevmode & os-family = "arch"}
 ]
 dev-repo: "git+https://github.com/CatalaLang/catala"
 url {


### PR DESCRIPTION
The `cataladev` and `catalaz3mode` variables in #28564 mean that the repository at the moment can't be used with `--strict` operations. This PR restores that.

cf. https://github.com/ocaml/opam/issues/5722 and https://github.com/ocaml/opam/issues/5248
cf. https://github.com/CatalaLang/catala/pull/895
cc @AltGr