### PR TITLE
Package otp.0.2.2

### DIFF
--- a/packages/otp/otp.0.2.2/opam
+++ b/packages/otp/otp.0.2.2/opam
@@ -45,7 +45,6 @@ build: [
 ]
 dev-repo: "git+https://github.com/Heyji2/otp.git"
 x-maintenance-intent: ["(latest)"]
-x-ci-accept-failures: ["fedora-42" "debian-13"]
 url {
   src: "https://github.com/Heyji2/otp/archive/refs/tags/0.2.2.tar.gz"
   checksum: [


### PR DESCRIPTION
### `otp.0.2.2`
Time-base One Time Password (OTP) based on RFC6238 with an HMAC-SHA1 algorithm and a 6 digits code in OCAML
It relies on the Cryptokit library for cryptography operations, as well as the Base32 
 library for base32 encoding. The library generate a QR Code with the qrc library. It is 
 tested against all test vectors provided in RFC 6238 and the test suite provides as well 
 a dynamic test which requires the use of an client authenticator (like Google Authenticator 
 or Microsoft Authenticator) as a final test.



---
* Homepage: https://github.com/Heyji2/otp
* Source repo: git+https://github.com/Heyji2/otp.git
* Bug tracker: https://github.com/Heyji2/otp/issues

---
:camel: Pull-request generated by opam-publish v2.7.0