### PR TITLE
[new release] hxd (0.4.0)

### DIFF
--- a/packages/hxd/hxd.0.4.0/opam
+++ b/packages/hxd/hxd.0.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/hxd"
+bug-reports:  "https://github.com/dinosaure/hxd/issues"
+dev-repo:     "git+https://github.com/dinosaure/hxd.git"
+doc:          "https://dinosaure.github.io/hxd/"
+license:      "MIT"
+synopsis:     "Hexdump in OCaml"
+description: """Please, help me to debug ocaml-git
+"""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.7"}
+  "dune-configurator" {>= "2.7"}
+  "cmdliner"          {>= "1.1.0"}
+]
+
+depopts: [
+  "lwt"
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/dinosaure/hxd/releases/download/v0.4.0/hxd-0.4.0.tbz"
+  checksum: [
+    "sha256=10030b7226a17504471809ad5afc0c200721264c5c6dd3d595d248040a718058"
+    "sha512=7cc6911729d6b030d10b25a6222649bf1275dc18efcaefd170138addf744c790f786ff2772aaae65071b112a00ed6bd51d0c3667d49a185f0399739b5e8cb693"
+  ]
+}
+x-commit-hash: "376b18753a3e219e269085c926f04e8503b54af5"


### PR DESCRIPTION
Hexdump in OCaml

- Project page: <a href="https://github.com/dinosaure/hxd">https://github.com/dinosaure/hxd</a>
- Documentation: <a href="https://dinosaure.github.io/hxd/">https://dinosaure.github.io/hxd/</a>

##### CHANGES:

- Add a new kind when we output with `hxd.caml`: the string kind (@reynir, @dinosaure, dinosaure/hxd#23)
- Still escape few more characters when we print comments (@dinosaure, db68d47)
