### PR TITLE
Package ocsigen-start.8.0.0

### DIFF
--- a/packages/ocsigen-start/ocsigen-start.8.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.8.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+authors: "dev@ocsigen.org"
+maintainer: "dev@ocsigen.org"
+synopsis: "Higher-level library for developing Web and mobile applications with users, registration, notifications, etc"
+description: """
+Ocsigen Start is a set of higher-level libraries for building client-server Web and mobile applications with Ocsigen (Js_of_ocaml and Eliom).
+It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users.
+Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management.
+This template is intended to serve as a basis for quickly building the Minimum Viable Product for Web and mobile applications with users.
+The goal is to enable the programmer to concentrate on the core of the app, and not on user management.
+"""
+homepage: "https://ocsigen.org/ocsigen-start/"
+bug-reports: "https://github.com/ocsigen/ocsigen-start/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-start.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "pgocaml" {>= "4.0"}
+  "pgocaml_ppx" {>= "4.0"}
+  "safepass" {>= "3.0"}
+  "ocsigen-i18n" {>= "4.0.0"}
+  "eliom" {>= "12.0.0" & < "13.0.0"}
+  "ocsigen-toolkit" {>= "2.7.0"}
+  "ocsigen-ppx-rpc" {>= "1.1"}
+  "ocsigen-i18n" {>= "3.7.0"}
+  "yojson" {>= "1.6.0"}
+  "resource-pooling" {>= "1.0" & < "2.0"}
+  "cohttp-lwt-unix"
+  "js_of_ocaml" {>= "6.3.2"}
+  "re" {>= "1.7.2"}
+  "ocsipersist-pgsql-config" {>= "2.0" & < "3.0"}
+  "conf-postgresql"
+]
+depexts: [
+  ["imagemagick" "ruby-sass"] {os-family = "debian"}
+  ["md5sha1sum" "sassc"] {os = "macos" & os-distribution = "homebrew"}
+]
+x-maintenance-intent: ["(latest)" ]
+url {
+  src:
+    "https://github.com/ocsigen/ocsigen-start/archive/refs/tags/8.0.0.tar.gz"
+  checksum: [
+    "md5=e054fdaf95f5a034eb0dec82684a6626"
+    "sha512=50660aecc62137f2d8f434b0b63b78f7344ed5d71d9102aadc451ee63323a770c3dc2c7ef80b1164a2489e97ec996feac7ed215ed559ca3a5166c32a95a85b12"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-start.8.0.0`
Higher-level library for developing Web and mobile applications with users, registration, notifications, etc
Ocsigen Start is a set of higher-level libraries for building client-server Web and mobile applications with Ocsigen (Js_of_ocaml and Eliom).
It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users.
Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management.
This template is intended to serve as a basis for quickly building the Minimum Viable Product for Web and mobile applications with users.
The goal is to enable the programmer to concentrate on the core of the app, and not on user management.



---
* Homepage: https://ocsigen.org/ocsigen-start/
* Source repo: git+https://github.com/ocsigen/ocsigen-start.git
* Bug tracker: https://github.com/ocsigen/ocsigen-start/issues

---
:camel: Pull-request generated by opam-publish v3.0.0