### PR TITLE
Package jsonfeed.1.1.0

### DIFF
--- a/packages/jsonfeed/jsonfeed.1.1.0/opam
+++ b/packages/jsonfeed/jsonfeed.1.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "JSON Feed format parser and serializer for OCaml"
+description:
+  "This library implements the JSON Feed specification (version 1.1) for OCaml. JSON Feed is a syndication format similar to RSS and Atom, but using JSON instead of XML. The library provides type-safe parsing and serialization using Jsonm and Ptime."
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy"
+license: "ISC"
+homepage: "https://tangled.sh/@anil.recoil.org/ocaml-jsonfeed"
+bug-reports: "https://tangled.sh/@anil.recoil.org/ocaml-jsonfeed"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.2.0"}
+  "jsont" {>= "0.2.0"}
+  "ptime" {>= "1.2.0"}
+  "bytesrw"
+  "odoc" {with-doc}
+  "alcotest" {with-test & >= "1.5.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://tangled.sh/@anil.recoil.org/ocaml-jsonfeed"
+url {
+  src:
+    "https://tangled.org/@anil.recoil.org/ocaml-jsonfeed/tags/f1ab140451f0a8d1ceccfe8ac208c907d34f1765/download/jsonfeed-1.1.0.tbz"
+  checksum: [
+    "md5=43c68cd44bd4d9b9617601f72dce9ecf"
+    "sha512=1e2458100d8a5f34b36b45eadc7868968fae222500525f782015e64f4ded8c91db081e4ef761bc74ab1ac632ec060f46bcb051b6d5ea9e10e73e025d93bafdff"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `jsonfeed.1.1.0`
JSON Feed format parser and serializer for OCaml
This library implements the JSON Feed specification (version 1.1) for OCaml. JSON Feed is a syndication format similar to RSS and Atom, but using JSON instead of XML. The library provides type-safe parsing and serialization using Jsonm and Ptime.



---
* Homepage: https://tangled.sh/@anil.recoil.org/ocaml-jsonfeed
* Source repo: git+https://tangled.sh/@anil.recoil.org/ocaml-jsonfeed
* Bug tracker: https://tangled.sh/@anil.recoil.org/ocaml-jsonfeed

---
:camel: Pull-request generated by opam-publish v2.5.1