### PR TITLE
Fix depext: exclude Amazon Linux from Fedora zlib-ng-compat-devel rule

### DIFF
--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -21,7 +21,7 @@ depexts: [
   ["zlib1g-dev"] {os-family = "ubuntu"}
   ["zlib-devel"] {os-distribution = "centos"}
   ["zlib-devel"] {os-family = "fedora" & os-version < "40" }
-  ["zlib-ng-compat-devel"] {os-family = "fedora" & os-version >= "40" }
+  ["zlib-ng-compat-devel"] {os-family = "fedora" & os-version >= "40" & os-distribution <> "amzn" }
   ["zlib-devel"] {os-distribution = "ol"}
   ["zlib"] {os-distribution = "nixos"}
   ["zlib"] {os-distribution = "homebrew" & os = "macos"}


### PR DESCRIPTION
Amazon Linux 2023 reports `os-family = "fedora"` but does not provide the `zlib-ng-compat-devel` package in its repositories. Because of this, opam incorrectly tries to install the Fedora-specific depext for `zlib-ng-compat-devel` when running on Amazon Linux, causing builds to fail on that platform.

This change updates the depext filter to explicitly exclude `os-distribution = "amzn"` from the Fedora >= 40 rule:

  - Before: applied to all `os-family = "fedora"` & `os-version >= 40`
  - After: same rule, but with `os-distribution <> "amzn"`

This prevents opam from requiring an unavailable package on Amazon Linux and restores compatibility for AL2023.