### PR TITLE
Constrain ocamlfind.1.9.8 to OCaml < 5.0.0 for MSYS2/Cygwin

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.9.8/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.8/opam
@@ -12,7 +12,7 @@ license: "MIT"
 homepage: "http://projects.camlcity.org/projects/findlib.html"
 bug-reports: "https://github.com/ocaml/ocamlfind/issues"
 depends: [
-  "ocaml" {>= "3.08.0"}
+  "ocaml" {>= "3.08.0" & (os != "cygwin" & os-distribution != "msys2" | < "5.0")}
 ]
 depopts: ["graphics"]
 build: [


### PR DESCRIPTION
There's no working version of ocamlfind for OCaml 5.0+ for Cygwin or when building using MSYS2 until https://github.com/ocaml/ocamlfind/pull/112 is merged. Update the ocamlfind.1.9.8 package to reflect this, which should stop CI unnecessarily testing packages (and then causing those authors to incorrect constrain their packages away from MSYS2...)