### PR TITLE
[new release] grace (0.3.0)

### DIFF
--- a/packages/grace/grace.0.3.0/opam
+++ b/packages/grace/grace.0.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "A fancy diagnostics library that allows your compilers to exit with grace"
+maintainer: ["alistair.obrien@trili.tech"]
+authors: ["Alistair O'Brien"]
+license: "MIT"
+homepage: "https://github.com/johnyob/grace"
+bug-reports: "https://github.com/johnyob/grace/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.4"}
+  "fmt" {>= "0.8.7"}
+  "iter"
+  "uutf"
+  "sexplib"
+  "ppx_sexp_conv"
+  "dedent" {with-test}
+  "core" {with-test}
+  "ppx_jane" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/johnyob/grace.git"
+url {
+  src:
+    "https://github.com/johnyob/grace/releases/download/0.3.0/grace-0.3.0.tbz"
+  checksum: [
+    "sha256=6948979d6ffb5e596773baead81e9ceef36726d6956261bdd62abb2666a45bfc"
+    "sha512=db8b39cc9a77d919ab3123bb4047bb6c672c61db9fc6810951e267b2b113c4ac07266ef57188c6db0c02cb4d43d054204cd66ebc91648dbd1da1228022b0e67b"
+  ]
+}
+x-commit-hash: "15251666a11a780dfd09f23e1b0c1e6b0e366dcf"


### PR DESCRIPTION
A fancy diagnostics library that allows your compilers to exit with grace

- Project page: <a href="https://github.com/johnyob/grace">https://github.com/johnyob/grace</a>

##### CHANGES:

- feat(renderer): add breaks in large diagnostics ([johnyob/grace#63](https://github.com/johnyob/grace/pull/63))
- feat(renderer): check for tty when rendering ([johnyob/grace#60](https://github.com/johnyob/grace/pull/60))
- fix(renderer): off-by-one in `lines_of_labels` ([johnyob/grace#65](https://github.com/johnyob/grace/pull/65))
- fix(renderer): create 0-sized segment on empty label range ([johnyob/grace#64](https://github.com/johnyob/grace/pull/64))
- fix(renderer): renderer multi-line labels when message is empty ([johnyob/grace#53](https://github.com/johnyob/grace/pull/53))
- fix(renderer): fix errors that occur with special zero-width segments ([johnyob/grace#41](https://github.com/johnyob/grace/pull/41))
- fix(renderer): use `Format.pp_infinity` in `Message.to_string` for OCaml >5.2 ([johnyob/grace#40](https://github.com/johnyob/grace/pull/40))
- refactor!: removes base/core dependency ([johnyob/grace#58](https://github.com/johnyob/grace/pull/58))

### BREAKING CHANGE

* Many base/core interfaces from `Grace` have been replaced with custom ones.
* `Source.reader` has been removed. Use `Source.Reader.t` instead.
