### PR TITLE
[new] neo4j_bolt.0.2.0

### DIFF
--- a/packages/neo4j_bolt/neo4j_bolt.0.2.0/opam
+++ b/packages/neo4j_bolt/neo4j_bolt.0.2.0/opam
@@ -33,5 +33,5 @@ depends: [
 ]
 url {
   src: "https://github.com/jeong-sik/ocaml-neo4j-bolt/archive/refs/tags/v0.2.0.tar.gz"
-  checksum: "sha512=749b997e6a0107a2257a9e8d8b48e1fe9b34545bb216462072a58378ea148333fa3c5cdd8ed3ae08ed86a1bfa67a2d259a0742eaa176f774a4097ddc0eb44917"
+  checksum: "sha512=0963fa5a039a4e97bbf4d29879f3657c5ba171a15132c0111db85ddadb4cfe8ec6ef782d36c46b9be940647ad26327343ee7533ea0428164054f39383af1c770"
 }


### PR DESCRIPTION
Pure OCaml Neo4j Bolt protocol client.

**Features**:
- Bolt 4.x/5.x protocol support
- PackStream binary serialization (spec compliant)
- Async I/O with Lwt
- Configurable timeouts

**Configuration** via environment variables:
- `NEO4J_HOST` (default: localhost)
- `NEO4J_PORT` (default: 7687)
- `NEO4J_USERNAME` (default: neo4j)
- `NEO4J_PASSWORD`
- `NEO4J_TIMEOUT` (default: 30.0)

**Links**:
- Source: https://github.com/jeong-sik/ocaml-neo4j-bolt
- PackStream Spec: https://neo4j.com/docs/bolt/current/packstream/
- Bolt Spec: https://neo4j.com/docs/bolt/current/bolt/

Note: This replaces the previously closed #29170 (security fix - removed hardcoded URL)