### PR TITLE
use sdl2-compat-devel as of Fedora 42

### DIFF
--- a/packages/conf-sdl2/conf-sdl2.1/opam
+++ b/packages/conf-sdl2/conf-sdl2.1/opam
@@ -20,7 +20,8 @@ depexts: [
   ["sdl2"] {os-distribution = "arch"}
   ["libsdl2-dev"] {os-family = "debian"}
   ["libsdl2-dev"] {os-family = "ubuntu"}
-  ["SDL2-devel"] {os-family = "fedora"}
+  ["sdl2-compat-devel"] {os-family = "fedora" & os-version >= "42"}
+  ["SDL2-devel"] {os-family = "fedora" & os-version < "42"}
   ["SDL2-devel" "libwayland-egl" "adwaita-cursor-theme"] {os-family = "fedora" & (os-version = "37" | os-version = "36")}
   ["epel-release" "SDL2-devel"] {os-distribution = "centos"}
   ["SDL2-devel"] {os-distribution = "ol"}


### PR DESCRIPTION
c.f. https://fedoraproject.org/wiki/Changes/SDL2onSDL3

Version support's confirmable with
```
dnf repoquery --releasever=42 --whatprovides SDL2-devel
```

I performed an `opam upgrade`, noticed that I was asked for a dependency that was already met, and confirmed this patch by reattempting the upgrade after pinning the changed file:

```
opam pin add conf-sdl2.1 packages/conf-sdl2/conf-sdl2.1 -n
```

On Fedora, attempting to install SDL2-devel prompts the installation of sdl2-compat-devel, and that repoquery returns sdl2-compat-devel for Fedora 42+, so there's probably an opam alternative to small patches like this.