### PR TITLE
add oq.1.0.3

### DIFF
--- a/packages/oq/oq.1.0.3/opam
+++ b/packages/oq/oq.1.0.3/opam
@@ -15,7 +15,7 @@ depends: [
   "core_unix"
   "stdio"
   "ppx_jane"
-  "cmdliner"
+  "cmdliner" {>= "2.1.0"}
   "re2"
 ]
 build: [


### PR DESCRIPTION
This PR adds package oq version 1.0.3.

oq is an agent-first, deterministic query CLI for Org files, optimized for automation workflows and stable machine-readable output.
Homepage: https://github.com/s-kostyaev/oq

- Source: https://github.com/s-kostyaev/oq/archive/refs/tags/v1.0.3.tar.gz
- sha256: 545d69801817e1ba07447bb5ff643f5e04508cb68baeca1be18fa537a9c6c249
- sha512: 219296b00f71da287c3b54aec764160cad5c100c576879d6826d282d813701359592fd1c32396561c6a1f289528fd4e1e20d22e77bf9ad49566b424551017a1c

Local validation:
- opam lint --strict packages/oq/oq.1.0.3/opam
