### PR TITLE
Change rocq-prover version from 9.0.0 to meta.1

### DIFF
--- a/packages/rocq-prover/rocq-prover.meta.1/opam
+++ b/packages/rocq-prover/rocq-prover.meta.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "The Rocq Prover with Stdlib"
+description: """
+The Rocq Prover is an interactive theorem prover, or proof assistant. It provides
+a formal language to write mathematical definitions, executable
+algorithms and theorems together with an environment for
+semi-interactive development of machine-checked proofs.
+
+Typical applications include the certification of properties of
+programming languages (e.g. the CompCert compiler certification
+project, or the Bedrock verified low-level programming library), the
+formalization of mathematics (e.g. the full formalization of the
+Feit-Thompson theorem or homotopy type theory) and teaching.
+
+This package is a virtual package gathering the rocq-core and rocq-stdlib packages."""
+maintainer: ["The Rocq development team <coqdev@inria.fr>"]
+authors: ["The Rocq development team, INRIA, CNRS, and contributors"]
+license: "LGPL-2.1-only"
+homepage: "https://rocq-prover.org"
+doc: "https://coq.github.io/doc/"
+bug-reports: "https://github.com/coq/coq/issues"
+depends: [
+  "rocq-core"
+  "rocq-stdlib"
+]
+dev-repo: "git+https://github.com/coq/coq.git"


### PR DESCRIPTION
Since https://github.com/ocaml/opam-repository/pull/28179 the rocq-prover package is a pure metapackage not depending on rocq-core version, this makes the old 9.0.0 version number (no longer updated) confusing, c.f., https://rocq-prover.zulipchat.com/#narrow/channel/237977-Rocq-users/topic/diff.20version.20Rocq.20Core.2C.20and.20Rocq.20Prover/with/561649780
A version number clearly conveying the metapackage status should help.
We have 9.0.0 < meta.1 in the version ordering which should avoid too much trouble.