### PR TITLE
[new release] tm-grammars (1.0.0)

### DIFF
--- a/packages/tm-grammars/tm-grammars.1.0.0/opam
+++ b/packages/tm-grammars/tm-grammars.1.0.0/opam
@@ -26,12 +26,13 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/davesnx/tm-grammars.git"
+x-ci-accept-failures: ["opensuse-15.6"]
 url {
   src:
     "https://github.com/davesnx/tm-grammars/releases/download/1.0.0/tm-grammars-1.0.0.tbz"
   checksum: [
-    "sha256=a44a4f0d07ee70c464a13960e8250c4913d70737161eb89a2b9fbc4c1e166916"
-    "sha512=184a5cb893392366c22438a87f6bf5d414cb2de129ccf0bd5c4748971f5c8e07da2d71795de5d23290b23b0a49753bcfff6e83a45d13c5295029f0eed5aa12fb"
+    "sha256=11f310b638e27aebd43f8b7bcae49123095cb5462f806a8344190b456ca1fef0"
+    "sha512=9a199c02fd5d8e8104d0ab9942ec116a26e7b1a0f0fe089b8d8076d31f1c2ba8e0306a686f47980830a112f06b880ea5cf52229dabb5d0f2015251e300f08c8a"
   ]
 }
-x-commit-hash: "35481e590f4c80b55c7a904c0581fae1b5064cf1"
+x-commit-hash: "d660229c9cc26c2421e06e769951dadd5a644ffd"


### PR DESCRIPTION
TextMate grammars as OCaml strings

- Project page: <a href="https://github.com/davesnx/tm-grammars">https://github.com/davesnx/tm-grammars</a>

##### CHANGES:

- Published OCaml package that exposes TextMate grammars as JSON strings.
- Each language is a findlib sublibrary (e.g. `tm-grammars.ocaml`, `tm-grammars.tsx`).
- Downstream users depend on `tm-grammars` and add only the sublibraries they need to `(libraries ...)`.
- Generated package setup driven by `sources.json`.
