### PR TITLE
Package binaryen.0.34.0

### DIFF
--- a/packages/binaryen/binaryen.0.34.0/opam
+++ b/packages/binaryen/binaryen.0.34.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "6.0.0" & < "7.0.0"}
+  "libbinaryen" {>= "124.0.1" & < "125.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.34.0/binaryen-archive-v0.34.0.tar.gz"
+  checksum: [
+    "md5=815e6b4fee4b5a3d7d6c14ff2a621d5f"
+    "sha512=042657b693d070dfef31faeb1406868c9f6455b122e1205ec304894af54a06408db88def0b785deb335419915ca4c9c9e46e6af3ef6089c828133b924f0f8875"
+  ]
+}
+x-maintenance-intent: ["0.(latest)"]


### PR DESCRIPTION
### `binaryen.0.34.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.34.0](https://github.com/grain-lang/binaryen.ml/compare/v0.33.0...v0.34.0) (2025-11-12)

### ⚠ BREAKING CHANGES

- Update Passes api for Binaryen v124
- Upgrade to Binaryen v124 ([#241](https://github.com/grain-lang/binaryen.ml/issues/241))

### Features

- Update Passes api for Binaryen v124 ([305137a](https://github.com/grain-lang/binaryen.ml/commit/305137a264049f3f38bf8828c57aad190195ca49))
- Upgrade to Binaryen v124 ([#241](https://github.com/grain-lang/binaryen.ml/issues/241)) ([02829f8](https://github.com/grain-lang/binaryen.ml/commit/02829f805cd3133bb4b04c83abac8380996bd0ec))


---
:camel: Pull-request generated by opam-publish v2.4.0