### PR TITLE
Package libbinaryen.123.0.1

### DIFF
--- a/packages/libbinaryen/libbinaryen.123.0.1/opam
+++ b/packages/libbinaryen/libbinaryen.123.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "7.0.0"}
+  "ocaml" {>= "4.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v123.0.1/libbinaryen.tar.gz"
+  checksum: [
+    "md5=f2a8ca94bb3524ab1a91532443ee5f2e"
+    "sha512=4c37e9482211b1f2fb3812e0e70a8efd936267153821c4ad041486f9072f1f4f0d5965d11925f951d31b447cadd3a642575bd948c01b44a1d0011b26babf624d"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `libbinaryen.123.0.1`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## What's Changed

- fix: Don't include binaryen submodules so Windows builds with opam by @ospencer in https://github.com/grain-lang/libbinaryen/pull/141

**Full Changelog**: https://github.com/grain-lang/libbinaryen/compare/v123.0.0...v123.0.1


---
:camel: Pull-request generated by opam-publish v2.4.0