### PR TITLE
Add a missing cmdliner.2.0.0 upper bound for runtime_event_tools*

### DIFF
--- a/packages/runtime_events_tools/runtime_events_tools.0.5.3/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.5.3/opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.0.0~"}
   "hdr_histogram"
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "trace-fuchsia" {>= "0.10"}
   "trace" {>= "0.10"}
   "menhir" {with-test}

--- a/packages/runtime_events_tools_bare/runtime_events_tools_bare.0.5.3/opam
+++ b/packages/runtime_events_tools_bare/runtime_events_tools_bare.0.5.3/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/tarides/runtime_events_tools/issues"
 depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.0.0~"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
```
=== ERROR while compiling runtime_events_tools.0.5.3 =========================#
 context              2.5.0~beta1 | linux/x86_64 | ocaml-base-compiler.5.4.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.4/.opam-switch/build/runtime_events_tools.0.5.3
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p runtime_events_tools -j 255 @install
 exit-code            1
 env-file             ~/.opam/log/runtime_events_tools-7-42489a.env
 output-file          ~/.opam/log/runtime_events_tools-7-42489a.out
### output ###
 (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I lib/olly_common/.olly_common.objs/byte -I /home/opam/.opam/5.4/lib/cmdliner -I /home/opam/.opam/5.4/lib/ocaml/runtime_events -I /home/opam/.opam/5.4/lib/ocaml/unix -no-alias-deps -open Olly_common -o lib/olly_common/.olly_common.objs/byte/olly_common__Cli.cmo -c -impl lib/olly_common/cli.ml)
 File "lib/olly_common/cli.ml", line 23, characters 20-77:
 23 |       let conv, _ = Cmdliner.Arg.enum (List.rev_map (fun s -> (s, s)) topics) in
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type
          string Cmdliner.Arg.conv = string Cmdliner.Arg.Conv.t
        but an expression was expected of type 'a * 'b
```

(and similarly for runtime_events_tools_bare.0.5.3)

Spotted on https://github.com/ocaml/opam-repository/pull/28962