### PR TITLE
ocaml 5.4.0 should not be "avoid-version"

### DIFF
--- a/packages/ocaml/ocaml.5.4.0/opam
+++ b/packages/ocaml/ocaml.5.4.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml-system" {>= "5.4.0~" & < "5.4.1~"} |
   "dkml-base-compiler" {>= "5.4.0~" & < "5.4.1~"}
 ]
-flags: [conf avoid-version]
+flags: [conf]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]


### PR DESCRIPTION
Resolves https://github.com/ocaml/opam-repository/issues/28786