### PR TITLE
conf-bzip2: fix failed install under cygwin

### DIFF
--- a/packages/conf-mingw-w64-bzip2-x86_64/conf-mingw-w64-bzip2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-bzip2-x86_64/conf-mingw-w64-bzip2-x86_64.1/opam
@@ -8,7 +8,14 @@ homepage: "https://sourceware.org/bzip2/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "bzip2"]
+build: [
+    "true"	{os = "win32" & os-distribution = "cygwin"}
+		# https://cygwin.com/cgi-bin2/package-cat.cgi?file=noarch%2Fmingw64-x86_64-bzip2%2Fmingw64-x86_64-bzip2-1.0.6-4
+		# no bzip2.pc file in cygwin package
+    "pkgconf"
+    "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"}
+    "bzip2"
+]
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
   "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}


### PR DESCRIPTION
The [Cygwin system package](https://cygwin.com/cgi-bin2/package-cat.cgi?file=noarch%2Fmingw64-x86_64-bzip2%2Fmingw64-x86_64-bzip2-1.0.6-4) does not install the pkgconf info (`bzip2.pc`).