### PR TITLE
[new release] httpcats (0.2.0)

### DIFF
--- a/packages/httpcats/httpcats.0.2.0/opam
+++ b/packages/httpcats/httpcats.0.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/httpcats"
+dev-repo: "git+https://github.com/robur-coop/httpcats.git"
+bug-reports: "https://github.com/robur-coop/httpcats/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.8.0"}
+  "logs" {with-test}
+  "miou" {>= "0.4.0"}
+  "fmt" {>= "0.9.0" & with-test}
+  "h2" {>= "0.13.0"}
+  "h1" {>= "1.1.0"}
+  "ca-certs"
+  "bstr"
+  "tls-miou-unix" {>= "1.0.1"}
+  "dns-client-miou-unix" {>= "9.0.0"}
+  "happy-eyeballs-miou-unix"
+  "mirage-crypto-rng-miou-unix" {with-test & >= "1.1.0"}
+  "alcotest" {>= "1.8.0" & with-test}
+  "digestif" {with-test & >= "1.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "A simple HTTP client / server using h1, h2, and miou"
+available: [ arch != "x86_32" ]
+url {
+  src:
+    "https://github.com/robur-coop/httpcats/releases/download/v0.2.0/httpcats-0.2.0.tbz"
+  checksum: [
+    "sha256=3587d8d1e297025340ab59b934acc2c96fabfc36ff60f07a7d64e7067521e631"
+    "sha512=8bb3be3ec6ff35e5ced00cd99d87c4a2f3941571cce90b54817de68374143a217b65ab1bd211a92414664a344fd41b61e1e92e908fcda900331cb14e5a2dd6f1"
+  ]
+}
+x-commit-hash: "0cfa8d27e219e8c898e2af9126aebf2f59b8ad65"


### PR DESCRIPTION
A simple HTTP client / server using h1, h2, and miou

- Project page: <a href="https://github.com/robur-coop/httpcats">https://github.com/robur-coop/httpcats</a>

##### CHANGES:

- Improve the OPAM file and the README.md (@geazi-anc, robur-coop/httpcats#39)
- Split out the core of `httpcats` to be re-usable by unikernels (@dinosaure, robur-coop/httpcats#40)
- Avoid a memory leak about logs (@dinosaure, robur-coop/httpcats#42)
- Upgrade GitHub CI and ocamlformat (@dinosaure, robur-coop/httpcats#43)
