### PR TITLE
Print opam variables (os, os-distribution, os-family, ...) in Windows workflows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -78,6 +78,7 @@ jobs:
         run: |
           opam --version
           opam exec -- ocaml -version
+          opam var
 
       - name: Get changed files
         id: changed-files


### PR DESCRIPTION
This 1-liner prints relevant opam variables (`os`, `os-distribution`, `os-family`, ...) in the Windows workflows.
The opam-repo-ci workflows already do something similar (`opam config report`), so it makes sense to do something similar under Windows. `opam config report` doesn't print `os-family` though, which I think is particular relevant under Windows (#28804, #28805).

This reveals why `conf-libpcre` isn't working under MinGW MSys https://github.com/ocaml/opam-repository/pull/28769#pullrequestreview-3378875378: 
`os-distribution` is `"msys2"` there, not `"cygwin"`, causing the wrong `build` command to trigger.
Looking more into this, I found that this changed in https://github.com/ocaml/opam/pull/5843 with opam.2.2.
It however means I have some `conf-`file correcting to do... :sweat_smile: 

FTR, the wiki is already correct about  `os-distribution` under MSys2:
https://github.com/ocaml/opam-repository/wiki/Depexts-os-distribution---os-family-values
One could add a note about the value changing from opam.2.2 though (I don't have write access to do so).