### PR TITLE
Package crockford.1.0.0

### DIFF
--- a/packages/crockford/crockford.1.0.0/opam
+++ b/packages/crockford/crockford.1.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Crockford Base32 encoding for OCaml"
+description:
+  "An OCaml implementation of Douglas Crockford's Base32 encoding with ISO 7064 checksum support. Provides encoding and decoding of int64 values to URI-friendly base32 strings, with optional checksum validation, padding, splitting, and random ID generation."
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy"
+license: "MIT"
+homepage: "https://tangled.org/@anil.recoil.org/ocaml-crockford"
+bug-reports: "https://tangled.org/@anil.recoil.org/ocaml-crockford/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14.1"}
+  "odoc" {with-doc}
+  "alcotest" {with-test & >= "1.5.0"}
+  "cmdliner" {>= "1.1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://tangled.sh/@anil.recoil.org/ocaml-crockford"
+url {
+  src:
+    "https://tangled.org/@anil.recoil.org/ocaml-crockford/tags/7d341c44e6509166245a0042a2ed17b599b099e2/download/crockford-1.0.0.tbz"
+  checksum: [
+    "md5=3e26e20be39cf0c98588dd256d8be3fd"
+    "sha512=90407e12691cd55cd32d556baf250d505f108fd0a4f83ed044f757829fe75dce481321d7d14eea7e93c882286ea7904029c3a2b5250da8b4981ea52e593d14e5"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `crockford.1.0.0`
Crockford Base32 encoding for OCaml
An OCaml implementation of Douglas Crockford's Base32 encoding with ISO 7064 checksum support. Provides encoding and decoding of int64 values to URI-friendly base32 strings, with optional checksum validation, padding, splitting, and random ID generation.



---
* Homepage: https://tangled.org/@anil.recoil.org/ocaml-crockford
* Source repo: git+https://tangled.sh/@anil.recoil.org/ocaml-crockford
* Bug tracker: https://tangled.org/@anil.recoil.org/ocaml-crockford/issues

---
:camel: Pull-request generated by opam-publish v2.5.1