### PR TITLE
3 packages from ocurrent/ocaml-dockerfile at 8.3.4

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.8.3.4/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.3.4/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- generation support"
+description: """\
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically."""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "astring"
+  "bos" {>= "0.2"}
+  "cmdliner"
+  "dockerfile-opam" {= version}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/8.3.4/ocaml-dockerfile-8.3.4.tbz"
+  checksum: [
+    "md5=0361e8b3f55d2c2ce40d02eb23860a0d"
+    "sha512=af64f551558a788d5deee00918174669c3b0974c7ea3f6dd8a3ad99cd339d365962e3b2576578a571158c248441775feb3a55c6c4522807a3a96b50cc2d23d75"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/dockerfile-opam/dockerfile-opam.8.3.4/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.8.3.4/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """\
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution support
+for generating dockerfiles."""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "dockerfile" {= version}
+  "fmt" {>= "0.8.7"}
+  "ocaml-version" {>= "3.5.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+  "alcotest" {>= "1.9.1" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/8.3.4/ocaml-dockerfile-8.3.4.tbz"
+  checksum: [
+    "md5=0361e8b3f55d2c2ce40d02eb23860a0d"
+    "sha512=af64f551558a788d5deee00918174669c3b0974c7ea3f6dd8a3ad99cd339d365962e3b2576578a571158c248441775feb3a55c6c4522807a3a96b50cc2d23d75"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/dockerfile/dockerfile.8.3.4/opam
+++ b/packages/dockerfile/dockerfile.8.3.4/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """\
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly."""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "fmt" {>= "0.8.7"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+  "alcotest" {>= "1.9.1" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/8.3.4/ocaml-dockerfile-8.3.4.tbz"
+  checksum: [
+    "md5=0361e8b3f55d2c2ce40d02eb23860a0d"
+    "sha512=af64f551558a788d5deee00918174669c3b0974c7ea3f6dd8a3ad99cd339d365962e3b2576578a571158c248441775feb3a55c6c4522807a3a96b50cc2d23d75"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `dockerfile.8.3.4`: Dockerfile eDSL in OCaml
- `dockerfile-cmd.8.3.4`: Dockerfile eDSL -- generation support
- `dockerfile-opam.8.3.4`: Dockerfile eDSL -- opam support



---
* Homepage: https://github.com/ocurrent/ocaml-dockerfile
* Source repo: git+https://github.com/ocurrent/ocaml-dockerfile.git
* Bug tracker: https://github.com/ocurrent/ocaml-dockerfile/issues

---
:camel: Pull-request generated by opam-publish v2.5.1