### PR TITLE
Correct `compiler` variable generation in ocaml.5.5.0

### DIFF
--- a/packages/ocaml/ocaml.5.5.0/opam
+++ b/packages/ocaml/ocaml.5.5.0/opam
@@ -35,7 +35,7 @@ build: [
   ["ocaml" "gen_ocaml_config.ml" version name
      # The packages referred to in this string must be in the disjunction above
      # and also all be in the ocaml-core-compiler conflict-class
-     "%{ocaml-system:installed?system}%%{ocaml-base-compiler:version}%%{dkml-base-compiler:version}%%{ocaml-variants:version}%"
+     "%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{dkml-base-compiler:version}%%{ocaml-variants:version}%"
      ocaml-system:installed
      # The order of these parameters matches the "convention" for the
      # ocaml-options-only packages


### PR DESCRIPTION
Alas, #29085 is missing a colon (with thanks to @Alizter for spotting it!).

This isn't critical, as it only affects system compilers, and 5.5 versions aren't installed yet. The effect at present is that the `ocaml:compiler` should be `system` when ocaml-system is installed, and at the moment it would be the empty string.