### PR TITLE
[new release] moonpool (2 packages) (0.10)

### DIFF
--- a/packages/moonpool-lwt/moonpool-lwt.0.10/opam
+++ b/packages/moonpool-lwt/moonpool-lwt.0.10/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Event loop for moonpool based on Lwt-engine (experimental)"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+homepage: "https://github.com/c-cube/moonpool"
+bug-reports: "https://github.com/c-cube/moonpool/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "moonpool" {= version}
+  "ocaml" {>= "5.0"}
+  "qcheck-core" {with-test & >= "0.19"}
+  "hmap" {with-test}
+  "lwt"
+  "base-unix"
+  "trace" {with-test}
+  "trace-tef" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/moonpool.git"
+url {
+  src:
+    "https://github.com/c-cube/moonpool/releases/download/v0.10/moonpool-0.10.tbz"
+  checksum: [
+    "sha256=6e3ddd37c8db9b2b7945031a72f716ba291753b1b212dd85af3cc1d62325375a"
+    "sha512=07e51249842078b08850506ff76800c4fc9185113a08b69c517fd3e6e561120dbd12a0aabd89518a540adf4d0711fd0785894595d2a3e39a799e764a427c25fc"
+  ]
+}
+x-commit-hash: "4de33f0121510a3115b11d5d1bc25408f3a236c4"

--- a/packages/moonpool/moonpool.0.10/opam
+++ b/packages/moonpool/moonpool.0.10/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Pools of threads supported by a pool of domains"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["thread" "pool" "domain" "futures" "fork-join"]
+homepage: "https://github.com/c-cube/moonpool"
+bug-reports: "https://github.com/c-cube/moonpool/issues"
+depends: [
+  "ocaml" {>= "5.0"}
+  "dune" {>= "3.0"}
+  "either" {>= "1.0"}
+  "trace" {with-test}
+  "trace-tef" {with-test}
+  "qcheck-core" {with-test & >= "0.19"}
+  "thread-local-storage" {>= "0.2" & < "0.3"}
+  "odoc" {with-doc}
+  "hmap" {with-test}
+  "picos" {>= "0.5" & < "0.7"}
+  "picos_std" {>= "0.5" & < "0.7"}
+  "mdx" {>= "1.9.0" & with-test}
+]
+depopts: [
+  "hmap"
+  "trace" {>= "0.6"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/moonpool.git"
+url {
+  src:
+    "https://github.com/c-cube/moonpool/releases/download/v0.10/moonpool-0.10.tbz"
+  checksum: [
+    "sha256=6e3ddd37c8db9b2b7945031a72f716ba291753b1b212dd85af3cc1d62325375a"
+    "sha512=07e51249842078b08850506ff76800c4fc9185113a08b69c517fd3e6e561120dbd12a0aabd89518a540adf4d0711fd0785894595d2a3e39a799e764a427c25fc"
+  ]
+}
+x-commit-hash: "4de33f0121510a3115b11d5d1bc25408f3a236c4"


### PR DESCRIPTION
Pools of threads supported by a pool of domains

- Project page: <a href="https://github.com/c-cube/moonpool">https://github.com/c-cube/moonpool</a>

##### CHANGES:

- breaking: remove `around_task` from schedulers
- breaking: remove `moonpool.fib` entirely. Please use `picos_std.structured`
    if you really need structured concurrency.
- remove deprecated moonpool-io and moonpool.sync

- feat core: add `Main`, salvaged from moonpool.fib
- block signals in background threads
- refactor `chan`; fix bug in `Chan.try_push`
- fix: make `Moonpool_lwt.fut_of_lwt` idempotent
