### PR TITLE
[new release] lrgrep (0.3)

### DIFF
--- a/packages/lrgrep/lrgrep.0.3/opam
+++ b/packages/lrgrep/lrgrep.0.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/lrgrep"
+bug-reports: "https://github.com/let-def/lrgrep"
+license: "ISC"
+dev-repo: "git+https://github.com/let-def/lrgrep.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0.0"}
+  "menhir" {>= "20231231"}
+  "cmon" {>= "0.2"}
+]
+synopsis: "Analyse the stack of a Menhir-generated LR parser using regular expressions"
+url {
+  src:
+    "https://github.com/let-def/lrgrep/releases/download/v0.3/lrgrep-0.3.tbz"
+  checksum: [
+    "sha256=84a1874d0c063da371e19c84243aac7c40bfcb9aaf204251e0eb0d1f077f2cde"
+    "sha512=5a16ff42a196fd741bc64a1bdd45b4dca0098633e73aa665829a44625ec15382891c3643fa210dbe3704336eab095d4024e093e37ae5313810f6754de6119d55"
+  ]
+}
+x-commit-hash: "43a5cbad7de01a88427431682f327017cc67b3f2"


### PR DESCRIPTION
Analyse the stack of a Menhir-generated LR parser using regular expressions

- Project page: <a href="https://github.com/let-def/lrgrep">https://github.com/let-def/lrgrep</a>

##### CHANGES:

First release published on Opam.
Main functionalities are working: compiler, interpreter, coverage, enumeration and .messages importer.

Main features missing for stable release:
- enumeration and coverage reports miss some ϵ-reductions
- reports are not provided in a processing-friendly format (most probably JSON)
- the frontend is grammar agnostic and use symbol names; I would like to provide a public functor to easily make LRgrep frontends specialized for a concrete lexical syntax
- documentation and tutorial
- applications to O(x)Caml are not ready, application to (Mini-)Elm has not been merged yet
