### PR TITLE
2 packages from kit-ty-kate/opam-build at 0.3.0

### DIFF
--- a/packages/opam-build/opam-build.0.3.0/opam
+++ b/packages/opam-build/opam-build.0.3.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to build projects"
+maintainer: "Kate <kit-ty-kate@exn.st>"
+authors: "Kate <kit-ty-kate@exn.st>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.5" & < "2.6"}
+  "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
+]
+available: opam-version >= "2.5" & opam-version < "2.6"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.3.0/opam-build-0.3.0.tar.gz"
+  checksum: [
+    "md5=b14bf4a7020672caf125df1eaba2dd98"
+    "sha512=09d68b1c4f57afd6ef20648a0b1c47d742f7ae8446e0d0b508f61f44674b65560d00a7a7e6c58073a99ac3b7c03b81c51fc5ec22fa32e95d24086b0a63a53104"
+  ]
+}

--- a/packages/opam-test/opam-test.0.3.0/opam
+++ b/packages/opam-test/opam-test.0.3.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to test projects"
+maintainer: "Kate <kit-ty-kate@exn.st>"
+authors: "Kate <kit-ty-kate@exn.st>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.5" & < "2.6"}
+  "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
+]
+available: opam-version >= "2.5" & opam-version < "2.6"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.3.0/opam-build-0.3.0.tar.gz"
+  checksum: [
+    "md5=b14bf4a7020672caf125df1eaba2dd98"
+    "sha512=09d68b1c4f57afd6ef20648a0b1c47d742f7ae8446e0d0b508f61f44674b65560d00a7a7e6c58073a99ac3b7c03b81c51fc5ec22fa32e95d24086b0a63a53104"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `opam-build.0.3.0`: An opam plugin to build projects
- `opam-test.0.3.0`: An opam plugin to test projects



---
* Homepage: https://github.com/kit-ty-kate/opam-build
* Source repo: git+https://github.com/kit-ty-kate/opam-build.git
* Bug tracker: https://github.com/kit-ty-kate/opam-build/issues

---
:camel: Pull-request generated by opam-publish v2.7.1