### PR TITLE
Frama-C: new release (32.0-Germanium)

### DIFF
--- a/packages/frama-c/frama-c.32.0/opam
+++ b/packages/frama-c/frama-c.32.0/opam
@@ -1,0 +1,209 @@
+opam-version: "2.0"
+synopsis: "Platform dedicated to the analysis of source code written in C"
+description:"""
+Frama-C gathers several analysis techniques in a single collaborative
+framework, based on analyzers (called "plug-ins") that can build upon the
+results computed by other analyzers in the framework.
+Thanks to this approach, Frama-C provides sophisticated tools, including:
+- an analyzer based on abstract interpretation (Eva plug-in);
+- a program proof framework based on weakest precondition calculus (WP plug-in);
+- a program slicer (Slicing plug-in);
+- a tool for verification of automata-based properties (Aoraï plug-in);
+- a runtime verification tool (E-ACSL plug-in);
+- several tools for code base exploration and dependency analysis
+  (plug-ins From, Impact, Metrics, Occurrence, Scope, etc.).
+These plug-ins communicate between each other via the Frama-C API
+and via ACSL (ANSI/ISO C Specification Language) properties.
+"""
+maintainer: "frama-ci-bot@frama-c.com"
+authors: [
+  "Michele Alberti"
+  "Thibaud Antignac"
+  "Gergö Barany"
+  "Patrick Baudin"
+  "Nicolas Bellec"
+  "Thibaut Benjamin"
+  "Allan Blanchard"
+  "Lionel Blatter"
+  "François Bobot"
+  "Richard Bonichon"
+  "Vincent Botbol"
+  "Quentin Bouillaguet"
+  "David Bühler"
+  "Zakaria Chihani"
+  "Sylvain Chiron"
+  "Loïc Correnson"
+  "Julien Crétin"
+  "Pascal Cuoq"
+  "Zaynah Dargaye"
+  "Basile Desloges"
+  "Jean-Christophe Filliâtre"
+  "Philippe Herrmann"
+  "Maxime Jacquemin"
+  "Benjamin Jorge"
+  "Florent Kirchner"
+  "Alexander Kogtenkov"
+  "Remi Lazarini"
+  "Tristan Le Gall"
+  "Kilyan Le Gallic"
+  "Jean-Christophe Léchenet"
+  "Matthieu Lemerre"
+  "Dara Ly"
+  "David Maison"
+  "Claude Marché"
+  "André Maroneze"
+  "Thibault Martin"
+  "Fonenantsoa Maurica"
+  "Melody Méaulle"
+  "Benjamin Monate"
+  "Yannick Moy"
+  "Pierre Nigron"
+  "Anne Pacalet"
+  "Valentin Perrelle"
+  "Guillaume Petiot"
+  "Dario Pinto"
+  "Virgile Prevosto"
+  "Armand Puccetti"
+  "Félix Ridoux"
+  "Virgile Robles"
+  "Jan Rochel"
+  "Muriel Roger"
+  "Cécile Ruet-Cros"
+  "Julien Signoles"
+  "Fabien Siron"
+  "Nicolas Stouls"
+  "Hugo Thievenaz"
+  "Kostyantyn Vorobyov"
+  "Boris Yakobowski"
+]
+homepage: "https://frama-c.com/"
+license: "LGPL-2.1-only"
+dev-repo: "git+https://git.frama-c.com/pub/frama-c.git"
+doc: "https://frama-c.com/download/user-manual-32.0-Germanium.pdf"
+bug-reports: "https://git.frama-c.com/pub/frama-c/issues"
+tags: [
+  "deductive verification"
+  "program verification"
+  "formal specification"
+  "automated theorem prover"
+  "interactive theorem prover"
+  "C"
+  "plugins"
+  "abstract interpretation"
+  "slicing"
+  "weakest precondition"
+  "ACSL"
+  "dataflow analysis"
+  "runtime verification"
+]
+
+build: [
+  ["bash" "dev/disable-plugins.sh" "e-acsl"] { os-family = "windows" }
+  ["bash" "dev/disable-plugins.sh" "gui"] { os = "macos" }
+  ["dune" "build" "-j%{jobs}%" "--release" "--promote-install-files=false"
+   "@install"
+   "@doc" { with-doc }
+  ]
+]
+
+install: [
+  [make
+   "RELEASE=yes" "PREFIX=%{prefix}%" "MANDIR=%{man}%"
+   "DOCDIR=%{doc}%" { with-doc }
+   "install"
+  ]
+]
+
+remove: [
+  [make "PREFIX=%{prefix}%" "-f" "ivette/Makefile.installation" "uninstall"]
+]
+
+run-test: [
+  ["dune" "exec" "--release" "--" "frama-c-ptests" "tests" "src/plugins/*/tests"
+  ] { arch != "ppc64" & arch != "x86_32" & arch != "arm32" & os-distribution != "freebsd" & os-family != "windows"}
+  ["dune" "build" "--release" "-j%{jobs}%" "@ptests_config"
+  ] { arch != "ppc64" & arch != "x86_32" & arch != "arm32" & os-distribution != "freebsd" & os-family != "windows"}
+]
+
+depends: [
+  "dune" { > "3.13.0" }
+  "dune-configurator"
+  "dune-site" { > "3.13.0" }
+  ( "alt-ergo-free" | "alt-ergo" )
+  "camlzip"
+  "conf-graphviz" { post }
+  "conf-time" { with-test }
+  "menhir" { >= "20181006" & build }
+  "ocaml" { >= "4.14.0" }
+  "ocamlgraph" { >= "2.0.0" }
+  "ocamlgraph" { with-test & >= "2.2.0" }
+  "ocp-indent" { with-dev-setup & >= "1.8.1" }
+  "odoc" { with-doc }
+  "unionFind" { >= "20220109" }
+  "why3" { >= "1.8.2" & < "1.9.0" }
+  "yaml" { >= "3.0.0" }
+  "yojson" {>= "1.6.0" & (>= "2.0.1" | !with-test)}
+  "zarith" { >= "1.13" }
+
+  # PPXs
+  "ppxlib" { >= "0.33.0" }
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_deriving_yaml" { >= "0.2.0" }
+  "ppx_inline_test"
+
+  # GTK3 disabled on macOS (segfaults), and made optional on Windows
+  # (due to complex situation with Cygwin + MinGW).
+  "lablgtk3" { >= "3.1.0" & os!="macos" & os-family!="windows" }
+  "lablgtk3-sourceview3" { os!="macos" & os-family!="windows" }
+  "conf-gtksourceview3" { os!="macos" & os-family!="windows" }
+]
+
+# Note: do not put particular versions here, if some version is *incompatible*,
+# use the field 'conflicts'.
+depopts: [
+  "apron"
+  "zmq"
+  "lablgtk3" { os-family="windows" }
+  "lablgtk3-sourceview3" { os-family="windows" }
+  "conf-gtksourceview3" { os-family="windows" }
+]
+
+conflicts: [
+  "cairo2" { < "0.6.2" }
+  "mlmpfr" { < "4.1.0-bugfix2" }
+  "pilat"  { <= "1.6" }
+  "result" { < "1.5" }
+]
+
+post-messages: [
+"The Frama-C/WP plug-in requires one or more external prover(s).
+Recommended provers are:
+- Alt-Ergo (https://alt-ergo.ocamlpro.com)
+- CVC4     (https://cvc4.github.io)
+- CVC5     (https://cvc5.github.io)
+- Z3       (https://github.com/Z3Prover/z3)
+Use 'why3 config detect' to configure new provers.
+ " { success }
+"Ivette is a new GUI for Frama-C, currently in development.
+Run 'ivette' once to finalize installation (requires an internet connection).
+Once finalized, 'ivette' will work offline.
+Finalization also requires Node v20 or v22 and Yarn:
+- install NVM (https://github.com/nvm-sh/nvm)
+- run 'nvm install 22'
+- run 'nvm use 22'
+- run 'npm install --global yarn'" { success }
+]
+
+x-maintenance-intent: [
+  "(latest).(any)"
+  "(latest-1).(latest)"
+  "(latest-2).(latest)"
+  "(latest-3).(latest)"
+  "(latest-4).(latest)"
+]
+
+url {
+  src: "https://www.frama-c.com/download/frama-c-32.0-Germanium.tar.gz"
+  checksum: "sha256=ad03562d1a52d1c200912d0e84bc700e7a2ffa3bb5e32aa2f357c8cd49630c7b"
+}


### PR DESCRIPTION
[Release page](https://frama-c.com/fc-versions/germanium.html)

Main changes:

# Kernel

- Color and style for terminals supporting ANSI escape code.
- Improved support for C (including C23) alignment directives.
- Support newly introduced `\aligned` predicate in ACSL.
- String literals are now global arrays (as specified in the standard), not pointers.
- Support for using information from mopsa-db compilation databases.
- Experimental sandbox mode for deploying Frama-C-as-a-Service.

# E-ACSL

- Support of nested inductive definitions.
- Support `\aligned` built-in predicate.

# Eva

- Check pointer alignment in analyzed programs.
- The taint domain can propagate several distinct taints, each identified by a unique name.
- Simplify running Mthread analyses.

# Ivette

- New sidebar and menu to manage Frama-C projects.
- New panel to view and modify Frama-C parameters.
- Redesign and multiple improvements of the 'Files' sidebar.
- Select WP goals according to selected annotation and show related statements.
- Minimal support of the Slicing plug-in.
