### PR TITLE
Require epel-release on `conf-ffmpeg` to enable the EPEL repository

### DIFF
--- a/packages/conf-ffmpeg/conf-ffmpeg.1/opam
+++ b/packages/conf-ffmpeg/conf-ffmpeg.1/opam
@@ -12,7 +12,8 @@ depexts: [
   ["libavutil-dev" "libavformat-dev" "libavcodec-dev" "libavdevice-dev" "libavfilter-dev" "libswresample-dev" "libswscale-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}
   ["ffmpeg"] {os = "freebsd" | os-distribution = "arch" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
-  ["ffmpeg-free-devel"] {(os-distribution = "centos" & os-version >= "9") | (os-distribution = "fedora" & os-version >= "41")}
+  ["ffmpeg-free-devel" "epel-release"] {os-distribution = "centos" & os-version >= "9"}
+  ["ffmpeg-free-devel"] {os-distribution = "fedora" & os-version >= "41"}
   ["ffmpeg-devel"] {(os-distribution = "centos" & os-version < "9") | (os-family = "fedora" & os-version < "41") | os-family = "suse" | os-family = "opensuse"}
 ]
 synopsis: "Virtual package relying on FFmpeg"


### PR DESCRIPTION
This is a follow-up to #28814.
I expected `epel-release` to be an opam-package, but it is (of course) a Centos package! :sweat_smile: 
This PR therefore requires that one as a depext.
With luck, this will get things running on Centos without red CI lights... :crossed_fingers: 