### PR TITLE
[new release] prettym (0.0.4)

### DIFF
--- a/packages/prettym/prettym.0.0.4/opam
+++ b/packages/prettym/prettym.0.0.4/opam
@@ -33,3 +33,4 @@ url {
   ]
 }
 x-commit-hash: "bb5c82804a79a585c3e797288a34ef81b6025b4d"
+x-maintenance-intent: [ "(latest)" ]


### PR DESCRIPTION
An memory-bounded encoder according to RFC 822

- Project page: <a href="https://github.com/dinosaure/prettym">https://github.com/dinosaure/prettym</a>
- Documentation: <a href="https://dinosaure.github.io/prettym/">https://dinosaure.github.io/prettym/</a>

##### CHANGES:

- Delete `fmt` dependency (@dinosaure dinosaure/prettym#5)
- Move to `bstr` (instead of `bigstringaf`) (@dinosaure, dinosaure/prettym#6)
