### PR TITLE
pacomb 1.4.1

### DIFF
--- a/packages/pacomb/pacomb.1.4.3/opam
+++ b/packages/pacomb/pacomb.1.4.3/opam
@@ -45,7 +45,6 @@ All this makes Pacomb a promising solution to write languages in OCaml.
 """
 
 opam-version: "2.0"
-version: "1.4.2"
 maintainer: "Christophe Raffalli <christophe@raffalli.eu>"
 bug-reports: "https://github.com/craff/pacomb/issues"
 homepage: "https://github.com/craff/pacomb"
@@ -57,7 +56,7 @@ license: "MIT"
 
 depends: [
   "ocaml" { >= "4.08.0" }
-  "dune"  { >= "1.9.0" }
+  "dune"  { >= "2.0.0" }
   "ppxlib" { >= "0.36.0" }
   "stdlib-shims"
 ]
@@ -65,9 +64,9 @@ depends: [
 build: [ [ "dune" "build" "-p" name "-j" jobs ] ]
 run-test: [ [ "dune" "runtest" "-p" name "-j" jobs ] ]
 url {
-  src: "https://github.com/craff/pacomb/archive/refs/tags/1.4.2.tar.gz"
+  src: "https://github.com/craff/pacomb/archive/refs/tags/1.4.3.tar.gz"
   checksum: [
-    "md5=86b07345b36bb872bfd36b41c8bc2abf"
-    "sha512=45b473143316327d1ced6dc5ede390e14f29b111ad4b749fb44c2bb98383e2b6fc749820acb73b41bb2521aed6a0709a6c8a5093c0f917b0cacfd4603e15b6b9"
+    "md5=069ec1895a09ffe5051ba7d21672af04"
+    "sha512=220e3dd7e7e99b07b97775de9fbf2a3da5195fd21aeec0553224e9f5bb5184ed9ab711617156133b61fc52df4eaf1e4dcd9261a504950622fbba99a5830b5ad5"
   ]
 }


### PR DESCRIPTION
Main changes since 1.3
- add a "not charset combinator" [!...], it is distinct from [^...] as it parses nothing.
- file was not closed by Grammar.parse_file in case of parse error 
- New Grammar.set_debug_merge to allow debugging ambiguous grammars (report by Matthieu Lemerre) 
- compatibility with latest ocaml and ppxlib
- travis action to check compilation
- various documentation fix
