### PR TITLE
Add: tsdl.1.2.0

### DIFF
--- a/packages/tsdl/tsdl.1.2.0/opam
+++ b/packages/tsdl/tsdl.1.2.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Thin bindings to SDL for OCaml"
+description: """\
+Tsdl is an OCaml library providing thin bindings to the cross-platform
+[SDL library].
+
+Tsdl depends on the C library SDL 2.0.18 (or later),
+[ocaml-ctypes][ctypes]. Tsdl is distributed under the ISC license.
+
+[SDL library]: https://www.libsdl.org/
+[ctypes]: https://github.com/ocamllabs/ocaml-ctypes
+
+Home page: <http://erratique.ch/software/tsdl>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The tsdl programmers"
+license: "ISC"
+tags: [
+  "audio"
+  "bindings"
+  "graphics"
+  "media"
+  "opengl"
+  "input"
+  "hci"
+  "org:erratique"
+]
+homepage: "https://erratique.ch/software/tsdl"
+doc: "https://erratique.ch/software/tsdl/doc/"
+bug-reports: "https://github.com/dbuenzli/tsdl/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.1"}
+  "conf-sdl2"
+  "ctypes" {>= "0.21.1"}
+  "ctypes-foreign" {>= "0.21.1"}
+]
+available:
+  os-distribution != "opensuse-leap" &
+  os-distribution != "opensuse-tumbleweed" |
+  os-distribution = "opensuse-leap" & os-version >= "16"
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/tsdl.git"
+url {
+  src: "https://erratique.ch/software/tsdl/releases/tsdl-1.2.0.tbz"
+  checksum:
+    "sha512=46f43f448b8c41b6ae0a3390a5a421974560a7cb7c75635cc6f21ba9b5a974b9fbeba88c6793cd3d9eced2e04f570079a9931945f047dc5efd00e1d4e3871044"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `tsdl.1.2.0` [home](https://erratique.ch/software/tsdl), [doc](https://erratique.ch/software/tsdl/doc/), [issues](https://github.com/dbuenzli/tsdl/issues)  
  *Thin bindings to SDL for OCaml*


---

#### `tsdl` v1.2.0 2025-11-10 Zagreb

- Add `Sdl.get_preferred_locales` and `Sdl.Event.locale_changed`.
  Thanks to Vu Ngoc San for the patches ([#111](https://github.com/dbuenzli/tsdl/issues/111), [#112](https://github.com/dbuenzli/tsdl/issues/112))
- Fix bug in `Message_box` color scheme handling.
  Thanks to Matthieu Dubuget for the patch ([#105](https://github.com/dbuenzli/tsdl/issues/105))
- Add `Sdl.{get,set}_texture_scale_mode.`
  Thanks to Maxence Guesdon for the patch ([#114](https://github.com/dbuenzli/tsdl/issues/114))
- Add `Sdl.render_get_window`
  Thanks to Léo Andrès for the patch ([#113](https://github.com/dbuenzli/tsdl/issues/113))
- Change `Sdl.rw_close` to use the static function.
  Thanks to Pierre Boutillier for the patch.
- Other Internal ctypes changes. 
  Thanks to Pierre Boutillier for the patches.

---

Use `b0 -- .opam publish tsdl.1.2.0` to update the pull request.