### PR TITLE
[new release] quickjs (0.4.1)

### DIFF
--- a/packages/quickjs/quickjs.0.4.1/opam
+++ b/packages/quickjs/quickjs.0.4.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Bindings for QuickJS (a Javascript Engine to be embedded https://bellard.org/quickjs)"
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/quickjs.ml"
+bug-reports: "https://github.com/ml-in-barcelona/quickjs.ml/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.14.0"}
+  "integers" {>= "0.7.0"}
+  "ctypes" {>= "0.13.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ml-in-barcelona/quickjs.ml.git"
+conflicts: [ "ocaml-option-bytecode-only" ]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ml-in-barcelona/quickjs.ml/releases/download/0.4.1/quickjs-0.4.1.tbz"
+  checksum: [
+    "sha256=146725bf2d0ef5ef95d7cf72a524c6f72697c7c619627be5fb2451f9daf6d28e"
+    "sha512=190962b9044f7b044bb36d8c8eb42223fbc7a31160429917725cf931e2c608c5ee0f669bcbca1a9fe731c62759c427c6e832fccad3f35a282ca517ad75631d25"
+  ]
+}
+x-commit-hash: "1aaba459b3fb3b192693d8855548b4d75bd686b6"


### PR DESCRIPTION
Bindings for QuickJS (a Javascript Engine to be embedded https://bellard.org/quickjs)

- Project page: <a href="https://github.com/ml-in-barcelona/quickjs.ml">https://github.com/ml-in-barcelona/quickjs.ml</a>

##### CHANGES:

- Remove `uutf`
