### PR TITLE
Package markdown_monolith.0.1.1

### DIFF
--- a/packages/markdown_monolith/markdown_monolith.0.1.1/opam
+++ b/packages/markdown_monolith/markdown_monolith.0.1.1/opam
@@ -12,9 +12,9 @@ homepage: "https://github.com/Durbatuluk1701/markdown_monolith"
 doc: "https://durbatuluk1701.github.io/markdown_monolith/"
 bug-reports: "https://github.com/Durbatuluk1701/markdown_monolith/issues"
 depends: [
+  "dune" {>= "3.20"}
   "lwt_ssl" {>= "1.2.0"}
   "ocaml" {>= "4.14"}
-  "dune" {>= "3.20"}
   "cmarkit"
   "cmdliner" {>= "2.0.0"}
   "lwt"
@@ -32,7 +32,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test & os != "freebsd"}
+    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]
@@ -42,7 +42,7 @@ url {
   src:
     "https://github.com/Durbatuluk1701/markdown_monolith/archive/refs/tags/v0.1.1.tar.gz"
   checksum: [
-    "md5=3c99fe51ae6b3c99e40b9f54cd5714b4"
-    "sha512=ef682bd7ddb5a2a0d911abd961a9776978934c42560963d89d4a9aa935f7fcb12656a559f45c18a474dd2f8af9d43fc9693b5e09fb5b7ed5c08cb4705d3e3da5"
+    "md5=780e6bb03f474a071eff8099862aaff5"
+    "sha512=d108fab9854ef32d23de532d66046511c202a1667106b20eb9339f82dec416c02f95589dc7183d5fcd44864cd53fd76c8a478639106e2e7e6523d2c526c7fbdb"
   ]
 }


### PR DESCRIPTION
### `markdown_monolith.0.1.1`
Produce a single monolithic Markdown file by inlining linked files
OCaml library and CLI to produce a single monolithic Markdown file by parsing with Cmarkit, detecting link lists, and recursively inlining referenced files. Supports local and remote (HTTP/HTTPS) sources with configurable depth limits and deduplication.



---
* Homepage: https://github.com/Durbatuluk1701/markdown_monolith
* Source repo: git+https://github.com/Durbatuluk1701/markdown_monolith.git
* Bug tracker: https://github.com/Durbatuluk1701/markdown_monolith/issues

---
:camel: Pull-request generated by opam-publish v2.7.1