### PR TITLE
[new release] syslog-rfc5424 (0.2)

### DIFF
--- a/packages/syslog-rfc5424/syslog-rfc5424.0.2/opam
+++ b/packages/syslog-rfc5424/syslog-rfc5424.0.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Syslog Protocol (RFC5424) parser and pretty-printer"
+description:
+  "This is a library for parsing and generating [RFC5424](https://tools.ietf.org/html/rfc5424) Syslog messages (obsoletes RFC3164)."
+maintainer: ["Vincent Bernardoff <vb@luminar.eu.org>"]
+authors: ["Vincent Bernardoff <vb@luminar.eu.org>"]
+license: "ISC"
+tags: ["log" "syslog" "rfc5424"]
+homepage: "https://github.com/vbmithr/ocaml-syslog-rfc5424"
+bug-reports: "https://github.com/vbmithr/ocaml-syslog-rfc5424/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml"
+  "rresult" {>= "0.7.0"}
+  "logs" {>= "0.10.0"}
+  "syslog-message" {>= "1.2.0"}
+  "fmt" {>= "0.11.0"}
+  "tyre" {>= "1.0"}
+  "alcotest" {with-test & >= "1.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/vbmithr/ocaml-syslog-rfc5424.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/vbmithr/ocaml-syslog-rfc5424/releases/download/0.2/syslog-rfc5424-0.2.tbz"
+  checksum: [
+    "sha256=b60de0a0e9fa065e9baf8ee96e8e9f78c0611b2bf421dd56e34ada09f7a3b78c"
+    "sha512=1e80eacebd6c8fb6c26ae5785fc1980c706a66cf3919073b9174b60a30427515ecad9ad7fbc2b7cbb518923b124b45297d00be718f9885118163698ea40d0125"
+  ]
+}
+x-commit-hash: "3990e0029b5bb1851c273d31ac39894d4a825e65"


### PR DESCRIPTION
Syslog Protocol (RFC5424) parser and pretty-printer

- Project page: <a href="https://github.com/vbmithr/ocaml-syslog-rfc5424">https://github.com/vbmithr/ocaml-syslog-rfc5424</a>

##### CHANGES:

- ocamlformat
- remove uint tag type and dependency to `uint`
- fix for tyre 1.0
