### PR TITLE
Package restricted-1.2.0

### DIFF
--- a/packages/restricted/restricted.1.2.0/opam
+++ b/packages/restricted/restricted.1.2.0/opam
@@ -8,14 +8,12 @@ Call it as early as possible in your program so that the rest of the code runs w
 - OpenBSD
 - Linux (only filesystem view)
 
-Even on other operating systems, you can still use `restricted` to document which privileges your program needs. Users can then test if your program respects these promises with tools such as [pledge on Linux](https://justine.lol/pledge/). Enjoy :)"""
+Even on other operating systems, you can still use [restricted](https://removewingman.codeberg.page/restricted/) to document which privileges your program needs. Users can then test if your program respects these promises with tools such as [pledge on Linux](https://justine.lol/pledge/). Enjoy :)"""
 maintainer: ["Remove Wingman <ocaml@rw8.addy.io>"]
 authors: ["Remove Wingman <ocaml@rw8.addy.io>"]
 license: "AGPL-3.0-or-later"
 tags: ["openbsd" "restricted"]
 homepage: "https://codeberg.org/removewingman/restricted"
-doc:
-  "https://codeberg.org/removewingman/restricted/src/branch/main/lib/types.mli"
 bug-reports: "https://codeberg.org/removewingman/restricted/issues"
 depends: [
   "dune" {>= "3.17"}


### PR DESCRIPTION
- add Linux (only filesystem view) via landlock(7)
  - except unlink/removing, whole other thing with LANDLOCK_ACCESS_FS_READ_FILE in landlock
- add [Semantic Versioning](https://semver.org/)
- change description to make it more clear
- tested with flambda switch on:
  - x86_64-openbsd
  - x86_64-arch-linux, x86_64-alpine-linux (Landlock ABI version: 7)