### PR TITLE
[new release] mirage-ptime (5.2.0)

### DIFF
--- a/packages/mirage-ptime/mirage-ptime.5.2.0/opam
+++ b/packages/mirage-ptime/mirage-ptime.5.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "hannes@mehnert.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray" "Hannes Mehnert"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-ptime"
+doc: "https://mirage.github.io/mirage-ptime/"
+bug-reports: "https://github.com/mirage/mirage-ptime/issues"
+synopsis: "Libraries and module types for portable clocks"
+description: """
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirageos.org) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements a POSIX clock which counts time since the Unix epoch.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "ptime" {>= "1.1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-ptime.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-ptime/releases/download/v5.2.0/mirage-ptime-5.2.0.tbz"
+  checksum: [
+    "sha256=60e5a926b7d0286f64842c0f6f99595ed7fe7e2a783740750009f663dcd12f28"
+    "sha512=c8f6ba732bf103fa6509708f58e4f7fe3b317d3c35d62662df2454a04cc3278f036eee125a4a6d12f4cd24d3c6aaf49bb46f3fc5a76bff5c6282c915de0a631f"
+  ]
+}
+x-commit-hash: "3ad2d158a287f1d5721a8951d0f6d1dea30446ac"


### PR DESCRIPTION
Libraries and module types for portable clocks

- Project page: <a href="https://github.com/mirage/mirage-ptime">https://github.com/mirage/mirage-ptime</a>
- Documentation: <a href="https://mirage.github.io/mirage-ptime/">https://mirage.github.io/mirage-ptime/</a>

##### CHANGES:

* Fix the compilation of the solo5 sublibrary with the host compiler
  (mirage/mirage-ptime#2 @dinosaure)
