### PR TITLE
fluxt.0.0.1~beta2 requires ptime

### DIFF
--- a/packages/fluxt/fluxt.0.0.1~beta2/opam
+++ b/packages/fluxt/fluxt.0.0.1~beta2/opam
@@ -19,6 +19,7 @@ depends: [
   "tar"               {>= "3.3.0"}
   "ptime"
   "bstr"
+  "ptime"
   "digestif"          {>= "1.3.0"}
   "angstrom"
   "flux"              {= version}


### PR DESCRIPTION
This dependence was missed at the last release but it seems required. It appears that transitively, no deps brings `ptime`. Not sure why the CI did not catch up this error. It's already fixed upstream.