### PR TITLE
[new release] virtfs (1.0.0)

### DIFF
--- a/packages/virtfs/virtfs.1.0.0/opam
+++ b/packages/virtfs/virtfs.1.0.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "An abstract implementation of file paths"
+description:
+  "Abstract on file paths to enable easy embedding of unit tests dependent on a file system"
+maintainer: [
+  "d-plaindoux <d.plaindoux@free.fr>"
+  "xhtmlboi <xhtmlboi@gmail.com>"
+  "xvw <xaviervdw@gmail.com>"
+  "msp <spawnmick@gmail.com>"
+  "grm <grimfw@gmail.com>"
+]
+authors: [
+  "d-plaindoux <d.plaindoux@free.fr>"
+  "xhtmlboi <xhtmlboi@gmail.com>"
+  "xvw <xaviervdw@gmail.com>"
+  "msp <spawnmick@gmail.com>"
+  "grm <grimfw@gmail.com>"
+]
+license: "BSD-3-Clause"
+homepage: "https://github.com/cargocut/virtfs"
+bug-reports: "https://github.com/cargocut/virtfs/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "5.0.0"}
+  "ppx_expect" {with-test & >= "0.17.3"}
+  "mdx" {with-test & >= "2.5.1"}
+  "utop" {with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+  "ocp-indent" {with-dev-setup}
+  "merlin" {with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/cargocut/virtfs.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/cargocut/virtfs/releases/download/v1.0.0/virtfs-1.0.0.tbz"
+  checksum: [
+    "sha256=e73c6e4ed5bf1215a715df1faff11107fe31be1da4c586f01e8cb124a9e483e4"
+    "sha512=9aadd14a4792de5d712da83aebe100a8ebfc2a2c805ef654794ae6814e61d8508b6d37cf7df389b036cb672259ae2e6b4c3f5071edebd3dfbde1f3632e63e26f"
+  ]
+}
+x-commit-hash: "80549451ee39ec82a2f8baab91343407cd7278d2"


### PR DESCRIPTION
An abstract implementation of file paths

- Project page: <a href="https://github.com/cargocut/virtfs">https://github.com/cargocut/virtfs</a>

##### CHANGES:

- First release of `virtfs`, exposing the modules `Path`, for
  abstracting file paths, `Tree` for describing an abstract file tree,
  and `Tree.Simple`, which is a very simple version of a file system
  (where the contents of files are strings) (by
  [mspwn](https://github.com/mspwn),
  [xhtmlboi](https://github.com/xhtmlboi),
  [gr-im](https://github.com/gr-im),
  [d-plaindoux](https://github.com/d-plaindoux)).
