### PR TITLE
Fix missing 's' in `x-ci-accept-failures` from git-net.0.2.0

### DIFF
--- a/packages/git-net/git-net.0.2.0/opam
+++ b/packages/git-net/git-net.0.2.0/opam
@@ -34,7 +34,7 @@ build: [
                & os-distribution != "opensuse"}
 ]
 x-maintenance-intent: [ "(latest)" ]
-x-ci-accept-failure: [ "alpine-3.21" "fedora-41" "fedora-42" "opensuse-15.6" "opensuse-tumbleweed" ]
+x-ci-accept-failures: [ "alpine-3.21" "fedora-41" "fedora-42" "opensuse-15.6" "opensuse-tumbleweed" ]
 url {
   src:
     "https://github.com/robur-coop/git-kv/releases/download/v0.2.0/git-kv-0.2.0.tbz"


### PR DESCRIPTION
Some PRs are bigger than others...

The missing `s` would cause the field lookup to fail, thus not silencing the errors as expected :shrug: 