### PR TITLE
Package binaryen.0.32.0

### DIFF
--- a/packages/binaryen/binaryen.0.32.0/opam
+++ b/packages/binaryen/binaryen.0.32.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "6.0.0" & < "7.0.0"}
+  "libbinaryen" {>= "122.0.1" & < "123.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.32.0/binaryen-archive-v0.32.0.tar.gz"
+  checksum: [
+    "md5=29238bad1300cc6f968004e2e6c69782"
+    "sha512=341e0436d2f55f1f12b64782ef870296a56ff717c5672bcc6e02f15cfe6995917833404b3a393a642fbc7630d6e4df956f8fa501bbcdcb9eac0861118b6c8276"
+  ]
+}
+x-maintenance-intent: ["0.(latest)"]


### PR DESCRIPTION
### `binaryen.0.32.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.32.0](https://github.com/grain-lang/binaryen.ml/compare/v0.31.0...v0.32.0) (2025-11-12)

### ⚠ BREAKING CHANGES

- Upgrade to Binaryen v122 ([#208](https://github.com/grain-lang/binaryen.ml/issues/208))
- Correct signature of `get_pass_argument` ([#247](https://github.com/grain-lang/binaryen.ml/issues/247))

### Features

- Upgrade to Binaryen v122 ([#208](https://github.com/grain-lang/binaryen.ml/issues/208)) ([434417d](https://github.com/grain-lang/binaryen.ml/commit/434417df5720205824b3fdfa3ce82fa72465c444))

### Bug Fixes

- Correct signature of `get_pass_argument` ([#247](https://github.com/grain-lang/binaryen.ml/issues/247)) ([986ecec](https://github.com/grain-lang/binaryen.ml/commit/986ecec07af320813f4137cfed4d454ae6c13f82))


---
:camel: Pull-request generated by opam-publish v2.4.0