### PR TITLE
Package qcaml.0.1.6

### DIFF
--- a/packages/qcaml/qcaml.0.1.6/opam
+++ b/packages/qcaml/qcaml.0.1.6/opam
@@ -29,7 +29,7 @@ doc: "https://elias-utf8.github.io/qcaml/"
 bug-reports: "https://github.com/elias-utf8/qcaml/issues"
 depends: [
   "ocaml" {>= "5.2"}
-  "dune" {>= "3.17" & >= "3.17"}
+  "dune" {>= "3.17"}
   "dune-configurator"
   "raylib"
   "alcotest" {with-test}


### PR DESCRIPTION
### `qcaml.0.1.6`
Experimental OCaml library for quantum computing simulation
QCaml is a lightweight OCaml library for experimenting with quantum states,
gates and measurements. It provides tools for learning quantum computing
concepts and visualizing qubit states on the Bloch sphere.

Features:
- Single qubit state representation with complex amplitudes
- Fundamental quantum gates (Hadamard, Pauli-X/Y/Z)
- Quantum measurements with probabilistic state collapse
- Interactive Bloch sphere visualization using Raylib
- Comprehensive test suite



---
* Homepage: https://github.com/elias-utf8/qcaml
* Source repo: git+https://github.com/elias-utf8/qcaml.git
* Bug tracker: https://github.com/elias-utf8/qcaml/issues

---
:camel: Pull-request generated by opam-publish v2.7.0