### PR TITLE
Package kqueue.0.5.1

### DIFF
--- a/packages/kqueue/kqueue.0.5.1/opam
+++ b/packages/kqueue/kqueue.0.5.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for kqueue event notification interface"
+maintainer: "Anurag Soni <anurag@sonianurag.com>"
+authors: "Anurag Soni"
+license: "BSD-3-clause"
+tags: "kqueue"
+homepage: "https://codeberg.org/anuragsoni/kqueue-ml"
+bug-reports: "https://codeberg.org/anuragsoni/kqueue-ml/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://codeberg.org/anuragsoni/kqueue-ml.git"
+url {
+  src:
+    "https://codeberg.org/anuragsoni/kqueue-ml/releases/download/0.5.1/kqueue-0.5.1.tbz"
+  checksum: [
+    "md5=7fff1e821d6d4f7c08e6ffd61d0fb30c"
+    "sha512=cb06f4667f9bc6cd1268c0d868c2dc60863ac455f96258d2dccd5d45811f99a9713936931ca467ef3133a66b52234bd636f3d73a3ae9fe8adfdc75f40c3d8a4d"
+  ]
+}


### PR DESCRIPTION
### `kqueue.0.5.1`
OCaml bindings for kqueue event notification interface



---
* Homepage: https://codeberg.org/anuragsoni/kqueue-ml
* Source repo: git+https://codeberg.org/anuragsoni/kqueue-ml.git
* Bug tracker: https://codeberg.org/anuragsoni/kqueue-ml/issues

---
:camel: Pull-request generated by opam-publish v2.7.1