### PR TITLE
Package visitors.20251114

### DIFF
--- a/packages/visitors/visitors.20251114/opam
+++ b/packages/visitors/visitors.20251114/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/visitors"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/visitors.git"
+bug-reports: "francois.pottier@inria.fr"
+license: "LGPL-2.1-only"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14.2"}
+  "ppxlib" {>= "0.37.0"}
+  "ppx_deriving" {>= "5.0"}
+  "result"
+  "dune" {>= "2.0"}
+]
+synopsis: "An OCaml syntax extension for generating visitor classes"
+description: """
+Annotating an algebraic data type definition with [@@deriving visitors { ... }]
+causes visitor classes to be automatically generated. A visitor is an object
+that knows how to traverse and transform a data structure."""
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/visitors/-/archive/20251114/archive.tar.gz"
+  checksum: [
+    "md5=7c01160dbafe507efc1e8e1dcf77e8f8"
+    "sha512=4925ff567954f2da32ea41a87ca2740689bb86e0d37dd9d95ef6eee3f8dd6b8081d513ff919ed29517c98d79ec5175f81f51df3d5c6afce1a162b50797225f14"
+  ]
+}


### PR DESCRIPTION
### `visitors.20251114`
An OCaml syntax extension for generating visitor classes
Annotating an algebraic data type definition with [@@deriving visitors { ... }]
causes visitor classes to be automatically generated. A visitor is an object
that knows how to traverse and transform a data structure.



---
* Homepage: https://gitlab.inria.fr/fpottier/visitors
* Source repo: git+https://gitlab.inria.fr/fpottier/visitors.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.5.0