### PR TITLE
Set upperbound of camlp5 version of HOL Light

### DIFF
--- a/packages/hol_light/hol_light.3.0.0/opam
+++ b/packages/hol_light/hol_light.3.0.0/opam
@@ -51,7 +51,7 @@ depends: [
   |
   ("ocaml" {>= "4.14.0"} &
    "ocaml-base-compiler" &
-   "camlp5" {>= "8.0"} &
+   "camlp5" {>= "8.0" & < "8.04"} &
    "zarith" {>= "1.5"} &
    "ledit")
 ]

--- a/packages/hol_light/hol_light.3.1.0/opam
+++ b/packages/hol_light/hol_light.3.1.0/opam
@@ -51,7 +51,7 @@ depends: [
   |
   ("ocaml" {>= "4.14.0"} &
    "ocaml-base-compiler" &
-   "camlp5" {>= "8.0"} &
+   "camlp5" {>= "8.0" & < "8.04"} &
    "zarith" {>= "1.5"} &
    "ledit")
 ]


### PR DESCRIPTION
HOL Light 3.0 and 3.1 don't support camlp5 8.04. This patch adds the upper bound so that their installation do not break.