### PR TITLE
Update version constraint in vsrocq-language-server.2.3.4

### DIFF
--- a/packages/vsrocq-language-server/vsrocq-language-server.2.3.4/opam
+++ b/packages/vsrocq-language-server/vsrocq-language-server.2.3.4/opam
@@ -16,10 +16,9 @@ build: [
 depends: [
   "ocaml" { >= "4.14" }
   "dune" { >= "3.5" }
-  ("coq-core" { ((>= "8.18" < "8.21") | (= "dev")) }
-  | "rocq-core" { ((>= "9.0+rc1" < "9.2~") | (= "dev")) })
-  ("coq-stdlib" { ((>= "8.18" < "8.21") | (= "dev")) }
-  | "rocq-stdlib" { ((>= "9.0+rc1" < "9.2~") | (= "dev")) })
+  (("coq-core" { ((>= "8.18" < "8.21") | (= "dev")) }
+    "coq-stdlib" { ((>= "8.18" < "8.21") | (= "dev")) })
+  | "rocq-core" { ((>= "9.0+rc1" < "9.3~") | (= "dev")) } )
   "yojson"
   "jsonrpc" { >= "1.15"}
   "ocamlfind"


### PR DESCRIPTION
- do not depend on rocq-stdlib
- this version is compatible with rocq 9.2