### PR TITLE
[new release] capnp-rpc (3 packages) (2.1.1)

### DIFF
--- a/packages/capnp-rpc-net/capnp-rpc-net.2.1.1/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.2.1.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides support for using Cap'n Proto services over a network,
+optionally using TLS."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "5.2"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.6.0"}
+  "capnp-rpc" {= version}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "cstruct" {>= "6.0.0"}
+  "tls-eio" {>= "1.0.2"}
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "prometheus" {>= "0.5"}
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "1.0.3"}
+  "dune" {>= "3.16"}
+  "mirage-crypto" {>= "1.2.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v2.1.1/capnp-rpc-2.1.1.tbz"
+  checksum: [
+    "sha256=6e9675034c8eac5873ed511f9b968db5223278145bb02ac4a970053a53970a48"
+    "sha512=2e2eb8389071bdad3ceef1d15200bf28987f13319f754f4d1603828d0d79202b4de90a6eb294f12ee088c7e3b73755286fbe7076b8fd3d0b29644221e0e7e080"
+  ]
+}
+x-commit-hash: "9cab53f15be0d38e76e11ef9478a0a8e5c169db4"

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.2.1.1/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.2.1.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+doc: "https://mirage.github.io/capnp-rpc/"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+depends: [
+  "ocaml" {>= "5.2"}
+  "capnp-rpc-net" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "cstruct" {>= "6.2.0"}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "extunix"
+  "base64" {>= "3.0.0"}
+  "dune" {>= "3.16"}
+  "ipaddr" {>= "5.3.0" }
+  "alcotest" {>= "1.6.0" & with-test}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "mdx" {>= "2.4.1" & with-test}
+  "eio_main" {with-test}
+  "eio" {>= "1.2"}
+]
+conflicts: [
+  "jbuilder"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v2.1.1/capnp-rpc-2.1.1.tbz"
+  checksum: [
+    "sha256=6e9675034c8eac5873ed511f9b968db5223278145bb02ac4a970053a53970a48"
+    "sha512=2e2eb8389071bdad3ceef1d15200bf28987f13319f754f4d1603828d0d79202b4de90a6eb294f12ee088c7e3b73755286fbe7076b8fd3d0b29644221e0e7e080"
+  ]
+}
+x-commit-hash: "9cab53f15be0d38e76e11ef9478a0a8e5c169db4"

--- a/packages/capnp-rpc/capnp-rpc.2.1.1/opam
+++ b/packages/capnp-rpc/capnp-rpc.2.1.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Eio for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "5.2"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.6.0"}
+  "stdint" {>= "0.6.0"}
+  "eio" {>= "1.2"}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "uri" {>= "1.6.0"}
+  "dune" {>= "3.16"}
+  "alcotest" {>= "1.6.0" & with-test}
+  "afl-persistent" {with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v2.1.1/capnp-rpc-2.1.1.tbz"
+  checksum: [
+    "sha256=6e9675034c8eac5873ed511f9b968db5223278145bb02ac4a970053a53970a48"
+    "sha512=2e2eb8389071bdad3ceef1d15200bf28987f13319f754f4d1603828d0d79202b4de90a6eb294f12ee088c7e3b73755286fbe7076b8fd3d0b29644221e0e7e080"
+  ]
+}
+x-commit-hash: "9cab53f15be0d38e76e11ef9478a0a8e5c169db4"


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

- Add compatibility with cmdliner 2.0+ (@avsm mirage/capnp-rpc#317).
