### PR TITLE
mlgpx: switch distfile over directly to tangled PDS serving

### DIFF
--- a/packages/mlgpx/mlgpx.1.0.0/opam
+++ b/packages/mlgpx/mlgpx.1.0.0/opam
@@ -40,7 +40,7 @@ build: [
 x-maintenance-intent: ["(latest)"]
 dev-repo: "git+https://tangled.sh/@anil.recoil.org/ocaml-gpx"
 url {
-  src: "https://www.cl.cam.ac.uk/~avsm2/distrib/mlgpx-1.0.0.tbz"
+  src: "https://tangled.org/@anil.recoil.org/ocaml-gpx/tags/05648ec051e3694b5b8800fe015f4ada1635bb9d/download/mlgpx-1.0.0.tbz"
   checksum: [
     "md5=5342bb7e601273245a9fe263e5a08770"
     "sha512=cd73b16e988b3ed3cc427a6c6c6d6c9c745adb1eb7efaae3c34e8d006e9c03d9f9d2616cd4118564bd9873903969d3e4053b585e79dbd3e3e7d0f541e2faac83"


### PR DESCRIPTION
This works now (with the same checksum) thanks to @oppiliappan adding support in https://tangled.org/@tangled.org/core/issues/174