### PR TITLE
[new release] mrmime (0.7.1)

### DIFF
--- a/packages/mrmime/mrmime.0.7.1/opam
+++ b/packages/mrmime/mrmime.0.7.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/mrmime"
+bug-reports:  "https://github.com/mirage/mrmime/issues"
+dev-repo:     "git+https://github.com/mirage/mrmime.git"
+doc:          "https://mirage.github.io/mrmime/"
+license:      "MIT"
+synopsis:     "Mr. MIME"
+description:  """Parser and generator of mail in OCaml"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.7"}
+  "ke"                {>= "0.4"}
+  "unstrctrd"         {>= "0.3"}
+  "ptime"             {>= "0.8.2"}
+  "uutf"
+  "rosetta"           {>= "0.3.0"}
+  "ipaddr"            {>= "5.0.0"}
+  "emile"             {>= "1.0"}
+  "base64"            {>= "3.1.0"}
+  "pecu"              {>= "0.6"}
+  "prettym"           {>= "0.0.2"}
+  "bigstringaf"       {>= "0.5.0"}
+  "bigarray-overlap"  {>= "0.2.0"}
+  "angstrom"          {>= "0.14.0"}
+  "fpath"             {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test & >= "2.0.0"}
+  "ocplib-endian"     {with-test}
+  "afl-persistent"    {with-test}
+  "alcotest"          {with-test}
+  "jsonm"             {with-test}
+  "crowbar"           {with-test}
+  "lwt"               {with-test}
+  "cmdliner"          {with-test & >= "1.1.0"}
+  "logs"              {with-test}
+]
+conflicts: [
+  "result"            {< "1.5"}
+]
+url {
+  src:
+    "https://github.com/mirage/mrmime/releases/download/v0.7.1/mrmime-0.7.1.tbz"
+  checksum: [
+    "sha256=1fc54e0e8f529877bdccb45484bf7d7009b42e9ea3cfb8551b98c31e2a75fcbb"
+    "sha512=39559056cf3c13157ae0c32bd954acb0590a0c9f9173a0fdb504515c9369db62ecab2e2cca2a8551427f488f61e75e1778f3ce7125438207aae4bbe1283a25f5"
+  ]
+}
+x-commit-hash: "7fc6c332ffd814bf9f217cd4b35584e4a833d022"


### PR DESCRIPTION
Mr. MIME

- Project page: <a href="https://github.com/mirage/mrmime">https://github.com/mirage/mrmime</a>
- Documentation: <a href="https://mirage.github.io/mrmime/">https://mirage.github.io/mrmime/</a>

##### CHANGES:

- Upgrade with last version of `ocamlformat` (@dinosaure, mirage/mrmime#107, mirage/mrmime#108)
- Remove extraneous cuts on mailboxes when we encode them (@madroach, mirage/mrmime#105)
