### PR TITLE
rocq-runtime/coq-core >= 8.19.2 < 9.1.1 is not compatible with OCaml 5.5

### DIFF
--- a/packages/coq-core/coq-core.8.19.2/opam
+++ b/packages/coq-core/coq-core.8.19.2/opam
@@ -26,7 +26,7 @@ doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.09.0"}
+  "ocaml" {>= "4.09.0" & < "5.5"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}
   "conf-linux-libc-dev" {os = "linux"}

--- a/packages/coq-core/coq-core.8.20.0/opam
+++ b/packages/coq-core/coq-core.8.20.0/opam
@@ -26,7 +26,7 @@ doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
   "dune" {>= "3.6.1"}
-  "ocaml" {>= "4.09.0"}
+  "ocaml" {>= "4.09.0" & < "5.5"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}
   "conf-linux-libc-dev" {os = "linux"}

--- a/packages/coq-core/coq-core.8.20.1/opam
+++ b/packages/coq-core/coq-core.8.20.1/opam
@@ -26,7 +26,7 @@ doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
   "dune" {>= "3.6.1"}
-  "ocaml" {>= "4.09.0"}
+  "ocaml" {>= "4.09.0" & < "5.5"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}
   "conf-linux-libc-dev" {os = "linux"}

--- a/packages/rocq-runtime/rocq-runtime.9.0.0/opam
+++ b/packages/rocq-runtime/rocq-runtime.9.0.0/opam
@@ -26,7 +26,7 @@ doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.09.0"}
+  "ocaml" {>= "4.09.0" & < "5.5"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}
   "conf-linux-libc-dev" {os = "linux"}

--- a/packages/rocq-runtime/rocq-runtime.9.0.1/opam
+++ b/packages/rocq-runtime/rocq-runtime.9.0.1/opam
@@ -26,7 +26,7 @@ doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.09.0"}
+  "ocaml" {>= "4.09.0" & < "5.5"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}
   "conf-linux-libc-dev" {os = "linux"}

--- a/packages/rocq-runtime/rocq-runtime.9.1.0/opam
+++ b/packages/rocq-runtime/rocq-runtime.9.1.0/opam
@@ -26,7 +26,7 @@ doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "4.14.0" & < "5.5"}
   "ocamlfind" {>= "1.9.1" & (>= "1.9.8" | os-family != "windows")}
   "zarith" {>= "1.11"}
   "conf-linux-libc-dev" {os = "linux"}


### PR DESCRIPTION
```
#=== ERROR while compiling rocq-runtime.9.1.0 =================================#
# context              2.5.0 | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/rocq-runtime.9.1.0
# command              ~/.opam/5.5/bin/dune build -p rocq-runtime -j 1 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/rocq-runtime-14-3e2fe4.env
# output-file          ~/.opam/log/rocq-runtime-14-3e2fe4.out
### output ###
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I gramlib/.gramlib.objs/byte -I /home/opam/.opam/5.5/lib/ocaml/str -I /home/opam/.opam/5.5/lib/ocaml/threads -I /home/opam/.opam/5.5/lib/ocaml/unix -I boot/.boot.objs/byte -I clib/.clib.objs/byte -I config/.config.objs/byte -I lib/.lib.objs/byte -I perf/.coqperf.objs/byte -cmi-file gramlib/.gramlib.objs/byte/gramlib__Grammar.cmi -no-alias-deps -open Gramlib -o gramlib/.gramlib.objs/byte/gramlib__Grammar.cmo -c -impl gramlib/grammar.ml)
# File "gramlib/grammar.ml", lines 399-400, characters 7-48:
# 399 | .......let Belast (NoRec2, r, s') = belast_rule NoRec2 r s' in
# 400 |        Belast (NoRec2, TNext (NoRec2, r, s), s')
# Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
#   Here is an example of a case that is not matched:
#     Belast (MayRec2, TStop, Stoken _)
```
```
#=== ERROR while compiling coq-core.8.19.2 ====================================#
# context              2.5.0 | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/coq-core.8.19.2
# command              ~/.opam/5.5/bin/dune build -p coq-core -j 1 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/coq-core-14-d93f2d.env
# output-file          ~/.opam/log/coq-core-14-d93f2d.out
### output ###
# File "gramlib/grammar.ml", lines 537-541, characters 4-24:
# 537 | ....function
# 538 |     | Node (NoRec3, {node = s; son = son; brother = bro}) ->
# 539 |       Node (NoRec3, {node = retype_symbol s; son = retype_tree son; brother = retype_tree bro})
# 540 |     | LocAct (k, kl) -> LocAct (k, kl)
# 541 |     | DeadEnd -> DeadEnd
# Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
#   Here is an example of a case that is not matched: Node (MayRec3, _)
```
See https://github.com/rocq-prover/rocq/pull/21584