### PR TITLE
[new release] opam-check-npm-deps (4.1.0)

### DIFF
--- a/packages/opam-check-npm-deps/opam-check-npm-deps.4.1.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.4.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis:
+  "An opam plugin to check for npm depexts inside the node_modules folder"
+description:
+  "Provides the `opam check-npm-deps` command, which given an opam switch, gathers all the depexts belonging to the npm platform and their version constraints, and checks the `node_modules` folder to see if the constraints are satisfied."
+maintainer: ["Javier Chávarri <javier.chavarri@ahrefs.com>"]
+authors: ["Javier Chávarri <javier.chavarri@ahrefs.com>"]
+tags: ["melange" "org:ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/opam-check-npm-deps"
+bug-reports: "https://github.com/ahrefs/opam-check-npm-deps/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.8"}
+  "opam-client" {>= "2.5" & < "2.6"}
+  "angstrom" {>= "0.15.0"}
+  "fmt" {>= "0.9.0"}
+  "lwt" {>= "5.0"}
+  "bos"
+  "yojson"
+  "odoc" {with-doc}
+]
+available: opam-version >= "2.5" & opam-version < "2.6"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/opam-check-npm-deps.git"
+flags: plugin
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/ahrefs/opam-check-npm-deps/releases/download/4.1.0/opam-check-npm-deps-4.1.0.tbz"
+  checksum: [
+    "sha256=95ba4bcb9f997c0bc404a428d3e792ff29c38e10a88ba5ffe1530d3b31d2d167"
+    "sha512=3f217b25475f3274d6ac9fe90cc59af04a5bed5215ebd38fcdcb39afbdd4adc5c9fab09305c3c8d6026aa61fc241b0dca53b557071cd458debc73c233a06404f"
+  ]
+}
+x-commit-hash: "697a56fd36844db462e71b8c7f8faf11d584d47d"


### PR DESCRIPTION
An opam plugin to check for npm depexts inside the node_modules folder

- Project page: <a href="https://github.com/ahrefs/opam-check-npm-deps">https://github.com/ahrefs/opam-check-npm-deps</a>

##### CHANGES:

- Support opam 2.5
- Remove most vendored code, keep only the semver parser
