### PR TITLE
camlp4.5.4 requires OCaml >= 5.4.1 on macOS and Windows

### DIFF
--- a/packages/camlp4/camlp4.5.4/opam
+++ b/packages/camlp4/camlp4.5.4/opam
@@ -17,6 +17,7 @@ homepage: "https://github.com/camlp4/camlp4"
 bug-reports: "https://github.com/camlp4/camlp4/issues"
 depends: [
   "ocaml" {>= "5.4" & < "5.5"}
+  "ocaml" {>= "5.4.1" & (os = "macos" | os = "win32")}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "camlp-streams"


### PR DESCRIPTION
See https://github.com/camlp4/camlp4/issues/170