### PR TITLE
[new release] testo (4 packages) (0.3.3)

### DIFF
--- a/packages/testo-diff/testo-diff.0.3.3/opam
+++ b/packages/testo-diff/testo-diff.0.3.3/opam
@@ -35,7 +35,7 @@ dev-repo: "git+https://github.com/semgrep/testo.git"
 x-maintenance-intent: ["(latest)"]
 url {
   src:
-    "https://github.com/semgrep/testo/releases/download/untagged-dd3cdaff8046e17822fc/testo-0.3.3.tbz"
+    "https://github.com/semgrep/testo/releases/download/0.3.3/testo-0.3.3.tbz"
   checksum: [
     "sha256=69d4a905fc059d633570c620a261ec9a0718b79584767e45bedcbc4035ecaa2e"
     "sha512=eddfada96e53b447aff691646fa7ba2a79d2da15bce9cafacb71b314faaf5948fc112b3cfcb0b12cb615667b34de146f064365daa7f6bac96612a493d35ad9e5"

--- a/packages/testo-lwt/testo-lwt.0.3.3/opam
+++ b/packages/testo-lwt/testo-lwt.0.3.3/opam
@@ -37,7 +37,7 @@ dev-repo: "git+https://github.com/semgrep/testo.git"
 x-maintenance-intent: ["(latest)"]
 url {
   src:
-    "https://github.com/semgrep/testo/releases/download/untagged-dd3cdaff8046e17822fc/testo-0.3.3.tbz"
+    "https://github.com/semgrep/testo/releases/download/0.3.3/testo-0.3.3.tbz"
   checksum: [
     "sha256=69d4a905fc059d633570c620a261ec9a0718b79584767e45bedcbc4035ecaa2e"
     "sha512=eddfada96e53b447aff691646fa7ba2a79d2da15bce9cafacb71b314faaf5948fc112b3cfcb0b12cb615667b34de146f064365daa7f6bac96612a493d35ad9e5"

--- a/packages/testo-util/testo-util.0.3.3/opam
+++ b/packages/testo-util/testo-util.0.3.3/opam
@@ -33,7 +33,7 @@ dev-repo: "git+https://github.com/semgrep/testo.git"
 x-maintenance-intent: ["(latest)"]
 url {
   src:
-    "https://github.com/semgrep/testo/releases/download/untagged-dd3cdaff8046e17822fc/testo-0.3.3.tbz"
+    "https://github.com/semgrep/testo/releases/download/0.3.3/testo-0.3.3.tbz"
   checksum: [
     "sha256=69d4a905fc059d633570c620a261ec9a0718b79584767e45bedcbc4035ecaa2e"
     "sha512=eddfada96e53b447aff691646fa7ba2a79d2da15bce9cafacb71b314faaf5948fc112b3cfcb0b12cb615667b34de146f064365daa7f6bac96612a493d35ad9e5"

--- a/packages/testo/testo.0.3.3/opam
+++ b/packages/testo/testo.0.3.3/opam
@@ -36,7 +36,7 @@ dev-repo: "git+https://github.com/semgrep/testo.git"
 x-maintenance-intent: ["(latest)"]
 url {
   src:
-    "https://github.com/semgrep/testo/releases/download/untagged-dd3cdaff8046e17822fc/testo-0.3.3.tbz"
+    "https://github.com/semgrep/testo/releases/download/0.3.3/testo-0.3.3.tbz"
   checksum: [
     "sha256=69d4a905fc059d633570c620a261ec9a0718b79584767e45bedcbc4035ecaa2e"
     "sha512=eddfada96e53b447aff691646fa7ba2a79d2da15bce9cafacb71b314faaf5948fc112b3cfcb0b12cb615667b34de146f064365daa7f6bac96612a493d35ad9e5"


### PR DESCRIPTION
Test framework for OCaml

- Project page: <a href="https://github.com/semgrep/testo">https://github.com/semgrep/testo</a>

##### CHANGES:

- Add support for checked output files ([#134](https://github.com/semgrep/testo/issues/134)).
- Add an option `inline_logs` to create a test for which logs are always or never shown inline ([#142](https://github.com/semgrep/testo/issues/142)).
- Add a command-line option `--max-inline-log-bytes` to limit the size of unchecked test output (logs) shown inline when reporting the status of a test. The default limit is 1MB ([#144](https://github.com/semgrep/testo/issues/144)).
- Improve internal error handling ([#153](https://github.com/semgrep/testo/pull/153), [#154](https://github.com/semgrep/testo/pull/154)).
- Add support for boolean selection queries on test tags, extending `-t` ([#5](https://github.com/semgrep/testo/issues/5)). The query language keywords `and`, `or`, `not`, `all`, and `none` can no longer be used as tag names.
- New experimental submodule \[Testo.Lazy_with_output\] module for lazy computations that cache standard output and error output in addition to the computation’s result or exception. This allows for sharing context between tests running in the same worker process. It saves unnecessary computations while providing the same logs for each test sharing this context ([#156](https://github.com/semgrep/testo/issues/156)).
- Report and highlight differences in Unix vs. Windows line endings as well as missing trailing newlines ([#163](https://github.com/semgrep/testo/pull/163)).
- Testo’s snapshot files are now open in text mode for Windows-Unix compatibility. When reading files on Windows, CRLFs are converted to LFs. When writing, LFs are converted to CRLFs. Git or equivalent must be set up to convert line endings appropriately when moving files across platforms ([#165](https://github.com/semgrep/testo/pull/165)).
- A series of functions for reading and writing files has been deprecated and renamed to hint that we’re reading or writing in text mode on Windows. These functions are `write_file`, `read_file`, `map_file`, `copy_file`, and `with_temp_file`. The new names are `write_text_file`, `read_text_file`, etc. ([#165](https://github.com/semgrep/testo/pull/165)).
- Testo’s own test suite now passes successfully on Windows.
- Add a `-C`/`--chdir` option to set the current working directory ([#167](https://github.com/semgrep/testo/pull/167)).
- Add support for a `Testo.check` function and testables, replicating the similar functionality found in Alcotest. This makes it practical to write tests that don’t depend on the Alcotest library ([#169](https://github.com/semgrep/testo/pull/169)).
- Show current working directory (cwd) when reporting missing files if one of the paths is relative ([#170](https://github.com/semgrep/testo/pull/170)).
- Rename the `broken` option of `Testo.create` and `Testo.update` to `flaky` ([#172](https://github.com/semgrep/testo/issues/172)).
