### PR TITLE
Add tezt 4.3.0

### DIFF
--- a/packages/tezt/tezt.4.3.0/opam
+++ b/packages/tezt/tezt.4.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://gitlab.com/nomadic-labs/tezt/"
+bug-reports: "https://gitlab.com/nomadic-labs/tezt/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/tezt.git"
+license: "MIT"
+x-maintenance-intent: ["(latest)"]
+depends: [
+  "dune" { >= "3.19.1" }
+  "ocaml" { >= "4.13" }
+  "re" { >= "1.7.2" }
+  "lwt" { >= "5.6.0" }
+  "base-unix"
+  "ezjsonm" { >= "1.1.0" }
+  "clap" { >= "0.3.0" }
+  "conf-npm" { with-test }
+  "js_of_ocaml" { with-test }
+  "js_of_ocaml-lwt" { with-test }
+  "ocamlformat" { with-test & = "0.27.0" }
+]
+x-ci-accept-failures: ["debian-11" "ubuntu-22.04"]
+depopts: [
+  "js_of_ocaml"
+  "js_of_ocaml-lwt"
+]
+conflicts: [
+  "js_of_ocaml" { < "4.0.0" }
+  "js_of_ocaml-lwt" { < "4.0.0" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch = "x86_64" & os = "linux" & os-distribution = "debian"}
+]
+synopsis: "Test framework for unit tests, integration tests, and regression tests"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/tezt/-/archive/4.3.0/tezt-4.3.0.tar.bz2"
+  checksum: [
+    "md5=15abf8d74a268d18dd42e539f894fbe8"
+    "sha512=fb30fc561a1e77f037a4ce7eb022345ef0620fa1ac3e16bd83b7f867ef3d0c0ff676255a967d3122e7ef25b22f4b0dc01fba9fe90fe1b486e68b268ba1e9a9c9"
+  ]
+}


### PR DESCRIPTION
Tezt 4.3.0 has been released. See [changelog](https://gitlab.com/nomadic-labs/tezt/-/blob/master/CHANGES.md).

I expect that the opam-repository CI will fail, given the history:
- [Tezt 4.2.0 PR](https://github.com/ocaml/opam-repository/pull/27220)
- [this other PR](https://github.com/ocaml/opam-repository/pull/28550)

I tried to fix some of the issues, but I may have to add more constraints to the `.opam` before we merge.