### PR TITLE
5 packages from c-cube/qcheck

### DIFF
--- a/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.9/opam
+++ b/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.9/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "PPX Deriver for QCheck"
+description: """\
+QCheck is a QuickCheck inspired property-based testing library for OCaml.
+
+The `ppx_deriving_qcheck` package can automatically derive generators from type
+definitions. It can derive generators for both the `QCheck` and `QCheck2`
+modules."""
+maintainer: "valentin.chb@gmail.com"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "ocaml" {>= "4.08.0"}
+  "qcheck-core" {>= "0.90"}
+  "ppxlib" {>= "0.36.0"}
+  "ppx_deriving" {>= "6.1.0"}
+  "odoc" {with-doc}
+  "alcotest" {with-test & >= "1.4.0"}
+  "qcheck-alcotest" {with-test & >= "0.24"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.90.tar.gz"
+  checksum: [
+    "md5=53cde85bd3f0431faeddeae493f32d9d"
+    "sha512=552871a95bcf27a81cd518a4aefc60ac0f08ef73c8e115f199952707b88ab20f7ecb762abb835a196c1adb7b948447e487daa0efbf6a39ee64bfcee0264f189f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck-alcotest/qcheck-alcotest.0.90/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.90/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Alcotest backend for QCheck"
+description: """\
+QCheck is a QuickCheck inspired property-based testing library for OCaml.
+
+The `qcheck-alcotest` library provides an integration layer for `QCheck` onto
+https://github.com/mirage/alcotest[`alcotest`], allowing to run property-based
+tests in `alcotest`."""
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "quickcheck" "qcheck" "alcotest"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "qcheck-core" {= version}
+  "alcotest" {>= "1.2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.90.tar.gz"
+  checksum: [
+    "md5=53cde85bd3f0431faeddeae493f32d9d"
+    "sha512=552871a95bcf27a81cd518a4aefc60ac0f08ef73c8e115f199952707b88ab20f7ecb762abb835a196c1adb7b948447e487daa0efbf6a39ee64bfcee0264f189f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck-core/qcheck-core.0.90/opam
+++ b/packages/qcheck-core/qcheck-core.0.90/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Core QCheck library"
+description: """\
+QCheck is a QuickCheck inspired property-based testing library for OCaml.
+
+The `qcheck-core` library provides the core property-based testing API with
+minimal dependendies: It requires only `unix` and `dune`."""
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "alcotest" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.90.tar.gz"
+  checksum: [
+    "md5=53cde85bd3f0431faeddeae493f32d9d"
+    "sha512=552871a95bcf27a81cd518a4aefc60ac0f08ef73c8e115f199952707b88ab20f7ecb762abb835a196c1adb7b948447e487daa0efbf6a39ee64bfcee0264f189f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck-ounit/qcheck-ounit.0.90/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.90/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "OUnit backend for QCheck"
+description: """\
+QCheck is a QuickCheck inspired property-based testing library for OCaml.
+
+The `qcheck-ounit` library provides an integration layer for `QCheck` onto
+https://github.com/gildor478/ounit[`OUnit`], allowing to run property-based
+tests in `OUnit`."""
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["qcheck" "quickcheck" "ounit"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "qcheck-core" {= version}
+  "ounit2"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.90.tar.gz"
+  checksum: [
+    "md5=53cde85bd3f0431faeddeae493f32d9d"
+    "sha512=552871a95bcf27a81cd518a4aefc60ac0f08ef73c8e115f199952707b88ab20f7ecb762abb835a196c1adb7b948447e487daa0efbf6a39ee64bfcee0264f189f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/qcheck/qcheck.0.90/opam
+++ b/packages/qcheck/qcheck.0.90/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Compatibility package for QCheck"
+description: """\
+QCheck is a QuickCheck inspired property-based testing library for OCaml.
+
+The `qcheck` library provides a compatibility API with older versions of QCheck,
+and depends upon both `qcheck-core` and `qcheck-ounit`.
+
+For fewer dependencies and new developments `qcheck-core` is recommended."""
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "the qcheck contributors"
+license: "BSD-2-Clause"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "qcheck-core" {= version}
+  "qcheck-ounit" {= version}
+  "alcotest" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.90.tar.gz"
+  checksum: [
+    "md5=53cde85bd3f0431faeddeae493f32d9d"
+    "sha512=552871a95bcf27a81cd518a4aefc60ac0f08ef73c8e115f199952707b88ab20f7ecb762abb835a196c1adb7b948447e487daa0efbf6a39ee64bfcee0264f189f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `ppx_deriving_qcheck.0.9`: PPX Deriver for QCheck
- `qcheck.0.90`: Compatibility package for QCheck
- `qcheck-alcotest.0.90`: Alcotest backend for QCheck
- `qcheck-core.0.90`: Core QCheck library
- `qcheck-ounit.0.90`: OUnit backend for QCheck



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: git+https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---
:camel: Pull-request generated by opam-publish v2.5.0