### PR TITLE
Add an OCaml 5.4.0 upper bound on boltzgen.0.9.5

### DIFF
--- a/packages/boltzgen/boltzgen.0.9.5/opam
+++ b/packages/boltzgen/boltzgen.0.9.5/opam
@@ -9,7 +9,7 @@ license: "GPL-3.0-or-later"
 homepage: "https://git.lacl.fr/barbot/boltzgen"
 bug-reports: "https://git.lacl.fr/barbot/boltzgen/-/issues"
 depends: [
-  "ocaml" {>= "5.0.0"}
+  "ocaml" {>= "5.0.0" & < "5.4.0"}
   "dune" {>= "3.15" & >= "3.15"}
   "ocaml-compiler-libs"
   "cmdliner" {>= "1.1.0"}


### PR DESCRIPTION
Labeled tuples changed the AST, causing it to be incompatible:
```
=== ERROR while compiling boltzgen.0.9.5 =====================================#
 context              2.5.0~beta1 | linux/x86_64 | ocaml-base-compiler.5.4.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.4/.opam-switch/build/boltzgen.0.9.5
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p boltzgen -j 71 @install
 exit-code            1
 env-file             ~/.opam/log/boltzgen-6-d565a7.env
 output-file          ~/.opam/log/boltzgen-6-d565a7.out
### output ###
 (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/.boltzgen.objs/byte -I /home/opam/.opam/5.4/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.4/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4/lib/ocaml/unix -cmi-file src/.boltzgen.objs/byte/parse_from_compiler.cmi -no-alias-deps -o src/.boltzgen.objs/byte/parse_from_compiler.cmo -c -impl src/runtime/parse_from_compiler.ml)
 File "src/runtime/parse_from_compiler.ml", line 96, characters 50-52:
 96 |   | Ptyp_tuple al -> Prod (List.map to_compo_type al)
                                                        ^^
 Error: The value al has type (string option * Parsetree.core_type) list
        but an expression was expected of type Parsetree.core_type list
        Type string option * Parsetree.core_type is not compatible with type
          Parsetree.core_type
 (cd _build/default && /home/opam/.opam/5.4/bin/ocamlopt.opt -w -40 -g -I src/.boltzgen.objs/byte -I src/.boltzgen.objs/native -I /home/opam/.opam/5.4/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.4/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4/lib/ocaml/unix -cmi-file src/.boltzgen.objs/byte/parse_from_compiler.cmi -no-alias-deps -o src/.boltzgen.objs/native/parse_from_compiler.cmx -c -impl src/runtime/parse_from_compiler.ml)
 File "src/runtime/parse_from_compiler.ml", line 96, characters 50-52:
 96 |   | Ptyp_tuple al -> Prod (List.map to_compo_type al)
                                                        ^^
 Error: The value al has type (string option * Parsetree.core_type) list
        but an expression was expected of type Parsetree.core_type list
        Type string option * Parsetree.core_type is not compatible with type
          Parsetree.core_type
```

(seen on #28962)