### PR TITLE
[new release] elpi (3.5.0)

### DIFF
--- a/packages/elpi/elpi.3.5.0/opam
+++ b/packages/elpi/elpi.3.5.0/opam
@@ -1,0 +1,92 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Claudio Sacerdoti Coen" "Enrico Tassi" ]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/LPCIC/elpi"
+doc: "https://LPCIC.github.io/elpi/"
+dev-repo: "git+https://github.com/LPCIC/elpi.git"
+bug-reports: "https://github.com/LPCIC/elpi/issues"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  [make "tests" "DUNE_OPTS=-p %{name}%" "SKIP=performance_HO" "SKIP+=performance_FO" "SKIP+=elpi_api_performance"] {with-test & os != "macos" & os-distribution != "alpine" & os-distribution != "freebsd"  & arch != "arm32" & arch != "x86_32"}
+]
+x-maintenance-intent: ["(latest)"]
+depends: [
+  "ocaml" {>= "4.13.0" }
+  "stdlib-shims"
+  "ppxlib" {>= "0.12.0"}
+  "ppx_optcomp"
+  "menhir" {>= "20211230" }
+  "re" {>= "1.7.2"}
+  "ppx_deriving" {>= "4.3"}
+  "ANSITerminal" {with-test}
+  "cmdliner"  {with-test & < "2.0"}
+  "fileutils" {with-test}
+  "yojson" {with-test}
+  "dune" {>= "2.9.0"}
+  "conf-time" {with-test}
+  "atdgen" {>= "2.10.0"}
+  "atdts" {>= "2.10.0"}
+  "odoc" {with-doc}
+]
+synopsis: "ELPI - Embeddable λProlog Interpreter"
+description: """
+ELPI implements a variant of λProlog enriched with Constraint Handling Rules,
+a programming language well suited to manipulate syntax trees with binders.
+
+ELPI is designed to be embedded into larger applications written in OCaml as
+an extension language. It comes with an API to drive the interpreter and 
+with an FFI for defining built-in predicates and data types, as well as
+quotations and similar goodies that are handy to adapt the language to the host
+application.
+
+This package provides both a command line interpreter (elpi) and a library to
+be linked in other applications (eg by passing -package elpi to ocamlfind).
+
+The ELPI programming language has the following features:
+
+- Native support for variable binding and substitution, via an Higher Order
+  Abstract Syntax (HOAS) embedding of the object language. The programmer
+  does not need to care about technical devices to handle bound variables,
+  like De Bruijn indices.
+
+- Native support for hypothetical context. When moving under a binder one can
+  attach to the bound variable extra information that is collected when the
+  variable gets out of scope. For example when writing a type-checker the
+  programmer needs not to care about managing the typing context.
+
+- Native support for higher order unification variables, again via HOAS.
+  Unification variables of the meta-language (λProlog) can be reused to
+  represent the unification variables of the object language. The programmer
+  does not need to care about the unification-variable assignment map and
+  cannot assign to a unification variable a term containing variables out of
+  scope, or build a circular assignment.
+
+- Native support for syntactic constraints and their meta-level handling rules.
+  The generative semantics of Prolog can be disabled by turning a goal into a
+  syntactic constraint (suspended goal). A syntactic constraint is resumed as
+  soon as relevant variables gets assigned. Syntactic constraints can be
+  manipulated by constraint handling rules (CHR).
+
+- Native support for backtracking. To ease implementation of search.
+
+- The constraint store is extensible.  The host application can declare
+  non-syntactic constraints and use custom constraint solvers to check their
+  consistency.
+
+- Clauses are graftable. The user is free to extend an existing program by
+  inserting/removing clauses, both at runtime (using implication) and at
+  "compilation" time by accumulating files.
+
+ELPI is free software released under the terms of LGPL 2.1 or above."""
+url {
+  src:
+    "https://github.com/LPCIC/elpi/releases/download/v3.5.0/elpi-3.5.0.tbz"
+  checksum: [
+    "sha256=0386ab1d26470063fa7b09c8b2851e5a8b354687c8ff9cf611433dc34ff353c8"
+    "sha512=573a78963f7363beff8a2d932ae3476976456ea0d3eaf4398349058e19b91335ca75522cae313dc28d62139b1ee6f5518858b05bae8eae98eaa61062070338ff"
+  ]
+}
+x-commit-hash: "0ab09b714e8054af37aa3c4109e424fb84e10110"


### PR DESCRIPTION
ELPI - Embeddable λProlog Interpreter

- Project page: <a href="https://github.com/LPCIC/elpi">https://github.com/LPCIC/elpi</a>
- Documentation: <a href="https://LPCIC.github.io/elpi/">https://LPCIC.github.io/elpi/</a>

##### CHANGES:

Requires Menhir 20211230 and OCaml 4.14 or above on Linux, Windows and
MacOS 14 (Sonoma). MacOS 15 (Sequoia) and later require OCaml 5.4.

- Typechecker:
  - Change: disallow undeclared data constructors and predicates

- Compiler:
  - New allow builtins to be declared in extension units (not just in the
    base)

- Typechecker:
  - Fix error messages when there is an arity mismatch, i.e. suggest some
    arguments may be missing
  - Change symbols without a declared signature raise a fatal error. Only
    undeclared predicates are tolerated, and only when the inferred type is
    unambiguously `prop`
