### PR TITLE
[new release] slipshow 0.9.0: Manim Black

### DIFF
--- a/packages/slipshow/slipshow.0.9.0/opam
+++ b/packages/slipshow/slipshow.0.9.0/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+synopsis: "A compiler from markdown to slipshow"
+description:
+  "Slipshow is an engine to write slips, a concept evolved from slides."
+maintainer: ["Paul-Elliot"]
+authors: ["Paul-Elliot"]
+license: ["GPL-3.0-or-later" "ISC" "BSD-3-Clause" "Apache-2.0" "OFL-1.1"]
+tags: ["slipshow" "presentation" "slideshow" "beamer"]
+homepage: "https://github.com/panglesd/slipshow"
+doc: "https://slipshow.readthedocs.io"
+bug-reports: "https://github.com/panglesd/slipshow/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.6"}
+  "crunch" {with-dev-setup}
+  "lambdasoup" {with-test}
+  "cmdliner" {>= "1.3.0"}
+  "base64"
+  "bos"
+  "lwt"
+  "inotify" {os = "linux"}
+  "cf-lwt" {>= "0.4"}
+  "astring"
+  "fmt"
+  "logs"
+  "fsevents-lwt"
+  "js_of_ocaml-compiler" {>= "6.0.1"}
+  "js_of_ocaml-lwt"
+  "magic-mime"
+  "dream" {>= "1.0.0~alpha5"}
+  "fpath"
+  "ppx_blob" {>= "0.8.0"}
+  "sexplib"
+  "ppx_sexp_conv"
+  "ppx_deriving_yojson"
+  "odoc" {with-doc}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/panglesd/slipshow.git"
+# We avoid 32 bits arcitecture because our usage of ppx_blob generates strings
+# whose size exceed the maximum size in 32 bits OCaml...
+available: arch != "arm32" & arch != "x86_32"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/panglesd/slipshow/releases/download/v0.9.0/slipshow-0.9.0.tbz"
+  checksum: [
+    "sha256=45e61d9ccae45e57ee91ad93b4b6b196a8515533806a4095e2b4853339726fb8"
+    "sha512=cb895b1e82ff7c141829bde83c22ba2615289504a19012e5385bbdb2342c4def48752346ec848549b5f9563d769923bccf1094cb2f5b449233a2d4fab0e1632c"
+  ]
+}
+x-commit-hash: "54284adeea4792275cc1d99e17c75ebabc1e85b0"


### PR DESCRIPTION
See the [release](https://github.com/panglesd/slipshow/releases/tag/v0.9.0) for a gif.

CHANGES:

### Added

- Support for Mermaid JS (panglesd/slipshow#205)
- Support for syntax highlighting of all highlightjs-supported languages and themes (panglesd/slipshow#200, panglesd/slipshow#208)
- Support for MathJax extensions, especially the html extension to allow actions to target math elements (panglesd/slipshow#202)
- Add KaTeX as a possible alternate renderer (panglesd/slipshow#202)
- Added `carousel-fixed-size` to have carousel not change size (panglesd/slipshow#207)

### Fix

- Fix impossibility to reopen speaker view after closing it on Firefox (panglesd/slipshow#198, issue panglesd/slipshow#194)
- Fix impossibility to open speaker view in serve mode (panglesd/slipshow#198, issue panglesd/slipshow#197)
- Fix links opening inside iframe (panglesd/slipshow#198)
- Fix ending excursions with `ijkl` only when needed (panglesd/slipshow#207)
- Fixed video long-step handling (panglesd/slipshow#207)
- Removed confusing auto-generated IDs (panglesd/slipshow#209)
- Fix `play-media` behavior when facing errors (panglesd/slipshow#210)

### Docs

- Add how to include TikZ figures in your Slipshow presentation (panglesd/slipshow#206)
- Add how to include Manim videos in your Slipshow presentation (panglesd/slipshow#207)