### PR TITLE
5 packages from benfaerber/liquid-ml at 0.1.3

### DIFF
--- a/packages/liquid_interpreter/liquid_interpreter.0.1.3/opam
+++ b/packages/liquid_interpreter/liquid_interpreter.0.1.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "The interpreter for Liquid"
+description: """
+The interpreter for Liquid
+"""
+maintainer: "faerberbendev@protonmail.com"
+authors: ["Ben Faerber"]
+homepage: "https://github.com/benfaerber/liquid-ml"
+bug-reports: "https://github.com/benfaerber/liquid-ml/issues"
+dev-repo: "git+https://github.com/benfaerber/liquid-ml.git"
+license: "MIT"
+depends: [
+    "ocaml" { >= "4.11" }
+    "dune" { >= "2.5" }
+    "base" { >= "v0.15.0" }
+    "core" { >= "v0.15.0" }
+    "stdio" { >= "v0.15.0" }
+    "re2" { >= "v0.13.0" }
+    "liquid_syntax" { = version }
+    "liquid_parser" { = version }
+    "liquid_std" { = version }
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/benfaerber/liquid-ml/archive/refs/tags/0.1.3.tar.gz"
+  checksum: [
+    "md5=24f974b1310954a4ee6202d659aafe96"
+    "sha512=8cacca711ef271678118f2959dc734e677d54cd878b95fd2123ab4caa9d3d0dfd1fe17a59660ae1d59374bceca3063fdb1e18cc1018f2aca5283edd4ac97beed"
+  ]
+}

--- a/packages/liquid_ml/liquid_ml.0.1.3/opam
+++ b/packages/liquid_ml/liquid_ml.0.1.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Shopify's Liquid templating language in OCaml"
+description: """
+Shopify's Liquid templating language for OCaml!
+"""
+maintainer: "faerberbendev@protonmail.com"
+authors: ["Ben Faerber"]
+homepage: "https://github.com/benfaerber/liquid-ml"
+bug-reports: "https://github.com/benfaerber/liquid-ml/issues"
+dev-repo: "git+https://github.com/benfaerber/liquid-ml.git"
+license: "MIT"
+
+depends: [
+    "ocaml" { >= "4.11" }
+    "dune" { >= "2.5" }
+    "base" { >= "v0.15.0" }
+    "core" { >= "v0.15.0" }
+    "stdio" { >= "v0.15.0" }
+    "re2" { >= "v0.13.0" }
+    "liquid_syntax" { = version }
+    "liquid_parser" { = version }
+    "liquid_std" { = version }
+    "liquid_interpreter" { = version }
+    "alcotest" { >= "1.5.0" & with-test }
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/benfaerber/liquid-ml/archive/refs/tags/0.1.3.tar.gz"
+  checksum: [
+    "md5=24f974b1310954a4ee6202d659aafe96"
+    "sha512=8cacca711ef271678118f2959dc734e677d54cd878b95fd2123ab4caa9d3d0dfd1fe17a59660ae1d59374bceca3063fdb1e18cc1018f2aca5283edd4ac97beed"
+  ]
+}

--- a/packages/liquid_parser/liquid_parser.0.1.3/opam
+++ b/packages/liquid_parser/liquid_parser.0.1.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "The parser for Liquid"
+description: """
+The parser for Liquid
+"""
+maintainer: "faerberbendev@protonmail.com"
+authors: ["Ben Faerber"]
+homepage: "https://github.com/benfaerber/liquid-ml"
+bug-reports: "https://github.com/benfaerber/liquid-ml/issues"
+dev-repo: "git+https://github.com/benfaerber/liquid-ml.git"
+license: "MIT"
+
+depends: [
+    "ocaml" { >= "4.11" }
+    "dune" { >= "2.5" }
+    "base" { >= "v0.15.0" }
+    "core" { >= "v0.15.0" }
+    "stdio" { >= "v0.15.0" }
+    "re2" { >= "v0.13.0" }
+    "liquid_syntax" { = version }
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/benfaerber/liquid-ml/archive/refs/tags/0.1.3.tar.gz"
+  checksum: [
+    "md5=24f974b1310954a4ee6202d659aafe96"
+    "sha512=8cacca711ef271678118f2959dc734e677d54cd878b95fd2123ab4caa9d3d0dfd1fe17a59660ae1d59374bceca3063fdb1e18cc1018f2aca5283edd4ac97beed"
+  ]
+}

--- a/packages/liquid_std/liquid_std.0.1.3/opam
+++ b/packages/liquid_std/liquid_std.0.1.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "The Standard Libarary for Liquid"
+description: """
+The Standard Libarary for Liquid
+"""
+maintainer: "faerberbendev@protonmail.com"
+authors: ["Ben Faerber"]
+homepage: "https://github.com/benfaerber/liquid-ml"
+bug-reports: "https://github.com/benfaerber/liquid-ml/issues"
+dev-repo: "git+https://github.com/benfaerber/liquid-ml.git"
+license: "MIT"
+depends: [
+    "ocaml" { >= "4.11" }
+    "dune" { >= "2.5" }
+    "base" { >= "v0.15.0" }
+    "core" { >= "v0.15.0" }
+    "stdio" { >= "v0.15.0" }
+    "re2" { >= "v0.13.0" }
+    "base64" { >= "3.5.1" }
+    "sha" { >= "1.0" }
+    "liquid_syntax" { = version }
+    "liquid_parser" { = version }
+    "liquid_syntax" { = version }
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/benfaerber/liquid-ml/archive/refs/tags/0.1.3.tar.gz"
+  checksum: [
+    "md5=24f974b1310954a4ee6202d659aafe96"
+    "sha512=8cacca711ef271678118f2959dc734e677d54cd878b95fd2123ab4caa9d3d0dfd1fe17a59660ae1d59374bceca3063fdb1e18cc1018f2aca5283edd4ac97beed"
+  ]
+}

--- a/packages/liquid_syntax/liquid_syntax.0.1.3/opam
+++ b/packages/liquid_syntax/liquid_syntax.0.1.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "The Syntax Definitions for Liquid"
+description: """
+The Syntax Definitions for Liquid
+"""
+maintainer: "faerberbendev@protonmail.com"
+authors: ["Ben Faerber"]
+homepage: "https://github.com/benfaerber/liquid-ml"
+bug-reports: "https://github.com/benfaerber/liquid-ml/issues"
+dev-repo: "git+https://github.com/benfaerber/liquid-ml.git"
+license: "MIT"
+depends: [
+    "ocaml" { >= "4.11" }
+    "dune" { >= "2.5" }
+    "base" { >= "v0.15.0" }
+    "core" { >= "v0.15.0" }
+    "stdio" { >= "v0.10.0" }
+    "re2" { >= "v0.13.0" }
+    "calendar" { >= "3.0.0" }
+    "ppx_deriving" { >= "5.0" }
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/benfaerber/liquid-ml/archive/refs/tags/0.1.3.tar.gz"
+  checksum: [
+    "md5=24f974b1310954a4ee6202d659aafe96"
+    "sha512=8cacca711ef271678118f2959dc734e677d54cd878b95fd2123ab4caa9d3d0dfd1fe17a59660ae1d59374bceca3063fdb1e18cc1018f2aca5283edd4ac97beed"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `liquid_interpreter.0.1.3`: The interpreter for Liquid
- `liquid_ml.0.1.3`: Shopify's Liquid templating language in OCaml
- `liquid_parser.0.1.3`: The parser for Liquid
- `liquid_std.0.1.3`: The Standard Libarary for Liquid
- `liquid_syntax.0.1.3`: The Syntax Definitions for Liquid



---
* Homepage: https://github.com/benfaerber/liquid-ml
* Source repo: git+https://github.com/benfaerber/liquid-ml.git
* Bug tracker: https://github.com/benfaerber/liquid-ml/issues

---
:camel: Pull-request generated by opam-publish v2.7.1