### PR TITLE
[new release] slipshow (0.7.0)

### DIFF
--- a/packages/slipshow/slipshow.0.7.0/opam
+++ b/packages/slipshow/slipshow.0.7.0/opam
@@ -59,8 +59,8 @@ url {
   src:
     "https://github.com/panglesd/slipshow/releases/download/v0.7.0/slipshow-0.7.0.tbz"
   checksum: [
-    "sha256=50232a067d16c416dc4a537e190a1330611117230cb1b4e5e9b1cc99e856c5b7"
-    "sha512=2cd32d0b3cdc84bd247c019f27ebbdf74060fc71c8d55790239f43412a6bff06e5704f97860960ecec2667fff84a8e47cbbf6a38bcbf879c15bf45ff28d49fcb"
+    "sha256=c719baa426fa8902abeda22c5b0896845af95fea430757b116fcb1bc60472344"
+    "sha512=498c75abefc6fc5178dbed66ea1848f618204591dedac9d19cd538dbc1074d473e706c3b902cceba17e2fe273eddea02fdbd0837f53ba8cd4bdd96efcccc2e4c"
   ]
 }
-x-commit-hash: "6cb624b13957bbb2daac21c9f4df617d940c1551"
+x-commit-hash: "452564bf4149376c48b18aa57f6681ecde409555"


### PR DESCRIPTION
See the [release notes](https://github.com/panglesd/slipshow/releases/tag/v0.7.0) for the changes and a funny gif!