### PR TITLE
[new release] csexp-query (0.1.0)

### DIFF
--- a/packages/csexp-query/csexp-query.0.1.0/opam
+++ b/packages/csexp-query/csexp-query.0.1.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Query tool for canonical s-expressions"
+description: """
+A minimal CLI tool to query csexp input using sexp-compatible query syntax.
+"""
+maintainer: "Josh Berdine <josh@berdine.net>"
+authors: ["Josh Berdine <josh@berdine.net>"]
+license: "MIT"
+homepage: "https://github.com/jberdine/csexp-query"
+bug-reports: "https://github.com/jberdine/csexp-query/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {build}
+  "csexp"
+  "dune-build-info"
+  "ppx_expect" {with-test}
+]
+build: [["%{make}%" "install"]]
+run-test: [["%{make}%" "test"]]
+dev-repo: "git+https://github.com/jberdine/csexp-query.git"
+url {
+  src:
+    "https://github.com/jberdine/csexp-query/releases/download/untagged-441870f7bc8eb1c6cf5a/csexp-query-0.1.0.tbz"
+  checksum: [
+    "sha256=4e60bc0ad8912c1629852cafc15ec3d3eb938420286734126269815be4f86b42"
+    "sha512=771a96c0ff3447d0e3d8a15ea7c6ff24ec0096d3ecee90070a2e4419aa40b143070e8de7bfe2f5ecde5d2ee827bd70781edf403ca6b37a41acb9a39267be3045"
+  ]
+}
+x-commit-hash: "e3881629118c198e83a3ecdb45b34e3d5bde4db0"


### PR DESCRIPTION
Query tool for canonical s-expressions

- Project page: <a href="https://github.com/jberdine/csexp-query">https://github.com/jberdine/csexp-query</a>

##### CHANGES:

Initial release.

- Query operations: field, index, each, pipe, cat, this
- Reads csexp from stdin, outputs standard sexp
