### PR TITLE
[new release] bstr (3 packages) (0.0.4)

### DIFF
--- a/packages/bin/bin.0.0.4/opam
+++ b/packages/bin/bin.0.0.4/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://git.robur.coop/robur/bstr"
+bug-reports:  "https://git.robur.coop/robur/bstr"
+dev-repo:     "git+https://github.com/robur-coop/bstr"
+doc:          "https://robur-coop.github.io/bstr/"
+license:      "MIT"
+synopsis:     "A DSL to describe binary formats"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.14.0"}
+  "dune"        {>= "3.5.0"}
+  "slice"       {= version}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/bstr/releases/download/v0.0.4/bstr-0.0.4.tbz"
+  checksum: [
+    "sha256=640836f15b2d555bdf2366f6d7783926e11598ad7e94557b167c785b255f4856"
+    "sha512=1954727f1a386c9909996cdabc1a3b150c23361a96e5632280b0f6e6faf8f0ab6a7ca974352378e757c5136375eb5a53235f95caa69e982f48d3a49907948ddd"
+  ]
+}
+x-commit-hash: "1ec658c8ac3a4bd67a004d41b7c5e6089f586fdf"

--- a/packages/bstr/bstr.0.0.4/opam
+++ b/packages/bstr/bstr.0.0.4/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://git.robur.coop/robur/bstr"
+bug-reports:  "https://git.robur.coop/robur/bstr"
+dev-repo:     "git+https://github.com/robur-coop/bstr"
+doc:          "https://robur-coop.github.io/bstr/"
+license:      "MIT"
+synopsis:     "A simple library for bigstrings"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.14.0"}
+  "dune"        {>= "3.5.0"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/bstr/releases/download/v0.0.4/bstr-0.0.4.tbz"
+  checksum: [
+    "sha256=640836f15b2d555bdf2366f6d7783926e11598ad7e94557b167c785b255f4856"
+    "sha512=1954727f1a386c9909996cdabc1a3b150c23361a96e5632280b0f6e6faf8f0ab6a7ca974352378e757c5136375eb5a53235f95caa69e982f48d3a49907948ddd"
+  ]
+}
+x-commit-hash: "1ec658c8ac3a4bd67a004d41b7c5e6089f586fdf"

--- a/packages/slice/slice.0.0.4/opam
+++ b/packages/slice/slice.0.0.4/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://git.robur.coop/robur/bstr"
+bug-reports:  "https://git.robur.coop/robur/bstr"
+dev-repo:     "git+https://github.com/robur-coop/bstr"
+doc:          "https://robur-coop.github.io/bstr/"
+license:      "MIT"
+synopsis:     "A Slice type for bigstrings and bytes"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.14.0"}
+  "dune"        {>= "3.5.0"}
+  "bstr"        {= version}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/bstr/releases/download/v0.0.4/bstr-0.0.4.tbz"
+  checksum: [
+    "sha256=640836f15b2d555bdf2366f6d7783926e11598ad7e94557b167c785b255f4856"
+    "sha512=1954727f1a386c9909996cdabc1a3b150c23361a96e5632280b0f6e6faf8f0ab6a7ca974352378e757c5136375eb5a53235f95caa69e982f48d3a49907948ddd"
+  ]
+}
+x-commit-hash: "1ec658c8ac3a4bd67a004d41b7c5e6089f586fdf"


### PR DESCRIPTION
A simple library for bigstrings

- Project page: <a href="https://git.robur.coop/robur/bstr">https://git.robur.coop/robur/bstr</a>
- Documentation: <a href="https://robur-coop.github.io/bstr/">https://robur-coop.github.io/bstr/</a>

##### CHANGES:

- Fix compilation of our C stubs (spotted by @hannesm, fixed by @dinosaure, [robur-coop/bstr#10][10])

[10]: https://git.robur.coop/robur/bstr/pulls/10
