### PR TITLE
Package qcaml.0.1.1

### DIFF
--- a/packages/qcaml/qcaml.0.1.1/opam
+++ b/packages/qcaml/qcaml.0.1.1/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Experimental OCaml library for quantum computing simulation"
+description: """\
+QCaml is a lightweight OCaml library for experimenting with quantum states,
+gates and measurements. It provides tools for learning quantum computing
+concepts and visualizing qubit states on the Bloch sphere.
+
+Features:
+- Single qubit state representation with complex amplitudes
+- Fundamental quantum gates (Hadamard, Pauli-X/Y/Z)
+- Quantum measurements with probabilistic state collapse
+- Interactive Bloch sphere visualization using OpenGL/GLUT
+- Comprehensive test suite"""
+maintainer: "elias.gauthier@etu.u-bordeaux.fr"
+authors: "Elias GAUTHIER"
+license: "Apache-2.0"
+tags: [
+  "quantum"
+  "computing"
+  "simulation"
+  "qubits"
+  "gates"
+  "visualization"
+  "bloch-sphere"
+]
+homepage: "https://github.com/elias-utf8/qcaml"
+doc: "https://elias-utf8.github.io/qcaml/"
+bug-reports: "https://github.com/elias-utf8/qcaml/issues"
+depends: [
+  "ocaml" {>= "5.2"}
+  "dune" {>= "2.9" & >= "2.9"}
+  "dune-configurator"
+  "conf-freeglut"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "bisect_ppx" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/elias-utf8/qcaml.git"
+url {
+  src: "https://github.com/elias-utf8/qcaml/archive/refs/tags/v0.1.2.tar.gz"
+  checksum: [
+    "md5=21ea66b25de391fff8c6bbc5a0481dd3"
+    "sha512=2f51ffbec81457559fdd36590469dc4933bc4ccb0ccae9e56e468369964c4aa840776d0c0aa30bef67050799b2c129ec7ec9668fc6ba4ab6b41ebc6bceb2b01a"
+  ]
+}


### PR DESCRIPTION
### `qcaml.0.1.1`
Experimental OCaml library for quantum computing simulation
QCaml is a lightweight OCaml library for experimenting with quantum states,
gates and measurements. It provides tools for learning quantum computing
concepts and visualizing qubit states on the Bloch sphere.

Features:
- Single qubit state representation with complex amplitudes
- Fundamental quantum gates (Hadamard, Pauli-X/Y/Z)
- Quantum measurements with probabilistic state collapse
- Interactive Bloch sphere visualization using OpenGL/GLUT
- Comprehensive test suite



---
* Homepage: https://github.com/elias-utf8/qcaml
* Source repo: git+https://github.com/elias-utf8/qcaml.git
* Bug tracker: https://github.com/elias-utf8/qcaml/issues

---
:camel: Pull-request generated by opam-publish v2.7.0