### PR TITLE
Add proven.0.9.0 - formally verified safety primitives

### DIFF
--- a/packages/proven/proven.0.9.1/opam
+++ b/packages/proven/proven.0.9.1/opam
@@ -1,6 +1,4 @@
 opam-version: "2.0"
-name: "proven"
-version: "0.9.0"
 synopsis: "Formally verified safety primitives for OCaml"
 description: """
 Safe operations with bounds checking, overflow detection, and security-focused
@@ -9,7 +7,7 @@ prevention, email validation, and network address classification.
 """
 maintainer: ["hyperpolymath"]
 authors: ["Hyperpolymath"]
-license: "PMPL-1.0"
+license: "Apache-2.0"
 homepage: "https://github.com/hyperpolymath/proven"
 bug-reports: "https://github.com/hyperpolymath/proven/issues"
 dev-repo: "git+https://github.com/hyperpolymath/proven.git"
@@ -23,5 +21,9 @@ build: [
   ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
 ]
 url {
-  src: "https://github.com/hyperpolymath/proven/archive/refs/tags/v0.9.0.tar.gz"
+  src: "https://github.com/hyperpolymath/proven/archive/refs/tags/v0.9.1.tar.gz"
+  checksum: [
+    "sha256=4d24ebaf9b64ff42304739264d0a988d134d9190d5cfb2908e91f1bc5e7685c0"
+    "sha512=f2f601652ebcfd9a94d89d12d60726b8de4774c6ed447964b6fa99e57eeade33f480d392065907a1fe390c7e7feb33f6e27ffb426ffaa5ab6548f1228a4563d6"
+  ]
 }


### PR DESCRIPTION
## Package: proven v0.9.0

**Description:** Formally verified safety primitives for OCaml - safe math with overflow protection, crypto comparisons, path traversal prevention, email validation, and network address classification.

**Repository:** https://github.com/hyperpolymath/proven

**License:** PMPL-1.0 (Apache-2.0 based)

**Dependencies:** ocaml >= 4.14.0, dune >= 3.0, alcotest (test)