### PR TITLE
fit: new release 1.4.0

### DIFF
--- a/packages/fit/fit.1.4.0/opam
+++ b/packages/fit/fit.1.4.0/opam
@@ -34,8 +34,7 @@ build: [
 dev-repo: "git+https://github.com/lindig/fit.git"
 
 x-maintenance-intent: ["(latest)"]
-available: [os-family != "windows" ] 
-available: arch != "x86_32" & arch != "arm32"
+available: [os-family != "windows" & arch != "x86_32" & arch != "arm32"]
 
 url {
   src: "https://github.com/lindig/fit/archive/1.4.0.zip"


### PR DESCRIPTION
* Fix typos in meta data
* Makefile target "changes"
* Fix: use any_uint8 for counter
* Limit CI to main branch
* Add support for 32-bit architectures, JSOO in particular
* Fix extraction of Device information
* Use Result.t in bin/main.ml
* Make device() more efficient
* fixup! Merge remote-tracking branch 'origin/main'
* Merge remote-tracking branch 'origin/main'
* Drop Rresult dependency
* Drop Rresult dependency
* Add minimal code to extract device information
* Merge remote-tracking branch 'origin/main'
* Add total_cycles to Record.t
* Add x-maintenance-intent
* More opam fixes based on CI
* Fix opam generation
