### PR TITLE
[new release] testo (4 packages) (0.4.0)

### DIFF
--- a/packages/testo-diff/testo-diff.0.4.0/opam
+++ b/packages/testo-diff/testo-diff.0.4.0/opam
@@ -35,7 +35,7 @@ dev-repo: "git+https://github.com/mjambon/testo.git"
 x-maintenance-intent: ["(latest)"]
 url {
   src:
-    "https://github.com/mjambon/testo/releases/download/untagged-a1b506fcf80822b76e0c/testo-0.4.0.tbz"
+    "https://github.com/mjambon/testo/releases/download/0.4.0/testo-0.4.0.tbz"
   checksum: [
     "sha256=70f9be1524b57c28f73c2c84937ee9f779478e91fa359dc63642898dd131697b"
     "sha512=332631c8a6c031f712a54ffe6f15969abd966c4771db569905c66bd574c3ead20a5ce3feb74883f0fe93b13ab99128347917165ba4dc5c2af23ffc1aa95eb7f9"

--- a/packages/testo-lwt/testo-lwt.0.4.0/opam
+++ b/packages/testo-lwt/testo-lwt.0.4.0/opam
@@ -37,7 +37,7 @@ dev-repo: "git+https://github.com/mjambon/testo.git"
 x-maintenance-intent: ["(latest)"]
 url {
   src:
-    "https://github.com/mjambon/testo/releases/download/untagged-a1b506fcf80822b76e0c/testo-0.4.0.tbz"
+    "https://github.com/mjambon/testo/releases/download/0.4.0/testo-0.4.0.tbz"
   checksum: [
     "sha256=70f9be1524b57c28f73c2c84937ee9f779478e91fa359dc63642898dd131697b"
     "sha512=332631c8a6c031f712a54ffe6f15969abd966c4771db569905c66bd574c3ead20a5ce3feb74883f0fe93b13ab99128347917165ba4dc5c2af23ffc1aa95eb7f9"

--- a/packages/testo-util/testo-util.0.4.0/opam
+++ b/packages/testo-util/testo-util.0.4.0/opam
@@ -33,7 +33,7 @@ dev-repo: "git+https://github.com/mjambon/testo.git"
 x-maintenance-intent: ["(latest)"]
 url {
   src:
-    "https://github.com/mjambon/testo/releases/download/untagged-a1b506fcf80822b76e0c/testo-0.4.0.tbz"
+    "https://github.com/mjambon/testo/releases/download/0.4.0/testo-0.4.0.tbz"
   checksum: [
     "sha256=70f9be1524b57c28f73c2c84937ee9f779478e91fa359dc63642898dd131697b"
     "sha512=332631c8a6c031f712a54ffe6f15969abd966c4771db569905c66bd574c3ead20a5ce3feb74883f0fe93b13ab99128347917165ba4dc5c2af23ffc1aa95eb7f9"

--- a/packages/testo/testo.0.4.0/opam
+++ b/packages/testo/testo.0.4.0/opam
@@ -38,7 +38,7 @@ dev-repo: "git+https://github.com/mjambon/testo.git"
 x-maintenance-intent: ["(latest)"]
 url {
   src:
-    "https://github.com/mjambon/testo/releases/download/untagged-a1b506fcf80822b76e0c/testo-0.4.0.tbz"
+    "https://github.com/mjambon/testo/releases/download/0.4.0/testo-0.4.0.tbz"
   checksum: [
     "sha256=70f9be1524b57c28f73c2c84937ee9f779478e91fa359dc63642898dd131697b"
     "sha512=332631c8a6c031f712a54ffe6f15969abd966c4771db569905c66bd574c3ead20a5ce3feb74883f0fe93b13ab99128347917165ba4dc5c2af23ffc1aa95eb7f9"


### PR DESCRIPTION
Test framework for OCaml

- Project page: <a href="https://github.com/mjambon/testo">https://github.com/mjambon/testo</a>

##### CHANGES:

- The legend printed at the start of a test run now mentions `--expert` as a way to hide it.
- Truncate long stack backtraces to 5 lines by default when reporting a test failure due to an exception. The full backtrace can be shown with the new `--stack-backtrace` option or with `-v`/`--verbose` ([mjambon/testo#181](https://github.com/mjambon/testo/issues/181)).
- Experimental: `Testo.with_capture` now supports an `is_binary_mode` option for reading back binary data correctly according to the channel’s mode on Windows ([mjambon/testo#178](https://github.com/mjambon/testo/issues/178)).
- De-deprecated `Testo.with_open_temp_file` which now supports `get_random_key`, `perms`, `windows_binary`, and `windows_file_share_delete` options. The main novelty is that temporary files are now opened with `FILE_SHARE_DELETE` on Windows to avoid a class of cleanup failures linked to duplicate file handles ([mjambon/testo#180](https://github.com/mjambon/testo/issues/180)).
