### PR TITLE
inotify.2.1 and .2.2: can't install with lwt option

### DIFF
--- a/packages/inotify/inotify.2.1/opam
+++ b/packages/inotify/inotify.2.1/opam
@@ -7,13 +7,12 @@ doc: "http://whitequark.github.io/ocaml-inotify"
 bug-reports: "https://github.com/whitequark/ocaml-inotify/issues"
 dev-repo: "git+https://github.com/whitequark/ocaml-inotify.git"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--%{lwt:enable}%-lwt" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
   [
     "ocaml"
     "setup.ml"
     "-configure"
-    "--%{lwt:enable}%-lwt"
     "--prefix"
     prefix
     "--enable-tests"
@@ -36,9 +35,8 @@ depends: [
   "fileutils" {with-test}
   "ounit" {with-test & >= "2.0.0"}
 ]
-depopts: ["lwt"]
 conflicts: [
-  "lwt" {with-test & >= "5.0.0"}
+  "lwt"
 ]
 available: os = "linux" | os = "macos"
 synopsis: "Inotify bindings for ocaml."

--- a/packages/inotify/inotify.2.2/opam
+++ b/packages/inotify/inotify.2.2/opam
@@ -7,13 +7,12 @@ doc: "http://whitequark.github.io/ocaml-inotify"
 bug-reports: "https://github.com/whitequark/ocaml-inotify/issues"
 dev-repo: "git+https://github.com/whitequark/ocaml-inotify.git"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--%{lwt:enable}%-lwt" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
   [
     "ocaml"
     "setup.ml"
     "-configure"
-    "--%{lwt:enable}%-lwt"
     "--prefix"
     prefix
     "--enable-tests"
@@ -36,9 +35,8 @@ depends: [
   "ocamlbuild" {build}
   "ounit" {with-test & >= "2.0.0"}
 ]
-depopts: ["lwt"]
 conflicts: [
-  "lwt" {with-test & >= "5.0.0"}
+  "lwt"
 ]
 available: [os = "linux"]
 synopsis: "Inotify bindings for ocaml."


### PR DESCRIPTION
marking as incompatible with lwt bc some packages can depend on inotify and lwt in order to ensure they depend on inotify's lwt option

other versions of inotify unaffected

observed error:

```
- File "_none_", line 1:
- Error: No implementations provided for the following modules:
-          Mutex referenced from /home/opam/.opam/4.14/lib/lwt/unix/lwt_unix.cmxa(Lwt_main)
- Command exited with code 2.
```