### PR TITLE
Package jupyter.3.0.0

### DIFF
--- a/packages/jupyter/jupyter.3.0.0/opam
+++ b/packages/jupyter/jupyter.3.0.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "An OCaml kernel for Jupyter"
+description: "This provides an OCaml REPL with a great user interface such as markdown/HTML documentation, LaTeX formula by MathJax, and image embedding."
+maintainer: [
+  "Akinori ABE <aabe.65535@gmail.com>"
+]
+authors: [
+  "Akinori ABE"
+]
+license: "MIT"
+homepage: "https://akabe.github.io/ocaml-jupyter/"
+bug-reports: "https://github.com/akabe/ocaml-jupyter/issues"
+dev-repo: "git+https://github.com/akabe/ocaml-jupyter.git"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "5.2.0"}
+  "base-threads"
+  "base-unix"
+  "uuidm" {>= "0.9.6"}
+  "base64" {>= "3.2.0"}
+  "lwt" {>= "4.0.0"}
+  "lwt_ppx" {>= "1.0.0"}
+  "logs" {>= "0.6.0"}
+  "stdint" {>= "0.4.2"}
+  "zmq" {>= "5.0.0"}
+  "zmq-lwt" {>= "5.0.0"}
+  "yojson" {>="1.6.0"}
+  "ppx_yojson_conv" {>= "0.14.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "cryptokit" {>= "1.12"}
+  "dune" {>= "1.0.0"}
+  "ounit2" {with-test & >= "2.0.0"}
+  "ocp-indent" {with-test & >= "1.7.0"}
+  "ppx_deriving" {with-test}
+]
+depopts: [
+  "merlin"
+]
+conflicts: [
+  "merlin" {< "3.0.0"}
+]
+
+post-messages: [
+  "Please run for registration of ocaml-jupyter kernel:"
+  ""
+  "$ ocaml-jupyter-opam-genspec"
+  "$ jupyter kernelspec install --name ocaml-jupyter \\"
+  "    %{share}%/jupyter"
+  {success}
+]
+url {
+  src:
+    "https://github.com/akabe/ocaml-jupyter/archive/refs/tags/v3.0.0.tar.gz"
+  checksum: [
+    "md5=72f54155f3f68965c2cea108847b9553"
+    "sha512=03d3fa9a56734710833a10d7185acf2e0ade29cf2f41de7dcf79eded6c31a8653e67a544a420c4633d9be1a1e962396fc150d5fa26fa62d09888ed359a824255"
+  ]
+}


### PR DESCRIPTION
### `jupyter.3.0.0`
An OCaml kernel for Jupyter
This provides an OCaml REPL with a great user interface such as markdown/HTML documentation, LaTeX formula by MathJax, and image embedding.



---
* Homepage: https://akabe.github.io/ocaml-jupyter/
* Source repo: git+https://github.com/akabe/ocaml-jupyter.git
* Bug tracker: https://github.com/akabe/ocaml-jupyter/issues

---
:camel: Pull-request generated by opam-publish v2.7.1