### PR TITLE
[new release] trace (4 packages) (0.11)

### DIFF
--- a/packages/ppx_trace/ppx_trace.0.11/opam
+++ b/packages/ppx_trace/ppx_trace.0.11/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A ppx-based preprocessor for trace"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "ppx"]
+homepage: "https://github.com/ocaml-tracing/ocaml-trace"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "ppxlib" {>= "0.37" & < "0.38"}
+  "trace" {= version}
+  "trace-tef" {= version & with-test}
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "mtime" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-trace/releases/download/v0.11/trace-0.11.tbz"
+  checksum: [
+    "sha256=a29329fcfb191a98bfed26c05c300ed9e1e915b73cc59f51e9d9cdc4d1f158bc"
+    "sha512=ff77a4ef19375f4ad3b1ddff7336657a4a5695924b679ac2c36a77b14b95c63d126539efd1590f83b415a1288bb843a5fb4308e53a807dcc22456cb40a8e0026"
+  ]
+}
+x-commit-hash: "c711a0dc66a731b9f2b300f321d2d763ccc21d75"

--- a/packages/trace-fuchsia/trace-fuchsia.0.11/opam
+++ b/packages/trace-fuchsia/trace-fuchsia.0.11/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "A high-performance backend for trace, emitting a Fuchsia trace into a file"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "tracing" "fuchsia"]
+homepage: "https://github.com/ocaml-tracing/ocaml-trace"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "trace" {= version}
+  "mtime" {>= "2.0"}
+  "base-bigarray"
+  "base-unix"
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-trace.git"
+available: arch != "s390x"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-trace/releases/download/v0.11/trace-0.11.tbz"
+  checksum: [
+    "sha256=a29329fcfb191a98bfed26c05c300ed9e1e915b73cc59f51e9d9cdc4d1f158bc"
+    "sha512=ff77a4ef19375f4ad3b1ddff7336657a4a5695924b679ac2c36a77b14b95c63d126539efd1590f83b415a1288bb843a5fb4308e53a807dcc22456cb40a8e0026"
+  ]
+}
+x-commit-hash: "c711a0dc66a731b9f2b300f321d2d763ccc21d75"

--- a/packages/trace-tef/trace-tef.0.11/opam
+++ b/packages/trace-tef/trace-tef.0.11/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "A simple backend for trace, emitting Catapult/TEF JSON into a file"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: [
+  "trace" "tracing" "catapult" "TEF" "chrome-format" "chrome-trace" "json"
+]
+homepage: "https://github.com/ocaml-tracing/ocaml-trace"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "trace" {= version}
+  "mtime" {>= "2.0"}
+  "base-unix"
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-trace/releases/download/v0.11/trace-0.11.tbz"
+  checksum: [
+    "sha256=a29329fcfb191a98bfed26c05c300ed9e1e915b73cc59f51e9d9cdc4d1f158bc"
+    "sha512=ff77a4ef19375f4ad3b1ddff7336657a4a5695924b679ac2c36a77b14b95c63d126539efd1590f83b415a1288bb843a5fb4308e53a807dcc22456cb40a8e0026"
+  ]
+}
+x-commit-hash: "c711a0dc66a731b9f2b300f321d2d763ccc21d75"

--- a/packages/trace/trace.0.11/opam
+++ b/packages/trace/trace.0.11/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "A lightweight stub for tracing/observability, agnostic in how data is collected"
+description: """
+ocaml-trace can be used to instrument libraries and programs with low overhead.
+
+              It doesn't do any IO unless a collector is plugged in, which only
+              the final executable should do."""
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["trace" "tracing" "observability" "profiling"]
+homepage: "https://github.com/ocaml-tracing/ocaml-trace"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "unix"
+  "mtime" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-trace/releases/download/v0.11/trace-0.11.tbz"
+  checksum: [
+    "sha256=a29329fcfb191a98bfed26c05c300ed9e1e915b73cc59f51e9d9cdc4d1f158bc"
+    "sha512=ff77a4ef19375f4ad3b1ddff7336657a4a5695924b679ac2c36a77b14b95c63d126539efd1590f83b415a1288bb843a5fb4308e53a807dcc22456cb40a8e0026"
+  ]
+}
+x-commit-hash: "c711a0dc66a731b9f2b300f321d2d763ccc21d75"


### PR DESCRIPTION
A lightweight stub for tracing/observability, agnostic in how data is collected

- Project page: <a href="https://github.com/ocaml-tracing/ocaml-trace">https://github.com/ocaml-tracing/ocaml-trace</a>

##### CHANGES:

- entire rework of the collector, now lighter, and using an open sum type
    for `span`. No global state is required anymore.
- add `enabled` to the collector
- extensible `metric`; pass level around in collector
- remove unused deps on hmap, thread-local-storage
- add `Trace.with_setup_collector`
- add `trace.debug` to find what spans were not closed on exit
- remove dead code and `on_tracing_error`
- remove subscriber entirely
- core: remove `current_span` from collector
- update deps to ppxlib=0.37~
- breaking: use poly variants for `user_data/span_flavor`
- use `at_exit` in `trace_tef` and `tldrs`
- fix fuchsia: bound check
