### PR TITLE
Package mset.0.1.0

### DIFF
--- a/packages/mset/mset.0.1.0/opam
+++ b/packages/mset/mset.0.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jean-Christophe.Filliatre@cnrs.fr"
+authors: "Jean-Christophe Filliâtre"
+synopsis: "A library for small multisets"
+description: "Implements small multisets using bitmaps."
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/backtracking/mset"
+doc: "https://backtracking.github.io/mset"
+bug-reports: "https://github.com/backtracking/mset/issues"
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/backtracking/mset.git"
+url {
+  src: "https://github.com/backtracking/mset/archive/refs/tags/0.1.0.tar.gz"
+  checksum: [
+    "md5=270d9a908f20a07e5e95107c9c85cf9f"
+    "sha512=26d1fd50db51c50490f30de68c3b76970774d6d46df65fe175a79d410ad1b2be0d4cdaf79e758552b19ee7da630f8c74980a38ac20026eaf8827337e49b38e3b"
+  ]
+}


### PR DESCRIPTION
### `mset.0.1.0`
A library for small multisets
Implements small multisets using bitmaps.



---
* Homepage: https://github.com/backtracking/mset
* Source repo: git+https://github.com/backtracking/mset.git
* Bug tracker: https://github.com/backtracking/mset/issues

---
:camel: Pull-request generated by opam-publish v2.3.0