### PR TITLE
Package oktree.0.2.3

### DIFF
--- a/packages/oktree/oktree.0.2.3/opam
+++ b/packages/oktree/oktree.0.2.3/opam
@@ -41,3 +41,11 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/anentropic/ocaml-oktree.git"
+url {
+  src:
+    "https://github.com/anentropic/ocaml-oktree/archive/refs/tags/v0.2.3.tar.gz"
+  checksum: [
+    "md5=76e32b47fc1f01b1770df13d62c73e67"
+    "sha512=a67410eed130f3ad90012402dafc7d327276e9b2c6057a602e78c83c94b2711227d1394fbdc779d34e549c14f127e5cc74f6dd6dc36f0087c600757bcac95d9a"
+  ]
+}


### PR DESCRIPTION
### `oktree.0.2.3`
OKtree: A simple octree implementation in OCaml
A simple octree implementation in OCaml, intended to efficiently find nearest match for an arbitrary point among a set of points in 3D coordinate space.



---
* Homepage: https://github.com/anentropic/ocaml-oktree
* Source repo: git+https://github.com/anentropic/ocaml-oktree.git
* Bug tracker: https://github.com/anentropic/ocaml-oktree/issues

---
:camel: Pull-request generated by opam-publish v2.7.1