### PR TITLE
[new release]: shakuhachi (0.2.0)

### DIFF
--- a/packages/shakuhachi/shakuhachi.0.2.0/opam
+++ b/packages/shakuhachi/shakuhachi.0.2.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "A music collection manager"
+description: """
+shakuhachi is mainly a music collection manager but it's also a music tagger.
+ It aims to be a rather simple collection manager extensible by plugins."""
+maintainer: ["EruEri <nayinayu@mailo.com>"]
+authors: ["EruEri <nayinayu@mailo.com>"]
+license: "GPL-3.0-or-later AND MPL-2.0"
+tags: ["music collection" "music tagger"]
+homepage: "https://codeberg.org/EruEri/shakuhachi"
+bug-reports: "https://codeberg.org/EruEri/shakuhachi/issues"
+depends: [
+  "dune" {>= "3.17.2"}
+  "ocaml" {>= "4.14.0"}
+  "xdg"
+  "angstrom" {>= "0.15.0"}
+  "cmdliner" {>= "1.1.0"}
+  "sqlite3" {>= "5.1.0"}
+  "re" {>= "1.10.3"}
+  "otaglibc" {>= "0.1.0"}
+  "uunf" {>= "15.1.0"}
+  "magic-mime" {>= "1.3.0"}
+  "ppx_deriving_yojson" {>= "3.5.3"}
+  "yojson" {>= "2.0.0"}
+  "qcheck" {<= "0.27" & with-test}
+  "qcheck-alcotest" {with-test}
+  "alcotest" {with-test}
+  "fmt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://codeberg.org/EruEri/shakuhachi.git"
+x-maintenance-intent: ["(latest)"]
+
+url {
+  src: "https://codeberg.org/EruEri/shakuhachi/archive/0.2.0.tar.gz"
+  checksum: [
+    "sha256=966fc8667c2aa9830e64950d2de74bd564a65d60e1f50cfd3dc1e99ef106dc47"
+    "sha512=6423ce04d784ba521a7f49fabdafbe036e2dd80cd08ca999fdc6767262d7f12aa4e5002d65efd4c568b343eaabf4d680191c88334d629e1ca0156084531e9e0b"
+  ]
+}


### PR DESCRIPTION
shakuhachi - a music collection manager
  - Project page: https://codeberg.org/EruEri/shakuhachi

**CHANGELOG**:
- misc : LICENSES
	- ocaml libraries installled with skhc : GPL-3.0-or-later -> MPL-2.0
- fix  : move _artist's artwork_ and _album's cover_ on modify.
- misc : always print to stderr warning (ignore _quiet_ flag).
- feat : parameterize _artist's artwork_ and _album's cover_ filename in  
configuration file instead of hardcoding. 
- fix : improve `TRACKNUMBER` metadata parsing.
- fix : plugin's name mismatch between config section name and plugin code
- fix : forgotten variable population.
	- BREAKING 
		- artist %title : Artist name -> not populated

### API CHANGES
- Added functions
	- _SkhcConfig.Plugin.init_
	- _SkhcConfig.Section.to\_string_
	- _SkhcConfig.Section.pp_
	- _SkhcConfig.Format.artist\_artwork_
	- _SkhcConfig.Format.album\_cover_
	
- Added modules
	- _Skhclibs.Format_

- Modified functions
	- _SkhcConfig.Format.init_
