### PR TITLE
Package binaryen.0.31.0

### DIFF
--- a/packages/binaryen/binaryen.0.31.0/opam
+++ b/packages/binaryen/binaryen.0.31.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "6.0.0" & < "7.0.0"}
+  "libbinaryen" {> "121.0.0" & < "122.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.31.0/binaryen-archive-v0.31.0.tar.gz"
+  checksum: [
+    "md5=cc18dfa2d3d65bf3682aaef7ddd70601"
+    "sha512=12ca58a5a10f163d55e6178ddf485630dc5a8d1d69c0c96036d2de6596843bcfcefd0820fe8656f210eb5fa1a9a7bd0a07aefdb5956edeefcf39c5f080298217"
+  ]
+}
+x-maintenance-intent: ["0.(latest)"]


### PR DESCRIPTION
### `binaryen.0.31.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.31.0](https://github.com/grain-lang/binaryen.ml/compare/v0.30.0...v0.31.0) (2025-11-02)

### ⚠ BREAKING CHANGES

- Upgrade to Binaryen v121 ([#207](https://github.com/grain-lang/binaryen.ml/issues/207))

### Features

- Upgrade to Binaryen v121 ([#207](https://github.com/grain-lang/binaryen.ml/issues/207)) ([7e51d5d](https://github.com/grain-lang/binaryen.ml/commit/7e51d5da5bd2336dd0122468bcc1e3030e13f86c))


---
:camel: Pull-request generated by opam-publish v2.4.0