### PR TITLE
[new release] coq-lsp (0.2.5+9.1)

### DIFF
--- a/packages/coq-lsp/coq-lsp.0.2.5+9.1/opam
+++ b/packages/coq-lsp/coq-lsp.0.2.5+9.1/opam
@@ -1,0 +1,81 @@
+synopsis: "Language Server Protocol native server for Coq"
+description:
+"""
+Language Server Protocol native server for Coq
+"""
+opam-version: "2.0"
+maintainer: "e@x80.org"
+bug-reports: "https://github.com/ejgallego/coq-lsp/issues"
+homepage: "https://github.com/ejgallego/coq-lsp"
+dev-repo: "git+https://github.com/ejgallego/coq-lsp.git"
+authors: [
+  "Emilio Jesús Gallego Arias <e@x80.org>"
+  "Ali Caglayan <alizter@gmail.com>"
+  "Shachar Itzhaky <shachari@cs.technion.ac.il>"
+  "Ramkumar Ramachandra <r@artagnon.com>"
+]
+license: "LGPL-2.1-or-later"
+doc: "https://ejgallego.github.io/coq-lsp/"
+
+depends: [
+
+    ("ocaml" {>= "5.0"} & "ocaml" { < "5.3"}
+  | ("ocaml" {>= "4.12"} & "memprof-limits" { >= "0.2.1" } ))
+
+  "dune"         { >= "3.13.0" } # Version interval [3.8-3.12] was
+                                 # broken for composed builds with Coq
+
+  # lsp dependencies
+  "cmdliner"     { >= "1.1.0" }
+  "yojson"       { >= "1.7.0" }
+  "uri"          { >= "4.2.0" }
+  "dune-build-info" { >= "3.2.0" }
+
+  # coq-layout-printer
+  "tyxml"        { >= "4.5.0" }
+
+  # for waterproof json parser
+  "menhir"       { >= "20220210" }
+
+  # unit testing
+  "ppx_inline_test"     { >= "v0.15.0" }
+
+  # This is now a hard dep due to API changes in 1.9.7
+  "ocamlfind" { >= "1.9.8" }
+
+  # Rocq
+  "rocq-core"          { >= "9.1" < "9.2"  }
+  "rocq-stdlib"        { >= "9" & with-test }
+
+  # serlib deps
+  "ppx_deriving"        { >= "5.2"                 }
+  "ppx_deriving_yojson" { >= "3.7.0"               }
+  "ppx_import"          { >= "1.11.0"              }
+  "sexplib"             { >= "v0.15.0" & < "v0.18" }
+  "ppx_sexp_conv"       { >= "v0.15.0" & < "v0.18" }
+  "ppx_compare"         { >= "v0.15.0" & < "v0.18" }
+  "ppx_hash"            { >= "v0.15.0" & < "v0.18" }
+]
+
+# older results get in mess with ppx_deriving, we cannot control how
+# it gets pulled, often in min-bound rev-dep, so we conflict with it
+conflicts: [ "result" { < "1.5" } ]
+
+depopts: ["lwt" "logs"]
+
+build: [
+  [ "rm" "-rf" "vendor" ]
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [ [ "dune" "runtest" "-p" name "-j" jobs ] ]
+
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-lsp/releases/download/0.2.5+9.1/coq-lsp-0.2.5+9.1.tbz"
+  checksum: [
+    "sha256=488520e2720cd0601a623be39ff87223d81ca1d2f81c77641f803fda21f3717e"
+    "sha512=146e43a6a9c516f4e7fe143d4fdf3e1e7ecdcd73ea5cc3e09b2886f68aa05210c016e905bf1596341faa0b55709ad530ef86212c92790b6dce6050a0a00e3325"
+  ]
+}
+x-commit-hash: "c73fee2d50557b03029545d8d575136cf6f5b355"


### PR DESCRIPTION
Language Server Protocol native server for Coq

- Project page: <a href="https://github.com/ejgallego/coq-lsp">https://github.com/ejgallego/coq-lsp</a>
- Documentation: <a href="https://ejgallego.github.io/coq-lsp/">https://ejgallego.github.io/coq-lsp/</a>

##### CHANGES:

--------------------------

 - [build] [wasm] [code] bump esbuild from 0.16 to 0.25, miscellaneous
   npm dependencies bump (@ejgallego, ejgallego/coq-lsp#1033)
 - [meta] Coq -> Rocq documentation rename (@ejgallego, ejgallego/coq-lsp#1034)
 - [fleche] Support `\begin{rocq}` in literate Tex files (@ejgallego,
   ejgallego/coq-lsp#1034)
 - [fleche] Fix crash in `coq/trimCaches` notification (ejgallego/coq-lsp#1035,
   @ejgallego, reported by @gbdrt)
 - [controller] [goals] Fix a couple of bugs where goal printing
   didn't respect the `pp_format` setting, introduced in
   ejgallego/coq-lsp#668. (@ejgallego, ejgallego/coq-lsp#1037, fixes ejgallego/coq-lsp#1030, thanks to Will Thomas for
   the report)
 - [opam] Require memprof-limits in OCaml >= 5.3 (@ejgallego, ejgallego/coq-lsp#1038)
 - [ocaml] Support for OCaml 5.4, drop support for OCaml 5.0, 5.1, and
   5.2, drop support for Coq 8.17, 8.18, 8.19 (@ejgallego, ejgallego/coq-lsp#1039)
 - [vscode] New command "Serialize Sentence at Point" that will print
   the AST of the Rocq sentence at point (@ejgallego, ejgallego/coq-lsp#1048)
 - [petanque] New request `petanque/run_at_pos` (@ejgallego, ejgallego/coq-lsp#1049)
 - [petanque] `petanque/get_state_at_pos` will default to the previous
   node state if there is no Rocq node at the current point
   (@ejgallego, ejgallego/coq-lsp#1049)
 - [layout-engine] Support for notations with binders (@ejgallego,
   ejgallego/coq-lsp#1050)
 - [layout-engine] Add background color for each box kind (@ejgallego,
   ejgallego/coq-lsp#1050)
 - [compiler] Fix handling of literate files (@ejgallego, ejgallego/coq-lsp#1056,
   reported by @jim-portegies)
 - [rocq] Create output directory on .vo file save if it doesn't
   exists. This is very useful in the web context where we don't yet
   have a proper virtual FS setup, thus making the "Save .vo file"
   command fail (@ejgallego, ejgallego/coq-lsp#1054)
 - [web worker] Add LSP root to Rocq's loadpath, this makes .vo file
   loading work even when no worker FS setup could happen (@ejgallego,
   ejgallego/coq-lsp#1054)
 - [fleche] New `coq/workspace_update` notification, which tells
   Flèche that `.vo` files in the workspace may have changed. This
   will make coq-lsp pick up changes in the filesystem and restart
   checking of Rocq's `Require`s when needed. The algorithm is not
   smart at all yet, as it invalidates all the requires for all open
   files. (@ejgallego, @helguo, ejgallego/coq-lsp#1059)
 - [goals] New option (LSP, petanque, API) to display and retrieve
   goals without the compacted context. See protocol docs for more
   information. (@ejgallego, alexJ, ejgallego/coq-lsp#1065, cc ejgallego/coq-lsp#1043)
 - [fleche] [rocq] New options and data fields to expose document
   comments. This is experimental, pass the `--record_comments` flags
   to `rocq-lsp`, `fcc`, or `pet-server` to enable it. Once this flag
   is passed, comments for a document will be stored in the new
   `doc.comments` field. (@ejgallego, alexJ, ejgallego/coq-lsp#1069, fixes ejgallego/coq-lsp#353)
 - [hover] New debug option `show_pr_vernac_on_hover`, that will
   re-print the sentence under point using the Rocq printer
   (@ejgallego, alexJ, ejgallego/coq-lsp#1070)
 - [petanque] New methods `proof_info` and `proof_info_at_pos` that
   return information about the current proof. As of today they return
   the proof name, text, range, ... (@DikieDick, @ejgallego, ejgallego/coq-lsp#1051)
 - [petanque] New method `list_notations_in_statement` which returns
   an analysis of notations appearing inside a Rocq statement
   (@JulesViennotFranca, @ejgallego, ejgallego/coq-lsp#1017)
 - [tools] New tool `rocq-checkdecls` for Rocq blueprints, inspired by
   the Lean version (ejgallego/coq-lsp#785, @ejgallego, Andrej Bauer)
 - [plugins] New demo plugin "baseline", that tries to proof existing
   lemmas using a set of pre-fixed tactics (@ejgallego, Shachar
   Itzhaky, Eytan Singher, ejgallego/coq-lsp#799)
 - [tools] New tool `checkdecls` for Coq blueprint, inspired by the
   Lean version (ejgallego/coq-lsp#785, @ejgallego, Andrej Bauer)
 - [lsp] [rocq] Example of Ltac2 AST analysis using serlib's Analzyer
   infra (@ejgallego, @jim-portegies, @DikieDick, ejgallego/coq-lsp#1058)
 - [lsp controller] Log internal errors to user-facing log
   (@ejgallego, ejgallego/coq-lsp#1074)
 - [doc] Example typescript client connecting to the WASM-based lsp
   server (@ejgallego, ejgallego/coq-lsp#626)
 - [hover] When the `show_doc_on_hover` option is enabled, hover will
   show coqdoc documentation when hovering on identifiers, using some
   heuristics to infer it from the comment just before
   it. Documentation is treated as Markdown. This feature is
   experimental and limited to documentation comments on the same file.
   (@ejgallego, ejgallego/coq-lsp#590)
 - [plugins] New plugin to dump document data (@ejgallego, Stefania
   Dumbrava, ejgallego/coq-lsp#1075)
 - [fcc] New option `--trace-file` that will generate trace data for
   visualizing with perfetto.dev (@ejgallego, AlexJ, Gaëtan Gilbert,
   ejgallego/coq-lsp#1076)
 - [fcc] New options `--save_vof` and `--load_vof` that can save a
   Fleche version of a document to a `.vof` file, thus avoiding `.vo`
   recompilation for example when calling `fcc --plugin=...` for a
   given file (@ejgallego, Alexj, ejgallego/coq-lsp#1077)
 - [vscode] Add config manager for handling client configuration
   changes in the infoview. Add configuration option for number of
   messages displayed (@Durbatuluk1701, ejgallego/coq-lsp#1067)
 - [wasm] Update interrupt patch to account for timeouts (@ejgallego,
   Shachar Itzhaky, ejgallego/coq-lsp#1078)
