### PR TITLE
[new release] bstr (3 packages) (0.0.3)

### DIFF
--- a/packages/bin/bin.0.0.3/opam
+++ b/packages/bin/bin.0.0.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://git.robur.coop/robur/bstr"
+bug-reports:  "https://git.robur.coop/robur/bstr"
+dev-repo:     "git+https://github.com/robur-coop/bstr"
+doc:          "https://robur-coop.github.io/bstr/"
+license:      "MIT"
+synopsis:     "A DSL to describe binary formats"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.14.0"}
+  "dune"        {>= "3.5.0"}
+  "slice"       {= version}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/bstr/releases/download/v0.0.3/bstr-0.0.3.tbz"
+  checksum: [
+    "sha256=503c4f74f67d16e30dd962a753ed3bca1469282c2202392f5b0e1b7e2a9b4562"
+    "sha512=2db7116df496c12892025b51b91cff87c739595e475eaa33b9a5bfcfbeb8a91cbe90da9b10d9408f41ccca9daec143d8ddf0099be2fac3f3330a3b3bfd25683e"
+  ]
+}
+x-commit-hash: "370e04f5beba9807d6a9115225f53eedb8a430aa"

--- a/packages/bstr/bstr.0.0.3/opam
+++ b/packages/bstr/bstr.0.0.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://git.robur.coop/robur/bstr"
+bug-reports:  "https://git.robur.coop/robur/bstr"
+dev-repo:     "git+https://github.com/robur-coop/bstr"
+doc:          "https://robur-coop.github.io/bstr/"
+license:      "MIT"
+synopsis:     "A simple library for bigstrings"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.14.0"}
+  "dune"        {>= "3.5.0"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/bstr/releases/download/v0.0.3/bstr-0.0.3.tbz"
+  checksum: [
+    "sha256=503c4f74f67d16e30dd962a753ed3bca1469282c2202392f5b0e1b7e2a9b4562"
+    "sha512=2db7116df496c12892025b51b91cff87c739595e475eaa33b9a5bfcfbeb8a91cbe90da9b10d9408f41ccca9daec143d8ddf0099be2fac3f3330a3b3bfd25683e"
+  ]
+}
+x-commit-hash: "370e04f5beba9807d6a9115225f53eedb8a430aa"

--- a/packages/slice/slice.0.0.3/opam
+++ b/packages/slice/slice.0.0.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://git.robur.coop/robur/bstr"
+bug-reports:  "https://git.robur.coop/robur/bstr"
+dev-repo:     "git+https://github.com/robur-coop/bstr"
+doc:          "https://robur-coop.github.io/bstr/"
+license:      "MIT"
+synopsis:     "A Slice type for bigstrings and bytes"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.14.0"}
+  "dune"        {>= "3.5.0"}
+  "bstr"        {= version}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/bstr/releases/download/v0.0.3/bstr-0.0.3.tbz"
+  checksum: [
+    "sha256=503c4f74f67d16e30dd962a753ed3bca1469282c2202392f5b0e1b7e2a9b4562"
+    "sha512=2db7116df496c12892025b51b91cff87c739595e475eaa33b9a5bfcfbeb8a91cbe90da9b10d9408f41ccca9daec143d8ddf0099be2fac3f3330a3b3bfd25683e"
+  ]
+}
+x-commit-hash: "370e04f5beba9807d6a9115225f53eedb8a430aa"


### PR DESCRIPTION
A simple library for bigstrings

- Project page: <a href="https://git.robur.coop/robur/bstr">https://git.robur.coop/robur/bstr</a>
- Documentation: <a href="https://robur-coop.github.io/bstr/">https://robur-coop.github.io/bstr/</a>

##### CHANGES:

- Fix SIGSEGV when we use `memmove` (retry) (@dinosaure, [robur-coop/bstr#4][4])
- Fix license and mention astring developpers (@dinosaure, [robur-coop/bstr#5][5])
- Apply ocamlformat.0.28.1 (@dinosaure, [robur-coop/bstr#7][7])
- Fix encoding of numbers with `Bin` (@swrup, @reynir, @dinosaure, [robur-coop/bstr#8][8])
- Add `Bstr.cuts` (@dinosaure, [robur-coop/bstr#6][6])

[4]: https://git.robur.coop/robur/bstr/pulls/4
[5]: https://git.robur.coop/robur/bstr/pulls/5
[7]: https://git.robur.coop/robur/bstr/pulls/7
[8]: https://git.robur.coop/robur/bstr/pulls/8
[6]: https://git.robur.coop/robur/bstr/pulls/6
