### PR TITLE
OCamlBrowser 5.4.0

### DIFF
--- a/packages/ocamlbrowser/ocamlbrowser.5.4.0/opam
+++ b/packages/ocamlbrowser/ocamlbrowser.5.4.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://garrigue.github.io/labltk/"
+bug-reports: "https://github.com/garrigue/labltk/issues"
+dev-repo: "git+https://github.com/garrigue/labltk.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+build: [
+  ["./configure" "-use-findlib" "-installbindir" bin]
+  [make "all"]
+]
+install: [
+  [make "install-browser"]
+]
+depends: [
+  "ocaml" {>= "5.4" & < "5.5"}
+  "labltk" {>= "8.06.15"}
+  "ocamlfind" {build}
+  "conf-tcl"
+  "conf-tk"
+]
+post-messages: [
+  "This package requires Tcl/Tk with its development packages installed on your system" {failure}
+]
+synopsis: "OCamlBrowser Library Explorer"
+description: "Requires LablTk. For details, see https://garrigue.github.io/labltk/"
+url {
+  src: "https://github.com/garrigue/labltk/archive/refs/tags/8.06.16.tar.gz"
+  checksum: [
+    "sha256=f816031d6fa024a7ff8cf768205ff24c528ae2c69eca86ad7d7b5ddab4e16022"
+    "md5=054be41cfb14672ff880f192a8ea0372"
+  ]
+}
+


### PR DESCRIPTION
This is a new release of OCamlBrowser for OCaml 5.4.
(It is based on LablTk-8.06.16, but the only changes are in ocamlbrowser)