### PR TITLE
Support conf-ffmpeg on Centos 9 and newer and Fedora 41 and newer

### DIFF
--- a/packages/conf-ffmpeg/conf-ffmpeg.1/opam
+++ b/packages/conf-ffmpeg/conf-ffmpeg.1/opam
@@ -12,7 +12,8 @@ depexts: [
   ["libavutil-dev" "libavformat-dev" "libavcodec-dev" "libavdevice-dev" "libavfilter-dev" "libswresample-dev" "libswscale-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os = "freebsd" | os-distribution = "arch" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
-  ["ffmpeg-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}
+  ["ffmpeg-free-devel"] {(os-distribution = "centos" & os-version >= "9") | (os-distribution = "fedora" & os-version >= "41")}
+  ["ffmpeg-devel"] {(os-distribution = "centos" & os-version < "9") | (os-family = "fedora" & os-version < "41") | os-family = "suse" | os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on FFmpeg"
 description:


### PR DESCRIPTION
On https://github.com/ocaml/opam-repository/pull/28810 I spotted lots of Centos and Fedora errors, e.g.
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/1ad1c6b061983bdeb27a2757dca4d07fcd0c892a/variant/distributions,centos-9-ocaml-4.14,ffmpeg.1.2.7
```
ffmpeg.1.2.7 is not installed. Install it? [Y/n] y
The following actions will be performed:
=== install 13 packages
  - install conf-ffmpeg       1              [required by ffmpeg-swresample, ffmpeg-avdevice, ffmpeg-av, etc.]
  - install conf-pkg-config   4              [required by ffmpeg-swresample, ffmpeg-avdevice, ffmpeg-av, etc.]
  - install csexp             1.5.2          [required by dune-configurator]
  - install dune              3.20.2         [required by ffmpeg]
  - install dune-configurator 3.20.2         [required by ffmpeg-swresample, ffmpeg-avdevice, ffmpeg-av, etc.]
  - install ffmpeg            1.2.7 (pinned)
  - install ffmpeg-av         1.2.7          [required by ffmpeg]
  - install ffmpeg-avcodec    1.2.7          [required by ffmpeg]
  - install ffmpeg-avdevice   1.2.7          [required by ffmpeg]
  - install ffmpeg-avfilter   1.2.7          [required by ffmpeg]
  - install ffmpeg-avutil     1.2.7          [required by ffmpeg]
  - install ffmpeg-swresample 1.2.7          [required by ffmpeg]
  - install ffmpeg-swscale    1.2.7          [required by ffmpeg]

The following system packages will first need to be installed:
    ffmpeg-devel

<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><><><>

opam believes some required external dependencies are missing. opam can:
> 1. Run yum to install them (may need root/sudo access)
  2. Display the recommended yum command and wait while you run it manually (e.g. in another terminal)
  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
  4. Abort the installation

[1/2/3/4] 1

+ /usr/bin/sudo "yum" "install" "-y" "ffmpeg-devel"
- Last metadata expiration check: 0:00:29 ago on Fri Oct 31 19:33:11 2025.
- No match for argument: ffmpeg-devel
- Error: Unable to find a match: ffmpeg-devel
[ERROR] System package install failed with exit code 1 at command:
            sudo yum install -y ffmpeg-devel
[ERROR] These packages are still missing: ffmpeg-devel
```

After some digging it seems the package is named `ffmpeg-free-devel` on those newer distribution versions:
https://pkgs.org/download/ffmpeg-free-devel

Why precisely Centos 9 and Fedora 41?

I have not been able to locate a source for the precise distribution version where the name changed.
From the following Fedora page, it seems it has been in effect since at least Fedora 41:
https://packages.fedoraproject.org/pkgs/ffmpeg/ffmpeg-free-devel/
I don't know of a Centos package database documenting when it changed there.
AFAIU Centos is a Fedora derivative and "Enterprise Linux" (EPEL) also links to the Fedora database from here:
https://repology.org/project/ffmpeg/versions

According to https://docs.fedoraproject.org/en-US/epel/epel-faq/
> EPEL provides packages for CentOS Stream 10, CentOS Stream 9, [...]

Hence Centos 9 and Fedora 41 is my best effort from the above sources... :shrug: 