### PR TITLE
[new release] melange-webapi (0.22.0)

### DIFF
--- a/packages/melange-webapi/melange-webapi.0.22.0/opam
+++ b/packages/melange-webapi/melange-webapi.0.22.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/melange-community/melange-webapi/issues"
 depends: [
   "dune" {>= "3.8"}
   "ocaml"
-  "melange" {>= "5.0.0"}
+  "melange" {>= "5.1.0"}
   "melange-fetch"
   "reason" {>= "3.10"}
   "ocaml-lsp-server" {with-test}


### PR DESCRIPTION
Melange bindings to the DOM

- Project page: <a href="https://github.com/melange-community/melange-webapi">https://github.com/melange-community/melange-webapi</a>

##### CHANGES:

* `(re_export melange.dom)` by @swrup (melange-community/melange-webapi#17)
* fix: `Webapi__Dom__Document.asHtmlDocument` by @davesnx (melange-community/melange-webapi#20)
* port `@mel.send.pipe` to `@mel.send` + `@mel.this` by @anmonteiro (melange-community/melange-webapi#23)
* build on Melange 6 / OCaml 5.4 by @anmonteiro (melange-community/melange-webapi#27)
