### PR TITLE
2 packages from rocq-prover/vsrocq at 2.3.3

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.3.3/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.3.3/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/rocq-prover/vsrocq"
+bug-reports: "https://github.com/rocq-prover/vsrocq/issues"
+dev-repo: "git+https://github.com/rocq-prover/vsrocq"
+depends: [
+  "vsrocq-language-server" {= version}
+]
+synopsis: "Compatibility meta package for the VsRocq language server after the Rocq renaming"
+available: arch != "arm32" & arch != "x86_32"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rocq-prover/vsrocq/releases/download/v2.3.3/vsrocq-language-server-2.3.3.tar.gz"
+  checksum: [
+    "md5=c3f17c36f162c6be3ed6f35a30e3a18d"
+    "sha512=32c67c0a915d0983332337d891ccc40d3204b04e83c8d307cffdda06df7798db8bedb74e705101d2c83d595cfb2e4f82ecbf576fe3c385ec7ead9689f50f7d05"
+  ]
+}

--- a/packages/vsrocq-language-server/vsrocq-language-server.2.3.3/opam
+++ b/packages/vsrocq-language-server/vsrocq-language-server.2.3.3/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/rocq-prover/vsrocq"
+bug-reports: "https://github.com/rocq-prover/vsrocq/issues"
+dev-repo: "git+https://github.com/rocq-prover/vsrocq"
+
+build: [
+  [make "dune-files"]
+  [
+    "etc/rocq-wrap-coqc.sh" {!coq-core:installed}
+    "dune" "build" "-p" name "-j" jobs 
+  ]
+]
+depends: [
+  "ocaml" { >= "4.14" }
+  "dune" { >= "3.5" }
+  ("coq-core" { ((>= "8.18" < "8.21") | (= "dev")) }
+  | "rocq-core" { ((>= "9.0+rc1" < "9.2~") | (= "dev")) })
+  ("coq-stdlib" { ((>= "8.18" < "8.21") | (= "dev")) }
+  | "rocq-stdlib" { ((>= "9.0+rc1" < "9.2~") | (= "dev")) })
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "ppx_optcomp"
+  "result" { >= "1.5" }
+  "lsp" { >= "1.15"}
+  "sel" {>= "0.6.0"}
+]
+conflicts: [
+    "vscoq-language-server" {< "2.2.7~"}
+]
+synopsis: "VSRocq language server"
+available: arch != "arm32" & arch != "x86_32"
+description: """
+LSP based language server for Rocq and its VSRocq user interface
+"""
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rocq-prover/vsrocq/releases/download/v2.3.3/vsrocq-language-server-2.3.3.tar.gz"
+  checksum: [
+    "md5=c3f17c36f162c6be3ed6f35a30e3a18d"
+    "sha512=32c67c0a915d0983332337d891ccc40d3204b04e83c8d307cffdda06df7798db8bedb74e705101d2c83d595cfb2e4f82ecbf576fe3c385ec7ead9689f50f7d05"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `vscoq-language-server.2.3.3`: Compatibility meta package for the VsRocq language server after the Rocq renaming
- `vsrocq-language-server.2.3.3`: VSRocq language server



---
* Homepage: https://github.com/rocq-prover/vsrocq
* Source repo: git+https://github.com/rocq-prover/vsrocq
* Bug tracker: https://github.com/rocq-prover/vsrocq/issues

---
:camel: Pull-request generated by opam-publish v2.5.0