### PR TITLE
restrict hurl to cmdliner < 2 with-test

### DIFF
--- a/packages/hurl/hurl.0.0.1~beta1/opam
+++ b/packages/hurl/hurl.0.0.1~beta1/opam
@@ -14,6 +14,7 @@ depends: [
   "hxd" {>= "0.3.4"}
   "multipart_form" {>= "0.6.0"}
   "cmdliner" {>= "1.3.0"}
+  "cmdliner" {with-test & < "2.0.0"}
   "jsonm"
   "decompress" {>= "1.5.0"}
   "bstr" {>= "0.0.2"}


### PR DESCRIPTION
the error observed in CI:

```
+ /home/opam/.opam/opam-init/hooks/sandbox.sh "build" "dune" "runtest" "-p" "hurl" "-j1" (CWD=/home/opam/.opam/5.4/.opam-switch/build/hurl.0.0.1~beta1)
- File "test/simple.t", line 1, characters 0-0:
- /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/simple.t _build/default/test/simple.t.corrected
- diff --git a/_build/default/test/simple.t b/_build/default/test/simple.t.corrected
- index 2d78cff..6783bf3 100644
- --- a/_build/default/test/simple.t
- +++ b/_build/default/test/simple.t.corrected
- @@ -57,21 +57,11 @@ -
-    <!doctype html><title>404 Not found</title><h1>Not found</h1>
-    $ hurl http://localhost:8000/get foo==bar foo==bar User-Agent:hurl/test --print=b
- -  {
- -    "args": {
- -      "foo": "bar",
- -      "foo": "bar"
- -    },
- -    "headers": {
- -      "User-Agent": "hurl/test",
- -      "host": "localhost",
- -      "connection": "close",
- -      "content-length": "0"
- -    },
- -    "origin": "127.0.0.1",
- -    "url": "http://localhost/get?foo=bar&foo=bar"
- -  }
- +  Usage: hurl [--help] [OPTION]… URL [REQUEST_ITEM]…
- +  hurl: unknown option '--print'. Did you mean '-p'?
- +  [124]
-    $ hurl http://localhost:8000/robot.txt --print=b
- -  User-Agent: *
- -  Disallow: /deny
- +  Usage: hurl [--help] [OPTION]… URL [REQUEST_ITEM]…
- +  hurl: unknown option '--print'. Did you mean '-p'?
- +  [124]
-    $ kill -INT $(cat srv.pid)
[ERROR] The compilation of hurl.0.0.1~beta1 failed at "dune runtest -p hurl -j1".
```

The development repository of hurl has a fix already.