### PR TITLE
[new release] ocaml-protoc (4 packages) (4.0)

### DIFF
--- a/packages/ocaml-protoc/ocaml-protoc.4.0/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Pure OCaml compiler for .proto files"
+maintainer: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+authors: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+license: "MIT"
+tags: ["protoc" "protobuf" "codegen"]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports: "https://github.com/mransan/ocaml-protoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "odoc" {with-doc}
+  "pbrt" {= version}
+  "pbrt_yojson" {= version & with-test}
+  "pbrt_services" {= version & with-test}
+  "ppx_deriving" {with-test}
+  "ocaml" {>= "4.08"}
+]
+dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@src/examples/runtest" {with-test}
+    "@src/tests/expectation/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mransan/ocaml-protoc/releases/download/v4.0/ocaml-protoc-4.0.tbz"
+  checksum: [
+    "sha256=88533848ee8ad662bfb063f34932286405977fa3810515b997119b06f05105e4"
+    "sha512=df12c71f7181eafc94cd0fc400edf7f258cdd3740a5badafce097f771b7828fed9a9a9c0a457e7e118848a8b1ddd87fe3134a5bdf88d4adcb0d0e04ba6808c5f"
+  ]
+}
+x-commit-hash: "258b49144dbf3d17adefa7c051616468d03d0ee6"

--- a/packages/pbrt/pbrt.4.0/opam
+++ b/packages/pbrt/pbrt.4.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Runtime library for Protobuf tooling"
+maintainer: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+authors: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+license: "MIT"
+tags: ["protobuf" "encode" "decode"]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports: "https://github.com/mransan/ocaml-protoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "stdlib-shims"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08"}
+]
+dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
+available: arch != "arm32" & arch != "x86_32" & arch != "ppc32" & arch != "ppc64"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@src/tests/unit-tests/pbrt/runtest" {with-test}  # custom path
+    "@doc" {with-doc}
+  ]
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mransan/ocaml-protoc/releases/download/v4.0/ocaml-protoc-4.0.tbz"
+  checksum: [
+    "sha256=88533848ee8ad662bfb063f34932286405977fa3810515b997119b06f05105e4"
+    "sha512=df12c71f7181eafc94cd0fc400edf7f258cdd3740a5badafce097f771b7828fed9a9a9c0a457e7e118848a8b1ddd87fe3134a5bdf88d4adcb0d0e04ba6808c5f"
+  ]
+}
+x-commit-hash: "258b49144dbf3d17adefa7c051616468d03d0ee6"

--- a/packages/pbrt_services/pbrt_services.4.0/opam
+++ b/packages/pbrt_services/pbrt_services.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Runtime library for ocaml-protoc to support RPC services"
+maintainer: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+authors: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+license: "MIT"
+tags: ["protobuf" "encode" "decode" "services" "rpc"]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports: "https://github.com/mransan/ocaml-protoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "pbrt" {= version}
+  "pbrt_yojson" {= version}
+]
+dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    # "@runtest" {with-test} # no tests
+    "@doc" {with-doc}
+  ]
+]x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mransan/ocaml-protoc/releases/download/v4.0/ocaml-protoc-4.0.tbz"
+  checksum: [
+    "sha256=88533848ee8ad662bfb063f34932286405977fa3810515b997119b06f05105e4"
+    "sha512=df12c71f7181eafc94cd0fc400edf7f258cdd3740a5badafce097f771b7828fed9a9a9c0a457e7e118848a8b1ddd87fe3134a5bdf88d4adcb0d0e04ba6808c5f"
+  ]
+}
+x-commit-hash: "258b49144dbf3d17adefa7c051616468d03d0ee6"

--- a/packages/pbrt_yojson/pbrt_yojson.4.0/opam
+++ b/packages/pbrt_yojson/pbrt_yojson.4.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Runtime library for ocaml-protoc to support JSON encoding/decoding"
+maintainer: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+authors: ["Maxime Ransan <maxime.ransan@gmail.com>" "Simon Cruanes"]
+license: "MIT"
+tags: ["protobuf" "encode" "decode"]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports: "https://github.com/mransan/ocaml-protoc/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+  "yojson" {>= "1.6"}
+  "base64" {>= "3.0"}
+]
+dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@src/tests/yojson/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mransan/ocaml-protoc/releases/download/v4.0/ocaml-protoc-4.0.tbz"
+  checksum: [
+    "sha256=88533848ee8ad662bfb063f34932286405977fa3810515b997119b06f05105e4"
+    "sha512=df12c71f7181eafc94cd0fc400edf7f258cdd3740a5badafce097f771b7828fed9a9a9c0a457e7e118848a8b1ddd87fe3134a5bdf88d4adcb0d0e04ba6808c5f"
+  ]
+}
+x-commit-hash: "258b49144dbf3d17adefa7c051616468d03d0ee6"


### PR DESCRIPTION
Pure OCaml compiler for .proto files

- Project page: <a href="https://github.com/mransan/ocaml-protoc">https://github.com/mransan/ocaml-protoc</a>

##### CHANGES:

- better parsing of protobuf options
- generation of validation code with `--pp_options`
- feat: add `--encode-only` and `--decode-only` features
- take presence semantics in account, to be closer to compliance
    with the official protobuf docs and implementation
  * use a bitfield to track presence for scalar fields
  * use options in more places
  * do not serialize non-present fields, to save space
  * always generate `make` builders, setters, presence checks
- merge mutable and immutable types, only generate a single record per
    message type
- feat codegen: use polyvariants for very large sum types
- fix parser: handle `reserved` in enums
- improved tests
