### PR TITLE
[new release] pxshot (0.1.1)

### DIFF
--- a/packages/pxshot/pxshot.0.1.1/opam
+++ b/packages/pxshot/pxshot.0.1.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Official OCaml SDK for the Pxshot screenshot API"
+description:
+  "A type-safe OCaml client for capturing screenshots via the Pxshot API. Supports configurable viewport sizes, full-page captures, various image formats, and cloud storage options."
+maintainer: ["Pxshot <support@pxshot.com>"]
+authors: ["Pxshot <support@pxshot.com>"]
+license: "MIT"
+tags: ["screenshot" "api" "pxshot" "web-capture"]
+homepage: "https://github.com/faiscadev/pxshot-ocaml"
+doc: "https://docs.pxshot.com/sdks/ocaml"
+bug-reports: "https://github.com/faiscadev/pxshot-ocaml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.0"}
+  "cohttp-lwt-unix" {>= "5.0.0"}
+  "lwt" {>= "5.6.0"}
+  "yojson" {>= "2.0.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {with-test & >= "1.6.0"}
+  "alcotest-lwt" {with-test & >= "1.6.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/faiscadev/pxshot-ocaml.git"
+url {
+  src:
+    "https://github.com/faiscadev/pxshot-ocaml/releases/download/v0.1.1/pxshot-0.1.1.tbz"
+  checksum: [
+    "sha256=9da8a2fac8d8939a64a16b8a22d2aaaa64f712bb24024527ba779c33fad55650"
+    "sha512=f8903cba7d9c8b248bad393e6d099147eb010407e4b9e08b91b8d764e15b6fa5a6ad7f1a896a6eed38ddaa07f3acd26d2cb03b21844e38e879ce75fa395598eb"
+  ]
+}
+x-commit-hash: "949766c59b366359f3dea2218d31330662ceebfe"


### PR DESCRIPTION
Official OCaml SDK for the Pxshot screenshot API

- Project page: https://github.com/faiscadev/pxshot-ocaml
- Documentation: https://docs.pxshot.com/sdks/ocaml

##### CHANGES:

- Fix module collision in examples (renamed usage.ml to usage_example.ml)
- Clean up build artifacts from repo
- Supersedes #29320