### PR TITLE
[new release] ppx_expect_nobase (0.17.3.0)

### DIFF
--- a/packages/ppx_expect_nobase/ppx_expect_nobase.0.17.3.0/opam
+++ b/packages/ppx_expect_nobase/ppx_expect_nobase.0.17.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Cram like framework for OCaml (with stripped dependencies)"
+description: """
+Testing framework: fork of ppx_expect, but with less dependecies.
+Original ppx_expect is a part of the Jane Street's PPX rewriters collection."""
+maintainer: ["Jane Street Group, LLC" "Dmitrii Kosarev a.k.a. Kakadu"]
+authors: ["Jane Street Group, LLC"]
+license: "MIT"
+homepage: "https://github.com/Kakadu/ppx_expect_nobase"
+bug-reports: "https://github.com/Kakadu/ppx_expect_nobase/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "4.14.2" & < "5.0.0" | >= "5.3.0" & <= "5.4.0"}
+  "ppx_inline_test_nobase" {>= "v0.17.0.2"}
+  "sexplib"
+  "ppxlib" {>= "0.35.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Kakadu/ppx_expect_nobase.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/Kakadu/ppx_expect_nobase/releases/download/v0.17.3.0/ppx_expect_nobase-0.17.3.0.tbz"
+  checksum: [
+    "sha256=ff2cb97c867a4bd3a0778ff0924c1cb8a82c7c531f81f2b0aa220b7c29758e40"
+    "sha512=3eae2efe081aeed87d44d46f960a66744ed6d90c78f07ba91639ff2694aea655d4b71c5865d97dd88c1681e3752b90c06c252595f67ff135fcce87c38085b81f"
+  ]
+}
+x-commit-hash: "13d7b425ef7c358609f51a9c05c5b503ca670ab7" 
+


### PR DESCRIPTION
Cram like framework for OCaml (with stripped dependencies)

- Project page: <a href="https://github.com/Kakadu/ppx_expect_nobase">https://github.com/Kakadu/ppx_expect_nobase</a>

##### CHANGES:

Strip base and other dependecies.
