### PR TITLE
Package binaryen.0.28.0

### DIFF
--- a/packages/binaryen/binaryen.0.28.0/opam
+++ b/packages/binaryen/binaryen.0.28.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "6.0.0" & < "7.0.0"}
+  "libbinaryen" {> "118.0.0" & < "119.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.28.0/binaryen-archive-v0.28.0.tar.gz"
+  checksum: [
+    "md5=d13ba0bdc217fb7c1a46c105f079e05f"
+    "sha512=26cd80e0c46e8cf30f940589fdde03727289b63a5f3f1b6eefe595299cf34531030f4868f1e1c04136c6ff64f34da87a51df24df5934c35ed98b87d6f2ce07ff"
+  ]
+}
+x-maintenance-intent: ["0.(latest)"]


### PR DESCRIPTION
### `binaryen.0.28.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.28.0](https://github.com/grain-lang/binaryen.ml/compare/v0.27.0...v0.28.0) (2025-11-01)

### ⚠ BREAKING CHANGES

- Upgrade to Binaryen v118 ([#204](https://github.com/grain-lang/binaryen.ml/issues/204))

### Features

- Upgrade to Binaryen v118 ([#204](https://github.com/grain-lang/binaryen.ml/issues/204)) ([6a5d0e8](https://github.com/grain-lang/binaryen.ml/commit/6a5d0e8ca24e306bc6d634bebc9f70efdf0896e0))


---
:camel: Pull-request generated by opam-publish v2.4.0