### PR TITLE
[new release] quickjs (0.4.0)

### DIFF
--- a/packages/quickjs/quickjs.0.4.0/opam
+++ b/packages/quickjs/quickjs.0.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Bindings for QuickJS (a Javascript Engine to be embedded https://bellard.org/quickjs)"
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/quickjs.ml"
+bug-reports: "https://github.com/ml-in-barcelona/quickjs.ml/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.14.0"}
+  "integers" {>= "0.7.0"}
+  "uutf" {>= "1.0.3"}
+  "ctypes" {>= "0.13.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ml-in-barcelona/quickjs.ml.git"
+conflicts: [ "ocaml-option-bytecode-only" ]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ml-in-barcelona/quickjs.ml/releases/download/0.4.0/quickjs-0.4.0.tbz"
+  checksum: [
+    "sha256=09f64b910cfd60c078cccaed2eb6775ada64a45644f83219134b3bb2e2fb4c74"
+    "sha512=35c8d98f93d4304a2ed4be32017c43d67edb92849b04efa11310b33a02c850ba47496d875aae37f716b31e57b2168c65ae416887c679ebcab0ab21fc90be955e"
+  ]
+}
+x-commit-hash: "b8035ff3bd3e3d12de03c66f0cadb4ffea4e8749"


### PR DESCRIPTION
Bindings for QuickJS (a Javascript Engine to be embedded https://bellard.org/quickjs)

- Project page: <a href="https://github.com/ml-in-barcelona/quickjs.ml">https://github.com/ml-in-barcelona/quickjs.ml</a>

##### CHANGES:

- **Breaking:** Migrated from `bellard/quickjs` to `quickjs-ng/quickjs` - the actively maintained community fork with Unicode 17.0.0 support, better spec compliance, and ongoing development
- Fix arm32v7 tests on 32-bits
- Fix `Global.parse_float` for incomplete exponents ("1e", "1e+", "1e-") to return the parsed number instead of `None`, matching JavaScript spec. Workaround for [quickjs-ng/quickjs#1259](https://github.com/quickjs-ng/quickjs/issues/1259)
