### PR TITLE
Camlzip 1.14

### DIFF
--- a/packages/camlzip/camlzip.1.14/opam
+++ b/packages/camlzip/camlzip.1.14/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis:
+  "Accessing compressed files in ZIP, GZIP and JAR format"
+description:
+  "The Camlzip library provides easy access to compressed files in ZIP and GZIP format, as well as to Java JAR files.  It provides functions for reading from and writing to compressed files in these formats."
+maintainer: ["Xavier Leroy <xavier.leroy@college-de-france.fr>"]
+authors: ["Xavier Leroy"]
+homepage: "https://github.com/xavierleroy/camlzip"
+bug-reports: "https://github.com/xavierleroy/camlzip/issues"
+dev-repo: "git+https://github.com/xavierleroy/camlzip.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+x-maintenance-intent: ["(latest)"]
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "ocamlfind" {build}
+  "conf-zlib"
+]
+build: [
+  [make "all"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/xavierleroy/camlzip/archive/refs/tags/v1.14.tar.gz"
+  checksum: [
+    "sha256=d2ce7ebc4d3b7c029daecd0b491a36163b22f7e1d95e86224d4a27a101f36177"
+    "sha512=b623efc5c5cfc28bad54dcb74f3d08e8cc4b9216d739e23cf3886d2490ef78c518ec37a344121fe1dab0a40e61b5c6e9908c8f12305a0754aaf9278a32c1dba6"
+  ]
+}


### PR DESCRIPTION
- 52: fix errors in local file headers for files > 4 Gb [Benoît Vaugon]
-  50: add a simple example (in directory example/) [John Withington]