### PR TITLE
Clarify the Windows CI build/host/targets environments

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,7 @@ jobs:
             D:\opamroot
           key: ${{ runner.os }}-${{ matrix.build_env }}-opam-${{ hashFiles('install.ps1') }}
 
-      - name: Add MSys2 to PATH and install prerequisites
+      - name: Add MSYS2 to PATH and install prerequisites
         if: matrix.build_env == 'msys2'
         run: |
           "C:\msys64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append


### PR DESCRIPTION
It's confusing to list jobs environments as Cygwin/MSYS2 as in the
Autoconf terminology these are the build environments, but the job is
targeting native Windows (*not* Cygwin or MSYS2) using MinGW-w64.
Here's the usual reminder: there are three OCaml ports (targets) to
Windows:
- Cygwin/MSYS2;
- MinGW-w64;
- MSVC.

All three ports use Cygwin/MSYS2 as their *build* environment.
Nowadays both Cygwin and MSYS2 use `x86_64-pc-cygwin` as their
triplet.

Without cross-compilation, the host and target environments are
identical.

Currently the opam CI for Windows does *not* check Cygwin, MSYS2, or
MSVC targets, but only MinGW-w64 on x86_64. As of 5.4, OCaml has *not*
been ported to Windows ARM64.

Cygwin/MSYS2 provide a POSIX emulation layer, so testing them as
target does *not* guarantee a native Windows compatibility.

MinGW-w64 and MSVC are totally different compilers and have a
different CLI API, ABI, and support different C/C++ dialects and
extensions. Testing one does *not* guarantee compatibility with the
other.

I hope that clearly identifying the build and host/target environments
will help remove any ambiguity around what platform is actually being
tested.

As I suspect users tend to care more about the target than the build
environment, I've chosen to display the job name reversed (as
target-host-build rather than the usual build-host-target) to make it
easier to identify the job when its name is truncated in the UI.

See also #28856, https://github.com/ocaml/ocaml/blob/trunk/README.win32.adoc, and https://github.com/ocaml/setup-ocaml/issues/950.