### PR TITLE
omod.0.0.4 doesn't build with OCaml 5.5+

### DIFF
--- a/packages/omod/omod.0.0.4/opam
+++ b/packages/omod/omod.0.0.4/opam
@@ -16,7 +16,7 @@ homepage: "https://erratique.ch/software/omod"
 doc: "https://erratique.ch/software/omod/doc/"
 bug-reports: "https://github.com/dbuenzli/omod/issues"
 depends: [
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "4.14.0" & < "5.5"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "1.0.3"}


### PR DESCRIPTION
omod isn't compatible with OCaml 5.5 owing to a change in the structure of .cma format:

```
# File "src/support/omod_ocamlc.ml", line 196, characters 54-60:
# 196 |     { name; cmos; custom; custom_cobjs; custom_copts; dllibs }
#                                                             ^^^^^^
# Error: The value dllibs has type (suffixed:bool * string) list
#        but an expression was expected of type string list
#        Type suffixed:bool * string is not compatible with type string
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'pkg.otarget']: exited with 10
```