### PR TITLE
Add a menhir upper bound on libsail 0.15-0.20.1

### DIFF
--- a/packages/libsail/libsail.0.15/opam
+++ b/packages/libsail/libsail.0.15/opam
@@ -31,7 +31,7 @@ depends: [
   "ocaml" {< "5.3"}
   "dune" {>= "3.0"}
   "dune-site" {>= "3.0.2"}
-  "menhir" {build & >= "20180523"}
+  "menhir" {build & >= "20180523" & < "20260122"}
   "ott" {>= "0.28" & build}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}

--- a/packages/libsail/libsail.0.16/opam
+++ b/packages/libsail/libsail.0.16/opam
@@ -32,7 +32,7 @@ depends: [
   "dune" {>= "3.0"}
   "dune-site" {>= "3.0.2"}
   "bisect_ppx" {dev & >= "2.5.0"}
-  "menhir" {>= "20180523" & build}
+  "menhir" {>= "20180523" & < "20260122" & build}
   "ott" {>= "0.28" & build}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}

--- a/packages/libsail/libsail.0.17.1/opam
+++ b/packages/libsail/libsail.0.17.1/opam
@@ -32,7 +32,7 @@ depends: [
   "dune" {>= "3.0"}
   "dune-site" {>= "3.0.2"}
   "bisect_ppx" {dev & >= "2.5.0"}
-  "menhir" {>= "20180523" & build}
+  "menhir" {>= "20180523" & < "20260122" & build}
   "ott" {>= "0.28" & build}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}

--- a/packages/libsail/libsail.0.18/opam
+++ b/packages/libsail/libsail.0.18/opam
@@ -32,7 +32,7 @@ depends: [
   "dune" {>= "3.0"}
   "dune-site" {>= "3.0.2"}
   "bisect_ppx" {dev & >= "2.5.0"}
-  "menhir" {>= "20240715" & build}
+  "menhir" {>= "20240715" & < "20260122" & build}
   "ott" {>= "0.28" & build}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}

--- a/packages/libsail/libsail.0.19.1/opam
+++ b/packages/libsail/libsail.0.19.1/opam
@@ -31,7 +31,7 @@ depends: [
   "dune" {>= "3.0"}
   "dune-site" {>= "3.0.2"}
   "bisect_ppx" {dev & >= "2.5.0"}
-  "menhir" {>= "20240715" & build}
+  "menhir" {>= "20240715" & < "20260122" & build}
   "ott" {>= "0.28" & build}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}

--- a/packages/libsail/libsail.0.19/opam
+++ b/packages/libsail/libsail.0.19/opam
@@ -31,7 +31,7 @@ depends: [
   "dune" {>= "3.0"}
   "dune-site" {>= "3.0.2"}
   "bisect_ppx" {dev & >= "2.5.0"}
-  "menhir" {>= "20240715" & build}
+  "menhir" {>= "20240715" & < "20260122" & build}
   "ott" {>= "0.28" & build}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}

--- a/packages/libsail/libsail.0.20.1/opam
+++ b/packages/libsail/libsail.0.20.1/opam
@@ -31,7 +31,7 @@ depends: [
   "dune" {>= "3.11"}
   "dune-site" {>= "3.0.2"}
   "bisect_ppx" {dev & >= "2.5.0"}
-  "menhir" {>= "20240715" & build}
+  "menhir" {>= "20240715" & < "20260122" & build}
   "ott" {>= "0.28" & build}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}

--- a/packages/libsail/libsail.0.20/opam
+++ b/packages/libsail/libsail.0.20/opam
@@ -31,7 +31,7 @@ depends: [
   "dune" {>= "3.11"}
   "dune-site" {>= "3.0.2"}
   "bisect_ppx" {dev & >= "2.5.0"}
-  "menhir" {>= "20240715" & build}
+  "menhir" {>= "20240715" & < "20260122" & build}
   "ott" {>= "0.28" & build}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}


### PR DESCRIPTION
As seen on https://github.com/ocaml/opam-repository/pull/29263:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/1b37faa806f25ffae47a4204ac0b15c79fa5a828/variant/compilers,4.14,menhirGLR.20260122,revdeps,sail.0.15
```
#=== ERROR while compiling libsail.0.15 =======================================#
# context              2.5.0 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/libsail.0.15
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p libsail -j 255 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/libsail-7-935afc.env
# output-file          ~/.opam/log/libsail-7-935afc.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/menhir src/lib/parser.mly --base src/lib/parser --infer-write-query src/lib/parser__mock.ml.mock)
# File "src/lib/parser.mly", line 668, characters 0-6:
# Error: this is an OCaml reserved word.
```

Upstream report: https://github.com/rems-project/sail/issues/1603
Upstream fix: https://github.com/rems-project/sail/pull/1604