### PR TITLE
Fix conf-python-3 on Centos

### DIFF
--- a/packages/conf-python-3/conf-python-3.9.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.9.0.0/opam
@@ -9,7 +9,8 @@ depexts: [
   ["python3"] {os-family = "debian" | os-family = "ubuntu"}
   ["python3"] {os-distribution = "nixos"}
   ["python3"] {os-distribution = "alpine"}
-  ["python39" "epel-release"] {os-distribution = "centos"}
+  ["python3"] {os-distribution = "centos" & os-version >= "9"}
+  ["python39" "epel-release"] {os-distribution = "centos" & os-version < "9"}
   ["python3"] {os-family = "fedora"}
   ["python3"] {os-distribution = "ol"}
   ["python"] {os-distribution = "arch"}


### PR DESCRIPTION
Spotted on #28750:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/0fd2245f35e2c69f0d17ec627e7c379c755893f8/variant/distributions,centos-10-ocaml-5.4,unikraft.0.20.0
```
+ /usr/bin/sudo "yum" "install" "-y" "python39"
- Extra Packages for Enterprise Linux 10 - x86_64  15 MB/s | 5.7 MB     00:00    
- Last metadata expiration check: 0:00:02 ago on Tue Oct 21 13:16:38 2025.
- No match for argument: python39
- Error: Unable to find a match: python39
[ERROR] System package install failed with exit code 1 at command:
            sudo yum install -y python39
[ERROR] These packages are still missing: epel-release python39
```

AFAICS, Centos 10 offers Python 3.12.
- If I am reading the package name correctly here: https://mirror.stream.centos.org/10-stream/BaseOS/x86_64/os/Packages/ there should a `python3` package available.
- https://repology.org/project/python/versions for Centos 10 however lists no `python3` package and
- https://gitlab.com/redhat/centos-stream/rpms/python3/-/tree/c10s?ref_type=heads says `dead.package` :grimacing: 

so this is an experiment... :crossed_fingers: 