### PR TITLE
conf-taglib_c.2: Add support for Debian >= 13

### DIFF
--- a/packages/conf-taglib_c/conf-taglib_c.2/opam
+++ b/packages/conf-taglib_c/conf-taglib_c.2/opam
@@ -11,7 +11,8 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libtag-c-dev"] { os-family = "ubuntu" & os-version >= "25.04" }
+  ["libtag-c-dev"] { (os-family = "debian" & os-version >= "13") |
+                     (os-family = "ubuntu" & os-version >= "25.04") }
   ["taglib-dev"] {os-family = "alpine"}
   ["libtag-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["taglib"] {os-family = "arch" | os = "freebsd" | os-distribution = "nixos"}


### PR DESCRIPTION
Based on https://pkgs.org/search/?q=taglib_c.pc