### PR TITLE
odig.0.1.0: relax pessimistic constraints on b0

### DIFF
--- a/packages/odig/odig.0.1.0/opam
+++ b/packages/odig/odig.0.1.0/opam
@@ -27,7 +27,7 @@ depends: [
   "topkg" {build & >= "1.1.0"}
   "cmdliner" {>= "2.0.0"}
   "odoc" {>= "2.0.0"}
-  "b0" {= "0.0.6"}
+  "b0" {>= "0.0.6"}
 ]
 build: [
   ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]


### PR DESCRIPTION
What the title says.