### PR TITLE
[new release] query-json (0.5.52)

### DIFF
--- a/packages/query-json/query-json.0.5.52/opam
+++ b/packages/query-json/query-json.0.5.52/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "3.17"}
   "dune-build-info"
   "menhir" {>= "20250903"}
-  "cmdliner"
+  "cmdliner" {>= "2.0.0"}
   "yojson" {>= "3.0.0"}
   "sedlex"
   "ppx_deriving"


### PR DESCRIPTION
Faster, simpler and more portable implementation of `jq` in OCaml

- Project page: <a href="https://github.com/davesnx/query-json">https://github.com/davesnx/query-json</a>

##### CHANGES:

- Remove melange-webapi
- Make development work in 5.3.0
