### PR TITLE
Fix conf-ppl support for Centos 9

### DIFF
--- a/packages/conf-ppl/conf-ppl.1/opam
+++ b/packages/conf-ppl/conf-ppl.1/opam
@@ -17,7 +17,8 @@ depexts: [
   ["libppl-dev"] {os-family = "ubuntu"}
   ["ppl"] {os-distribution = "arch"}
   ["dev-libs/ppl"] {os-distribution = "gentoo"}
-  ["libppl" "libppl-devel"] {os-distribution = "centos"}
+  ["epel-release" "ppl-devel"] {os-distribution = "centos" & os-version = "9"}
+  ["libppl" "libppl-devel"] {os-distribution = "centos" & os-version != "9"}
   ["ppl"] {os = "freebsd"}
   ["ppl"] {os = "openbsd"}
   ["ppl"] {os = "macos" & os-distribution = "homebrew"}


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/29104
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/51c4cd2bff919e58bb581bc12b0f49c9fae18d3f/variant/distributions,centos-9-ocaml-5.4,jasmin.2025.06.3
```
<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><><><>

opam believes some required external dependencies are missing. opam can:
> 1. Run yum to install them (may need root/sudo access)
  2. Display the recommended yum command and wait while you run it manually (e.g. in another terminal)
  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
  4. Abort the installation

[1/2/3/4] 1

+ /usr/bin/sudo "yum" "install" "-y" "gmp-devel" "libppl" "libppl-devel" "mpfr-devel" "perl-Pod-Html"
- Last metadata expiration check: 0:00:05 ago on Thu Dec 18 16:47:45 2025.
- No match for argument: libppl
- No match for argument: libppl-devel
- Error: Unable to find a match: libppl libppl-devel
[ERROR] System package install failed with exit code 1 at command:
            sudo yum install -y gmp-devel libppl libppl-devel mpfr-devel perl-Pod-Html
[ERROR] These packages are still missing: gmp-devel libppl libppl-devel mpfr-devel perl-Pod-Html
```

https://pkgs.org/search/?q=ppl_c.h reveals a Centos 9 package through the EPEL repo, but nothing for Centos 10 unfortunately.