### PR TITLE
Add an OCaml 5.4.0 upper bound on why3 1.6.0-1.8.0

### DIFF
--- a/packages/why3/why3.1.6.0/opam
+++ b/packages/why3/why3.1.6.0/opam
@@ -55,7 +55,7 @@ install: [
 
 depends: [
   "conf-autoconf" {build | dev}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4.0"}
   "ocamlfind" {build}
   "menhir" {>= "20170418"}
   "num"

--- a/packages/why3/why3.1.7.0/opam
+++ b/packages/why3/why3.1.7.0/opam
@@ -56,7 +56,7 @@ install: [
 
 depends: [
   "conf-autoconf" {build & dev}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4.0"}
   "ocamlfind" {build}
   "menhir" {>= "20170418"}
   "num"

--- a/packages/why3/why3.1.7.1/opam
+++ b/packages/why3/why3.1.7.1/opam
@@ -56,7 +56,7 @@ install: [
 
 depends: [
   "conf-autoconf" {build & dev}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4.0"}
   "ocamlfind" {build}
   "menhir" {>= "20170418"}
   "num"

--- a/packages/why3/why3.1.7.2/opam
+++ b/packages/why3/why3.1.7.2/opam
@@ -56,7 +56,7 @@ install: [
 
 depends: [
   "conf-autoconf" {build & dev}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4.0"}
   "ocamlfind" {build}
   "menhir" {>= "20170418"}
   "num"

--- a/packages/why3/why3.1.8.0/opam
+++ b/packages/why3/why3.1.8.0/opam
@@ -52,7 +52,7 @@ install: [
 
 depends: [
   "conf-autoconf" {build & dev}
-  "ocaml" {>= "4.09"}
+  "ocaml" {>= "4.09" & < "5.4.0"}
   "ocamlfind" {build}
   "menhir" {>= "20200211"}
   "zarith"


### PR DESCRIPTION
why3 1.6.0-1.8.0 fails to compile on 5.4.0 with:
```
=== ERROR while compiling why3.1.8.0 =========================================#
 context              2.5.0~beta1 | linux/x86_64 | ocaml-base-compiler.5.4.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.4/.opam-switch/build/why3.1.8.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build make -j71 all byte
 exit-code            2
 env-file             ~/.opam/log/why3-7-b5590a.env
 output-file          ~/.opam/log/why3-7-b5590a.out
### output ###
 Generate src/util/config.ml
 Ocamllex src/util/rc.mll
 Ocamllex src/util/lexlib.mll

[...]

 Ocamlc   src/transform/congruence.mli
 File "src/util/debug_optim.ml", line 23, characters 49-63:
 23 |                         Pexp_ident { txt = Ldot (Lident "Debug", "dprintf")}},
                                                       ^^^^^^^^^^^^^^
 Error: This pattern should not be a constructor, the expected type is
        Longident.t Location.loc
 Ocamlc   src/transform/induction.mli
 make: *** [Makefile:416: src/util/ppx_debug_optim] Error 2
```

This is due to https://github.com/ocaml/ocaml/pull/13302 changing the Longident.t AST.

Spotted on https://github.com/ocaml/opam-repository/pull/28962