### PR TITLE
[new release] passage (0.3.2)

### DIFF
--- a/packages/passage/passage.0.3.2/opam
+++ b/packages/passage/passage.0.3.2/opam
@@ -18,7 +18,7 @@ depends: [
   "ppx_expect" {with-test}
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "qrc"
-  "re"
+  "re" {>= "1.14.0"}
   "sedlex"
   "odoc" {with-doc}
 ]
@@ -32,7 +32,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]
@@ -48,7 +47,9 @@ x-ci-accept-failures: [
   "fedora-41"
   "fedora-42"
   "fedora-43"
+  "freebsd-14.3"
   "opensuse-15.6"
+  "opensuse-16.0"
   "opensuse-tumbleweed"
 ]
 url {


### PR DESCRIPTION
Passage - used to store and manage access to shared secrets

- Project page: <a href="https://github.com/ahrefs/passage">https://github.com/ahrefs/passage</a>

##### CHANGES:

remove `devkit` dependency
remove `re2` dependency, use `re` instead
mark ppx-expect as `with-test`
