### PR TITLE
avoid oldest version of kinetic-client

### DIFF
--- a/packages/kinetic-client/kinetic-client.0.0.1/opam
+++ b/packages/kinetic-client/kinetic-client.0.0.1/opam
@@ -22,7 +22,8 @@ depexts: [
 ]
 dev-repo: "git+https://github.com/CloudFounders/kinetic-ocaml-client"
 synopsis: "Client for Seagate's kinetic drives."
-flags: [ light-uninstall avoid-version ]
+flags: light-uninstall
+available: false
 url {
   src:
     "https://github.com/CloudFounders/kinetic-ocaml-client/archive/0.0.1.tar.gz"


### PR DESCRIPTION
```
=== ERROR while compiling kinetic-client.0.0.1 ===============================#
context              2.5.0 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
path                 ~/.opam/4.14/.opam-switch/build/kinetic-client.0.0.1
command              ~/.opam/opam-init/hooks/sandbox.sh build make
exit-code            2
env-file             ~/.opam/log/kinetic-client-7-53fb67.env
output-file          ~/.opam/log/kinetic-client-7-53fb67.out
=== output ===
piqi of-proto src/kinetic.proto -o src/kinetic.proto.piqi
[libprotobuf WARNING google/protobuf/compiler/parser.cc:646] No syntax specified for the proto file: src/kinetic.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
piqic-ocaml --embed-piqi -C src src/kinetic.proto.piqi
patch -d src < src/kinetic_piqi.patch
patching file kinetic_piqi.ml
Hunk #1 FAILED at 236.
Hunk #2 FAILED at 602.
Hunk #3 FAILED at 1080.
Hunk #4 FAILED at 1463.
4 out of 4 hunks FAILED -- saving rejects to file kinetic_piqi.ml.rej
make: *** [Makefile:11: kinetic_piqi_ml] Error 1
```