### PR TITLE
[Alpine] flint-dev is now in edgecommunity

### DIFF
--- a/packages/conf-flint/conf-flint.3.0/opam
+++ b/packages/conf-flint/conf-flint.3.0/opam
@@ -29,7 +29,7 @@ depexts: [
   ["flint"] {os-distribution = "macports" & os = "macos"}
   ["flint" "flint-devel"] {os-family = "fedora"}
   ["flint" "flint-devel"] {os-distribution = "ol"}
-  ["flint-dev@testing"] {os-distribution = "alpine"}
+  ["flint-dev@edgecommunity"] {os-distribution = "alpine"}
   ["flint-devel"] {os-family = "opensuse"}
   ["libflint-devel"] {os = "win32" & os-distribution = "cygwinports" }
   ["libflint-devel"] {os = "cygwin" & os-distribution = "cygwin" }


### PR DESCRIPTION
It should still work when it migrates to community (which is usually not tagged)