### PR TITLE
spurs.0.1.1: add a qcheck upper bound

### DIFF
--- a/packages/spurs/spurs.0.1.1/opam
+++ b/packages/spurs/spurs.0.1.1/opam
@@ -13,9 +13,9 @@ depends: [
   "ppx_deriving"
   "ppx_fields_conv"
   "fmt"
-  "alcotest" {with-test}
-  "qcheck" {with-test}
-  "qcheck-alcotest" {with-test}
+  "alcotest" {with-test & < "0.26"}
+  "qcheck" {with-test & < "0.26"}
+  "qcheck-alcotest" {with-test & < "0.26"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Since qcheck.0.26 its `float` generator can produce `nan` values, causing some spurs.0.1.1 property-based tests to fail:

```
- (cd _build/default/test && ./prop_csmat.exe)
- qcheck random seed: 911787329
- Testing `Spurs.Csmat.Props'.
- This run has ID `XJ2MLFJC'.
-
-   [OK]          matrix properties          0   m = m |> csr_of_dense |> to_de...
-   [OK]          matrix properties          1   m = m |> csc_of_dense |> to_de...
-   [OK]          matrix properties          2   m.!!(i) works.
-   [OK]          matrix properties          3   m = m |> to_other |> to_other.
-   [FAIL]        matrix properties          4   x = m |> insert (i, j) x |> ge...
-
- ┌──────────────────────────────────────────────────────────────────────────────┐
- │ [FAIL]        matrix properties          4   x = m |> insert (i, j) x |>...  │
- └──────────────────────────────────────────────────────────────────────────────┘
-
- law x = m |> insert (i, j) x |> get (i, j): 136 relevant cases (136 total)
-
- test `x = m |> insert (i, j) x |> get (i, j)` failed on ≥ 1 cases:
- ({ Csmat.storage = Csmat.CSR; nrows = 96; ncols = 4;
-   indptr =
-   [0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-     2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-     2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-     2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3];
-   indices = [0, 3, 3]; data = [0, -nan, -nan] }, (0, 0), -nan) (after 5 shrink steps)
-
- [exception] test `x = m |> insert (i, j) x |> get (i, j)` failed on ≥ 1 cases:
- ({ Csmat.storage = Csmat.CSR; nrows = 96; ncols = 4;
-   indptr =
-   [0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-     2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-     2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-     2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3];
-   indices = [0, 3, 3]; data = [0, -nan, -nan] }, (0, 0), -nan) (after 5 shrink steps)
-
-             Raised at QCheck2.Test.check_result in file "src/core/QCheck2.ml", line 2252, characters 6-38
-             Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 186, characters 17-23
-             Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
```

Seen on #29114