### PR TITLE
[MLCUDDIDL] supports 5.0 by removing modules

### DIFF
--- a/packages/mlcuddidl/mlcuddidl.3.0.8/opam
+++ b/packages/mlcuddidl/mlcuddidl.3.0.8/opam
@@ -22,6 +22,7 @@ depends: [
 ]
 patches : [
   "compilation_ocaml5.diff" { ocaml:version >= "5" }
+  "exn_init_val_unit.diff"
 ]
 synopsis: "OCaml interface to the CUDD BDD library"
 post-messages: [
@@ -43,3 +44,10 @@ extra-source "compilation_ocaml5.diff" {
   ]
 }
 
+extra-source "exn_init_val_unit.diff" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/mlcuddidl/exn_init_val_unit.diff"
+  checksum: [
+      "sha256=a00ceaaca0aa26b1fabd1cdb893769f5de6c5481ff33331035c6fbf91210b0c7"
+  ]
+}


### PR DESCRIPTION
Mlcuddidl is a binding for cudd (BDD) which added some interesting functionalities in the C code. It went as far as letting the user put OCaml values as leaf of a BDD, so inside a C datastructure. This require some expert (god?) level collaboration with the runtime. The massive change of the runtime for ocaml 5.0 makes those juggling even more complicated.

This PR removes, only for OCaml >= 5.0, the problematic modules, so that the users can still use the usual BDD datastructure.

I'm not the maintainer which is @nberth , but he seems to be busy: https://framagit.org/nberth/mlcuddidl/-/issues/2