### PR TITLE
Package natural-deduction.1.0

### DIFF
--- a/packages/natural-deduction/natural-deduction.1.0/opam
+++ b/packages/natural-deduction/natural-deduction.1.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis:
+  "A basic proof assistant for natural deduction in first-order logic"
+maintainer: "Eric Johannesson <eric@ericjohannesson.com>"
+authors: "Eric Johannesson <eric@ericjohannesson.com>"
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/ericjohannesson/natural-deduction"
+bug-reports: "https://github.com/ericjohannesson/natural-deduction/issues"
+depends: [
+  "ocaml"
+  "uuseg"
+  "ocamlfind" {build}
+  "menhir" {build}
+]
+build: [make "build"]
+install: [make "install"]
+dev-repo: "git+https://github.com/ericjohannesson/natural-deduction.git"
+url {
+  src:
+    "https://github.com/ericjohannesson/natural-deduction/archive/refs/tags/1.0.tar.gz"
+  checksum: [
+    "md5=9d717c0b352fce80e776a4f41096263c"
+    "sha512=899482438db93723b6030d6849e3ed8bf29ba7882cd2379d0bc9e01559fdd2ec05b570402e8a97275e9b77e054a40b518dd9f8df0776d37da23f14c918093669"
+  ]
+}


### PR DESCRIPTION
### `natural-deduction.1.0`
A basic proof assistant for natural deduction in first-order logic



---
* Homepage: https://github.com/ericjohannesson/natural-deduction
* Source repo: git+https://github.com/ericjohannesson/natural-deduction.git
* Bug tracker: https://github.com/ericjohannesson/natural-deduction/issues

---
:camel: Pull-request generated by opam-publish v2.7.1