### PR TITLE
[new release] dune (18 packages) (3.22.0~alpha0)

### DIFF
--- a/packages/chrome-trace/chrome-trace.3.22.0~alpha0/opam
+++ b/packages/chrome-trace/chrome-trace.3.22.0~alpha0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Chrome trace event generation library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/dune-action-plugin/dune-action-plugin.3.22.0~alpha0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.22.0~alpha0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "dune-glob" {= version}
+  "csexp" {>= "1.5.0"}
+  "ppx_expect" {with-test}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "dune-rpc" {= version}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/dune-action-trace/dune-action-trace.3.22.0~alpha0/opam
+++ b/packages/dune-action-trace/dune-action-trace.3.22.0~alpha0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Dune Action Traces"
+description: "Produce trace events from dune actions"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "csexp"
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/dune-build-info/dune-build-info.3.22.0~alpha0/opam
+++ b/packages/dune-build-info/dune-build-info.3.22.0~alpha0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Embed build information inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/dune-configurator/dune-configurator.3.22.0~alpha0/opam
+++ b/packages/dune-configurator/dune-configurator.3.22.0~alpha0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/dune-glob/dune-glob.3.22.0~alpha0/opam
+++ b/packages/dune-glob/dune-glob.3.22.0~alpha0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "stdune" {= version}
+  "dyn"
+  "re"
+  "ordering"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/dune-private-libs/dune-private-libs.3.22.0~alpha0/opam
+++ b/packages/dune-private-libs/dune-private-libs.3.22.0~alpha0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "csexp" {>= "1.5.0"}
+  "pp" {>= "1.1.0"}
+  "dyn" {= version}
+  "stdune" {= version}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.22.0~alpha0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.22.0~alpha0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc and Lwt"
+description: "Specialization of dune-rpc to Lwt"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "dune-rpc" {= version}
+  "csexp" {>= "1.5.0"}
+  "lwt" {>= "5.6.0"}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/dune-rpc/dune-rpc.3.22.0~alpha0/opam
+++ b/packages/dune-rpc/dune-rpc.3.22.0~alpha0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocamlc-loc"
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/dune-site/dune-site.3.22.0~alpha0/opam
+++ b/packages/dune-site/dune-site.3.22.0~alpha0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Embed locations information inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/dune/dune.3.22.0~alpha0/opam
+++ b/packages/dune/dune.3.22.0~alpha0/opam
@@ -1,0 +1,75 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+Dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+Dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+Dune is composable; supporting multi-package development by simply
+dropping multiple repositories into the same directory.
+
+Dune also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "2.0.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  "ocaml" {>= "4.08"}
+  "base-unix"
+  "base-threads"
+  "lwt" { with-dev-setup & os != "win32" }
+  "cinaps" { with-dev-setup }
+  "csexp" { with-dev-setup & >= "1.3.0" }
+  "js_of_ocaml" { with-dev-setup & >= "6.1.0" & os != "win32" }
+  "js_of_ocaml-compiler" { with-dev-setup & >= "6.1.0" & os != "win32" }
+  "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
+  "menhir" { with-dev-setup & os != "win32" }
+  "ocamlfind" { with-dev-setup & os != "win32" }
+  "odoc" { with-dev-setup & >= "2.4.0" & os != "win32" }
+  "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
+  "spawn" { with-dev-setup }
+  "ppx_inline_test" { with-dev-setup & os != "win32" }
+  "ppxlib" { with-dev-setup & >= "0.37.0" & os != "win32" }
+  "ctypes" { with-dev-setup & os != "win32" }
+  "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
+  "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }
+  "uutf" { with-dev-setup }
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/dyn/dyn.3.22.0~alpha0/opam
+++ b/packages/dyn/dyn.3.22.0~alpha0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.08.0"}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/fs-io/fs-io.3.22.0~alpha0/opam
+++ b/packages/fs-io/fs-io.3.22.0~alpha0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "File System Operations"
+description: "Misc. Collection of File System Operations"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "base-unix"
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/ocamlc-loc/ocamlc-loc.3.22.0~alpha0/opam
+++ b/packages/ocamlc-loc/ocamlc-loc.3.22.0~alpha0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Parse ocaml compiler output into structured form"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.08.0"}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-lsp-server" {< "1.15.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/ordering/ordering.3.22.0~alpha0/opam
+++ b/packages/ordering/ordering.3.22.0~alpha0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/stdune/stdune.3.22.0~alpha0/opam
+++ b/packages/stdune/stdune.3.22.0~alpha0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "dyn" {= version}
+  "fs-io" {= version}
+  "ordering" {= version}
+  "pp" {>= "2.0.0"}
+  "top-closure" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/top-closure/top-closure.3.22.0~alpha0/opam
+++ b/packages/top-closure/top-closure.3.22.0~alpha0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Topological Closure"
+description: "Generic Topological Closure"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"

--- a/packages/xdg/xdg.3.22.0~alpha0/opam
+++ b/packages/xdg/xdg.3.22.0~alpha0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.22.0_alpha0/dune-3.22.0.alpha0.tbz"
+  checksum: [
+    "sha256=bee595a9bb3b5345c019820d2038bdfc12831adbf2e114784257d606c6df2530"
+    "sha512=382eef6b97f10a17d82edc01ec2b053c136b1441abc8444a7a4ce3db32b2f896ebc7ed9cbca7652fb171ec41e405c3dfa07cd8cd5ce5f2208bee4705643deedb"
+  ]
+}
+x-commit-hash: "f6b0df318861541609a50fb106df055bceac8f23"


### PR DESCRIPTION
Fast, portable, and opinionated build system

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

### Fixed

- `Dyn.to_string` now uses a smarter way to convert floats. This ensures that
  floats are printed with enough precision to round-trip and are valid OCaml
  lexemes. (ocaml/dune#12982, fixes ocaml/dune#12980, @Alizter)

- Fix `dune install --prefix` failing with relative paths outside the workspace
  like `../foo` (ocaml/dune#12993, fixes ocaml/dune#12241, @benodiwal)

- Delete sandboxes with broken permissions (ocaml/dune#13511, @rgrinberg)

- Fix compiling Menhir parsers that refer to sibling modules within a
  subdirectory of `(include_subdirs qualified)`. (ocaml/dune#13118, fixes ocaml/dune#11119,
  @anmonteiro)

- Fixed the dependency specification of C stubs, which could result in C
  stubs not getting rebuilt when needed (which could in turn lead to
  segmentation faults and other hard-to-track bugs).
  (ocaml/dune#13652, fixes ocaml/dune#13651, @nojb)

- Fix rpc not transferring promotion warnings to the client
  (ocaml/dune#12604, fixes ocaml/dune#12578, @ElectreAAS)

- Fix issue where `dune exec -w` was unable to kill running programs on
  rebuild. (ocaml/dune#12360, fixes ocaml/dune#12323, @Alizter)

- Resolve context and workspace binaries introduced by the respective `(env
  (binaries ..))` stanzas. (ocaml/dune#12952, fixes ocaml/dune#6220, @anmonteiro)

- Fix `diff` promotions originating from sandboxed rules. Previously, they
  would be completely ignored as the sandbox with the promoted file would be
  destroyed if the promotion fired (ocaml/dune#13520, @rgrinberg)

- Fix failure to digest installed directory targets, allowing them to be used
  as dependencies to other rules. (ocaml/dune#13045, @anmonteiro)

- Fix handling of `(select ..)` field when used with `(include_subdirs ..)`.
  `(select <path> from ..)` modules now parse `path` as a relative path
  starting from the module group root (ocaml/dune#13175, fixes ocaml/dune#4383, ocaml/dune#12450,
  @anmonteiro)

- Fix dune trying to kill processes that were already reaped due to race
  conditions (ocaml/dune#13245, @rgrinberg)

- Add `O_CLOEXEC` to all files used for stdin/stdout/stderr (ocaml/dune#13385, @rgrinberg)

- Fix `$ dune promote dir/foo` when `dir` does not exist (ocaml/dune#13493, @rgrinberg)

- Fix `(select ..)` field evaluation when a transitive library has optional
  dependencies (fixes ocaml/dune#13299, ocaml/dune#13389, @anmonteiro)

- Fix sandboxed builds of `library` stanzas that set
  `(stdlib (modules_before_stdlib ..))` (ocaml/dune#13624, @anmonteiro)

- Fixed non-build caches not following `$DUNE_CACHE_ROOT` and instead only
  relying on `$XDG_CACHE_HOME`.
  This means the normal build cache moves:
  `$DUNE_CACHE_ROOT -> $DUNE_CACHE_ROOT/db` (no changes if that variable was
  unset). Affected users can prevent a full cache invalidation by moving
  previous contents:
  `cd $DUNE_CACHE_ROOT; mkdir db; mv <contents of directory> db`.
  (ocaml/dune#11612, fixes ocaml/dune#11584, @ElectreAAS)

- `$ dune promotion list` writes output to stdout rather than stderr (ocaml/dune#13462)

- Improve handling of empty files in the `diff` action. These are now correctly
  distinguished from *empty* files. (ocaml/dune#13696, @rgrinberg)

- Pass `/dev/null` to `--diff-command` instead of non-existent files (ocaml/dune#13696,
  @rgrinberg)

- Fix failure when multiple `rocq.extraction` stanzas existing in a directory
  (ocaml/dune#13531, fixes ocaml/dune#8042, @rlepigre-skylabs-ai)


- Print `$ dune promotion show` output to stdout rather than stderr (ocaml/dune#13481,
  @rgrinberg)

- Fix deadlock in the `memo` library in the presence of dependency cycles
  (ocaml/dune#13625, @anmonteiro)

- Fix promotions that modify a directory into a file (ocaml/dune#13516, fixes ocaml/dune#4067,
  @rgrinberg)

- Fix installation of implementations of virtual libraries. This failed when
  the implementation had no private modules, but the virtual library did
  (ocaml/dune#10635, @rgrinberg)

- Respect the `(dir ..)` field on packages when setting up cram tests (ocaml/dune#13581,
  @rgrinberg)

### Added

- Add support for generating `.cms` files using oxcaml and adding `.cms` or
  `.cmt` files as compilation dependencies (ocaml/dune#13397, @spiessimon)

- Add trace events for custom actions (ocaml/dune#13265, @rgrinberg)

- Allow enabling extensions with `(using ..)` in `dune-workspace` files
  (ocaml/dune#13395, @spiessimon)

- Add sandbox extraction trace event (ocaml/dune#13544, @rgrinberg)

- Add the initial cwd to the first config event (ocaml/dune#13026, @rgrinberg)

- Dune produces trace events in `DUNE_ACTION_TRACE_DIR` if this variable
  is set. (ocaml/dune#13302, @rgrinberg)

- Add file watching events to the trace file (ocaml/dune#13038, @rgrinberg)

- Introduce the `$ dune trace cat` subcommand to view the trace file. (ocaml/dune#13055,
  @rgrinberg)

- Add diagnostic events to the trace. (ocaml/dune#13041, @rgrinberg)

- Add `DUNE_JOBS` environment variable for controlling concurrency of Dune from
  environment. The `INSIDE_DUNE` variable also now no longer controls
  concurrency (ocaml/dune#12800, @Alizter)

- Support for Rocq expected output tests (ocaml/dune#13632, @rlepigre-skylabs-ai)

- Add `rusage` information to completed processes in the trace (@rgrinberg,
  ocaml/dune#13241)

- Add process start events to the trace (ocaml/dune#13261, rgrinberg)

- Generate odoc documentation in markdown using the `@doc-markdown` alias
  (ocaml/dune#12581, @davesnx)

- Add timing information for every command executed by cram (ocaml/dune#13092,
  @rgrinberg)

- Add the workspace root to the config trace event (ocaml/dune#12922, @rgrinberg)

- Introduce the `dune-action-trace` library. This public library is to be used
  by custom actions to emit trace events while executed as part of a dune
  build. The trace events emitted through this library will be incorporated
  into dune's own trace (ocaml/dune#13348, @rgrinberg)

- Add `dune-find-dominating` to `dune.el`, a command to find the
  dominating dune file. (ocaml/dune#12696, @arvidj)

- Add a `--no-recursive` flag to `$ dune describe workspace` (ocaml/dune#13590, @rgrinberg)

- Trace events for files written directly by dune (ocaml/dune#13618, @rgrinberg)

- Allow expansion of special forms like `(:include ..)` and `%{read-lines:..}`
  in the `modules` specification for the `ocamllex`, `ocamlyacc` and `menhir`
  stanzas. (ocaml/dune#13105, ocaml/dune#13135, ocaml/dune#13157, @anmonteiro)

- Add a trace event for snapshotting the sandbox (ocaml/dune#13541, @rgrinberg)

- Add signal send and receive events to the trace (ocaml/dune#13193, @rgrinberg)

- Emit final trace event before exiting. (ocaml/dune#13018, @rgrinberg)

- `dune runtest` can now run individual test executables from `(tests)` stanzas
  and inline tests from `(library (inline_tests))` stanzas by providing their
  source files as arguments. (ocaml/dune#13064, fixes ocaml/dune#870, @Alizter)

- Add a `shell` field to the cram stanza. This field allows customizing the
  shell to be `bash` rather than `sh` (ocaml/dune#13083, @haochenx)

### Changed

- Start sandboxing the execution of tests defined with the `test` and `tests`
  stanzas (ocaml/dune#13510, ocaml/dune#13617, @rgrinberg)

- Disabled cram tests can now be run explicitly with `dune runtest disabled.t`.
  The `enabled_if` field now only controls whether a test is included in
  the `@runtest` alias. (ocaml/dune#13081, @Alizter)

- Process categories in trace events are moved to their own field in `args`
  (ocaml/dune#13024, @rgrinberg)

- Sandbox running `ocamllex` and `ocamlyacc` actions. (ocaml/dune#13098, @anmonteiro)

- Sandboxing mdx test actions is now the default starting from `0.5` (ocaml/dune#13504,
  @rgrinberg)

- Start sandboxing Melange rules by default in the `(library ..)` and
  `(melange.emit ..)` stanzas (ocaml/dune#13619, @anmonteiro)

- Introduce a promotion trace event and remove the corresponding verbose log
  message. (ocaml/dune#12949, ocaml/dune#13444, @rgrinberg)

- Change dune's trace format to emit canonical s-expressions. This improves
  performance and is better aligned with dune's usage of the format
  elsewhere. `$ dune trace cat` can also emit the trace in `--chrome-trace`
  for perfetto, or `--sexp` for regular s-expressions for interactive usage.
  (ocaml/dune#13059, @rgrinberg)

- Move all logging statements to the trace file. All log statements now contain
  structured payloads (ocaml/dune#13015, fixes ocaml/dune#12904, @rgrinberg)

- Add a target resolution event to replace the equivalent log message (ocaml/dune#12955,
  @rgrinberg)
