### PR TITLE
otel-cohttp-lwt fix compat error with too-recent cohttp

### DIFF
--- a/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.12/opam
+++ b/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.12/opam
@@ -16,7 +16,7 @@ depends: [
   "opentelemetry-lwt" {= version}
   "odoc" {with-doc}
   "lwt" {>= "5.3"}
-  "cohttp-lwt" {>= "6.0.0"}
+  "cohttp-lwt" {>= "6.0.0" & < "6.2.0"}
   "alcotest" {with-test}
 ]
 build: [


### PR DESCRIPTION
Observed error:

```
 File "src/integrations/cohttp/opentelemetry_cohttp_lwt.ml", line 233, characters 10-16:
 233 |   (module Traced : Cohttp_lwt.S.Client)
                 ^^^^^^
 Error: Signature mismatch:
        ...
        The module IO is required but not provided
        File "cohttp-lwt/src/s.ml", line 196, characters 2-42:
          Expected declaration
```

changelog mentions IO in https://github.com/mirage/ocaml-cohttp/releases/tag/v6.2.0 