### PR TITLE
[new release] melange-testing-library (0.2.0)

### DIFF
--- a/packages/melange-testing-library/melange-testing-library.0.2.0/opam
+++ b/packages/melange-testing-library/melange-testing-library.0.2.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis:
+  "Melange bindings for testing-library (dom-testing-library and react-testing-library)"
+maintainer: ["David Sancho Moreno <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho Moreno <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/melange-community/melange-testing-library"
+bug-reports: "https://github.com/melange-community/melange-testing-library"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml"
+  "melange" {>= "5.0.0"}
+  "reason-react"
+  "melange-jest" {with-test}
+  "opam-check-npm-deps" {with-test}
+  "melange-webapi" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo:
+  "git+https://github.com/melange-community/melange-testing-library.git"
+depexts: [
+  ["@testing-library/react"] {npm-version = "^11.1.0"}
+  ["@testing-library/dom"] {npm-version = "^7.26.3"}
+]
+pin-depends: [
+  [ "bisect_ppx.dev"        "git+https://github.com/jchavarri/bisect_ppx.git#a0c2375ca20beceb55e53776e03812def3bc32ba" ]
+]
+url {
+  src:
+    "https://github.com/melange-community/melange-testing-library/releases/download/0.2.0/melange-testing-library-0.2.0.tbz"
+  checksum: [
+    "sha256=20192de29aeef985630e79b18f232dd58cb524eabe4894b163dd0b62b57d594d"
+    "sha512=1126fdc8fa9b6ddba43d070ffa3ae124b833fb1dfd1cbd3d63c06bf167a07dfe8c7f5de9db68bc8589ab17e27a220feb49c2f95390cd292630e640aa1d0d38f0"
+  ]
+}
+x-commit-hash: "44d39f775df565f5ef847ee7aa282affc36557a3"


### PR DESCRIPTION
Melange bindings for testing-library (dom-testing-library and react-testing-library)

- Project page: <a href="https://github.com/melange-community/melange-testing-library">https://github.com/melange-community/melange-testing-library</a>

##### CHANGES:

- port `[@mel.send.pipe]` to `[@mel.send]` and `[@mel.this]` by @anmonteiro (melange-community/melange-testing-library#9)
