### PR TITLE
Package print-table.0.1.2

### DIFF
--- a/packages/print-table/print-table.0.1.2/opam
+++ b/packages/print-table/print-table.0.1.2/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Simple Unicode/ANSI and Markdown text table rendering"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "ISC"
+homepage: "https://github.com/mbarbin/print-table"
+doc: "https://mbarbin.github.io/print-table/"
+bug-reports: "https://github.com/mbarbin/print-table/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/print-table.git"
+description: """\
+
+print-table provides a minimal library for rendering text tables
+with Unicode box-drawing characters and optional ANSI colors, or as
+GitHub-flavored Markdown.
+
+The API is straightforward and declarative, designed for readable
+tables in command-line tools, tests, and tutorials.
+
+This library has taken some inspiration from 2 existing and more
+feature-complete libraries, which we link to here for more advanced
+usages: see [printbox] and [ascii_table].
+
+[printbox]: https://github.com/c-cube/printbox
+[ascii_table]: https://github.com/janestreet/textutils
+
+"""
+tags: [ "table" "markdown" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/print-table/releases/download/0.1.2/print-table-0.1.2.tbz"
+  checksum: [
+    "sha256=ce9e3047ba1615a0e1c0db460cdd9c85fad1e993c5abd8af2a77cd64da836ee5"
+    "sha512=dd05d18c5709642fec76d6ba3bcc49a3566e41d3bbf886acf005b6d43b3873f0d539d43eae5360f3bef15a06728565c358baa75cdcf0ddeadd639de485d98c13"
+  ]
+}
+x-commit-hash: "6a462bda6ad7f1a048b4f1a5e0600fb32fcc2f35"


### PR DESCRIPTION
### `print-table.0.1.2`
Simple Unicode/ANSI and Markdown text table rendering
print-table provides a minimal library for rendering text tables
with Unicode box-drawing characters and optional ANSI colors, or as
GitHub-flavored Markdown.

The API is straightforward and declarative, designed for readable
tables in command-line tools, tests, and tutorials.

This library has taken some inspiration from 2 existing and more
feature-complete libraries, which we link to here for more advanced
usages: see [printbox] and [ascii_table].

[printbox]: https://github.com/c-cube/printbox
[ascii_table]: https://github.com/janestreet/textutils



---
* Homepage: https://github.com/mbarbin/print-table
* Source repo: git+https://github.com/mbarbin/print-table.git
* Bug tracker: https://github.com/mbarbin/print-table/issues

---
## 0.1.2 (2026-01-25)

### Fixed

- Unify dune lang of `dune-workspace` with `dune-project` to fix opam CI (@mbarbin).

## 0.1.1 (2026-01-24)

This patch release brings internal changes only, with an improvement to the distribution process (immutable releases).

### Added

- Experimental CI workflow based on `setup-dune` ([#9](https://github.com/mbarbin/print-table/pull/9), [#10](https://github.com/mbarbin/print-table/pull/10), @mbarbin).
- Add dunolint workflow ([#7](https://github.com/mbarbin/print-table/pull/7), @mbarbin).

### Changed

- Switch to GitHub immutable releases for distribution (@mbarbin).
- Refactor internal directory structure ([#6](https://github.com/mbarbin/print-table/pull/6), @mbarbin).
- Internal cleanup of tests and dev dependencies ([#4](https://github.com/mbarbin/print-table/pull/4), [#8](https://github.com/mbarbin/print-table/pull/8), @mbarbin).


---
:camel: Pull-request generated by opam-publish v2.7.1