### PR TITLE
[new release] merlin (4 packages) (5.6.1-504)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.5.6.1-504/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.6.1-504/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" }
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.6.1-504/merlin-5.6.1-504.tbz"
+  checksum: [
+    "sha256=cc3c7c01f19a454c96f6bc8a39538023e01042519f001a895fd61488e2b49fb5"
+    "sha512=4268a932a8494023699abd98e0d52deb6f201f656863849db230dc8692050e0fe00cc25a50d70e902410f17a27268fd8335c32636f616ef012cf86fc9a43e019"
+  ]
+}
+x-commit-hash: "a0b096c243bbcea483bf8728a71c30eeafb18d11"

--- a/packages/merlin-lib/merlin-lib.5.6.1-504/opam
+++ b/packages/merlin-lib/merlin-lib.5.6.1-504/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="5.4" & <"5.5"}
+  "dune" {>= "3.0.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test & >= "1.3.0" }
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.6.1-504/merlin-5.6.1-504.tbz"
+  checksum: [
+    "sha256=cc3c7c01f19a454c96f6bc8a39538023e01042519f001a895fd61488e2b49fb5"
+    "sha512=4268a932a8494023699abd98e0d52deb6f201f656863849db230dc8692050e0fe00cc25a50d70e902410f17a27268fd8335c32636f616ef012cf86fc9a43e019"
+  ]
+}
+x-commit-hash: "a0b096c243bbcea483bf8728a71c30eeafb18d11"

--- a/packages/merlin/merlin.5.6.1-504/opam
+++ b/packages/merlin/merlin.5.6.1-504/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {= version}
+  "ocaml-index" {= version & post}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.6.1-504/merlin-5.6.1-504.tbz"
+  checksum: [
+    "sha256=cc3c7c01f19a454c96f6bc8a39538023e01042519f001a895fd61488e2b49fb5"
+    "sha512=4268a932a8494023699abd98e0d52deb6f201f656863849db230dc8692050e0fe00cc25a50d70e902410f17a27268fd8335c32636f616ef012cf86fc9a43e019"
+  ]
+}
+x-commit-hash: "a0b096c243bbcea483bf8728a71c30eeafb18d11"

--- a/packages/ocaml-index/ocaml-index.5.6.1-504/opam
+++ b/packages/ocaml-index/ocaml-index.5.6.1-504/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A tool that indexes value usages from cmt files"
+description:
+  "ocaml-index should integrate with the build system to index codebase and allow tools such as Merlin to perform project-wide occurrences queries."
+maintainer: ["ulysse@tarides.com"]
+authors: ["ulysse@tarides.com"]
+license: "MIT"
+homepage: "https://github.com/ocaml/merlin/ocaml-index"
+bug-reports: "https://github.com/ocaml/merlin/issues"
+x-maintenance-intent: ["(latest)"]
+depends: [
+  "dune" {>= "3.0.0"}
+  "ocaml" {>= "5.4"}
+  "merlin-lib" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.6.1-504/merlin-5.6.1-504.tbz"
+  checksum: [
+    "sha256=cc3c7c01f19a454c96f6bc8a39538023e01042519f001a895fd61488e2b49fb5"
+    "sha512=4268a932a8494023699abd98e0d52deb6f201f656863849db230dc8692050e0fe00cc25a50d70e902410f17a27268fd8335c32636f616ef012cf86fc9a43e019"
+  ]
+}
+x-commit-hash: "a0b096c243bbcea483bf8728a71c30eeafb18d11"


### PR DESCRIPTION
Editor helper, provides completion, typing and source browsing in Vim and Emacs

- Project page: <a href="https://github.com/ocaml/merlin">https://github.com/ocaml/merlin</a>

##### CHANGES:

Sat Dec 20 11:15:42 CET 2025

  + merlin binary
    - Fix a plethora of minor issues with the C code (ocaml/merlin#1998)
  + merlin library
    - Signature help should not appear on the function name (ocaml/merlin#1997)
    - Fix completion not working for inlined records labels (ocaml/merlin#1978, fixes ocaml/merlin#1977)
    - Perform buffer indexing only if the query requires it (ocaml/merlin#1990 and ocaml/merlin#1991)
    - Stop unnecessarily forcing substitutions when initializing short-paths graph (ocaml/merlin#1988)
    - Fix Mocaml.with_printer didn't update replacement_printer_doc (ocaml/merlin#2010)
  + test suite
    - Add a test to ensure the behavior showed in issue ocaml/merlin#1517 is no longer relevant (ocaml/merlin#1995)
    - Add a test to ensure the code fragment exhibited in issue ocaml/merlin#1118 no longer makes Merlin crash (ocaml/merlin#1996)
    - Add a test case illustrating how a snippet produces two unrelated errors in issue ocaml/merlin#2000. (ocaml/merlin#2003)
    - Add a test reproducing issue ocaml/merlin#1983 where `document` command which sometime concatenates consecutive variants and labels (ocaml/merlin#2005)
    - Signature-help should trigger on unfinished `let ... in` bindings (ocaml/merlin#2009)
