### PR TITLE
opam-publish,orb: add upper bound on opam 2.5

### DIFF
--- a/packages/opam-publish/opam-publish.2.5.1/opam
+++ b/packages/opam-publish/opam-publish.2.5.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.08.0"}
-  "opam-core" {>= "2.2.0"}
+  "opam-core" {>= "2.2.0" & < "2.5"}
   "opam-format" {>= "2.2.0"}
   "opam-state" {>= "2.2.0"}
   "github" {>= "4.3.2"}

--- a/packages/opam-publish/opam-publish.2.6.0/opam
+++ b/packages/opam-publish/opam-publish.2.6.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.08.0"}
-  "opam-core" {>= "2.2.0"}
+  "opam-core" {>= "2.2.0" & < "2.5"}
   "opam-format" {>= "2.2.0"}
   "opam-state" {>= "2.2.0"}
   "github" {>= "4.3.2"}

--- a/packages/opam-publish/opam-publish.2.7.0/opam
+++ b/packages/opam-publish/opam-publish.2.7.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.0"}
   "tls-lwt" {>= "0.16.0"}
   "ocaml" {>= "4.08.0"}
-  "opam-core" {>= "2.2.0"}
+  "opam-core" {>= "2.2.0" & < "2.5"}
   "opam-format" {>= "2.2.0"}
   "opam-state" {>= "2.2.0"}
   "github" {>= "4.3.2"}

--- a/packages/orb/orb.1.0.0/opam
+++ b/packages/orb/orb.1.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "opam-client" {>= "2.2.1"}
   "opam-repository" {>= "2.2.1"}
-  "opam-core" {>= "2.2.1"}
+  "opam-core" {>= "2.2.1" & < "2.5"}
   "opam-format" {>= "2.2.1"}
   "opam-solver" {>= "2.2.1"}
   "opam-state" {>= "2.2.1"}


### PR DESCRIPTION
They fail with:
[opam-publish.2.5.1 (failed: Unbound value OpamStd.String.contains_char)](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/6643b4b12a62bcd38151b36c048dae629b547d40/variant/compilers,4.14,opam-repository.2.5.0~alpha1,revdeps,opam-publish.2.5.1)
[opam-publish.2.6.0 (failed: Unbound value OpamStd.String.contains_char)](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/6643b4b12a62bcd38151b36c048dae629b547d40/variant/compilers,4.14,opam-repository.2.5.0~alpha1,revdeps,opam-publish.2.6.0)
[opam-publish.2.7.0 (failed: Unbound value OpamStd.String.contains_char)](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/6643b4b12a62bcd38151b36c048dae629b547d40/variant/compilers,4.14,opam-repository.2.5.0~alpha1,revdeps,opam-publish.2.7.0)
[orb.1.0.0 (failed: Unbound value OpamStd.Option.iter)](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/6643b4b12a62bcd38151b36c048dae629b547d40/variant/compilers,4.14,opam-repository.2.5.0~alpha1,revdeps,orb.1.0.0)