### PR TITLE
Package ocsigen-ppx-rpc.1.1

### DIFF
--- a/packages/ocsigen-ppx-rpc/ocsigen-ppx-rpc.1.1/opam
+++ b/packages/ocsigen-ppx-rpc/ocsigen-ppx-rpc.1.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+authors: "dev@ocsigen.org"
+maintainer: "dev@ocsigen.org"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocsigen/ocsigen-ppx-rpc/"
+bug-reports: "https://github.com/ocsigen/ocsigen-ppx-rpc/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-ppx-rpc.git"
+synopsis: "This PPX adds a syntax for RPCs for Eliom and Ocsigen Start"
+
+available: os != "win32"
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {>= "2.8"}
+  "ppxlib" {>= "0.37.0"}
+]
+url {
+  src:
+    "https://github.com/ocsigen/ocsigen-ppx-rpc/archive/refs/tags/1.1.tar.gz"
+  checksum: [
+    "md5=314c601099e3371b776001a278209fdc"
+    "sha512=035ebb4e8b29a9b64fc04e5f060af2fe4c572f4b5d3389db11950a5dbe31c8ece709db374e2acdcb5a4192b5f363674db8494678be8d410cfd7b5d350a728d13"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-ppx-rpc.1.1`
This PPX adds a syntax for RPCs for Eliom and Ocsigen Start



---
* Homepage: https://github.com/ocsigen/ocsigen-ppx-rpc/
* Source repo: git+https://github.com/ocsigen/ocsigen-ppx-rpc.git
* Bug tracker: https://github.com/ocsigen/ocsigen-ppx-rpc/issues

---
:camel: Pull-request generated by opam-publish v2.7.1