### PR TITLE
Package mset.0.2.0

### DIFF
--- a/packages/mset/mset.0.2.0/opam
+++ b/packages/mset/mset.0.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jean-Christophe.Filliatre@cnrs.fr"
+authors: "Jean-Christophe Filliâtre"
+synopsis: "A library for small multisets"
+description: "Implements small multisets using bitmaps."
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/backtracking/mset"
+doc: "https://backtracking.github.io/mset"
+bug-reports: "https://github.com/backtracking/mset/issues"
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {>= "2.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/backtracking/mset.git"
+url {
+  src: "https://github.com/backtracking/mset/archive/refs/tags/0.2.0.tar.gz"
+  checksum: [
+    "md5=25331ce4aef92d04a9bbdc18aec7a545"
+    "sha512=083e58170f5ec786e2e33894e0b92a91da754b7f1a7e3ed75c66d24e06747e653e77df31dc53a4720c79ddf4e23a6815373d75024e2c3ca369449792fe2bae58"
+  ]
+}


### PR DESCRIPTION
### `mset.0.2.0`
A library for small multisets
Implements small multisets using bitmaps.



---
* Homepage: https://github.com/backtracking/mset
* Source repo: git+https://github.com/backtracking/mset.git
* Bug tracker: https://github.com/backtracking/mset/issues

---
:camel: Pull-request generated by opam-publish v2.3.0