### PR TITLE
[new release] tracy-client (0.7)

### DIFF
--- a/packages/tracy-client/tracy-client.0.7/opam
+++ b/packages/tracy-client/tracy-client.0.7/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Client bindings to the Tracy profiler (v0.13)"
+maintainer: ["Simon Cruanes"]
+authors: ["Bartosz Taudul" "Simon Cruanes"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-tracing/ocaml-tracy"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-tracy/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "trace" {>= "0.11" & < "0.12"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-tracy.git"
+depexts: [
+ ["linux-headers"] {os-distribution = "alpine"}
+]
+available: [os != "win32"]
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-tracy/releases/download/v0.7/tracy-client-0.7.tbz"
+  checksum: [
+    "sha256=80494862d94c2dee0bea6407d22ea7693fc958a1ceaf6ef6004143156d75c9ed"
+    "sha512=3ce205ef8f27b49d5ec448ecc70aa078fb776af0ba79f20aa651bf368b668265e6430cce7bb88168a0a5bf33b2a5c8e4090c121f4b6678ae9ec923cd5ce275f2"
+  ]
+}
+x-commit-hash: "149ecb97c5dab000e4cbbee08f4cffe5a4a978df"


### PR DESCRIPTION
Client bindings to the Tracy profiler (v0.13)

- Project page: <a href="https://github.com/ocaml-tracing/ocaml-tracy">https://github.com/ocaml-tracing/ocaml-tracy</a>

##### CHANGES:

- move to trace 0.11
- move to tracy v0.13.1
