### PR TITLE
expr: Initial Opam release

### DIFF
--- a/packages/expr/expr.0.5.2/opam
+++ b/packages/expr/expr.0.5.2/opam
@@ -12,7 +12,7 @@ license: "Unlicense"
 homepage: "https://github.com/lindig/expr"
 bug-reports: "https://github.com/lindig/expr/issues"
 depends: [
-  "dune" {>= "2.7" & >= "2.0"}
+  "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
   "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "odoc" {with-doc}


### PR DESCRIPTION
A simple library to parse and evaluate arithmetic expressions that
  may include variables. The purpose is for other code to accept an
  expression rather than just a literal value. Both float and boolean
  expressions are supported."