### PR TITLE
Restrict older versions of ocp-index to their appropriate OCaml versions

### DIFF
--- a/packages/ocp-index/ocp-index.1.3.7/opam
+++ b/packages/ocp-index/ocp-index.1.3.7/opam
@@ -22,7 +22,7 @@ tags: [ "org:ocamlpro" "org:typerex" ]
 dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.4"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}

--- a/packages/ocp-index/ocp-index.1.4.0/opam
+++ b/packages/ocp-index/ocp-index.1.4.0/opam
@@ -15,7 +15,7 @@ tags: ["org:ocamlpro" "org:typerex"]
 homepage: "http://www.typerex.org/ocp-index.html"
 bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.5"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}


### PR DESCRIPTION
```
#=== ERROR while compiling ocp-index.1.4.0 ====================================#
# context              2.5.0 | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/ocp-index.1.4.0
# command              ~/.opam/5.5/bin/dune build -p ocp-index -j 1
# exit-code            1
# env-file             ~/.opam/log/ocp-index-14-9f3e62.env
# output-file          ~/.opam/log/ocp-index-14-9f3e62.out
### output ###
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -w -9 -g -bin-annot -bin-annot-occurrences -I libs/.indexLib.objs/byte -I /home/opam/.opam/5.5/lib/ocaml/compiler-libs -I /home/opam/.opam/5.5/lib/ocp-indent/lexer -I /home/opam/.opam/5.5/lib/ocp-indent/utils -cmi-file libs/.indexLib.objs/byte/indexPredefined.cmi -no-alias-deps -o libs/.indexLib.objs/byte/indexPredefined.cmo -c -impl libs/indexPredefined.pp.ml)
# File "libs/indexPredefined.ml", line 49, characters 8-19:
# Error: This record expression is expected to have type
#          Outcometree.out_type_decl
#        There is no field otype_cstrs within type Outcometree.out_type_decl
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlopt.opt -w -40 -w -9 -g -I libs/.indexLib.objs/byte -I libs/.indexLib.objs/native -I /home/opam/.opam/5.5/lib/ocaml/compiler-libs -I /home/opam/.opam/5.5/lib/ocp-indent/lexer -I /home/opam/.opam/5.5/lib/ocp-indent/utils -cmi-file libs/.indexLib.objs/byte/indexPredefined.cmi -no-alias-deps -o libs/.indexLib.objs/native/indexPredefined.cmx -c -impl libs/indexPredefined.pp.ml)
# File "libs/indexPredefined.ml", line 49, characters 8-19:
# Error: This record expression is expected to have type
#          Outcometree.out_type_decl
#        There is no field otype_cstrs within type Outcometree.out_type_decl
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -w -9 -g -bin-annot -bin-annot-occurrences -I libs/.indexLib.objs/byte -I /home/opam/.opam/5.5/lib/ocaml/compiler-libs -I /home/opam/.opam/5.5/lib/ocp-indent/lexer -I /home/opam/.opam/5.5/lib/ocp-indent/utils -cmi-file libs/.indexLib.objs/byte/indexBuild.cmi -no-alias-deps -o libs/.indexLib.objs/byte/indexBuild.cmo -c -impl libs/indexBuild.pp.ml)
# File "libs/indexBuild.ml", line 231, characters 27-35:
# Error: The field open_row is not part of the record argument for the Outcometree.out_type.Otyp_object constructor
```
```
#=== ERROR while compiling ocp-index.1.3.7 ====================================#
# context              2.5.0 | linux/x86_64 | ocaml-base-compiler.5.4.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.4/.opam-switch/build/ocp-index.1.3.7
# command              ~/.opam/5.4/bin/dune build -p ocp-index -j 1
# exit-code            1
# env-file             ~/.opam/log/ocp-index-14-cafcd3.env
# output-file          ~/.opam/log/ocp-index-14-cafcd3.out
### output ###
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w -40 -w -9 -g -bin-annot -bin-annot-occurrences -I libs/.indexLib.objs/byte -I /home/opam/.opam/5.4/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4/lib/ocp-indent/lexer -I /home/opam/.opam/5.4/lib/ocp-indent/utils -cmi-file libs/.indexLib.objs/byte/indexBuild.cmi -no-alias-deps -o libs/.indexLib.objs/byte/indexBuild.cmo -c -impl libs/indexBuild.pp.ml)
# File "libs/indexBuild.ml", line 283, characters 18-27:
# Error: This pattern matches values of type 'a * 'b
#        but a pattern was expected which matches values of type
#          Outcometree.out_package
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w -40 -w -9 -g -bin-annot -bin-annot-occurrences -I libs/.indexLib.objs/byte -I /home/opam/.opam/5.4/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4/lib/ocp-indent/lexer -I /home/opam/.opam/5.4/lib/ocp-indent/utils -cmi-file libs/.indexLib.objs/byte/indexPredefined.cmi -no-alias-deps -o libs/.indexLib.objs/byte/indexPredefined.cmo -c -impl libs/indexPredefined.pp.ml)
# File "libs/indexPredefined.ml", line 191, characters 24-31:
# Error: This expression has type Outcometree.out_type
#        but an expression was expected of type
#          string option * Outcometree.out_type
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlopt.opt -w -40 -w -9 -g -I libs/.indexLib.objs/byte -I libs/.indexLib.objs/native -I /home/opam/.opam/5.4/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4/lib/ocp-indent/lexer -I /home/opam/.opam/5.4/lib/ocp-indent/utils -cmi-file libs/.indexLib.objs/byte/indexPredefined.cmi -no-alias-deps -o libs/.indexLib.objs/native/indexPredefined.cmx -c -impl libs/indexPredefined.pp.ml)
# File "libs/indexPredefined.ml", line 191, characters 24-31:
# Error: This expression has type Outcometree.out_type
#        but an expression was expected of type
#          string option * Outcometree.out_type
```