### PR TITLE
Package binaryen.0.33.0

### DIFF
--- a/packages/binaryen/binaryen.0.33.0/opam
+++ b/packages/binaryen/binaryen.0.33.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "6.0.0" & < "7.0.0"}
+  "libbinaryen" {>= "123.0.1" & < "124.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.33.0/binaryen-archive-v0.33.0.tar.gz"
+  checksum: [
+    "md5=c50567bd7b1aa4a98217aa5fd887593b"
+    "sha512=93f82601398cfe67e418825763c8f62f26d8b22f3a581cba478b4989f924e2e33f27c9a88de9bc274dec76e69108b5d6a3f0b72d58e94a897e99ba6912ebba64"
+  ]
+}
+x-maintenance-intent: ["0.(latest)"]


### PR DESCRIPTION
### `binaryen.0.33.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.33.0](https://github.com/grain-lang/binaryen.ml/compare/v0.32.0...v0.33.0) (2025-11-12)

### ⚠ BREAKING CHANGES

- Upgrade to Binaryen v123 ([#256](https://github.com/grain-lang/binaryen.ml/issues/256))

### Features

- Implement optimization settings api ([#243](https://github.com/grain-lang/binaryen.ml/issues/243)) ([1f25caf](https://github.com/grain-lang/binaryen.ml/commit/1f25cafc96a1f6969a1ecca8ea778aeefae893a8))
- Upgrade to Binaryen v123 ([#256](https://github.com/grain-lang/binaryen.ml/issues/256)) ([dd6bfa7](https://github.com/grain-lang/binaryen.ml/commit/dd6bfa7bd1c072b33bbc1731a046d169ceb9ea39))


---
:camel: Pull-request generated by opam-publish v2.4.0