### PR TITLE
3 packages from pirbo/json-data-encoding at 1.1.0

### DIFF
--- a/packages/json-data-encoding-browser/json-data-encoding-browser.1.1.0/opam
+++ b/packages/json-data-encoding-browser/json-data-encoding-browser.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (browser support)"
+maintainer: "Pierre Boutillier <pierre.boutillier@laposte.net>"
+authors: ["Nomadic Labs" "Ocamlpro"]
+license: "MIT"
+homepage: "https://github.com/pirbo/json-data-encoding"
+bug-reports: "https://github.com/pirbo/json-data-encoding/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.10"}
+  "json-data-encoding" {= version}
+  "js_of_ocaml" {>= "3.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/pirbo/json-data-encoding.git"
+url {
+  src:
+    "https://github.com/pirbo/json-data-encoding/archive/refs/tags/1.1.0.tar.gz"
+  checksum: [
+    "md5=2e233968b3844b1e0c69bd33b5869098"
+    "sha512=269ab63a99a1f9cf3115707d36876d1d7355fa4eb9b8e380187023919aa0caf5b2da9279782ba2e56aecc9579b17874a39c4087db6fcf39f6f1010eb4837fdc6"
+  ]
+}

--- a/packages/json-data-encoding-bson/json-data-encoding-bson.1.1.0/opam
+++ b/packages/json-data-encoding-bson/json-data-encoding-bson.1.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (bson support)"
+maintainer: "Pierre Boutillier <pierre.boutillier@laposte.net>"
+authors: ["Nomadic Labs" "Ocamlpro"]
+license: "MIT"
+homepage: "https://github.com/pirbo/json-data-encoding"
+bug-reports: "https://github.com/pirbo/json-data-encoding/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.10"}
+  "json-data-encoding" {= version}
+  "ocplib-endian" {>= "1.0"}
+  "crowbar" {with-test & >= "0.2.2"}
+  "alcotest" {with-test & >= "1.9.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/pirbo/json-data-encoding.git"
+url {
+  src:
+    "https://github.com/pirbo/json-data-encoding/archive/refs/tags/1.1.0.tar.gz"
+  checksum: [
+    "md5=2e233968b3844b1e0c69bd33b5869098"
+    "sha512=269ab63a99a1f9cf3115707d36876d1d7355fa4eb9b8e380187023919aa0caf5b2da9279782ba2e56aecc9579b17874a39c4087db6fcf39f6f1010eb4837fdc6"
+  ]
+}

--- a/packages/json-data-encoding/json-data-encoding.1.1.0/opam
+++ b/packages/json-data-encoding/json-data-encoding.1.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON"
+maintainer: "Pierre Boutillier <pierre.boutillier@laposte.net>"
+authors: ["Nomadic Labs" "Ocamlpro"]
+license: "MIT"
+homepage: "https://github.com/pirbo/json-data-encoding"
+bug-reports: "https://github.com/pirbo/json-data-encoding/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.10"}
+  "uri" {>= "1.9.0"}
+  "crowbar" {with-test & >= "0.2.2"}
+  "alcotest" {with-test & >= "1.9.1"}
+  "js_of_ocaml-compiler" { with-test }
+  "conf-npm" { with-test }
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/pirbo/json-data-encoding.git"
+url {
+  src:
+    "https://github.com/pirbo/json-data-encoding/archive/refs/tags/1.1.0.tar.gz"
+  checksum: [
+    "md5=2e233968b3844b1e0c69bd33b5869098"
+    "sha512=269ab63a99a1f9cf3115707d36876d1d7355fa4eb9b8e380187023919aa0caf5b2da9279782ba2e56aecc9579b17874a39c4087db6fcf39f6f1010eb4837fdc6"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `json-data-encoding.1.1.0`: Type-safe encoding to and decoding from JSON
- `json-data-encoding-browser.1.1.0`: Type-safe encoding to and decoding from JSON (browser support)
- `json-data-encoding-bson.1.1.0`: Type-safe encoding to and decoding from JSON (bson support)



---
* Homepage: https://github.com/pirbo/json-data-encoding
* Source repo: git+https://github.com/pirbo/json-data-encoding.git
* Bug tracker: https://github.com/pirbo/json-data-encoding/issues

---
:camel: Pull-request generated by opam-publish v2.7.1