### PR TITLE
Mark github-unix as incompatible with yojson 3.0.0

### DIFF
--- a/packages/github-unix/github-unix.3.1.0/opam
+++ b/packages/github-unix/github-unix.3.1.0/opam
@@ -34,6 +34,7 @@ depends: [
   "stringext"
   "lambda-term" {< "2.0"}
   "cmdliner" {>= "0.9.8" & < "2.0.0"}
+  "yojson" {< "3.0.0"}
   "base-unix"
 ]
 synopsis: "GitHub APIv3 OCaml Library"

--- a/packages/github-unix/github-unix.4.0.0/opam
+++ b/packages/github-unix/github-unix.4.0.0/opam
@@ -28,6 +28,7 @@ depends: [
   "stringext"
   "lambda-term" {< "2.0"}
   "cmdliner" {>= "0.9.8" & < "2.0.0"}
+  "yojson" {< "3.0.0"}
   "base-unix"
 ]
 build: [

--- a/packages/github-unix/github-unix.4.1.0/opam
+++ b/packages/github-unix/github-unix.4.1.0/opam
@@ -28,6 +28,7 @@ depends: [
   "stringext"
   "lambda-term" {>="2.0"}
   "cmdliner" {>= "0.9.8" & < "2.0.0"}
+  "yojson" {< "3.0.0"}
   "base-unix"
 ]
 build: [

--- a/packages/github-unix/github-unix.4.2.0/opam
+++ b/packages/github-unix/github-unix.4.2.0/opam
@@ -35,6 +35,7 @@ depends: [
   "stringext"
   "lambda-term" {>= "2.0"}
   "cmdliner" {>= "0.9.8" & < "2.0.0"}
+  "yojson" {< "3.0.0"}
   "base-unix"
 ]
 url {

--- a/packages/github-unix/github-unix.4.3.0/opam
+++ b/packages/github-unix/github-unix.4.3.0/opam
@@ -35,6 +35,7 @@ depends: [
   "stringext"
   "lambda-term" {>= "2.0"}
   "cmdliner" {>= "0.9.8" & < "2.0.0"}
+  "yojson" {< "3.0.0"}
   "base-unix"
 ]
 url {

--- a/packages/github-unix/github-unix.4.3.1/opam
+++ b/packages/github-unix/github-unix.4.3.1/opam
@@ -35,6 +35,7 @@ depends: [
   "stringext"
   "lambda-term" {>= "2.0"}
   "cmdliner" {>= "0.9.8" & < "2.0.0"}
+  "yojson" {< "3.0.0"}
   "base-unix"
 ]
 url {

--- a/packages/github-unix/github-unix.4.3.2/opam
+++ b/packages/github-unix/github-unix.4.3.2/opam
@@ -34,6 +34,7 @@ depends: [
   "cohttp-lwt-unix" {>= "0.99.0"}
   "stringext"
   "cmdliner" {>= "0.9.8" & < "2.0.0"}
+  "yojson" {< "3.0.0"}
   "base-unix"
 ]
 url {

--- a/packages/github-unix/github-unix.4.4.0/opam
+++ b/packages/github-unix/github-unix.4.4.0/opam
@@ -28,6 +28,7 @@ depends: [
   "cohttp-lwt-unix" {>= "4.0.0"}
   "stringext"
   "cmdliner" {>= "0.9.8" & < "2.0.0"}
+  "yojson" {< "3.0.0"}
   "base-unix"
   "lwt"
   "odoc" {with-doc}

--- a/packages/github-unix/github-unix.4.4.1/opam
+++ b/packages/github-unix/github-unix.4.4.1/opam
@@ -28,6 +28,7 @@ depends: [
   "cohttp-lwt-unix" {>= "4.0.0"}
   "stringext"
   "cmdliner" {>= "0.9.8" & < "2.0.0"}
+  "yojson" {< "3.0.0"}
   "base-unix"
   "lwt"
   "odoc" {with-doc}

--- a/packages/github-unix/github-unix.4.5.0/opam
+++ b/packages/github-unix/github-unix.4.5.0/opam
@@ -28,6 +28,7 @@ depends: [
   "cohttp-lwt-unix" {>= "4.0.0"}
   "stringext"
   "cmdliner" {>= "1.1.0"}
+  "yojson" {< "3.0.0"}
   "base-unix"
   "lwt"
 ]


### PR DESCRIPTION
See https://github.com/mirage/ocaml-github/pull/281
Required for https://github.com/ocaml/opam-repository/pull/29055

```
#=== ERROR while compiling github-unix.4.5.0 ==================================#
# context              2.5.0 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/github-unix.4.5.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p github-unix -j 71
# exit-code            1
# env-file             ~/.opam/log/github-unix-7-39b89d.env
# output-file          ~/.opam/log/github-unix-7-39b89d.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I gist/.gist.eobjs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/atdgen-runtime -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/biniou -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cohttp-lwt-unix -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-lwt-unix -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/easy-format -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/github -I /home/opam/.opam/4.14/lib/github-data -I /home/opam/.opam/4.14/lib/http -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/logs/fmt -I /home/opam/.opam/4.14/lib/logs/lwt -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/yojson -I passwd/.passwd.objs/byte -I unix/.github_unix.objs/byte -no-alias-deps -open Dune__exe -o gist/.gist.eobjs/byte/dune__exe__Json.cmo -c -impl gist/json.ml)
# File "gist/json.ml", line 45, characters 6-14:
# 45 |     | `Tuple l ->
#            ^^^^^^^^
# Error: This pattern matches values of type [? `Tuple of 'a ]
#        but a pattern was expected which matches values of type Yojson.t
#        The second variant type does not allow tag(s) `Tuple
```