### PR TITLE
[new release] ppx_expect_nobase (0.17.3.0)

### DIFF
--- a/packages/ppx_expect_nobase/ppx_expect_nobase.0.17.3.0/opam
+++ b/packages/ppx_expect_nobase/ppx_expect_nobase.0.17.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Cram like framework for OCaml (with stripped dependencies)"
+description: """
+Testing framework: fork of ppx_expect, but with less dependecies.
+Original ppx_expect is a part of the Jane Street's PPX rewriters collection."""
+maintainer: ["Jane Street Group, LLC" "Dmitrii Kosarev a.k.a. Kakadu"]
+authors: ["Jane Street Group, LLC"]
+license: "MIT"
+homepage: "https://github.com/Kakadu/ppx_expect_nobase"
+bug-reports: "https://github.com/Kakadu/ppx_expect_nobase/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "4.14.2" & < "5.0.0" | >= "5.3.0" & <= "5.4.0"}
+  "ppx_inline_test_nobase" {>= "v0.17.0.2"}
+  "sexplib"
+  "ppxlib" {>= "0.35.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Kakadu/ppx_expect_nobase.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/Kakadu/ppx_expect_nobase/releases/download/0.17.3.0/ppx_expect_nobase-0.17.3.0.tbz"
+  checksum: [
+    "sha256=a6544cf7e9ed30f15a324209eb8d290a16d16d7136fe9975a6854d43dfbcec37"
+    "sha512=ea95af95bb881a4d8a536663bf10b3ff5cee0637a5a763cd4322a84b62efcdd94f9b10f1f54debcf4d7dc7dd6d32a36f70bac44c9809be087eaa936f13fd5de6"
+  ]
+}
+x-commit-hash: "4e305cd0d86f28c91c650f26bec4323de4bf575c" 
+


### PR DESCRIPTION
Cram like framework for OCaml (with stripped dependencies)

- Project page: <a href="https://github.com/Kakadu/ppx_expect_nobase">https://github.com/Kakadu/ppx_expect_nobase</a>

##### CHANGES:

Strip base and other dependecies.
