### PR TITLE
[new release] js_of_ocaml (8 packages) (6.3.1)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.3.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.3.1/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.13" & < "5.5"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.16.1" & with-test}
+  "ppxlib" {>= "0.35"}
+  "ocaml-compiler-libs" {>= "v0.12.4"}
+  "re" {with-test}
+  "cmdliner" {>= "2.0"}
+  "sedlex" {>= "3.3"}
+  "qcheck" {with-test}
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson" {>= "2.1"}
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.3.1/js_of_ocaml-6.3.1.tbz"
+  checksum: [
+    "sha256=a2b679d4ad92f4482311ca8f7616e55d568d14b7d6192d94b2501f88252ea69d"
+    "sha512=f35771273aa3d292a4def10afc2ebcb6b3812e5c5f57404fdca5f87b17a25be5c7b527e26d76816e3a8acd6292c39ed39243e340ed54f72000c6850b768a957a"
+  ]
+}
+x-commit-hash: "69bd3193432ae6d54db921c5bf4d466d9fac79a7"

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.6.3.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.6.3.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "lwt" {>= "2.4.4" & != "5.9.2"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["graphics" "lwt_log"]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.3.1/js_of_ocaml-6.3.1.tbz"
+  checksum: [
+    "sha256=a2b679d4ad92f4482311ca8f7616e55d568d14b7d6192d94b2501f88252ea69d"
+    "sha512=f35771273aa3d292a4def10afc2ebcb6b3812e5c5f57404fdca5f87b17a25be5c7b527e26d76816e3a8acd6292c39ed39243e340ed54f72000c6850b768a957a"
+  ]
+}
+x-commit-hash: "69bd3193432ae6d54db921c5bf4d466d9fac79a7"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.6.3.1/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.6.3.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.35"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.3.1/js_of_ocaml-6.3.1.tbz"
+  checksum: [
+    "sha256=a2b679d4ad92f4482311ca8f7616e55d568d14b7d6192d94b2501f88252ea69d"
+    "sha512=f35771273aa3d292a4def10afc2ebcb6b3812e5c5f57404fdca5f87b17a25be5c7b527e26d76816e3a8acd6292c39ed39243e340ed54f72000c6850b768a957a"
+  ]
+}
+x-commit-hash: "69bd3193432ae6d54db921c5bf4d466d9fac79a7"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.6.3.1/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.6.3.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.35"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.3.1/js_of_ocaml-6.3.1.tbz"
+  checksum: [
+    "sha256=a2b679d4ad92f4482311ca8f7616e55d568d14b7d6192d94b2501f88252ea69d"
+    "sha512=f35771273aa3d292a4def10afc2ebcb6b3812e5c5f57404fdca5f87b17a25be5c7b527e26d76816e3a8acd6292c39ed39243e340ed54f72000c6850b768a957a"
+  ]
+}
+x-commit-hash: "69bd3193432ae6d54db921c5bf4d466d9fac79a7"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.6.3.1/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.6.3.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml-compiler" {= version}
+  "ocamlfind" {>= "1.5.1"}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.35"}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.3.1/js_of_ocaml-6.3.1.tbz"
+  checksum: [
+    "sha256=a2b679d4ad92f4482311ca8f7616e55d568d14b7d6192d94b2501f88252ea69d"
+    "sha512=f35771273aa3d292a4def10afc2ebcb6b3812e5c5f57404fdca5f87b17a25be5c7b527e26d76816e3a8acd6292c39ed39243e340ed54f72000c6850b768a957a"
+  ]
+}
+x-commit-hash: "69bd3193432ae6d54db921c5bf4d466d9fac79a7"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.6.3.1/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.6.3.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "react" {>= "1.2.2"}
+  "reactiveData" {>= "0.2"}
+  "tyxml" {>= "4.6"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.3.1/js_of_ocaml-6.3.1.tbz"
+  checksum: [
+    "sha256=a2b679d4ad92f4482311ca8f7616e55d568d14b7d6192d94b2501f88252ea69d"
+    "sha512=f35771273aa3d292a4def10afc2ebcb6b3812e5c5f57404fdca5f87b17a25be5c7b527e26d76816e3a8acd6292c39ed39243e340ed54f72000c6850b768a957a"
+  ]
+}
+x-commit-hash: "69bd3193432ae6d54db921c5bf4d466d9fac79a7"

--- a/packages/js_of_ocaml/js_of_ocaml.6.3.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.6.3.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml-compiler" {= version}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.35"}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.3.1/js_of_ocaml-6.3.1.tbz"
+  checksum: [
+    "sha256=a2b679d4ad92f4482311ca8f7616e55d568d14b7d6192d94b2501f88252ea69d"
+    "sha512=f35771273aa3d292a4def10afc2ebcb6b3812e5c5f57404fdca5f87b17a25be5c7b527e26d76816e3a8acd6292c39ed39243e340ed54f72000c6850b768a957a"
+  ]
+}
+x-commit-hash: "69bd3193432ae6d54db921c5bf4d466d9fac79a7"

--- a/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.3.1/opam
+++ b/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.3.1/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to WebAssembly"
+description:
+  "Wasm_of_ocaml is a compiler from OCaml bytecode to WebAssembly. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.14"}
+  "js_of_ocaml" {= version}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.35"}
+  "re" {with-test}
+  "cmdliner" {>= "2.0"}
+  "opam-format" {with-test}
+  "sedlex" {>= "2.3"}
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson" {>= "2.1"}
+  "conf-binaryen"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.3.1/js_of_ocaml-6.3.1.tbz"
+  checksum: [
+    "sha256=a2b679d4ad92f4482311ca8f7616e55d568d14b7d6192d94b2501f88252ea69d"
+    "sha512=f35771273aa3d292a4def10afc2ebcb6b3812e5c5f57404fdca5f87b17a25be5c7b527e26d76816e3a8acd6292c39ed39243e340ed54f72000c6850b768a957a"
+  ]
+}
+x-commit-hash: "69bd3193432ae6d54db921c5bf4d466d9fac79a7"


### PR DESCRIPTION
Compiler from OCaml bytecode to JavaScript

- Project page: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>
- Documentation: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>

##### CHANGES:

## Changes
*  Misc: fix installation of completion files in monorepo, working around
   bugs in dune
