### PR TITLE
[new release] quickterface (0.1.2)

### DIFF
--- a/packages/quickterface/quickterface.0.1.2/opam
+++ b/packages/quickterface/quickterface.0.1.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Quick-to-program app interfaces in OCaml for terminal and web"
+maintainer: ["Ofsouzap <ofsouzap@gmail.com>"]
+authors: ["Ofsouzap <ofsouzap@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ofsouzap/quickterface"
+bug-reports: "https://github.com/ofsouzap/quickterface/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "5.1.0"}
+  "core"
+  "js_of_ocaml" {>= "6.0.0"}
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-compiler" {>= "6.2.0"}
+  "lwt"
+  "lwt_ppx"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "cohttp-lwt-jsoo"
+  "fpath"
+  "bos"
+  "notty" {>= "0.2.3"}
+  "cmdliner" {>= "2.1.0"}
+  "ocamlfind" {>= "1.9.8"}
+  "ppx_jane" {>= "v0.17.0"}
+  "ocamlformat" {with-dev-setup & = "0.28.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ofsouzap/quickterface.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ofsouzap/quickterface/releases/download/0.1.2/quickterface-0.1.2.tbz"
+  checksum: [
+    "sha256=9f0352868034f4fd75e1a0bd47e7413ce3888a2fd2fa252af688397afbcf2ace"
+    "sha512=bf73ccdc8721497414238604f32af36245091a578f8ca4704116b8d31ce1d506692454f1f555049d0b07cb132dadf233cc6c9b078adb4d9e25aaaf11394bb6a7"
+  ]
+}
+x-commit-hash: "4687de8821c82311b4bd4e93ee7a2621f9e8980d"


### PR DESCRIPTION
Quick-to-program app interfaces in OCaml for terminal and web

- Project page: <a href="https://github.com/ofsouzap/quickterface">https://github.com/ofsouzap/quickterface</a>

##### CHANGES:

Added `js_of_ocaml-compiler` dependency to `quickterface_web_app` web app library
