### PR TITLE
[new release] neo4j_bolt.0.3.0

### DIFF
--- a/packages/neo4j_bolt/neo4j_bolt.0.3.0/opam
+++ b/packages/neo4j_bolt/neo4j_bolt.0.3.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Pure OCaml Neo4j Bolt protocol client with TLS support"
+description: """
+A pure OCaml implementation of the Neo4j Bolt protocol with TLS/SSL support.
+Supports bolt://, bolt+s://, bolts://, and bolt+ssc:// connection schemes."""
+maintainer: "Jeongshik Yoon <yousleepwhen@gmail.com>"
+authors: ["Jeongshik Yoon <yousleepwhen@gmail.com>"]
+homepage: "https://github.com/jeong-sik/ocaml-neo4j-bolt"
+bug-reports: "https://github.com/jeong-sik/ocaml-neo4j-bolt/issues"
+dev-repo: "git+https://github.com/jeong-sik/ocaml-neo4j-bolt.git"
+doc: "https://jeong-sik.github.io/ocaml-neo4j-bolt"
+license: "MIT"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0"}
+  "lwt" {>= "5.6"}
+  "lwt_ppx" {>= "2.1"}
+  "lwt_ssl" {>= "1.2"}
+  "ssl" {>= "0.7"}
+  "yojson" {>= "2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+]
+url {
+  src: "https://github.com/jeong-sik/ocaml-neo4j-bolt/archive/refs/tags/v0.3.0.tar.gz"
+  checksum: [
+    "sha512=77bbf2a38cb070ffe6633c569e7ed5ba6bfed3cf7cee5f0dffb6914fedd660d0e205f61b7b094b6e145fb64c330d26d3139ac23678500a38b5b6f8e9826a13ae"
+  ]
+}


### PR DESCRIPTION
## New Features

- **TLS/SSL support** for secure Neo4j connections
  - `bolt+s://` - TLS with certificate verification
  - `bolts://` - Alias for bolt+s://
  - `bolt+ssc://` - TLS without certificate verification (self-signed)
- URI-based connection configuration
- New dependencies: `lwt_ssl`, `ssl`

## Changes from v0.2.0

- Added `tls_mode` type: `NoTLS | TLS | TLSSelfSigned`
- Added `parse_uri` function for automatic scheme detection
- Added `connect_uri` convenience function
- Added `is_tls_connection` and `connection_info` helpers

## Testing

- 39 tests passing (31 PackStream + 8 Bolt TLS tests)
- Tested against Neo4j Aura and Railway (bolt+s://)

## Links

- Repository: https://github.com/jeong-sik/ocaml-neo4j-bolt
- Documentation: https://jeong-sik.github.io/ocaml-neo4j-bolt
- Release: https://github.com/jeong-sik/ocaml-neo4j-bolt/releases/tag/v0.3.0