### PR TITLE
Cryptokit 1.21

### DIFF
--- a/packages/cryptokit/cryptokit.1.21/opam
+++ b/packages/cryptokit/cryptokit.1.21/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.13.0"}
   "dune" {>= "2.5"}
   "dune-configurator"
-  "zarith" {>= "1.10"}
+  "zarith" {>= "1.13"}
   "conf-zlib"
   "conf-gmp-powm-sec"
 ]


### PR DESCRIPTION
- Add Cryptokit.Paillier: Paillier's homomorphic, public-key encryption. (Contributed by Atish Pranav.) (https://github.com/xavierleroy/cryptokit/pull/39)
 -  Change Cryptokit.RSA to use two distinct types for public keys and for private keys. (Breaking change.) (https://github.com/xavierleroy/cryptokit/pull/41)
 -  Add SHA512/256 and SHA512/224 hash functions. (Contributed by Pierre-Yves Strub.) (https://github.com/xavierleroy/cryptokit/pull/42)
 -  Add some support for elliptic-curve cryptography: curves in short Weierstrass form, ECDSA signature, ECDH key exchange.
 -  Add Cryptokit.KD with key derivation functions.