### PR TITLE
Package libbinaryen.121.0.0-b

### DIFF
--- a/packages/libbinaryen/libbinaryen.121.0.0-b/opam
+++ b/packages/libbinaryen/libbinaryen.121.0.0-b/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "7.0.0"}
+  "ocaml" {>= "4.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v121.0.0-b/libbinaryen.tar.gz"
+  checksum: [
+    "md5=d0d94584e6d326466a048e83db4a177b"
+    "sha512=2a1d36a07ae0388fca123eec126a3a71a530d9828f0bc8b325c967ebb0369a65de9cb7299ce5641890f5e354528b52d8a63c6644d4c3ecfd312b07b59e2020c9"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.121.0.0-b`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
:camel: Pull-request generated by opam-publish v2.4.0