### PR TITLE
[new release] server-reason-react (0.4.0)

### DIFF
--- a/packages/server-reason-react/server-reason-react.0.4.0/opam
+++ b/packages/server-reason-react/server-reason-react.0.4.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Rendering React components on the server natively"
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/server-reason-react"
+bug-reports: "https://github.com/ml-in-barcelona/server-reason-react/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "4.14.1"}
+  "reason" {>= "3.14.0"}
+  "melange" {>= "3.0.0"}
+  "uucp" {>= "16.0.0"}
+  "ppxlib" {> "0.23.0"}
+  "quickjs" {>= "0.1.2" & < "0.2.0"}
+  "lwt" {>= "5.9.2"}
+  "lwt_ppx" {>= "2.1.0"}
+  "uri" {>= "4.2.0"}
+  "yojson" {>= "2.2.0"}
+  "integers" {>= "0.7.0"}
+  "melange-fetch" {>= "0.2.0"}
+  "melange-json" {>= "2.0.0"}
+  "melange-json-native" {>= "2.0.0"}
+  "melange-webapi" {>= "0.21.0"}
+  "reason-react" {>= "0.16.0"}
+  "odoc" {with-doc}
+  "ocamlformat" {= "0.27.0" & with-test}
+  "ocaml-lsp-server" {with-dev-setup}
+  "dream" {= "1.0.0~alpha8" & with-dev-setup}
+  "reason-react-ppx" {with-dev-setup}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "fmt" {with-test}
+  "merlin" {with-test}
+  "core_unix" {with-test}
+  "core_bench" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ml-in-barcelona/server-reason-react.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ml-in-barcelona/server-reason-react/releases/download/0.4.0/server-reason-react-0.4.0.tbz"
+  checksum: [
+    "sha256=7811cd16a7256edbebd06057072142fc2fa1d81de784442e21f3225f06f08ce2"
+    "sha512=d60084b34f4086bc401f5f1e209714ab297b5dd94b9b55050816ba9dd0579b2c88745b1813ab57d9584c826af9602df279e8ecfdc04cde62f94d1fec9506dd45"
+  ]
+}
+x-commit-hash: "3d9f43a83104d0c4b0bc646242c5f04918559ec1"


### PR DESCRIPTION
Rendering React components on the server natively

- Project page: <a href="https://github.com/ml-in-barcelona/server-reason-react">https://github.com/ml-in-barcelona/server-reason-react</a>

##### CHANGES:

* Expand styles prop into className and style props with optional handling by @pedrobslisboa in https://github.com/ml-in-barcelona/server-reason-react/pull/324
* Lowercase components have ?key:string by @davesnx in https://github.com/ml-in-barcelona/server-reason-react/pull/323
* Wrap client value on React.Upper_case_component by @pedrobslisboa in https://github.com/ml-in-barcelona/server-reason-react/pull/322
* Fix remove last element on nested_modules by @pedrobslisboa in https://github.com/ml-in-barcelona/server-reason-react/pull/321
* Add searchParams function to native URL by @pedrobslisboa in https://github.com/ml-in-barcelona/server-reason-react/pull/320
* Specify model values at React by @pedrobslisboa in https://github.com/ml-in-barcelona/server-reason-react/pull/309
* Allow async in client props by @pedrobslisboa in https://github.com/ml-in-barcelona/server-reason-react/pull/315
* Improve the Fiber and Model stream context by @pedrobslisboa in https://github.com/ml-in-barcelona/server-reason-react/pull/312
* Align Suspense with reason-react by @pedrobslisboa in https://github.com/ml-in-barcelona/server-reason-react/pull/311
* Make client component to execute in runtime by @pedrobslisboa in https://github.com/ml-in-barcelona/server-reason-react/pull/306
* Fix mismatch of the model and html on render_html by @pedrobslisboa in https://github.com/ml-in-barcelona/server-reason-react/pull/305
* Fix createFromFetch interface and avoid transition on navigation by @davesnx in https://github.com/ml-in-barcelona/server-reason-react/pull/299
* Change ppx execution order (styles expansion in server-reason-react) by @davesnx in https://github.com/ml-in-barcelona/server-reason-react/pull/297
* Rename use function to usePromise in Experimental module by @pedrobslisboa in https://github.com/ml-in-barcelona/server-reason-react/pull/298
* Add shared-folder-prefix arg to ppx by @davesnx in https://github.com/ml-in-barcelona/server-reason-react/pull/294
