### PR TITLE
6 packages from zoggy.frama.io/ojs-base/releases/ojs-base-0.9.0.tar.bz2

### DIFF
--- a/packages/ojs_base/ojs_base.0.9.0/opam
+++ b/packages/ojs_base/ojs_base.0.9.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Base library for developing OCaml web apps based on websockets and js_of_ocaml"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+tags: ["javascript" "web" "components"]
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.1.0"}
+  "js_of_ocaml" {>= "6.0.1"}
+  "js_of_ocaml-ppx" {>= "6.0.1"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.2"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "websocket" {>= "2.14"}
+  "websocket-lwt-unix" {>= "2.14"}
+  "xtmpl" {>= "1.2.0"}
+  "xtmpl_ppx" {>= "1.2.0"}
+  "yojson" {>= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src: "https://zoggy.frama.io/ojs-base/releases/ojs-base-0.9.0.tar.bz2"
+  checksum: [
+    "md5=d1280f8b88bd6e03f62084c63027cf47"
+    "sha512=ff933d51b7a64a4d7356442284f0d992de746523fb28217d01c7d4ca0f461920b9f05d2f22ae4ba51f5a819c6b923e64b600150164ae58439b86e186d284b2ee"
+  ]
+}

--- a/packages/ojs_base_all/ojs_base_all.0.9.0/opam
+++ b/packages/ojs_base_all/ojs_base_all.0.9.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install all ojs_base packages"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ojs_base" {= version}
+  "ojs_filetree" {= version}
+  "ojs_list" {= version}
+  "ojs_ed" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src: "https://zoggy.frama.io/ojs-base/releases/ojs-base-0.9.0.tar.bz2"
+  checksum: [
+    "md5=d1280f8b88bd6e03f62084c63027cf47"
+    "sha512=ff933d51b7a64a4d7356442284f0d992de746523fb28217d01c7d4ca0f461920b9f05d2f22ae4ba51f5a819c6b923e64b600150164ae58439b86e186d284b2ee"
+  ]
+}

--- a/packages/ojs_base_ppx/ojs_base_ppx.0.9.0/opam
+++ b/packages/ojs_base_ppx/ojs_base_ppx.0.9.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "PPx extension for the Ojs_base library"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.1.0"}
+  "ojs_base" {= version}
+  "ppxlib" {>= "0.37.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src: "https://zoggy.frama.io/ojs-base/releases/ojs-base-0.9.0.tar.bz2"
+  checksum: [
+    "md5=d1280f8b88bd6e03f62084c63027cf47"
+    "sha512=ff933d51b7a64a4d7356442284f0d992de746523fb28217d01c7d4ca0f461920b9f05d2f22ae4ba51f5a819c6b923e64b600150164ae58439b86e186d284b2ee"
+  ]
+}

--- a/packages/ojs_ed/ojs_ed.0.9.0/opam
+++ b/packages/ojs_ed/ojs_ed.0.9.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Using file editor in ojs_base applications, common part"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ojs_base" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src: "https://zoggy.frama.io/ojs-base/releases/ojs-base-0.9.0.tar.bz2"
+  checksum: [
+    "md5=d1280f8b88bd6e03f62084c63027cf47"
+    "sha512=ff933d51b7a64a4d7356442284f0d992de746523fb28217d01c7d4ca0f461920b9f05d2f22ae4ba51f5a819c6b923e64b600150164ae58439b86e186d284b2ee"
+  ]
+}

--- a/packages/ojs_filetree/ojs_filetree.0.9.0/opam
+++ b/packages/ojs_filetree/ojs_filetree.0.9.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Using filetrees in ojs_base applications, common part"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ojs_base" {= version}
+  "magic-mime" {>= "1.2.0"}
+  "base64" {>= "3.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src: "https://zoggy.frama.io/ojs-base/releases/ojs-base-0.9.0.tar.bz2"
+  checksum: [
+    "md5=d1280f8b88bd6e03f62084c63027cf47"
+    "sha512=ff933d51b7a64a4d7356442284f0d992de746523fb28217d01c7d4ca0f461920b9f05d2f22ae4ba51f5a819c6b923e64b600150164ae58439b86e186d284b2ee"
+  ]
+}

--- a/packages/ojs_list/ojs_list.0.9.0/opam
+++ b/packages/ojs_list/ojs_list.0.9.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Using lists in ojs_base applications, common part"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ojs_base" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src: "https://zoggy.frama.io/ojs-base/releases/ojs-base-0.9.0.tar.bz2"
+  checksum: [
+    "md5=d1280f8b88bd6e03f62084c63027cf47"
+    "sha512=ff933d51b7a64a4d7356442284f0d992de746523fb28217d01c7d4ca0f461920b9f05d2f22ae4ba51f5a819c6b923e64b600150164ae58439b86e186d284b2ee"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `ojs_base.0.9.0`: Base library for developing OCaml web apps based on websockets and
  js_of_ocaml
- `ojs_base_all.0.9.0`: Virtual package to install all ojs_base packages
- `ojs_base_ppx.0.9.0`: PPx extension for the Ojs_base library
- `ojs_ed.0.9.0`: Using file editor in ojs_base applications, common part
- `ojs_filetree.0.9.0`: Using filetrees in ojs_base applications, common part
- `ojs_list.0.9.0`: Using lists in ojs_base applications, common part



---
* Homepage: http://zoggy.frama.io/ojs-base/
* Source repo: git+https://framagit.org/zoggy/ojs-base.git
* Bug tracker: https://framagit.org/zoggy/ojs-base/issues

---
:camel: Pull-request generated by opam-publish v2.5.1