### PR TITLE
[new] neo4j_bolt.0.4.0, neo4j_bolt_eio.0.4.0

### DIFF
--- a/packages/neo4j_bolt/neo4j_bolt.0.4.0/opam
+++ b/packages/neo4j_bolt/neo4j_bolt.0.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Pure OCaml Neo4j Bolt protocol client with TLS support (Lwt)"
+description: """
+A pure OCaml implementation of the Neo4j Bolt protocol with TLS/SSL support.
+Uses Lwt for async I/O. Supports bolt://, bolt+s://, and bolt+ssc:// connection schemes.
+"""
+maintainer: ["Jeongshik Yoon <yousleepwhen@gmail.com>"]
+authors: ["Jeongshik Yoon <yousleepwhen@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/jeong-sik/ocaml-neo4j-bolt"
+doc: "https://jeong-sik.github.io/ocaml-neo4j-bolt"
+bug-reports: "https://github.com/jeong-sik/ocaml-neo4j-bolt/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0"}
+  "lwt" {>= "5.6"}
+  "lwt_ppx" {>= "2.1"}
+  "lwt_ssl" {>= "1.2"}
+  "ssl" {>= "0.7"}
+  "yojson" {>= "2.0"}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jeong-sik/ocaml-neo4j-bolt.git"
+url {
+  src: "https://github.com/jeong-sik/ocaml-neo4j-bolt/archive/refs/tags/v0.4.0.tar.gz"
+  checksum: "sha256=a6f8d6b382e19639488de71541d9da344cb3e37ae28b41499a14af5534d4f8ee"
+}

--- a/packages/neo4j_bolt_eio/neo4j_bolt_eio.0.4.0/opam
+++ b/packages/neo4j_bolt_eio/neo4j_bolt_eio.0.4.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Pure OCaml Neo4j Bolt protocol client (Eio)"
+description: """
+A pure OCaml implementation of the Neo4j Bolt protocol using Eio for direct-style async I/O.
+Requires OCaml 5.0+ with effect handlers. Supports bolt:// connections.
+"""
+maintainer: ["Jeongshik Yoon <yousleepwhen@gmail.com>"]
+authors: ["Jeongshik Yoon <yousleepwhen@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/jeong-sik/ocaml-neo4j-bolt"
+doc: "https://jeong-sik.github.io/ocaml-neo4j-bolt"
+bug-reports: "https://github.com/jeong-sik/ocaml-neo4j-bolt/issues"
+depends: [
+  "ocaml" {>= "5.0"}
+  "dune" {>= "3.0"}
+  "eio" {>= "1.0"}
+  "eio_main" {>= "1.0"}
+  "tls-eio" {>= "1.0"}
+  "yojson" {>= "2.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/jeong-sik/ocaml-neo4j-bolt.git"
+url {
+  src: "https://github.com/jeong-sik/ocaml-neo4j-bolt/archive/refs/tags/v0.4.0.tar.gz"
+  checksum: "sha256=a6f8d6b382e19639488de71541d9da344cb3e37ae28b41499a14af5534d4f8ee"
+}


### PR DESCRIPTION
## Summary

Pure OCaml Neo4j Bolt protocol client.

### Packages

| Package | Description |
|---------|-------------|
| `neo4j_bolt` | Lwt-based async I/O with TLS support |
| `neo4j_bolt_eio` | Eio-based direct-style (OCaml 5.0+) |

### Features

- **PackStream**: Complete Neo4j binary serialization format
- **Bolt Protocol**: Full handshake, authentication, query execution
- **TLS Support** (Lwt): `bolt://`, `bolt+s://`, `bolt+ssc://` schemes
- **Direct-style** (Eio): No monadic syntax, structured concurrency

### Links

- Repository: https://github.com/jeong-sik/ocaml-neo4j-bolt
- Documentation: https://jeong-sik.github.io/ocaml-neo4j-bolt