### PR TITLE
diffast-langs-common: add upper bound on ocaml 5.4

### DIFF
--- a/packages/diffast-langs-common/diffast-langs-common.0.1.1/opam
+++ b/packages/diffast-langs-common/diffast-langs-common.0.1.1/opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/codinuum/diffast"
 doc: "https://github.com/codinuum/diffast/README.md"
 bug-reports: "https://github.com/codinuum/diffast/issues"
 depends: [
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.14" & < "5.4"}
   "dune" {>= "3.17"}
   "sedlex" {>= "3.3"}
   "menhirLib"

--- a/packages/diffast-langs-common/diffast-langs-common.0.1/opam
+++ b/packages/diffast-langs-common/diffast-langs-common.0.1/opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/codinuum/diffast"
 doc: "https://github.com/codinuum/diffast/README.md"
 bug-reports: "https://github.com/codinuum/diffast/issues"
 depends: [
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.14" & < "5.4"}
   "dune" {>= "3.17"}
   "sedlex" {>= "3.3"}
   "menhirLib"

--- a/packages/diffast-langs-common/diffast-langs-common.0.2/opam
+++ b/packages/diffast-langs-common/diffast-langs-common.0.2/opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/codinuum/diffast"
 doc: "https://github.com/codinuum/diffast/README.md"
 bug-reports: "https://github.com/codinuum/diffast/issues"
 depends: [
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.14" & < "5.4"}
   "dune" {>= "3.17"}
   "sedlex" {>= "3.3"}
   "menhirLib"

--- a/packages/diffast-langs-common/diffast-langs-common.0.3.5.1/opam
+++ b/packages/diffast-langs-common/diffast-langs-common.0.3.5.1/opam
@@ -17,7 +17,7 @@ doc: "https://github.com/codinuum/diffast/README.md"
 bug-reports: "https://github.com/codinuum/diffast/issues"
 x-maintenance-intent: ["(latest)"]
 depends: [
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.14" & < "5.4"}
   "dune" {>= "3.17"}
   "sedlex" {>= "3.3"}
   "menhirLib"


### PR DESCRIPTION
```
#=== ERROR while compiling diffast-langs-common.0.3.5.1 =======================#
# context              2.4.1 | linux/x86_64 | ocaml-base-compiler.5.4.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.4/.opam-switch/build/diffast-langs-common.0.3.5.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p diffast-langs-common -j 71 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/diffast-langs-common-8-100663.env
# output-file          ~/.opam/log/diffast-langs-common-8-100663.out
### output ###
# (cd _build/default/src/api/dev && /usr/bin/git describe --always --dirty) > _build/default/src/api/dev/v
# fatal: not a git repository (or any parent up to mount point /)
# Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlopt.opt -w -40 -O3 -I src/langs-common/.langs_common.objs/byte -I src/langs-common/.langs_common.objs/native -I /home/opam/.opam/5.4/lib/base64/rfc2045 -I /home/opam/.opam/5.4/lib/bytesrw -I /home/opam/.opam/5.4/lib/bytesrw/zlib -I /home/opam/.opam/5.4/lib/cryptokit -I /home/opam/.opam/5.4/lib/diffast-misc -I /home/opam/.opam/5.4/lib/gen -I /home/opam/.opam/5.4/lib/markup -I /home/opam/.opam/5.4/lib/menhirLib -I /home/opam/.opam/5.4/lib/ocaml/dynlink -I /home/opam/.opam/5.4/lib/ocaml/str -I /home/opam/.opam/5.4/lib/ocaml/unix -I /home/opam/.opam/5.4/lib/sedlex -I /home/opam/.opam/5.4/lib/seq -I /home/opam/.opam/5.4/lib/uutf -I /home/opam/.opam/5.4/lib/vlt -I /home/opam/.opam/5.4/lib/zarith -cmi-file src/langs-common/.langs_common.objs/byte/langs_common__Unparsing_base.cmi -no-alias-deps -open Langs_common -o src/langs-common/.langs_common.objs/native/langs_common__Unparsing_base.cmx -c -impl src/langs-common/common/unparsing_base.pp.ml)
# File "src/langs-common/common/unparsing_base.ml", lines 144-149, characters 13-14:
# 144 | .............{ Format.out_string  = out_string;
# 145 |                Format.out_flush   = orig_functions.Format.out_flush;
# 146 |                Format.out_newline = out_newline;
# 147 |                Format.out_spaces  = orig_functions.Format.out_spaces;
# 148 |                Format.out_indent  = orig_functions.Format.out_indent;
# 149 |              }
# Error: Some record fields are undefined: out_width
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/langs-common/.langs_common.objs/byte -I /home/opam/.opam/5.4/lib/base64/rfc2045 -I /home/opam/.opam/5.4/lib/bytesrw -I /home/opam/.opam/5.4/lib/bytesrw/zlib -I /home/opam/.opam/5.4/lib/cryptokit -I /home/opam/.opam/5.4/lib/diffast-misc -I /home/opam/.opam/5.4/lib/gen -I /home/opam/.opam/5.4/lib/markup -I /home/opam/.opam/5.4/lib/menhirLib -I /home/opam/.opam/5.4/lib/ocaml/dynlink -I /home/opam/.opam/5.4/lib/ocaml/str -I /home/opam/.opam/5.4/lib/ocaml/unix -I /home/opam/.opam/5.4/lib/sedlex -I /home/opam/.opam/5.4/lib/seq -I /home/opam/.opam/5.4/lib/uutf -I /home/opam/.opam/5.4/lib/vlt -I /home/opam/.opam/5.4/lib/zarith -cmi-file src/langs-common/.langs_common.objs/byte/langs_common__Unparsing_base.cmi -no-alias-deps -open Langs_common -o src/langs-common/.langs_common.objs/byte/langs_common__Unparsing_base.cmo -c -impl src/langs-common/common/unparsing_base.pp.ml)
# File "src/langs-common/common/unparsing_base.ml", lines 144-149, characters 13-14:
# 144 | .............{ Format.out_string  = out_string;
# 145 |                Format.out_flush   = orig_functions.Format.out_flush;
# 146 |                Format.out_newline = out_newline;
# 147 |                Format.out_spaces  = orig_functions.Format.out_spaces;
# 148 |                Format.out_indent  = orig_functions.Format.out_indent;
# 149 |              }
# Error: Some record fields are undefined: out_width
```

Signed-off-by: Marcello Seri