### PR TITLE
ocaml: update 5.5.0+trunk package

### DIFF
--- a/packages/ocaml-compiler/ocaml-compiler.5.5/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.5/opam
@@ -16,7 +16,7 @@ authors: [
 ]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.5"
 depends: [
   # This is OCaml 5.5.0
   "ocaml" {= "5.5.0" & post}
@@ -115,7 +115,7 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/5.5.tar.gz"
 }
 depopts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-variants/ocaml-variants.5.5.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.5.0+trunk/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
-synopsis: "Current trunk"
+synopsis: "Latest 5.5 development"
 maintainer: [
   "David Allsopp <david@tarides.com>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
@@ -16,7 +16,7 @@ authors: [
 ]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.5"
 depends: [
   "ocaml-compiler" {= "5.5"}
 


### PR DESCRIPTION
This PR updates the 5.5 compiler and ocaml-variants.5.5.0+trunk to point towards the newly created 5.5 branch of the compiler.

I will update the main branch of the compiler once this is merged in order to ensure that there are no version mismatch between the opam package and the in-tree version.