### PR TITLE
Add serialport.0.1

### DIFF
--- a/packages/serialport/serialport.0.1/opam
+++ b/packages/serialport/serialport.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Serial communication library"
+description: "A cross-platform serial port library for OCaml"
+maintainer: ["Mikhail Lopatin <dx3mod@bk.ru>"]
+authors: ["Mikhail Lopatin <dx3mod@bk.ru>"]
+license: "MIT"
+tags: ["serial" "comport" "com" "unix"]
+homepage: "https://github.com/dx3mod/serialport"
+bug-reports: "https://github.com/dx3mod/serialport/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+depopts: ["lwt"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dx3mod/serialport.git"
+x-maintenance-intent: ["(latest)"]
+available: [os != "win32" & os != "cygwin"]
+url {
+  src: "https://github.com/dx3mod/serialport/archive/refs/tags/0.1.tar.gz"
+  checksum: [
+    "md5=b560d273759979f59b129fe5bee51dc3"
+    "sha512=409badc4e2f5a6391c9e9451b010b0f003103d6ae29911a9e7d8c368dfd9c970d047eb091bdb598424f430436646ec7dc17842457e2eb97f7ab5225cba2c9fb3"
+  ]
+}


### PR DESCRIPTION
A cross-platform library for serial port communication in OCaml, which supports both POSIX ~~and Windows systems~~. It provides a synchronous and asynchronous interface using various I/O libraries.

The main motivation behind creating this project is to address the lack of a comprehensive library for managing serial port communication in different environments, as well as the lack of an intuitive API for this task. The existing [OSerial](https://github.com/m-laniakea/oserial) library has significant limitations in terms of functionality and future development, making it unsuitable for use in modern environments.

* [Homepage](https://github.com/dx3mod/serialport)