### PR TITLE
Fix shcaml.0.2.1 when in presence of topkg >= 1.1.0

### DIFF
--- a/packages/shcaml/shcaml.0.2.1/opam
+++ b/packages/shcaml/shcaml.0.2.1/opam
@@ -18,6 +18,9 @@ depends: [
   "stdcompat"
 ]
 depopts: [ "lwt" "base-unix" ]
+build-env: [
+  [TOPKG_CONF_DEBUGGER_SUPPORT = "false"] # https://github.com/dbuenzli/topkg/issues/144
+]
 build:
 [
   [ "ocaml" "pkg/pkg.ml" "build"


### PR DESCRIPTION
Upstream issue: https://github.com/dbuenzli/topkg/issues/144