### PR TITLE
lwt: fix ocamlfind version constraint

### DIFF
--- a/packages/lwt/lwt.4.2.0/opam
+++ b/packages/lwt/lwt.4.2.0/opam
@@ -26,8 +26,8 @@ depends: [
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
-  "bisect_ppx" {dev & >= "1.3.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "bisect_ppx" {with-dev-setup & >= "1.3.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 depopts: [
   "base-threads"

--- a/packages/lwt/lwt.4.2.1-1/opam
+++ b/packages/lwt/lwt.4.2.1-1/opam
@@ -26,8 +26,8 @@ depends: [
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
-  "bisect_ppx" {dev & >= "1.3.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "bisect_ppx" {with-dev-setup & >= "1.3.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 depopts: [
   "base-threads"

--- a/packages/lwt/lwt.4.2.1/opam
+++ b/packages/lwt/lwt.4.2.1/opam
@@ -26,8 +26,8 @@ depends: [
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
-  "bisect_ppx" {dev & >= "1.3.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "bisect_ppx" {with-dev-setup & >= "1.3.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 depopts: [
   "base-threads"

--- a/packages/lwt/lwt.4.3.0/opam
+++ b/packages/lwt/lwt.4.3.0/opam
@@ -26,8 +26,8 @@ depends: [
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
-  "bisect_ppx" {dev & >= "1.3.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "bisect_ppx" {with-dev-setup & >= "1.3.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.4.3.1/opam
+++ b/packages/lwt/lwt.4.3.1/opam
@@ -26,8 +26,8 @@ depends: [
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
-  "bisect_ppx" {dev & >= "1.3.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "bisect_ppx" {with-dev-setup & >= "1.3.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.4.4.0/opam
+++ b/packages/lwt/lwt.4.4.0/opam
@@ -26,8 +26,8 @@ depends: [
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
-  "bisect_ppx" {dev & >= "1.3.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "bisect_ppx" {with-dev-setup & >= "1.3.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.4.5.0/opam
+++ b/packages/lwt/lwt.4.5.0/opam
@@ -26,8 +26,8 @@ depends: [
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
-  "bisect_ppx" {dev & >= "1.3.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "bisect_ppx" {with-dev-setup & >= "1.3.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.5.0.0/opam
+++ b/packages/lwt/lwt.5.0.0/opam
@@ -26,8 +26,8 @@ depends: [
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
-  "bisect_ppx" {dev & >= "1.3.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "bisect_ppx" {with-dev-setup & >= "1.3.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.5.0.1/opam
+++ b/packages/lwt/lwt.5.0.1/opam
@@ -26,8 +26,8 @@ depends: [
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
-  "bisect_ppx" {dev & >= "1.3.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "bisect_ppx" {with-dev-setup & >= "1.3.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.5.1.0/opam
+++ b/packages/lwt/lwt.5.1.0/opam
@@ -26,8 +26,8 @@ depends: [
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
-  "bisect_ppx" {dev & >= "1.3.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "bisect_ppx" {with-dev-setup & >= "1.3.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.5.1.1/opam
+++ b/packages/lwt/lwt.5.1.1/opam
@@ -26,8 +26,8 @@ depends: [
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
-  "bisect_ppx" {dev & >= "1.3.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "bisect_ppx" {with-dev-setup & >= "1.3.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.5.1.2/opam
+++ b/packages/lwt/lwt.5.1.2/opam
@@ -26,8 +26,8 @@ depends: [
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
-  "bisect_ppx" {dev & >= "1.3.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "bisect_ppx" {with-dev-setup & >= "1.3.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.5.2.0/opam
+++ b/packages/lwt/lwt.5.2.0/opam
@@ -26,8 +26,8 @@ depends: [
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
-  "bisect_ppx" {dev & >= "1.3.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "bisect_ppx" {with-dev-setup & >= "1.3.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.5.3.0/opam
+++ b/packages/lwt/lwt.5.3.0/opam
@@ -27,8 +27,8 @@ depends: [
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
-  "bisect_ppx" {dev & >= "2.0.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "bisect_ppx" {with-dev-setup & >= "2.0.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.5.4.0/opam
+++ b/packages/lwt/lwt.5.4.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ocplib-endian"
   "result"
   "seq"
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 depopts: ["base-threads" "base-unix" "conf-libev"]
 conflicts: [

--- a/packages/lwt/lwt.5.4.1/opam
+++ b/packages/lwt/lwt.5.4.1/opam
@@ -29,8 +29,8 @@ depends: [
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
   # Until https://github.com/aantron/bisect_ppx/pull/327.
-  # "bisect_ppx" {dev & >= "2.0.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  # "bisect_ppx" {with-dev-setup & >= "2.0.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.5.4.2/opam
+++ b/packages/lwt/lwt.5.4.2/opam
@@ -28,8 +28,8 @@ depends: [
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
   # Until https://github.com/aantron/bisect_ppx/pull/327.
-  # "bisect_ppx" {dev & >= "2.0.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  # "bisect_ppx" {with-dev-setup & >= "2.0.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.5.5.0/opam
+++ b/packages/lwt/lwt.5.5.0/opam
@@ -28,8 +28,8 @@ depends: [
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
   # Until https://github.com/aantron/bisect_ppx/pull/327.
-  # "bisect_ppx" {dev & >= "2.0.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  # "bisect_ppx" {with-dev-setup & >= "2.0.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.5.6.0/opam
+++ b/packages/lwt/lwt.5.6.0/opam
@@ -24,8 +24,8 @@ depends: [
   "ocplib-endian"
 
   # Until https://github.com/aantron/bisect_ppx/pull/327.
-  # "bisect_ppx" {dev & >= "2.0.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  # "bisect_ppx" {with-dev-setup & >= "2.0.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.5.6.1/opam
+++ b/packages/lwt/lwt.5.6.1/opam
@@ -24,8 +24,8 @@ depends: [
   "ocplib-endian"
 
   # Until https://github.com/aantron/bisect_ppx/pull/327.
-  # "bisect_ppx" {dev & >= "2.0.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  # "bisect_ppx" {with-dev-setup & >= "2.0.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.5.7.0/opam
+++ b/packages/lwt/lwt.5.7.0/opam
@@ -24,8 +24,8 @@ depends: [
   "ocplib-endian"
 
   # Until https://github.com/aantron/bisect_ppx/pull/327.
-  # "bisect_ppx" {dev & >= "2.0.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  # "bisect_ppx" {with-dev-setup & >= "2.0.0"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
 ]
 
 depopts: [

--- a/packages/lwt/lwt.5.8.0/opam
+++ b/packages/lwt/lwt.5.8.0/opam
@@ -23,7 +23,7 @@ depends: [
   "dune" {>= "1.12"}
   "ocaml" {>= "4.08"}
   "cppo" {build & >= "1.1.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3.0"}
   "dune-configurator"
   "ocplib-endian"

--- a/packages/lwt/lwt.5.8.1/opam
+++ b/packages/lwt/lwt.5.8.1/opam
@@ -23,7 +23,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "cppo" {build & >= "1.1.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3.0"}
   "dune-configurator"
   "ocplib-endian"

--- a/packages/lwt/lwt.5.9.0/opam
+++ b/packages/lwt/lwt.5.9.0/opam
@@ -23,7 +23,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "cppo" {build & >= "1.1.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3.0"}
   "dune-configurator"
   "ocplib-endian"

--- a/packages/lwt/lwt.5.9.1/opam
+++ b/packages/lwt/lwt.5.9.1/opam
@@ -23,7 +23,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "cppo" {build & >= "1.1.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3.0"}
   "dune-configurator"
   "ocplib-endian"

--- a/packages/lwt/lwt.5.9.2/opam
+++ b/packages/lwt/lwt.5.9.2/opam
@@ -23,7 +23,7 @@ depends: [
   "dune" {>= "3.15"}
   "ocaml" {>= "4.08"}
   "cppo" {build & >= "1.1"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3"}
   "dune-configurator"
   "ocplib-endian"

--- a/packages/lwt/lwt.6.0.0-beta01/opam
+++ b/packages/lwt/lwt.6.0.0-beta01/opam
@@ -23,7 +23,7 @@ depends: [
   "dune" {>= "3.15"}
   "ocaml" {>= "4.14"}
   "cppo" {build & >= "1.1"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3"}
   "dune-configurator"
   "ocplib-endian"

--- a/packages/lwt/lwt.6.0.0~alpha00/opam
+++ b/packages/lwt/lwt.6.0.0~alpha00/opam
@@ -23,7 +23,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "cppo" {build & >= "1.1.0"}
-  "ocamlfind" {dev & >= "1.7.3-1"}
+  "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3.0"}
   "bisect_ppx" {with-test}
   "dune-configurator"


### PR DESCRIPTION
used to be `dev` which made no sense (we don't want to depend on dev version of `ocamlfind`), now is `with-dev-setup`

see https://github.com/ocaml/opam-repository/pull/29184#pullrequestreview-3630353677