### PR TITLE
Package shibboleth.0.0.4

### DIFF
--- a/packages/shibboleth/shibboleth.0.0.4/opam
+++ b/packages/shibboleth/shibboleth.0.0.4/opam
@@ -22,6 +22,7 @@ depends: [
   "ocamlformat"
   "re"
   "fmt"
+  "ez_file"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
### `shibboleth.0.0.4`
A converter between SML and OCaml
A tool that converts Standard ML code to OCaml code and vice versa, facilitating interoperability between the two languages.



---
* Homepage: https://github.com/wizard7377/sml-ocaml-converter
* Source repo: git+https://github.com/wizard7377/sml-ocaml-converter.git
* Bug tracker: https://github.com/wizard7377/sml-ocaml-converter/issues

---
:camel: Pull-request generated by opam-publish v2.7.1