### PR TITLE
Package libbinaryen.122.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.122.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.122.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "7.0.0"}
+  "ocaml" {>= "4.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v122.0.0/libbinaryen-v122.0.0.tar.gz"
+  checksum: [
+    "md5=c038d05f4dbc2f52595ac56aa345f77e"
+    "sha512=84a8608e490cb680063d2a438c375239f326c2ce56e5ce0cafd62b7fabcd207982e090b1fad5deb0a6857bd4d903fbcae372b54e60b0cbb9b9f1c867a3a8978a"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `libbinaryen.122.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [122.0.0](https://github.com/grain-lang/libbinaryen/compare/v121.0.0...v122.0.0) (2025-10-31)

### ⚠ BREAKING CHANGES

- Upgrade to Binaryen v122 ([#102](https://github.com/grain-lang/libbinaryen/issues/102))
- Require node `>= 22` for jsoo `6` ([#114](https://github.com/grain-lang/libbinaryen/issues/114))
- Drop support for OCaml 4.12

### Features

- Bump `conf-cmake` ([#117](https://github.com/grain-lang/libbinaryen/issues/117)) ([938f5f0](https://github.com/grain-lang/libbinaryen/commit/938f5f0c9e862ede17229fa812747d0021ffe9ab))
- Bump `conf-cmake` to `v4.1.2` ([#125](https://github.com/grain-lang/libbinaryen/issues/125)) ([64bab40](https://github.com/grain-lang/libbinaryen/commit/64bab409dfb604beb9bccd158abfb27eb1f5fdb1))
- Require node `&gt;= 22` for jsoo `6` ([#114](https://github.com/grain-lang/libbinaryen/issues/114)) ([01d2926](https://github.com/grain-lang/libbinaryen/commit/01d29269fe8bbefa85a87d16204f49ea0cadd15d))
- Support OCaml 5 ([bad98c6](https://github.com/grain-lang/libbinaryen/commit/bad98c67e44b0edbf177055ccb5d9bca562be6ec))
- Upgrade to Binaryen v122 ([#102](https://github.com/grain-lang/libbinaryen/issues/102)) ([686e0c0](https://github.com/grain-lang/libbinaryen/commit/686e0c02eabe843a2d35a5ef46003473b05cb8e5))

### Miscellaneous Chores

- Drop support for OCaml 4.12 ([bad98c6](https://github.com/grain-lang/libbinaryen/commit/bad98c67e44b0edbf177055ccb5d9bca562be6ec))


---
:camel: Pull-request generated by opam-publish v2.4.0