### PR TITLE
[new release] ppx_expect_nobase (0.17.3.0) 

### DIFF
--- a/packages/ppx_expect_nobase/ppx_expect_nobase.v0.17.3.0/opam
+++ b/packages/ppx_expect_nobase/ppx_expect_nobase.v0.17.3.0/opam
@@ -10,7 +10,8 @@ homepage: "https://github.com/Kakadu/ppx_expect_nobase"
 bug-reports: "https://github.com/Kakadu/ppx_expect_nobase/issues"
 depends: [
   "dune" {>= "3.11"}
-  "ocaml" {>= "4.14.2" & < "5.0.0" | >= "5.3.0" & <= "5.4.0"}
+  "ocaml" {>= "4.14.2" & < "5.0.0" | >= "5.3.0" } 
+  # There are not plans to maintain 5.1 and 5.2 right now
   "ppx_inline_test_nobase" {>= "v0.17.0.2"}
   "sexplib"
   "ppxlib" {>= "0.35.0"}


### PR DESCRIPTION
Cram like framework for OCaml (with stripped dependencies)

- Project page: <a href="https://github.com/Kakadu/ppx_expect_nobase">https://github.com/Kakadu/ppx_expect_nobase</a>
 
