### PR TITLE
[new release] dune (17 packages) (3.21.0~alpha4)

### DIFF
--- a/packages/chrome-trace/chrome-trace.3.21.0~alpha4/opam
+++ b/packages/chrome-trace/chrome-trace.3.21.0~alpha4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Chrome trace event generation library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/dune-action-plugin/dune-action-plugin.3.21.0~alpha4/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.21.0~alpha4/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "dune-glob" {= version}
+  "csexp" {>= "1.5.0"}
+  "ppx_expect" {with-test}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "dune-rpc" {= version}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/dune-build-info/dune-build-info.3.21.0~alpha4/opam
+++ b/packages/dune-build-info/dune-build-info.3.21.0~alpha4/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Embed build information inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/dune-configurator/dune-configurator.3.21.0~alpha4/opam
+++ b/packages/dune-configurator/dune-configurator.3.21.0~alpha4/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/dune-glob/dune-glob.3.21.0~alpha4/opam
+++ b/packages/dune-glob/dune-glob.3.21.0~alpha4/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "stdune" {= version}
+  "dyn"
+  "re"
+  "ordering"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/dune-private-libs/dune-private-libs.3.21.0~alpha4/opam
+++ b/packages/dune-private-libs/dune-private-libs.3.21.0~alpha4/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "csexp" {>= "1.5.0"}
+  "pp" {>= "1.1.0"}
+  "dyn" {= version}
+  "stdune" {= version}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.21.0~alpha4/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.21.0~alpha4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc and Lwt"
+description: "Specialization of dune-rpc to Lwt"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "dune-rpc" {= version}
+  "csexp" {>= "1.5.0"}
+  "lwt" {>= "5.6.0"}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/dune-rpc/dune-rpc.3.21.0~alpha4/opam
+++ b/packages/dune-rpc/dune-rpc.3.21.0~alpha4/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocamlc-loc"
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/dune-site/dune-site.3.21.0~alpha4/opam
+++ b/packages/dune-site/dune-site.3.21.0~alpha4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Embed locations information inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/dune/dune.3.21.0~alpha4/opam
+++ b/packages/dune/dune.3.21.0~alpha4/opam
@@ -1,0 +1,75 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+Dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+Dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+Dune is composable; supporting multi-package development by simply
+dropping multiple repositories into the same directory.
+
+Dune also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "2.0.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  "ocaml" {>= "4.08"}
+  "base-unix"
+  "base-threads"
+  "lwt" { with-dev-setup & os != "win32" }
+  "cinaps" { with-dev-setup }
+  "csexp" { with-dev-setup & >= "1.3.0" }
+  "js_of_ocaml" { with-dev-setup & >= "6.1.0" & os != "win32" }
+  "js_of_ocaml-compiler" { with-dev-setup & >= "6.1.0" & os != "win32" }
+  "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
+  "menhir" { with-dev-setup & os != "win32" }
+  "ocamlfind" { with-dev-setup & os != "win32" }
+  "odoc" { with-dev-setup & >= "2.4.0" & os != "win32" }
+  "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
+  "spawn" { with-dev-setup }
+  "ppx_inline_test" { with-dev-setup & os != "win32" }
+  "ppxlib" { with-dev-setup & >= "0.37.0" & os != "win32" }
+  "ctypes" { with-dev-setup & os != "win32" }
+  "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
+  "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }
+  "uutf" { with-dev-setup }
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/dyn/dyn.3.21.0~alpha4/opam
+++ b/packages/dyn/dyn.3.21.0~alpha4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.08.0"}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/fs-io/fs-io.3.21.0~alpha4/opam
+++ b/packages/fs-io/fs-io.3.21.0~alpha4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "File System Operations"
+description: "Misc. Collection of File System Operations"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "base-unix"
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/ocamlc-loc/ocamlc-loc.3.21.0~alpha4/opam
+++ b/packages/ocamlc-loc/ocamlc-loc.3.21.0~alpha4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Parse ocaml compiler output into structured form"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.08.0"}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-lsp-server" {< "1.15.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/ordering/ordering.3.21.0~alpha4/opam
+++ b/packages/ordering/ordering.3.21.0~alpha4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/stdune/stdune.3.21.0~alpha4/opam
+++ b/packages/stdune/stdune.3.21.0~alpha4/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "dyn" {= version}
+  "fs-io" {= version}
+  "ordering" {= version}
+  "pp" {>= "2.0.0"}
+  "top-closure" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/top-closure/top-closure.3.21.0~alpha4/opam
+++ b/packages/top-closure/top-closure.3.21.0~alpha4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Topological Closure"
+description: "Generic Topological Closure"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"

--- a/packages/xdg/xdg.3.21.0~alpha4/opam
+++ b/packages/xdg/xdg.3.21.0~alpha4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.21.0_alpha4/dune-3.21.0.alpha4.tbz"
+  checksum: [
+    "sha256=3d2b99b6084bc74faa4a8c859ea1f03e1cf58df8b711b80bfeb85dc511af6b4f"
+    "sha512=ea5e93f6ef5c238fae50684f9d03b4aadc3eb9a2ae004889bf17420d464d191cb92e01ba2904e57d422ee103fc016fbd49c0f006ad1cefc414b33ae88b5bcdb8"
+  ]
+}
+x-commit-hash: "633b604b6bc40b5f669dced28ded1b0b7bb5d819"


### PR DESCRIPTION
Fast, portable, and opinionated build system

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

### Fixed

- Fix `include_subdirs qualified` incorrectly picking the furthest module
  instead of the closest when resolving module name ambiguities. (ocaml/dune#12587,
  @ElectreAAS and @Alizter)

- Fix: include the module alias in the transitive dependency closure with
  `(include_subdirs qualified)`. (ocaml/dune#12299, @anmonteiro)

- Improve error messages for invalid version formats containing non-ASCII
  characters. Previously, non-ASCII characters in version strings (e.g., `(lang
  dune è)` or `(using menhir π3.14)`) would fail with a generic "Invalid file"
  error. Now they display a clear message: "Invalid atom: contains non-ASCII
  character(s). Atoms must only contain ASCII characters." The fix is
  implemented at the lexer level, providing consistent error handling across all
  s-expression parsing. (ocaml/dune#12844, fixes ocaml/dune#12836, @benodiwal)

- Pass private modules with -H when this is available (ocaml/dune#12666, @rgrinberg)

- Allow multiple modules in `(modules_flags ...)`, in `coq.theory` (ocaml/dune#12733, @rlepigre)

- Improve error message for invalid version formats in both `(lang dune ...)` and
  `(using extension ...)` declarations. Changes "Atom of the form NNN.NNN expected"
  to "Invalid version. Version must be two numbers separated by a dot." (ocaml/dune#12833, @benodiwal)

- Fix crash when running `dune build @check` on a library with virtual modules.
  (ocaml/dune#12644, fixes ocaml/dune#12636, @Alizter)

- Provide a more informative error message when `(pkg enabled)` is put in
  `dune-project` instead of `dune-workspace`. (ocaml/dune#12802, fixes ocaml/dune#12801,
  @benodiwal)

- Improve error message when invalid version strings are used in `dune-project`
  files. Non-ASCII characters and malformed versions now show a helpful hint
  with an example of the correct format. (ocaml/dune#12794, fixes ocaml/dune#12751, @benodiwal)

- Stop hiding the `root_module` from the include path (ocaml/dune#12239, @rgrinberg)

- Allow `$ dune init` to work on absolute paths (ocaml/dune#12601, fixes ocaml/dune#7806,
  @rgrinberg)

- `(include_subdirs qualified)`: Add missing alias dependency to module group.
  (ocaml/dune#12530, @anmonteiro)

- Add Melange compilation to the `@all` alias in libraries (ocaml/dune#12628,
  @anmonteiro)

- Fix greedy version location in lang declarations. Previously, error locations for
  invalid lang versions would span multiple bytes for multi-byte UTF-8 characters,
  causing carets to appear misaligned and seemingly include the closing
  parenthesis. Now, error locations for ASCII strings show the full length (e.g.,
  "Ali" shows `^^^`), while non-ASCII strings show only the first byte (e.g., "è"
  shows `^`) to avoid multi-byte character display issues. (ocaml/dune#12869, fixes ocaml/dune#12806,
  @benodiwal)

- melange support: don't emit empty JavaScript modules for generated module
  aliases. (ocaml/dune#12464, @anmonteiro)

### Added

- (Experimental): Introduce the `library_parameter` stanza. It allows users to
  declare a parameter when using the OxCaml compiler.
  (ocaml/dune#11963, implements ocaml/dune#12084, @maiste)


- Added the ability to scroll horizontally in TUI. (ocaml/dune#12386, @Alizter)

- Feature: Include shell command that was executed when a cram test has
  occurred in the error message (ocaml/dune#12307, @rgrinberg)

-  support expanding variables in `(promote (into ..))` (ocaml/dune#12832, fixes ocaml/dune#12742,
   @anmonteiro)

- Add support for `%{cmt:...}` and `%{cmti:...}` variables to reference
  compiled annotation files (.cmt and .cmti) containing typed abstract syntax
  trees with location and type information. (ocaml/dune#12634, grants ocaml/dune#12633, @Alizter)

- Add `$ dune describe tests` to describe the tests in the workspace
  (@Gromototo, ocaml/dune#12545, fixes ocaml/dune#12030)

- Add `argv`, the process environment, and the dune version to the config event
  in the trace (ocaml/dune#12909, @rgrinberg)

- Allow `dune runtest` to properly run while a watch mode server is running.
  (ocaml/dune#12473, grants ocaml/dune#8114, @gridbugs and @ElectreAAS)

- Use copy-on-write (COW) when copying files on filesystems that support it
  (Btrfs, ZFS, XFS, etc), under Linux. (ocaml/dune#12074, fixes ocaml/dune#12071, @nojb)

- Add support for Tangled ATproto-based code repositories (ocaml/dune#12197, @avsm)

- Add support for instantiating OxCaml parameterised libraries.
  (ocaml/dune#12561, @art-w)

- Add a `(conflict_markers error|ignore)` option to the cram stanza. When
  `(conflict_markers error)` is set, the cram test will fail in the presence of
  conflict markers. Git, diff3 and jujutsu conflict markers are detected.
  (ocaml/dune#12538, ocaml/dune#12617, ocaml/dune#12655, fixes ocaml/dune#12512, @rgrinberg, @Alizter)

- Introduce a `%{ppx:lib1+..+libn}` stanza to make it possible to refer to ppx
  executables built by dune. This is useful for writing tests (ocaml/dune#12711,
  @rgrinberg)

- Introduce a `(dir ..)` field on packages defined in the `dune-project`. This
  field allows to associate a directory with a particular package. This makes
  dune automatically filter out all stanzas in this directory and its
  descendants with `--only-packages`. All users are recommended to switch to
  using this field. (ocaml/dune#12614, fixes ocaml/dune#3255, @rgrinberg)

- Add support for `DUNE_ROOT` environment variable, similar to the existing
  `--root` CLI parameter. (fixes ocaml/dune#12399 @sir4ur0n)

- Introduce an `unused-libs` alias to detect unused libraries.
  (ocaml/dune#12623, fixes ocaml/dune#650, @rgrinberg)

- Add `--files` flag to `dune describe opam-files` to print only the names of
  the opam files line by line. (ocaml/dune#9793, @reynir and @Alizter)

- `dune exec` now accepts absolute paths inside the workspace.
  (ocaml/dune#12094, @Alizter)

- Add `coqdoc_header` and `coqdoc_footer` fields to the `coq` field of the
  `env` stanza, and to the `coq.theory` stanza, allowing to configure a
  custom header or footer respectively in the HTML output of `coqdoc`.
  (ocaml/dune#11131, @rlepigre)

- Allow `dune fmt` to properly run while a watch mode server is running.
  Note that the `--preview` flag is not supported in this mode.
  (ocaml/dune#12064, @ElectreAAS)

- Support for generating `_CoqProject` files for `coq.theory` stanzas.
  (ocaml/dune#11752, @rlepigre)

- Added `(files)` stanza, similar to `(dirs)` to control which files are visible
  to Dune on a per-directory basis. (ocaml/dune#12879, @nojb)
- Add support for %{ocaml-config:ox} (ocaml/dune#12236, @jonludlam)

- Introduce `dune promotion show` command to display the contents of corrected
  files that are ready for promotion. This allows users to preview changes
  before running `dune promote`. The command accepts file arguments to show
  specific files, or displays all promotable files when called without
  arguments. (ocaml/dune#12669, fixes ocaml/dune#3883, @MixiMaxiMouse)
- New `(lang rocq)` build mode for Rocq 9.0 and later. This new mode
  is very similar to the existing `(lang coq)`, except that it doesn't
  need the `coq*` compatibility wrappers. As of today `(lang rocq)`
  doesn't support yet composed builds with Rocq itself, this will be
  added later.  `(lang coq)` is deprecated, development is frozen, and
  will be removed at some point in the future. (ocaml/dune#12035, @ejgallego,
  @lysxia, fixes ocaml/dune#11572)

### Changed

- Don't run `ocamldep` to compute false dependencies on the `root_module`
  (ocaml/dune#12227, @rgrinberg)

- `dune format-dune-file` now uses the syntax version of the Dune project that
  contains the file being formatted (if any) instead of using the latest version
  available, which remains the default if there is no Dune project in scope.
  (ocaml/dune#11865, @nojb)

- Persistent DB and process events have been slightly modified. Persistent
  DB events have more concise names and job events always include full
  information. (ocaml/dune#12867, @rgrinberg)

- Removed the `--trace-extended` flag. Its functionality is always enabled when
  tracing is active (ocaml/dune#12908, @rgrinberg)

- The `test/dune` file generated by `dune init proj` now depends on the project library. (ocaml/dune#12791, @shonfeder)

- Starting with version 3.21 of the Dune language, Dune no longer changes the
  default set of compiler warnings. For users that would like to keep the old
  behaviour, the variable `%{dune-warnings}` can be used in an `(env)` stanza in
  a top-level Dune file: `(env (dev (flags :standard %{dune-warnings})))`.
  (ocaml/dune#12766, @nojb)
- Fix: stop generating `cmt` files for cinaps binaries (ocaml/dune#12530, @rgrinberg)
