### PR TITLE
Package ppx_mikmatch.1.2

### DIFF
--- a/packages/ppx_mikmatch/ppx_mikmatch.1.2/opam
+++ b/packages/ppx_mikmatch/ppx_mikmatch.1.2/opam
@@ -9,7 +9,7 @@ license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 homepage: "https://github.com/ahrefs/ppx_mikmatch"
 bug-reports: "https://github.com/ahrefs/ppx_mikmatch/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.10"}
   "dune" {>= "1.11"}
   "ppxlib" {>= "0.36.0"}
   "re" {>= "1.7.2"}


### PR DESCRIPTION
### `ppx_mikmatch.1.2`
Matching Regular Expressions with OCaml Patterns using Mikmatch's syntax
This syntax extension turns
```
match%mikmatch x with
| {| re1 |} -> e1
...
| {| reN |} -> eN
| _ -> e0
```

into suitable invocations to the ocaml-re library. The patterns are plain
strings of the form accepted by Re_pcre, except groups can be bound to
variables using the syntax (... as var). The type of var will be
string if a match is of the groups is guaranteed given a match of the
whole pattern, and string option if the variable is bound to or nested
below an optionally matched group.

Additional extensions:

- `let%mikmatch name = {|re|}` defines reusable patterns for use within `(?U/N<name>)` patterns
- `type name = {%mikmatch| re |}` generates record types with parse/pp functions from patterns
- let destructuring via `let%pcre/mikmatch {| regex |} = s`, where `regex` binds values and `s` is the input string
- `/regex/flags` for providing compiler flags. `i` for caseless, `a` (%pcre) anchored, `u` (%mikmatch) unanchored
- Caseless groups via the `~` operator
- Mixed matching (raw strings supported) via `function | {%mikmatch| ... |} -> ... | "raw string" -> ...`
- Matching guards are supported across all match extensions



---
* Homepage: https://github.com/ahrefs/ppx_mikmatch
* Source repo: git+https://github.com/ahrefs/ppx_mikmatch.git
* Bug tracker: https://github.com/ahrefs/ppx_mikmatch/issues

---
:camel: Pull-request generated by opam-publish v2.7.1