### PR TITLE
[new release] ppx_deriving_jsont (0.1.1)

### DIFF
--- a/packages/ppx_deriving_jsont/ppx_deriving_jsont.0.1.1/opam
+++ b/packages/ppx_deriving_jsont/ppx_deriving_jsont.0.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A ppx deriver for Jsont"
+description:
+  "A convenient tool to generate Jsont descriptions for various OCaml types."
+maintainer: ["Ulysse Gérard"]
+authors: ["Ulysse Gérard"]
+license: "MIT"
+homepage: "https://github.com/voodoos/ppx_deriving_jsont"
+bug-reports: "https://github.com/voodoos/ppx_deriving_jsont/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ppxlib" {>= "0.36.0"}
+  "jsont"
+  "bytesrw" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/voodoos/ppx_deriving_jsont.git"
+url {
+  src:
+    "https://github.com/voodoos/ppx_deriving_jsont/releases/download/0.1.1/ppx_deriving_jsont-0.1.1.tbz"
+  checksum: [
+    "sha256=40d4069e3db7705c0a0b2ad326e05174d7e4f675e6beb813f8ec82c3104a9dc6"
+    "sha512=73acea0ed7baf2e589ab189be77c601620c34f1472cc3780251e523e624565a30a569407436b653f2e0b176ae61079148e4d5c878f8b2ef2108e6c6a4d44fa9e"
+  ]
+}
+x-commit-hash: "d5ed6853140c40e5438354d037bfc86229a59446"


### PR DESCRIPTION
A ppx deriver for Jsont

- Project page: <a href="https://github.com/voodoos/ppx_deriving_jsont">https://github.com/voodoos/ppx_deriving_jsont</a>

##### CHANGES:

Compatibility with OCaml 4.14
