### PR TITLE
fix conf-oniguruma depext on nixos

### DIFF
--- a/packages/conf-oniguruma/conf-oniguruma.1/opam
+++ b/packages/conf-oniguruma/conf-oniguruma.1/opam
@@ -18,7 +18,7 @@ depexts: [
   ["oniguruma"] {os-distribution = "homebrew"}
   ["oniguruma"] {os = "freebsd"}
   ["oniguruma"] {os = "netbsd"}
-  ["oniguruma"] {os = "nixos"}
+  ["oniguruma"] {os-distribution = "nixos"}
 ]
 x-ci-accept-failures: [
   "centos-7"


### PR DESCRIPTION
I'm afraid I made a mistake in https://github.com/ocaml/opam-repository/pull/26866 -- `os` is "linux" on NixOS, we should use `os-distribution` instead.