### PR TITLE
Add menhir upper bounds to ocamlformat-mlx-lib 0.26.2.0-0.28.1.1

### DIFF
--- a/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.26.2.0/opam
+++ b/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.26.2.0/opam
@@ -24,9 +24,9 @@ depends: [
   "either"
   "fix"
   "fpath"
-  "menhir" {>= "20201216"}
-  "menhirLib" {>= "20201216"}
-  "menhirSdk" {>= "20201216"}
+  "menhir" {>= "20201216" & < "20260112"}
+  "menhirLib" {>= "20201216" & < "20260112"}
+  "menhirSdk" {>= "20201216" & < "20260112"}
   "ocaml-version" {>= "3.5.0"}
   "ocamlformat-rpc-lib" {with-test & = version}
   "ocp-indent" {with-test = "false" & >= "1.8.0" | with-test & >= "1.8.1"}

--- a/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.27.0.1/opam
+++ b/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.27.0.1/opam
@@ -23,9 +23,9 @@ depends: [
   "either"
   "fix"
   "fpath" {>= "0.7.3"}
-  "menhir" {>= "20201216"}
-  "menhirLib" {>= "20201216"}
-  "menhirSdk" {>= "20201216"}
+  "menhir" {>= "20201216" & < "20260112"}
+  "menhirLib" {>= "20201216" & < "20260112"}
+  "menhirSdk" {>= "20201216" & < "20260112"}
   "ocaml-version" {>= "3.5.0"}
   "ocp-indent" {with-test = "false" & >= "1.8.0" | with-test & >= "1.8.1"}
   "stdio"

--- a/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.27.0/opam
+++ b/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.27.0/opam
@@ -23,9 +23,9 @@ depends: [
   "either"
   "fix"
   "fpath" {>= "0.7.3"}
-  "menhir" {>= "20201216"}
-  "menhirLib" {>= "20201216"}
-  "menhirSdk" {>= "20201216"}
+  "menhir" {>= "20201216" & < "20260112"}
+  "menhirLib" {>= "20201216" & < "20260112"}
+  "menhirSdk" {>= "20201216" & < "20260112"}
   "ocaml-version" {>= "3.5.0"}
   "ocp-indent" {with-test = "false" & >= "1.8.0" | with-test & >= "1.8.1"}
   "stdio"

--- a/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.28.1.1/opam
+++ b/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.28.1.1/opam
@@ -23,9 +23,9 @@ depends: [
   "either"
   "fix"
   "fpath" {>= "0.7.3"}
-  "menhir" {>= "20201216"}
-  "menhirLib" {>= "20201216"}
-  "menhirSdk" {>= "20201216"}
+  "menhir" {>= "20201216" & < "20260112"}
+  "menhirLib" {>= "20201216" & < "20260112"}
+  "menhirSdk" {>= "20201216" & < "20260112"}
   "ocaml-version" {>= "3.5.0"}
   "ocp-indent" {with-test = "false" & >= "1.8.0" | with-test & >= "1.8.1"}
   "stdio"


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/29263:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/1b37faa806f25ffae47a4204ac0b15c79fa5a828/variant/compilers,5.4,menhirSdk.20260122,revdeps,ocamlformat-mlx-lib.0.28.1.1
```
#=== ERROR while compiling ocamlformat-mlx-lib.0.28.1.1 =======================#
# context              2.5.0 | linux/x86_64 | ocaml-base-compiler.5.4.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.4/.opam-switch/build/ocamlformat-mlx-lib.0.28.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ocamlformat-mlx-lib -j 255 @install
# exit-code            1
# env-file             ~/.opam/log/ocamlformat-mlx-lib-7-6b4d3e.env
# output-file          ~/.opam/log/ocamlformat-mlx-lib-7-6b4d3e.out
### output ###
# (cd _build/default && /home/opam/.opam/5.4/bin/menhir --lalr --strict --unused-token COMMENT --unused-token DOCSTRING --unused-token EOL --unused-token GREATERRBRACKET --fixed-exception --table --strategy simplified vendor/parser-extended/parser.mly --base vendor/parser-extended/parser)
# File "vendor/parser-extended/parser.mly", line 673, characters 7-16:
# Error: the token LESSSLASH is unused.
# (cd _build/default && /home/opam/.opam/5.4/bin/menhir --lalr --strict --unused-token COMMENT --unused-token DOCSTRING --unused-token EOL --unused-token GREATERRBRACKET --fixed-exception --table --strategy simplified vendor/parser-standard/parser.mly --base vendor/parser-standard/parser)
# File "vendor/parser-standard/parser.mly", line 787, characters 7-16:
# Error: the token LESSSLASH is unused.
```

These fail since menhir's `--strict` mode considers warnings as errors since 20260112:
https://gitlab.inria.fr/fpottier/menhir/-/blob/master/CHANGES.md?ref_type=heads#20260112