### PR TITLE
Hotfixes for labgtk3 for Windows

### DIFF
--- a/packages/lablgtk3/lablgtk3.3.1.5-1/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.5-1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+3"
+description: """
+OCaml interface to GTK+3
+
+See https://garrigue.github.io/lablgtk/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3/lablgtk3"
+
+depends: [
+  "ocaml"     {         >= "4.09.0" }
+  "camlp-streams" {     >= "5.0" & build }
+  "dune"      {         >= "1.8.0"  }
+  "cairo2"    {         >= "0.6"    }
+  "conf-gtk3" {         >= "18"     }
+  "ocamlfind" { dev                 }
+  "camlp5"    { dev                 }
+]
+depopts: [
+  "host-system-msvc"
+  "host-system-mingw"
+]
+
+build: [
+  [ "sed" "-i" "-e" "/c_flags/s/-Wno-deprecated-declarations//" "src/dune" ] {host-system-msvc:installed}
+  [ "sed" "-i" "-e" "/c_flags/s/-W/-Wno-error=incompatible-pointer-types -W/" "src/dune" ] {host-system-mingw:installed}
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "build" "-p" name "-j" jobs "examples/buttons.exe" ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/releases/download/3.1.5/lablgtk3-3.1.5.tbz"
+  checksum: [
+    "sha256=d4821cdbecf3ae374f20317d63e43fe58030c3ba9657b51a2e83e652197e8eac"
+    "sha512=83f0be38a1e21737de93f88b0adac15cdcc50cf712d773720b9bc1e8d8ffdb2c660d35840f25d326a42a9d4e6537e6cef466099bf72494196b2cc79977e703e3"
+  ]
+}
+x-commit-hash: "afbd6d2ee90b98cb0ea49cba34659e15b00cbfe3"


### PR DESCRIPTION
The MSVC part hot-fixes https://github.com/garrigue/lablgtk/pull/190, which I haven't yet fully tested because I'm still reviewing the MSVC patches for cairo2 for opam.

The mingw-w64 part I think is almost certainly a wider GCC-15 related patch needed for all systems, which I haven't yet upstreamed. With this second part, I can build #28851 with GCC-15 on MSYS2 (before I was accidentally building with GCC-13).