### PR TITLE
[new release] dream-html (2 packages) (3.11.2)

### DIFF
--- a/packages/dream-html/dream-html.3.11.2/opam
+++ b/packages/dream-html/dream-html.3.11.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.14.0"}
+  "ppxlib" {>= "0.36.0" & < "1.0.0"}
+  "pure-html" {= version}
+  "dream" {>= "1.0.0~alpha8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.11.2/dream-html-3.11.2.tbz"
+  checksum: [
+    "sha256=ece5aa53d17f5df311842a2ca528b537547f5ed8f88f9a64d292462dae9ff0b5"
+    "sha512=7dec8608c53a2e7c611ce3bc624ac7364aaf5d645e2927e4a0883321da87a9ab880a07f12cdaa9c812f092ca4880f5fc9e8d9d2e62144e9d08b412f3c58c0473"
+  ]
+}
+x-commit-hash: "108c1f617e25ffff4ae870f0cafd2541cd14de09"

--- a/packages/pure-html/pure-html.3.11.2/opam
+++ b/packages/pure-html/pure-html.3.11.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+tags: ["org:yawaramin"]
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "uri" {>= "4.4.0" & < "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v3.11.2/dream-html-3.11.2.tbz"
+  checksum: [
+    "sha256=ece5aa53d17f5df311842a2ca528b537547f5ed8f88f9a64d292462dae9ff0b5"
+    "sha512=7dec8608c53a2e7c611ce3bc624ac7364aaf5d645e2927e4a0883321da87a9ab880a07f12cdaa9c812f092ca4880f5fc9e8d9d2e62144e9d08b412f3c58c0473"
+  ]
+}
+x-commit-hash: "108c1f617e25ffff4ae870f0cafd2541cd14de09"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

See https://github.com/yawaramin/dream-html/tags
