### PR TITLE
release solo5 0.10.1

### DIFF
--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.10.1/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.10.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["env" "TARGET_CC=aarch64-linux-gnu-gcc" "TARGET_LD=aarch64-linux-gnu-ld" "TARGET_OBJCOPY=aarch64-linux-gnu-objcopy" "./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install-toolchain"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+  "solo5" {= version}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["gcc-aarch64-linux-gnu"] {os-family = "debian"}
+]
+available: [
+  (arch != "arm64") &
+  (os = "linux" & os-family = "debian")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to cross-build
+MirageOS unikernels for the aarch64 architecture.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.10.1/solo5-v0.10.1.tar.gz"
+  checksum: "sha512=a364446b8cf39d63e0afe79475419cc81ec56f239cb38eef6c351fc849e836982f4d875b34f368bdfd1c7df72e8b162f95cf5e6d00e95077f9a57f2594f441bf"
+}

--- a/packages/solo5/solo5.0.10.1/opam
+++ b/packages/solo5/solo5.0.10.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.7.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+  "solo5-bindings-xen"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the host system.
+"""
+x-maintenance-intent: [ "(latest)" ]
+x-ci-accept-failures: [ "centos-7" "opensuse-15.6" ] # too old GCC compiler (OpenSUSE uses GCC 7 and we require GCC 10)
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.10.1/solo5-v0.10.1.tar.gz"
+  checksum: "sha512=a364446b8cf39d63e0afe79475419cc81ec56f239cb38eef6c351fc849e836982f4d875b34f368bdfd1c7df72e8b162f95cf5e6d00e95077f9a57f2594f441bf"
+}


### PR DESCRIPTION
- VirtIO: negotiate EVENT_IDX, improves network performance roughly by a factor
  of 2 (solo5/solo5#630 @dinosaure)
- VirtIO: add memory barriers (solo5/solo5#630 @dinosaure)
- Add better error reporting for ELF loader (solo5/solo5#624 @m-wkr @hannesm, fixes solo5/solo5#396)
- configure.sh: Linux: force -no-pie for TARGET_CC_LDFLAGS (solo5/solo5#629 @Firobe,
  fixes solo5/solo5#626 reported by @kit-ty-kate)
- configure.sh: OpenBSD: fix TARGET_CC_FLAGS (solo5/solo5#627 @omegametabroccolo)
- Muen: update sinfo to 04 (@reet-, solo5/solo5#622)
- Opam: uniquify x-ci-accept-failures (@hannesm, adapted from @art-w
  https://github.com/ocaml/opam-repository/pull/28865)
- Fix typos (solo5/solo5#621 solo5/solo5#628 @hannesm)

Partially sponsored by Tarides