### PR TITLE
Fix CI merge error by disabling windows workflow on pushes to `master`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,6 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.analyse.outputs.matrix) }}
+    if: ${{ fromJSON(needs.analyse.outputs.matrix).packages.length > 0 }}
     runs-on: windows-latest
     needs: analyse
     steps:


### PR DESCRIPTION
Since the merge of #29040 including 703ece768e I've been getting an error email every time I merge a PR.

(The email has `Subject: [ocaml/opam-repository] Run failed: Windows CI - master (9684018)`
and a body that says "Windows CI: All jobs were successful" ... but I digress :sweat_smile: )

Looking at the GitHub Actions CI interface, I observed that `Get changed files` is not run on a merge commit, since it is guarded by `if: github.event_name != 'push'`, but the subsequent steps depending on the changed files info are still enabled:

<img width="762" height="554" alt="windows-ci-screenshot" src="https://github.com/user-attachments/assets/e45eb131-6de6-4458-9f2f-263b2b481c95" />

Up until 703ece768e the subsequent steps were similarly guarded, so I started by inserting those again.
I then realized that running a workflow on pushes to `master` only to hit a series of disabled workflow steps that perform any actual checks makes little sense.

This PR therefore disables the windows CI workflow on pushes to master (incl.merge) where checks are disabled already.
It should only make a difference to opam maintainers who hopefully won't get an error email after this.