### PR TITLE
Add upper bound of dune 3.21 to opam-dune-lint

### DIFF
--- a/packages/opam-dune-lint/opam-dune-lint.0.3/opam
+++ b/packages/opam-dune-lint/opam-dune-lint.0.3/opam
@@ -8,7 +8,7 @@ license: "ISC"
 homepage: "https://github.com/ocurrent/opam-dune-lint"
 bug-reports: "https://github.com/ocurrent/opam-dune-lint/issues"
 depends: [
-  "dune" {>= "3.10"}
+  "dune" {>= "3.10" & < "3.21"}
   "fpath" {>= "0.7.3"}
   "astring" {>= "0.8.5"}
   "sexplib" {>= "v0.14.0"}

--- a/packages/opam-dune-lint/opam-dune-lint.0.4/opam
+++ b/packages/opam-dune-lint/opam-dune-lint.0.4/opam
@@ -8,7 +8,7 @@ license: "ISC"
 homepage: "https://github.com/ocurrent/opam-dune-lint"
 bug-reports: "https://github.com/ocurrent/opam-dune-lint/issues"
 depends: [
-  "dune" {>= "3.10"}
+  "dune" {>= "3.10" & < "3.21"}
   "fpath" {>= "0.7.3"}
   "astring" {>= "0.8.5"}
   "sexplib" {>= "v0.14.0"}

--- a/packages/opam-dune-lint/opam-dune-lint.0.5/opam
+++ b/packages/opam-dune-lint/opam-dune-lint.0.5/opam
@@ -8,7 +8,7 @@ license: "ISC"
 homepage: "https://github.com/ocurrent/opam-dune-lint"
 bug-reports: "https://github.com/ocurrent/opam-dune-lint/issues"
 depends: [
-  "dune" {>= "3.10"}
+  "dune" {>= "3.10" & < "3.21"}
   "fpath" {>= "0.7.3"}
   "astring" {>= "0.8.5"}
   "sexplib" {>= "v0.14.0"}

--- a/packages/opam-dune-lint/opam-dune-lint.0.6/opam
+++ b/packages/opam-dune-lint/opam-dune-lint.0.6/opam
@@ -8,7 +8,7 @@ license: "ISC"
 homepage: "https://github.com/ocurrent/opam-dune-lint"
 bug-reports: "https://github.com/ocurrent/opam-dune-lint/issues"
 depends: [
-  "dune" {>= "3.10"}
+  "dune" {>= "3.10" & < "3.21"}
   "fpath" {>= "0.7.3"}
   "astring" {>= "0.8.5"}
   "sexplib" {>= "v0.14.0"}


### PR DESCRIPTION
There is a small breaking change to the dune formatting api affecting this dependency. See https://github.com/ocaml/dune/issues/12897

This is motivated by the release https://github.com/ocaml/opam-repository/pull/29189