### PR TITLE
Package libbinaryen.117.0.0-b

### DIFF
--- a/packages/libbinaryen/libbinaryen.117.0.0-b/opam
+++ b/packages/libbinaryen/libbinaryen.117.0.0-b/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "7.0.0"}
+  "ocaml" {>= "4.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v117.0.0-b/libbinaryen-v117.0.0-b.tar.gz"
+  checksum: [
+    "md5=e1239f59de30071a1e53db6a92e3248e"
+    "sha512=930e6836839f9d410bf83cb6d292bc84e78b7292278af7f513112d95cd7f6d15fd2e575032b8c71918ff3593a1810cd9f3efe9173b8e8faf356a4a9d512be004"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.117.0.0-b`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
# libbinaryen v117.0.0-b

## [117.0.0-b](https://github.com/grain-lang/libbinaryen/compare/v117.0.0...v117.0.0-b) (2025-10-22)

### Features

- Update libbinaryen v117 for esy@0.8.0 and ocaml 5 ([#119](https://github.com/grain-lang/libbinaryen/pull/119))


---
:camel: Pull-request generated by opam-publish v2.4.0