### PR TITLE
[new release] miou (0.5.2)

### DIFF
--- a/packages/miou/miou.0.5.2/opam
+++ b/packages/miou/miou.0.5.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/robur-coop/miou"
+bug-reports:  "https://github.com/robur-coop/miou/issues"
+dev-repo:     "git+https://github.com/robur-coop/miou.git"
+doc:          "https://docs.osau.re/miou/"
+license:      "MIT"
+synopsis:     "Composable concurrency primitives for OCaml"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"             {>= "5.0.0"}
+  "dune"              {>= "3.13.0"}
+  "dune-configurator"
+  "dscheck"           {with-test & >= "0.4.0"}
+  "digestif"          {with-test}
+  "happy-eyeballs"    {with-test & >= "0.6.0"}
+  "dns-client"        {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test}
+  "ipaddr"            {with-test}
+  "logs"              {with-test & >= "0.7.0"}
+  "dns"               {with-test}
+  "dns-client"        {with-test}
+  "mtime"             {with-test & >= "2.0.0"}
+  "ocamlformat"       {with-dev-setup & = "0.27.0"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/miou/releases/download/v0.5.2/miou-0.5.2.tbz"
+  checksum: [
+    "sha256=7895fd48e0fce4e20eb021d6db6c931aa8ef4ce9933bbb08f65a2cb1dda35020"
+    "sha512=7e1fd4c6d40ec8aaa5a4e04dc30ec5ec3bc5795d25a226b0a74bd51a170a075e734873db4b17716d6627cc81d21a21910eb3f0cfd05e081deda764cd405c83eb"
+  ]
+}
+x-commit-hash: "dd40e46d32f29c3db005295954a9cc1d8705df1f"


### PR DESCRIPTION
Composable concurrency primitives for OCaml

- Project page: <a href="https://github.com/robur-coop/miou">https://github.com/robur-coop/miou</a>
- Documentation: <a href="https://docs.osau.re/miou/">https://docs.osau.re/miou/</a>

##### CHANGES:

- Add the Windows support (from our old `Unix.select` implementation)
  (@dinosaure, robur-coop/miou#94)
- Use `-Werror` only on the released mode (@dinosaure, robur-coop/miou#93)
