### PR TITLE
why3: add conflict with ppxlib version

### DIFF
--- a/packages/why3/why3.1.8.2/opam
+++ b/packages/why3/why3.1.8.2/opam
@@ -71,7 +71,7 @@ conflicts: [
   "why3-base"
   "ocamlgraph" {< "1.8.2"}
   "mlmpfr" {< "4.0.0"}
-  "ppxlib" {< "0.33.0}
+  "ppxlib" {< "0.33.0"}
 ]
 
 synopsis: "Why3 environment for deductive program verification"


### PR DESCRIPTION
Due to
```
# File "src/util/debug_optim.ml", line 20, characters 2-44:
# 20 |   Ppxlib.Context_free.Rule.special_function'
#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Ppxlib.Context_free.Rule.special_function'
# Hint: Did you mean special_function?
# make: *** [Makefile:415: src/util/ppx_debug_optim] Error 2
# make: *** Waiting for unfinished jobs....
# File "src/util/vector.ml", line 21, characters 22-30:
# 21 | let create ?capacity:(capacity: (int) option) ~dummy:(dummy: 'a) : 'a t =
#                            ^^^^^^^^
# Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
```