### PR TITLE
[new release] react-rules-of-hooks-ppx (1.0.0)

### DIFF
--- a/packages/react-rules-of-hooks-ppx/react-rules-of-hooks-ppx.1.0.0/opam
+++ b/packages/react-rules-of-hooks-ppx/react-rules-of-hooks-ppx.1.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "This ppx validates the rules of React hooks in reason-react components"
+description:
+  "Validates exhaustive dependencies in useEffect, useLayoutEffect, useInsertionEffect, useCallback, useMemo and ensures hooks are called at the top level, never conditionally or inside loops."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx"
+bug-reports:
+  "https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "ppxlib" {>= "0.36.0"}
+  "reason" {with-test & >= "3.10.0"}
+  "melange" {with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "mlx" {with-dev-setup}
+  "ocamlformat-mlx" {with-dev-setup}
+  "ocamlmerlin-mlx" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo:
+  "git+https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx.git"
+url {
+  src:
+    "https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx/releases/download/1.0.0/react-rules-of-hooks-ppx-1.0.0.tbz"
+  checksum: [
+    "sha256=6b7fdca0f32c2f05f1480db5a0b85e0726cdb1ed3d7136054a4071b4d41a8188"
+    "sha512=18b51e6a70b6cfa31cc00e8f5601ed6fe85456c5388dc41f1cc7ed21830b8ca737f3e1dff47f8736aa5553b0e463f6f8dcac165e328b5c0a1590507e1bd3ed3d"
+  ]
+}
+x-commit-hash: "68c568b38da8a9e60d9b424a18de3e768865b80c"


### PR DESCRIPTION
This ppx validates the rules of React hooks in reason-react components

- Project page: <a href="https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx">https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx</a>

##### CHANGES:

- Detect hooks called conditionally, in loops, or in nested functions
- Detect hooks called outside of `[@react.component]` functions or custom hooks
- Check exhaustive dependencies in `useEffect`, `useMemo`, `useCallback`, `useLayoutEffect`, and `useInsertionEffect`
- Disable order of hooks check globally with `-order-of-hooks` ppx flag
- Disable exhaustive deps check globally with `-exhaustive-deps` ppx flag
- Suppress exhaustive deps warning locally with `[@disable_exhaustive_deps]` attribute
- `-corrections` flag to generate `.ppx-corrected` files with suggested fixes for missing dependencies
