### PR TITLE
[new release] goblint (2.7.0)

### DIFF
--- a/packages/goblint/goblint.2.7.0/opam
+++ b/packages/goblint/goblint.2.7.0/opam
@@ -1,0 +1,126 @@
+opam-version: "2.0"
+synopsis: "Static analysis framework for C"
+description: """
+Goblint is a sound static analysis framework for C programs using abstract interpretation.
+It specializes in thread-modular verification of multi-threaded programs, especially regarding data races.
+Goblint includes analyses for assertions, overflows, deadlocks, etc and can be extended with new analyses.
+"""
+maintainer: [
+  "Simmo Saan <simmo.saan@gmail.com>"
+  "Michael Schwarz <michael.schwarz93@gmail.com>"
+  "Karoliine Holter <karoliine.holter@ut.ee>"
+]
+authors: [
+  "Simmo Saan"
+  "Michael Schwarz"
+  "Julian Erhard"
+  "Sarah Tilscher"
+  "Karoliine Holter"
+  "Michael Petter"
+  "Ali Rasim Kocal"
+  "Ralf Vogler"
+  "Kalmer Apinis"
+  "Vesal Vojdani"
+]
+license: "MIT"
+tags: [
+  "program analysis"
+  "program verification"
+  "static analysis"
+  "abstract interpretation"
+  "C"
+  "data race analysis"
+  "concurrency"
+]
+homepage: "https://goblint.in.tum.de"
+doc: "https://goblint.readthedocs.io/en/latest/"
+bug-reports: "https://github.com/goblint/analyzer/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "4.14"}
+  "goblint-cil" {>= "2.0.9"}
+  "batteries" {>= "3.9.0"}
+  "zarith" {>= "1.10"}
+  "yojson" {>= "2.0.0" & < "3"}
+  "qcheck-core" {>= "0.19"}
+  "ppx_deriving" {>= "6.0.2"}
+  "ppx_deriving_hash" {>= "0.1.2"}
+  "ppx_deriving_yojson" {>= "3.7.0"}
+  "ppx_blob" {>= "0.8.0"}
+  "ppxlib" {>= "0.30.0"}
+  "ounit2" {with-test}
+  "qcheck-ounit" {with-test}
+  "odoc" {with-doc}
+  "fpath"
+  "dune-site"
+  "dune-build-info"
+  "json-data-encoding"
+  "jsonrpc" {>= "1.12"}
+  "sha" {>= "1.12"}
+  "fileutils" {>= "0.6.4"}
+  "cpu"
+  "arg-complete" {>= "0.2.1"}
+  "yaml" {>= "3.0.0"}
+  "uuidm"
+  "catapult"
+  "catapult-file"
+  "conf-gmp" {>= "3"}
+  "conf-ruby" {with-test}
+  "benchmark" {with-test}
+  "conf-gcc"
+  "domain-local-await"
+  "domain_shims"
+]
+depopts: ["apron" "z3" "domainslib"]
+conflicts: [
+  "result" {< "1.5"}
+  "apron" {< "v0.9.15"}
+  "camlidl" {< "1.13"}
+  "ez-conf-lib" {= "1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/goblint/analyzer.git"
+# on `dune build` goblint.opam will be generated from goblint.opam.template and dune-project
+# also remember to generate/adjust goblint.opam.locked!
+x-maintenance-intent: ["(latest)" "(latest).(latest-1)"] # also keep previous minor version (with two releases per year, always keep a SV-COMP release)
+available: os-family != "bsd" & os-distribution != "alpine" & (arch != "arm64" | os = "macos")
+# pin-depends: [
+  # published goblint-cil 2.0.9 is currently up-to-date, so no pin needed
+  # [ "goblint-cil.2.0.9" "git+https://github.com/goblint/cil.git#1b48fc0ce4f3576a51618305251121ffedd0bf1e" ]
+  # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new apron release
+  # [ "apron.v0.9.15" "git+https://github.com/antoinemine/apron.git#418a217c7a70dae3f422678f3aaba38ae374d91a" ]
+# ]
+depexts: [
+  ["libgraph-easy-perl"] {os-distribution = "ubuntu" & with-test} # doesn't work (https://github.com/ocaml/opam/issues/5836)
+]
+post-messages: [
+  "Do not benchmark Goblint on OCaml 5 (https://goblint.readthedocs.io/en/latest/user-guide/benchmarking/)." {ocaml:version >= "5.0.0"}
+]
+x-ci-accept-failures: [
+  "macos-homebrew" # newer MacOS headers cannot be parsed (https://github.com/ocaml/opam-repository/pull/26307#issuecomment-2258080206)
+  "opensuse-tumbleweed" # not GNU diff, so some cram tests fail (https://discuss.ocaml.org/t/opensuse-and-opam-tests/14641/2)
+]
+url {
+  src:
+    "https://github.com/goblint/analyzer/releases/download/v2.7.0/goblint-2.7.0.tbz"
+  checksum: [
+    "sha256=4dc96a8b8671a02befdc04eb375241862e3c1f72799ad681d12b6be8c0b32d7a"
+    "sha512=738de19f2d08fa3892976f55a21beeead95d2a811badf3bf82e08868d34c3ae0d05fb51f10dd22cb3f22095ba6ffe110ba0917d04656d59bda69dad1cf39304a"
+  ]
+}
+x-commit-hash: "270caa0fe4962f4196f83565aa7b2c3d3ef8f616"


### PR DESCRIPTION
Static analysis framework for C

- Project page: <a href="https://goblint.in.tum.de">https://goblint.in.tum.de</a>
- Documentation: <a href="https://goblint.readthedocs.io/en/latest/">https://goblint.readthedocs.io/en/latest/</a>

##### CHANGES:

Functionally equivalent to Goblint in SV-COMP 2026.

* Add sequential portfolio for SV-COMP (goblint/analyzer#1845, goblint/analyzer#1867, goblint/analyzer#1877).
* Add struct bitfield support (goblint/analyzer#1739, goblint/analyzer#1823).
* Improve bitwise operations for integer domains (goblint/analyzer#1739).
* Reimplement HTML output in OCaml (goblint/analyzer#1752).
* Remove YAML witness version 0.1 support (goblint/analyzer#1812, goblint/analyzer#1817, goblint/analyzer#1852, goblint/analyzer#1853, goblint/analyzer#1855).
* Fix incorrect invariants in witnesses (goblint/analyzer#1818, goblint/analyzer#1876).
* Simplify relational invariants in witnesses (goblint/analyzer#1826, goblint/analyzer#1871, goblint/analyzer#1873).
* Fix argument types in Goblint stubs (goblint/analyzer#1684, goblint/analyzer#1814, goblint/analyzer#1779, goblint/analyzer#1820).
