### PR TITLE
Add frontmatter_extractor.0.1

### DIFF
--- a/packages/frontmatter_extractor/frontmatter_extractor.0.1/opam
+++ b/packages/frontmatter_extractor/frontmatter_extractor.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Front-matter extractor library"
+maintainer: ["Mikhail Lopatin <dx3mod@bk.ru>"]
+authors: ["Mikhail Lopatin <dx3mod@bk.ru>"]
+license: "MIT"
+homepage: "https://github.com/dx3mod/frontmatter_extractor"
+bug-reports: "https://github.com/dx3mod/frontmatter_extractor/issues"
+tags: ["front-matter" "front" "text"]
+depends: [
+  "dune" {>= "3.15"}
+  "ocaml"
+  "odoc" {with-doc}
+]
+depopts: ["yaml"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dx3mod/frontmatter_extractor.git"
+url {
+  src: "https://github.com/dx3mod/frontmatter_extractor/archive/refs/tags/0.1.tar.gz"
+  checksum: [
+    "md5=b420d881d289e6e8f27adbcd02464f6e"
+    "sha512=ee9bc98c62304b409911f42a738d2f4c01db2492e91bf184812c9fd6c0ca28c9be061003416e44bf1e95345da3d864a0970ff84e299d1938ba79d0bd6121aeff"
+  ]
+}
+


### PR DESCRIPTION
The small utility library for extracting front-matter section from text in OCaml.

[Home page](https://github.com/dx3mod/frontmatter_extractor)

I wrote this because not found some this...

```ocaml
let some_text = {|
---
title: "My First Blog Post"
data: 2025-12-1
---

Hello! It's just some text...
|};;

# Frontmatter_extractor_yaml.of_string_exn some_text;;
```

It's not fully tested, but it's usable as a first version.