### PR TITLE
Add odoc upper bounds for gospel.0.2.0 and 0.3.0

### DIFF
--- a/packages/gospel/gospel.0.2.0/opam
+++ b/packages/gospel/gospel.0.2.0/opam
@@ -28,7 +28,7 @@ depends: [
   "ppxlib" {>= "0.26.0" & < "0.36.0"}
   "ppx_deriving" {>= "5.2.1"}
   "pp_loc" {>= "2.1.0"}
-  "odoc" {with-test}
+  "odoc" {with-test & < "3.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/gospel/gospel.0.3.0/opam
+++ b/packages/gospel/gospel.0.3.0/opam
@@ -44,7 +44,7 @@ depends: [
   "ppxlib" {>= "0.26.0" & < "0.36.0"}
   "ppx_deriving" {>= "5.2.1"}
   "pp_loc" {>= "2.1.0"}
-  "odoc" {with-test}
+  "odoc" {with-test & < "3.0.0"}
 ]
 
 url {


### PR DESCRIPTION
Spotted on #29263 (and many others before it):

https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/1b37faa806f25ffae47a4204ac0b15c79fa5a828/variant/compilers,4.14,menhirGLR.20260122,revdeps,gospel.0.3.0
```
#=== ERROR while compiling gospel.0.3.0 =======================================#
# context              2.5.0 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/gospel.0.3.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p gospel -j 255 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/gospel-7-090821.env
# output-file          ~/.opam/log/gospel-7-090821.out
### output ###
# File "test/ppx/odoc_output.t", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/ppx/odoc_output.t _build/default/test/ppx/odoc_output.t.corrected
# diff --git a/_build/default/test/ppx/odoc_output.t b/_build/default/test/ppx/odoc_output.t.corrected
# index 7aa3bee..f34613a 100644
# --- a/_build/default/test/ppx/odoc_output.t
# +++ b/_build/default/test/ppx/odoc_output.t.corrected
# @@ -7,6 +7,28 @@ First, we compile the file, running the source preprocessor and the ppx:
#  Then run Odoc
#  
#    $ odoc compile odoc_of_gospel.cmti
# +  File "odoc_of_gospel.mli", line 5, character 6 to line 7, character 21:
# +  Warning: Code blocks should be indented at the opening `{`.
# +  File "odoc_of_gospel.mli", line 9, character 6 to line 11, character 38:
# +  Warning: Code blocks should be indented at the opening `{`.
# +  File "odoc_of_gospel.mli", line 13, character 6 to line 15, character 49:
# +  Warning: Code blocks should be indented at the opening `{`.
# +  File "odoc_of_gospel.mli", line 17, character 6 to line 21, character 26:
# +  Warning: Code blocks should be indented at the opening `{`.
# +  File "odoc_of_gospel.mli", line 23, character 6 to line 25, character 41:
# +  Warning: Code blocks should be indented at the opening `{`.
# +  File "odoc_of_gospel.mli", line 27, character 6 to line 29, character 18:
# +  Warning: Code blocks should be indented at the opening `{`.
# +  File "odoc_of_gospel.mli", line 31, character 6 to line 35, character 21:
# +  Warning: Code blocks should be indented at the opening `{`.
# +  File "odoc_of_gospel.mli", line 37, character 6 to line 41, character 19:
# +  Warning: Code blocks should be indented at the opening `{`.
# +  File "odoc_of_gospel.mli", line 42, character 6 to line 44, character 38:
# +  Warning: Code blocks should be indented at the opening `{`.
# +  File "odoc_of_gospel.mli", line 43, character 6 to line 45, character 20:
# +  Warning: Code blocks should be indented at the opening `{`.
# +  File "odoc_of_gospel.mli", line 44, character 6 to line 46, character 19:
# +  Warning: Code blocks should be indented at the opening `{`.
#  
#  We test the html and the latex outputs
#  
```

odoc.3.0.0 and later emits code block indentation warnings, causing cram test differences in gospel tests and hence red CI lights. This PR therefore adds an upper bound for `odoc` to restore green check marks to the universe. :crossed_fingers: :heavy_check_mark: 