### PR TITLE
[new release] yocaml (14 packages) (3.0.0)

### DIFF
--- a/packages/yocaml/yocaml.3.0.0/opam
+++ b/packages/yocaml/yocaml.3.0.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Core engine of the YOCaml Static Site Generator"
+description: "YOCaml is a build system dedicated to generate static document"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.1.1"}
+  "logs" {>= "0.7.0"}
+  "odoc" {with-doc}
+  "sherlodoc" {with-doc}
+  "fmt" {with-test}
+  "alcotest" {with-test & >= "1.3.0"}
+  "qcheck" {with-test & >= "0.91"}
+  "qcheck-alcotest" {with-test & >= "0.91"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "ocamlformat" {with-dev-setup}
+  "ocp-indent" {with-dev-setup}
+  "merlin" {with-dev-setup}
+  "utop" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v3.0.0/yocaml-3.0.0.tbz"
+  checksum: [
+    "sha256=c5237c5f345f76c829fd9f4ec5fcd05051e6f4372b24ecf798a48c2649ce9a0e"
+    "sha512=babeab686e031160882b739f07773bf1a2ae94a10de8992a4d812b35a487a353c2d3d915ac17fe74b7961570984c62d022c9108aa72562b5d81f93829ef62576"
+  ]
+}
+x-commit-hash: "9673ba3463162b72b3eab1e8d3c75814daa79628"

--- a/packages/yocaml_cmarkit/yocaml_cmarkit.3.0.0/opam
+++ b/packages/yocaml_cmarkit/yocaml_cmarkit.3.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis:
+  "Yocaml plugin for using Markdown (via Cmarkit package) as a Markup language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "cmarkit"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v3.0.0/yocaml-3.0.0.tbz"
+  checksum: [
+    "sha256=c5237c5f345f76c829fd9f4ec5fcd05051e6f4372b24ecf798a48c2649ce9a0e"
+    "sha512=babeab686e031160882b739f07773bf1a2ae94a10de8992a4d812b35a487a353c2d3d915ac17fe74b7961570984c62d022c9108aa72562b5d81f93829ef62576"
+  ]
+}
+x-commit-hash: "9673ba3463162b72b3eab1e8d3c75814daa79628"

--- a/packages/yocaml_eio/yocaml_eio.3.0.0/opam
+++ b/packages/yocaml_eio/yocaml_eio.3.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "The Eio runtime YOCaml"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "yocaml_runtime" {= version}
+  "eio" {>= "1.1"}
+  "eio_main" {>= "1.1"}
+  "cohttp-eio" {>= "6.0.0~beta2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v3.0.0/yocaml-3.0.0.tbz"
+  checksum: [
+    "sha256=c5237c5f345f76c829fd9f4ec5fcd05051e6f4372b24ecf798a48c2649ce9a0e"
+    "sha512=babeab686e031160882b739f07773bf1a2ae94a10de8992a4d812b35a487a353c2d3d915ac17fe74b7961570984c62d022c9108aa72562b5d81f93829ef62576"
+  ]
+}
+x-commit-hash: "9673ba3463162b72b3eab1e8d3c75814daa79628"

--- a/packages/yocaml_git/yocaml_git.3.0.0/opam
+++ b/packages/yocaml_git/yocaml_git.3.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Yocaml plugins for generating Yocaml program into a Git repository"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "lwt" {>= "5.7.0"}
+  "mimic" {>= "0.0.9"}
+  "cstruct" {>= "6.2.0"}
+  "git-kv" {>= "0.2.0"}
+  "git-net" {>= "0.2.0"}
+  "mirage-clock" {>= "4.2.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "yocaml" {= version}
+  "yocaml_runtime" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v3.0.0/yocaml-3.0.0.tbz"
+  checksum: [
+    "sha256=c5237c5f345f76c829fd9f4ec5fcd05051e6f4372b24ecf798a48c2649ce9a0e"
+    "sha512=babeab686e031160882b739f07773bf1a2ae94a10de8992a4d812b35a487a353c2d3d915ac17fe74b7961570984c62d022c9108aa72562b5d81f93829ef62576"
+  ]
+}
+x-commit-hash: "9673ba3463162b72b3eab1e8d3c75814daa79628"

--- a/packages/yocaml_jingoo/yocaml_jingoo.3.0.0/opam
+++ b/packages/yocaml_jingoo/yocaml_jingoo.3.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for using Jingoo as a template language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "jingoo" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v3.0.0/yocaml-3.0.0.tbz"
+  checksum: [
+    "sha256=c5237c5f345f76c829fd9f4ec5fcd05051e6f4372b24ecf798a48c2649ce9a0e"
+    "sha512=babeab686e031160882b739f07773bf1a2ae94a10de8992a4d812b35a487a353c2d3d915ac17fe74b7961570984c62d022c9108aa72562b5d81f93829ef62576"
+  ]
+}
+x-commit-hash: "9673ba3463162b72b3eab1e8d3c75814daa79628"

--- a/packages/yocaml_liquid/yocaml_liquid.3.0.0/opam
+++ b/packages/yocaml_liquid/yocaml_liquid.3.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for using Liquid as a template language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "ocaml" {>= "5.1.1"}
+  "dune" {>= "3.18" & >= "3.18"}
+  "ppx_expect"
+  "mdx" {>= "2.5.0" & with-test}
+  "yocaml" {= version}
+  "liquid_ml" {>= "0.1.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v3.0.0/yocaml-3.0.0.tbz"
+  checksum: [
+    "sha256=c5237c5f345f76c829fd9f4ec5fcd05051e6f4372b24ecf798a48c2649ce9a0e"
+    "sha512=babeab686e031160882b739f07773bf1a2ae94a10de8992a4d812b35a487a353c2d3d915ac17fe74b7961570984c62d022c9108aa72562b5d81f93829ef62576"
+  ]
+}
+x-commit-hash: "9673ba3463162b72b3eab1e8d3c75814daa79628"

--- a/packages/yocaml_markdown/yocaml_markdown.3.0.0/opam
+++ b/packages/yocaml_markdown/yocaml_markdown.3.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "The recommended plugin for processing Markdown documents (based on Cmarkit)"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "cmarkit"
+  "hilite" {>= "0.5.0"}
+  "textmate-language"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v3.0.0/yocaml-3.0.0.tbz"
+  checksum: [
+    "sha256=c5237c5f345f76c829fd9f4ec5fcd05051e6f4372b24ecf798a48c2649ce9a0e"
+    "sha512=babeab686e031160882b739f07773bf1a2ae94a10de8992a4d812b35a487a353c2d3d915ac17fe74b7961570984c62d022c9108aa72562b5d81f93829ef62576"
+  ]
+}
+x-commit-hash: "9673ba3463162b72b3eab1e8d3c75814daa79628"

--- a/packages/yocaml_mustache/yocaml_mustache.3.0.0/opam
+++ b/packages/yocaml_mustache/yocaml_mustache.3.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for using Mustache as a template language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "mustache" {>= "3.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v3.0.0/yocaml-3.0.0.tbz"
+  checksum: [
+    "sha256=c5237c5f345f76c829fd9f4ec5fcd05051e6f4372b24ecf798a48c2649ce9a0e"
+    "sha512=babeab686e031160882b739f07773bf1a2ae94a10de8992a4d812b35a487a353c2d3d915ac17fe74b7961570984c62d022c9108aa72562b5d81f93829ef62576"
+  ]
+}
+x-commit-hash: "9673ba3463162b72b3eab1e8d3c75814daa79628"

--- a/packages/yocaml_omd/yocaml_omd.3.0.0/opam
+++ b/packages/yocaml_omd/yocaml_omd.3.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis:
+  "Yocaml plugin for using Markdown (via OMD package) as a Markup language"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "omd" {>= "2.0.0~alpha4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v3.0.0/yocaml-3.0.0.tbz"
+  checksum: [
+    "sha256=c5237c5f345f76c829fd9f4ec5fcd05051e6f4372b24ecf798a48c2649ce9a0e"
+    "sha512=babeab686e031160882b739f07773bf1a2ae94a10de8992a4d812b35a487a353c2d3d915ac17fe74b7961570984c62d022c9108aa72562b5d81f93829ef62576"
+  ]
+}
+x-commit-hash: "9673ba3463162b72b3eab1e8d3c75814daa79628"

--- a/packages/yocaml_otoml/yocaml_otoml.3.0.0/opam
+++ b/packages/yocaml_otoml/yocaml_otoml.3.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for dealing with TOML as metadata provider"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "otoml" {>= "1.0.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v3.0.0/yocaml-3.0.0.tbz"
+  checksum: [
+    "sha256=c5237c5f345f76c829fd9f4ec5fcd05051e6f4372b24ecf798a48c2649ce9a0e"
+    "sha512=babeab686e031160882b739f07773bf1a2ae94a10de8992a4d812b35a487a353c2d3d915ac17fe74b7961570984c62d022c9108aa72562b5d81f93829ef62576"
+  ]
+}
+x-commit-hash: "9673ba3463162b72b3eab1e8d3c75814daa79628"

--- a/packages/yocaml_runtime/yocaml_runtime.3.0.0/opam
+++ b/packages/yocaml_runtime/yocaml_runtime.3.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Tool for describing runtimes (using Logs and Digestif)"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "cohttp" {>= "5.3.11"}
+  "magic-mime" {>= "1.3.1"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.9.0"}
+  "digestif" {>= "1.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v3.0.0/yocaml-3.0.0.tbz"
+  checksum: [
+    "sha256=c5237c5f345f76c829fd9f4ec5fcd05051e6f4372b24ecf798a48c2649ce9a0e"
+    "sha512=babeab686e031160882b739f07773bf1a2ae94a10de8992a4d812b35a487a353c2d3d915ac17fe74b7961570984c62d022c9108aa72562b5d81f93829ef62576"
+  ]
+}
+x-commit-hash: "9673ba3463162b72b3eab1e8d3c75814daa79628"

--- a/packages/yocaml_syndication/yocaml_syndication.3.0.0/opam
+++ b/packages/yocaml_syndication/yocaml_syndication.3.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for dealing with RSS and Atom feed"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.1.1"}
+  "yocaml" {= version}
+  "fmt" {with-test}
+  "alcotest" {with-test & >= "1.3.0"}
+  "qcheck" {with-test & >= "0.91"}
+  "qcheck-alcotest" {with-test & >= "0.91"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v3.0.0/yocaml-3.0.0.tbz"
+  checksum: [
+    "sha256=c5237c5f345f76c829fd9f4ec5fcd05051e6f4372b24ecf798a48c2649ce9a0e"
+    "sha512=babeab686e031160882b739f07773bf1a2ae94a10de8992a4d812b35a487a353c2d3d915ac17fe74b7961570984c62d022c9108aa72562b5d81f93829ef62576"
+  ]
+}
+x-commit-hash: "9673ba3463162b72b3eab1e8d3c75814daa79628"

--- a/packages/yocaml_unix/yocaml_unix.3.0.0/opam
+++ b/packages/yocaml_unix/yocaml_unix.3.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "The Unix runtime for YOCaml"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "httpcats" {>= "0.0.1"}
+  "yocaml" {= version}
+  "yocaml_runtime" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v3.0.0/yocaml-3.0.0.tbz"
+  checksum: [
+    "sha256=c5237c5f345f76c829fd9f4ec5fcd05051e6f4372b24ecf798a48c2649ce9a0e"
+    "sha512=babeab686e031160882b739f07773bf1a2ae94a10de8992a4d812b35a487a353c2d3d915ac17fe74b7961570984c62d022c9108aa72562b5d81f93829ef62576"
+  ]
+}
+x-commit-hash: "9673ba3463162b72b3eab1e8d3c75814daa79628"

--- a/packages/yocaml_yaml/yocaml_yaml.3.0.0/opam
+++ b/packages/yocaml_yaml/yocaml_yaml.3.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Yocaml plugin for dealing with Yaml as metadata provider"
+maintainer: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+authors: ["The XHTMLBoy <xhtmlboi@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/xhtmlboi/yocaml"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.1.1"}
+  "ppx_expect"
+  "mdx" {with-test & >= "2.5.0"}
+  "yocaml" {= version}
+  "yaml" {>= "3.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/xhtmlboi/yocaml/releases/download/v3.0.0/yocaml-3.0.0.tbz"
+  checksum: [
+    "sha256=c5237c5f345f76c829fd9f4ec5fcd05051e6f4372b24ecf798a48c2649ce9a0e"
+    "sha512=babeab686e031160882b739f07773bf1a2ae94a10de8992a4d812b35a487a353c2d3d915ac17fe74b7961570984c62d022c9108aa72562b5d81f93829ef62576"
+  ]
+}
+x-commit-hash: "9673ba3463162b72b3eab1e8d3c75814daa79628"


### PR DESCRIPTION
Core engine of the YOCaml Static Site Generator

- Project page: <a href="https://github.com/xhtmlboi/yocaml">https://github.com/xhtmlboi/yocaml</a>

##### CHANGES:

#### Yocaml

- Use `float` instead of `int` for `time` and `mtime` (by [xhtmlboi](https://github.com/xhtmlboi))
- Add `Action.write_files` (_et consort_) to share tasks between the creation of several files (by [xhtmlboi](https://github.com/xhtmlboi))
- Fix `Path.relocate` (by [mspwn](https://github.com/mspwn))
- Add `Data.Validation.req` and `Data.Validation.opt` for compact validation and alternative name (by [xhtmlboi](https://github.com/xhtmlboi))
- Add `Data.Validation.where_opt` (and `String`, `Int` and `Float` version) (by [xvw](https://xvw.lol))
- Improve pretty-printing of validation errors (by [Linda-Njau](https://github.com/Linda-Njau))
- Fix typos and improve logs display (by [clementd](https://clementd.wtf))

#### Yocaml_unix

- Improve rendering of 500 error pages on server (by [Linda-Njau](https://github.com/Linda-Njau))
- Use `float` instead of `int` for `time` and `mtime` (by [xhtmlboi](https://github.com/xhtmlboi))

#### Yocaml_eio

- Improve rendering of 500 error pages on server (by [Linda-Njau](https://github.com/Linda-Njau))
- Use `float` instead of `int` for `time` and `mtime` (by [xhtmlboi](https://github.com/xhtmlboi))

#### Yocaml_git

- Use `float` instead of `int` for `time` and `mtime` (by [xhtmlboi](https://github.com/xhtmlboi))
