### PR TITLE
Fix Windows CI (alternative fix)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.analyse.outputs.matrix) }}
-    if: ${{ fromJSON(needs.analyse.outputs.matrix).packages.length > 0 }}
+    if: ${{ join(fromJSON(needs.analyse.outputs.matrix).packages) != '' }}
     runs-on: windows-latest
     needs: analyse
     steps:


### PR DESCRIPTION
As noticed by @dra27 in #29084, my fix in #29078 was buggy, causing the CI to always skip the `build` step after completing `analyse`.

This PR contains a short fix based on https://github.com/orgs/community/discussions/27096

I've tested this time around with self PRs:
- with `packages/` changes https://github.com/jmid/opam-repository/pull/28
- without `packages/` changes https://github.com/jmid/opam-repository/pull/29

IMO its a shorter and less invasive fix than #29084