### PR TITLE
Package libbinaryen.123.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.123.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.123.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "7.0.0"}
+  "ocaml" {>= "4.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v123.0.0/libbinaryen-v123.0.0.tar.gz"
+  checksum: [
+    "md5=96e0736fc40db8c99e128dcbcbc56c37"
+    "sha512=9132f497c948e47e320c3046362ab77fd3b97d76b4ebfd7f8110588f3bbb6ba04852a56507585279abcfee556dbfa789af54d814e57e0a2096bb88a0f08a13b0"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `libbinaryen.123.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [123.0.0](https://github.com/grain-lang/libbinaryen/compare/v122.0.0...v123.0.0) (2025-11-02)

### ⚠ BREAKING CHANGES

- Upgrade to Binaryen v123 ([#129](https://github.com/grain-lang/libbinaryen/issues/129))

### Features

- Upgrade to Binaryen v123 ([#129](https://github.com/grain-lang/libbinaryen/issues/129)) ([cb37a90](https://github.com/grain-lang/libbinaryen/commit/cb37a909a8b27ab2f5ef89b5c5c346e2622424f0))


---
:camel: Pull-request generated by opam-publish v2.4.0