### PR TITLE
conf-oniguma using pkgconf in win32

### DIFF
--- a/packages/conf-oniguruma/conf-oniguruma.1/opam
+++ b/packages/conf-oniguruma/conf-oniguruma.1/opam
@@ -22,6 +22,9 @@ depexts: [
   ["oniguruma"] {os = "freebsd"}
   ["oniguruma"] {os = "netbsd"}
   ["oniguruma"] {os-distribution = "nixos"}
+  ["libonig-devel"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-x86_64-oniguruma"] {os = "win32" & os-distribution = "msys2" & arch = "x86_64"}
+  ["mingw-w64-i686-oniguruma"] {os = "win32" & os-distribution = "msys2" & arch = "x86_32"}
 ]
 x-ci-accept-failures: [
   "centos-7"


### PR DESCRIPTION
Found out in https://github.com/davesnx/tm-grammars/actions/runs/22453134362/job/65027001843 that conf-oniguruma uses pkg-config directly and looking at https://github.com/ocaml/opam-repository/blob/be2b59848b26034698f26d606d5293c9b2b53e4a/packages/conf-gtksourceview3/conf-gtksourceview3.0%2B2/opam#L8 I applied similar fix