### PR TITLE
[new release] mirage-crypto (7 packages) (2.0.3)

### DIFF
--- a/packages/mirage-crypto-ec/mirage-crypto-ec.2.0.3/opam
+++ b/packages/mirage-crypto-ec/mirage-crypto-ec.2.0.3/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Elliptic Curve Cryptography with primitives taken from Fiat"
+description: """
+An implementation of key exchange (ECDH) and digital signature (ECDSA/EdDSA)
+algorithms using code from Fiat (<https://github.com/mit-plv/fiat-crypto>).
+
+The curves P256 (SECP256R1), P384 (SECP384R1),
+P521 (SECP521R1), and 25519 (X25519, Ed25519) are implemented by this package.
+"""
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "Nathan Rebours <nathan.p.rebours@gmail.com>"
+  "Clément Pascutto <clement@tarides.com>"
+  "Etienne Millon <me@emillon.org>"
+  "Virgile Robles <virgile.robles@protonmail.ch>"
+# and from the fiat-crypto AUTHORS file
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+  "Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mirage/mirage-crypto"
+doc: "https://mirage.github.io/mirage-crypto/doc"
+bug-reports: "https://github.com/mirage/mirage-crypto/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.13.0"}
+  "dune-configurator"
+  "eqaf" {>= "0.7"}
+  "mirage-crypto-rng" {=version}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "ppx_deriving_yojson" {with-test}
+  "ppx_deriving" {with-test}
+  "yojson" {with-test & >= "1.6.0"}
+  "asn1-combinators" {with-test & >= "0.3.1"}
+  "ohex" {with-test & >= "0.2.0"}
+  "ounit2" {with-test}
+]
+conflicts: [
+  "ocaml-freestanding"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
+tags: ["org:mirage"]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.0.3/mirage-crypto-2.0.3.tbz"
+  checksum: [
+    "sha256=3919a8bda3635959bb662d4ffa32266eb73c450ecc2a2b66ba5e1ecf88f7ad23"
+    "sha512=0580c8787cac821531c6038b9f82d32f6a7d3beee0b4c6900c2bf9fa3fa1b2a8d460b4d53ade8cd03e5e8e968b85f2c870c17818ad6e0f12d6834da92db4bef8"
+  ]
+}
+x-commit-hash: "5a753ec5ee9c0d3f1ea4e63695a62c1a50b66c5e"

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.2.0.3/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.2.0.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "ounit2" {with-test}
+  "randomconv" {with-test & >= "0.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "digestif" {>= "1.2.0"}
+  "zarith" {>= "1.13"}
+  "eqaf" {>= "0.8"}
+]
+conflicts: [
+  "ocaml-freestanding"
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.0.3/mirage-crypto-2.0.3.tbz"
+  checksum: [
+    "sha256=3919a8bda3635959bb662d4ffa32266eb73c450ecc2a2b66ba5e1ecf88f7ad23"
+    "sha512=0580c8787cac821531c6038b9f82d32f6a7d3beee0b4c6900c2bf9fa3fa1b2a8d460b4d53ade8cd03e5e8e968b85f2c870c17818ad6e0f12d6834da92db4bef8"
+  ]
+}
+x-commit-hash: "5a753ec5ee9c0d3f1ea4e63695a62c1a50b66c5e"

--- a/packages/mirage-crypto-rng-miou-unix/mirage-crypto-rng-miou-unix.2.0.3/opam
+++ b/packages/mirage-crypto-rng-miou-unix/mirage-crypto-rng-miou-unix.2.0.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an miou.unix-friendly way"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7"}
+  "miou" {>= "0.2.0"}
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "mtime" {>= "1.0.0"}
+  "digestif" {>= "1.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+description: """
+Mirage-crypto-rng-miou-unix feeds the entropy source for Mirage_crypto_rng-based
+random number generator implementations, in an miou.unix-friendly way.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.0.3/mirage-crypto-2.0.3.tbz"
+  checksum: [
+    "sha256=3919a8bda3635959bb662d4ffa32266eb73c450ecc2a2b66ba5e1ecf88f7ad23"
+    "sha512=0580c8787cac821531c6038b9f82d32f6a7d3beee0b4c6900c2bf9fa3fa1b2a8d460b4d53ade8cd03e5e8e968b85f2c870c17818ad6e0f12d6834da92db4bef8"
+  ]
+}
+x-commit-hash: "5a753ec5ee9c0d3f1ea4e63695a62c1a50b66c5e"

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.2.0.3/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.2.0.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "BSD-2-Clause"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "logs"
+  "lwt" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.8.0"}
+  "mirage-sleep" {>= "4.0.0"}
+  "mirage-mtime" {>= "4.0.0"}
+  "mirage-unix" {with-test & >= "5.0.0"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.0.3/mirage-crypto-2.0.3.tbz"
+  checksum: [
+    "sha256=3919a8bda3635959bb662d4ffa32266eb73c450ecc2a2b66ba5e1ecf88f7ad23"
+    "sha512=0580c8787cac821531c6038b9f82d32f6a7d3beee0b4c6900c2bf9fa3fa1b2a8d460b4d53ade8cd03e5e8e968b85f2c870c17818ad6e0f12d6834da92db4bef8"
+  ]
+}
+x-commit-hash: "5a753ec5ee9c0d3f1ea4e63695a62c1a50b66c5e"

--- a/packages/mirage-crypto-rng-mkernel/mirage-crypto-rng-mkernel.2.0.3/opam
+++ b/packages/mirage-crypto-rng-mkernel/mirage-crypto-rng-mkernel.2.0.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in a mkernel friendly way"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7"}
+  "miou" {>= "0.2.0"}
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "digestif" {>= "1.2.0"}
+  "mkernel"
+]
+description: """
+Mirage-crypto-rng-mkernel feeds the entropy source for Mirage_crypto_rng-based
+random number generator implementations, in a mkernel friendly way.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.0.3/mirage-crypto-2.0.3.tbz"
+  checksum: [
+    "sha256=3919a8bda3635959bb662d4ffa32266eb73c450ecc2a2b66ba5e1ecf88f7ad23"
+    "sha512=0580c8787cac821531c6038b9f82d32f6a7d3beee0b4c6900c2bf9fa3fa1b2a8d460b4d53ade8cd03e5e8e968b85f2c870c17818ad6e0f12d6834da92db4bef8"
+  ]
+}
+x-commit-hash: "5a753ec5ee9c0d3f1ea4e63695a62c1a50b66c5e"

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.2.0.3/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.2.0.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "duration"
+  "logs"
+  "mirage-crypto" {=version}
+  "digestif" {>= "1.1.4"}
+  "ounit2" {with-test}
+  "randomconv" {with-test & >= "0.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.0.3/mirage-crypto-2.0.3.tbz"
+  checksum: [
+    "sha256=3919a8bda3635959bb662d4ffa32266eb73c450ecc2a2b66ba5e1ecf88f7ad23"
+    "sha512=0580c8787cac821531c6038b9f82d32f6a7d3beee0b4c6900c2bf9fa3fa1b2a8d460b4d53ade8cd03e5e8e968b85f2c870c17818ad6e0f12d6834da92db4bef8"
+  ]
+}
+x-commit-hash: "5a753ec5ee9c0d3f1ea4e63695a62c1a50b66c5e"

--- a/packages/mirage-crypto/mirage-crypto.2.0.3/opam
+++ b/packages/mirage-crypto/mirage-crypto.2.0.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit2" {with-test}
+  "ohex" {with-test & >= "0.2.0"}
+  "eqaf" {>= "0.8"}
+]
+conflicts: [
+  "ocaml-freestanding"
+  "result" {< "1.5"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305).
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.0.3/mirage-crypto-2.0.3.tbz"
+  checksum: [
+    "sha256=3919a8bda3635959bb662d4ffa32266eb73c450ecc2a2b66ba5e1ecf88f7ad23"
+    "sha512=0580c8787cac821531c6038b9f82d32f6a7d3beee0b4c6900c2bf9fa3fa1b2a8d460b4d53ade8cd03e5e8e968b85f2c870c17818ad6e0f12d6834da92db4bef8"
+  ]
+}
+x-commit-hash: "5a753ec5ee9c0d3f1ea4e63695a62c1a50b66c5e"


### PR DESCRIPTION
Simple symmetric cryptography for the modern age

- Project page: <a href="https://github.com/mirage/mirage-crypto">https://github.com/mirage/mirage-crypto</a>
- Documentation: <a href="https://mirage.github.io/mirage-crypto/doc">https://mirage.github.io/mirage-crypto/doc</a>

##### CHANGES:

* Add mirage-crypto-rng-mkernel (mirage/mirage-crypto#266 @dinosaure)
* Add PPC macros (mirage/mirage-crypto#269 @barracuda156)

Partially sponsored by Tarides