### PR TITLE
Package qcaml.0.1.4

### DIFF
--- a/packages/qcaml/qcaml.0.1.4/opam
+++ b/packages/qcaml/qcaml.0.1.4/opam
@@ -54,7 +54,7 @@ dev-repo: "git+https://github.com/elias-utf8/qcaml.git"
 url {
   src: "https://github.com/elias-utf8/qcaml/archive/refs/tags/v0.1.4.tar.gz"
   checksum: [
-    "md5=75602ae520e812b4a2288e47b3b35769"
-    "sha512=8681758db62f0b6a19be735e12fe2f662277666658c7cfe4df565c199e78c530cfbd8b3c413614c929f99e73ec0841edb1e53c13203a9787a016f0f2320719a9"
+    "md5=cdda9603871a788171bcc9abfb09fd41"
+    "sha512=f6b7c88938fc772e9fc81066432d08333043cb02107dcb9593a73b1d04d84a968371cd07e3afb9d3d7d17729d9cfaa19b4ed1dd4b7bf05e0eb355a3b54d512e1"
   ]
 }


### PR DESCRIPTION
### `qcaml.0.1.4`
Experimental OCaml library for quantum computing simulation
QCaml is a lightweight OCaml library for experimenting with quantum states,
gates and measurements. It provides tools for learning quantum computing
concepts and visualizing qubit states on the Bloch sphere.

Features:
- Single qubit state representation with complex amplitudes
- Fundamental quantum gates (Hadamard, Pauli-X/Y/Z)
- Quantum measurements with probabilistic state collapse
- Interactive Bloch sphere visualization using OpenGL/GLUT
- Comprehensive test suite



---
* Homepage: https://github.com/elias-utf8/qcaml
* Source repo: git+https://github.com/elias-utf8/qcaml.git
* Bug tracker: https://github.com/elias-utf8/qcaml/issues

---
:camel: Pull-request generated by opam-publish v2.7.0