### PR TITLE
OCaml 5.3.0 pre-releases: mark as unmaintained

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.1~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.1~rc1/opam
@@ -97,3 +97,4 @@ extra-source "ocaml-base-compiler.install" {
     "md5=3e969b841df1f51ca448e6e6295cb451"
   ]
 }
+x-maintained: false

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.3.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.3.0~alpha1/opam
@@ -27,3 +27,4 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
+x-maintained: false

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.3.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.3.0~beta1/opam
@@ -27,3 +27,4 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
+x-maintained: false

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.3.0~beta2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.3.0~beta2/opam
@@ -27,3 +27,4 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
+x-maintained: false

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.3.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.3.0~rc1/opam
@@ -27,3 +27,4 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
+x-maintained: false

--- a/packages/ocaml-compiler/ocaml-compiler.5.3.0~alpha1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3.0~alpha1/opam
@@ -125,3 +125,4 @@ extra-source "ocaml-compiler.install" {
     "md5=781ea69255fd0cb643a9617ff56fd6ba"
   ]
 }
+x-maintained: false

--- a/packages/ocaml-compiler/ocaml-compiler.5.3.0~beta1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3.0~beta1/opam
@@ -125,3 +125,4 @@ extra-source "ocaml-compiler.install" {
     "md5=781ea69255fd0cb643a9617ff56fd6ba"
   ]
 }
+x-maintained: false

--- a/packages/ocaml-compiler/ocaml-compiler.5.3.0~beta2/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3.0~beta2/opam
@@ -125,3 +125,4 @@ extra-source "ocaml-compiler.install" {
     "md5=781ea69255fd0cb643a9617ff56fd6ba"
   ]
 }
+x-maintained: false

--- a/packages/ocaml-compiler/ocaml-compiler.5.3.0~rc1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3.0~rc1/opam
@@ -125,3 +125,4 @@ extra-source "ocaml-compiler.install" {
     "md5=781ea69255fd0cb643a9617ff56fd6ba"
   ]
 }
+x-maintained: false

--- a/packages/ocaml-variants/ocaml-variants.5.3.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0~alpha1+options/opam
@@ -24,3 +24,4 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
+x-maintained: false

--- a/packages/ocaml-variants/ocaml-variants.5.3.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0~beta1+options/opam
@@ -24,3 +24,4 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
+x-maintained: false

--- a/packages/ocaml-variants/ocaml-variants.5.3.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0~beta2+options/opam
@@ -24,3 +24,4 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
+x-maintained: false

--- a/packages/ocaml-variants/ocaml-variants.5.3.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0~rc1+options/opam
@@ -24,3 +24,4 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
+x-maintained: false


### PR DESCRIPTION
Taking the opam-repository archiving into account, these old releases can safely be archived. The 5.4.x pre-releases are kept (due to earlier discussions with Florian). If you think they should as well be archived, please let me know.

//cc @Octachron 