### PR TITLE
add oq.1.0.4

### DIFF
--- a/packages/oq/oq.1.0.4/opam
+++ b/packages/oq/oq.1.0.4/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Agent-first org query CLI"
+description: "oq is a deterministic query CLI for Org files optimized for agent workflows."
+maintainer: ["Sergey Kostyaev"]
+authors: ["Sergey Kostyaev"]
+license: "MIT"
+homepage: "https://github.com/s-kostyaev/oq"
+bug-reports: "https://github.com/s-kostyaev/oq/issues"
+dev-repo: "git+https://github.com/s-kostyaev/oq.git"
+depends: [
+  "ocaml" {>= "5.1"}
+  "dune" {>= "3.14"}
+  "base"
+  "core"
+  "core_unix"
+  "stdio"
+  "ppx_jane"
+  "cmdliner" {>= "2.1.0"}
+  "re2"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/s-kostyaev/oq/archive/refs/tags/v1.0.4.tar.gz"
+  checksum: [
+    "sha256=fd09bc0bc22e5ad46128c01eb67aca814513207915f47d730cccaf67b8d29fd6"
+    "sha512=5cdb3d24df9d3af124c758f04bd54dc73dad19d7133439759a75fee62b4bca539aa09e2efda6e080baaaa86a371b2a56258b9e453465e9b887cd86cf4de5b0f3"
+  ]
+}


### PR DESCRIPTION
This PR adds package oq version 1.0.4.

oq is an agent-first, deterministic query CLI for Org files, optimized for automation workflows and stable machine-readable output.
Homepage: https://github.com/s-kostyaev/oq

- Source: https://github.com/s-kostyaev/oq/archive/refs/tags/v1.0.4.tar.gz
- sha256: fd09bc0bc22e5ad46128c01eb67aca814513207915f47d730cccaf67b8d29fd6
- sha512: 5cdb3d24df9d3af124c758f04bd54dc73dad19d7133439759a75fee62b4bca539aa09e2efda6e080baaaa86a371b2a56258b9e453465e9b887cd86cf4de5b0f3

Notes:
- Requires cmdliner >= 2.1.0 to satisfy lower-bounds checks.

Local validation:
- opam lint --strict packages/oq/oq.1.0.4/opam
