### PR TITLE
add post-messages to conf-libpcre for debian failure

### DIFF
--- a/packages/conf-libpcre/conf-libpcre.2/opam
+++ b/packages/conf-libpcre/conf-libpcre.2/opam
@@ -35,6 +35,7 @@ depexts: [
   ["pcre"] {os = "macos" & os-distribution = "macports"}
   ["pcre"] {os = "win32" & os-distribution = "cygwinports"}
 ]
+post-messages: [ "On Debian 13 (Trixie), the libpcre3-dev package was removed from the code package repository. You can find it in third party repository DebianMultimedia or install it manually." { failure & os-family = "debian" } ]
 synopsis: "Virtual package relying on a libpcre system installation"
 description:
   "This package can only install if the libpcre is installed on the system."


### PR DESCRIPTION
Because of the failure observed in https://github.com/ocaml/opam-repository/pull/28754

```
  * Missing dependency:
    - passage >= 0.1.8 -> devkit >= 1.20240429 -> pcre -> conf-libpcre
    depends on the unavailable system package 'libpcre3-dev'. Use `--no-depexts' to attempt installation anyway, or it is possible that a depext package name in the opam file is incorrect.
```
