### PR TITLE
Summary section for archiving policy

### DIFF
--- a/governance/policies/archiving.md
+++ b/governance/policies/archiving.md
@@ -8,9 +8,10 @@ To remain in the primary opam repository, a package version must:
   - Be installable (but not necessarily pass tests)
     - on at least one supported platform
     - with at least one recent compiler (currently, meaning 4.08+)
-  - Be marked as a maintained version, e.g. by using `x-maintenance-intent:
-    ["(latest)"]` to mark the latest version as maintained.  (Other values are
-    possible: see below)
+  - Be maintained, according to the metadata of the latest version:
+    - `x-maintenance-intent: ["(latest)"]` means that only the latest version is maintained
+    - No `x-maintenance-intent` field means (for now) that all versions are maintained
+    - Other values are possible (see below for a full list)
 
 Package versions which don't meet these criteria and are not dependencies of
 anything meeting these criteria will be periodically archived, removing them


### PR DESCRIPTION
While it is precise and detailed, I found the new archiving policy a bit hard to read as a package maintainer when @jmid linked it on a recent package upload PR of mine. This patch adds a summary to the top which will hopefully be helpful to others who come across this policy for the first time.

I'm not proposing any changes to the policy itself: the summary is based on my understanding of the text below, and (I hope) doesn't contradict it anywhere, even if it doesn't spell out all details up front.

**Maintenance note**: the summary also includes the current compiler cutoff threshold, so if this PR is accepted there will be _two_ locations in the document that need to be updated when the threshold changes.

cc @hannesm 