### PR TITLE
Package loc.0.3.3

### DIFF
--- a/packages/loc/loc.0.3.3/opam
+++ b/packages/loc/loc.0.3.3/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Representing ranges of lexing positions from parsed files"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/loc"
+doc: "https://mbarbin.github.io/loc/"
+bug-reports: "https://github.com/mbarbin/loc/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "dyn" {>= "3.17"}
+  "fpath" {>= "0.7.3"}
+  "sexplib0" {>= "v0.16"}
+  "stdune" {>= "3.17"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/loc.git"
+description: """\
+
+Loc is an OCaml library for manipulating code locations, which are
+ranges of lexing positions from a parsed file.
+
+Attaching locations to nodes manipulated by programs can be useful for
+various applications such as compilers, interpreters, linters, and
+refactoring tools.
+
+"""
+tags: [ "code-locations" "lexing" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/loc/releases/download/0.3.3/loc-0.3.3.tbz"
+  checksum: [
+    "sha256=d1894623628948203f77a932d7a41a2730b17894cc79b6a7488e55f254b0bb3c"
+    "sha512=e7a4a0380687d6f06277e3c08977278f4ef1e8ab1a226b1665295ae9fd94ba080576fe9d3ae46c071132326a25fb0793b190e8ca80c958c66c16b808323f779e"
+  ]
+}
+x-commit-hash: "f6bcceb9022075e94b0ab411b60ffa7107b5a8a6"


### PR DESCRIPTION
### `loc.0.3.3`
Representing ranges of lexing positions from parsed files
Loc is an OCaml library for manipulating code locations, which are
ranges of lexing positions from a parsed file.

Attaching locations to nodes manipulated by programs can be useful for
various applications such as compilers, interpreters, linters, and
refactoring tools.



---
* Homepage: https://github.com/mbarbin/loc
* Source repo: git+https://github.com/mbarbin/loc.git
* Bug tracker: https://github.com/mbarbin/loc/issues

---
## 0.3.3 (2026-01-25)

This patch release brings internal changes only, with an improvement to the distribution process (immutable releases).

### Added

- Add more CI workflows based on `setup-dune` (@mbarbin).

### Changed

- Improved CI scripts; upgrade and pin CI dependencies (@mbarbin).

## 0.3.2 (2025-12-22)

### Added

- Add support to generate `Dyn` values for most types ([#18](https://github.com/mbarbin/loc/pull/18), @mbarbin).
- Enable OCaml `5.4` in CI ([#17](https://github.com/mbarbin/loc/pull/17), @mbarbin).
- Added SPDX-License headers to source files (a1897699, @mbarbin).
- Add new workflow based on `setup-dune` ([#13](https://github.com/mbarbin/loc/pull/13), @mbarbin).

### Changed

- Experiment with CI based on setup-dune ([#21](https://github.com/mbarbin/loc/pull/21), @mbarbin).
- Reduce test dependencies ([#20](https://github.com/mbarbin/loc/pull/20), @mbarbin).
- Simplify handling of dev dependencies ([#16](https://github.com/mbarbin/loc/pull/16), @mbarbin).
- Internal changes to improve the CI & test `setup-dune` ([#14](https://github.com/mbarbin/loc/pull/14), @mbarbin).

## 0.3.1 (2025-07-29)

### Changed

- Internal `ppx_js_style` configuration change (allow let-operators) (@mbarbin).
- Removed pkg upper bounds by default unless there is a known issue (@mbarbin).

### Fixed

- Enable `implicit_transitive_deps` depending on OCaml version (@mbarbin).

## 0.3.0 (2025-03-15)

### Changed

- Required `dune.3.17` (@mbarbin).

### Deprecated

- Deprecate `Loc.in_file` and `Loc.in_file_line` and add `ocamlmig` migration annotations ([#11](https://github.com/mbarbin/loc/pull/11), @mbarbin, @v-gb).


---
:camel: Pull-request generated by opam-publish v2.7.1