### PR TITLE
notty-community fails to build on windows

### DIFF
--- a/packages/notty-community/notty-community.0.2.4/opam
+++ b/packages/notty-community/notty-community.0.2.4/opam
@@ -42,6 +42,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: os != "win32"
 dev-repo: "git+https://github.com/ocaml-community/notty-community.git"
 url {
   src:


### PR DESCRIPTION
```
=== ERROR while compiling notty-community.0.2.4 ==============================
 context     2.5.0 | win32/x86_64 | ocaml.5.4.0 | file://D:/a/opam-repository/opam-repository
 path        D:\opamroot\default\.opam-switch\build\notty-community.0.2.4
 command     D:\opamroot\default\bin\dune.exe build -p notty-community -j 3 @install
 exit-code   1
 env-file    D:\opamroot\log\notty-community-9852-6eb665.env
 output-file D:\opamroot\log\notty-community-9852-6eb665.out
=== output ===
 File "src-unix/dune", line 8, characters 11-18:
 8 |     (names winsize)
                ^^^^^^^
 (cd _build/default/src-unix && D:\opamroot\default\bin\x86_64-w64-mingw32-gcc.exe -O2 -fno-strict-aliasing -fwrapv -mms-bitfields -Wall -fdiagnostics-color=always -Wall -Wextra -O3 -g -I D:/opamroot/default/lib/ocaml -I D:/opamroot/default/lib/ocaml\unix -I D:\opamroot\default\lib\uutf -I ../src -o winsize.o -c native/winsize.c)
 native/winsize.c:1:10: fatal error: sys/ioctl.h: No such file or directory
     1 | #include <sys/ioctl.h>
       |          ^~~~~~~~~~~~~
 compilation terminated.
```

as seen on the CI results of https://github.com/ocaml/opam-repository/pull/29265