### PR TITLE
[new release] dune-release (2.2.0)

### DIFF
--- a/packages/dune-release/dune-release.2.2.0/opam
+++ b/packages/dune-release/dune-release.2.2.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "Release dune packages in opam"
+description: """
+`dune-release` is a tool to streamline the release of Dune packages in
+[opam](https://opam.ocaml.org). It supports projects built
+with [Dune](https://github.com/ocaml/dune) and hosted on
+[GitHub](https://github.com)."""
+maintainer: ["Nathan Rebours <nathan.p.rebours@gmail.com>"]
+authors: [
+  "Daniel Bünzli"
+  "Thomas Gazagnaire"
+  "Nathan Rebours"
+  "Guillaume Petiot"
+  "Sonja Heinze"
+]
+license: "ISC"
+homepage: "https://github.com/tarides/dune-release"
+bug-reports: "https://github.com/tarides/dune-release/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "dune" {>= "3.14" & with-test}
+  "curly" {>= "0.3.0"}
+  "fmt" {>= "0.8.7"}
+  "fpath" {>= "0.7.3"}
+  "bos" {>= "0.1.3"}
+  "cmdliner" {>= "2.0.0"}
+  "re" {>= "1.7.2"}
+  "astring"
+  "opam-file-format" {>= "2.1.2"}
+  "opam-format" {>= "2.1.0"}
+  "opam-state" {>= "2.1.0"}
+  "opam-core" {>= "2.1.0"}
+  "rresult" {>= "0.6.0"}
+  "logs"
+  "odoc"
+  "alcotest" {with-test}
+  "yojson" {>= "1.6"}
+  "ocamlformat" {= "0.27.0" & with-dev-setup}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/dune-release.git"
+url {
+  src:
+    "https://github.com/tarides/dune-release/releases/download/2.2.0/dune-release-2.2.0.tbz"
+  checksum: [
+    "sha256=571c17b46fa7d53795169e02b005a61bb5f7ba76c800ad3d9289e6f8a4d6f06e"
+    "sha512=6d5910162361cac2eaea808b987742d55ce4371bb2818cdd57f17c05d5b30f9fc254425f84c1e05e10acfc3ab30698b41c1d66b94b2f733596b4f61d6df660ae"
+  ]
+}
+x-commit-hash: "afb7133195ce9c120c8b7aa740f5fa4d23d8cb2a"


### PR DESCRIPTION
Release dune packages in opam

- Project page: <a href="https://github.com/tarides/dune-release">https://github.com/tarides/dune-release</a>

##### CHANGES:

### Breaking

- Update to use cmdliner 2.0.0. Shortened arguments will not work anymore. (tarides/dune-release#512, @psafont)
