### PR TITLE
[new release] merlin (2 packages) (4.7.1-413)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.7.1/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.7.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08.0" & < "5.0.0"}
+  "dune" {>= "2.9.0"}
+  "yojson" {>= "1.6.0"}
+  "ocamlfind" {>= "1.6.0"}
+  "csexp" {>= "1.5.1"}
+]
+description:
+  "Helper process: reads .merlin files and gives the normalized content to merlin"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.7.1-413/merlin-4.7.1-413.tbz"
+  checksum: [
+    "sha256=a3047da285283ab28b3a965b2980e6f10d997c39fa0bc189c1417fe0741545c2"
+    "sha512=ae97758f642ecfd968bfe478c06f61e36cc07002391ee7c1c0237055031fae948376e48daf33509e03bd45e97c6d5620e9c15149d0a8939a83dcea57fb2809cf"
+  ]
+}
+x-commit-hash: "6cea213c2f9f6ee63dea914b7313977c7a13ef60"

--- a/packages/merlin/merlin.4.7.1-413/opam
+++ b/packages/merlin/merlin.4.7.1-413/opam
@@ -1,0 +1,79 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.13" & < "4.14"}
+  "dune" {>= "2.9.0"}
+  "dot-merlin-reader" {>= "4.2"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.5.1"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+  "ppxlib" {with-test}
+]
+conflicts: "seq" {!= "base"}
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.7.1-413/merlin-4.7.1-413.tbz"
+  checksum: [
+    "sha256=a3047da285283ab28b3a965b2980e6f10d997c39fa0bc189c1417fe0741545c2"
+    "sha512=ae97758f642ecfd968bfe478c06f61e36cc07002391ee7c1c0237055031fae948376e48daf33509e03bd45e97c6d5620e9c15149d0a8939a83dcea57fb2809cf"
+  ]
+}
+x-commit-hash: "6cea213c2f9f6ee63dea914b7313977c7a13ef60"
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
Editor helper, provides completion, typing and source browsing in Vim and Emacs

- Project page: <a href="https://github.com/ocaml/merlin">https://github.com/ocaml/merlin</a>

##### CHANGES:

Fri Dec 19 21:50:42 CET 2022

  + merlin binary
    - Fix an issue preventing installation. (fixes ocaml/merlin#1993)
