### PR TITLE
[new release] opentelemetry (7 packages) (0.13)

### DIFF
--- a/packages/opentelemetry-client-cohttp-eio/opentelemetry-client-cohttp-eio.0.13/opam
+++ b/packages/opentelemetry-client-cohttp-eio/opentelemetry-client-cohttp-eio.0.13/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Collector client for opentelemetry, using cohttp + eio"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team" "ocaml-tracing contributors"]
+license: "MIT"
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.00"}
+  "mtime" {>= "1.4"}
+  "ca-certs"
+  "mirage-crypto-rng-eio"
+  "opentelemetry" {= version}
+  "odoc" {with-doc}
+  "cohttp-eio" {>= "6.1.0"}
+  "eio" {>= "1.2"}
+  "eio_main" {with-test}
+  "tls-eio" {>= "2.0"}
+  "cohttp-lwt-unix" {with-test}
+  "lwt_ppx" {>= "2.0" & with-test}
+  "alcotest" {with-test}
+  "containers" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.13/opentelemetry-0.13.tbz"
+  checksum: [
+    "sha256=e29a0aa7168357ebbed0f50b1ba9374bc277b280935531e77d90183c732b98f6"
+    "sha512=2fd9dcf03695be7b7888c5fb3d0dbe2acdcfbb7c99dfa7b2ff2fc0bb626c4e35ec8d2be71632e440b9df1cc79529c5258ca98876a373a41cff48e4b1757c5767"
+  ]
+}
+x-commit-hash: "28810fec51faa01af5f578566a6cd74c5f9af536"

--- a/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.13/opam
+++ b/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.13/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Collector client for opentelemetry, using cohttp + lwt"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team" "ocaml-tracing contributors"]
+license: "MIT"
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "mtime" {>= "1.4"}
+  "opentelemetry" {= version}
+  "odoc" {with-doc}
+  "opentelemetry-lwt" {= version}
+  "lwt" {>= "5.3"}
+  "lwt_ppx" {>= "2.0"}
+  "cohttp-lwt" {>= "6.0"}
+  "cohttp-lwt-unix"
+  "alcotest" {with-test}
+  "containers" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.13/opentelemetry-0.13.tbz"
+  checksum: [
+    "sha256=e29a0aa7168357ebbed0f50b1ba9374bc277b280935531e77d90183c732b98f6"
+    "sha512=2fd9dcf03695be7b7888c5fb3d0dbe2acdcfbb7c99dfa7b2ff2fc0bb626c4e35ec8d2be71632e440b9df1cc79529c5258ca98876a373a41cff48e4b1757c5767"
+  ]
+}
+x-commit-hash: "28810fec51faa01af5f578566a6cd74c5f9af536"

--- a/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.13/opam
+++ b/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.13/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Collector client for opentelemetry, using http + ezcurl"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team" "ocaml-tracing contributors"]
+license: "MIT"
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "mtime" {>= "1.4"}
+  "opentelemetry" {= version}
+  "odoc" {with-doc}
+  "ezcurl" {>= "0.3" & < "0.4"}
+  "ocurl"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.13/opentelemetry-0.13.tbz"
+  checksum: [
+    "sha256=e29a0aa7168357ebbed0f50b1ba9374bc277b280935531e77d90183c732b98f6"
+    "sha512=2fd9dcf03695be7b7888c5fb3d0dbe2acdcfbb7c99dfa7b2ff2fc0bb626c4e35ec8d2be71632e440b9df1cc79529c5258ca98876a373a41cff48e4b1757c5767"
+  ]
+}
+x-commit-hash: "28810fec51faa01af5f578566a6cd74c5f9af536"

--- a/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.13/opam
+++ b/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.13/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Opentelemetry tracing for Cohttp HTTP servers"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team" "ocaml-tracing contributors"]
+license: "MIT"
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "opentelemetry" {= version}
+  "opentelemetry-lwt" {= version}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "cohttp-lwt" {>= "6.0.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.13/opentelemetry-0.13.tbz"
+  checksum: [
+    "sha256=e29a0aa7168357ebbed0f50b1ba9374bc277b280935531e77d90183c732b98f6"
+    "sha512=2fd9dcf03695be7b7888c5fb3d0dbe2acdcfbb7c99dfa7b2ff2fc0bb626c4e35ec8d2be71632e440b9df1cc79529c5258ca98876a373a41cff48e4b1757c5767"
+  ]
+}
+x-commit-hash: "28810fec51faa01af5f578566a6cd74c5f9af536"

--- a/packages/opentelemetry-logs/opentelemetry-logs.0.13/opam
+++ b/packages/opentelemetry-logs/opentelemetry-logs.0.13/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Opentelemetry tracing for Cohttp HTTP servers"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team" "ocaml-tracing contributors"]
+license: "MIT"
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "opentelemetry" {= version}
+  "odoc" {with-doc}
+  "containers" {>= "3.12" & with-test}
+  "cohttp-lwt-unix" {with-test}
+  "opentelemetry-client-cohttp-lwt" {= version & with-test}
+  "opentelemetry-cohttp-lwt" {= version & with-test}
+  "logs" {>= "0.7.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.13/opentelemetry-0.13.tbz"
+  checksum: [
+    "sha256=e29a0aa7168357ebbed0f50b1ba9374bc277b280935531e77d90183c732b98f6"
+    "sha512=2fd9dcf03695be7b7888c5fb3d0dbe2acdcfbb7c99dfa7b2ff2fc0bb626c4e35ec8d2be71632e440b9df1cc79529c5258ca98876a373a41cff48e4b1757c5767"
+  ]
+}
+x-commit-hash: "28810fec51faa01af5f578566a6cd74c5f9af536"

--- a/packages/opentelemetry-lwt/opentelemetry-lwt.0.13/opam
+++ b/packages/opentelemetry-lwt/opentelemetry-lwt.0.13/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Lwt-compatible instrumentation for https://opentelemetry.io"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team" "ocaml-tracing contributors"]
+license: "MIT"
+tags: ["instrumentation" "tracing" "opentelemetry" "datadog" "lwt"]
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "opentelemetry" {= version}
+  "cohttp-lwt-unix" {with-test}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "lwt_ppx" {>= "2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.13/opentelemetry-0.13.tbz"
+  checksum: [
+    "sha256=e29a0aa7168357ebbed0f50b1ba9374bc277b280935531e77d90183c732b98f6"
+    "sha512=2fd9dcf03695be7b7888c5fb3d0dbe2acdcfbb7c99dfa7b2ff2fc0bb626c4e35ec8d2be71632e440b9df1cc79529c5258ca98876a373a41cff48e4b1757c5767"
+  ]
+}
+x-commit-hash: "28810fec51faa01af5f578566a6cd74c5f9af536"

--- a/packages/opentelemetry/opentelemetry.0.13/opam
+++ b/packages/opentelemetry/opentelemetry.0.13/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Instrumentation for https://opentelemetry.io"
+maintainer: [
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  "Matt Bray <mattjbray@gmail.com>"
+  "ELLIOTTCABLE <opam@ell.io>"
+]
+authors: ["the Imandra team" "ocaml-tracing contributors"]
+license: "MIT"
+tags: ["instrumentation" "tracing" "opentelemetry" "datadog" "jaeger"]
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "ptime"
+  "hmap"
+  "atomic"
+  "thread-local-storage" {>= "0.2" & < "0.3"}
+  "mtime" {>= "2.0"}
+  "odoc" {with-doc}
+  "alcotest" {with-test}
+  "pbrt" {>= "3.0" & < "4.0"}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ambient-context" {>= "0.2" & < "0.3"}
+  "ocamlformat" {with-dev-setup & >= "0.27" & < "0.28"}
+]
+depopts: ["trace" "lwt" "eio"]
+conflicts: [
+  "trace" {< "0.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.13/opentelemetry-0.13.tbz"
+  checksum: [
+    "sha256=e29a0aa7168357ebbed0f50b1ba9374bc277b280935531e77d90183c732b98f6"
+    "sha512=2fd9dcf03695be7b7888c5fb3d0dbe2acdcfbb7c99dfa7b2ff2fc0bb626c4e35ec8d2be71632e440b9df1cc79529c5258ca98876a373a41cff48e4b1757c5767"
+  ]
+}
+x-commit-hash: "28810fec51faa01af5f578566a6cd74c5f9af536"


### PR DESCRIPTION
Instrumentation for https://opentelemetry.io

- Project page: <a href="https://github.com/ocaml-tracing/ocaml-opentelemetry">https://github.com/ocaml-tracing/ocaml-opentelemetry</a>

##### CHANGES:

- feat: adapt to trace 0.12 (callbacks-based collector API, extensible span type, no more manual spans, ambient-span-provider)
- breaking: remove vendored `opentelemetry.ambient-context`; use the
    `ambient-context` 0.2 package directly instead. To configure the
    storage backend, call `Ambient_context.set_current_storage` (e.g.
    `Ambient_context.set_current_storage Ambient_context_lwt.storage`).
- move to ezcurl 0.3
- add a `hmap` in Scope.t
