### PR TITLE
Package libbinaryen.124.0.1

### DIFF
--- a/packages/libbinaryen/libbinaryen.124.0.1/opam
+++ b/packages/libbinaryen/libbinaryen.124.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "7.0.0"}
+  "ocaml" {>= "4.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v124.0.1/libbinaryen-v124.0.1.tar.gz"
+  checksum: [
+    "md5=9e2b99d0ef6a8ef1984101fe09d349e5"
+    "sha512=17d55d3a6735b821a0b3952b6308e4d169d419be1b727cab0e057f65c65cff3beb32922055330d8e5969261f122603ae9e49697ebbdda437684f42d4bab1414e"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `libbinaryen.124.0.1`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [124.0.1](https://github.com/grain-lang/libbinaryen/compare/v124.0.0...v124.0.1) (2025-11-06)

### Bug Fixes

- Don't include binaryen submodules so Windows builds with opam ([#138](https://github.com/grain-lang/libbinaryen/issues/138)) ([e87751a](https://github.com/grain-lang/libbinaryen/commit/e87751af8a30f99a4cfeeb153d364d60c83deadc))


---
:camel: Pull-request generated by opam-publish v2.4.0