### PR TITLE
Add a cmdliner upper bound for diskuvbox.0.1.0 and diskuvbox.0.1.1

### DIFF
--- a/packages/diskuvbox/diskuvbox.0.1.0/opam
+++ b/packages/diskuvbox/diskuvbox.0.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "logs" {>= "0.7.0"}
   "mdx" {>= "2.0.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "headache" {>= "1.05" & build}
   "ocamlformat" {>= "0.19.0" & build}
 ]

--- a/packages/diskuvbox/diskuvbox.0.1.1/opam
+++ b/packages/diskuvbox/diskuvbox.0.1.1/opam
@@ -16,7 +16,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "logs" {>= "0.7.0"}
   "mdx" {>= "2.0.0" & with-test}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "dkml-workflows" {>= "1.1.0" & build}
   "headache" {>= "1.05" & build}
   "ocamlformat" {>= "0.19.0" & build}


### PR DESCRIPTION
Spotted on PR [#28752](https://github.com/ocaml/opam-repository/pull/28752)

```
[ERROR] The compilation of diskuvbox.0.1.1 failed at "dune build -p diskuvbox -j 255 @install".

#=== ERROR while compiling diskuvbox.0.1.1 ====================================#
# context              2.4.1 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/diskuvbox.0.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p diskuvbox -j 255 @install
# exit-code            1
# env-file             ~/.opam/log/diskuvbox-7-16efcb.env
# output-file          ~/.opam/log/diskuvbox-7-16efcb.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/bin/.main.eobjs/byte -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/bos -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/fmt/cli -I /home/opam/.opam/4.14/lib/fmt/tty -I /home/opam/.opam/4.14/lib/fpath -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/logs/cli -I /home/opam/.opam/4.14/lib/logs/fmt -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/rresult -I src/lib/.diskuvbox.objs/byte -no-alias-deps -open Dune__exe -o src/bin/.main.eobjs/byte/dune__exe__Main.cmo -c -impl src/bin/main.ml)
# File "src/bin/main.ml", line 203, characters 4-13:
# 203 |     Term.info "copy-file" ~doc ~exits:Term.default_exits ~man )
#           ^^^^^^^^^
# Error: Unbound value Term.info
```

The equivalent upper bounds for diskuvbox.0.1.2 was added in 4d3fb27660 from #28602