### PR TITLE
[new release] pf-qubes (0.1.2)

### DIFF
--- a/packages/pf-qubes/pf-qubes.0.1.2/opam
+++ b/packages/pf-qubes/pf-qubes.0.1.2/opam
@@ -10,7 +10,7 @@ license:      "AGPL-3.0-only"
 tags: "org:mirage"
 
 build: [
-  [ "dune" "subst"] {pinned}
+  [ "dune" "subst"] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
   [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]


### PR DESCRIPTION
QubesOS firewall ruleset handling library

- Project page: <a href="https://github.com/robur-coop/ocaml-pf">https://github.com/robur-coop/ocaml-pf</a>
- Documentation: <a href="https://robur-coop.github.io/ocaml-pf/just-qubes/">https://robur-coop.github.io/ocaml-pf/just-qubes/</a>

##### CHANGES:

* Drop bisect_ppx dependency (robur-coop/ocaml-pf#5 @hannesm)
* Update to fmt deprecations (robur-coop/ocaml-pf#5 @hannesm)

Sponsored by Tarides