### PR TITLE
[new release] lambda-term (3.3.3)

### DIFF
--- a/packages/lambda-term/lambda-term.3.3.3/opam
+++ b/packages/lambda-term/lambda-term.3.3.3/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Terminal manipulation library for OCaml"
+description: """
+Lambda-term is a cross-platform library for manipulating the terminal. It
+provides an abstraction for keys, mouse events, colors, as well as a set of
+widgets to write curses-like applications. The main objective of lambda-term is
+to provide a higher level functional interface to terminal manipulation than,
+for example, ncurses, by providing a native OCaml interface instead of bindings
+to a C library. Lambda-term integrates with zed to provide text edition
+facilities in console applications."""
+maintainer: ["ZAN DoYe <zandoye+ocaml@gmail.com>"]
+authors: ["Jérémie Dimino"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/lambda-term"
+bug-reports: "https://github.com/ocaml-community/lambda-term/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "logs"
+  "lwt" {>= "4.2.0"}
+  "lwt_react"
+  "mew_vi" {>= "0.5.0" & < "0.6.0"}
+  "react"
+  "zed" {>= "3.2.0" & < "4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-community/lambda-term.git"
+url {
+  src:
+    "https://github.com/ocaml-community/lambda-term/archive/refs/tags/3.3.3.tar.gz"
+  checksum: [
+    "sha512=34be68128d82b7219a963ca7442948842fc26ff9dbd3be9eb76092be3a4cf7cb19bad043fdeed7f5607178375c472dc51c6eebea82145541836e7883320d342c"
+  ]
+}
+x-commit-hash: "7dd817a3048e0d6402b3932a254e325a10f8abff"


### PR DESCRIPTION
* `LTerm_vi`: eliminate the incompatibility with lwt6

This PR makes `lambda-term` and `utop` compatible with the newly released `lwt6`