### PR TITLE
Package handlebars-ml.0.2.0

### DIFF
--- a/packages/handlebars-ml/handlebars-ml.0.2.0/opam
+++ b/packages/handlebars-ml/handlebars-ml.0.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "yojson" {>= "2.0"}
   "ppx_deriving"
-  "ppx_inline_test" {with-test}
+  "alcotest" {with-test}
   "odoc" {with-doc}
 ]
 build: [
@@ -35,9 +35,9 @@ dev-repo: "git+https://github.com/nikochiko/handlebars-ml.git"
 x-maintenance-intent: ["(latest)"]
 url {
   src:
-    "https://github.com/nikochiko/handlebars-ml/archive/refs/tags/0.2.0.tar.gz"
+    "https://github.com/nikochiko/handlebars-ml/archive/refs/tags/0.2.1.tar.gz"
   checksum: [
-    "md5=67f1188f955ff83091c8c91539548d12"
-    "sha512=6e0fe9498bbdf2f17a4f2f83ab969e4792971f5c0a08eb77ad39baa3a35448df32eb2573479a6626b5d002bba4cce66685a3f57a88edf685320ecd978e848da7"
+    "md5=fc0e8b65d541e10ce8603fd568fa368a"
+    "sha512=c24e148f822c378796a7cffd2b7f2af0c4e6570740245ccfb9e323cc049b7135a18907e06d987a85bc22e8669bf800116cdabd96794874b3c647dcdf266a417d"
   ]
 }


### PR DESCRIPTION
### `handlebars-ml.0.2.0`
Handlebars templating for OCaml
OCaml port of the Handlebars.js templating engine



---
* Homepage: https://github.com/nikochiko/handlebars-ml
* Source repo: git+https://github.com/nikochiko/handlebars-ml.git
* Bug tracker: https://github.com/nikochiko/handlebars-ml/issues

---
:camel: Pull-request generated by opam-publish v2.7.0