### PR TITLE
conf-zlib: update for ortools_solvers

### DIFF
--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -29,10 +29,10 @@ depexts: [
   ["zlib"] {os-family = "arch"}
   ["zlib"] {os = "win32" & os-distribution = "cygwinports"}
   ["zlib-devel"] {os = "cygwin"}
-  ["zlib-ng-compat-devel"]  {os-family = "suse"}
-  ["zlib-devel"]	    {os-family = "opensuse" & os-version < "16"}
-  ["zlib-ng-compat-devel"]  {os-family = "opensuse" & os-version >= "16"}
-  ["libzip"] {os-distribution = "freebsd"}
+  ["zlib-ng-compat-devel"]  {os-family = "opensuse"}
+  ["zlib-devel"]	    {os-family = "suse" & os-version < "16"}
+  ["zlib-ng-compat-devel"]  {os-family = "suse" & os-version >= "16"}
+  # FreeBSD includes zlib in sysroot
 ]
 synopsis: "Virtual package relying on zlib"
 description:


### PR DESCRIPTION
Changes allowing conf-zlib to be used as a dependency for ortools_solvers.

for centos < 10: include zlib-static
for centos >= 10: use zlib-ng-compat-devel
add msys2
add suse and opensuse
add freebsd