### PR TITLE
Package soupault.5.2.0

### DIFF
--- a/packages/soupault/soupault.5.2.0/opam
+++ b/packages/soupault/soupault.5.2.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "Static website generator based on HTML element tree rewriting"
+description: """
+A website generator that works with page element trees rather than text
+and allows you to manipulate pages and retrieve metadata from
+existing HTML using arbitrary CSS selectors.
+
+With soupault you can:
+
+* Generate ToC and footnotes.
+* Insert file content or an HTML snippet in any element.
+* Preprocess element content with external programs (e.g. run `<pre>` tags through a highlighter)
+* Extract page metadata (think microformats) and render it using a Jingoo template,
+  a Lua plugin, or an external script.
+
+Soupault is extensible with Lua (2.5) plugins and provides an API for element tree manipulation,
+similar to web browsers.
+
+The website generator mode is optional, you can use it as post-processor for existing sites.
+"""
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: "Daniil Baturin <daniil+soupault@baturin.org>"
+license: "MIT"
+homepage: "https://www.soupault.net"
+bug-reports: "https://github.com/PataphysicalSociety/soupault/issues"
+dev-repo: "git+https://github.com/PataphysicalSociety/soupault"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.3.0"}
+  "dune" {>= "2.0.0"}
+  "containers" {>= "3.9"}
+  "fileutils" {>= "0.6.3"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "lambdasoup" {>= "1.1.1"}
+  "markup" {>= "1.0.0-1"}
+  "otoml" {>= "1.0.5"}
+  "ezjsonm" {>= "1.2.0"}
+  "yaml" {>= "2.0.0"}
+  "csv" {>= "2.4"}
+  "re" {>= "1.9.0"}
+  "odate" {>= "0.6"}
+  "spelll" {>= "0.4"}
+  "base64" {>= "3.0.0"}
+  "jingoo" {>= "1.4.2"}
+  "camomile" {>= "2.0.0"}
+  "digestif" {>= "0.7.3"}
+  "tsort" {>= "2.2.0"}
+  "lua-ml" {>= "0.9.3"}
+  "cmarkit" {>= "0.3.0"}
+]
+
+conflicts: [
+  "result" {< "1.5"}
+]
+
+url {
+  src:
+    "https://github.com/PataphysicalSociety/soupault/archive/refs/tags/5.2.0.tar.gz"
+  checksum: [
+    "sha512=ad490894f052c0bedd1f2687afc0f042af377ed751002599b8d03a2335bd4ffe23db339c98cc78bb1406071f5c38b292afea8624f9390a96d5582d877c482fbb"
+  ]
+}


### PR DESCRIPTION
# 5.2.0 (2025-11-19)

## New features

### New Lua API functions

* `Sys.strip_extension(str)` for stripping only the last extension
  from a file name.

## Bug fixes

* Fixed a regression that caused errors when saving
  pages generated by index processors
  (GitHub issue #85, discovery by Yiming Xiang).
* Fixed incorrect formatting of the log message
  for plugins that are missing file/lua_source options.
