### PR TITLE
[new release] pxshot (0.1.2)

### DIFF
--- a/packages/pxshot/pxshot.0.1.2/opam
+++ b/packages/pxshot/pxshot.0.1.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Official OCaml SDK for the Pxshot screenshot API"
+description:
+  "A type-safe OCaml client for capturing screenshots via the Pxshot API. Supports configurable viewport sizes, full-page captures, various image formats, and cloud storage options."
+maintainer: ["Pxshot <support@pxshot.com>"]
+authors: ["Pxshot <support@pxshot.com>"]
+license: "MIT"
+tags: ["screenshot" "api" "pxshot" "web-capture"]
+homepage: "https://github.com/faiscadev/pxshot-ocaml"
+doc: "https://docs.pxshot.com/sdks/ocaml"
+bug-reports: "https://github.com/faiscadev/pxshot-ocaml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.0"}
+  "cohttp-lwt-unix" {>= "5.0.0"}
+  "lwt" {>= "5.6.0"}
+  "yojson" {>= "2.0.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {with-test & >= "1.6.0"}
+  "alcotest-lwt" {with-test & >= "1.6.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/faiscadev/pxshot-ocaml.git"
+url {
+  src:
+    "https://github.com/faiscadev/pxshot-ocaml/releases/download/v0.1.2/pxshot-0.1.2.tbz"
+  checksum: [
+    "sha256=3af9325059bfa07d0445b01528a538bf600d76187871e3ae93d409b7f0dd62ff"
+    "sha512=e7954e56968a9bf73171377b3dec641fd99a9fb8b0fc91e4f3971b3cf19f39937fe21e4163eb1d9646ff913ac751c947fdd319a3b00edc76317dadb51ad02369"
+  ]
+}
+x-commit-hash: "139f6ce8b855db75e9b1ab6755dabb58627703cb"


### PR DESCRIPTION
Official OCaml SDK for the Pxshot screenshot API

- Project page: https://github.com/faiscadev/pxshot-ocaml
- Documentation: https://docs.pxshot.com/sdks/ocaml

##### CHANGES (0.1.2):
- Exclude examples from package build (fixes lower-bounds CI)

##### CHANGES (0.1.1):
- Fix module collision in examples

Supersedes #29324