### PR TITLE
[new release] melange-str (0.1.0)

### DIFF
--- a/packages/melange-str/melange-str.0.1.0/opam
+++ b/packages/melange-str/melange-str.0.1.0/opam
@@ -31,6 +31,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/davesnx/melange-str.git"
+x-ci-accept-failures: ["alpine-3.22" "ubuntu-22.04"]
 url {
   src:
     "https://github.com/davesnx/melange-str/releases/download/0.1.0/melange-str-0.1.0.tbz"


### PR DESCRIPTION
Str module for Melange

- Project page: <a href="https://github.com/davesnx/melange-str">https://github.com/davesnx/melange-str</a>

##### CHANGES:

- Initial release of `melange-str`
- Complete implementation of OCaml's `Str` module API for Melange
- JavaScript `RegExp` backend with OCaml Str regex syntax translation
- String matching, searching, replacement, and splitting
- Capture group support
- Case-insensitive matching
