### PR TITLE
[new release] ocp-index (2 packages) (1.4.1)

### DIFF
--- a/packages/ocp-browser/ocp-browser.1.4.1/opam
+++ b/packages/ocp-browser/ocp-browser.1.4.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "louis.gesbert@ocamlpro.com"
+synopsis: "Console browser for the documentation of installed OCaml libraries"
+description: """
+ocp-browser is a ncurses-like interface that allows to easily browse the
+interfaces and documentation of all installed OCaml modules.
+"""
+authors: [
+  "Louis Gesbert"
+  "Gabriel Radanne"
+]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+license: "GPL-3.0-only"
+tags: [ "org:ocamlpro" "org:typerex" ]
+dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.0"}
+  "ocp-index" {= version}
+  "cmdliner" {>= "1.3.0"}
+  "lambda-term" {>= "3.3.0"}
+  "zed" {>= "2.0.0"}
+  "odoc" {with-test}
+]
+url {
+  src:
+    "https://github.com/OCamlPro/ocp-index/releases/download/1.4.1/ocp-index-1.4.1.tbz"
+  checksum: [
+    "sha256=59adbd99a9c88106dcf23bc0e3424a00f840fcedee4e4b644eaf0385ada3f911"
+    "sha512=53c9b83ee7c274bf1981de716081e4d7f603d2d4cc25c83a20d2f4c599d88d2200393feef54f4cdb25e014ea058d498ac711581c40e298df30f33a7cf8f65ff6"
+  ]
+}
+x-commit-hash: "3d4e25f3adbe845d0061096f3b195da87a36e492"

--- a/packages/ocp-index/ocp-index.1.4.1/opam
+++ b/packages/ocp-index/ocp-index.1.4.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "louis.gesbert@ocamlpro.com"
+synopsis:
+  "Lightweight completion and documentation browsing for OCaml libraries"
+description: """
+This package includes
+* The `ocp-index` library and command-line tool
+* `ocp-grep`, a tool that finds uses of a given (qualified) identifier in a source tree
+* bindings for emacs and vim (sublime text also [available](https://github.com/whitequark/sublime-ocp-index/))
+
+To automatically configure your editors, install this with package `user-setup`.
+"""
+authors: [
+  "Louis Gesbert"
+  "Gabriel Radanne"
+  "Kate Deplaix"
+]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+license: ["LGPL-2.1-only WITH OCaml-LGPL-linking-exception" "GPL-3.0-only"]
+tags: [ "org:ocamlpro" "org:typerex" ]
+dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.0"}
+  "ocp-indent" {>= "1.4.2"}
+  "re" {>= "1.9.0"}
+  "cmdliner" {>= "1.3.0"}
+  "odoc" {with-doc}
+]
+post-messages:
+  "This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path \"%{prefix}%/share/emacs/site-lisp\")
+  (require 'ocp-index)
+
+* for Vim, add the following line to ~/.vimrc:
+  set rtp+=%{share}%/ocp-index/vim
+" {success & !user-setup:installed}
+url {
+  src:
+    "https://github.com/OCamlPro/ocp-index/releases/download/1.4.1/ocp-index-1.4.1.tbz"
+  checksum: [
+    "sha256=59adbd99a9c88106dcf23bc0e3424a00f840fcedee4e4b644eaf0385ada3f911"
+    "sha512=53c9b83ee7c274bf1981de716081e4d7f603d2d4cc25c83a20d2f4c599d88d2200393feef54f4cdb25e014ea058d498ac711581c40e298df30f33a7cf8f65ff6"
+  ]
+}
+x-commit-hash: "3d4e25f3adbe845d0061096f3b195da87a36e492"


### PR DESCRIPTION
Lightweight completion and documentation browsing for OCaml libraries

- Project page: <a href="http://www.typerex.org/ocp-index.html">http://www.typerex.org/ocp-index.html</a>

##### CHANGES:

* Support for Ocaml 5.5
