### PR TITLE
[new release] quickjs (0.4.2)

### DIFF
--- a/packages/quickjs/quickjs.0.4.2/opam
+++ b/packages/quickjs/quickjs.0.4.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Bindings for QuickJS (a Javascript Engine to be embedded https://bellard.org/quickjs)"
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/quickjs.ml"
+bug-reports: "https://github.com/ml-in-barcelona/quickjs.ml/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.14.0"}
+  "integers" {>= "0.7.0"}
+  "ctypes" {>= "0.13.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ml-in-barcelona/quickjs.ml.git"
+conflicts: [ "ocaml-option-bytecode-only" ]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ml-in-barcelona/quickjs.ml/releases/download/0.4.2/quickjs-0.4.2.tbz"
+  checksum: [
+    "sha256=594fac60b9273af7e1903f0689efa353121309d8de911376f91966c32cd3ab7f"
+    "sha512=68beb126919a214fa9e46d84566c97e6ff3667c6c4478f352f1145e5bf1888b2a5eaca9855f39d734b2e9dc5bc0c7650f45679d177d546a2b0ba53dced5f2d1f"
+  ]
+}
+x-commit-hash: "7b165a17aba6f88765b159e3da670224225ea541"


### PR DESCRIPTION
Bindings for QuickJS (a Javascript Engine to be embedded https://bellard.org/quickjs)

- Project page: <a href="https://github.com/ml-in-barcelona/quickjs.ml">https://github.com/ml-in-barcelona/quickjs.ml</a>

##### CHANGES:

- Rename `RegExp.lastIndex` -> `RegExp.last_index`
- Rename `RegExp.setLastIndex` -> `RegExp.set_last_index`
