### PR TITLE
Frama-C: new release (32.0~beta-Germanium)

### DIFF
--- a/packages/frama-c/frama-c.32.0~beta/opam
+++ b/packages/frama-c/frama-c.32.0~beta/opam
@@ -201,6 +201,15 @@ url {
   src: "https://www.frama-c.com/download/frama-c-32.0-beta-Germanium.tar.gz"
   checksum: "sha256=868d57ef8007fe6c0836cd151d8c294003af34aa678285eff9547662cad36aa3"
 }
+
+x-maintenance-intent: [
+  "(latest).(any)"
+  "(latest-1).(latest)"
+  "(latest-2).(latest)"
+  "(latest-3).(latest)"
+  "(latest-4).(latest)"
+]
+
 x-ci-accept-failures: [  # the following either uses musl or has an incompatible gcc version
   "alpine-3.22"
   "centos-9"


### PR DESCRIPTION
# Frama-C 32.0~beta Germanium

[Release page](https://frama-c.com/fc-versions/germanium.html)

## Kernel

- Color and style for terminals supporting ANSI escape code.
- Improved support for C (including C23) alignment directives.
- Support newly introduced `\aligned` predicate in ACSL.
- String literals are now global arrays (as specified in the standard), not pointers.
- Support for using information from mopsa-db compilation databases.
- Experimental sandbox mode for deploying Frama-C-as-a-Service.

## E-ACSL

- Support of nested inductive definitions.
- Support `\aligned` built-in predicate.

## Eva

- Check pointer alignment in analyzed programs.
- The taint domain can propagate several distinct taints, each identified by a unique name.
- Simplify running Mthread analyses.

## Ivette

- New sidebar and menu to manage Frama-C projects.
- New panel to view and modify Frama-C parameters.
- Redesign and multiple improvements of the 'Files' sidebar.
- Select WP goals according to selected annotation and show related statements.
- Minimal support of the Slicing plug-in.
