### PR TITLE
Add a ppx_repr upper bound for ppx_irmin 3.0.0-3.11.0

### DIFF
--- a/packages/ppx_irmin/ppx_irmin.3.0.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.0.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.1.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.1.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.10.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.10.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.11.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.11.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.2.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.2.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.2.1/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.2.1/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.2.2/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.2.2/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.3.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.3.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.3.1/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.3.1/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.3.2/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.3.2/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.4.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.4.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.4.1/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.4.1/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.4.2/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.4.2/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.4.3/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.4.3/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.5.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.5.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.5.1/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.5.1/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.5.2/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.5.2/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.6.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.6.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.6.1/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.6.1/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.7.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.7.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.7.1/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.7.1/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.7.2/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.7.2/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.8.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.8.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}

--- a/packages/ppx_irmin/ppx_irmin.3.9.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.9.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
   "ppx_repr" {>= "0.2.0"}
+  "ppx_repr" {with-test & < "0.8.0"}
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}


### PR DESCRIPTION
This is triggering on https://github.com/ocaml/opam-repository/pull/28963 with the new `repr` a `ppx_repr` 0.8.0 release, for example:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/e3af1e2cb25e7b7a93f95895076b7271072ac4e2/variant/compilers,4.14,ppx_repr.0.8.0,revdeps,ppx_irmin.3.0.0
```
#=== ERROR while compiling ppx_irmin.3.0.0 ====================================#
# context              2.5.0~beta1 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/ppx_irmin.3.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p ppx_irmin -j 255
# exit-code            1
# env-file             ~/.opam/log/ppx_irmin-7-de14df.env
# output-file          ~/.opam/log/ppx_irmin-7-de14df.out
### output ###
# File "test/ppx_irmin/test_logs-processed.expected", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/ppx_irmin/test_logs-processed.expected _build/default/test/ppx_irmin/test_logs-processed.actual
# diff --git a/_build/default/test/ppx_irmin/test_logs-processed.expected b/_build/default/test/ppx_irmin/test_logs-processed.actual
# index a1beace..39baa73 100644
# --- a/_build/default/test/ppx_irmin/test_logs-processed.expected
# +++ b/_build/default/test/ppx_irmin/test_logs-processed.actual
# @@ -45,18 +45,14 @@ let () =
#         | Logs.Warning -> "Warning"
#         | Logs.Info -> "Info"
#         | Logs.Debug -> "Debug") in
# -  let report _src level ~over  k msgf =
# +  let report _src level ~over k msgf =
#      let k _ = over (); k () in
#      msgf @@
# -      (fun ?header:_ ->
# -         fun ?(tags= Logs.Tag.empty) ->
# -           fun fmt ->
# -             let source_pos =
# -               Logs.Tag.find Ppx_irmin_internal_lib.Source_code_position.tag
# -                 tags in
# -             (let open Fmt in kpf k stdout)
# -               ("[%a] [%a] @[" ^^ (fmt ^^ "@]@.")) (Fmt.option pp_source_pos)
# -               source_pos pp_level level) in
# +      (fun ?header:_ ?(tags= Logs.Tag.empty) fmt ->
# +         let source_pos =
# +           Logs.Tag.find Ppx_irmin_internal_lib.Source_code_position.tag tags in
# +         (let open Fmt in kpf k stdout) ("[%a] [%a] @[" ^^ (fmt ^^ "@]@."))
# +           (Fmt.option pp_source_pos) source_pos pp_level level) in
#    Logs.set_reporter { Logs.report = report };
#    Logs.set_level (Some Debug);
#    test ()
```

As it is triggering on `runtest` (not installation) I've added it as a `with-test` upper bound.