### PR TITLE
Package binaryen.0.30.0

### DIFF
--- a/packages/binaryen/binaryen.0.30.0/opam
+++ b/packages/binaryen/binaryen.0.30.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "6.0.0" & < "7.0.0"}
+  "libbinaryen" {> "120.0.0" & < "121.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.30.0/binaryen-archive-v0.30.0.tar.gz"
+  checksum: [
+    "md5=1a5f478c03c1c97ae2f2d5ea4b9a0969"
+    "sha512=3f74cad0970df66dd66854e0fc5f6d589c129580a14cb797769287589d664036a120087172305f928b250e891f784ae3ef197aa71f4f0a237df48e11fed3c13f"
+  ]
+}
+x-maintenance-intent: ["0.(latest)"]


### PR DESCRIPTION
### `binaryen.0.30.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.30.0](https://github.com/grain-lang/binaryen.ml/compare/v0.29.0...v0.30.0) (2025-11-02)

### ⚠ BREAKING CHANGES

- Upgrade to Binaryen v120 ([#206](https://github.com/grain-lang/binaryen.ml/issues/206))

### Features

- Upgrade to Binaryen v120 ([#206](https://github.com/grain-lang/binaryen.ml/issues/206)) ([4d69831](https://github.com/grain-lang/binaryen.ml/commit/4d6983154c19140af2ab2ac4451c5b69f0f2a736))


---
:camel: Pull-request generated by opam-publish v2.4.0