### PR TITLE
Package binaryen.0.27.0

### DIFF
--- a/packages/binaryen/binaryen.0.27.0/opam
+++ b/packages/binaryen/binaryen.0.27.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "6.0.0" & < "7.0.0"}
+  "libbinaryen" {> "117.0.0" & < "118.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.27.0/binaryen-archive-v0.27.0.tar.gz"
+  checksum: [
+    "md5=d06bf46d38ba2602170381b8eb6b1d90"
+    "sha512=bb03c201aa1c0a8145a3640ff03feb079c0fb91d2f8de6a06e07b28875840cacee28f9f284fe5ffec611c76cf6c821c77d334e1820160c9d244517cdcf6bb8c2"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.27.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.27.0](https://github.com/grain-lang/binaryen.ml/compare/v0.26.0...v0.27.0) (2025-10-29)

### ⚠ BREAKING CHANGES

- Upgrade to Binaryen v117 ([#225](https://github.com/grain-lang/binaryen.ml/issues/225))
- Require jsoo >= 6.0 ([#211](https://github.com/grain-lang/binaryen.ml/issues/211))
- Require node `22` or above ([#219](https://github.com/grain-lang/binaryen.ml/issues/219))

### Features

- Upgrade to Binaryen v117 ([#225](https://github.com/grain-lang/binaryen.ml/issues/225)) ([246d9fc](https://github.com/grain-lang/binaryen.ml/commit/246d9fc365bdfd40d8631e3a3b6ddd92efbb8fad))

### Miscellaneous Chores

- Require jsoo &gt;= 6.0 ([#211](https://github.com/grain-lang/binaryen.ml/issues/211)) ([cf53ffc](https://github.com/grain-lang/binaryen.ml/commit/cf53ffc132caed040ee9e7eca179cfd697bb5868))
- Require node `22` or above ([#219](https://github.com/grain-lang/binaryen.ml/issues/219)) ([3e1261e](https://github.com/grain-lang/binaryen.ml/commit/3e1261eabd76d8e5d546e104219c05201440053a))


---
:camel: Pull-request generated by opam-publish v2.4.0