### PR TITLE
Add conf-libclang.21 using a generic configure script

### DIFF
--- a/packages/conf-libclang/conf-libclang.21/opam
+++ b/packages/conf-libclang/conf-libclang.21/opam
@@ -54,7 +54,7 @@ synopsis: "Virtual package relying on the installation of llvm and clang librari
 flags: conf
 extra-source "configure.sh" {
   src:
-    "https://raw.githubusercontent.com/jmid/opam-source-archives/conf-libclang-generic/patches/conf-libclang/configure-generic.sh.1"
+    "https://github.com/ocaml/opam-source-archives/raw/refs/heads/main/patches/conf-libclang/configure-generic.sh.1"
   checksum:
     "sha512=e33c39519a809689d9fd2ef61d174668e3cbeaa04e3188c7363d2c0844497624a137c60b0cb4674e07807b57831781a30b72242d9a672918d5c827bf24ff9ea4"
 }


### PR DESCRIPTION
There is a current issue with `conf-libclang` which has not evolved as fast as new clang versions are upgraded in distributions.

The current `conf-libclang.15` is thus failing on several distributions because system packages such as `libclang-15-dev` are no longer available on a recent distro, causing a downgrade to `conf-libclang.12` (with unversioned system package constraints) which will instead fail the version check, as "libclang.21 is not in [3;12]".

This WIP PR
- takes a first shot at a `conf-libclang.21` more up to date with distribution versions and
- attempts to make the bash configure script generic, so that we don't have to submit PRs to both `opam-source-archives` and `opam-repository` to roll a new version. 

AFAICS we were already passing the opam `version` variable to `configure.sh` in earlier versions, but not using it? :thinking: 

Here's a diff to assess what has changed in the configure script:
```diff
$ diff -db patches/conf-libclang/configure.sh.15 patches/conf-libclang/configure-generic.sh.1
9c9,20
< maximum_version=15
---
> if [ $# != 1 ]; then
>     echo "Error: Expected exactly one argument, but got $#"
>     echo "Usage: $0 <maximum-llvm-version-to-check>"
>     exit 1
> fi
> 
> if [ $1 -lt 3 ]; then
>     echo "Error: version argument should be at least 3"
>     exit 1
> fi
> 
> maximum_version=$1
130c141
< echo "Error: No usable version of LLVM <=15.0.x found."
---
> echo "Error: No usable version of LLVM <= $maximum_version.0.x found."
```