### PR TITLE
2 packages from huml-lang/huml-ml at 0.1.1

### DIFF
--- a/packages/huml-cli/huml-cli.0.1.1/opam
+++ b/packages/huml-cli/huml-cli.0.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Command line interface for Huml parser"
+description: "Command line interface for Huml parser"
+maintainer: "Kaustubh M <ktvm42@gmail.com>"
+authors: "Kaustubh M <ktvm42@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/nikochiko/huml-ml"
+doc: "https://github.com/nikochiko/huml-ml"
+bug-reports: "https://github.com/nikochiko/huml-ml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml"
+  "huml" {= version}
+  "yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/nikochiko/huml-ml.git"
+url {
+  src:
+    "https://github.com/huml-lang/huml-ml/releases/download/0.1.1/huml-0.1.1.tar.gz"
+  checksum: [
+    "md5=6110742ac994d03ac675f095614c4ada"
+    "sha512=f382fded5ffa2ab8781d174e2338698fa43c818902d88525a11bbe1d0772b48c6316dc746c8507fc8a95c4f2abacffeda7ef0f1ac699433e329173d49937b80b"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/huml/huml.0.1.1/opam
+++ b/packages/huml/huml.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "OCaml parser for the Huml markup language"
+description: "OCaml parser for the Huml markup language"
+maintainer: "Kaustubh M <ktvm42@gmail.com>"
+authors: "Kaustubh M <ktvm42@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/nikochiko/huml-ml"
+doc: "https://github.com/nikochiko/huml-ml"
+bug-reports: "https://github.com/nikochiko/huml-ml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml"
+  "menhir" {>= "20180523"}
+  "alcotest" {with-test}
+  "yojson" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/nikochiko/huml-ml.git"
+url {
+  src:
+    "https://github.com/huml-lang/huml-ml/releases/download/0.1.1/huml-0.1.1.tar.gz"
+  checksum: [
+    "md5=6110742ac994d03ac675f095614c4ada"
+    "sha512=f382fded5ffa2ab8781d174e2338698fa43c818902d88525a11bbe1d0772b48c6316dc746c8507fc8a95c4f2abacffeda7ef0f1ac699433e329173d49937b80b"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `huml.0.1.1`: OCaml parser for the Huml markup language
- `huml-cli.0.1.1`: Command line interface for Huml parser



---
* Homepage: https://github.com/nikochiko/huml-ml
* Source repo: git+https://github.com/nikochiko/huml-ml.git
* Bug tracker: https://github.com/nikochiko/huml-ml/issues

---
:camel: Pull-request generated by opam-publish v2.6.0