### PR TITLE
[new release] mrmime (0.7.1)

### DIFF
--- a/packages/mrmime/mrmime.0.7.1/opam
+++ b/packages/mrmime/mrmime.0.7.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/mrmime"
+bug-reports:  "https://github.com/mirage/mrmime/issues"
+dev-repo:     "git+https://github.com/mirage/mrmime.git"
+doc:          "https://mirage.github.io/mrmime/"
+license:      "MIT"
+synopsis:     "Mr. MIME"
+description:  """Parser and generator of mail in OCaml"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.7"}
+  "ke"                {>= "0.4"}
+  "bstr"              {>= "0.0.3"}
+  "unstrctrd"         {>= "0.3"}
+  "ptime"             {>= "0.8.2"}
+  "uutf"
+  "rosetta"           {>= "0.3.0"}
+  "ipaddr"            {>= "5.0.0"}
+  "emile"             {>= "1.0"}
+  "base64"            {>= "3.1.0"}
+  "pecu"              {>= "0.6"}
+  "prettym"           {>= "0.0.2"}
+  "angstrom"          {>= "0.14.0"}
+  "fpath"             {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test & >= "2.0.0"}
+  "ocplib-endian"     {with-test}
+  "afl-persistent"    {with-test}
+  "alcotest"          {with-test}
+  "jsonm"             {with-test}
+  "crowbar"           {with-test}
+  "lwt"               {with-test}
+  "cmdliner"          {with-test & >= "1.1.0"}
+  "logs"              {with-test}
+]
+conflicts: [
+  "result"            {< "1.5"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mrmime/releases/download/v0.7.1/mrmime-0.7.1.tbz"
+  checksum: [
+    "sha256=b8a5be12d81f3618a123b6cda13462042f65954d7fdb9f8f676984a4559801e7"
+    "sha512=96fe45cf1b7686aae7251aaf7657c633e1e4670797bc5d954f50f4911396a2bb9a972c44b8bea88485bb44795b9b5f8fc1637822c544ff97362a440f309e6d31"
+  ]
+}
+x-commit-hash: "e8189cba8098d034e90322d6371978306629dcf7"


### PR DESCRIPTION
Mr. MIME

- Project page: <a href="https://github.com/mirage/mrmime">https://github.com/mirage/mrmime</a>
- Documentation: <a href="https://mirage.github.io/mrmime/">https://mirage.github.io/mrmime/</a>

##### CHANGES:

- Upgrade with last version of `ocamlformat` (@dinosaure, mirage/mrmime#107, mirage/mrmime#108)
- Remove extraneous cuts on mailboxes when we encode them (@madroach, mirage/mrmime#105)
- Replace `bigstringaf` by `bstr` (@dinosaure, mirage/mrmime#110)
