### PR TITLE
timmy-lwt: upper bound lwt < 6.1.0

### DIFF
--- a/packages/timmy-lwt/timmy-lwt.1.1.5/opam
+++ b/packages/timmy-lwt/timmy-lwt.1.1.5/opam
@@ -13,7 +13,7 @@ depends: [
   "alcotest" {with-test & >= "1.4.0"}
   "alcotest-lwt" {with-test & >= "1.4.0"}
   "logs" {>= "0.7.0"}
-  "lwt"
+  "lwt" {< "6.1.0"}
   "timmy" {= version}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Fails with
```
#=== ERROR while compiling timmy-lwt.1.1.5 ====================================#
# context              2.5.0 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/timmy-lwt.1.1.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p timmy-lwt -j 71 @install
# exit-code            1
# env-file             ~/.opam/log/timmy-lwt-7-10f672.env
# output-file          ~/.opam/log/timmy-lwt-7-10f672.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I timmy-lwt/virtual/.timmy_lwt_virtual.objs/byte -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/js_of_ocaml -I /home/opam/.opam/4.14/lib/js_of_ocaml-compiler/runtime -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/timmy -I /home/opam/.opam/4.14/lib/timmy/clock -I /home/opam/.opam/4.14/lib/timmy/clock-virtual -I /home/opam/.opam/4.14/lib/timmy/clock/virtual -I timmy-lwt/lib/.timmy_lwt.objs/byte -I timmy-lwt/platform/.timmy_lwt_platform.objs/byte -intf-suffix .ml -no-alias-deps -o timmy-lwt/virtual/.timmy_lwt_virtual.objs/byte/timmy_lwt_virtual.cmo -c -impl timmy-lwt/virtual/src/timmy_lwt_virtual.pp.ml)
# File "timmy-lwt/virtual/src/timmy_lwt_virtual.ml", lines 8-46, characters 4-7:
#  8 | ....object (self)
#  9 |       inherit Lwt_engine.abstract
# 10 | 
# 11 |       method register_writable fd f =
# 12 |         let event = actual#on_writable fd (fun _ -> f ()) in
# ...
# 43 |                      f ()))
# 44 |           in
# 45 |           Lazy.force stop
# 46 |     end
# Error: This object has virtual methods.
#        The following methods are virtual : id
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I timmy-lwt/virtual/.timmy_lwt_virtual.objs/byte -I timmy-lwt/virtual/.timmy_lwt_virtual.objs/native -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/js_of_ocaml -I /home/opam/.opam/4.14/lib/js_of_ocaml-compiler/runtime -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/timmy -I /home/opam/.opam/4.14/lib/timmy/clock -I /home/opam/.opam/4.14/lib/timmy/clock-virtual -I /home/opam/.opam/4.14/lib/timmy/clock/virtual -I timmy-lwt/lib/.timmy_lwt.objs/byte -I timmy-lwt/lib/.timmy_lwt.objs/native -I timmy-lwt/platform/.timmy_lwt_platform.objs/byte -I timmy-lwt/platform/.timmy_lwt_platform.objs/native -intf-suffix .ml -no-alias-deps -o timmy-lwt/virtual/.timmy_lwt_virtual.objs/native/timmy_lwt_virtual.cmx -c -impl timmy-lwt/virtual/src/timmy_lwt_virtual.pp.ml)
# File "timmy-lwt/virtual/src/timmy_lwt_virtual.ml", lines 8-46, characters 4-7:
#  8 | ....object (self)
#  9 |       inherit Lwt_engine.abstract
# 10 | 
# 11 |       method register_writable fd f =
# 12 |         let event = actual#on_writable fd (fun _ -> f ()) in
# ...
# 43 |                      f ()))
# 44 |           in
# 45 |           Lazy.force stop
# 46 |     end
# Error: This object has virtual methods.
#        The following methods are virtual : id
```