### PR TITLE
Package print-table.0.1.1

### DIFF
--- a/packages/print-table/print-table.0.1.1/opam
+++ b/packages/print-table/print-table.0.1.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Simple Unicode/ANSI and Markdown text table rendering"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "ISC"
+homepage: "https://github.com/mbarbin/print-table"
+doc: "https://mbarbin.github.io/print-table/"
+bug-reports: "https://github.com/mbarbin/print-table/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/print-table.git"
+description: """\
+
+print-table provides a minimal library for rendering text tables
+with Unicode box-drawing characters and optional ANSI colors, or as
+GitHub-flavored Markdown.
+
+The API is straightforward and declarative, designed for readable
+tables in command-line tools, tests, and tutorials.
+
+This library has taken some inspiration from 2 existing and more
+feature-complete libraries, which we link to here for more advanced
+usages: see [printbox] and [ascii_table].
+
+[printbox]: https://github.com/c-cube/printbox
+[ascii_table]: https://github.com/janestreet/textutils
+
+"""
+tags: [ "table" "markdown" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/print-table/releases/download/0.1.1/print-table-0.1.1.tbz"
+  checksum: [
+    "sha256=90192fa2852e812cc91d82228b4b30009a3a79504b05da186f7ed1e9deffb547"
+    "sha512=2d21392fc79b88ef77b5f45589c392b99f54ba7332e6e15acf5851fa134308223922e1051780dde5091d32a939f2478c8c3603a540d6940f23eaed892f4b8c50"
+  ]
+}
+x-commit-hash: "ee71f02377d93aedd3c41b77541f5306815f5ab5"


### PR DESCRIPTION
### `print-table.0.1.1`
Simple Unicode/ANSI and Markdown text table rendering
print-table provides a minimal library for rendering text tables
with Unicode box-drawing characters and optional ANSI colors, or as
GitHub-flavored Markdown.

The API is straightforward and declarative, designed for readable
tables in command-line tools, tests, and tutorials.

This library has taken some inspiration from 2 existing and more
feature-complete libraries, which we link to here for more advanced
usages: see [printbox] and [ascii_table].

[printbox]: https://github.com/c-cube/printbox
[ascii_table]: https://github.com/janestreet/textutils



---
* Homepage: https://github.com/mbarbin/print-table
* Source repo: git+https://github.com/mbarbin/print-table.git
* Bug tracker: https://github.com/mbarbin/print-table/issues

---
## 0.1.1 (2026-01-24)

This patch release brings internal changes only, with an improvement to the distribution process (immutable releases).

### Added

- Experimental CI workflow based on `setup-dune` ([#9](https://github.com/mbarbin/print-table/pull/9), [#10](https://github.com/mbarbin/print-table/pull/10), @mbarbin).
- Add dunolint workflow ([#7](https://github.com/mbarbin/print-table/pull/7), @mbarbin).

### Changed

- Switch to GitHub immutable releases for distribution (@mbarbin).
- Refactor internal directory structure ([#6](https://github.com/mbarbin/print-table/pull/6), @mbarbin).
- Internal cleanup of tests and dev dependencies ([#4](https://github.com/mbarbin/print-table/pull/4), [#8](https://github.com/mbarbin/print-table/pull/8), @mbarbin).


---
:camel: Pull-request generated by opam-publish v2.7.1