### PR TITLE
[new release] coin (0.1.5)

### DIFF
--- a/packages/coin/coin.0.1.5/opam
+++ b/packages/coin/coin.0.1.5/opam
@@ -28,3 +28,4 @@ url {
   ]
 }
 x-commit-hash: "adb82c98a97d94277842a2d1e9615df69eabc35e"
+x-maintenance-intent: [ "(latest)" ]


### PR DESCRIPTION
Mapper of KOI8-{U,R} to Unicode

- Project page: <a href="https://github.com/mirage/coin">https://github.com/mirage/coin</a>
- Documentation: <a href="https://mirage.github.io/coin/">https://mirage.github.io/coin/</a>

##### CHANGES:

* Delete the `re` dependency and the `ocamlfind` tool (mirage/coin#7)
