### PR TITLE
[new release] ocamlformat-lib, ocamlformat and ocamlformat-rpc-lib (0.28.0)

### DIFF
--- a/packages/ocamlformat-lib/ocamlformat-lib.0.28.0/opam
+++ b/packages/ocamlformat-lib/ocamlformat-lib.0.28.0/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis: "OCaml Code Formatter"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: [
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+  "Emile Trotignon <emile@tarides.com>"
+]
+authors: [
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "alcotest" {with-test & >= "1.3.0"}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.8"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath" {>= "0.7.3"}
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.5.0"}
+  "ocamlformat-rpc-lib" {with-test & = version}
+  "ocp-indent" {with-test = "false" & >= "1.8.0" | with-test & >= "1.8.1"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "astring"
+  "camlp-streams"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+# OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.28.0/ocamlformat-0.28.0.tbz"
+  checksum: [
+    "sha256=e8c56b5b7f1c7b6b4c1827980b7591356dac93985175859e6088aa39f773bed0"
+    "sha512=934cc1e70a0e6cc7e30228d17cd0438b6bb500532cfe352ac2e2919f84f0bb9539813c8fc941e34609046b7cf1301c72a36bd87b69350222ff81f6c6501d06be"
+  ]
+}
+x-commit-hash: "ca452510f87fd2a6805a46f0228ac2eb43eaf517"

--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.28.0/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.28.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: [
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+  "Emile Trotignon <emile@tarides.com>"
+]
+authors: [
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08"}
+  "csexp" {>= "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.28.0/ocamlformat-0.28.0.tbz"
+  checksum: [
+    "sha256=e8c56b5b7f1c7b6b4c1827980b7591356dac93985175859e6088aa39f773bed0"
+    "sha512=934cc1e70a0e6cc7e30228d17cd0438b6bb500532cfe352ac2e2919f84f0bb9539813c8fc941e34609046b7cf1301c72a36bd87b69350222ff81f6c6501d06be"
+  ]
+}
+x-commit-hash: "ca452510f87fd2a6805a46f0228ac2eb43eaf517"

--- a/packages/ocamlformat/ocamlformat.0.28.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.28.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description: """
+**ocamlformat** is a code formatter for OCaml. It comes with opinionated default settings but is also fully customizable to suit your coding style.
+
+- **Profiles:** ocamlformat offers profiles we predefined formatting configurations. Profiles include `default`, `ocamlformat`, `janestreet`.
+- **Configurable:** Users can change the formatting profile and configure every option in their `.ocamlformat` configuration file.
+- **Format Comments:** ocamlformat can format comments, docstrings, and even code blocks in your comments.
+- **RPC:** ocamlformat provides an RPC server that can be used by other tools to easily format OCaml Code."""
+maintainer: [
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+  "Emile Trotignon <emile@tarides.com>"
+]
+authors: [
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "cmdliner" {with-test = "false" & >= "1.1.0" | with-test & >= "1.2.0"}
+  "csexp" {>= "1.4.0"}
+  "dune" {>= "2.8"}
+  "ocamlformat-lib" {= version}
+  "ocamlformat-rpc-lib" {with-test & = version}
+  "re" {>= "1.10.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+# OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.28.0/ocamlformat-0.28.0.tbz"
+  checksum: [
+    "sha256=e8c56b5b7f1c7b6b4c1827980b7591356dac93985175859e6088aa39f773bed0"
+    "sha512=934cc1e70a0e6cc7e30228d17cd0438b6bb500532cfe352ac2e2919f84f0bb9539813c8fc941e34609046b7cf1301c72a36bd87b69350222ff81f6c6501d06be"
+  ]
+}
+x-commit-hash: "ca452510f87fd2a6805a46f0228ac2eb43eaf517"


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

### Highlight

- \* Support for OCaml 5.4 (ocaml-ppx/ocamlformat#2717, ocaml-ppx/ocamlformat#2720, @Julow, @Octachron)
  OCamlformat now supports OCaml 5.4 syntax.
  Module packing of the form `((module M) : (module S))` are no longer
  rewritten to `(module M : S)` because these are now two different syntaxes.

- \* Reduce indentation after `|> map (fun` (ocaml-ppx/ocamlformat#2694, @EmileTrotignon)
  Notably, the indentation no longer depends on the length of the infix
  operator, for example:
  ```ocaml
  (* before *)
  v
  |>>>>>> map (fun x ->
              x )
  (* after *)
  v
  |>>>>>> map (fun x ->
      x )
  ```
  `@@ match` can now also be on one line.

### Added

- Added option `module-indent` option (ocaml-ppx/ocamlformat#2711, @HPRIOR) to control the indentation
  of items within modules. This affects modules and signatures. For example,
  module-indent=4:
  ```ocaml
  module type M = sig
      type t

      val f : (string * int) list -> int
  end
  ```

- `exp-grouping=preserve` is now the default in `default` and `ocamlformat`
  profiles. This means that its now possible to use `begin ... end` without
  tweaking ocamlformat. (ocaml-ppx/ocamlformat#2716, @EmileTrotignon)

### Deprecated

- Starting in this release, ocamlformat can use cmdliner >= 2.0.0. When that is
  the case, the tool no longer accepts unambiguous option names prefixes. For
  example, `--max-iter` is not accepted anymore, you have to pass the full
  option `--max-iters`. This does not apply to the keys in the `.ocamlformat`
  configuration files, which have always required the full name.
  See dbuenzli/cmdliner#200.
  (ocaml-ppx/ocamlformat#2680, @emillon)

### Changed

- \* The formatting of infix extensions is now consistent with regular
  formatting by construction. This reduces indentation in `f @@ match%e`
  expressions to the level of indentation in `f @@ match`. Other unknown
  inconsistencies might also be fixed. (ocaml-ppx/ocamlformat#2676, @EmileTrotignon)

- \* The spacing of infix attributes is now consistent across keywords. Every
  keyword but `begin` `function`, and `fun` had attributes stuck to the keyword:
  `match[@a]`, but `fun [@a]`. Now its also `fun[@a]`. (ocaml-ppx/ocamlformat#2676, @EmileTrotignon)

- \* The formatting of`let a = b in fun ...` is now consistent with other
  contexts like `a ; fun ...`. A check for the syntax `let a = fun ... in ...`
  was made more precise. (ocaml-ppx/ocamlformat#2705, @EmileTrotignon)

- \* `|> begin`, `~arg:begin`, `begin if`, `lazy begin`, `begin match`,
  `begin fun` and `map li begin fun`  can now be printed on the same line, with
  one less indentation level for the body of the inner expression.
  (ocaml-ppx/ocamlformat#2664, ocaml-ppx/ocamlformat#2666, ocaml-ppx/ocamlformat#2671, ocaml-ppx/ocamlformat#2672, ocaml-ppx/ocamlformat#2681, ocaml-ppx/ocamlformat#2685, ocaml-ppx/ocamlformat#2693, @EmileTrotignon)
  For example :
  ```ocaml
  (* before *)
  begin
    fun x ->
      some code
  end
  (* after *)
  begin fun x ->
    some code
  end
  ```

- \* `break-struct=natural` now also applies to `sig ... end`. (ocaml-ppx/ocamlformat#2682, @EmileTrotignon)

### Fixed

- Fixed `wrap-comments=true` not working with the janestreet profile (ocaml-ppx/ocamlformat#2645, @Julow)
  Asterisk-prefixed comments are also now formatted the same way as with the
  default profile.

- Fixed `nested-match=align` not working with `match%ext` (ocaml-ppx/ocamlformat#2648, @EmileTrotignon)

- Fixed the AST generated for bindings of the form `let pattern : type = function ...`
  (ocaml-ppx/ocamlformat#2651, @v-gb)

- Print valid syntax for the corner case (1).a (ocaml-ppx/ocamlformat#2653, @v-gb)

- `Ast_mapper.default_mapper` now iterates on the location of `in` in `let+ .. in ..`
  (ocaml-ppx/ocamlformat#2658, @v-gb)

- Fix missing parentheses in `let+ (Cstr _) : _ = _` (ocaml-ppx/ocamlformat#2661, @Julow)
  This caused a crash as the generated code wasn't valid syntax.

- Fix bad indentation of `let%ext { ...` (ocaml-ppx/ocamlformat#2663, @EmileTrotignon)
  with `dock-collection-brackets` enabled.

- ocamlformat is now more robust when used as a library to print modified ASTs
  (ocaml-ppx/ocamlformat#2659, @v-gb)

- Fix crash due to edge case with asterisk-prefixed comments (ocaml-ppx/ocamlformat#2674, @Julow)

- Fix crash when formatting `mld` files that cannot be lexed as ocaml (e.g.
  containing LaTeX or C code) (ocaml-ppx/ocamlformat#2684, @emillon)

- \* Fix double parens around module constraint in functor application :
  `module M = F ((A : T))` becomes `module M = F (A : T)`. (ocaml-ppx/ocamlformat#2678, @EmileTrotignon)

- Fix misplaced `;;` due to interaction with floating doc comments.
  (ocaml-ppx/ocamlformat#2691, @EmileTrotignon)

- The formatting of attributes of expression is now aware of the attributes
  infix or postix positions: `((fun [@a] x -> y) [@b])` is formatted without
  moving attributes. (ocaml-ppx/ocamlformat#2676, @EmileTrotignon)

- `begin%e ... end` and `begin [@a] ... end` nodes are always preserved.
  (ocaml-ppx/ocamlformat#2676, @EmileTrotignon)

- `begin end` syntax for `()` is now preserved. (ocaml-ppx/ocamlformat#2676, @EmileTrotignon)

- Fix a crash on `type 'a t = A : 'a. {a: 'a} -> 'a t`. (ocaml-ppx/ocamlformat#2710, @EmileTrotignon)

- Fix a crash where `type%e nonrec t = t` was formatted as `type nonrec%e t = t`,
  which is invalid syntax. (ocaml-ppx/ocamlformat#2712, @EmileTrotignon)

- Fix commandline parsing being quadratic in the number of arguments
  (ocaml-ppx/ocamlformat#2724, @let-def)

- \* Fix `;;` being added after a documentation comment (ocaml-ppx/ocamlformat#2683, @EmileTrotignon)
  This results in more `;;` being inserted, for example:
  ```ocaml
  (* before *)
  print_endline "foo"
  let a = 3

  (* after *)
  print_endline "foo" ;;
  let a = 3
  ```
