### PR TITLE
[new release] passage (0.3.0)

### DIFF
--- a/packages/passage/passage.0.3.0/opam
+++ b/packages/passage/passage.0.3.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Passage - used to store and manage access to shared secrets"
+description: "Passage - used to store and manage access to shared secrets"
+maintainer: ["Ahrefs Pte Ltd <github@ahrefs.com>"]
+authors: ["Ahrefs Pte Ltd <github@ahrefs.com>"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/passage"
+bug-reports: "https://github.com/ahrefs/passage/issues"
+depends: [
+  "bos"
+  "cmdliner" {< "2.0.0"}
+  "ocaml" {>= "4.14"}
+  "conf-age"
+  "dune" {>= "3.9"}
+  "devkit" {>= "1.20240429"}
+  "extunix"
+  "fileutils"
+  "fpath"
+  "menhir" {>= "20231231"}
+  "ppx_expect"
+  "ocamlformat" {with-dev-setup & = "0.26.2"}
+  "qrc"
+  "re2"
+  "sedlex"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/passage.git"
+available: os != "win32" & os != "macos"
+x-ci-accept-failures: [
+  "alpine-3.22"
+  "centos-9"
+  "archlinux"
+  "debian-11"
+  "fedora-41"
+  "fedora-42"
+  "fedora-43"
+  "opensuse-15.6"
+  "opensuse-tumbleweed"
+]
+url {
+  src:
+    "https://github.com/ahrefs/passage/releases/download/0.3.0/passage-0.3.0.tbz"
+  checksum: [
+    "sha256=a3b38acf832c48e9c753364db6d79f8e27fce1152f26fc24389498fde0040810"
+    "sha512=1bf6e63ba1d0a896aec318014bdd81a8c7db721fb8422b47f8f374877e4dd3fff9165c1d629e85fcb25acf6dd050706bef41eda19549aa2221c300a9d0e2a553"
+  ]
+}
+x-commit-hash: "b67bcfe6015219a963201eb18a28e583a24317cb"


### PR DESCRIPTION
Passage - used to store and manage access to shared secrets

- Project page: <a href="https://github.com/ahrefs/passage">https://github.com/ahrefs/passage</a>

##### CHANGES:

- Refactor passage to be lib-first. Commands and utility functions are now available for usage by lib users
- Update os availability in opam. Not available in macos anymore.
