### PR TITLE
Package binaryen.0.29.0

### DIFF
--- a/packages/binaryen/binaryen.0.29.0/opam
+++ b/packages/binaryen/binaryen.0.29.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "6.0.0" & < "7.0.0"}
+  "libbinaryen" {> "119.0.0" & < "120.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.29.0/binaryen-archive-v0.29.0.tar.gz"
+  checksum: [
+    "md5=2f2a9c16fe5a5c49cda72b944366a3ea"
+    "sha512=a47276375b6bdc515cfd59f9411f14a0b703c2ecd616da3a440316871d3db7b002b508a2e579b80f8149b9b21794434763837ea019f952f5aef552586f9ede4b"
+  ]
+}
+x-maintenance-intent: ["0.(latest)"]


### PR DESCRIPTION
### `binaryen.0.29.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.29.0](https://github.com/grain-lang/binaryen.ml/compare/v0.28.0...v0.29.0) (2025-11-01)

### ⚠ BREAKING CHANGES

- Upgrade to Binaryen v119 ([#205](https://github.com/grain-lang/binaryen.ml/issues/205))

### Features

- Upgrade to Binaryen v119 ([#205](https://github.com/grain-lang/binaryen.ml/issues/205)) ([3a6b775](https://github.com/grain-lang/binaryen.ml/commit/3a6b77594908b1585864160a1895c9ba25319b8f))


---
:camel: Pull-request generated by opam-publish v2.4.0