### PR TITLE
[new release] dns (13 packages) (10.2.4)

### DIFF
--- a/packages/dns-certify/dns-certify.10.2.4/opam
+++ b/packages/dns-certify/dns-certify.10.2.4/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.2.0"}
+  "duration" {>= "0.1.2"}
+  "x509" {>= "1.0.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-sleep" {>= "4.0.0"}
+  "mirage-ptime" {>= "5.0.0"}
+  "tcpip" {>= "8.2.0"}
+  "logs"
+  "mirage-crypto-ec"
+  "mirage-crypto-pk" {>= "1.0.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "MirageOS let's encrypt certificate retrieval"
+description: """
+A function to retrieve a certificate when providing a hostname, TSIG key, server
+IP, and an optional key seed. Best used with an letsencrypt unikernel.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v10.2.4/dns-10.2.4.tbz"
+  checksum: [
+    "sha256=d852d15ca2f58db573679bf18688745600b91296e2e54486609869d666f3d12f"
+    "sha512=09d3b1cf76bccbff1a0c042922a3e9d6fa3605770d3d9d9aab3462f32d9156c87f6468b531f27dbcc1ce9030c1bd5f3c81c051f5f6a7ee7d802c1fddf1848058"
+  ]
+}
+x-commit-hash: "facec28258bce53fd9532fbcb66164c169f9f704"

--- a/packages/dns-cli/dns-cli.10.2.4/opam
+++ b/packages/dns-cli/dns-cli.10.2.4/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns" {= version}
+  "dnssec" {= version}
+  "dns-tsig" {= version}
+  "dns-client-lwt" {= version}
+  "dns-server" {= version}
+  "dns-certify" {= version}
+  "dns-resolver" {= version}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.0"}
+  "fpath" {>= "0.7.2"}
+  "x509" {>= "1.0.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-pk" {>= "1.0.0"}
+  "mirage-crypto-rng" {>= "2.0.0"}
+  "mirage-mtime" {>= "5.0.0"}
+  "mtime" {>= "2.1.0"}
+  "ptime" {>= "1.2.0"}
+  "tcpip" {>= "8.2.0"}
+  "ohex" {>= "0.2.0"}
+  "logs" {>= "0.6.3"}
+  "fmt" {>= "0.8.8"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.0.0"}
+  "randomconv" {>= "0.2.0"}
+  "metrics" {>= "0.5.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Unix command line utilities using uDNS"
+description: """
+'oupdate' sends a DNS update frome to a DNS server that sets 'hostname A ip'.
+For authentication via TSIG, a hmac secret needs to be provided.
+
+'ocertify' updates DNS with a certificate signing request, and polls a matching
+certificate. Best used with an letsencrypt unikernel.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v10.2.4/dns-10.2.4.tbz"
+  checksum: [
+    "sha256=d852d15ca2f58db573679bf18688745600b91296e2e54486609869d666f3d12f"
+    "sha512=09d3b1cf76bccbff1a0c042922a3e9d6fa3605770d3d9d9aab3462f32d9156c87f6468b531f27dbcc1ce9030c1bd5f3c81c051f5f6a7ee7d802c1fddf1848058"
+  ]
+}
+x-commit-hash: "facec28258bce53fd9532fbcb66164c169f9f704"

--- a/packages/dns-client-lwt/dns-client-lwt.10.2.4/opam
+++ b/packages/dns-client-lwt/dns-client-lwt.10.2.4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns-client" {= version}
+  "dns" {= version}
+  "ipaddr" {>= "5.3.0"}
+  "lwt" {>= "4.2.1"}
+  "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "happy-eyeballs-lwt" {>= "2.0.0"}
+  "happy-eyeballs" {>= "2.0.0"}
+  "tls-lwt" {>= "2.0.0"}
+  "ca-certs" {>= "1.0.0"}
+]
+synopsis: "DNS client API using lwt"
+description: """
+A client implementation using uDNS and lwt for side effects.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v10.2.4/dns-10.2.4.tbz"
+  checksum: [
+    "sha256=d852d15ca2f58db573679bf18688745600b91296e2e54486609869d666f3d12f"
+    "sha512=09d3b1cf76bccbff1a0c042922a3e9d6fa3605770d3d9d9aab3462f32d9156c87f6468b531f27dbcc1ce9030c1bd5f3c81c051f5f6a7ee7d802c1fddf1848058"
+  ]
+}
+x-commit-hash: "facec28258bce53fd9532fbcb66164c169f9f704"

--- a/packages/dns-client-miou-unix/dns-client-miou-unix.10.2.4/opam
+++ b/packages/dns-client-miou-unix/dns-client-miou-unix.10.2.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.8.0"}
+  "ocaml" {>= "5.0.0"}
+  "dns-client" {= version}
+  "domain-name" {>= "0.4.0"}
+  "ipaddr" {>= "5.3.0"}
+  "miou" {>= "0.1.0"}
+  "tls-miou-unix" {>= "2.0.0"}
+  "happy-eyeballs" {>= "2.0.0"}
+  "happy-eyeballs-miou-unix" {>= "2.0.0"}
+]
+synopsis: "DNS client API for Miou"
+description: """
+A client implementation using uDNS using Miou.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v10.2.4/dns-10.2.4.tbz"
+  checksum: [
+    "sha256=d852d15ca2f58db573679bf18688745600b91296e2e54486609869d666f3d12f"
+    "sha512=09d3b1cf76bccbff1a0c042922a3e9d6fa3605770d3d9d9aab3462f32d9156c87f6468b531f27dbcc1ce9030c1bd5f3c81c051f5f6a7ee7d802c1fddf1848058"
+  ]
+}
+x-commit-hash: "facec28258bce53fd9532fbcb66164c169f9f704"

--- a/packages/dns-client-mirage/dns-client-mirage.10.2.4/opam
+++ b/packages/dns-client-mirage/dns-client-mirage.10.2.4/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns-client" {= version}
+  "domain-name" {>= "0.4.0"}
+  "ipaddr" {>= "5.3.0"}
+  "lwt" {>= "4.2.1"}
+  "tcpip" {>= "8.2.0"}
+  "mirage-sleep" {>= "4.0.0"}
+  "mirage-mtime" {>= "5.0.0"}
+  "mirage-ptime" {>= "5.0.0"}
+  "happy-eyeballs-mirage" {>= "2.0.0"}
+  "happy-eyeballs" {>= "2.0.0"}
+  "tls-mirage" {>= "2.0.0"}
+  "x509" {>= "1.0.0"}
+  "ca-certs-nss" {>= "3.108-1"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+]
+synopsis: "DNS client API for MirageOS"
+description: """
+A client implementation using uDNS using MirageOS.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v10.2.4/dns-10.2.4.tbz"
+  checksum: [
+    "sha256=d852d15ca2f58db573679bf18688745600b91296e2e54486609869d666f3d12f"
+    "sha512=09d3b1cf76bccbff1a0c042922a3e9d6fa3605770d3d9d9aab3462f32d9156c87f6468b531f27dbcc1ce9030c1bd5f3c81c051f5f6a7ee7d802c1fddf1848058"
+  ]
+}
+x-commit-hash: "facec28258bce53fd9532fbcb66164c169f9f704"

--- a/packages/dns-client/dns-client.10.2.4/opam
+++ b/packages/dns-client/dns-client.10.2.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns" {= version}
+  "randomconv" {>= "0.2.0"}
+  "domain-name" {>= "0.4.0"}
+  "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "fmt" {>= "0.9.0"}
+  "ipaddr" {>= "5.5.0"}
+  "alcotest" {with-test}
+]
+synopsis: "DNS client API"
+description: """
+A client implementation using uDNS.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v10.2.4/dns-10.2.4.tbz"
+  checksum: [
+    "sha256=d852d15ca2f58db573679bf18688745600b91296e2e54486609869d666f3d12f"
+    "sha512=09d3b1cf76bccbff1a0c042922a3e9d6fa3605770d3d9d9aab3462f32d9156c87f6468b531f27dbcc1ce9030c1bd5f3c81c051f5f6a7ee7d802c1fddf1848058"
+  ]
+}
+x-commit-hash: "facec28258bce53fd9532fbcb66164c169f9f704"

--- a/packages/dns-mirage/dns-mirage.10.2.4/opam
+++ b/packages/dns-mirage/dns-mirage.10.2.4/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "ipaddr" {>= "5.2.0"}
+  "lwt" {>= "4.2.1"}
+  "tcpip" {>= "8.2.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.robur.coop/Posts/DNS) for a more
+detailed overview.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v10.2.4/dns-10.2.4.tbz"
+  checksum: [
+    "sha256=d852d15ca2f58db573679bf18688745600b91296e2e54486609869d666f3d12f"
+    "sha512=09d3b1cf76bccbff1a0c042922a3e9d6fa3605770d3d9d9aab3462f32d9156c87f6468b531f27dbcc1ce9030c1bd5f3c81c051f5f6a7ee7d802c1fddf1848058"
+  ]
+}
+x-commit-hash: "facec28258bce53fd9532fbcb66164c169f9f704"

--- a/packages/dns-resolver/dns-resolver.10.2.4/opam
+++ b/packages/dns-resolver/dns-resolver.10.2.4/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns" {= version}
+  "dns-server" {= version}
+  "dns-mirage" {= version}
+  "dnssec" {= version}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.2.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-sleep" {>= "4.0.0"}
+  "mirage-mtime" {>= "5.0.0"}
+  "mirage-ptime" {>= "5.0.0"}
+  "tcpip" {>= "8.2.0"}
+  "alcotest" {with-test}
+  "logs"
+  "tls" {>= "1.0.0"}
+  "tls-mirage" {>= "1.0.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "ca-certs-nss" {>= "3.113.1"}
+  "ipaddr" {>= "5.6.1"}
+  "metrics" {>= "0.5.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS resolver business logic"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v10.2.4/dns-10.2.4.tbz"
+  checksum: [
+    "sha256=d852d15ca2f58db573679bf18688745600b91296e2e54486609869d666f3d12f"
+    "sha512=09d3b1cf76bccbff1a0c042922a3e9d6fa3605770d3d9d9aab3462f32d9156c87f6468b531f27dbcc1ce9030c1bd5f3c81c051f5f6a7ee7d802c1fddf1848058"
+  ]
+}
+x-commit-hash: "facec28258bce53fd9532fbcb66164c169f9f704"

--- a/packages/dns-server/dns-server.10.2.4/opam
+++ b/packages/dns-server/dns-server.10.2.4/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.2.0"}
+  "duration" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-sleep" {>= "4.0.0"}
+  "mirage-mtime" {>= "5.0.0"}
+  "mirage-ptime" {>= "5.0.0"}
+  "tcpip" {>= "8.2.0"}
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
+  "alcotest" {with-test}
+  "dns-tsig" {with-test}
+  "base64" {with-test & >= "3.0.0"}
+  "metrics"
+  "logs" {>= "0.7.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS server, primary and secondary"
+description: """
+Primary and secondary DNS server implemented in value-passing style. Needs an
+effectful layer to be useful.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v10.2.4/dns-10.2.4.tbz"
+  checksum: [
+    "sha256=d852d15ca2f58db573679bf18688745600b91296e2e54486609869d666f3d12f"
+    "sha512=09d3b1cf76bccbff1a0c042922a3e9d6fa3605770d3d9d9aab3462f32d9156c87f6468b531f27dbcc1ce9030c1bd5f3c81c051f5f6a7ee7d802c1fddf1848058"
+  ]
+}
+x-commit-hash: "facec28258bce53fd9532fbcb66164c169f9f704"

--- a/packages/dns-stub/dns-stub.10.2.4/opam
+++ b/packages/dns-stub/dns-stub.10.2.4/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dns-client-mirage" {= version}
+  "dns-mirage" {= version}
+  "dns-resolver" {= version}
+  "dns-tsig" {= version}
+  "dns-server" {= version}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.2.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-ptime" {>= "5.0.0"}
+  "tcpip" {>= "8.2.0"}
+  "metrics"
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "tls-mirage" {>= "2.0.2"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS stub resolver"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v10.2.4/dns-10.2.4.tbz"
+  checksum: [
+    "sha256=d852d15ca2f58db573679bf18688745600b91296e2e54486609869d666f3d12f"
+    "sha512=09d3b1cf76bccbff1a0c042922a3e9d6fa3605770d3d9d9aab3462f32d9156c87f6468b531f27dbcc1ce9030c1bd5f3c81c051f5f6a7ee7d802c1fddf1848058"
+  ]
+}
+x-commit-hash: "facec28258bce53fd9532fbcb66164c169f9f704"

--- a/packages/dns-tsig/dns-tsig.10.2.4/opam
+++ b/packages/dns-tsig/dns-tsig.10.2.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns" {= version}
+  "digestif" {>= "1.2.0"}
+  "base64" {>= "3.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "TSIG support for DNS"
+description: """
+TSIG is used to authenticate nsupdate frames using a HMAC.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v10.2.4/dns-10.2.4.tbz"
+  checksum: [
+    "sha256=d852d15ca2f58db573679bf18688745600b91296e2e54486609869d666f3d12f"
+    "sha512=09d3b1cf76bccbff1a0c042922a3e9d6fa3605770d3d9d9aab3462f32d9156c87f6468b531f27dbcc1ce9030c1bd5f3c81c051f5f6a7ee7d802c1fddf1848058"
+  ]
+}
+x-commit-hash: "facec28258bce53fd9532fbcb66164c169f9f704"

--- a/packages/dns/dns.10.2.4/opam
+++ b/packages/dns/dns.10.2.4/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "logs" "ptime"
+  "fmt" {>= "0.8.8"}
+  "domain-name" {>= "0.4.0"}
+  "gmap" {>= "0.3.0"}
+  "ipaddr" {>= "5.2.0"}
+  "alcotest" {with-test}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "metrics"
+  "ohex" {>= "0.2.0"}
+  "base64" {>= "3.3.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.robur.coop/Posts/DNS) for a more
+detailed overview.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v10.2.4/dns-10.2.4.tbz"
+  checksum: [
+    "sha256=d852d15ca2f58db573679bf18688745600b91296e2e54486609869d666f3d12f"
+    "sha512=09d3b1cf76bccbff1a0c042922a3e9d6fa3605770d3d9d9aab3462f32d9156c87f6468b531f27dbcc1ce9030c1bd5f3c81c051f5f6a7ee7d802c1fddf1848058"
+  ]
+}
+x-commit-hash: "facec28258bce53fd9532fbcb66164c169f9f704"

--- a/packages/dnssec/dnssec.10.2.4/opam
+++ b/packages/dnssec/dnssec.10.2.4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot coop"
+authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.8.0"}
+  "ocaml" {>= "4.13.0"}
+  "dns" {= version}
+  "alcotest" {with-test & >= "1.9.1"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-pk" {>= "1.0.0"}
+  "mirage-crypto-ec" {>= "1.0.0"}
+  "domain-name" {>= "0.4.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "logs" {>= "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNSSec support for OCaml-DNS"
+description: """
+DNSSec (DNS security extensions) for OCaml-DNS, including
+signing and verifying of RRSIG records.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v10.2.4/dns-10.2.4.tbz"
+  checksum: [
+    "sha256=d852d15ca2f58db573679bf18688745600b91296e2e54486609869d666f3d12f"
+    "sha512=09d3b1cf76bccbff1a0c042922a3e9d6fa3605770d3d9d9aab3462f32d9156c87f6468b531f27dbcc1ce9030c1bd5f3c81c051f5f6a7ee7d802c1fddf1848058"
+  ]
+}
+x-commit-hash: "facec28258bce53fd9532fbcb66164c169f9f704"


### PR DESCRIPTION
An opinionated Domain Name System (DNS) library

- Project page: <a href="https://github.com/mirage/ocaml-dns">https://github.com/mirage/ocaml-dns</a>
- Documentation: <a href="https://mirage.github.io/ocaml-dns/">https://mirage.github.io/ocaml-dns/</a>

##### CHANGES:

* Dns_resolver: propagate timeouts and errors (always reply to a request); esp.
  for stateful connections (TCP, TLS, OCaml callback) (mirage/ocaml-dns#411 @reynir)
* DNS: Ptr uses a `` [`raw] Domain_name.t `` now, instead of a
  `` [`host] Domain_name.t `` (suggested by @samoht mirage/ocaml-dns#408, mirage/ocaml-dns#410 @hannesm)

Partially sponsored by Tarides