### PR TITLE
Package kqueue.0.7.0

### DIFF
--- a/packages/kqueue/kqueue.0.7.0/opam
+++ b/packages/kqueue/kqueue.0.7.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for kqueue event notification interface"
+maintainer: "Anurag Soni <anurag@sonianurag.com>"
+authors: "Anurag Soni"
+license: "BSD-3-clause"
+tags: "kqueue"
+homepage: "https://codeberg.org/anuragsoni/kqueue-ml"
+bug-reports: "https://codeberg.org/anuragsoni/kqueue-ml/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://codeberg.org/anuragsoni/kqueue-ml.git"
+url {
+  src:
+    "https://codeberg.org/anuragsoni/kqueue-ml/releases/download/0.7.0/kqueue-0.7.0.tbz"
+  checksum: [
+    "md5=74fbb1453ef9d87720c35f6a04c52a2e"
+    "sha512=c7496206351a49064e9e13865908a2875950584927d8090962dcf67cd3e93fa577603571b7b3f777c684f21378a75beb84058ef2db05fdb1f817d93c40681723"
+  ]
+}


### PR DESCRIPTION
### `kqueue.0.7.0`
OCaml bindings for kqueue event notification interface

* Use kqueuex if `KQUEUE_CLOEXEC` is defined.
* Allow calling `fold` for events.
* Simpler interface for adding events that avoids allocating a record/callback.
* Remove intermediate event type from Event_list module.
* Add simple tests that hook into dune runtest.
* Add EVFILT_USER and EVFILT_SIGNAL


---
* Homepage: https://codeberg.org/anuragsoni/kqueue-ml
* Source repo: git+https://codeberg.org/anuragsoni/kqueue-ml.git
* Bug tracker: https://codeberg.org/anuragsoni/kqueue-ml/issues

---
:camel: Pull-request generated by opam-publish v3.0.0