### PR TITLE
[new release] containers (2 packages) (3.18)

### DIFF
--- a/packages/containers-data/containers-data.3.18/opam
+++ b/packages/containers-data/containers-data.3.18/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "A set of advanced datatypes for containers"
+maintainer: ["c-cube"]
+authors: ["c-cube"]
+license: "BSD-2-Clause"
+tags: ["containers" "RAL" "function" "vector" "okasaki"]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "containers" {= version}
+  "qcheck-core" {>= "0.91" & with-test}
+  "iter" {with-test}
+  "gen" {with-test}
+  "mdx" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+url {
+  src:
+    "https://github.com/c-cube/ocaml-containers/releases/download/v3.18/containers-3.18.tbz"
+  checksum: [
+    "sha256=52eeff91ce42b52305e6aaa8a58b88ce8f0a5a984199e59ca7e2fd9ebabe61d7"
+    "sha512=dc7337e6cbc9850542c7c9228d3bcb4e4add57a55e2a2992f21fb4761b3e10a68ef1d57ca37a7f5b303fc875fe3df5ecb69dbf2930bfcd1561ce03f7ae83e24b"
+  ]
+}
+x-commit-hash: "42bfe9c8c6fbb265951b6f8dacf52dd557db4200"

--- a/packages/containers/containers.3.18/opam
+++ b/packages/containers/containers.3.18/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "A modular, clean and powerful extension of the OCaml standard library"
+maintainer: ["c-cube"]
+authors: ["c-cube"]
+license: "BSD-2-Clause"
+tags: ["stdlib" "containers" "iterators" "list" "heap" "queue"]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "either"
+  "dune-configurator"
+  "qcheck-core" {>= "0.91" & with-test}
+  "yojson" {with-test}
+  "iter" {with-test}
+  "gen" {with-test}
+  "csexp" {with-test}
+  "uutf" {with-test}
+  "odoc" {with-doc}
+]
+depopts: ["base-unix" "base-threads"]
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+url {
+  src:
+    "https://github.com/c-cube/ocaml-containers/releases/download/v3.18/containers-3.18.tbz"
+  checksum: [
+    "sha256=52eeff91ce42b52305e6aaa8a58b88ce8f0a5a984199e59ca7e2fd9ebabe61d7"
+    "sha512=dc7337e6cbc9850542c7c9228d3bcb4e4add57a55e2a2992f21fb4761b3e10a68ef1d57ca37a7f5b303fc875fe3df5ecb69dbf2930bfcd1561ce03f7ae83e24b"
+  ]
+}
+x-commit-hash: "42bfe9c8c6fbb265951b6f8dacf52dd557db4200"


### PR DESCRIPTION
A modular, clean and powerful extension of the OCaml standard library

- Project page: <a href="https://github.com/c-cube/ocaml-containers/">https://github.com/c-cube/ocaml-containers/</a>

##### CHANGES:

- fix leb128 slice bug
- fix leb128 `Int64.min_int` bug
- add tests for leb128 library (c-cube/ocaml-containers#486)
- some breaking changes after the big bump to 4.08 as lower bound, thanks to @fardale for the cleanup
  * breaking: CCListLabel.compare and CCListLabel.equal takes the function on the elements as named arguments
  * breaking: CCListLabel.init now takes the length as a named arguments to follow the Stdlib
  * breaking: change the semantic of CCFloat.{min,max} with respect to NaN to follow the Stdlib
  * breaking: change the semantic of CCInt.rem with respect to negative number to follow the Stdlib
  * breaking: change the order of argument of `CCMap.add_seq` to align with the stdlib.
