### PR TITLE
Add: cmdliner.2.1.0

### DIFF
--- a/packages/cmdliner/cmdliner.2.1.0/opam
+++ b/packages/cmdliner/cmdliner.2.1.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Declarative definition of command line interfaces for OCaml"
+description: """\
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles command line completion, syntax errors,
+help messages and UNIX man page generation. It supports programs with
+single or multiple commands and respects most of the [POSIX] and [GNU]
+conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+Homepage: <http://erratique.ch/software/cmdliner>
+
+[POSIX]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[GNU]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The cmdliner programmers"
+license: "ISC"
+tags: ["cli" "system" "declarative" "org:erratique"]
+homepage: "https://erratique.ch/software/cmdliner"
+doc: "https://erratique.ch/software/cmdliner/doc"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+]
+build: [make "all" "PREFIX=%{prefix}%"]
+install: [
+  [
+    make
+    "install"
+    "BINDIR=%{_:bin}%"
+    "LIBDIR=%{_:lib}%"
+    "DOCDIR=%{_:doc}%"
+    "SHAREDIR=%{share}%"
+    "MANDIR=%{man}%"
+  ]
+  [
+    make
+    "install-doc"
+    "LIBDIR=%{_:lib}%"
+    "DOCDIR=%{_:doc}%"
+    "SHAREDIR=%{share}%"
+    "MANDIR=%{man}%"
+  ]
+]
+dev-repo: "git+https://erratique.ch/repos/cmdliner.git"
+url {
+  src: "https://erratique.ch/software/cmdliner/releases/cmdliner-2.1.0.tbz"
+  checksum:
+    "sha512=2ca8c9a2b392e031f88aa0e76f2ab50c8e9e28d77852d04ca2d5b62326630ca41567ce0832e9a9334d9b130b48deede66c7880a9d0aee75a1afe7541097e249f"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `cmdliner.2.1.0` [home](https://erratique.ch/software/cmdliner), [doc](https://erratique.ch/software/cmdliner/doc), [issues](https://github.com/dbuenzli/cmdliner/issues)  
  *Declarative definition of command line interfaces for OCaml*


---

#### `cmdliner` v2.1.0 2025-11-25 Zagreb

- completion: add support for powershell ([#214](https://github.com/dbuenzli/cmdliner/issues/214)).
  Thanks to Brian Ward for the work.

- bash completion: improve bash completion on files and directories ([#238](https://github.com/dbuenzli/cmdliner/issues/238)).
  Thanks to Brian Ward for the report and fix.

- bash completion: improve completion of long options with `=` ([#231](https://github.com/dbuenzli/cmdliner/issues/231)).
  Thanks to Brian Ward for the patch.

- zsh completion: fix completion of files and directories on glued
  forms ([#230](https://github.com/dbuenzli/cmdliner/issues/230)).
  Thanks to Brian Ward for the help.

- zsh completion: strip ANSI escapes from doc strings. The experience
  is too unreliable ([#220](https://github.com/dbuenzli/cmdliner/issues/220)).

- cmdliner tool: add support for generating standalone completion
  scripts via the `--standalone-completion` option. Can be used if you
  distribute your software in a context where the cmdliner library
  may not be installed ([#243](https://github.com/dbuenzli/cmdliner/issues/243)).
  Thanks to Brian Ward for suggesting.

- Add alternative instructions to the cookbook for installing tool support
  files with `dune` ([#250](https://github.com/dbuenzli/cmdliner/issues/250)).
  Thanks to Brian Ward for the patch and research.

- `--help` output, improve graceful degradation on groff or pager
  errors ([#140](https://github.com/dbuenzli/cmdliner/issues/140)).
  Thanks to Sergey Fedorov for the report.

---

Use `b0 -- .opam publish cmdliner.2.1.0` to update the pull request.