### PR TITLE
4 packages from c-cube/qcheck at 0.27

### DIFF
--- a/packages/qcheck-alcotest/qcheck-alcotest.0.27/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.27/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Alcotest backend for QCheck"
+description: """\
+QCheck is a QuickCheck inspired property-based testing library for OCaml.
+
+The `qcheck-alcotest` library provides an integration layer for `QCheck` onto
+https://github.com/mirage/alcotest[`alcotest`], allowing to run property-based
+tests in `alcotest`."""
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "quickcheck" "qcheck" "alcotest"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "qcheck-core" {= version}
+  "alcotest" {>= "1.2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.27.tar.gz"
+  checksum: [
+    "md5=dd6df3f9b934567e4b1292a183af0554"
+    "sha512=8269cd3f4f73f9b62292c0288b430092ae0572682c167dc31d6837cbc833b8a5db66448768f8b88994ae94385c45cda489edcbdd4674f230b2e62527b1b744ac"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck-core/qcheck-core.0.27/opam
+++ b/packages/qcheck-core/qcheck-core.0.27/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Core QCheck library"
+description: """\
+QCheck is a QuickCheck inspired property-based testing library for OCaml.
+
+The `qcheck-core` library provides the core property-based testing API with
+minimal dependendies: It requires only `unix` and `dune`."""
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "alcotest" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.27.tar.gz"
+  checksum: [
+    "md5=dd6df3f9b934567e4b1292a183af0554"
+    "sha512=8269cd3f4f73f9b62292c0288b430092ae0572682c167dc31d6837cbc833b8a5db66448768f8b88994ae94385c45cda489edcbdd4674f230b2e62527b1b744ac"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck-ounit/qcheck-ounit.0.27/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.27/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "OUnit backend for QCheck"
+description: """\
+QCheck is a QuickCheck inspired property-based testing library for OCaml.
+
+The `qcheck-ounit` library provides an integration layer for `QCheck` onto
+https://github.com/gildor478/ounit[`OUnit`], allowing to run property-based
+tests in `OUnit`."""
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["qcheck" "quickcheck" "ounit"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "qcheck-core" {= version}
+  "ounit2"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.27.tar.gz"
+  checksum: [
+    "md5=dd6df3f9b934567e4b1292a183af0554"
+    "sha512=8269cd3f4f73f9b62292c0288b430092ae0572682c167dc31d6837cbc833b8a5db66448768f8b88994ae94385c45cda489edcbdd4674f230b2e62527b1b744ac"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck/qcheck.0.27/opam
+++ b/packages/qcheck/qcheck.0.27/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Compatibility package for QCheck"
+description: """\
+QCheck is a QuickCheck inspired property-based testing library for OCaml.
+
+The `qcheck` library provides a compatibility API with older versions of QCheck,
+and depends upon both `qcheck-core` and `qcheck-ounit`.
+
+For fewer dependencies and new developments `qcheck-core` is recommended."""
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "qcheck-core" {= version}
+  "qcheck-ounit" {= version}
+  "alcotest" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.27.tar.gz"
+  checksum: [
+    "md5=dd6df3f9b934567e4b1292a183af0554"
+    "sha512=8269cd3f4f73f9b62292c0288b430092ae0572682c167dc31d6837cbc833b8a5db66448768f8b88994ae94385c45cda489edcbdd4674f230b2e62527b1b744ac"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `qcheck.0.27`: Compatibility package for QCheck
- `qcheck-alcotest.0.27`: Alcotest backend for QCheck
- `qcheck-core.0.27`: Core QCheck library
- `qcheck-ounit.0.27`: OUnit backend for QCheck



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: git+https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---
:camel: Pull-request generated by opam-publish v2.5.0