### PR TITLE
conf-taglib_c.2: add a zlib-dev dependency on Alpine

### DIFF
--- a/packages/conf-taglib_c/conf-taglib_c.2/opam
+++ b/packages/conf-taglib_c/conf-taglib_c.2/opam
@@ -13,7 +13,7 @@ depends: [
 depexts: [
   ["libtag-c-dev"] { (os-family = "debian" & os-version >= "13") |
                      (os-family = "ubuntu" & os-version >= "25.04") }
-  ["taglib-dev"] {os-family = "alpine"}
+  ["taglib-dev" "zlib-dev"] {os-family = "alpine"}
   ["libtag-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["taglib"] {os-family = "arch" | os = "freebsd" | os-distribution = "nixos"}
   ["taglib"] {os = "macos" & os-distribution = "homebrew"}


### PR DESCRIPTION
In #29136 we have puzzled over an Alpine build error:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/74aaa4da4f1e7b3367000caa2bb2e750ab4121a4/variant/distributions,alpine-3.22-ocaml-5.4,shakuhachi.0.1.0
```
#=== ERROR while compiling otaglibc.0.1.0 =====================================#
# context              2.5.0 | linux/x86_64 | ocaml-base-compiler.5.4.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.4/.opam-switch/build/otaglibc.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p otaglibc -j 255 @install
# exit-code            1
# env-file             ~/.opam/log/otaglibc-7-597753.env
# output-file          ~/.opam/log/otaglibc-7-597753.out
### output ###
# File "lib/dune", lines 1-13, characters 0-264:
#  1 | (library
#  2 |  (public_name otaglibc)
#  3 |  (name otaglibc)
# ....
# 11 |    (:include taglib_c_cflags.sexp)))
# 12 |  (c_library_flags
# 13 |   (:include taglib_c_clibrary_flags.sexp)))
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlmklib -g -o lib/otaglibc_stubs lib/caml_taglibc.o -ldopt -ltag_c -ldopt -ltag -ldopt -lz)
# /usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lz: No such file or directory
# collect2: error: ld returned 1 exit status
```

@EruEri has found that taglib is compiled with zlib support on Alpine - explaining why it then fails to link without it:
https://build.alpinelinux.org/buildlogs/build-3-22-x86_64/community/taglib/taglib-2.0.2-r0.log

This prompted me to look at the sister package `conf-taglib` - and it turns out that it has listed `zlib-dev` as a Alpine dependency since Oct. 2021 https://github.com/ocaml/opam-repository/pull/19919

This PR therefore adds the same `depexts` entry for Alpine on `conf-taglib_c`... :smiley: 

I expect the same CI failures as on https://github.com/ocaml/opam-repository/pull/29141