### PR TITLE
Package otp.0.2

### DIFF
--- a/packages/otp/otp.0.2/opam
+++ b/packages/otp/otp.0.2/opam
@@ -15,6 +15,13 @@ tags: ["OTP" "TOTP" "HMAC-SHA1" "One Time Password"]
 homepage: "https://github.com/Heyji2/otp"
 doc: "https://heyji2.github.io"
 bug-reports: "https://github.com/Heyji2/otp/issues"
+url {
+  src: "https://github.com/Heyji2/otp/archive/refs/tags/0.2.tar.gz"
+  checksum: [
+    "md5=10e7e9ec1c962298e78e9c3bb2445b59"
+    "sha256=b210ef2ca1bc332fd3e873c6a8b81d18b3a70f491b191c42d7931a8adf7c0e51"
+  ]
+}
 depends: [
   "dune" {>= "3.18"}
   "ocaml" {>= "4.13"}
@@ -46,10 +53,3 @@ build: [
 dev-repo: "git+https://github.com/Heyji2/otp.git"
 x-maintenance-intent: ["(latest)"]
 x-ci-accept-failures: ["fedora-42" "debian-13"]
-url {
-  src: "https://github.com/Heyji2/otp/archive/refs/tags/0.2.tar.gz"
-  checksum: [
-    "md5=0a0f0946ccc2af37eb34132793785db8"
-    "sha512=49d3d444291ccfa430a846090305beb1b6561e89ae40db8d77aa8eac87ed43af24c58dd7e75ca9bfaa3ec5f65af790d67de07057bfcbc37a5bf8d75f291d247e"
-  ]
-}


### PR DESCRIPTION
### `otp.0.2`
Time-base One Time Password (OTP) based on RFC6238 with an HMAC-SHA1 algorithm and a 6 digits code in OCAML
It relies on the Cryptokit library for cryptography operations, as well as the Base32 
 library for base32 encoding. The library generate a QR Code with the qrc library. It is 
 tested against all test vectors provided in RFC 6238 and the test suite provides as well 
 a dynamic test which requires the use of an client authenticator (like Google Authenticator 
 or Microsoft Authenticator) as a final test.



---
* Homepage: https://github.com/Heyji2/otp
* Source repo: git+https://github.com/Heyji2/otp.git
* Bug tracker: https://github.com/Heyji2/otp/issues

---
:camel: Pull-request generated by opam-publish v2.7.1