### PR TITLE
[new release] react-rules-of-hooks-ppx (1.2.0)

### DIFF
--- a/packages/react-rules-of-hooks-ppx/react-rules-of-hooks-ppx.1.2.0/opam
+++ b/packages/react-rules-of-hooks-ppx/react-rules-of-hooks-ppx.1.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "This ppx validates the rules of React hooks in reason-react components"
+description:
+  "Validates exhaustive dependencies in useEffect, useLayoutEffect, useInsertionEffect, useCallback, useMemo and ensures hooks are called at the top level, never conditionally or inside loops."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx"
+bug-reports:
+  "https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "4.14"}
+  "ppxlib" {>= "0.36.0"}
+  "reason" {with-test & >= "3.10.0"}
+  "melange" {with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "mlx" {with-test | with-dev-setup}
+  "ocamlformat-mlx" {with-dev-setup}
+  "ocamlmerlin-mlx" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo:
+  "git+https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx.git"
+url {
+  src:
+    "https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx/releases/download/1.2.0/react-rules-of-hooks-ppx-1.2.0.tbz"
+  checksum: [
+    "sha256=ee569398e9fde0d18c694c1a13be0bcdbbb0df7ffb4d2844d908c645e1c20b3c"
+    "sha512=f8e178d0be3e5b39cf070e2bd35c838c563947829f6e8a4b15bf8ba59a2b324918d169c52e5a4651d0c84d883e404d430502d893b16a6a219789c95b1a6bcd5a"
+  ]
+}
+x-commit-hash: "289d31a40c4dca5b18ee4b0b444f660198fa6958"


### PR DESCRIPTION
This ppx validates the rules of React hooks in reason-react components

- Project page: <a href="https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx">https://github.com/ml-in-barcelona/react-rules-of-hooks-ppx</a>

##### CHANGES:

- [FEAT] Support `use` + numbers as a valid hook name
- [FIX] Outer scope bindings (module-level values and functions) no longer trigger missing dependency warnings in exhaustive deps checks
