### PR TITLE
Package pageantty.0.0.3

### DIFF
--- a/packages/pageantty/pageantty.0.0.3/opam
+++ b/packages/pageantty/pageantty.0.0.3/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Run a pager to display diffs and other outputs in the terminal"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/git-pager"
+doc: "https://mbarbin.github.io/git-pager/"
+bug-reports: "https://github.com/mbarbin/git-pager/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "pp" {>= "2.0.0"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/git-pager.git"
+description: """\
+
+[pageantty] provides utility libraries for running pagers in the
+terminal.
+
+It includes [Git_pager], a small one-module library for displaying
+Git diffs and other custom outputs in a terminal pager.
+
+This is useful for tools that integrate with Git and need to display
+output exceeding one screen, while respecting user color preferences
+and Git's configuration.
+
+"""
+tags: [ "git" "pager" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/git-pager/releases/download/0.0.3/pageantty-0.0.3.tbz"
+  checksum: [
+    "sha256=6b32385d8f487a3f9a63aeb37f49924c826a8a47e5ec370ee8b0011a41ca3acd"
+    "sha512=c242703ab3be71615156cf4cde13c6b4b07d01742d0bbb178059138ba4819c8d0a474c9d31db8521dae821aafe9f24ffc375872e7f30cd1de72a36f1441a4c19"
+  ]
+}
+x-commit-hash: "02010cb8504b2706baaf5a2b114b2b16ec1f4e30"


### PR DESCRIPTION
### `pageantty.0.0.3`
Run a pager to display diffs and other outputs in the terminal
[pageantty] provides utility libraries for running pagers in the
terminal.

It includes [Git_pager], a small one-module library for displaying
Git diffs and other custom outputs in a terminal pager.

This is useful for tools that integrate with Git and need to display
output exceeding one screen, while respecting user color preferences
and Git's configuration.



---
* Homepage: https://github.com/mbarbin/git-pager
* Source repo: git+https://github.com/mbarbin/git-pager.git
* Bug tracker: https://github.com/mbarbin/git-pager/issues

---
## 0.0.3 (2025-10-07)

This is a small upgrade with no change to the code itself, which reduces the number of transitive dependencies required by the package.

This will help with:

- the release of downstream libraries depending on the git-pager;
- eventually being able to deprecate the `pplumbing` meta package, was was broken down into smaller specialized packages to isolate dependencies.

### Changed

- Switch to `pplumbing-${SUB_PKG}` dependencies ([#8](https://github.com/mbarbin/git-pager/pull/8), @mbarbin).


---
:camel: Pull-request generated by opam-publish v2.7.0