### PR TITLE
Add an ocaml.5.4.0 upper bound on fstar.2025.06.20-2025.09.04

### DIFF
--- a/packages/fstar/fstar.2025.06.20/opam
+++ b/packages/fstar/fstar.2025.06.20/opam
@@ -8,7 +8,7 @@ authors: [
 homepage: "http://fstar-lang.org"
 license: "Apache-2.0"
 depends: [
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "4.14.0" & < "5.4"}
   "batteries"
   "zarith" {>= "1.14"}
   "stdint"

--- a/packages/fstar/fstar.2025.08.07/opam
+++ b/packages/fstar/fstar.2025.08.07/opam
@@ -8,7 +8,7 @@ authors: [
 homepage: "http://fstar-lang.org"
 license: "Apache-2.0"
 depends: [
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "4.14.0" & < "5.4"}
   "batteries"
   "zarith" {>= "1.14"}
   "stdint"

--- a/packages/fstar/fstar.2025.09.04/opam
+++ b/packages/fstar/fstar.2025.09.04/opam
@@ -8,7 +8,7 @@ authors: [
 homepage: "http://fstar-lang.org"
 license: "Apache-2.0"
 depends: [
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "4.14.0" & < "5.4"}
   "batteries"
   "zarith" {>= "1.14"}
   "stdint"


### PR DESCRIPTION
Spotted on #29263:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/1b37faa806f25ffae47a4204ac0b15c79fa5a828/variant/compilers,5.4,menhir.20260122,revdeps,fstar.2025.09.04
```
#=== ERROR while compiling fstar.2025.09.04 ===================================#
# context              2.5.0 | linux/x86_64 | ocaml-base-compiler.5.4.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.4/.opam-switch/build/fstar.2025.09.04
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j 71 ADMIT=1
# exit-code            2
# env-file             ~/.opam/log/fstar-7-13e185.env
# output-file          ~/.opam/log/fstar-7-13e185.out
### output ###
#   STAGE 0          
#    DUNE BUILD      
#    INSTALL LIB SRC  
# (cd _build/.sandbox/12a43f09a0c190620227e1a982fafd76/default && /home/opam/.opam/5.4/bin/menhir fstar-guts/FStarC_Parser_Parse.mly --base fstar-guts/FStarC_Parser_Parse --infer-write-query fstar-guts/FStarC_Parser_Parse__mock.ml.mock)
# File "fstar-guts/FStarC_Parser_Parse.mly", line 129, characters 60-70:
# Warning: the token LBRACK_BAR is unused.
# File "fstar-guts/FStarC_Parser_Parse.mly", line 325, characters 0-15:
# Warning: symbol decoratableDecl is unreachable from any of the start symbols.
# File "fstar-guts/FStarC_Parser_Parse.mly", line 308, characters 0-16:
# Warning: symbol noDecorationDecl is unreachable from any of the start symbols.
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -w -A -g -I fstar-guts/.fstarcompiler.objs/byte -I /home/opam/.opam/5.4/lib/batteries -I /home/opam/.opam/5.4/lib/batteries/unthreaded -I /home/opam/.opam/5.4/lib/camlp-streams -I /home/opam/.opam/5.4/lib/gen -I /home/opam/.opam/5.4/lib/menhirLib -I /home/opam/.opam/5.4/lib/mtime -I /home/opam/.opam/5.4/lib/mtime/clock -I /home/opam/.opam/5.4/lib/num -I /home/opam/.opam/5.4/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.4/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.4/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4/lib/ocaml/dynlink -I /home/opam/.opam/5.4/lib/ocaml/str -I /home/opam/.opam/5.4/lib/ocaml/threads -I /home/opam/.opam/5.4/lib/ocaml/unix -I /home/opam/.opam/5.4/lib/pprint -I /home/opam/.opam/5.4/lib/ppx_derivers -I /home/opam/.opam/5.4/lib/ppx_deriving/runtime -I /home/opam/.opam/5.4/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.4/lib/ppxlib -I /home/opam/.opam/5.4/lib/ppxlib/ast -I /home/opam/.opam/5.4/lib/ppxlib/astlib -I /home/opam/.opam/5.4/lib/ppxlib/print_diff -I /home/opam/.opam/5.4/lib/ppxlib/stdppx -I /home/opam/.opam/5.4/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.4/lib/process -I /home/opam/.opam/5.4/lib/sedlex -I /home/opam/.opam/5.4/lib/seq -I /home/opam/.opam/5.4/lib/sexplib0 -I /home/opam/.opam/5.4/lib/stdint -I /home/opam/.opam/5.4/lib/stdlib-shims -I /home/opam/.opam/5.4/lib/yojson -I /home/opam/.opam/5.4/lib/zarith -no-alias-deps -opaque -open Fstarcompiler -o fstar-guts/.fstarcompiler.objs/byte/fstarcompiler__FStarC_Extraction_ML_PrintML.cmo -c -impl fstar-guts/ml/FStarC_Extraction_ML_PrintML.pp.ml)
# File "fstar-guts/ml/FStarC_Extraction_ML_PrintML.ml", line 79, characters 23-41:
# 79 |          | [] ->  Ldot(Lident path_abbrev, sym) |> mk_sym_lident
#                             ^^^^^^^^^^^^^^^^^^
# Error: This expression should not be a constructor, the expected type is
#        Longident.t with_loc
# (cd _build/.sandbox/9e2f8c21f3dda575a542d986ec016c2f/default && /home/opam/.opam/5.4/bin/menhir fstar-guts/FStarC_Parser_Parse.mly --base fstar-guts/FStarC_Parser_Parse --infer-read-reply fstar-guts/FStarC_Parser_Parse__mock.mli.inferred)
# Warning: 20 states have shift/reduce conflicts.
# Warning: 232 states have end-of-stream conflicts.
# Warning: 301 shift/reduce conflicts were arbitrarily resolved.
# Warning: 232 end-of-stream conflicts were arbitrarily resolved.
# make[1]: *** [Makefile:34: build] Error 1
# make: *** [Makefile:91: stage0/out/bin/fstar.exe] Error 2
```
A similar upper bound was added for to fstar.2025.10.06 in #29230, so this PR just adds a similar bound to the previous 3 releases.