### PR TITLE
Release of lmdb.1.1

### DIFF
--- a/packages/lmdb/lmdb.1.1.1/opam
+++ b/packages/lmdb/lmdb.1.1.1/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.07"}
   "bigstringaf" {>= "0.10.0"}
-  "dune" {>= "1.2"}
+  "dune" {>= "3.14"}
   "dune-configurator" {build}
   "alcotest" {with-test}
   "benchmark" {with-test}
@@ -42,9 +42,9 @@ depexts: [
   ["liblmdb-devel"] {os-family = "mageia"}
 ]
 url {
-  src: "https://github.com/Drup/ocaml-lmdb/archive/refs/heads/windows.tar.gz"
+  src: "https://github.com/Drup/ocaml-lmdb/archive/refs/tags/1.1.1.tar.gz"
   checksum: [
-    "md5=052d7b102aee7e81084f2c1d1d53706f"
-    "sha512=a7cf710c5f26f5274eddaa24ec8d547598a108db1d86ed8e39eb74379fb22df51dbdc753fda530a9d4853941a7f6f575ac6abbbbfb81df1eeb1ae88db567bdcf"
+    "md5=07b36ae61d71a2666de177dfdf331524"
+    "sha512=d6a1978c2a69da9f6bd1bc929a5eab7c61a94fdba31bbc95961d21634da7ff12946e3636142e60ff67d1650b785ec38d3ad8d3be9498dcb66dadc02ee8323241"
   ]
 }


### PR DESCRIPTION
* Fix bad allocation pattern in `mdbs_cursor_get` causing sporadic segfaults.
* Add `Map.close`. Map/dbi slots are not freed by the GC anymore.
* Implement `Map.to_dispenser` iterator to be used with the `Stdlib.Seq` module.
* Deprecate iterators in the `Cursor` module. They can be easily constructed from a dispenser via `Stdlib.Seq` or the [Gen](https://c-cube.github.io/gen/last/gen/Gen/index.html) module.
* adjust depexts for alpine, rhel, centos, opensuse
* Fix bogus warning about unused type in `Map.create`
* fix `simle_db.ml` example
* few documentation fixes