### PR TITLE
Release of Solo5.0.10.0

### DIFF
--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.10.0/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.10.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["env" "TARGET_CC=aarch64-linux-gnu-gcc" "TARGET_LD=aarch64-linux-gnu-ld" "TARGET_OBJCOPY=aarch64-linux-gnu-objcopy" "./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install-toolchain"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+  "solo5" {= version}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["gcc-aarch64-linux-gnu"] {os-family = "debian"}
+]
+available: [
+  (arch != "arm64") &
+  (os = "linux" & os-family = "debian")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to cross-build
+MirageOS unikernels for the aarch64 architecture.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.10.0/solo5-v0.10.0.tar.gz"
+  checksum: "sha512=fadc0f0920b3c77f828f5396db267755a9b45fb19b44970f2363224a91a11ba8593fe27caf3c14c321a52f993a6d21ec200f0eb950dd7bb0f5bbe5f7102aba5f"
+}

--- a/packages/solo5/solo5.0.10.0/opam
+++ b/packages/solo5/solo5.0.10.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.7.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+  "solo5-bindings-xen"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+x-ci-accept-failures: [ "centos-7" ]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the host system.
+"""
+x-maintenance-intent: [ "(latest)" ]
+x-ci-accept-failures: [ "opensuse-15.6" ] # too old GCC compiler (OpenSUSE uses GCC 7 and we require GCC 10)
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.10.0/solo5-v0.10.0.tar.gz"
+  checksum: "sha512=fadc0f0920b3c77f828f5396db267755a9b45fb19b44970f2363224a91a11ba8593fe27caf3c14c321a52f993a6d21ec200f0eb950dd7bb0f5bbe5f7102aba5f"
+}


### PR DESCRIPTION
- Fix compilation on OpenBSD about `#ifdef` (@omegametabroccolo, @hannesm, @reynir, solo5/solo5#614, related with solo5/solo5#600)
- Add GitHub actions to test Solo5 on different platforms (@hannesm, solo5/solo5#616, solo5/solo5#617 & solo5/solo5#540)
- Do not use `-Wstringopt-overflow` when we use `clang` for `test_ssp` (@hannesm, solo5/solo5#607)
- Show errors and exit instead of `assert false` (@shym, @edwintorok, @hannesm, @reynir, solo5/solo5#613 & solo5/solo5#612)
- Define `.note.GNU-stack` when it's needed (@shym, @Kensan, @hannesm, @palainp, @dinosaure, solo5/solo5#619, solo5/solo5#570 & solo5/solo5#562)
- Detect MTU on TAP interface for hvt, spt and virtio (@reynir, @hannesm, @dinosaure, solo5/solo5#605 & solo5/solo5#606)