### PR TITLE
[new release] csexp-query (0.1.0)

### DIFF
--- a/packages/csexp-query/csexp-query.0.1.0/opam
+++ b/packages/csexp-query/csexp-query.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Query tool for canonical s-expressions"
+description: """
+A minimal CLI tool to query csexp input using sexp-compatible query syntax.
+"""
+maintainer: "Josh Berdine <josh@berdine.net>"
+authors: ["Josh Berdine <josh@berdine.net>"]
+license: "MIT"
+homepage: "https://github.com/jberdine/csexp-query"
+bug-reports: "https://github.com/jberdine/csexp-query/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune"
+  "csexp"
+  "dune-build-info"
+  "ppx_expect" {with-test}
+]
+build: [
+  ["touch" "empty"]
+  ["dune" "build" "-p" name "-j" jobs "--workspace=empty"]
+  ["rm" "empty"]
+]
+run-test: [
+  ["touch" "empty"]
+  ["dune" "runtest" "-p" name "-j" jobs "--workspace=empty"]
+  ["rm" "empty"]
+]
+dev-repo: "git+https://github.com/jberdine/csexp-query.git"
+url {
+  src:
+    "https://github.com/jberdine/csexp-query/releases/download/0.1.0/csexp-query-0.1.0.tbz"
+  checksum: [
+    "sha256=5e42f84c168b58adc71a5e79c9d388da077b1c88b6b4489d3ae065cfcd458835"
+    "sha512=1d08b5491856d05347125fa32d56200e0ca97d1a4c7b6e3164a85817dca858c27cf401b2c1f7f7d02632c38a95ab1ed37721373485b202e210dfdf41703f6178"
+  ]
+}
+x-commit-hash: "6d8027b729d5a74dcad79b7df3ac11cbf7968383"


### PR DESCRIPTION
Query tool for canonical s-expressions

- Project page: <a href="https://github.com/jberdine/csexp-query">https://github.com/jberdine/csexp-query</a>

##### CHANGES:

Initial release.

- Query operations: field, index, each, pipe, cat, this
- Reads csexp from stdin, outputs standard sexp
