### PR TITLE
[new release] uuuu (0.4.0)

### DIFF
--- a/packages/uuuu/uuuu.0.4.0/opam
+++ b/packages/uuuu/uuuu.0.4.0/opam
@@ -28,3 +28,4 @@ url {
   ]
 }
 x-commit-hash: "44066c6d15300d85debccc1046f4e578bec58d34"
+x-maintenance-intent: [ "(latest)" ]


### PR DESCRIPTION
Mapper of ISO-8859-* to Unicode

- Project page: <a href="https://github.com/mirage/uuuu">https://github.com/mirage/uuuu</a>
- Documentation: <a href="https://mirage.github.io/uuuu/">https://mirage.github.io/uuuu/</a>

##### CHANGES:

* Improve the distribution and remove the dependency to `re` and `ocamlfind`
  (@dinosaure, mirage/uuuu#6)
