### PR TITLE
Disable runtest for raven.1.0.0~alpha1 packages

### DIFF
--- a/packages/fehu/fehu.1.0.0~alpha1/opam
+++ b/packages/fehu/fehu.1.0.0~alpha1/opam
@@ -31,7 +31,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    # "@runtest" {with-test}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/kaun/kaun.1.0.0~alpha1/opam
+++ b/packages/kaun/kaun.1.0.0~alpha1/opam
@@ -32,7 +32,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    # "@runtest" {with-test}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/nx-datasets/nx-datasets.1.0.0~alpha1/opam
+++ b/packages/nx-datasets/nx-datasets.1.0.0~alpha1/opam
@@ -36,7 +36,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    # "@runtest" {with-test}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/nx/nx.1.0.0~alpha1/opam
+++ b/packages/nx/nx.1.0.0~alpha1/opam
@@ -31,7 +31,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    # "@runtest" {with-test}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/rune/rune.1.0.0~alpha1/opam
+++ b/packages/rune/rune.1.0.0~alpha1/opam
@@ -38,7 +38,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    # "@runtest" {with-test}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/sowilo/sowilo.1.0.0~alpha1/opam
+++ b/packages/sowilo/sowilo.1.0.0~alpha1/opam
@@ -29,7 +29,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    # "@runtest" {with-test}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/talon/talon.1.0.0~alpha1/opam
+++ b/packages/talon/talon.1.0.0~alpha1/opam
@@ -30,7 +30,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    # "@runtest" {with-test}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]


### PR DESCRIPTION
The raven.1.0.0~alpha1 packages (fehu, kaun, nx-datasets, nx, rune, sowilo, and talon) were merged in #28626 with 87 CI failures. They are now showing up, e.g., on #29394:

```
#=== ERROR while compiling fehu.1.0.0~alpha1 ==================================#
# context              2.5.0 | linux/x86_64 | ocaml-base-compiler.5.4.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.4/.opam-switch/build/fehu.1.0.0~alpha1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p fehu -j 255 --promote-install-files=false @install @runtest
# exit-code            1
# env-file             ~/.opam/log/fehu-7-ff5124.env
# output-file          ~/.opam/log/fehu-7-ff5124.out
### output ###
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlopt.opt -w -40 -g -o fehu/test/test_training.exe /home/opam/.opam/5.4/lib/yojson/yojson.cmxa /home/opam/.opam/5.4/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.4/lib/logs/logs.cmxa /home/opam/.opam/5.4/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/5.4/lib/integers/integers.cmxa -I /home/opam/.opam/5.4/lib/integers /home/opam/.opam/5.4/lib/ctypes/ctypes.cmxa -I /home/opam/.opam/5.4/lib/ctypes /home/opam/.opam/5.4/lib/rune/jit/rune_jit.cmxa /home/opam/.opam/5.4/lib/rune/jit/metal_or_missing/rune_jit_metal_or_missing.cmxa /home/opam/.opam/5.4/lib/rune/llvm/llvm.cmxa -I /home/opam/.opam/5.4/lib/rune/llvm /home/opam/.opam/5.4/lib/rune/llvm/target/llvm_target.cmxa -I /home/opam/.opam/5.4/lib/rune/llvm/target /home/opam/.opam/5.4/lib/rune/llvm/executionengine/llvm_executionengine.cmxa -I /home/opam/.opam/5.4/lib/rune/llvm/executionengine /home/opam/.opam/5.4/lib/rune/llvm/analysis/llvm_analysis.cmxa -I /home/opam/.opam/5.4/lib/rune/llvm/analysis /home/opam/.opam/5.4/lib/rune/llvm/all_backends/llvm_all_backends.cmxa -I /home/opam/.opam/5.4/lib/rune/llvm/all_backends /home/opam/.opam/5.4/lib/rune/llvm/passbuilder/llvm_passbuilder.cmxa -I /home/opam/.opam/5.4/lib/rune/llvm/passbuilder /home/opam/.opam/5.4/lib/ocaml/threads/threads.cmxa /home/opam/.opam/5.4/lib/ctypes-foreign/ctypes_foreign.cmxa -I /home/opam/.opam/5.4/lib/ctypes-foreign /home/opam/.opam/5.4/lib/rune/jit/llvm/rune_jit_llvm.cmxa /home/opam/.opam/5.4/lib/nx/bigarray_ext/bigarray_ext.cmxa -I /home/opam/.opam/5.4/lib/nx/bigarray_ext /home/opam/.opam/5.4/lib/ocaml/str/str.cmxa /home/opam/.opam/5.4/lib/nx/core/nx_core.cmxa /home/opam/.opam/5.4/lib/nx/pocketfft/pocketfft.cmxa -I /home/opam/.opam/5.4/lib/nx/pocketfft /home/opam/.opam/5.4/lib/nx/c/nx_c.cmxa -I /home/opam/.opam/5.4/lib/nx/c /home/opam/.opam/5.4/lib/nx/nx.cmxa /home/opam/.opam/5.4/lib/rune/rune.cmxa fehu/lib/fehu.cmxa fehu/lib/environments/fehu_envs.cmxa /home/opam/.opam/5.4/lib/nx/safetensors/safetensors.cmxa /home/opam/.opam/5.4/lib/nx/zip/zip.cmxa -I /home/opam/.opam/5.4/lib/nx/zip /home/opam/.opam/5.4/lib/nx/io/npy/npy.cmxa -I /home/opam/.opam/5.4/lib/nx/io/npy /home/opam/.opam/5.4/lib/nx/io/stb_image/stb_image.cmxa -I /home/opam/.opam/5.4/lib/nx/io/stb_image /home/opam/.opam/5.4/lib/nx/io/stb_image_write/stb_image_write.cmxa -I /home/opam/.opam/5.4/lib/nx/io/stb_image_write /home/opam/.opam/5.4/lib/nx/io/nx_io.cmxa /home/opam/.opam/5.4/lib/backoff/backoff.cmxa /home/opam/.opam/5.4/lib/multicore-magic/__private__/multicore_magic_atomic_array_unboxed5_4/multicore_magic_atomic_array_unboxed5_4.cmxa /home/opam/.opam/5.4/lib/multicore-magic/Multicore_magic.cmxa /home/opam/.opam/5.4/lib/saturn/saturn.cmxa /home/opam/.opam/5.4/lib/thread-table/Thread_table.cmxa /home/opam/.opam/5.4/lib/domain-local-await/Domain_local_await.cmxa /home/opam/.opam/5.4/lib/domainslib/domainslib.cmxa /home/opam/.opam/5.4/lib/kaun/kaun.cmxa fehu/lib/algorithms/fehu_algorithms.cmxa /home/opam/.opam/5.4/lib/astring/astring.cmxa /home/opam/.opam/5.4/lib/cmdliner/cmdliner.cmxa /home/opam/.opam/5.4/lib/uutf/uutf.cmxa /home/opam/.opam/5.4/lib/alcotest/stdlib_ext/alcotest_stdlib_ext.cmxa /home/opam/.opam/5.4/lib/fmt/fmt.cmxa /home/opam/.opam/5.4/lib/fmt/cli/fmt_cli.cmxa /home/opam/.opam/5.4/lib/re/re.cmxa /home/opam/.opam/5.4/lib/alcotest/engine/alcotest_engine.cmxa /home/opam/.opam/5.4/lib/fmt/tty/fmt_tty.cmxa /home/opam/.opam/5.4/lib/alcotest/alcotest.cmxa -I /home/opam/.opam/5.4/lib/alcotest fehu/test/.test_space.eobjs/native/dune__exe.cmx fehu/test/.test_space.eobjs/native/dune__exe__Test_training.cmx)
# lto-wrapper: warning: using serial compilation of 9 LTRANS jobs
# lto-wrapper: note: see the '-flto' option documentation for more information
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlopt.opt -w -40 -g -o fehu/test/test_wrapper.exe /home/opam/.opam/5.4/lib/yojson/yojson.cmxa /home/opam/.opam/5.4/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.4/lib/logs/logs.cmxa /home/opam/.opam/5.4/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/5.4/lib/integers/integers.cmxa -I /home/opam/.opam/5.4/lib/integers /home/opam/.opam/5.4/lib/ctypes/ctypes.cmxa -I /home/opam/.opam/5.4/lib/ctypes /home/opam/.opam/5.4/lib/rune/jit/rune_jit.cmxa /home/opam/.opam/5.4/lib/rune/jit/metal_or_missing/rune_jit_metal_or_missing.cmxa /home/opam/.opam/5.4/lib/rune/llvm/llvm.cmxa -I /home/opam/.opam/5.4/lib/rune/llvm /home/opam/.opam/5.4/lib/rune/llvm/target/llvm_target.cmxa -I /home/opam/.opam/5.4/lib/rune/llvm/target /home/opam/.opam/5.4/lib/rune/llvm/executionengine/llvm_executionengine.cmxa -I /home/opam/.opam/5.4/lib/rune/llvm/executionengine /home/opam/.opam/5.4/lib/rune/llvm/analysis/llvm_analysis.cmxa -I /home/opam/.opam/5.4/lib/rune/llvm/analysis /home/opam/.opam/5.4/lib/rune/llvm/all_backends/llvm_all_backends.cmxa -I /home/opam/.opam/5.4/lib/rune/llvm/all_backends /home/opam/.opam/5.4/lib/rune/llvm/passbuilder/llvm_passbuilder.cmxa -I /home/opam/.opam/5.4/lib/rune/llvm/passbuilder /home/opam/.opam/5.4/lib/ocaml/threads/threads.cmxa /home/opam/.opam/5.4/lib/ctypes-foreign/ctypes_foreign.cmxa -I /home/opam/.opam/5.4/lib/ctypes-foreign /home/opam/.opam/5.4/lib/rune/jit/llvm/rune_jit_llvm.cmxa /home/opam/.opam/5.4/lib/nx/bigarray_ext/bigarray_ext.cmxa -I /home/opam/.opam/5.4/lib/nx/bigarray_ext /home/opam/.opam/5.4/lib/ocaml/str/str.cmxa /home/opam/.opam/5.4/lib/nx/core/nx_core.cmxa /home/opam/.opam/5.4/lib/nx/pocketfft/pocketfft.cmxa -I /home/opam/.opam/5.4/lib/nx/pocketfft /home/opam/.opam/5.4/lib/nx/c/nx_c.cmxa -I /home/opam/.opam/5.4/lib/nx/c /home/opam/.opam/5.4/lib/nx/nx.cmxa /home/opam/.opam/5.4/lib/rune/rune.cmxa fehu/lib/fehu.cmxa fehu/lib/environments/fehu_envs.cmxa /home/opam/.opam/5.4/lib/nx/safetensors/safetensors.cmxa /home/opam/.opam/5.4/lib/nx/zip/zip.cmxa -I /home/opam/.opam/5.4/lib/nx/zip /home/opam/.opam/5.4/lib/nx/io/npy/npy.cmxa -I /home/opam/.opam/5.4/lib/nx/io/npy /home/opam/.opam/5.4/lib/nx/io/stb_image/stb_image.cmxa -I /home/opam/.opam/5.4/lib/nx/io/stb_image /home/opam/.opam/5.4/lib/nx/io/stb_image_write/stb_image_write.cmxa -I /home/opam/.opam/5.4/lib/nx/io/stb_image_write /home/opam/.opam/5.4/lib/nx/io/nx_io.cmxa /home/opam/.opam/5.4/lib/backoff/backoff.cmxa /home/opam/.opam/5.4/lib/multicore-magic/__private__/multicore_magic_atomic_array_unboxed5_4/multicore_magic_atomic_array_unboxed5_4.cmxa /home/opam/.opam/5.4/lib/multicore-magic/Multicore_magic.cmxa /home/opam/.opam/5.4/lib/saturn/saturn.cmxa /home/opam/.opam/5.4/lib/thread-table/Thread_table.cmxa /home/opam/.opam/5.4/lib/domain-local-await/Domain_local_await.cmxa /home/opam/.opam/5.4/lib/domainslib/domainslib.cmxa /home/opam/.opam/5.4/lib/kaun/kaun.cmxa fehu/lib/algorithms/fehu_algorithms.cmxa /home/opam/.opam/5.4/lib/astring/astring.cmxa /home/opam/.opam/5.4/lib/cmdliner/cmdliner.cmxa /home/opam/.opam/5.4/lib/uutf/uutf.cmxa /home/opam/.opam/5.4/lib/alcotest/stdlib_ext/alcotest_stdlib_ext.cmxa /home/opam/.opam/5.4/lib/fmt/fmt.cmxa /home/opam/.opam/5.4/lib/fmt/cli/fmt_cli.cmxa /home/opam/.opam/5.4/lib/re/re.cmxa /home/opam/.opam/5.4/lib/alcotest/engine/alcotest_engine.cmxa /home/opam/.opam/5.4/lib/fmt/tty/fmt_tty.cmxa /home/opam/.opam/5.4/lib/alcotest/alcotest.cmxa -I /home/opam/.opam/5.4/lib/alcotest fehu/test/.test_space.eobjs/native/dune__exe.cmx fehu/test/.test_space.eobjs/native/dune__exe__Test_wrapper.cmx)
# lto-wrapper: warning: using serial compilation of 9 LTRANS jobs
# lto-wrapper: note: see the '-flto' option documentation for more information
# File "fehu/test/dune", line 5, characters 2-14:
# 5 |   test_wrapper
#       ^^^^^^^^^^^^
# (cd _build/default/fehu/test && ./test_wrapper.exe)
# Command got signal SEGV.
```

This PR disables `runtest` for the failing packages.

There's now a raven `alpha2` release - which doesn't fail `runtest`, so in the interest of limiting CI noise, I see no point in keep triggering known failures.
