### PR TITLE
2 packages from mbarbin/fpath-base at 0.4.0

### DIFF
--- a/packages/fpath-base/fpath-base.0.4.0/opam
+++ b/packages/fpath-base/fpath-base.0.4.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Adds a few functions to Fpath to use alongside Base"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/fpath-base"
+doc: "https://mbarbin.github.io/fpath-base/"
+bug-reports: "https://github.com/mbarbin/fpath-base/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "base" {>= "v0.17"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/fpath-base.git"
+description: """\
+
+[Fpath_base] is an OCaml module designed to be opened to shadow and
+further extend the four modules from [fpath-sexplib0]: [Fpath],
+[Fsegment], [Absolute_path] and [Relative_path] for a better
+compatibility with [base].
+
+The extended modules export [hashable] and [comparable] interfaces,
+making them compatible with [base]-style containers such as [Map],
+[Set], [Hashtbl], and [Hash_set].
+
+[base]: https://github.com/janestreet/base
+[fpath]: https://github.com/dbuenzli/fpath
+
+"""
+tags: [ "fpath" "fpath-sexp0" "absolute-paths" "relative-paths" "base" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/fpath-base/releases/download/0.4.0/fpath-base-0.4.0.tbz"
+  checksum: [
+    "sha256=1d7c13dd6daf879876b80b72e403ba9334b921d51397ccb3f4e3ab64bebd93f7"
+    "sha512=51c9d2236f4707f22d5e09e9134482acf5c11e51b63ef9add4324a768e65ddfcf43fc7e6322fa2ee95e013cc00874ccb29926ad610bd38c5eacdd799dfba9623"
+  ]
+}
+x-commit-hash: "c52bcf1fa78ead87251c05cc4c9d6c9f2fe1d372"

--- a/packages/fpath-sexp0/fpath-sexp0.0.4.0/opam
+++ b/packages/fpath-sexp0/fpath-sexp0.0.4.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis:
+  "Adds Fpath.sexp_of_t and defines 3 new modules: Fsegment, Absolute_path and Relative_path"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/fpath-base"
+doc: "https://mbarbin.github.io/fpath-base/"
+bug-reports: "https://github.com/mbarbin/fpath-base/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "fpath" {>= "0.7.3"}
+  "sexplib0" {>= "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/fpath-base.git"
+description: """\
+
+[Fpath_sexplib0] is an OCaml module designed to be opened to extend
+the [fpath] package. It introduces three new modules to the scope:
+[Fsegment], [Absolute_path] and [Relative_path].
+
+[Absolute_path] and [Relative_path] are helper modules that
+distinguish between classes of paths in the type system, enhancing
+type safety for applications manipulating paths.
+
+[Fpath] is shadowed and retains all its original functionality, with
+the addition of a sexp serializer and new helpers for casting between
+the types of paths offered by the package (absolute and relative
+paths).
+
+[fpath]: https://github.com/dbuenzli/fpath
+
+"""
+tags: [ "fpath" "absolute-paths" "relative-paths" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/fpath-base/releases/download/0.4.0/fpath-base-0.4.0.tbz"
+  checksum: [
+    "sha256=1d7c13dd6daf879876b80b72e403ba9334b921d51397ccb3f4e3ab64bebd93f7"
+    "sha512=51c9d2236f4707f22d5e09e9134482acf5c11e51b63ef9add4324a768e65ddfcf43fc7e6322fa2ee95e013cc00874ccb29926ad610bd38c5eacdd799dfba9623"
+  ]
+}
+x-commit-hash: "c52bcf1fa78ead87251c05cc4c9d6c9f2fe1d372"


### PR DESCRIPTION
This pull-request concerns:
- `fpath-base.0.4.0`: Adds a few functions to Fpath to use alongside Base
- `fpath-sexp0.0.4.0`: Adds Fpath.sexp_of_t and defines 3 new modules: Fsegment, Absolute_path and Relative_path



---
* Homepage: https://github.com/mbarbin/fpath-base
* Source repo: git+https://github.com/mbarbin/fpath-base.git
* Bug tracker: https://github.com/mbarbin/fpath-base/issues

---
## 0.4.0 (2025-10-20)

### Added

- Document handling of escaping relative paths ([#20](https://github.com/mbarbin/fpath-base/pull/20), @mbarbin).

### Changed

- `Relative_path.t` now rejects paths that escape above their starting point ([#20](https://github.com/mbarbin/fpath-base/pull/20), @mbarbin).


---
:camel: Pull-request generated by opam-publish v2.7.0