### PR TITLE
opam-client >= 2.2.0 < 2.5.0~beta1 is not compatible with OCaml 5.5

### DIFF
--- a/packages/opam-client/opam-client.2.2.0/opam
+++ b/packages/opam-client/opam-client.2.2.0/opam
@@ -21,7 +21,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.5"}
   "opam-state" {= version}
   "opam-solver" {= version}
   "base64" {>= "3.1.0"}

--- a/packages/opam-client/opam-client.2.2.1/opam
+++ b/packages/opam-client/opam-client.2.2.1/opam
@@ -21,7 +21,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.5"}
   "opam-state" {= version}
   "opam-solver" {= version}
   "base64" {>= "3.1.0"}

--- a/packages/opam-client/opam-client.2.3.0/opam
+++ b/packages/opam-client/opam-client.2.3.0/opam
@@ -21,7 +21,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.5"}
   "opam-state" {= version}
   "opam-solver" {= version}
   "base64" {>= "3.1.0"}

--- a/packages/opam-client/opam-client.2.4.0/opam
+++ b/packages/opam-client/opam-client.2.4.0/opam
@@ -21,7 +21,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.5"}
   "opam-state" {= version}
   "opam-solver" {= version}
   "base64" {>= "3.1.0"}

--- a/packages/opam-client/opam-client.2.4.0~alpha1/opam
+++ b/packages/opam-client/opam-client.2.4.0~alpha1/opam
@@ -21,7 +21,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.5"}
   "opam-state" {= version}
   "opam-solver" {= version}
   "base64" {>= "3.1.0"}

--- a/packages/opam-client/opam-client.2.4.0~alpha2/opam
+++ b/packages/opam-client/opam-client.2.4.0~alpha2/opam
@@ -21,7 +21,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.5"}
   "opam-state" {= version}
   "opam-solver" {= version}
   "base64" {>= "3.1.0"}

--- a/packages/opam-client/opam-client.2.4.0~beta1/opam
+++ b/packages/opam-client/opam-client.2.4.0~beta1/opam
@@ -21,7 +21,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.5"}
   "opam-state" {= version}
   "opam-solver" {= version}
   "base64" {>= "3.1.0"}

--- a/packages/opam-client/opam-client.2.4.0~rc1/opam
+++ b/packages/opam-client/opam-client.2.4.0~rc1/opam
@@ -21,7 +21,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.5"}
   "opam-state" {= version}
   "opam-solver" {= version}
   "base64" {>= "3.1.0"}

--- a/packages/opam-client/opam-client.2.4.1/opam
+++ b/packages/opam-client/opam-client.2.4.1/opam
@@ -21,7 +21,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.5"}
   "opam-state" {= version}
   "opam-solver" {= version}
   "base64" {>= "3.1.0"}

--- a/packages/opam-client/opam-client.2.5.0~alpha1/opam
+++ b/packages/opam-client/opam-client.2.5.0~alpha1/opam
@@ -21,7 +21,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.5"}
   "opam-state" {= version}
   "opam-solver" {= version}
   "base64" {>= "3.1.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling opam-client.2.4.1 ==================================#
# context              2.5.0 | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/opam-client.2.4.1
# command              ~/.opam/5.5/bin/dune build -p opam-client -j 1
# exit-code            1
# env-file             ~/.opam/log/opam-client-14-5a9567.env
# output-file          ~/.opam/log/opam-client-14-5a9567.out
### output ###
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -w +a-4-40-42-44-48 -safe-string -g -bin-annot -bin-annot-occurrences -I src/client/.opam_client.objs/byte -I /home/opam/.opam/5.5/lib/0install-solver -I /home/opam/.opam/5.5/lib/base64 -I /home/opam/.opam/5.5/lib/cmdliner -I /home/opam/.opam/5.5/lib/cudf -I /home/opam/.opam/5.5/lib/dose3/algo -I /home/opam/.opam/5.5/lib/dose3/common -I /home/opam/.opam/5.5/lib/extlib -I /home/opam/.opam/5.5/lib/jsonm -I /home/opam/.opam/5.5/lib/mccs -I /home/opam/.opam/5.5/lib/mccs/glpk/internal -I /home/opam/.opam/5.5/lib/ocaml/unix -I /home/opam/.opam/5.5/lib/ocamlgraph -I /home/opam/.opam/5.5/lib/opam-0install-cudf -I /home/opam/.opam/5.5/lib/opam-core -I /home/opam/.opam/5.5/lib/opam-file-format -I /home/opam/.opam/5.5/lib/opam-format -I /home/opam/.opam/5.5/lib/opam-repository -I /home/opam/.opam/5.5/lib/opam-solver -I /home/opam/.opam/5.5/lib/opam-state -I /home/opam/.opam/5.5/lib/patch -I /home/opam/.opam/5.5/lib/re -I /home/opam/.opam/5.5/lib/re/pcre -I /home/opam/.opam/5.5/lib/sha -I /home/opam/.opam/5.5/lib/spdx_licenses -I /home/opam/.opam/5.5/lib/stdlib-shims -I /home/opam/.opam/5.5/lib/swhid_core -I /home/opam/.opam/5.5/lib/uutf -cmi-file src/client/.opam_client.objs/byte/opamTreeCommand.cmi -no-alias-deps -o src/client/.opam_client.objs/byte/opamTreeCommand.cmo -c -impl src/client/opamTreeCommand.ml)
# File "src/client/opamTreeCommand.ml", lines 158-160, characters 8-61:
# 158 | ........match node with
# 159 |         | Root p -> Root p (* but impossible *)
# 160 |         | Dependency x -> Dependency { x with is_dup = true }
# Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
#   Here is an example of a case that is not matched: Requirement _
```
See https://github.com/ocaml/opam/pull/6670