### PR TITLE
Package jsonfeed.1.0.0

### DIFF
--- a/packages/jsonfeed/jsonfeed.1.0.0/opam
+++ b/packages/jsonfeed/jsonfeed.1.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "JSON Feed format parser and serializer for OCaml"
+description:
+  "This library implements the JSON Feed specification (version 1.1) for OCaml. JSON Feed is a syndication format similar to RSS and Atom, but using JSON instead of XML. The library provides type-safe parsing and serialization using Jsonm and Ptime."
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy"
+license: "ISC"
+homepage: "https://tangled.sh/@anil.recoil.org/ocaml-jsonfeed"
+bug-reports: "https://tangled.sh/@anil.recoil.org/ocaml-jsonfeed"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.2.0"}
+  "jsont" {>= "0.2.0"}
+  "ptime" {>= "1.2.0"}
+  "bytesrw"
+  "odoc" {with-doc}
+  "alcotest" {with-test & >= "1.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://tangled.sh/@anil.recoil.org/ocaml-jsonfeed"
+url {
+  src:
+    "https://tangled.org/@anil.recoil.org/ocaml-jsonfeed/tags/c8fb1126b311f9d1288ca3402ec38f9eeefbc232/download/jsonfeed-1.0.0.tbz"
+  checksum: [
+    "md5=5271d5b38d1bd46e89fbc00d4f836382"
+    "sha512=a83def40768a3003f3e39cde24f1faba70098c50563b227f0e2cc81b1f8e4f4fc63eb26a219cfb83016ecb1b5f898f6bbc66fec1d1fc5521e00d6a1347424763"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `jsonfeed.1.0.0`
JSON Feed format parser and serializer for OCaml
This library implements the JSON Feed specification (version 1.1) for OCaml. JSON Feed is a syndication format similar to RSS and Atom, but using JSON instead of XML. The library provides type-safe parsing and serialization using Jsonm and Ptime.



---
* Homepage: https://tangled.sh/@anil.recoil.org/ocaml-jsonfeed
* Source repo: git+https://tangled.sh/@anil.recoil.org/ocaml-jsonfeed
* Bug tracker: https://tangled.sh/@anil.recoil.org/ocaml-jsonfeed

---
:camel: Pull-request generated by opam-publish v2.5.1