### PR TITLE
[new release] slipshow 0.8.0: Les gnomes voleurs de Slipshow

### DIFF
--- a/packages/slipshow/slipshow.0.8.0/opam
+++ b/packages/slipshow/slipshow.0.8.0/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+synopsis: "A compiler from markdown to slipshow"
+description:
+  "Slipshow is an engine to write slips, a concept evolved from slides."
+maintainer: ["Paul-Elliot"]
+authors: ["Paul-Elliot"]
+license: ["GPL-3.0-or-later" "ISC" "BSD-3-Clause" "Apache-2.0" "OFL-1.1"]
+tags: ["slipshow" "presentation" "slideshow" "beamer"]
+homepage: "https://github.com/panglesd/slipshow"
+doc: "https://slipshow.readthedocs.io"
+bug-reports: "https://github.com/panglesd/slipshow/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.6"}
+  "crunch" {with-dev-setup}
+  "lambdasoup" {with-test}
+  "cmdliner" {>= "1.3.0"}
+  "base64"
+  "bos"
+  "lwt"
+  "inotify" {os = "linux"}
+  "cf-lwt" {>= "0.4"}
+  "astring"
+  "fmt"
+  "logs"
+  "fsevents-lwt"
+  "js_of_ocaml-compiler" {>= "6.0.1"}
+  "js_of_ocaml-lwt"
+  "magic-mime"
+  "dream" {>= "1.0.0~alpha5"}
+  "fpath"
+  "ppx_blob" {>= "0.8.0"}
+  "sexplib"
+  "ppx_sexp_conv"
+  "ppx_deriving_yojson"
+  "odoc" {with-doc}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/panglesd/slipshow.git"
+# We avoid 32 bits arcitecture because our usage of ppx_blob generates strings
+# whose size exceed the maximum size in 32 bits OCaml...
+available: arch != "arm32" & arch != "x86_32"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/panglesd/slipshow/releases/download/v0.8.0/slipshow-0.8.0.tbz"
+  checksum: [
+    "sha256=bf35f4f0c60bdd91260f728f2d81f4f67fb429905ecc90fd12b7cd8e51434b76"
+    "sha512=5fa0484a217818889b2cec4c43c52fc38d9b4234a067b85363b08c92261955e4bca1db806725491939f0f88b27c1b2e5ad17043db0fa5ebb2f464b6821b06dba"
+  ]
+}
+x-commit-hash: "f78ed9af300c2036a9a022adee4b3696044cd369"


### PR DESCRIPTION
Check out the [release page](https://github.com/panglesd/slipshow/releases/tag/v0.8.0) for a funny gif.

CHANGES:

### Features

- Add a "mirror mode" to the speaker view, which mirrors the entire screen you are sharing with the audience (panglesd/slipshow#188)
- Add support for external files through CLI and frontmatter (panglesd/slipshow#191)
- Add shortcut to delete or unselect selection in drawing editing (panglesd/slipshow#192)
- Add a "Close editing panel" button when there are no strokes (panglesd/slipshow#192)
- Default file names for drawing recording depend on their names (panglesd/slipshow#192)
- Improve `-o` argument wrt directories (panglesd/slipshow#190)
- Inline SVGs instead of adding them as images, allowing the use of classes and ids in SVGs (panglesd/slipshow#190)
- Rework the docs! (panglesd/slipshow#190)

### Fix

- Fix pauses time not updated after a rerecording (panglesd/slipshow#192)
- Fix drawing editing shortcuts triggering even when focusing on a textarea (panglesd/slipshow#192)
- Fix interaction between fields and drawing editing shortcuts (panglesd/slipshow#192)
- Fix order of `clear` and `draw` action: the first comes first (panglesd/slipshow#192)
- Use .woff2 for embedded fonts (panglesd/slipshow#190)