### PR TITLE
Package kqueue.0.7.0

### DIFF
--- a/packages/kqueue/kqueue.0.7.0/opam
+++ b/packages/kqueue/kqueue.0.7.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for kqueue event notification interface"
+maintainer: "Anurag Soni <anurag@sonianurag.com>"
+authors: "Anurag Soni"
+license: "BSD-3-clause"
+tags: "kqueue"
+homepage: "https://codeberg.org/anuragsoni/kqueue-ml"
+bug-reports: "https://codeberg.org/anuragsoni/kqueue-ml/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://codeberg.org/anuragsoni/kqueue-ml.git"
+url {
+  src:
+    "https://codeberg.org/anuragsoni/kqueue-ml/releases/download/0.7.0/kqueue-0.7.0.tbz"
+  checksum: [
+    "md5=10ab1b5d707acc6ce9fa6682c74ba734"
+    "sha512=b001b358619d2ff6e31d99a265321eae0503a7b08940e13e00744b99700ee41fdc3e9631b01a9facfef7c91753e217db654e9091c43b7d8592342d325853297a"
+  ]
+}


### PR DESCRIPTION
### `kqueue.0.7.0`
OCaml bindings for kqueue event notification interface

* Use kqueuex if `KQUEUE_CLOEXEC` is defined.
* Allow calling `fold` for events.
* Simpler interface for adding events that avoids allocating a record/callback.
* Remove intermediate event type from Event_list module.
* Add simple tests that hook into dune runtest.

---
* Homepage: https://codeberg.org/anuragsoni/kqueue-ml
* Source repo: git+https://codeberg.org/anuragsoni/kqueue-ml.git
* Bug tracker: https://codeberg.org/anuragsoni/kqueue-ml/issues

---
:camel: Pull-request generated by opam-publish v3.0.0