### PR TITLE
Package libbinaryen.118.0.0-b

### DIFF
--- a/packages/libbinaryen/libbinaryen.118.0.0-b/opam
+++ b/packages/libbinaryen/libbinaryen.118.0.0-b/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "7.0.0"}
+  "ocaml" {>= "4.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v118.0.0-b/libbinaryen-v118.0.0-b.tar.gz"
+  checksum: [
+    "md5=3cc7a5d89cadb9a92e51133d9fd30f46"
+    "sha512=21b455cf39ea044ea313563da2045e6b1f9533d2e9ce6972c78e3f8ad00c6618bd03c919b08f639c84ca97b85b1284e4a8d57f44c8776df8891a2fde55231209"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.118.0.0-b`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## What's Changed

- feat: Update libbinaryen v118 for esy@0.8.0 and ocaml 5 by @spotandjake in https://github.com/grain-lang/libbinaryen/pull/121

**Full Changelog**: https://github.com/grain-lang/libbinaryen/compare/v118.0.0...v118.0.0-b


---
:camel: Pull-request generated by opam-publish v2.4.0