### PR TITLE
Package libbinaryen.124.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.124.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.124.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "7.0.0"}
+  "ocaml" {>= "4.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v124.0.0/libbinaryen-v124.0.0.tar.gz"
+  checksum: [
+    "md5=98406ca09319050dbe16a1f6c401dcfb"
+    "sha512=2c35fb54185abd786d89604dcb2853afe01751f9a912a291bd2584437d65235248a744884015cb583341cca5db045569ae9acbdfccc372691e8fa15218288ae0"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `libbinaryen.124.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [124.0.0](https://github.com/grain-lang/libbinaryen/compare/v123.0.0...v124.0.0) (2025-11-02)

### ⚠ BREAKING CHANGES

- Upgrade to Binaryen v124 ([#131](https://github.com/grain-lang/libbinaryen/issues/131))

### Features

- Upgrade to Binaryen v124 ([#131](https://github.com/grain-lang/libbinaryen/issues/131)) ([947b291](https://github.com/grain-lang/libbinaryen/commit/947b2912d5d9eeadb37f6d20df0fb13840f6303c))


---
:camel: Pull-request generated by opam-publish v2.4.0