### PR TITLE
[new release] caisar (5.0)

### DIFF
--- a/packages/caisar/caisar.5.0/opam
+++ b/packages/caisar/caisar.5.0/opam
@@ -63,4 +63,5 @@ url {
     "sha512=a26c724a19fca7c22a000367d1cd79c1e0474f373bf7265449928e55275ac44103190536dc8c76f5ac00a2a1897c3bd2ee06bb6f22140165079b72a27011e6df"
   ]
 }
+x-ci-accept-failures: [ "archlinux" ]
 x-commit-hash: "6252e07cf4f0af934dc04a2f978b8f7c648947fa"


### PR DESCRIPTION
CHANGES:

- [language] Added support for global robustness properties. It is now possible to specify and verify global robustness properties with CAISAR. This opens the possibility to specify properties on a whole input domain. See the manual for more details, including examples.

- [prover] Added the prover-precision option. This option allows to automatically adjust the tradeoff between precision and speed for all of CAISAR supported provers.

- [prover] Support ABCrown configuration file by default.

- [nir] Fix a bug in NNet to ONNX conversion.

- [nir] Support the representation of Radial-Based Function (RBF) kernels for Support Vector Machines.

- [caisarpy] Convert the Python API to emit and send CAISAR-compliant JSON values.

- [dependencies] Bump Why3 version to 1.8.2.