### PR TITLE
Package libbinaryen.119.0.0-b

### DIFF
--- a/packages/libbinaryen/libbinaryen.119.0.0-b/opam
+++ b/packages/libbinaryen/libbinaryen.119.0.0-b/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "7.0.0"}
+  "ocaml" {>= "4.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v119.0.0-b/libbinaryen.tar.gz"
+  checksum: [
+    "md5=244d11c037a7ab9e5147c7d28146a4ae"
+    "sha512=9c2da27b86682e936861864f7f52af312a500773a08f65fa1ae5c939e66fbe639898a09542e075f4da8998bb3d934abee6a61dc8c32c371f8e9ed320b2430631"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.119.0.0-b`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
:camel: Pull-request generated by opam-publish v2.4.0