### PR TITLE
[new release] passage (0.3.1)

### DIFF
--- a/packages/passage/passage.0.3.1/opam
+++ b/packages/passage/passage.0.3.1/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "Passage - used to store and manage access to shared secrets"
+description: "Passage - used to store and manage access to shared secrets"
+maintainer: ["Ahrefs Pte Ltd <github@ahrefs.com>"]
+authors: ["Ahrefs Pte Ltd <github@ahrefs.com>"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/passage"
+bug-reports: "https://github.com/ahrefs/passage/issues"
+depends: [
+  "bos"
+  "cmdliner" {< "2.0.0"}
+  "ocaml" {>= "4.14"}
+  "conf-age"
+  "dune" {>= "3.9"}
+  "devkit" {>= "1.20240429"}
+  "extunix"
+  "fileutils"
+  "fpath"
+  "menhir" {>= "20231231"}
+  "ppx_expect"
+  "ocamlformat" {with-dev-setup & = "0.26.2"}
+  "qrc"
+  "re2"
+  "sedlex"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/passage.git"
+available: os != "win32" & os != "macos"
+x-maintenance-intent: ["(latest)"]
+x-ci-accept-failures: [
+  "alpine-3.22"
+  "centos-9"
+  "centos-10"
+  "archlinux"
+  "debian-11"
+  "fedora-41"
+  "fedora-42"
+  "fedora-43"
+  "opensuse-15.6"
+  "opensuse-tumbleweed"
+]
+url {
+  src:
+    "https://github.com/ahrefs/passage/releases/download/0.3.1/passage-0.3.1.tbz"
+  checksum: [
+    "sha256=1c642ca4e7def82574d9a8949de135c7cd4fe6b75493d574de53468acda34d4a"
+    "sha512=d6b6a523a40419ad02eb20e3a3c2ec89c24a791b415ca56b251dae608e163c9215ca1e6e69965eabcdab96f2d80c93af84bdb947c07d70ab2a1c59c51706ec96"
+  ]
+}
+x-commit-hash: "bf22416363cbbad59d2009ba897bede4fb670a99"


### PR DESCRIPTION
Passage - used to store and manage access to shared secrets

- Project page: <a href="https://github.com/ahrefs/passage">https://github.com/ahrefs/passage</a>

##### CHANGES:

- Add installion state on `passage healthcheck command`
- Add `x-maintenance-intent` policy
- Add centos 10 to opam ci exclusions
