### PR TITLE
[new release] ortools (2 packages) (9.15.0)

### DIFF
--- a/packages/ortools/ortools.9.15.0/opam
+++ b/packages/ortools/ortools.9.15.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+
+synopsis:
+"Build and export Google OR-Tools models"
+
+description: """
+Google OR-Tools is an open source software suite for optimization, tuned
+for tackling the world's toughest problems in vehicle routing, flows,
+integer and linear programming, and constraint programming. This package
+provides OCaml functions for working with the Protocol Buffer formats that
+are read and written by the different solvers. It does not actually depend
+on the OR-Tools software, which need not even be installed. The interface
+currently only supports a subset of the features provided by the CP-SAT solver.
+Pull requests for more features and solvers are welcome."""
+
+maintainer:  ["Timothy Bourke <tim@tbrk.org>"]
+authors:     ["Timothy Bourke <tim@tbrk.org>"]
+license:     "Apache-2.0"
+homepage:    "https://github.com/inria/ocaml-ortools"
+bug-reports: "https://github.com/inria/ocaml-ortools/issues"
+dev-repo:    "git+https://github.com/inria/ocaml-ortools.git"
+x-maintenance-intent: ["(latest)"]
+
+depends: [
+  "ocaml"	{>= "4.14.2"}
+  "dune"	{>= "3.21"}
+  "pbrt"	{>= "4.0"}
+  "odoc"	{with-doc}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/INRIA/ocaml-ortools/releases/download/9.15.0/ortools-9.15.0.tbz"
+  checksum: [
+    "sha256=5af56816304ac19c0a228ac0cba6514eabee4a90904433d02f46832063d5759e"
+    "sha512=2f39a679cd6fd72d2c334b34fb50338b25ae1216fba5b87b5072255269f7dda7d0045c501b6930328bc60f9e338b4d71e4efb68790362ebaff3472da72b6fe64"
+  ]
+}
+x-commit-hash: "e758f9b851c434a123ffd940320ee299d3d09617"
+

--- a/packages/ortools_solvers/ortools_solvers.9.15.0/opam
+++ b/packages/ortools_solvers/ortools_solvers.9.15.0/opam
@@ -1,0 +1,137 @@
+opam-version: "2.0"
+
+synopsis:
+"Call Google OR-Tools solvers"
+
+description: """
+Google OR-Tools is an open source software suite for optimization, tuned
+for tackling the world's toughest problems in vehicle routing, flows,
+integer and linear programming, and constraint programming. This package
+provides OCaml wrappers for calling the OR-Tools solvers. It currently only
+supports the CP-SAT solver. Pull requests for other solvers are welcome."""
+
+maintainer:  ["Timothy Bourke <tim@tbrk.org>"]
+authors:     ["Timothy Bourke <tim@tbrk.org>"]
+license:     "Apache-2.0"
+homepage:    "https://github.com/inria/ocaml-ortools"
+bug-reports: "https://github.com/inria/ocaml-ortools/issues"
+dev-repo:    "git+https://github.com/inria/ocaml-ortools.git"
+x-maintenance-intent: ["(latest)"]
+
+depends: [
+  "ocaml"      {>= "4.14.2"}
+  "dune"       {>= "3.21"}
+  "ortools"    {>= "9.15"}
+  "conf-cmake" {build}
+  "sexplib0"   {build}
+  "csexp"      {build}
+  "odoc"       {with-doc}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+
+depexts: [
+## solid
+
+  #zlib 1.3.1
+  ["zlib"]		    {os = "macos" & os-distribution = "homebrew"}
+  ["libz-dev"]		    {os-distribution = "debian"}
+  ["zlib-dev"]		    {os-distribution = "alpine"}
+  ["zlib"]		    {os-distribution = "archinux"}
+  ["libzstd"]		    {os-distribution = "centos-9"}
+  ["libzstd"]		    {os-distribution = "centos-10"}
+  ["zlib-ng-compat-devel" "zlib-ng-compat-static"]
+			    {os-distribution = "fedora"}
+  ["libzip"]		    {os-distribution = "freebsd"}
+  ["libz1"]		    {os-distribution = "opensuse"}
+  ["zlib1g-dev"]	    {os-distribution = "ubuntu"}
+
+  # 1.0.8
+  ["bzip2"]		    {os = "macos" & os-distribution = "homebrew"}
+  ["libbz2-dev"]	    {os-distribution = "debian"}
+  ["bzip2-dev"]		    {os-distribution = "alpine"}
+  ["bzip2"]		    {os-distribution = "archlinux"}
+  ["bzip2-libs"]	    {os-distribution = "centos-9"}
+  ["bzip2-libs"]	    {os-distribution = "centos-10"}
+  ["bzip2-devel"]	    {os-distribution = "fedora"}
+  ["bzip2"]		    {os-distribution = "freebsd"}
+  ["bzip2"]		    {os-distribution = "openbsd"}
+  ["libbz2-dev"]	    {os-distribution = "opensuse"}
+  ["libbz2-dev"]	    {os-distribution = "ubuntu"}
+
+  # 3.4.1
+  ["eigen@3"]		    {os = "macos" & os-distribution = "homebrew"}
+  ["libeigen3-dev"]	    {os-distribution = "debian"}
+  ["eigen-dev"]		    {os-distribution = "alpine"}
+  ["eigen3"]		    {os-distribution = "archlinux"}
+  ["eigen3"]		    {os-distribution = "centos-9"}
+  ["eigen3"]		    {os-distribution = "centos-10"}
+  ["eigen3-devel"]	    {os-distribution = "fedora"}
+  ["eigen"]		    {os-distribution = "freebsd"}
+  ["eigen3"]		    {os-distribution = "openbsd"}
+  ["eigen3"]		    {os-distribution = "opensuse"}
+  ["libeigen3-dev"]	    {os-distribution = "ubuntu"}
+
+  # needed to compile abseil (linux/futex.h)
+  ["linux-headers"]	{os-distribution = "alpine"}
+
+## brittle
+## debian, alpine, archlinux: build with OCaml ortools_solvers package
+
+  # abseil 20260107.0
+  ["abseil"]		{os = "macos" & os-distribution = "homebrew"}
+
+  # protobuf 33.4
+  ["protobuf"]		{os = "macos" & os-distribution = "homebrew"}
+
+  # protobuf-c 1.5.2
+  ["protobuf-c"]	{os = "macos" & os-distribution = "homebrew"}
+
+  # re2 2025-11-05
+  ["re2"]		{os = "macos" & os-distribution = "homebrew"}
+
+]
+
+x-ci-accept-failures: [
+  "debian-12"
+# "fedora-42"
+# "fedora-43"
+# "freebsd-14.3"
+  "opensuse-15.6"	# cannot compile with cmake
+  "opensuse-16.0"	# incorrect paths in /usr/lib64/cmake/ZLIB/* files
+  "ubuntu-22.04"	# cmake is too old
+  "ubuntu-24.04"
+  "cygwin"
+  "msys2"
+]
+
+post-messages: [
+  """Failed to install ortools_solvers.
+Ensure the required dependencies are properly installed.
+See https://github.com/inria/ocaml-ortools.
+"""
+  {failure}
+]
+url {
+  src:
+    "https://github.com/INRIA/ocaml-ortools/releases/download/9.15.0/ortools-9.15.0.tbz"
+  checksum: [
+    "sha256=5af56816304ac19c0a228ac0cba6514eabee4a90904433d02f46832063d5759e"
+    "sha512=2f39a679cd6fd72d2c334b34fb50338b25ae1216fba5b87b5072255269f7dda7d0045c501b6930328bc60f9e338b4d71e4efb68790362ebaff3472da72b6fe64"
+  ]
+}
+x-commit-hash: "e758f9b851c434a123ffd940320ee299d3d09617"
+


### PR DESCRIPTION
Build and export Google OR-Tools models

- Project page: <a href="https://github.com/inria/ocaml-ortools">https://github.com/inria/ocaml-ortools</a>

##### CHANGES:

Include the v9.15 Google OR-tools source and build together with the OCaml
interface. Rewrite the interface in C++ to avoid an unnecessary copy and
allow feasible solution observers.
