### PR TITLE
Add a failure post-message for conf-libpcre on Centos 10 and OpenSUSE Tumbleweed

### DIFF
--- a/packages/conf-libpcre/conf-libpcre.2/opam
+++ b/packages/conf-libpcre/conf-libpcre.2/opam
@@ -38,6 +38,7 @@ depexts: [
 post-messages: [
   "On Debian 13 (Trixie), the libpcre3-dev package was removed from the code package repository. You can find it in third party repository DebianMultimedia or install it manually." { failure & os-family = "debian" }
   "On Centos 10 the pcre-devel package was removed from the code package repository. You will need to install it manually." { failure & os-family = "centos" }
+  "On OpenSUSE Tumbleweed the pcre-devel package was removed from the code package repository. You will need to install it manually." { failure & os-family = "opensuse" }
 ]
 synopsis: "Virtual package relying on a libpcre system installation"
 description:


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/28969

A search on https://pkgs.org/search/?q=libpcre.pc
reveals that it is not available on Centos 10 (even EPEL) or OpenSUSE Tumbleweed.