### PR TITLE
[new release] ppx_matches (0.1.0)

### DIFF
--- a/packages/ppx_matches/ppx_matches.0.1.0/opam
+++ b/packages/ppx_matches/ppx_matches.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A syntax extension for Rust's `matches!` in OCaml 🐪"
+maintainer: ["ajob410@gmail.com"]
+authors: ["Alistair O'Brien"]
+license: "MIT"
+homepage: "https://github.com/johnyob/ppx-matches"
+bug-reports: "https://github.com/johnyob/ppx-matches/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.6"}
+  "ppxlib" {>= "0.31.0"}
+  "core"
+  "core_unix" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/johnyob/ppx-matches.git"
+url {
+  src:
+    "https://github.com/johnyob/ppx-matches/releases/download/0.1.0/ppx_matches-0.1.0.tbz"
+  checksum: [
+    "sha256=201ed363af24391d72255967e9cb9df7c7519a0edcceea3ff89193082a3e2349"
+    "sha512=94cccbfecc7634cc29be17d6848fb97847ee1d112da5bcf58d1d401667552a98beb684258694470d250a76a942f93b643cbabf1e71fbe76d01c248171f56202c"
+  ]
+}
+x-commit-hash: "17c10dc6d621dddbf1fce1234d26c37054003af8"
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
A syntax extension for Rust's `matches!` in OCaml 🐪

- Project page: <a href="https://github.com/johnyob/ppx-matches">https://github.com/johnyob/ppx-matches</a>

##### CHANGES:

Initial release
