### PR TITLE
[new release] testo (4 packages) (0.3.1)

### DIFF
--- a/packages/testo-diff/testo-diff.0.3.1/opam
+++ b/packages/testo-diff/testo-diff.0.3.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Pure-OCaml diff implementation"
+description: """
+This is a pure-OCaml implementation for computing line-by-line diffs.
+The current implementation uses an algorithm similar to gestalt pattern
+matching ported to OCaml by Gabriel Jaldon from Paul Butler's
+Python implementation.
+See https://github.com/paulgb/simplediff"""
+maintainer: ["Martin Jambon <martin@semgrep.com>"]
+authors: ["Martin Jambon" "Gabriel Jaldon"]
+license: "ISC"
+homepage: "https://github.com/semgrep/testo"
+bug-reports: "https://github.com/semgrep/testo/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.08.0"}
+  "ppx_deriving"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/semgrep/testo.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/semgrep/testo/releases/download/0.3.1/testo-0.3.1.tbz"
+  checksum: [
+    "sha256=40c161c91c1c212fd54d29127fa41f1a7c96483590d32219b0d55a5deca1b449"
+    "sha512=c40811f64ab1a4926bbf73e8e9ae81f6989499bab77a4989aa1712244fa786dcd3468789e097938cec9f53f503dfa56321e12ba3146104e4718f6cd5e94bd7e0"
+  ]
+}
+x-commit-hash: "b339abe15d5b5a07cf491ac355434dfd9e990963"

--- a/packages/testo-lwt/testo-lwt.0.3.1/opam
+++ b/packages/testo-lwt/testo-lwt.0.3.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Test framework for OCaml, Lwt variant"
+description: """
+Use this if the tests return Lwt promises and you can't make them synchronous
+because 'Lwt_main.run' is not supported by your platform e.g. JavaScript."""
+maintainer: ["Martin Jambon <martin@semgrep.com>"]
+authors: ["Martin Jambon" "Gabriel Jaldon"]
+license: "ISC"
+homepage: "https://github.com/semgrep/testo"
+bug-reports: "https://github.com/semgrep/testo/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "lwt" {>= "5.6.0"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "fpath"
+  "re" {>= "1.10.0"}
+  "testo-util" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/semgrep/testo.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/semgrep/testo/releases/download/0.3.1/testo-0.3.1.tbz"
+  checksum: [
+    "sha256=40c161c91c1c212fd54d29127fa41f1a7c96483590d32219b0d55a5deca1b449"
+    "sha512=c40811f64ab1a4926bbf73e8e9ae81f6989499bab77a4989aa1712244fa786dcd3468789e097938cec9f53f503dfa56321e12ba3146104e4718f6cd5e94bd7e0"
+  ]
+}
+x-commit-hash: "b339abe15d5b5a07cf491ac355434dfd9e990963"

--- a/packages/testo-util/testo-util.0.3.1/opam
+++ b/packages/testo-util/testo-util.0.3.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Modules shared by testo, testo-lwt, etc"
+description: "Testo is a test framework for OCaml."
+maintainer: ["Martin Jambon <martin@semgrep.com>"]
+authors: ["Martin Jambon" "Gabriel Jaldon"]
+license: "ISC"
+homepage: "https://github.com/semgrep/testo"
+bug-reports: "https://github.com/semgrep/testo/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.08.0"}
+  "fpath"
+  "re" {>= "1.10.0"}
+  "ppx_deriving"
+  "testo-diff" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/semgrep/testo.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/semgrep/testo/releases/download/0.3.1/testo-0.3.1.tbz"
+  checksum: [
+    "sha256=40c161c91c1c212fd54d29127fa41f1a7c96483590d32219b0d55a5deca1b449"
+    "sha512=c40811f64ab1a4926bbf73e8e9ae81f6989499bab77a4989aa1712244fa786dcd3468789e097938cec9f53f503dfa56321e12ba3146104e4718f6cd5e94bd7e0"
+  ]
+}
+x-commit-hash: "b339abe15d5b5a07cf491ac355434dfd9e990963"

--- a/packages/testo/testo.0.3.1/opam
+++ b/packages/testo/testo.0.3.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Test framework for OCaml"
+description: """
+Testo is a test framework for OCaml providing new subcommands for capturing,
+checking, and approving the output of tests."""
+maintainer: ["Martin Jambon <martin@semgrep.com>"]
+authors: ["Martin Jambon" "Gabriel Jaldon"]
+license: "ISC"
+homepage: "https://github.com/semgrep/testo"
+bug-reports: "https://github.com/semgrep/testo/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "fpath"
+  "re" {>= "1.10.0"}
+  "testo-util" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/semgrep/testo.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/semgrep/testo/releases/download/0.3.1/testo-0.3.1.tbz"
+  checksum: [
+    "sha256=40c161c91c1c212fd54d29127fa41f1a7c96483590d32219b0d55a5deca1b449"
+    "sha512=c40811f64ab1a4926bbf73e8e9ae81f6989499bab77a4989aa1712244fa786dcd3468789e097938cec9f53f503dfa56321e12ba3146104e4718f6cd5e94bd7e0"
+  ]
+}
+x-commit-hash: "b339abe15d5b5a07cf491ac355434dfd9e990963"


### PR DESCRIPTION
Test framework for OCaml

- Project page: <a href="https://github.com/semgrep/testo">https://github.com/semgrep/testo</a>

##### CHANGES:

* Add support for checked output files ([#134](https://github.com/semgrep/testo/issues/134)).
* Add an option `inline_logs` to create a test for which logs are always or never shown inline ([#142](https://github.com/semgrep/testo/issues/142)).
* Add a command-line option `--max-inline-log-bytes` to limit the size of unchecked test output (logs) shown inline when reporting the status of a test. The default limit is 1MB ([#144](https://github.com/semgrep/testo/issues/144)).
* Improve internal error handling ([#153](https://github.com/semgrep/testo/pull/153), [#154](https://github.com/semgrep/testo/pull/154)).
* Add support for boolean selection queries on test tags, extending `-t` ([#5](https://github.com/semgrep/testo/issues/5)). The query language keywords `and`, `or`, `not`, `all`, and `none` can no longer be used as tag names.
* New experimental submodule [Testo.Lazy_with_output] module for lazy computations that cache standard output and error output in addition to the computation's result or exception. This allows for sharing context between tests running in the same worker process. It saves unnecessary computations while providing the same logs for each test sharing this context ([#156](https://github.com/semgrep/testo/issues/156)).
* Report and highlight differences in Unix vs. Windows line endings as well as missing trailing newlines
  ([#163](https://github.com/semgrep/testo/pull/163)).
* Testo's snapshot files are now open in text mode for Windows-Unix compatibility. When reading files on Windows, CRLFs are converted to LFs. When writing, LFs are converted to CRLFs. Git or equivalent must be set up to convert line endings appropriately when moving files across platforms ([#165](https://github.com/semgrep/testo/pull/165)).
* A series of functions for reading and writing files has been deprecated and renamed to hint that we're reading or writing in text mode on Windows. These functions are `write_file`, `read_file`, `map_file`, `copy_file`, and `with_temp_file`. The new names are
  `write_text_file`, `read_text_file`, etc. ([#165](https://github.com/semgrep/testo/pull/165)).
* Testo's own test suite now passes successfully on Windows.
* Add a `-C`/`--chdir` option to set the current working directory ([#167](https://github.com/semgrep/testo/pull/167)).
* Add support for a `Testo.check` function and testables, replicating the similar functionality found in Alcotest. This makes it practical to write tests that don't depend on the Alcotest library ([#169](https://github.com/semgrep/testo/pull/169)).
* Show current working directory (cwd) when reporting missing files if one of the paths is relative ([#170](https://github.com/semgrep/testo/pull/170)).
* Rename the `broken` option of `Testo.create` and `Testo.update` to `flaky` ([#172](https://github.com/semgrep/testo/issues/172)).
