### PR TITLE
fix: solo5 declares x-ci-accept-failures twice

### DIFF
--- a/packages/solo5/solo5.0.10.0/opam
+++ b/packages/solo5/solo5.0.10.0/opam
@@ -37,7 +37,6 @@ available: [
   (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]
-x-ci-accept-failures: [ "centos-7" ]
 synopsis: "Solo5 sandboxed execution environment"
 description: """
 Solo5 is a sandboxed execution environment primarily intended
@@ -48,7 +47,7 @@ This package provides the Solo5 components needed to build and
 run MirageOS unikernels on the host system.
 """
 x-maintenance-intent: [ "(latest)" ]
-x-ci-accept-failures: [ "opensuse-15.6" ] # too old GCC compiler (OpenSUSE uses GCC 7 and we require GCC 10)
+x-ci-accept-failures: [ "centos-7" "opensuse-15.6" ] # too old GCC compiler (OpenSUSE uses GCC 7 and we require GCC 10)
 url {
   src: "https://github.com/Solo5/solo5/releases/download/v0.10.0/solo5-v0.10.0.tar.gz"
   checksum: "sha512=fadc0f0920b3c77f828f5396db267755a9b45fb19b44970f2363224a91a11ba8593fe27caf3c14c321a52f993a6d21ec200f0eb950dd7bb0f5bbe5f7102aba5f"

--- a/packages/solo5/solo5.0.9.2/opam
+++ b/packages/solo5/solo5.0.9.2/opam
@@ -38,7 +38,6 @@ available: [
   (os = "linux" | os = "freebsd" | os = "openbsd") &
   os-family != "opensuse"
 ]
-x-ci-accept-failures: [ "centos-7" ]
 synopsis: "Solo5 sandboxed execution environment"
 description: """
 Solo5 is a sandboxed execution environment primarily intended
@@ -53,4 +52,4 @@ url {
   src: "https://github.com/Solo5/solo5/releases/download/v0.9.2/solo5-v0.9.2.tar.gz"
   checksum: "sha512=a883461432f69fa2a74ca5b03df0f6a6149c1ce2abf8ae97af04d23734c4870ebefe43fe8e69b0ba6c88507b244d082cd6bc14ec4a4c8ef1a54d1fa9f05e8098"
 }
-x-ci-accept-failures: [ "opensuse-15.6" ] # too old GCC compiler (OpenSUSE uses GCC 7 and we require GCC 10)
+x-ci-accept-failures: [ "centos-7" "opensuse-15.6" ] # too old GCC compiler (OpenSUSE uses GCC 7 and we require GCC 10)

--- a/packages/solo5/solo5.0.9.3/opam
+++ b/packages/solo5/solo5.0.9.3/opam
@@ -37,7 +37,6 @@ available: [
   (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]
-x-ci-accept-failures: [ "centos-7" ]
 synopsis: "Solo5 sandboxed execution environment"
 description: """
 Solo5 is a sandboxed execution environment primarily intended
@@ -48,7 +47,7 @@ This package provides the Solo5 components needed to build and
 run MirageOS unikernels on the host system.
 """
 x-maintenance-intent: [ "(latest)" ]
-x-ci-accept-failures: [ "opensuse-15.6" ] # too old GCC compiler (OpenSUSE uses GCC 7 and we require GCC 10)
+x-ci-accept-failures: [ "centos-7" "opensuse-15.6" ] # too old GCC compiler (OpenSUSE uses GCC 7 and we require GCC 10)
 url {
   src: "https://github.com/Solo5/solo5/releases/download/v0.9.3/solo5-v0.9.3.tar.gz"
   checksum: "sha512=e8eed5c0be0d5ee5f528ac91874363f4fded71618ed19bdbd354d303ed7fdc73394fd2531ccb780c579fa789e13181205d062e34c6e82916b072936ebaadf9dd"


### PR DESCRIPTION
The following solo5 packages have duplicate entries for `x-ci-accept-failures` (and are the only packages with duplicate fields definition!). This causes `opam2json` to error, which could be fixed with https://github.com/tweag/opam2json/pull/3, but it's probably easier to just fix these package definitions to avoid the ambiguity. Note that `opam show --raw` only keeps the latest entry instead of the concatenation suggested here. cc @dinosaure 