### PR TITLE
[new release] windtrap (0.1.0)

### DIFF
--- a/packages/ppx_windtrap/ppx_windtrap.0.1.0/opam
+++ b/packages/ppx_windtrap/ppx_windtrap.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "PPX and instrumentation backend for windtrap"
+description:
+  "PPX syntax for tests (let%test, let%expect_test, module%test, [%expect], [%%run_tests]) and code coverage instrumentation for windtrap."
+maintainer: ["Thibaut Mattio <thibaut.mattio@gmail.com>"]
+authors: ["Thibaut Mattio <thibaut.mattio@gmail.com>"]
+license: "ISC"
+tags: ["testing" "ppx" "expect-test" "coverage"]
+homepage: "https://github.com/invariant-hq/windtrap"
+bug-reports: "https://github.com/invariant-hq/windtrap/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "5.0"}
+  "windtrap" {= version}
+  "ppxlib" {>= "0.37.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/invariant-hq/windtrap.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/invariant-hq/windtrap/releases/download/0.1.0/windtrap-0.1.0.tbz"
+  checksum: [
+    "sha256=2241b294b24ed5d56ea8b834d296e6fabc5dbdd924a89f51c14b00da66c50a25"
+    "sha512=c6cf83028bb09d0f2afeb38fce6825620873a6bbeff4b5b77e928bc2fc69262d49fe341961cba2b451c9dc9bd0df414f06bb73020c7131b125c6abd85c6bc5dd"
+  ]
+}
+x-commit-hash: "5a6d0e2f470047306435a7d46e443d6eadb07be2"

--- a/packages/windtrap/windtrap.0.1.0/opam
+++ b/packages/windtrap/windtrap.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "One library for all your OCaml tests"
+description:
+  "Unit tests, property-based tests, snapshot tests, and expect tests in a single package with one API."
+maintainer: ["Thibaut Mattio <thibaut.mattio@gmail.com>"]
+authors: ["Thibaut Mattio <thibaut.mattio@gmail.com>"]
+license: "ISC"
+tags: [
+  "testing" "unit-test" "property-testing" "expect-test" "snapshot-testing"
+]
+homepage: "https://github.com/invariant-hq/windtrap"
+bug-reports: "https://github.com/invariant-hq/windtrap/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/invariant-hq/windtrap.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/invariant-hq/windtrap/releases/download/0.1.0/windtrap-0.1.0.tbz"
+  checksum: [
+    "sha256=2241b294b24ed5d56ea8b834d296e6fabc5dbdd924a89f51c14b00da66c50a25"
+    "sha512=c6cf83028bb09d0f2afeb38fce6825620873a6bbeff4b5b77e928bc2fc69262d49fe341961cba2b451c9dc9bd0df414f06bb73020c7131b125c6abd85c6bc5dd"
+  ]
+}
+x-commit-hash: "5a6d0e2f470047306435a7d46e443d6eadb07be2"


### PR DESCRIPTION
One library for all your OCaml tests

- Project page: <a href="https://github.com/invariant-hq/windtrap">https://github.com/invariant-hq/windtrap</a>

##### CHANGES:

Windtrap is an all-in-one OCaml testing framework that unifies unit tests, property-based tests, snapshot tests, and expect tests under a single API. Instead of juggling multiple testing libraries, Windtrap gives you one cohesive package with a PPX for inline expect tests (`windtrap.ppx`).

- Unit tests with combinators, tags, skip, brackets, and timeouts.
- Property-based testing with configurable seeds and shrinking.
- Snapshot testing with automatic file management and diffing.
- Inline expect tests via `windtrap.ppx` with automatic correction.
- CLI test runner with filtering, verbosity, and color support.
- Test coverage reporting with `bisect_ppx` integration.

### Acknowledgments

Windtrap builds on ideas and code from several OCaml projects:

- **[Alcotest](https://github.com/mirage/alcotest)** by Thomas Gazagnaire — test structure and runner design
- **Craig Ferguson's Alcotest PRs** ([invariant-hq/windtrap#294](https://github.com/mirage/alcotest/pull/294), [invariant-hq/windtrap#247](https://github.com/mirage/alcotest/pull/247)) — API design, subcomponent diffing, and Levenshtein distance (ISC)
- **[QCheck2](https://github.com/c-cube/qcheck)** by Simon Cruanes et al. — generator design and integrated shrinking (BSD 2-Clause)
- **[ppx_expect](https://github.com/janestreet/ppx_expect)** and **[ppx_inline_test](https://github.com/janestreet/ppx_inline_test)** by Jane Street — expect test paradigm and dune integration
- **[Bisect_ppx](https://github.com/aantron/bisect_ppx)** by Anton Bachin et al. — coverage instrumentation and runtime (MIT)
