### PR TITLE
Add conf-mbedtls.4.0.0

### DIFF
--- a/packages/conf-mbedtls/conf-mbedtls.4.0.0/opam
+++ b/packages/conf-mbedtls/conf-mbedtls.4.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+authors: "Mbedtls contributors"
+maintainer: "Andy Li <andy@onthewings.net>"
+homepage: "https://www.trustedfirmware.org/projects/mbed-tls/"
+bug-reports: "https://github.com/Mbed-TLS/mbedtls/issues"
+license: "Apache-2.0"
+available: os-distribution != "cygwin"
+build: [
+ "pkgconf" {os = "win32" & os-distribution = "cygwin"}
+  "--personality=x86_64-w64-mingw32"
+    {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
+  "pkg-config" {os != "win32" | os-distribution != "cygwin"}
+  "--atleast-version=4.0.0"
+  "mbedtls"
+]
+depends: [
+  "conf-pkg-config" {build}
+  "host-arch-x86_64" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}
+  "conf-mingw-w64-mbedtls-x86_64" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}
+]
+depexts: [
+  ["mbedtls-dev"] {os-distribution = "alpine"}
+  ["libmbedtls-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["mbedtls-devel"] {os-family = "fedora"}
+  ["mbedtls-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["mbedtls-devel" "epel-release"] {os-distribution = "centos"}
+  ["mbedtls"] {os-distribution = "nixos"}
+  ["mbedtls"] {os-distribution = "homebrew" & os = "macos"}
+  ["mbedtls"] {os-distribution = "arch"}
+  ["mbedtls"] {os = "freebsd"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-7"
+  "oraclelinux-8"
+  "oraclelinux-9"
+]
+synopsis: "Virtual package relying on an mbedtls 4.0.0 system installation"
+description: "This package can only install if mbedtls 4.0.0 is installed on the system."
+flags: conf


### PR DESCRIPTION
This takes the `mbedtls.2` opam file and adds a new package that checks that the `mbedtls >= 4.0.0` depext is installed (modelled after the  the `conf-zstd.1.3.8` package). Note that this is expected to fail [mostly everywhere](https://repology.org/project/mbedtls/versions) as the release is quite new.