### PR TITLE
[new release] opam-check-npm-deps (4.1.0)

### DIFF
--- a/packages/opam-check-npm-deps/opam-check-npm-deps.4.1.0/opam
+++ b/packages/opam-check-npm-deps/opam-check-npm-deps.4.1.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/ahrefs/opam-check-npm-deps/issues"
 depends: [
   "ocaml" {>= "4.14.0"}
   "dune" {>= "3.8"}
-  "opam-client" {>= "2.5" & < "2.6"}
+  "opam-client" {>= "2.5.0" & < "2.6"}
   "angstrom" {>= "0.15.0"}
   "fmt" {>= "0.9.0"}
   "lwt" {>= "5.0"}


### PR DESCRIPTION
An opam plugin to check for npm depexts inside the node_modules folder

- Project page: <a href="https://github.com/ahrefs/opam-check-npm-deps">https://github.com/ahrefs/opam-check-npm-deps</a>

##### CHANGES:

- Support opam 2.5
- Remove most vendored code, keep only the semver parser
