### PR TITLE
Fix conf-secp256k1 macOS homebrew support

### DIFF
--- a/packages/conf-secp256k1/conf-secp256k1.2/opam
+++ b/packages/conf-secp256k1/conf-secp256k1.2/opam
@@ -5,7 +5,8 @@ homepage: "https://github.com/dakk/conf-secp256k1"
 bug-reports: "https://github.com/dakk/conf-secp256k1/issues"
 license: "MIT"
 dev-repo: "git+https://github.com/dakk/conf-secp256k1"
-
+build: ["pkg-config" "--print-errors" "--exists" "libsecp256k1"] {os != "win32"}
+depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libsecp256k1-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["dev-libs/libsecp256k1"] {os-distribution = "gentoo"}


### PR DESCRIPTION
Spotted on #29095:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/b861922612b6e65a0de56210291cc4af42f0b229/variant/macos,macos-homebrew-ocaml-4.14-amd64,secp256k1.0.5.0
```
<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><><><>

opam believes some required external dependencies are missing. opam can:
> 1. Run brew to install them (may need root/sudo access)
  2. Display the recommended brew command and wait while you run it manually (e.g. in another terminal)
  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
  4. Abort the installation

[1/2/3/4] 1

+ /usr/local/bin/brew "install" "domt4/crypto/libsecp256k1"
- ==> Tapping domt4/crypto
- Cloning into '/usr/local/Homebrew/Library/Taps/domt4/homebrew-crypto'...
- Tapped 7 formulae (20 files, 912.5KB).
- Warning: No available formula or cask with the name "domt4/crypto/libsecp256k1". Did you mean domt4/crypto/bearssl?
[ERROR] System package install failed with exit code 1 at command:
            brew install domt4/crypto/libsecp256k1
[ERROR] These packages are still missing: domt4/crypto/libsecp256k1
```

`secp256k1` is apparently now available from the official homebrew package repo: https://formulae.brew.sh/formula/secp256k1