### PR TITLE
conf-zlib: also install libz.a on fedora

### DIFF
--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -22,7 +22,7 @@ depexts: [
   ["zlib-devel" "zlib-static"] {os-distribution = "centos" & os-version < "10" }
   ["zlib-ng-compat-devel" "zlib-ng-compat-static"] {os-distribution = "centos" & os-version >= "10" }
   ["zlib-devel"] {os-family = "fedora" & os-version < "40" }
-  ["zlib-ng-compat-devel"] {os-family = "fedora" & os-version >= "40" }
+  ["zlib-ng-compat-devel" "zlib-ng-compat-static"] {os-family = "fedora" & os-version >= "40" }
   ["zlib-devel"] {os-distribution = "ol"}
   ["zlib"] {os-distribution = "nixos"}
   ["zlib"] {os-distribution = "homebrew" & os = "macos"}


### PR DESCRIPTION
ocaml-ortools CI fails on Fedora 42 and 43 due to missing libz.a file.