### PR TITLE
[new release] react-rules-of-hooks-ppx (1.1.0)

### DIFF
--- a/packages/react-rules-of-hooks-ppx/react-rules-of-hooks-ppx.1.1.0/opam
+++ b/packages/react-rules-of-hooks-ppx/react-rules-of-hooks-ppx.1.1.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "This ppx validates the rules of React hooks in reason-react components"
+description:
+  "Validates exhaustive dependencies in useEffect, useLayoutEffect, useInsertionEffect, useCallback, useMemo and ensures hooks are called at the top level, never conditionally or inside loops."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx"
+bug-reports:
+  "https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "ppxlib" {>= "0.36.0"}
+  "reason" {with-test & >= "3.10.0"}
+  "melange" {with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "mlx" {with-test | with-dev-setup}
+  "ocamlformat-mlx" {with-dev-setup}
+  "ocamlmerlin-mlx" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo:
+  "git+https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx.git"
+url {
+  src:
+    "https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx/releases/download/1.1.0/react-rules-of-hooks-ppx-1.1.0.tbz"
+  checksum: [
+    "sha256=74e2877586bf3ee984ade800636affaadd08273d4c997bdd92dccc0e4ddffc71"
+    "sha512=49eb112d8155c14fb075b3b2da3d7261bbedad71a0d79ee995bb1cecf4b25d7edcb7a4ee5e7774fe46daa62242ba8ee08c5eb5a33948b59e01f1243ab7a43f4c"
+  ]
+}
+x-commit-hash: "1ecf2a211a254c1af7aeb3af68a91123a38a5d25"


### PR DESCRIPTION
This ppx validates the rules of React hooks in reason-react components

- Project page: <a href="https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx">https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx</a>

##### CHANGES:

- [FEAT] Disable order of hooks attribute `[@disable_order_of_hooks]`
- [FIX] Add support for snake_case hooks (`use_state`, `use_effect`, `use_custom_hook`)
- [FIX] SVG `<use>` element no longer incorrectly flagged as a hook (JSX elements excluded from hook detection)
- [FIX] False positive when multiple hooks are defined
- [FIX] Hooks name can be "use"
- [FIX] Fix static deps scope leaking between components (useState setters, useReducer dispatchers, useRef results now properly scoped per component)
- [FIX] JSX context reset bug where multiple hooks in the same JSX element weren't all flagged as violations
- [FEAT] Add `Pexp_letop` support for monadic `let+`/`and+` syntax in exhaustive deps checking
- [TEST] Add test cases inspired by React's eslint-plugin-react-hooks
- [FEAT] Add `REACT_HOOKS_PPX_TIMING` env var to print timing diagnostics
- [FIX] Use Set for O(log n) lookups, single-pass AST analysis, caching
- [FIX] Simplify diff function
- [FIX] Replace `List.length > 0` with `<> []`
- [FIX] Optimize `find_duplicates` to deduplicate during traversal
