### PR TITLE
Add: cmarkit.0.4.0

### DIFF
--- a/packages/cmarkit/cmarkit.0.4.0/opam
+++ b/packages/cmarkit/cmarkit.0.4.0/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis: "CommonMark parser and renderer for OCaml"
+description: """\
+Cmarkit parses the [CommonMark specification]. It provides:
+
+- A CommonMark parser for UTF-8 encoded documents. Link label resolution
+  can be customized and a non-strict parsing mode can be activated to add: 
+  strikethrough, LaTeX math, footnotes, task items and tables.
+  
+- An extensible abstract syntax tree for CommonMark documents with
+  source location tracking and best-effort source layout preservation.
+
+- Abstract syntax tree mapper and folder abstractions for quick and
+  concise tree transformations.
+  
+- Extensible renderers for HTML, LaTeX and CommonMark with source
+  layout preservation.
+
+Cmarkit is distributed under the ISC license. It has no dependencies.
+
+[CommonMark specification]: https://spec.commonmark.org/
+
+Homepage: <https://erratique.ch/software/cmarkit>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The cmarkit programmers"
+license: "ISC"
+tags: ["codec" "commonmark" "markdown" "org:erratique"]
+homepage: "https://erratique.ch/software/cmarkit"
+doc: "https://erratique.ch/software/cmarkit/doc"
+bug-reports: "https://github.com/dbuenzli/cmarkit/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+  "uucp" {dev}
+  "b0" {dev & with-test}
+]
+depopts: ["cmdliner"]
+conflicts: [
+  "cmdliner" {< "2.0.0"}
+]
+build: [
+  [
+    "ocaml"
+    "pkg/pkg.ml"
+    "build"
+    "--dev-pkg"
+    "%{dev}%"
+    "--with-cmdliner"
+    "%{cmdliner:installed}%"
+  ]
+  [
+    "cmdliner"
+    "install"
+    "tool-support"
+    "--update-opam-install=%{_:name}%.install"
+    "_build/src/tool/cmarkit_main.native:cmarkit" {ocaml:native}
+    "_build/src/tool/cmarkit_main.byte:cmarkit" {!ocaml:native}
+    "_build/cmdliner-install"
+  ] {cmdliner:installed}
+]
+dev-repo: "git+https://erratique.ch/repos/cmarkit.git"
+url {
+  src: "https://erratique.ch/software/cmarkit/releases/cmarkit-0.4.0.tbz"
+  checksum:
+    "sha512=4f0be18c1a16265710d20b85e48b3f8d8632dd708f413264f2a3b7653a860fd80440b81dc40f5ec63d63411705ae389bb07bdb74365e277bec24895b44ba8a0a"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `cmarkit.0.4.0` [home](https://erratique.ch/software/cmarkit), [doc](https://erratique.ch/software/cmarkit/doc), [issues](https://github.com/dbuenzli/cmarkit/issues)  
  *CommonMark parser and renderer for OCaml*


---

#### `cmarkit` v0.4.0 2025-11-01 Zagreb

- Support for the CommonMark 0.31.2 specification ([#17](https://github.com/dbuenzli/cmarkit/issues/17)).

- Change task items extension semantics: the task marker is no longer
  considered part of the list marker. The new semantics can lead to 
  surprises with item subparagraphs which can show up as indented code 
  blocks, but it avoids huge indentations for subtasks and is consistent 
  with what at least GFM and `md4c` do.
  Thanks to Thomas Gazagnaire for the report ([#24](https://github.com/dbuenzli/cmarkit/issues/24)).

- `Cmarkit_latex`. Add option `?first_heading_level` to the renderer
  to set the LaTeX heading level to use for the first CommonMark
  heading level. A corresponding option `--first-heading-level` is
  added to `cmarkit latex`.
  Thanks to Léo Andrès for the patch ([#16](https://github.com/dbuenzli/cmarkit/issues/16)).

- `cmarkit html` command: add option `--body-id` to identify page body
  elements.

- `cmarkit` tool: install manpages and completions.

- Less eager escaping of `#` characters in CommonMark renderings.
  Thanks to Thomas Gazagnaire for the report ([#25](https://github.com/dbuenzli/cmarkit/issues/25)).

- Less eager escaping of `.` and `)` characters in CommonMark rendering. 
  Thanks to Ty Overby for the report ([#19](https://github.com/dbuenzli/cmarkit/issues/19)).

- Fix incorrect parsing of code spans if they start with an escaped
  backtick ([#21](https://github.com/dbuenzli/cmarkit/issues/21)).

- Fix incorrect escaping of backticks in CommonMark renderings ([#26](https://github.com/dbuenzli/cmarkit/issues/26)).

- Fix incorrect escaping of tildes for CommonMark rendering interpreted
  with extensions (strikethrough becomes code fence).
  Thanks to Tianyi Song for the report ([#20](https://github.com/dbuenzli/cmarkit/issues/20)).

- Fix `Cmarkit.Mapper`. Do not drop empty table cells.
  Thanks to Hannes Mehnert for the report ([#14](https://github.com/dbuenzli/cmarkit/issues/14)).

- Fix out of bounds exception when lists are terminated by the end of file. 
  Thanks to Ty Overby for the report ([#18](https://github.com/dbuenzli/cmarkit/issues/18)).

- Fix invalid HTML markup generated for cancelled task items.
  Thanks to Sebastien Mondet for the report ([#15](https://github.com/dbuenzli/cmarkit/issues/15)).

- Fix misspelling of `--leading_l` variable in `cmarkit html`'s
  CSS file.

- Updated data for Unicode 17.0.0.

- Require (depopt) `cmdliner` 2.0.0.

---

Use `b0 -- .opam publish cmarkit.0.4.0` to update the pull request.