### PR TITLE
[new release] albatross (2.6.1)

### DIFF
--- a/packages/albatross/albatross.2.6.1/opam
+++ b/packages/albatross/albatross.2.6.1/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/robur-coop/albatross"
+dev-repo: "git+https://github.com/robur-coop/albatross.git"
+bug-reports: "https://github.com/robur-coop/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "2.7.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "conf-libev"
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "5.3.0"}
+  "logs"
+  "bos" {>= "0.2.0"}
+  "ptime" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "1.0.0"}
+  "tls" {>= "1.0.2"}
+  "tls-lwt" {>= "1.0.2"}
+  "asn1-combinators" {>= "0.3.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "metrics" {>= "0.5.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "ohex" {>= "0.2.0"}
+  "http-lwt-client" {>= "0.3.0"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.4.0"}
+  "cachet" {>= "0.0.2"}
+  "fpath" {>= "0.7.3"}
+  "logs-syslog" {>= "0.4.1"}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+available: os != "openbsd"
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/albatross/releases/download/v2.6.1/albatross-2.6.1.tbz"
+  checksum: [
+    "sha256=5576805b14771565bb9e54626d611dd27e98ae8fdcfc15cf641d30ce2d050ca5"
+    "sha512=5d114aa9aedde004cf408bb8d533612119c0cad29f64f30f19fe6232ba1ccf1c205fd87f00ddd9363989a39545bf18d92765fd16a22a2aa14669d3c5017cda71"
+  ]
+}
+x-commit-hash: "817f73d52c1f8315a321756cd64f172c1c555fcb"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/robur-coop/albatross">https://github.com/robur-coop/albatross</a>

##### CHANGES:

* BREAKING Vmm_core.Name: add a Label and Path submodule (robur-coop/albatross#233 @hannesm @reynir)
* albatross_console:
  - only drop if we have at least 512 bytes (robur-coop/albatross#242 @reynir, fixes robur-coop/albatross#234)
  - limit the amount of ring buffers for each path (console_add now carries an
    integer), reduces memory usage of albatross_console
    (robur-coop/albatross#238 robur-coop/albatross#239 @hannesm @reynir, fixes robur-coop/albatross#237)
  - limit the number of subscribers for each unikernel to 5 (adjustable via
    command-line argument) (robur-coop/albatross#240 @hannesm, fixes robur-coop/albatross#237)
  - add a new command Console_list_inactive to find the available ring buffers
    of inactive unikernels (robur-coop/albatross#241 @reynir @hannesm)
  - close the client file descriptor more systematically (robur-coop/albatross#243 @hannesm @reynir)
* destroy of a unikernel: report fewer data back to the caller, log failures
  (robur-coop/albatross#244 @hannesm, fixes robur-coop/albatross#235)
