### PR TITLE
Update OCaml 5.5 packages for Relocatable OCaml

### DIFF
--- a/packages/ocaml/ocaml.5.5.0/opam
+++ b/packages/ocaml/ocaml.5.5.0/opam
@@ -17,13 +17,12 @@ authors: [
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 depends: [
-  "ocaml-config" {>= "3"}
   "ocaml-base-compiler" {= "5.5.0"} |
   "ocaml-variants" {>= "5.5.0~" & < "5.5.1~"} |
   "ocaml-system" {>= "5.5.0~" & < "5.5.1~"} |
   "dkml-base-compiler" {>= "5.5.0~" & < "5.5.1~"}
 ]
-flags: [conf avoid-version]
+flags: avoid-version
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   # Legacy opam variable
@@ -32,9 +31,33 @@ setenv: [
 x-env-path-rewrite: [
   [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
+build: [
+  ["ocaml" "gen_ocaml_config.ml" version name
+     # The packages referred to in this string must be in the disjunction above
+     # and also all be in the ocaml-core-compiler conflict-class
+     "%{ocaml-system:installed?system}%%{ocaml-base-compiler:version}%%{dkml-base-compiler:version}%%{ocaml-variants:version}%"
+     ocaml-system:installed
+     # The order of these parameters matches the "convention" for the
+     # ocaml-options-only packages
+     "%{ocaml-option-32bit:installed?+32bit:}%"
+     "%{ocaml-option-afl:installed?+afl:}%"
+     "%{ocaml-option-bytecode-only:installed?+bytecode-only:}%"
+     "%{ocaml-option-fp:installed?+fp:}%"
+     "%{ocaml-option-flambda:installed?+flambda:}%"
+     "%{ocaml-option-musl:installed?+musl:}%"
+     "%{ocaml-option-no-flat-float-array:installed?+no-flat-float-array:}%"
+     "%{ocaml-option-static:installed?+static:}%"]
+]
 build-env: [
   [CAML_LD_LIBRARY_PATH = ""]
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
 ]
-build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+extra-source "gen_ocaml_config.ml" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/ocaml/5799ec070df18cec96e5d828bc8e10b86cb0ed2c/tools/opam/gen_ocaml_config.ml"
+  checksum: [
+    "sha512=e679b89e87cda2f012fd13685807b7f1e1037fc0fc8f525aebec5a299d5634960f532a3dbf2fe519d9a5e19759f8dd99170999c252c35dd5762d4d0509f4179a"
+    "sha256=664da1ec2b19a7cfb55338ee10d9c8634cdca255d6cc46df66cd4d3e7e759969"
+  ]
+}


### PR DESCRIPTION
Requires [ocaml/ocaml#14250](ocaml/ocaml#14250) to be merged. Three salient changes:
1. ~~`--with-additional-stublibsdir` from [ocaml/ocaml#14243](https://github.com/ocaml/ocaml/pull/14243) provides the required upstream support to fix [#16406](#16406) in this package~~ - see [#29089](https://github.com/ocaml/opam-repository/pull/29089)
2. [ocaml/ocaml#14250](https://github.com/ocaml/ocaml/pull/14250) refactors the packaging process so that ocaml-config is no longer required, using an `extra-source` in the ocaml package instead. The inclusion of an `extra-source` fields means the `conf` flag disappears
3. [ocaml/ocaml#14250](https://github.com/ocaml/ocaml/pull/14250) also adds support for relative paths when generating the configuration

For the last point, at present you get:

```console
$ opam switch create test-5.5 --empty
$ opam pin add ocaml-variants --dev-repo
$ opam var ocaml:stubsdir
../stublibs:./stublibs:.
```
where the last line is incorrect. With this new ocaml.5.5.0 package, you get:
```console
$ opam var ocaml:stubsdir
/home/dra/.opam/test-5.5/lib/ocaml/../stublibs:/home/dra/.opam/test-5.5/lib/ocaml/stublibs:/home/dra/.opam/test-5.5/lib/ocaml
```
with the correct paths.