### PR TITLE
Add intel_hex.0.1

### DIFF
--- a/packages/intel_hex/intel_hex.0.1/opam
+++ b/packages/intel_hex/intel_hex.0.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Intel HEX manipulation library"
+maintainer: ["Mikhail Lopatin <dx3mod@bk.ru>"]
+authors: ["Mikhail Lopatin <dx3mod@bk.ru>"]
+license: "MIT"
+tags: ["embedded" "hex" "intelhex"]
+homepage: "https://github.com/dx3mod/intel_hex"
+bug-reports: "https://github.com/dx3mod/intel_hex/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.14"}
+  "cstruct" {>= "6.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dx3mod/intel_hex.git"
+url {
+  src: "https://github.com/dx3mod/intel_hex/archive/refs/tags/0.1.tar.gz"
+  checksum: [
+    "md5=282b8073f574d7a5ace12030bd3ce022"
+    "sha512=a64ebe3707a7a2bb061a6269991a4ed14a70d98fd26d768da6090187aeffb607b17a48dff62c30bdc58d1fb67156c76d102e65e057f52a68a549b51021400fd6"
+  ]
+}


### PR DESCRIPTION
The Intel HEX manipulation library for OCaml provides functions to read, write, and create Intel HEX format data, which is commonly used in embedded systems programming.