### PR TITLE
Add obuild.0.2.2

### DIFF
--- a/packages/obuild/obuild.0.2.2/opam
+++ b/packages/obuild/obuild.0.2.2/opam
@@ -25,6 +25,6 @@ depends: ["ocaml" "ocamlfind" {build}]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/v0.2.2.tar.gz"
   checksum: [
-    "sha256=2c401e7a2780b745acd1504fc3bce073434d73bfa7a59f2d5767bc4e257690bf"
+    "sha256=fc1650981abf4aae833ef9aaa7a06ff4bf247509087572432c14db1615c9c7ef"
   ]
 }


### PR DESCRIPTION
- A lot of fixes with missing dependencies and parsing of META files.
- Add support for generators (atd, menhir, etc.).
- Performance improvements.
- New CLI.
- Doesn't require bash anymore for bootstrap.
- Add support for cstubs.