### PR TITLE
[new release] quickterface (0.1.1)

### DIFF
--- a/packages/quickterface/quickterface.0.1.1/opam
+++ b/packages/quickterface/quickterface.0.1.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Quick-to-program app interfaces in OCaml for terminal and web"
+maintainer: ["Ofsouzap <ofsouzap@gmail.com>"]
+authors: ["Ofsouzap <ofsouzap@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ofsouzap/quickterface"
+bug-reports: "https://github.com/ofsouzap/quickterface/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "5.1.0"}
+  "core"
+  "js_of_ocaml" {>= "6.0.0"}
+  "js_of_ocaml-ppx"
+  "lwt"
+  "lwt_ppx"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "cohttp-lwt-jsoo"
+  "fpath"
+  "bos"
+  "notty" {>= "0.2.3"}
+  "cmdliner" {>= "2.1.0"}
+  "ocamlfind" {>= "1.9.8"}
+  "ppx_jane" {>= "v0.17.0"}
+  "ocamlformat" {with-dev-setup & = "0.28.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ofsouzap/quickterface.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ofsouzap/quickterface/releases/download/0.1.1/quickterface-0.1.1.tbz"
+  checksum: [
+    "sha256=93537febf436f3503494659f1593ad4b94cd982e17c1546b5dbfb09f8ee10eb9"
+    "sha512=4962fb0d173e6254d7f9644a6220f00ff3f9165e3e69a374cf217e91623ae45d19103ad7f1317a4ce6eaa3985c1887d093ac030cae4b93915f7414530fb800d7"
+  ]
+}
+x-commit-hash: "26e5b5d15cf8a3d23339314dacd33263a12edea5"


### PR DESCRIPTION
Quick-to-program app interfaces in OCaml for terminal and web

- Project page: <a href="https://github.com/ofsouzap/quickterface">https://github.com/ofsouzap/quickterface</a>

##### CHANGES:

Added `js_of_ocaml-compiler` dependency to `quickterface_web_app` web app library
