### PR TITLE
Add: topkg.1.1.1, topkg-care.1.1.1

### DIFF
--- a/packages/topkg-care/topkg-care.1.1.1/opam
+++ b/packages/topkg-care/topkg-care.1.1.1/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "The transitory OCaml software packager"
+description: """\
+**Warning** Topkg is in maintenance mode and should not longer be used.
+
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution, creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml opam repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-format`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser
+
+Home page: <http://erratique.ch/software/topkg>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The topkg programmers"
+license: "ISC"
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+homepage: "https://erratique.ch/software/topkg"
+doc: "https://erratique.ch/software/topkg/doc"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build & >= "1.6.1"}
+  "ocamlbuild"
+  "topkg" {= version}
+  "fmt" {>= "0.9.0"}
+  "logs"
+  "bos" {>= "0.2.1"}
+  "cmdliner" {>= "1.3.0"}
+  "webbrowser"
+  "opam-format" {>= "2.0.0"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/topkg.git"
+url {
+  src: "https://erratique.ch/software/topkg/releases/topkg-1.1.1.tbz"
+  checksum:
+    "sha512=c36c549a362ddf5b7fe3f6ff91c79b7ab531c43633bb9737576370bcbd69db7e1625d247c278a869b503d45a175e9753231ccf595e5bfa4e3b7e2602ac3d3b42"
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/topkg/topkg.1.1.1/opam
+++ b/packages/topkg/topkg.1.1.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "The transitory OCaml software packager"
+description: """\
+**Warning** Topkg is in maintenance mode and should not longer be used.
+
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution, creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml opam repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-format`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser
+
+Home page: <http://erratique.ch/software/topkg>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The topkg programmers"
+license: "ISC"
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+homepage: "https://erratique.ch/software/topkg"
+doc: "https://erratique.ch/software/topkg/doc"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build & >= "1.6.1"}
+  "ocamlbuild"
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/topkg.git"
+url {
+  src: "https://erratique.ch/software/topkg/releases/topkg-1.1.1.tbz"
+  checksum:
+    "sha512=c36c549a362ddf5b7fe3f6ff91c79b7ab531c43633bb9737576370bcbd69db7e1625d247c278a869b503d45a175e9753231ccf595e5bfa4e3b7e2602ac3d3b42"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `topkg.1.1.1` [home](https://erratique.ch/software/topkg), [doc](https://erratique.ch/software/topkg/doc), [issues](https://github.com/dbuenzli/topkg/issues)  
  *The transitory OCaml software packager*
* Add: `topkg-care.1.1.1` [home](https://erratique.ch/software/topkg), [doc](https://erratique.ch/software/topkg/doc), [issues](https://github.com/dbuenzli/topkg/issues)  
  *The transitory OCaml software packager*


---

#### `topkg-care`, `topkg` v1.1.1 2025-11-03 Zagreb

- Support for large package builds. On build, generate a `pkg.itarget`
  at the root with the files to build and invoke `ocamlbuild` with
  `pkg.otarget` rather than the explicit list of files. The
  `pkg.itarget` file can be ignored by your VCS, it is generated on
  the fly on each build. As a side effect, improves error reporting on
  build failures.

---

Use `b0 -- .opam publish topkg.1.1.1 topkg-care.1.1.1` to update the pull request.