### PR TITLE
Mark lwt < 6.1.1 incompatible with OCaml 5.5

### DIFF
--- a/packages/lwt/lwt.5.3.0/opam
+++ b/packages/lwt/lwt.5.3.0/opam
@@ -22,7 +22,7 @@ depends: [
   "dune-configurator"
   "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
   "ocaml" {>= "4.02.0" & < "4.12"}
-  ("ocaml" {>= "4.08.0"} | "ocaml-syntax-shims")
+  ("ocaml" {>= "4.08.0" & < "5.5"} | "ocaml-syntax-shims")
   "ocplib-endian"
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.

--- a/packages/lwt/lwt.5.4.0/opam
+++ b/packages/lwt/lwt.5.4.0/opam
@@ -23,7 +23,7 @@ depends: [
   "dune-configurator"
   "mmap" {>= "1.1.0"}
   "ocaml" {>= "4.02.0" & < "5.0"}
-  ("ocaml" {>= "4.08.0"} | "ocaml-syntax-shims")
+  ("ocaml" {>= "4.08.0" & < "5.5"} | "ocaml-syntax-shims")
   "ocplib-endian"
   "result"
   "seq"

--- a/packages/lwt/lwt.5.4.1/opam
+++ b/packages/lwt/lwt.5.4.1/opam
@@ -23,7 +23,7 @@ depends: [
   "dune-configurator"
   "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
   "ocaml" {>= "4.02.0" & < "5.0"}
-  ("ocaml" {>= "4.08.0"} | "ocaml-syntax-shims")
+  ("ocaml" {>= "4.08.0" & < "5.5"} | "ocaml-syntax-shims")
   "ocplib-endian"
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.

--- a/packages/lwt/lwt.5.4.2/opam
+++ b/packages/lwt/lwt.5.4.2/opam
@@ -22,7 +22,7 @@ depends: [
   "dune-configurator"
   "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
   "ocaml" {>= "4.02.0" & < "5.0"}
-  ("ocaml" {>= "4.08.0"} | "ocaml-syntax-shims")
+  ("ocaml" {>= "4.08.0" & < "5.5"} | "ocaml-syntax-shims")
   "ocplib-endian"
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.

--- a/packages/lwt/lwt.5.5.0/opam
+++ b/packages/lwt/lwt.5.5.0/opam
@@ -21,8 +21,8 @@ depends: [
   "dune" {>= "1.8.0"}
   "dune-configurator"
   "mmap" {>= "1.1.0" & "os" != "win32"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
-  "ocaml" {(>= "4.02.0" & "os" != "win32" | >= "4.06.0") & < "5.0"}
-  ("ocaml" {>= "4.08.0"} | "ocaml-syntax-shims")
+  "ocaml" {("os" != "win32" & >= "4.02.0" | >= "4.06.0") & < "5.0"}
+  ("ocaml" {>= "4.08.0" & < "5.5"} | "ocaml-syntax-shims")
   "ocplib-endian"
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.

--- a/packages/lwt/lwt.5.7.0/opam
+++ b/packages/lwt/lwt.5.7.0/opam
@@ -20,7 +20,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.8.0"}
   "dune-configurator"
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.5"}
   "ocplib-endian"
 
   # Until https://github.com/aantron/bisect_ppx/pull/327.

--- a/packages/lwt/lwt.5.8.0/opam
+++ b/packages/lwt/lwt.5.8.0/opam
@@ -21,7 +21,7 @@ doc: "https://ocsigen.org/lwt"
 bug-reports: "https://github.com/ocsigen/lwt/issues"
 depends: [
   "dune" {>= "1.12"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.5"}
   "cppo" {build & >= "1.1.0"}
   "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3.0"}

--- a/packages/lwt/lwt.5.8.1/opam
+++ b/packages/lwt/lwt.5.8.1/opam
@@ -21,7 +21,7 @@ doc: "https://ocsigen.org/lwt"
 bug-reports: "https://github.com/ocsigen/lwt/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.5"}
   "cppo" {build & >= "1.1.0"}
   "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3.0"}

--- a/packages/lwt/lwt.5.9.0/opam
+++ b/packages/lwt/lwt.5.9.0/opam
@@ -21,7 +21,7 @@ doc: "https://ocsigen.org/lwt"
 bug-reports: "https://github.com/ocsigen/lwt/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.5"}
   "cppo" {build & >= "1.1.0"}
   "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3.0"}

--- a/packages/lwt/lwt.5.9.1/opam
+++ b/packages/lwt/lwt.5.9.1/opam
@@ -21,7 +21,7 @@ doc: "https://ocsigen.org/lwt"
 bug-reports: "https://github.com/ocsigen/lwt/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.5"}
   "cppo" {build & >= "1.1.0"}
   "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3.0"}

--- a/packages/lwt/lwt.5.9.2/opam
+++ b/packages/lwt/lwt.5.9.2/opam
@@ -21,7 +21,7 @@ doc: "https://ocsigen.org/lwt"
 bug-reports: "https://github.com/ocsigen/lwt/issues"
 depends: [
   "dune" {>= "3.15"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.5"}
   "cppo" {build & >= "1.1"}
   "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3"}

--- a/packages/lwt/lwt.6.0.0/opam
+++ b/packages/lwt/lwt.6.0.0/opam
@@ -21,7 +21,7 @@ doc: "https://ocsigen.org/lwt"
 bug-reports: "https://github.com/ocsigen/lwt/issues"
 depends: [
   "dune" {>= "3.18"}
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.14" & < "5.5"}
   "cppo" {build & >= "1.1"}
   "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3"}

--- a/packages/lwt/lwt.6.0.0~alpha00/opam
+++ b/packages/lwt/lwt.6.0.0~alpha00/opam
@@ -21,7 +21,7 @@ doc: "https://ocsigen.org/lwt"
 bug-reports: "https://github.com/ocsigen/lwt/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.5"}
   "cppo" {build & >= "1.1.0"}
   "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3.0"}

--- a/packages/lwt/lwt.6.0.0~beta01/opam
+++ b/packages/lwt/lwt.6.0.0~beta01/opam
@@ -21,7 +21,7 @@ doc: "https://ocsigen.org/lwt"
 bug-reports: "https://github.com/ocsigen/lwt/issues"
 depends: [
   "dune" {>= "3.15"}
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.14" & < "5.5"}
   "cppo" {build & >= "1.1"}
   "ocamlfind" {with-dev-setup & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3"}

--- a/packages/lwt/lwt.6.1.0/opam
+++ b/packages/lwt/lwt.6.1.0/opam
@@ -21,7 +21,7 @@ doc: "https://ocsigen.org/lwt"
 bug-reports: "https://github.com/ocsigen/lwt/issues"
 depends: [
   "dune" {>= "3.18"}
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.14" & < "5.5"}
   "cppo" {build & >= "1.1"}
   "ocamlfind" {dev & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3"}


### PR DESCRIPTION
See https://github.com/ocsigen/lwt/pull/1100
```
#=== ERROR while compiling lwt.6.1.0 ==========================================#
# context              2.5.0 | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/lwt.6.1.0
# command              ~/.opam/5.5/bin/dune build -p lwt -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/lwt-14-cbc69c.env
# output-file          ~/.opam/log/lwt-14-cbc69c.out
### output ###
# File "src/unix/dune", line 92, characters 3-18:
# 92 |    unix_bytes_recv
#         ^^^^^^^^^^^^^^^
# (cd _build/default/src/unix && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -fPIC -pthread -D_FILE_OFFSET_BITS=64 -Wall -fdiagnostics-color=always -Wall -fPIC -pthread -g -I /home/opam/.opam/5.5/lib/ocaml -I /home/opam/.opam/5.5/lib/bytes -I /home/opam/.opam/5.5/lib/ocaml/threads -I /home/opam/.opam/5.5/lib/ocaml/unix -I /home/opam/.opam/5.5/lib/ocplib-endian -I /home/opam/.opam/5.5/lib/ocplib-endian/bigstring -I ../core -o unix_bytes_recv.o -c unix_bytes_recv.c)
# In file included from lwt_unix.h:14,
#                  from unix_bytes_recv.c:17:
# /home/opam/.opam/5.5/lib/ocaml/caml/socketaddr.h:117:5: error: expected declaration specifiers or '...' before '(' token
#   117 |     (vaddr),                                                  \
#       |     ^
# /home/opam/.opam/5.5/lib/ocaml/caml/socketaddr.h:69:22: note: in expansion of macro 'caml_unix_get_sockaddr'
#    69 | #define get_sockaddr caml_unix_get_sockaddr
#       |                      ^~~~~~~~~~~~~~~~~~~~~~
# unix_recv_send_utils.h:48:13: note: in expansion of macro 'get_sockaddr'
#    48 | extern void get_sockaddr(value mladdr, union sock_addr_union *addr /*out*/,
#       |             ^~~~~~~~~~~~
# /home/opam/.opam/5.5/lib/ocaml/caml/socketaddr.h:118:5: error: expected declaration specifiers or '...' before '_Generic'
#   118 |     _Generic((addr),                                          \
#       |     ^~~~~~~~
# /home/opam/.opam/5.5/lib/ocaml/caml/socketaddr.h:69:22: note: in expansion of macro 'caml_unix_get_sockaddr'
#    69 | #define get_sockaddr caml_unix_get_sockaddr
#       |                      ^~~~~~~~~~~~~~~~~~~~~~
# unix_recv_send_utils.h:48:13: note: in expansion of macro 'get_sockaddr'
#    48 | extern void get_sockaddr(value mladdr, union sock_addr_union *addr /*out*/,
#       |             ^~~~~~~~~~~~
# /home/opam/.opam/5.5/lib/ocaml/caml/socketaddr.h:122:5: error: expected declaration specifiers or '...' before '(' token
#   122 |     (addr_len))
#       |     ^
# /home/opam/.opam/5.5/lib/ocaml/caml/socketaddr.h:69:22: note: in expansion of macro 'caml_unix_get_sockaddr'
#    69 | #define get_sockaddr caml_unix_get_sockaddr
[...]
```