### PR TITLE
[new release] qcow (4 packages) (0.12.2)

### DIFF
--- a/packages/qcow-stream/qcow-stream.0.12.2/opam
+++ b/packages/qcow-stream/qcow-stream.0.12.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Library offering QCOW streaming capabilities"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "qcow-types" {= version}
+  "cstruct-lwt"
+  "io-page"
+  "lwt" {>= "5.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.2/qcow-0.12.2.tbz"
+  checksum: [
+    "sha256=bb12f9f37ad69b54af000e64add460034ea09102687aacb4f748488afe83c868"
+    "sha512=883fc7a1d98ee1c272408829050a0b56c785664bc16c0820440d638039e08e55c458813728c2f8c8ac49ceea582a79c3d93142664d5134f87e6bb6618a6b8f66"
+  ]
+}
+x-commit-hash: "b7fc9dfd4b071b49eebbfdf7401551eb305bda01"

--- a/packages/qcow-tool/qcow-tool.0.12.2/opam
+++ b/packages/qcow-tool/qcow-tool.0.12.2/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "A command-line tool for manipulating qcow2-formatted data"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "qcow" {= version}
+  "qcow-stream" {= version}
+  "conf-qemu-img" {with-test}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
+  "cstruct"
+  "result"
+  "unix-type-representations"
+  "lwt"
+  "mirage-block" {>= "3.0.0"}
+  "sha" {>= "1.15.4"}
+  "sexplib"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "astring"
+  "io-page" {>= "2.4.0"}
+  "ounit" {with-test}
+  "mirage-block-ramdisk" {with-test}
+  "ezjsonm" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & arch != "arm32" & arch != "x86_32"}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.2/qcow-0.12.2.tbz"
+  checksum: [
+    "sha256=bb12f9f37ad69b54af000e64add460034ea09102687aacb4f748488afe83c868"
+    "sha512=883fc7a1d98ee1c272408829050a0b56c785664bc16c0820440d638039e08e55c458813728c2f8c8ac49ceea582a79c3d93142664d5134f87e6bb6618a6b8f66"
+  ]
+}
+x-commit-hash: "b7fc9dfd4b071b49eebbfdf7401551eb305bda01"

--- a/packages/qcow-types/qcow-types.0.12.2/opam
+++ b/packages/qcow-types/qcow-types.0.12.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Minimal set of dependencies for qcow-stream, shared with qcow"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "astring"
+  "cstruct" {>= "6.1.0"}
+  "diet" {>= "0.3.0"}
+  "logs"
+  "lwt"
+  "mirage-block" {>= "3.0.0"}
+  "ppx_sexp_conv"
+  "prometheus"
+  "sexplib"
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.2/qcow-0.12.2.tbz"
+  checksum: [
+    "sha256=bb12f9f37ad69b54af000e64add460034ea09102687aacb4f748488afe83c868"
+    "sha512=883fc7a1d98ee1c272408829050a0b56c785664bc16c0820440d638039e08e55c458813728c2f8c8ac49ceea582a79c3d93142664d5134f87e6bb6618a6b8f66"
+  ]
+}
+x-commit-hash: "b7fc9dfd4b071b49eebbfdf7401551eb305bda01"

--- a/packages/qcow/qcow.0.12.2/opam
+++ b/packages/qcow/qcow.0.12.2/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Support for Qcow2 images"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "qcow-types" {= version}
+  "base-bytes"
+  "cstruct" {>= "3.4.0"}
+  "result"
+  "io-page" {>= "2.4.0"}
+  "lwt" {>= "5.5.0"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-block-unix" {>= "2.5.0"}
+  "mirage-block-combinators"
+  "mirage-sleep"
+  "sexplib"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "astring"
+  "prometheus"
+  "unix-type-representations"
+  "stdlib-shims"
+  "sha"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ounit" {with-test}
+  "mirage-block-ramdisk" {with-test & >= "0.5"}
+  "ezjsonm" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.2/qcow-0.12.2.tbz"
+  checksum: [
+    "sha256=bb12f9f37ad69b54af000e64add460034ea09102687aacb4f748488afe83c868"
+    "sha512=883fc7a1d98ee1c272408829050a0b56c785664bc16c0820440d638039e08e55c458813728c2f8c8ac49ceea582a79c3d93142664d5134f87e6bb6618a6b8f66"
+  ]
+}
+x-commit-hash: "b7fc9dfd4b071b49eebbfdf7401551eb305bda01"


### PR DESCRIPTION
Support for Qcow2 images

- Project page: <a href="https://github.com/mirage/ocaml-qcow">https://github.com/mirage/ocaml-qcow</a>

##### CHANGES:

- opam: metadata fixes discovered by CI (psafont mirage/ocaml-qcow#130, last-genius mirage/ocaml-qcow#131)
- Use upstream diet package (psafont mirage/ocaml-qcow#113)
- qcow_stream can now read QCOW files with no data cluster_bits, and empty raw
  disks (last-genius mirage/ocaml-qcow#131)
