### PR TITLE
[new release] ca-certs-nss (3.118)

### DIFF
--- a/packages/ca-certs-nss/ca-certs-nss.3.118/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.118/opam
@@ -51,3 +51,4 @@ url {
   ]
 }
 x-commit-hash: "6940cfa1f98316b7b21b9df396862e519440c3b1"
+x-maintenance-intent: [ "(latest)" ]


### PR DESCRIPTION
X.509 trust anchors extracted from Mozilla's NSS

- Project page: <a href="https://github.com/mirage/ca-certs-nss">https://github.com/mirage/ca-certs-nss</a>
- Documentation: <a href="https://mirage.github.io/ca-certs-nss/doc">https://mirage.github.io/ca-certs-nss/doc</a>

##### CHANGES:

* Update to NSS 3.118 (2025-11-18)
