### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,9 +33,11 @@ jobs:
               if (package)
                 packages.push(package[1]);
             }
-            const splits =
+            let splits =
               Array.from({ length: Math.ceil(packages.length / 75) },
                          (_, i) => packages.slice(i * 75, i * 75 + 75).join(' '));
+            if (splits.length === 0)
+              splits = [""];
             return {build_env: ['cygwin', 'msys2'], packages: splits};
 
   build:
@@ -43,21 +45,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.analyse.outputs.matrix) }}
-    if: ${{ fromJSON(needs.analyse.outputs.matrix).packages.length > 0 }}
     runs-on: windows-latest
     needs: analyse
     steps:
       - name: Checkout tree
+        if: matrix.packages != ''
         uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
       - name: Download install.ps1
+        if: matrix.packages != ''
         run: |
           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
           (New-Object System.Net.WebClient).DownloadFile("https://raw.githubusercontent.com/ocaml/opam/master/shell/install.ps1", ".\install.ps1")
 
       - name: Restore opam cache
+        if: matrix.packages != ''
         id: cache-opam
         uses: actions/cache/restore@v5
         with:
@@ -67,33 +71,34 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.build_env }}-opam-${{ hashFiles('install.ps1') }}
 
       - name: Add MSYS2 to PATH and install prerequisites
-        if: matrix.build_env == 'msys2'
+        if: matrix.packages != '' && matrix.build_env == 'msys2'
         run: |
           "C:\msys64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           C:\msys64\usr\bin\pacman.exe --noconfirm -Syuu  # Core update (in case any core packages are outdated)
           C:\msys64\usr\bin\pacman.exe --noconfirm -Syuu m4 make mingw-w64-i686-gcc mingw-w64-x86_64-gcc rsync unzip
 
       - name: Install opam
-        if: steps.cache-opam.outputs.cache-hit != 'true'
+        if: matrix.packages != '' && steps.cache-opam.outputs.cache-hit != 'true'
         run: |
           Invoke-Expression "& ./install.ps1 -OpamBinDir 'D:\opam\bin'"
 
       - name: Add opam to PATH
+        if: matrix.packages != ''
         run: |
           D:\opam\bin\opam --version
           "D:\opam\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Init opam
-        if: steps.cache-opam.outputs.cache-hit != 'true'
+        if: matrix.packages != '' && steps.cache-opam.outputs.cache-hit != 'true'
         run: opam init --yes --no-setup ${{ matrix.build_env == 'msys2' && '--cygwin-local-install' || '' }} .
 
       - name: Restrict testing to available compilers
-        if: steps.cache-opam.outputs.cache-hit != 'true'
+        if: matrix.packages != '' && steps.cache-opam.outputs.cache-hit != 'true'
         # TODO Amend this lowerbound as older compiler packages are updated
         run: opam switch set-invariant --formula "`"ocaml`" {>= `"4.13`"}"
 
       - name: Save opam cache
-        if: steps.cache-opam.outputs.cache-hit != 'true'
+        if: matrix.packages != '' && steps.cache-opam.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: |
@@ -102,6 +107,7 @@ jobs:
           key: ${{ steps.cache-opam.outputs.cache-primary-key }}
 
       - name: Print version and configuration information
+        if: matrix.packages != ''
         run: |
           opam --version
           opam exec -- ocaml -version
@@ -109,6 +115,7 @@ jobs:
           opam var
 
       - name: Install packages
+        if: matrix.packages != ''
         run: |
           $failed = $false
           opam update


### PR DESCRIPTION
#29078 appears to have fallen into the classic formal verification trap - CI is always passing because it now doesn't appear to test anything 🫣🙂

I can't get anything convincing out of LLMs or the GitHub Actions "documentation", and of course the tooling is virtually non-existent (but, hey, it's free...)... my best conclusion is that `needs` is not available in `if` at the level of the job, because it appears to be always evaluating to false.

This slightly more ugly approach here avoids the empty array (yet another ridiculous wart of GitHub Actions... but, hey, it's free!)... from my testing this wastes a small amount of resource by pointlessly running two workers for an empty matrix, but it does also appear to test packages again!