### PR TITLE
Remove dependency of `inifiles` on `ocamlfind`

### DIFF
--- a/packages/inifiles/inifiles.2.0/opam
+++ b/packages/inifiles/inifiles.2.0/opam
@@ -10,7 +10,6 @@ authors: [ "Eric Stokes" ]
 depends: [
   "ocaml"
   "dune" {>= "3.13"}
-  "ocamlfind"
   "pcre2"
 ]
 conflicts: ["ocaml-option-bytecode-only" "ocaml-inifiles"]


### PR DESCRIPTION
I couldn't find a place where it would be used.

Upstream PR: https://github.com/ahrefs/inifiles/pull/2