### PR TITLE
[new release] grenier (0.16)

### DIFF
--- a/packages/grenier/grenier.0.16/opam
+++ b/packages/grenier/grenier.0.16/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/grenier"
+bug-reports: "https://github.com/let-def/grenier"
+license: "ISC"
+dev-repo: "git+https://github.com/let-def/grenier.git"
+doc: "https://let-def.github.io/grenier/doc"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.0.0"}
+]
+synopsis: "A collection of various algorithms in OCaml"
+description: """
+This library implements various datastructures and algorithms:
+- automata minimization and transformation to regular expression
+- balanced trees
+- binpacking
+- cardinality estimation (hyperloglog)
+- immutable sequences
+- jump consistent hashing
+- solutions to the order maintenance problem
+- congruence closure
+- ...
+"""
+url {
+  src:
+    "https://github.com/let-def/grenier/releases/download/v0.16/grenier-0.16.tbz"
+  checksum: [
+    "sha256=8fd22abf9f4589c206008654fa9eebb1cf4a58737ebb34138c6709520f36b75f"
+    "sha512=f60315eccfecaec9cb4c3bd020ef6f94d05ed6b13038109b904ead6e4e5662f4ed95415855b3c763293b762b696f1962045393fd592742d54cf5607d0ef2961a"
+  ]
+}
+x-commit-hash: "a159a56118ea514330e290afa828a667b9cd4589"


### PR DESCRIPTION
A collection of various algorithms in OCaml

- Project page: <a href="https://github.com/let-def/grenier">https://github.com/let-def/grenier</a>
- Documentation: <a href="https://let-def.github.io/grenier/doc">https://let-def.github.io/grenier/doc</a>

##### CHANGES:

Balmap:
- add `is_singleton` to fix compatibility with OCaml 5.5, contributed by @kit-ty-kate
- add functions for accessing elements by rank (accessing "n-th" element)
