### PR TITLE
Package coq-waterproof.3.1.0+9.1

### DIFF
--- a/packages/coq-waterproof/coq-waterproof.3.1.0+9.1/opam
+++ b/packages/coq-waterproof/coq-waterproof.3.1.0+9.1/opam
@@ -36,6 +36,8 @@ build: [
 
 available: (arch != "s390x") & (arch != "ppc64")
 
+conflicts: [ "ocaml-option-bytecode-only" ]
+
 tags: [
   "keyword:mathematics education"
   "category:Mathematics/Education"


### PR DESCRIPTION
### `coq-waterproof.3.1.0+9.1`
Coq proofs in a style that resembles non-mechanized mathematical proofs
The Waterproof plugin for the Coq proof assistant allows you to write Coq proofs in a style that resembles handwritten mathematical proofs, designed to help university students with learning how to prove mathematical statements.



---
* Homepage: https://github.com/impermeable/coq-waterproof
* Source repo: git+https://github.com/impermeable/coq-waterproof.git
* Bug tracker: https://github.com/impermeable/coq-waterproof/issues

---
:camel: Pull-request generated by opam-publish v2.2.0