### PR TITLE
Add a missing cmdliner.2.0.0 upper bound on carton.0.4.3

### DIFF
--- a/packages/carton/carton.0.4.3/opam
+++ b/packages/carton/carton.0.4.3/opam
@@ -23,7 +23,7 @@ depends: [
   "checkseum" {>= "0.3.2"}
   "logs"
   "bigarray-compat"
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "2.0.0"}
   "hxd" {>= "0.3.0"}
   "psq" {>= "0.2.0"}
   "fmt" {>= "0.8.9"}


### PR DESCRIPTION
Spotted on the revdeps of [#28907](https://github.com/ocaml/opam-repository/pull/28907):

https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/fdb37fd425316c3f17ff1a672f38d79e17f64d31/variant/compilers,4.14,crowbar.0.2.2,revdeps,carton.0.4.3
```
#=== ERROR while compiling carton.0.4.3 =======================================#
# context              2.5.0~beta1 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/carton.0.4.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p carton -j 71
# exit-code            1
# env-file             ~/.opam/log/carton-7-cbcf23.env
# output-file          ~/.opam/log/carton-7-cbcf23.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I bin/carton/.hxd_cmdliner.objs/byte -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/hxd/core -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/rresult -no-alias-deps -o bin/carton/.hxd_cmdliner.objs/byte/hxd_cmdliner.cmo -c -impl bin/carton/hxd_cmdliner.ml)
# File "bin/carton/hxd_cmdliner.ml", line 124, characters 12-23:
# 124 |   let env = Arg.env_var "HXD_COLOR" in
#                   ^^^^^^^^^^^
# Error: Unbound value Arg.env_var
# [...]
```

with the deprecated `Arg.env_var` removed in `cmdliner.2.0.0`:
https://github.com/dbuenzli/cmdliner/blob/master/CHANGES.md#api-changes