### PR TITLE
Package cryptoverif.2.12

### DIFF
--- a/packages/cryptoverif/cryptoverif.2.12/opam
+++ b/packages/cryptoverif/cryptoverif.2.12/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "CryptoVerif: Cryptographic protocol verifier in the computational model"
+description: """
+CryptoVerif is an automatic protocol prover sound in the computational model. It can prove
+
+  - secrecy;
+  - correspondences, which include in particular authentication;
+  - indistinguishability between two games.
+
+It provides a generic mechanism for specifying the security assumptions on cryptographic primitives, which can handle in particular symmetric encryption, message authentication codes, public-key encryption, signatures, hash functions.
+
+The generated proofs are proofs by sequences of games, as used by cryptographers. These proofs are valid for a number of sessions polynomial in the security parameter, in the presence of an active adversary. CryptoVerif can also evaluate the probability of success of an attack against the protocol as a function of the probability of breaking each cryptographic primitive and of the number of sessions (exact security).
+
+This software is under development; please use it at your own risk. Comments and bug reports welcome. 
+"""
+maintainer: "Bruno Blanchet <Bruno.Blanchet@inria.fr>"
+x-maintenance-intent: [ "(latest)" ]
+authors: "Bruno Blanchet <Bruno.Blanchet@inria.fr>, Pierre Boutry <boutry.pierre@gmail.com>, David Cadé <David.Cade@normalesup.org>, Christian Doczkal <christian.doczkal@mpi-sp.org>, Aymeric Fromherz <Aymeric.Fromherz@inria.fr>, Charlie Jacomme <Charlie.Jacomme@inria.fr>, Benjamin Lipp <Benjamin.Lipp@mpi-sp.org>, and Pierre-Yves Strub <pierre-yves@strub.nu>"
+license: "CECILL-B"
+homepage: "https://cryptoverif.inria.fr"
+dev-repo: "git+https://gitlab.inria.fr/bblanche/CryptoVerif.git"
+bug-reports: "Bruno.Blanchet@inria.fr"
+depends: [ "ocaml" { >= "4.08" } "ocamlfind" { post } "cryptokit" { post } "conf-m4" { post } ]
+build: [
+       [ "./build" "byte" { !ocaml:native } ] 
+]
+install: [ "./build" "install" "%{prefix}%" ]
+url {
+  src: "https://cryptoverif.inria.fr/cryptoverif2.12.tar.gz"
+  checksum: [
+    "md5=a7d04beb0aa5f1ed6f28c0e05f24104b"
+    "sha512=46bcd2ff73545a7de3963c0064539b87961fc415d030e1ad7d2d24451f9056b34c3bd2d8a08b5feac9ad1ee00bdb5934a1a79f02e82d62a39e8d6ad91c4aa88a"
+  ]
+}


### PR DESCRIPTION
### `cryptoverif.2.12`
CryptoVerif: Cryptographic protocol verifier in the computational model
CryptoVerif is an automatic protocol prover sound in the computational model. It can prove

  - secrecy;
  - correspondences, which include in particular authentication;
  - indistinguishability between two games.

It provides a generic mechanism for specifying the security assumptions on cryptographic primitives, which can handle in particular symmetric encryption, message authentication codes, public-key encryption, signatures, hash functions.

The generated proofs are proofs by sequences of games, as used by cryptographers. These proofs are valid for a number of sessions polynomial in the security parameter, in the presence of an active adversary. CryptoVerif can also evaluate the probability of success of an attack against the protocol as a function of the probability of breaking each cryptographic primitive and of the number of sessions (exact security).

This software is under development; please use it at your own risk. Comments and bug reports welcome.



---
* Homepage: https://cryptoverif.inria.fr
* Source repo: git+https://gitlab.inria.fr/bblanche/CryptoVerif.git
* Bug tracker: Bruno.Blanchet@inria.fr

---
:camel: Pull-request generated by opam-publish v2.5.0