### PR TITLE
[new release] sel (0.8.0)

### DIFF
--- a/packages/sel/sel.0.8.0/opam
+++ b/packages/sel/sel.0.8.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Simple Event Library"
+description:
+  "This library is the result of our experience in using threads and the Lwt async monad to tame the problem of writing a server which has to listen and react to multiple sources of events. The library itself is just sugar atop Unix.select. You can read more about the library on https://github.com/gares/sel"
+maintainer: ["Enrico Tassi <enrico.tassi@inria.fr>"]
+authors: ["Enrico Tassi"]
+license: "MIT"
+tags: ["event" "input" "output"]
+homepage: "https://github.com/gares/sel"
+bug-reports: "https://github.com/gares/sel/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.5"}
+  "ppx_deriving"
+  "ppx_sexp_conv" {with-test}
+  "ppx_inline_test" {with-test}
+  "ppx_assert" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/gares/sel.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src: "https://github.com/gares/sel/releases/download/v0.8.0/sel-0.8.0.tbz"
+  checksum: [
+    "sha256=8d302359d6a88a8479f86f7aaa8398f895eb258d34785ef2ed68464a21707ea8"
+    "sha512=ac9ac3e90d0a300a489bbadcaea44c0e083219cb76dc60166f3134729d2c9d0177a801f787610aa487c8bd3a74f911112c778f05f0e2df581a44fd96f5167abd"
+  ]
+}
+x-commit-hash: "f11c2c7107f4950f69ce9f5341370059ab1eb8b8"


### PR DESCRIPTION
Simple Event Library

- Project page: <a href="https://github.com/gares/sel">https://github.com/gares/sel</a>

##### CHANGES:

- New parameter `~undup` to `Sel.now` to avoid duplicate events
