### PR TITLE
WIP: possibly mark bitwuzla-cxx.0.{2,3,4}.0 as unavailable

### DIFF
--- a/packages/bitwuzla-cxx/bitwuzla-cxx.0.2.0/opam
+++ b/packages/bitwuzla-cxx/bitwuzla-cxx.0.2.0/opam
@@ -1,4 +1,3 @@
-#bump
 opam-version: "2.0"
 synopsis: "SMT solver for AUFBVFP (C++ API)"
 description: """
@@ -14,7 +13,7 @@ homepage: "https://bitwuzla.github.io"
 doc: "https://bitwuzla.github.io/docs/ocaml/"
 bug-reports: "https://github.com/bitwuzla/ocaml-bitwuzla/issues"
 depends: [
-  "dune" {>= "3.7"}
+  "dune" {>= "3.8"}
   "ocaml" {>= "4.12" & < "5.0~"}
   "conf-git" {build}
   "conf-gcc" {build}


### PR DESCRIPTION
These showed up as a failing revdep in https://github.com/ocaml/opam-repository/pull/29189

[bitwuzla-cxx.0.2.0 (failed: 'replace' is not a member of 'std')](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/6caba29379107c345f957d6faf6186749fa27569/variant/compilers,4.14,dune.3.21.0~alpha5,revdeps,bitwuzla-cxx.0.2.0)
[bitwuzla-cxx.0.3.0 (failed: 'replace' is not a member of 'std')](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/6caba29379107c345f957d6faf6186749fa27569/variant/compilers,4.14,dune.3.21.0~alpha5,revdeps,bitwuzla-cxx.0.3.0)
[bitwuzla-cxx.0.4.0 (failed: 'abs' is not a member of 'std')](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/6caba29379107c345f957d6faf6186749fa27569/variant/compilers,4.14,dune.3.21.0~alpha5,revdeps,bitwuzla-cxx.0.4.0)

Local testing indicated the packages may be broken, so I'd like to run one thru CI.