### PR TITLE
Package libbinaryen.122.0.1

### DIFF
--- a/packages/libbinaryen/libbinaryen.122.0.1/opam
+++ b/packages/libbinaryen/libbinaryen.122.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "7.0.0"}
+  "ocaml" {>= "4.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v122.0.1/libbinaryen.tar.gz"
+  checksum: [
+    "md5=5af8c2fb6afb7bff8502445034c7db16"
+    "sha512=5aecad7d8dbe96046e310543d6b025ff75380c05eb5d3eb959f12407df890096b94f65c659617fa00ef5f6b4aab5d0efb43341726f28c6ae8a6bfe8bade74f34"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `libbinaryen.122.0.1`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## What's Changed

- fix: Don't include binaryen submodules so Windows builds with opam by @ospencer in https://github.com/grain-lang/libbinaryen/pull/140

**Full Changelog**: https://github.com/grain-lang/libbinaryen/compare/v122.0.0...v122.0.1


---
:camel: Pull-request generated by opam-publish v2.4.0