### PR TITLE
[new release] ppx_deriving_jsont (0.1.0)

### DIFF
--- a/packages/ppx_deriving_jsont/ppx_deriving_jsont.0.1.0/opam
+++ b/packages/ppx_deriving_jsont/ppx_deriving_jsont.0.1.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/voodoos/ppx_deriving_jsont/issues"
 depends: [
   "dune" {>= "3.17"}
   "ppxlib" {>= "0.36.0"}
-  "jsont" {with-test}
+  "jsont"
   "bytesrw" {with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
A ppx deriver for Jsont

- Project page: <a href="https://github.com/voodoos/ppx_deriving_jsont">https://github.com/voodoos/ppx_deriving_jsont</a>

##### CHANGES:

First release.
