### PR TITLE
Correct constraint in ocaml.5.6.0

### DIFF
--- a/packages/ocaml/ocaml.5.6.0/opam
+++ b/packages/ocaml/ocaml.5.6.0/opam
@@ -17,7 +17,7 @@ authors: [
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 depends: [
-  "ocaml-base-compiler" {= "5.6.0"} |
+  "ocaml-base-compiler" {>= "5.6.0" & < "5.6.1~"} |
   "ocaml-variants" {>= "5.6.0~" & < "5.6.1~"} |
   "ocaml-system" {>= "5.6.0~" & < "5.6.1~"} |
   "dkml-base-compiler" {>= "5.6.0~" & < "5.6.1~"}


### PR DESCRIPTION
Following on from #29472, I think that the initial `"ocaml-base-compiler" {= "x.y.z"}` constraint is hang-over from pre-OCaml 4.12 (!!) days when the pre-release packages were in ocaml-variants (and so the constraint was correct).

We don't need to be keeping this "incorrect" one during the development and then having to remember to correct it at the first alpha release, so here's an update to the 5.6.0 package in advance of its release!