### PR TITLE
Fix mismatched description of leak and address sanitizers

### DIFF
--- a/packages/ocaml-option-address-sanitizer/ocaml-option-address-sanitizer.1/opam
+++ b/packages/ocaml-option-address-sanitizer/ocaml-option-address-sanitizer.1/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 synopsis: "Set OCaml to be compiled with address sanitizer"
 description: """
-This configuration package enables memory leak sanitzation using
-the -fsanitize=leak gcc and clang option.
+This configuration package enables memory address sanitization using
+the -fsanitize=address gcc and clang option.
 """
 authors: [
   "David Allsopp"

--- a/packages/ocaml-option-leak-sanitizer/ocaml-option-leak-sanitizer.1/opam
+++ b/packages/ocaml-option-leak-sanitizer/ocaml-option-leak-sanitizer.1/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 synopsis: "Set OCaml to be compiled with leak sanitizer"
 description: """
-This configuration package enables memory address sanitzation using
-the -fsanitize=address gcc and clang option.
+This configuration package enables memory leak sanitization using
+the -fsanitize=leak gcc and clang option.
 """
 authors: [
   "David Allsopp"


### PR DESCRIPTION
The real ocaml packages are correct, it's just the description that's been switched.