### PR TITLE
Package calendars.2.0.0

### DIFF
--- a/packages/calendars/calendars.2.0.0/opam
+++ b/packages/calendars/calendars.2.0.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis:
+  "Convert dates between gregorian/julian/french/hebrew/islamic calendars"
+description:
+  "OCaml library to convert dates between gregorian/julian/french/hebrew/islamic calendars. Code is originally from Geneweb."
+maintainer: [
+  "Elie Canonici-Merle <elie.canonicimerle@geneanet.org>"
+  "Olivier Pierre <olivier.pierre@geneanet.org>"
+]
+authors: "Daniel de Rauglaudre"
+license: "GPL-2.0-only"
+tags: [
+  "moon-phase"
+  "gregorian"
+  "julian"
+  "hebrew"
+  "islamic"
+  "french-republican"
+  "calendar"
+  "date"
+]
+homepage: "https://github.com/geneweb/calendars"
+bug-reports: "https://github.com/geneweb/calendars/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/geneweb/calendars.git"
+url {
+  src: "https://github.com/geneweb/calendars/archive/refs/tags/v2.0.0.tar.gz"
+  checksum: [
+    "md5=5a5f5f843a7b03095c4ef061e88c528c"
+    "sha512=a5173392af5c5e6dcbf02fae20ba484667210758f6be64686e0b3874343b4308500a7aca0d43af0b97931d298761d1e2aeceb2ffabd1387f256c9d1561f42939"
+  ]
+}


### PR DESCRIPTION
### `calendars.2.0.0`
Convert dates between gregorian/julian/french/hebrew/islamic calendars
OCaml library to convert dates between gregorian/julian/french/hebrew/islamic calendars. Code is originally from Geneweb.



---
* Homepage: https://github.com/geneweb/calendars
* Source repo: git+https://github.com/geneweb/calendars.git
* Bug tracker: https://github.com/geneweb/calendars/issues

---
:camel: Pull-request generated by opam-publish v2.7.1