### PR TITLE
[new release] miou (0.5.3)

### DIFF
--- a/packages/miou/miou.0.5.3/opam
+++ b/packages/miou/miou.0.5.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/robur-coop/miou"
+bug-reports:  "https://github.com/robur-coop/miou/issues"
+dev-repo:     "git+https://github.com/robur-coop/miou.git"
+doc:          "https://docs.osau.re/miou/"
+license:      "MIT"
+synopsis:     "Composable concurrency primitives for OCaml"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"             {>= "5.0.0"}
+  "dune"              {>= "3.13.0"}
+  "dune-configurator"
+  "dscheck"           {with-test & >= "0.4.0"}
+  "digestif"          {with-test}
+  "happy-eyeballs"    {with-test & >= "0.6.0"}
+  "dns-client"        {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test}
+  "ipaddr"            {with-test}
+  "logs"              {with-test & >= "0.7.0"}
+  "dns"               {with-test}
+  "dns-client"        {with-test}
+  "mtime"             {with-test & >= "2.0.0"}
+  "ocamlformat"       {with-dev-setup & = "0.27.0"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/miou/releases/download/v0.5.3/miou-0.5.3.tbz"
+  checksum: [
+    "sha256=eb6eb7830711d9eb8da9bf19492a4f996ce9f047b316505a1f3675aef1e605f2"
+    "sha512=37b2bc9439363371bbc35ba625a0737024f8da4285467cb9bf6243bbe48b090606d1deba86231b7f43dbef6ccda3d728d592285710a2467e2a6429b38fecf2dc"
+  ]
+}
+x-commit-hash: "0c989f5934cb34f874f6d11372f0607b8d990b9e"


### PR DESCRIPTION
Composable concurrency primitives for OCaml

- Project page: <a href="https://github.com/robur-coop/miou">https://github.com/robur-coop/miou</a>
- Documentation: <a href="https://docs.osau.re/miou/">https://docs.osau.re/miou/</a>

##### CHANGES:

- Fix how we handle signals and transfer them to the `dom0` (robur-coop/miou#98, @dinosaure,
  reported by @voodoos)
