### PR TITLE
[new release] multicore-magic (2 packages) (2.3.2)

### DIFF
--- a/packages/multicore-magic-dscheck/multicore-magic-dscheck.2.3.2/opam
+++ b/packages/multicore-magic-dscheck/multicore-magic-dscheck.2.3.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "An implementation of multicore-magic API using the atomic module of DScheck to make DScheck tests possible in libraries using multicore-magic"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-magic"
+bug-reports: "https://github.com/ocaml-multicore/multicore-magic/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "4.12.0"}
+  "dscheck" {>= "0.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-magic.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-magic/releases/download/2.3.2/multicore-magic-2.3.2.tbz"
+  checksum: [
+    "sha256=8d8d70a823aae1ce0430380842aa881c4ac838d245caf27ed0ff25775087175f"
+    "sha512=9379322c92fcdf28d285c6671dae634ad5b87e086572b00485cbfcd8e3046c130db63c749190168ebc7e12f3739ae2f7ba7bb6227fd1d8fb055a29f84b6e379f"
+  ]
+}
+x-commit-hash: "8ede1b84f4ebe8ea138c462beb48d5bddf3fc2af"

--- a/packages/multicore-magic/multicore-magic.2.3.2/opam
+++ b/packages/multicore-magic/multicore-magic.2.3.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Low-level multicore utilities for OCaml"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/multicore-magic"
+bug-reports: "https://github.com/ocaml-multicore/multicore-magic/issues"
+depends: [
+  "dune" {>= "3.14"}
+  "ocaml" {>= "4.12.0"}
+  "domain_shims" {>= "0.1.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "js_of_ocaml" {>= "5.4.0" & with-test}
+  "conf-npm" {arch != "x86_32" & os != "win32" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/multicore-magic.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml-multicore/multicore-magic/releases/download/2.3.2/multicore-magic-2.3.2.tbz"
+  checksum: [
+    "sha256=8d8d70a823aae1ce0430380842aa881c4ac838d245caf27ed0ff25775087175f"
+    "sha512=9379322c92fcdf28d285c6671dae634ad5b87e086572b00485cbfcd8e3046c130db63c749190168ebc7e12f3739ae2f7ba7bb6227fd1d8fb055a29f84b6e379f"
+  ]
+}
+x-commit-hash: "8ede1b84f4ebe8ea138c462beb48d5bddf3fc2af"


### PR DESCRIPTION
Low-level multicore utilities for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/multicore-magic">https://github.com/ocaml-multicore/multicore-magic</a>

##### CHANGES:

- Unboxed `Atomic_array` on 5.4 (@polytypic)
