### PR TITLE
Add ambient-context upper bounds for opentelemetry.0.6-0.10

### DIFF
--- a/packages/opentelemetry/opentelemetry.0.10/opam
+++ b/packages/opentelemetry/opentelemetry.0.10/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "ptime"
   "hmap"
-  "ambient-context"
+  "ambient-context" {< "0.2"}
   "odoc" {with-doc}
   "alcotest" {with-test}
   "pbrt" {>= "3.0" & < "4.0"}

--- a/packages/opentelemetry/opentelemetry.0.6/opam
+++ b/packages/opentelemetry/opentelemetry.0.6/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "ptime"
-  "ambient-context"
+  "ambient-context" {< "0.2"}
   "odoc" {with-doc}
   "alcotest" {with-test}
   "opentelemetry-client-cohttp-lwt" {with-test & = version}

--- a/packages/opentelemetry/opentelemetry.0.7/opam
+++ b/packages/opentelemetry/opentelemetry.0.7/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.08"}
   "ptime"
-  "ambient-context"
+  "ambient-context" {< "0.2"}
   "odoc" {with-doc}
   "alcotest" {with-test}
   "pbrt" {>= "3.0" & < "4.0"}

--- a/packages/opentelemetry/opentelemetry.0.8/opam
+++ b/packages/opentelemetry/opentelemetry.0.8/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "ptime"
   "hmap"
-  "ambient-context"
+  "ambient-context" {< "0.2"}
   "odoc" {with-doc}
   "alcotest" {with-test}
   "pbrt" {>= "3.0" & < "4.0"}

--- a/packages/opentelemetry/opentelemetry.0.9/opam
+++ b/packages/opentelemetry/opentelemetry.0.9/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "ptime"
   "hmap"
-  "ambient-context"
+  "ambient-context" {< "0.2"}
   "odoc" {with-doc}
   "alcotest" {with-test}
   "pbrt" {>= "3.0" & < "4.0"}


### PR DESCRIPTION
From #29418 causing:
```
#=== ERROR while compiling opentelemetry.0.10 =================================#
# context              2.5.0 | linux/x86_64 | ocaml-base-compiler.4.14.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/opentelemetry.0.10
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p opentelemetry -j 255 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/opentelemetry-7-105be0.env
# output-file          ~/.opam/log/opentelemetry-7-105be0.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -warn-error -a+8 -w +a-4-30-40-41-42-44-48-70 -strict-sequence -warn-error -a+8 -g -bin-annot -I src/core/.opentelemetry.objs/byte -I /home/opam/.opam/4.14/lib/ambient-context -I /home/opam/.opam/4.14/lib/ambient-context/atomic -I /home/opam/.opam/4.14/lib/ambient-context/core -I /home/opam/.opam/4.14/lib/hmap -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/pbrt -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/ptime/clock -I src/atomic/.opentelemetry_atomic.objs/byte -I src/proto/.opentelemetry_proto.objs/byte -no-alias-deps -open Opentelemetry__ -o src/core/.opentelemetry.objs/byte/opentelemetry.cmo -c -impl src/core/opentelemetry.ml)
# File "src/core/opentelemetry.ml", line 787, characters 28-47:
# 787 |   let ambient_scope_key : t Ambient_context.key = Ambient_context.create_key ()
#                                   ^^^^^^^^^^^^^^^^^^^
# Error: Unbound type constructor Ambient_context.key
```

This PR adds an upper bound on the `opentelemetry` packages.
Initially I had also added upper bounds on the `opentelemetry-lwt` packages, but then removed them again as those aren't failing the CI.