### PR TITLE
[new release] hxd (0.3.6)

### DIFF
--- a/packages/hxd/hxd.0.3.6/opam
+++ b/packages/hxd/hxd.0.3.6/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/hxd"
+bug-reports:  "https://github.com/dinosaure/hxd/issues"
+dev-repo:     "git+https://github.com/dinosaure/hxd.git"
+doc:          "https://dinosaure.github.io/hxd/"
+license:      "MIT"
+synopsis:     "Hexdump in OCaml"
+description: """Please, help me to debug ocaml-git
+"""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.7"}
+  "dune-configurator" {>= "2.7"}
+  "cmdliner"          {>= "1.1.0"}
+]
+
+depopts: [
+  "lwt"
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/dinosaure/hxd/releases/download/v0.3.6/hxd-0.3.6.tbz"
+  checksum: [
+    "sha256=7a1df20c5dd01b7dd9b5ffe2de7216b5989652ab325175512327a269ddedf3b9"
+    "sha512=348065400d96135c637fc09da71c60b9e6a21285f536e6634d9a46a84beda8c93bfd635515103e29af9696ea155ed6926ffeaf65f6f86b2c8d970633603561bf"
+  ]
+}
+x-commit-hash: "9eb6cd9f8dfa0cf0506bd41a6892f33115b524d6"


### PR DESCRIPTION
Hexdump in OCaml

- Project page: <a href="https://github.com/dinosaure/hxd">https://github.com/dinosaure/hxd</a>
- Documentation: <a href="https://dinosaure.github.io/hxd/">https://dinosaure.github.io/hxd/</a>

##### CHANGES:

* Fix the `caml` support (@dinosaure, dinosaure/hxd#21)
  + Escape the character '"'
  + Print out into `ppf` when we configure hxd with `caml`
