### PR TITLE
Add depopts for cmarkit in hilite

### DIFF
--- a/packages/hilite/hilite.0.5.0/opam
+++ b/packages/hilite/hilite.0.5.0/opam
@@ -15,6 +15,9 @@ depends: [
   "textmate-language" {>= "0.3.3"}
   "odoc" {with-doc}
 ]
+depopts:[
+  "cmarkit" {>= "0.3.0"}
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
Cmarkit is an optional dependency of `hilite.markdown`