### PR TITLE
[new release] patricia-tree (0.12.0)

### DIFF
--- a/packages/patricia-tree/patricia-tree.0.12.0/opam
+++ b/packages/patricia-tree/patricia-tree.0.12.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis:
+  "Patricia Tree data structure in OCaml for maps and sets. Supports generic key-value pairs"
+maintainer: ["Dorian Lesbre <dorian.lesbre@cea.fr>"]
+authors: [
+  "Matthieu Lemerre <matthieu.lemerre@cea.fr>"
+  "Dorian Lesbre <dorian.lesbre@cea.fr>"
+]
+license: "LGPL-2.1-only"
+homepage: "https://codex.top/api/patricia-tree/"
+doc: "https://codex.top/api/patricia-tree/"
+bug-reports:
+  "https://github.com/codex-semantics-library/patricia-tree/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0"}
+  "qcheck" {>= "0.21.2" & < "0.90" & with-test}
+  "ppx_inline_test" {>= "v0.16.0" & with-test}
+  "mdx" {>= "2.4.1" & with-test}
+  "odoc" {>= "2.4.0" & with-doc}
+  "sherlodoc" {with-doc}
+  "bechamel" {with-dev-setup}
+  "csv" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/codex-semantics-library/patricia-tree.git"
+url {
+  src:
+    "https://github.com/codex-semantics-library/patricia-tree/releases/download/v0.12.0/patricia-tree-0.12.0.tbz"
+  checksum: [
+    "sha256=88f2c7c92d609e5a92d2b6242d1d355c85273200f0a1e7e9eab858c4ded09650"
+    "sha512=89083fb58c894f5af255172c7bf43e4871bc31afcf86c4cd622773984cd8550ea1e61b31c676c431b6ba5eaf4b4e562ffeaa0cfba893121d783b5cceb7a55623"
+  ]
+}
+x-commit-hash: "386d6d5174b3fcc2369ff4ecdb53019c88f3376a"


### PR DESCRIPTION
Patricia Tree data structure in OCaml for maps and sets. Supports generic key-value pairs
-  Project page: https://codex.top/api/patricia-tree/
-  Documentation: https://codex.top/api/patricia-tree/

## Public changes

- Specify that hash-consed and weak nodes are not thread safe (issue [#17](https://github.com/codex-semantics-library/patricia-tree/issues/17))
- Add `MutexProtectNode` functors to enable multithreaded use of non-thread safe nodes ([#24](https://github.com/codex-semantics-library/patricia-tree/pull/24)).
- Also add `Make[Heterogeneous]Hashconsed[Set|Map]WithMutex` functors using `MutexProtectNode`
  for convenience  ([#24](https://github.com/codex-semantics-library/patricia-tree/pull/24)).
- Fix a bug with `nonreflexive_same_domain_forall2` (by [julow](https://github.com/Julow) in [#19](https://github.com/codex-semantics-library/patricia-tree/pull/19))

## Dev changes

- Add coverage with bisect_ppx (by [julow](https://github.com/Julow) in [#20](https://github.com/codex-semantics-library/patricia-tree/pull/20))
- Add model based qcheck test (by [julow](https://github.com/Julow) in [#21](https://github.com/codex-semantics-library/patricia-tree/pull/21))
- Add benchmarks (by [julow](https://github.com/Julow) in [#22](https://github.com/codex-semantics-library/patricia-tree/pull/22))
