### PR TITLE
Add epel-release depext to conf-age for Centos

### DIFF
--- a/packages/conf-age/conf-age.1/opam
+++ b/packages/conf-age/conf-age.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["age"] {os-distribution = "nixos"}
   ["age"] {os-distribution = "arch"}
   ["age"] {os-family = "fedora"}
-  ["age"] {os-distribution = "centos"}
+  ["epel-release" "age"] {os-distribution = "centos"}
   ["age"] {os = "macos" & os-distribution = "homebrew"}
   ["age"] {os = "macos" & os-distribution = "macports"}
   ["age"] {os = "freebsd"}


### PR DESCRIPTION
Currently the `age` package is not found, causing a failure:
```
<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><><><>

opam believes some required external dependencies are missing. opam can:
> 1. Run yum to install them (may need root/sudo access)
  2. Display the recommended yum command and wait while you run it manually (e.g. in another terminal)
  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
  4. Abort the installation

[1/2/3/4] 1

+ /usr/bin/sudo "yum" "install" "-y" "age" "libcurl-devel" "libevent-devel" "openssl-devel" "pcre-devel"
- Last metadata expiration check: 0:00:07 ago on Wed Nov 26 17:35:22 2025.
- No match for argument: age
- Error: Unable to find a match: age
[ERROR] System package install failed with exit code 1 at command:
            sudo yum install -y age libcurl-devel libevent-devel openssl-devel pcre-devel
[ERROR] These packages are still missing: age libcurl-devel libevent-devel openssl-devel pcre-devel
```

On Centos `age` is available via the EPEL repository https://pkgs.org/download/age hence we should require the `epel-release` package enabling it