### PR TITLE
[new release] html_of_jsx (0.0.7)

### DIFF
--- a/packages/html_of_jsx/html_of_jsx.0.0.7/opam
+++ b/packages/html_of_jsx/html_of_jsx.0.0.7/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Render HTML with JSX"
+description:
+  "html_of_jsx is a JSX transformation and a library to write HTML declaratively in OCaml (mlx) and Reason."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/davesnx/html_of_jsx"
+bug-reports: "https://github.com/davesnx/html_of_jsx/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "ppxlib" {>= "0.25.0"}
+  "odoc" {with-doc}
+  "alcotest" {with-test}
+  "benchmark" {with-test}
+  "reason" {>= "3.10.0" & with-test}
+  "ocamlformat" {>= "0.26.1" & (with-dev-setup | with-test)}
+  "mlx" {with-test | with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "tiny_httpd" {with-dev-setup}
+  "ocamlformat-mlx" {>= "0.26.1" & (with-dev-setup)}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/html_of_jsx.git"
+url {
+  src:
+    "https://github.com/davesnx/html_of_jsx/releases/download/0.0.7/html_of_jsx-0.0.7.tbz"
+  checksum: [
+    "sha256=83b5437638815bb3d9c152a31f2125fda1989d6fc7d86774fbbfa4c90d0d8ea8"
+    "sha512=8c1f72403083b714beac9bf0676e0e3d2fef7a7b6891a9ae9d40487ac6aa85e53fc80566be39b1623c94678c957b6da8c772fe36ccc5e8d3a9a74bb5d471fe93"
+  ]
+}
+x-commit-hash: "ac435d20cb7da85beccd8fba1d0bdc5412afb11d"


### PR DESCRIPTION
Render HTML with JSX

- Project page: <a href="https://github.com/davesnx/html_of_jsx">https://github.com/davesnx/html_of_jsx</a>

##### CHANGES:

- Static HTML optimization: elements with static content are now pre-rendered at compile time for ~10x faster rendering (@davesnx)
- Add `-no-static-opt` flag to disable static HTML optimization (use `JSX.node` for all elements) (@davesnx)
- [BREAKING] Remove `JSX.Debug` module (the opaque `JSX.element` type is no longer inspectable) (@davesnx)
