### PR TITLE
lwt 6 alpha and beta packages: stricter mutual constraints

### DIFF
--- a/packages/lwt_direct/lwt_direct.6.0.0-beta01/opam
+++ b/packages/lwt_direct/lwt_direct.6.0.0-beta01/opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "3.15"}
   "ocaml" {>= "5.0"}
   "base-unix"
-  "lwt" {>= "6"}
+  "lwt" {= version}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/lwt_direct/lwt_direct.6.0.0~alpha00/opam
+++ b/packages/lwt_direct/lwt_direct.6.0.0~alpha00/opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "5.0"}
   "base-unix"
-  "lwt" {>= "6"}
+  "lwt" {= version}
   "bisect_ppx" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/lwt_ppx/lwt_ppx.6.0.0-beta01/opam
+++ b/packages/lwt_ppx/lwt_ppx.6.0.0-beta01/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "3.15"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.36"}
-  "lwt" {>= "6" & >= "6.0.0-beta01"}
+  "lwt" {= version}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
this avoids lwt_ppx beta being installed with lwt non-beta (and the like)

it should prevent https://github.com/ocaml/opam-repository/pull/29295#issuecomment-3828088895 (thanks @jmid )