### PR TITLE
Package opam-publish.3.0.0

### DIFF
--- a/packages/opam-publish/opam-publish.3.0.0/opam
+++ b/packages/opam-publish/opam-publish.3.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A tool to ease contributions to opam repositories"
+description: """\
+opam-publish automates publishing packages to package repositories: it checks that the
+opam file is complete using `opam lint`, verifies and adds the archive URL and its
+checksum and files a GitHub pull request for merging it."""
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+depends: [
+  "cmdliner" {>= "2.0.0"}
+  "dune" {>= "1.0"}
+  "lwt" {>= "3.0.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "ocaml" {>= "4.08.0"}
+  "opam-core" {>= "2.2.0"}
+  "opam-format" {>= "2.2.0"}
+  "opam-state" {>= "2.2.0"}
+  "github" {>= "4.3.2"}
+  "cohttp" {>= "0.99"}
+  "cohttp-lwt-unix" {>= "0.99"}
+]
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+url {
+  src:
+    "https://github.com/ocaml/opam-publish/releases/download/3.0.0/opam-publish-3.0.0.tar.gz"
+  checksum: [
+    "md5=5a29a85e77053acd6b2b1d3b9c3310f9"
+    "sha512=edaa3c6de2a3757b53275da8506194feb65212400d38ca43cf7521b691f44e5158dc15e9f60b6ae23090b98e723a5e31d93e2d2b81fa0bfea9659a65094d4c3e"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `opam-publish.3.0.0`
A tool to ease contributions to opam repositories
opam-publish automates publishing packages to package repositories: it checks that the
opam file is complete using `opam lint`, verifies and adds the archive URL and its
checksum and files a GitHub pull request for merging it.



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v3.0.0