### PR TITLE
Release ocaml-solo5 and ocaml-solo5-cross-aarch64 1.2.0

### DIFF
--- a/packages/ocaml-solo5-cross-aarch64/ocaml-solo5-cross-aarch64.1.2.0/opam
+++ b/packages/ocaml-solo5-cross-aarch64/ocaml-solo5-cross-aarch64.1.2.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-solo5"
+bug-reports: "https://github.com/mirage/ocaml-solo5/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
+build: [
+  ["./configure.sh"
+   "--prefix=%{prefix}%"
+   "--sysroot=%{_:lib}%"
+   "--target=aarch64-solo5-none-static"
+   "--ocaml-configure-option=--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+   "--ocaml-configure-option=--enable-flambda" {ocaml-option-flambda:installed}
+  ]
+  [make "-j%{jobs}%"]
+  [make "%{name}%.install"]
+]
+install: [
+  [make "install-ocaml"]
+]
+depopts: [
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+]
+run-test: [
+  [make "test"]
+]
+depends: [
+  "opatch" {build} # to patch the compiler sources
+  "ocamlfind" {build}
+  "ocaml-src" {build}
+  "ocaml" {= "5.3.0" | = "5.4.0"}
+  "solo5" {>= "0.9.1"}
+  "solo5-cross-aarch64" {>= "0.9.1" }
+]
+conflicts: [
+  "ocaml-solo5"
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available: [
+  ((os = "linux" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "freebsd" & arch = "x86_64")
+  | (os = "openbsd" & arch = "x86_64"))
+]
+x-maintenance-intent: [ "(latest)" ]
+synopsis: "OCaml cross-compiler to the freestanding 64-bit ARM Solo5 backend"
+description:
+  "This package provides a OCaml cross-compiler for ARM64, suitable for linking with a Solo5 unikernel."
+url {
+  src:
+    "https://github.com/mirage/ocaml-solo5/archive/refs/tags/v1.2.0.tar.gz"
+  checksum: [
+    "md5=4d07934aea2d32b77ba1b8bb062c6594"
+    "sha512=2ec008da088f7998d024b790679605813f1954de36b999031db0b003706e67f3f13554e93fa07be00f26633ea27c2b2f9f987e8b08f85c63f956bfbc306bd620"
+  ]
+}

--- a/packages/ocaml-solo5/ocaml-solo5.1.2.0/opam
+++ b/packages/ocaml-solo5/ocaml-solo5.1.2.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-solo5"
+bug-reports: "https://github.com/mirage/ocaml-solo5/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
+build: [
+  ["./configure.sh"
+   "--prefix=%{prefix}%"
+   "--target=x86_64-solo5-none-static" { arch = "x86_64" }
+   "--target=aarch64-solo5-none-static" { arch = "arm64" }
+   "--ocaml-configure-option=--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+   "--ocaml-configure-option=--enable-flambda" {ocaml-option-flambda:installed}
+  ]
+  [make "-j%{jobs}%"]
+  [make "%{name}%.install"]
+]
+install: [
+  [make "install-ocaml"]
+]
+depopts: [
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+]
+run-test: [
+  [make "test"]
+]
+depends: [
+  "opatch" {build} # to patch the compiler sources
+  "ocamlfind" {build}
+  "ocaml-src" {build}
+  "ocaml" {= "5.3.0" | = "5.4.0"}
+  "solo5" {>= "0.9.1"}
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available: [
+  ((os = "linux" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "freebsd" & arch = "x86_64")
+  | (os = "openbsd" & arch = "x86_64"))
+]
+x-maintenance-intent: [ "(latest)" ]
+synopsis: "OCaml cross-compiler to the freestanding Solo5 backend"
+description:
+  "This package provides a OCaml cross-compiler, suitable for linking with a Solo5 unikernel."
+url {
+  src:
+    "https://github.com/mirage/ocaml-solo5/archive/refs/tags/v1.2.0.tar.gz"
+  checksum: [
+    "md5=4d07934aea2d32b77ba1b8bb062c6594"
+    "sha512=2ec008da088f7998d024b790679605813f1954de36b999031db0b003706e67f3f13554e93fa07be00f26633ea27c2b2f9f987e8b08f85c63f956bfbc306bd620"
+  ]
+}


### PR DESCRIPTION
* Support OCaml 5.4.0 (@shym mirage/ocaml-solo5#155)
* Add test of (host) ocaml-installed fmt in one example (@dinosaure mirage/ocaml-solo5#155)
* Use plain text diffs, use opatch instead of git apply (@shym @dinosaure @hannesm mirage/ocaml-solo5#154)
* Cleanup opam package dependencies (@shym mirage/ocaml-solo5#156)