### PR TITLE
osc: avoid-version for old unmaintained version

### DIFF
--- a/packages/osc/osc.0.1.4/opam
+++ b/packages/osc/osc.0.1.4/opam
@@ -41,7 +41,7 @@ conflicts: [
   "lwt" {with-test & >= "5.0.0"}
 ]
 synopsis: "Pure OCaml OpenSoundControl client and server implementation"
-flags: light-uninstall
+flags: [ light-uninstall avoid-version ]
 url {
   src: "https://github.com/johnelse/ocaml-osc/archive/osc.0.1.4.tar.gz"
   checksum: [


### PR DESCRIPTION
https://github.com/ocaml/opam-repository/pull/29147#issuecomment-3704313297 ← maintainer saying they'd rather remove the old version