### PR TITLE
Package ocsigen-toolkit.4.2.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.4.2.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.4.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+available: arch != "x86_32" & arch != "arm32"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "js_of_ocaml" {>= "6.0.0"}
+  "eliom" {>= "11.0.0"}
+  "calendar" {>= "2.0.0"}
+]
+x-maintenance-intent: ["(latest)" ]
+url {
+  src:
+    "https://github.com/ocsigen/ocsigen-toolkit/archive/refs/tags/4.2.0.tar.gz"
+  checksum: [
+    "md5=20bd60f116dd41348a00710b885aef31"
+    "sha512=01542f4d936db5abacbfb8e39a2e031dd6507bdb036523915b3b3fea1d916b9e4e624368a49571d69e9d55bd6db2c993afbbee4c026144d4e167f4e2c81562eb"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.4.2.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.7.1