### PR TITLE
Package libbinaryen.120.0.0-b

### DIFF
--- a/packages/libbinaryen/libbinaryen.120.0.0-b/opam
+++ b/packages/libbinaryen/libbinaryen.120.0.0-b/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "7.0.0"}
+  "ocaml" {>= "4.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v120.0.0-b/libbinaryen.tar.gz"
+  checksum: [
+    "md5=ce03e8fb3be257b9b5a61e14bf1c6589"
+    "sha512=ce9843193e457c7109f5168dda015602e611ee51d1e09dc6a0bd0691e725fd6b79d7c65e6a4645744c25ed0961aead1531a543393dd07edecb74088bed5f34c0"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.120.0.0-b`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
:camel: Pull-request generated by opam-publish v2.4.0