### PR TITLE
Fix avro-simple project meta-data

### DIFF
--- a/packages/avro-simple/avro-simple.0.1/opam
+++ b/packages/avro-simple/avro-simple.0.1/opam
@@ -44,10 +44,10 @@ dev-repo: "git+https://github.com/tmcgilchrist/avro-simple.git"
 x-maintenance-intent: ["(latest)"]
 url {
   src:
-    "https://github.com/tmcgilchrist/avro-simple/archive/refs/tags/0.1.tar.gz"
+    "https://github.com/ocaml/opam-source-archives/raw/refs/heads/main/avro-simple-0.1.tbz"
   checksum: [
-    "sha256=14594bc6c41071f660403bd540370ef62299b04eda6463af350672aaba8a01bb"
-    "sha512=04fa43ae5d94dcda250e3d8c07b0b0331a38688b69fabd0de82bfa24840c6243d5e20a8e74d4aa7879a4afc4e38922b053018bcaf225ab238153c1e63048fab8"
+    "sha256=2f0f7e750a884920d2302fed302d920598789eba3673443d86ee1d7b57a663bc"
+    "sha512=25830478f5f2724b46e1a620e6e42486b53f95e1fc833c82a4a20d021ad9658ac4b50defc3b324dd7393e806460106bb4bad412c37114617ec361b0d64903f03"
   ]
 }
 x-commit-hash: "e68a8de8fa3b69fd05189ed88ef45da9c6291442"


### PR DESCRIPTION
Adding missing author and fixed the GitHub link so it points to the correct project.