### PR TITLE
archiving.md: Amend the periodic pruning process

### DIFF
--- a/governance/policies/archiving.md
+++ b/governance/policies/archiving.md
@@ -61,7 +61,8 @@ Note that this property is transitive along a package's dependency tree: if a pa
 
 At regular intervals, no less than every six months, the opam repo maintainers will reevaluate all packages to determine if they satisfy the [primary repo criteria](#criteria-for-inclusion-to-the-primary-repo-the-default-opam-repository). Packages that do not will be subject to archiving, according to the following process:
 
-- If the package version falls outside the package's maintenance intent, it will be archived.
+- If the package version falls outside the package's maintenance intent, it will be archived unless the next newer version that is left has been added to the repository in the past year (this check is to be done incrementally from latest to oldest version of each packages).
+  - This exception do not apply to package versions that are pre-releases, flagged with `avoid-version` or that have `available: false`.
 - The package version's maintainers will be notified of the intent to archive.
   - Maintainers will have two weeks to fix the version so that it satisfies the criteria or approve of the archiving.
   - If two weeks pass without hearing from the maintainers, the package will be marked as unmaintained and a call for a new maintainer will be submitted to the community via [discuss.ocaml.org under the opam-repository topic](https://discuss.ocaml.org/tag/opam-repository).


### PR DESCRIPTION
An example of this is:

- `pkg.1` (released 3 years ago)
- `pkg.2` (released 2 years ago)
- `pkg.3` (released within the year)
- `pkg.4` (released a month ago)
- `pkg.5` (released a month ago as well)

if `pkg.4` contains `x-maintenance-intent: ["(latest)"]`, under the current scheme `1`, `2`, `3` and `4` would be archived.

With this amendment, only `1` would be archived since:
- `pkg.5`: is the latest, so it is kept
- `pkg.4`: the newer kept `pkg.5` has been released within the year, so it is also kept
- `pkg.3`: the newer kept `pkg.4` has been released within the year, so it is also kept
- `pkg.2`: the newer kept `pkg.3` has been released within the year, so it is also kept
- `pkg.1`: the newer kept `pkg.2` is older than a year so it is free to be archived