### PR TITLE
Package why3find.1.3.0

### DIFF
--- a/packages/why3find/why3find.1.3.0/opam
+++ b/packages/why3find/why3find.1.3.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "A Why3 Package Manager"
+description:
+  "The why3find utility is designed for managing packages for why3 developpers and associated OCaml extracted code."
+maintainer: ["benjamin.jorge@cea.fr" "loic.correnson@cea.fr"]
+authors: [
+  "Loïc Correnson <loic.correnson@cea.fr>"
+  "Benjamin Jorge <benjamin.jorge@cea.fr>"
+]
+license: "LGPL-2.1-only"
+tags: "why3"
+homepage: "https://git.frama-c.com/pub/why3find"
+doc: "https://git.frama-c.com/pub/why3find"
+bug-reports: "https://git.frama-c.com/pub/why3find/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "dune-site" {>= "3.12"}
+  "why3" {>= "1.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "yojson" {>= "1.7.0"}
+  "terminal_size" {>= "0.2.0"}
+  "zmq" {with-test}
+  "alt-ergo" {with-test & = "2.4.2"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "zmq" {>= "5.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/why3find.git"
+url {
+  src:
+    "https://git.frama-c.com/pub/why3find/-/archive/1.3.0/why3find-1.3.0.tar.gz"
+  checksum: [
+    "md5=435da830a513fd91ec5411c91126b763"
+    "sha512=fd8b04eb16d569c0dc9e5595a40b174d7858121b080c81d459b2f28fb3af1ebc32ef408859d5c1c5f45c61790625c027c2ecfc3d45e597943543de7212bab8d6"
+  ]
+}


### PR DESCRIPTION
### `why3find.1.3.0`
A Why3 Package Manager
The why3find utility is designed for managing packages for why3 developpers and associated OCaml extracted code.



---
* Homepage: https://git.frama-c.com/pub/why3find
* Source repo: git+https://git.frama-c.com/pub/why3find.git
* Bug tracker: https://git.frama-c.com/pub/why3find/issues

---
:camel: Pull-request generated by opam-publish v2.7.1