### PR TITLE
Package kqueue.0.6.0

### DIFF
--- a/packages/kqueue/kqueue.0.6.0/opam
+++ b/packages/kqueue/kqueue.0.6.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for kqueue event notification interface"
+maintainer: "Anurag Soni <anurag@sonianurag.com>"
+authors: "Anurag Soni"
+license: "BSD-3-clause"
+tags: "kqueue"
+homepage: "https://codeberg.org/anuragsoni/kqueue-ml"
+bug-reports: "https://codeberg.org/anuragsoni/kqueue-ml/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://codeberg.org/anuragsoni/kqueue-ml.git"
+url {
+  src:
+    "https://codeberg.org/anuragsoni/kqueue-ml/releases/download/0.6.0/kqueue-0.6.0.tbz"
+  checksum: [
+    "md5=9d8e5b597ae43b5054733fa6567e5f76"
+    "sha512=3c3cb1d6ba2abbc8b1568f5a42165e0870d6e9b064ae4cb0303cc6117fb3b05be93d715607243884c7c6c48498354f05491b3bdc9c6c53d9a66c588be6588b1d"
+  ]
+}


### PR DESCRIPTION
### `kqueue.0.6.0`
OCaml bindings for kqueue event notification interface

#### Changelog

##### 0.6.0

* Zero out the backing array when first creating an event list
* Track the number of events specified by the user in the event list


---
* Homepage: https://codeberg.org/anuragsoni/kqueue-ml
* Source repo: git+https://codeberg.org/anuragsoni/kqueue-ml.git
* Bug tracker: https://codeberg.org/anuragsoni/kqueue-ml/issues

---
:camel: Pull-request generated by opam-publish v2.7.1