### PR TITLE
11 packages from benodiwal/testcontainers-ocaml at 0.1.1

### DIFF
--- a/packages/testcontainers-elasticsearch/testcontainers-elasticsearch.0.1.1/opam
+++ b/packages/testcontainers-elasticsearch/testcontainers-elasticsearch.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Elasticsearch module for testcontainers"
+description: "Elasticsearch container module for testcontainers-ocaml"
+maintainer: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+authors: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/benodiwal/testcontainers-ocaml"
+doc: "https://benodiwal.github.io/testcontainers-ocaml"
+bug-reports: "https://github.com/benodiwal/testcontainers-ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "testcontainers" {= version}
+  "lwt_ppx" {>= "2.1.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "alcotest-lwt" {with-test & >= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/benodiwal/testcontainers-ocaml.git"
+url {
+  src:
+    "https://github.com/benodiwal/testcontainers-ocaml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=3cf74d78fdc396166cb01a7d42064c09"
+    "sha512=ded916bf0e2e6c86947388fd02a69d3e516eee683e6c767ec4c6954a0934f57d5240649535f4ded61368fa374b1ce3e5cb07607a788c80dd8d4aabcd2267dbea"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/testcontainers-kafka/testcontainers-kafka.0.1.1/opam
+++ b/packages/testcontainers-kafka/testcontainers-kafka.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Kafka module for testcontainers"
+description: "Apache Kafka container module for testcontainers-ocaml"
+maintainer: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+authors: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/benodiwal/testcontainers-ocaml"
+doc: "https://benodiwal.github.io/testcontainers-ocaml"
+bug-reports: "https://github.com/benodiwal/testcontainers-ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "testcontainers" {= version}
+  "lwt_ppx" {>= "2.1.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "alcotest-lwt" {with-test & >= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/benodiwal/testcontainers-ocaml.git"
+url {
+  src:
+    "https://github.com/benodiwal/testcontainers-ocaml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=3cf74d78fdc396166cb01a7d42064c09"
+    "sha512=ded916bf0e2e6c86947388fd02a69d3e516eee683e6c767ec4c6954a0934f57d5240649535f4ded61368fa374b1ce3e5cb07607a788c80dd8d4aabcd2267dbea"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/testcontainers-localstack/testcontainers-localstack.0.1.1/opam
+++ b/packages/testcontainers-localstack/testcontainers-localstack.0.1.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "LocalStack module for testcontainers"
+description:
+  "LocalStack (AWS emulation) container module for testcontainers-ocaml"
+maintainer: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+authors: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/benodiwal/testcontainers-ocaml"
+doc: "https://benodiwal.github.io/testcontainers-ocaml"
+bug-reports: "https://github.com/benodiwal/testcontainers-ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "testcontainers" {= version}
+  "lwt_ppx" {>= "2.1.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "alcotest-lwt" {with-test & >= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/benodiwal/testcontainers-ocaml.git"
+url {
+  src:
+    "https://github.com/benodiwal/testcontainers-ocaml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=3cf74d78fdc396166cb01a7d42064c09"
+    "sha512=ded916bf0e2e6c86947388fd02a69d3e516eee683e6c767ec4c6954a0934f57d5240649535f4ded61368fa374b1ce3e5cb07607a788c80dd8d4aabcd2267dbea"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/testcontainers-memcached/testcontainers-memcached.0.1.1/opam
+++ b/packages/testcontainers-memcached/testcontainers-memcached.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Memcached module for testcontainers"
+description: "Memcached container module for testcontainers-ocaml"
+maintainer: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+authors: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/benodiwal/testcontainers-ocaml"
+doc: "https://benodiwal.github.io/testcontainers-ocaml"
+bug-reports: "https://github.com/benodiwal/testcontainers-ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "testcontainers" {= version}
+  "lwt_ppx" {>= "2.1.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "alcotest-lwt" {with-test & >= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/benodiwal/testcontainers-ocaml.git"
+url {
+  src:
+    "https://github.com/benodiwal/testcontainers-ocaml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=3cf74d78fdc396166cb01a7d42064c09"
+    "sha512=ded916bf0e2e6c86947388fd02a69d3e516eee683e6c767ec4c6954a0934f57d5240649535f4ded61368fa374b1ce3e5cb07607a788c80dd8d4aabcd2267dbea"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/testcontainers-mockserver/testcontainers-mockserver.0.1.1/opam
+++ b/packages/testcontainers-mockserver/testcontainers-mockserver.0.1.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "MockServer module for testcontainers"
+description:
+  "MockServer container module for mocking HTTP services in testcontainers-ocaml"
+maintainer: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+authors: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/benodiwal/testcontainers-ocaml"
+doc: "https://benodiwal.github.io/testcontainers-ocaml"
+bug-reports: "https://github.com/benodiwal/testcontainers-ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "testcontainers" {= version}
+  "lwt_ppx" {>= "2.1.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "alcotest-lwt" {with-test & >= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/benodiwal/testcontainers-ocaml.git"
+url {
+  src:
+    "https://github.com/benodiwal/testcontainers-ocaml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=3cf74d78fdc396166cb01a7d42064c09"
+    "sha512=ded916bf0e2e6c86947388fd02a69d3e516eee683e6c767ec4c6954a0934f57d5240649535f4ded61368fa374b1ce3e5cb07607a788c80dd8d4aabcd2267dbea"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/testcontainers-mongo/testcontainers-mongo.0.1.1/opam
+++ b/packages/testcontainers-mongo/testcontainers-mongo.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "MongoDB module for testcontainers"
+description: "MongoDB container module for testcontainers-ocaml"
+maintainer: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+authors: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/benodiwal/testcontainers-ocaml"
+doc: "https://benodiwal.github.io/testcontainers-ocaml"
+bug-reports: "https://github.com/benodiwal/testcontainers-ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "testcontainers" {= version}
+  "lwt_ppx" {>= "2.1.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "alcotest-lwt" {with-test & >= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/benodiwal/testcontainers-ocaml.git"
+url {
+  src:
+    "https://github.com/benodiwal/testcontainers-ocaml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=3cf74d78fdc396166cb01a7d42064c09"
+    "sha512=ded916bf0e2e6c86947388fd02a69d3e516eee683e6c767ec4c6954a0934f57d5240649535f4ded61368fa374b1ce3e5cb07607a788c80dd8d4aabcd2267dbea"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/testcontainers-mysql/testcontainers-mysql.0.1.1/opam
+++ b/packages/testcontainers-mysql/testcontainers-mysql.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "MySQL module for testcontainers"
+description: "MySQL container module for testcontainers-ocaml"
+maintainer: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+authors: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/benodiwal/testcontainers-ocaml"
+doc: "https://benodiwal.github.io/testcontainers-ocaml"
+bug-reports: "https://github.com/benodiwal/testcontainers-ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "testcontainers" {= version}
+  "lwt_ppx" {>= "2.1.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "alcotest-lwt" {with-test & >= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/benodiwal/testcontainers-ocaml.git"
+url {
+  src:
+    "https://github.com/benodiwal/testcontainers-ocaml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=3cf74d78fdc396166cb01a7d42064c09"
+    "sha512=ded916bf0e2e6c86947388fd02a69d3e516eee683e6c767ec4c6954a0934f57d5240649535f4ded61368fa374b1ce3e5cb07607a788c80dd8d4aabcd2267dbea"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/testcontainers-postgres/testcontainers-postgres.0.1.1/opam
+++ b/packages/testcontainers-postgres/testcontainers-postgres.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "PostgreSQL module for testcontainers"
+description: "PostgreSQL container module for testcontainers-ocaml"
+maintainer: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+authors: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/benodiwal/testcontainers-ocaml"
+doc: "https://benodiwal.github.io/testcontainers-ocaml"
+bug-reports: "https://github.com/benodiwal/testcontainers-ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "testcontainers" {= version}
+  "lwt_ppx" {>= "2.1.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "alcotest-lwt" {with-test & >= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/benodiwal/testcontainers-ocaml.git"
+url {
+  src:
+    "https://github.com/benodiwal/testcontainers-ocaml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=3cf74d78fdc396166cb01a7d42064c09"
+    "sha512=ded916bf0e2e6c86947388fd02a69d3e516eee683e6c767ec4c6954a0934f57d5240649535f4ded61368fa374b1ce3e5cb07607a788c80dd8d4aabcd2267dbea"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/testcontainers-rabbitmq/testcontainers-rabbitmq.0.1.1/opam
+++ b/packages/testcontainers-rabbitmq/testcontainers-rabbitmq.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "RabbitMQ module for testcontainers"
+description: "RabbitMQ container module for testcontainers-ocaml"
+maintainer: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+authors: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/benodiwal/testcontainers-ocaml"
+doc: "https://benodiwal.github.io/testcontainers-ocaml"
+bug-reports: "https://github.com/benodiwal/testcontainers-ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "testcontainers" {= version}
+  "lwt_ppx" {>= "2.1.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "alcotest-lwt" {with-test & >= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/benodiwal/testcontainers-ocaml.git"
+url {
+  src:
+    "https://github.com/benodiwal/testcontainers-ocaml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=3cf74d78fdc396166cb01a7d42064c09"
+    "sha512=ded916bf0e2e6c86947388fd02a69d3e516eee683e6c767ec4c6954a0934f57d5240649535f4ded61368fa374b1ce3e5cb07607a788c80dd8d4aabcd2267dbea"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/testcontainers-redis/testcontainers-redis.0.1.1/opam
+++ b/packages/testcontainers-redis/testcontainers-redis.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Redis module for testcontainers"
+description: "Redis container module for testcontainers-ocaml"
+maintainer: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+authors: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/benodiwal/testcontainers-ocaml"
+doc: "https://benodiwal.github.io/testcontainers-ocaml"
+bug-reports: "https://github.com/benodiwal/testcontainers-ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "testcontainers" {= version}
+  "lwt_ppx" {>= "2.1.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "alcotest-lwt" {with-test & >= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/benodiwal/testcontainers-ocaml.git"
+url {
+  src:
+    "https://github.com/benodiwal/testcontainers-ocaml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=3cf74d78fdc396166cb01a7d42064c09"
+    "sha512=ded916bf0e2e6c86947388fd02a69d3e516eee683e6c767ec4c6954a0934f57d5240649535f4ded61368fa374b1ce3e5cb07607a788c80dd8d4aabcd2267dbea"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/testcontainers/testcontainers.0.1.1/opam
+++ b/packages/testcontainers/testcontainers.0.1.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Docker containers for OCaml integration tests"
+description: """\
+TestContainers is an OCaml library that provides lightweight, throwaway
+   instances of databases, message brokers, or any service that runs in a
+   Docker container. Enables reliable integration testing with real services
+   instead of mocks."""
+maintainer: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+authors: "Sachin Beniwal <sachinbeniwal0101@gmail.com>"
+license: "Apache-2.0"
+tags: [
+  "docker" "testing" "integration-testing" "containers" "testcontainers"
+]
+homepage: "https://github.com/benodiwal/testcontainers-ocaml"
+doc: "https://benodiwal.github.io/testcontainers-ocaml"
+bug-reports: "https://github.com/benodiwal/testcontainers-ocaml/issues"
+depends: [
+  "ocaml" {>= "5.0"}
+  "dune" {>= "3.20" & >= "3.20"}
+  "lwt" {>= "5.7.0"}
+  "lwt_ppx" {>= "2.1.0"}
+  "yojson" {>= "2.0"}
+  "re" {>= "1.11.0"}
+  "uri" {>= "4.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.9.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "alcotest-lwt" {with-test & >= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/benodiwal/testcontainers-ocaml.git"
+url {
+  src:
+    "https://github.com/benodiwal/testcontainers-ocaml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=3cf74d78fdc396166cb01a7d42064c09"
+    "sha512=ded916bf0e2e6c86947388fd02a69d3e516eee683e6c767ec4c6954a0934f57d5240649535f4ded61368fa374b1ce3e5cb07607a788c80dd8d4aabcd2267dbea"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `testcontainers.0.1.1`: Docker containers for OCaml integration tests
- `testcontainers-elasticsearch.0.1.1`: Elasticsearch module for testcontainers
- `testcontainers-kafka.0.1.1`: Kafka module for testcontainers
- `testcontainers-localstack.0.1.1`: LocalStack module for testcontainers
- `testcontainers-memcached.0.1.1`: Memcached module for testcontainers
- `testcontainers-mockserver.0.1.1`: MockServer module for testcontainers
- `testcontainers-mongo.0.1.1`: MongoDB module for testcontainers
- `testcontainers-mysql.0.1.1`: MySQL module for testcontainers
- `testcontainers-postgres.0.1.1`: PostgreSQL module for testcontainers
- `testcontainers-rabbitmq.0.1.1`: RabbitMQ module for testcontainers
- `testcontainers-redis.0.1.1`: Redis module for testcontainers



---
* Homepage: https://github.com/benodiwal/testcontainers-ocaml
* Source repo: git+https://github.com/benodiwal/testcontainers-ocaml.git
* Bug tracker: https://github.com/benodiwal/testcontainers-ocaml/issues

---
:camel: Pull-request generated by opam-publish v2.7.1