### PR TITLE
fix ocaml 5.5.0 alpha1: allow ocaml-base-compiler

### DIFF
--- a/packages/ocaml/ocaml.5.5.0/opam
+++ b/packages/ocaml/ocaml.5.5.0/opam
@@ -17,7 +17,7 @@ authors: [
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 depends: [
-  "ocaml-base-compiler" {>= "5.5.0~" < "5.5.1~" } |
+  "ocaml-base-compiler" {>= "5.5.0~" & < "5.5.1~" } |
   "ocaml-variants" {>= "5.5.0~" & < "5.5.1~"} |
   "ocaml-system" {>= "5.5.0~" & < "5.5.1~"} |
   "dkml-base-compiler" {>= "5.5.0~" & < "5.5.1~"}


### PR DESCRIPTION
Somehow my local test for the `ocaml-base-compiler` missed the fact that the bound for `ocaml-base-compiler` on the ocaml.5.5.0` was too strict to allow installing prerelease compiler.