### PR TITLE
Add upper bound before cohttp-lwt-unix 6.2

### DIFF
--- a/packages/opentelemetry-lwt/opentelemetry-lwt.0.12/opam
+++ b/packages/opentelemetry-lwt/opentelemetry-lwt.0.12/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.08"}
   "opentelemetry" {= version}
-  "cohttp-lwt-unix" {with-test}
+  "cohttp-lwt-unix" {with-test & < "6.2"}
   "odoc" {with-doc}
   "lwt" {>= "5.3"}
   "lwt_ppx" {>= "2.0"}


### PR DESCRIPTION
There is a breaking change to the Client interface introduced in https://github.com/mirage/ocaml-cohttp/pull/1118

This was caught in revdeps tests for https://github.com/ocaml/opam-repository/pull/29100