### PR TITLE
[new release] tiny_httpd (3 packages) (0.20)

### DIFF
--- a/packages/tiny_httpd/tiny_httpd.0.20/opam
+++ b/packages/tiny_httpd/tiny_httpd.0.20/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Minimal HTTP server using threads"
+maintainer: ["c-cube"]
+authors: ["c-cube"]
+license: "MIT"
+tags: [
+  "http" "thread" "server" "tiny_httpd" "http_of_dir" "simplehttpserver"
+]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "seq"
+  "base-threads"
+  "result"
+  "hmap"
+  "iostream" {>= "0.2"}
+  "ocaml" {>= "4.13"}
+  "odoc" {with-doc}
+  "logs" {with-test}
+  "conf-libcurl" {with-test}
+  "ptime" {with-test}
+  "qcheck-core" {>= "0.91" & with-test}
+]
+depopts: [
+  "logs"
+  "magic-mime"
+  "mtime" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+url {
+  src:
+    "https://github.com/c-cube/tiny_httpd/releases/download/v0.20/tiny_httpd-0.20.tbz"
+  checksum: [
+    "sha256=618f0ec983d8986f2408e2f68e4f030c9cc7f3be2779f18ca288d3cb9266edce"
+    "sha512=f13b04ae7a84981d29eccb865c74cf5b4ab58ebdd635fb686f51b19b8c4213f770ad568767cf47031f351ff882b0b4b18522105cb62246401a46a14bfd2d4369"
+  ]
+}
+x-commit-hash: "f7ec687158da627778f482520ca5311947de5167"

--- a/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.20/opam
+++ b/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.20/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Interface to camlzip for tiny_httpd"
+maintainer: ["c-cube"]
+authors: ["c-cube"]
+license: "MIT"
+homepage: "https://github.com/c-cube/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "tiny_httpd" {= version}
+  "camlzip" {>= "1.06"}
+  "iostream-camlzip" {>= "0.2.1"}
+  "logs" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+url {
+  src:
+    "https://github.com/c-cube/tiny_httpd/releases/download/v0.20/tiny_httpd-0.20.tbz"
+  checksum: [
+    "sha256=618f0ec983d8986f2408e2f68e4f030c9cc7f3be2779f18ca288d3cb9266edce"
+    "sha512=f13b04ae7a84981d29eccb865c74cf5b4ab58ebdd635fb686f51b19b8c4213f770ad568767cf47031f351ff882b0b4b18522105cb62246401a46a14bfd2d4369"
+  ]
+}
+x-commit-hash: "f7ec687158da627778f482520ca5311947de5167"

--- a/packages/tiny_httpd_eio/tiny_httpd_eio.0.20/opam
+++ b/packages/tiny_httpd_eio/tiny_httpd_eio.0.20/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Use eio for tiny_httpd"
+maintainer: ["c-cube"]
+authors: ["c-cube"]
+license: "MIT"
+homepage: "https://github.com/c-cube/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "tiny_httpd" {= version}
+  "eio" {>= "1.0" & < "2.0"}
+  "base-unix"
+  "logs" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+url {
+  src:
+    "https://github.com/c-cube/tiny_httpd/releases/download/v0.20/tiny_httpd-0.20.tbz"
+  checksum: [
+    "sha256=618f0ec983d8986f2408e2f68e4f030c9cc7f3be2779f18ca288d3cb9266edce"
+    "sha512=f13b04ae7a84981d29eccb865c74cf5b4ab58ebdd635fb686f51b19b8c4213f770ad568767cf47031f351ff882b0b4b18522105cb62246401a46a14bfd2d4369"
+  ]
+}
+x-commit-hash: "f7ec687158da627778f482520ca5311947de5167"


### PR DESCRIPTION
Minimal HTTP server using threads

- Project page: <a href="https://github.com/c-cube/tiny_httpd/">https://github.com/c-cube/tiny_httpd/</a>

##### CHANGES:

- eio backend, second try (c-cube/tiny_httpd#95)
- hardening bugfixes
- feat WS: abstraction for critical section
- feat route: add `to_url`, to produce a URL path from a route
- fix some warnings
