### PR TITLE
[new release] quickterface (0.1.0)

### DIFF
--- a/packages/quickterface/quickterface.0.1.0/opam
+++ b/packages/quickterface/quickterface.0.1.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Quick-to-program app interfaces in OCaml for terminal and web"
+maintainer: ["Ofsouzap <ofsouzap@gmail.com>"]
+authors: ["Ofsouzap <ofsouzap@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ofsouzap/quickterface"
+bug-reports: "https://github.com/ofsouzap/quickterface/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "5.1.0"}
+  "core"
+  "js_of_ocaml" {>= "6.0.0"}
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-compiler" {>= "6.2.0"}
+  "lwt"
+  "lwt_ppx"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "cohttp-lwt-jsoo"
+  "fpath"
+  "bos"
+  "notty" {>= "0.2.3"}
+  "cmdliner" {>= "2.1.0"}
+  "ocamlfind" {>= "1.9.8"}
+  "ppx_jane" {>= "v0.17.0"}
+  "ocamlformat" {with-dev-setup & = "0.28.1"}
+  "bigstringaf" {>= "0.6.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ofsouzap/quickterface.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ofsouzap/quickterface/releases/download/0.1.0/quickterface-0.1.0.tbz"
+  checksum: [
+    "sha256=e1dc198ab2727898ff8c8ed23e500665777de7c95410cfa6674c4a8047010551"
+    "sha512=4a2e616e5f14b36a5dac5bac829155acd054b2355efd7a327751a89c2ec733625ab58adb216baa5d7563810fdf9e7ac70916d84f34854c6ef8570e56f468f7ff"
+  ]
+}
+x-commit-hash: "3b41921c4d47d49b2619069e4e3c2665c35c5f63"


### PR DESCRIPTION
Quick-to-program app interfaces in OCaml for terminal and web

- Project page: <a href="https://github.com/ofsouzap/quickterface">https://github.com/ofsouzap/quickterface</a>

##### CHANGES:

Added `js_of_ocaml-compiler` dependency to `quickterface_web_app` web app library
