### PR TITLE
curl_lwt: relax de version with lwt

### DIFF
--- a/packages/curl_lwt/curl_lwt.0.10.0/opam
+++ b/packages/curl_lwt/curl_lwt.0.10.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.11"}
   "base-unix"
   "curl" {= version}
-  "lwt" {< "6~"}
+  "lwt"
   "lwt_ppx" {with-dev-setup}
   "odoc" {with-doc}
 ]
@@ -31,6 +31,10 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+]
+conflicts: [
+	"lwt" {= "6.0.0~alpha00" }
+	"lwt" {= "6.0.0~beta01" }
 ]
 dev-repo: "git+https://github.com/ygrek/ocurl.git"
 url {


### PR DESCRIPTION
constraint was added during the alpha/beta phase of the lwt6 release cycle