### PR TITLE
[new release] tm-grammars and co (1.0.0)

### DIFF
--- a/packages/tm-grammars/tm-grammars.1.0.0/opam
+++ b/packages/tm-grammars/tm-grammars.1.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "TextMate grammars as OCaml strings"
+description: "OCaml package that exposes TextMate grammars as JSON strings."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/davesnx/tm-grammars"
+bug-reports: "https://github.com/davesnx/tm-grammars/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/tm-grammars.git"
+url {
+  src:
+    "https://github.com/davesnx/tm-grammars/releases/download/1.0.0/tm-grammars-1.0.0.tbz"
+  checksum: [
+    "sha256=a44a4f0d07ee70c464a13960e8250c4913d70737161eb89a2b9fbc4c1e166916"
+    "sha512=184a5cb893392366c22438a87f6bf5d414cb2de129ccf0bd5c4748971f5c8e07da2d71795de5d23290b23b0a49753bcfff6e83a45d13c5295029f0eed5aa12fb"
+  ]
+}
+x-commit-hash: "35481e590f4c80b55c7a904c0581fae1b5064cf1"


### PR DESCRIPTION
All bundled TextMate grammars

- Project page: <a href="https://github.com/davesnx/tm-grammars">https://github.com/davesnx/tm-grammars</a>

##### CHANGES:

- Published OCaml packages that expose TextMate grammars as JSON strings.
- Added individual `tm-grammar-<language>` packages for the supported language IDs.
- Added `tm-grammars`, a bundled package with direct accessors for all included grammars.
- Added generated package setup driven by `sources.json`.
