### PR TITLE
[new release] csexp-query (0.1.0)

### DIFF
--- a/packages/csexp-query/csexp-query.0.1.0/opam
+++ b/packages/csexp-query/csexp-query.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Query tool for canonical s-expressions"
+description: """
+A minimal CLI tool to query csexp input using sexp-compatible query syntax.
+"""
+maintainer: "Josh Berdine <josh@berdine.net>"
+authors: ["Josh Berdine <josh@berdine.net>"]
+license: "MIT"
+homepage: "https://github.com/jberdine/csexp-query"
+bug-reports: "https://github.com/jberdine/csexp-query/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune"
+  "csexp"
+  "dune-build-info"
+  "ppx_expect" {with-test}
+]
+build: [
+  ["touch" "empty"]
+  ["dune" "build" "-p" name "-j" jobs "--workspace=empty"]
+  ["rm" "empty"]
+]
+run-test: [
+  ["touch" "empty"]
+  ["dune" "runtest" "-p" name "-j" jobs "--workspace=empty"]
+  ["rm" "empty"]
+]
+dev-repo: "git+https://github.com/jberdine/csexp-query.git"
+url {
+  src:
+    "https://github.com/jberdine/csexp-query/releases/download/untagged-ae7530690de04b37f146/csexp-query-0.1.0.tbz"
+  checksum: [
+    "sha256=d6473ef191b835172740b9e99285d41b6adee77baaf069ed833a711ec314052a"
+    "sha512=c7e4a4dcef2b57a60b6795718e2bb1e2992ff5ef05a86c12ed616d23d9f2fb071907907720ac087901b512a1e5d4b7042cd065777926239cfc6400a83dabcb25"
+  ]
+}
+x-commit-hash: "8fa0d962d930e7e127f9fa685ff9558db8baba7c"


### PR DESCRIPTION
Query tool for canonical s-expressions

- Project page: <a href="https://github.com/jberdine/csexp-query">https://github.com/jberdine/csexp-query</a>

##### CHANGES:

Initial release.

- Query operations: field, index, each, pipe, cat, this
- Reads csexp from stdin, outputs standard sexp
