### PR TITLE
fstar.2025.12.15

### DIFF
--- a/packages/fstar/fstar.2025.12.15/opam
+++ b/packages/fstar/fstar.2025.12.15/opam
@@ -13,7 +13,7 @@ depends: [
   "zarith" {>= "1.14"}
   "stdint"
   "yojson"
-  "dune" { >= "3.15.0"}
+  "dune" { >= "3.16.0"}
   "memtrace" {>= "0.2.3"}
   "menhirLib"
   "menhir" {build & >= "20230415"}


### PR DESCRIPTION
Just a new F* release. For this release, we are switching the source tarball to be a "source package" containing the OCaml-extracted sources of F*, avoiding the need to bootstrap the compiler when installing via OPAM.