### PR TITLE
3 packages from mbarbin/dunolint at 0.0.20260306

### DIFF
--- a/packages/dunolint-lib-base/dunolint-lib-base.0.0.20260306/opam
+++ b/packages/dunolint-lib-base/dunolint-lib-base.0.0.20260306/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "An extension of dunolint-lib for use with Base"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/dunolint"
+doc: "https://mbarbin.github.io/dunolint/"
+bug-reports: "https://github.com/mbarbin/dunolint/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "base" {>= "v0.16"}
+  "dunolint-lib" {= version}
+  "ppx_compare" {>= "v0.16"}
+  "ppx_enumerate" {>= "v0.16"}
+  "ppx_sexp_conv" {>= "v0.16"}
+  "ppxlib" {>= "0.35.0"}
+  "re" {>= "1.8.0"}
+  "sexplib0" {>= "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/dunolint.git"
+url {
+  src:
+    "https://github.com/mbarbin/dunolint/releases/download/0.0.20260306/dunolint-0.0.20260306.tbz"
+  checksum: [
+    "sha256=d92e0d705b661ea12b22dcc9bdd83815c507218c1de085d75140fd47bea0c5ec"
+    "sha512=fdf4fbb4906aba4aeab766dfa5202b64950c71c988b1b84363319dd05edb93b34142355f968a5687057977e40defdced20a2a17ee0614565096eb123655621f3"
+  ]
+}
+x-commit-hash: "b3dad0b66eb21cd15dbe3b697e54d6a298957b55"

--- a/packages/dunolint-lib/dunolint-lib.0.0.20260306/opam
+++ b/packages/dunolint-lib/dunolint-lib.0.0.20260306/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "A library to create dunolint configs"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/dunolint"
+doc: "https://mbarbin.github.io/dunolint/"
+bug-reports: "https://github.com/mbarbin/dunolint/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "re" {>= "1.8.0"}
+  "sexplib0" {>= "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/dunolint.git"
+description: """\
+
+[dunolint] is a set of OCaml libraries and a cli tool to lint and help
+manage files in (large) dune projects.
+
+[dunolint-lib] is the package you need as a user to define a dunolint
+config, without pulling all the dependencies required by the linter
+engine and command line.
+
+It defines a configuration language in which you can express linting
+invariants for your projects. The tool will enforce these invariants,
+applying global and systematic changes automatically when able, and
+help with general ergonomics questions.
+
+For example: "I want for all libs in this subdirectory to enable
+`bisect_ppx`, please go patch my dune files". Or, "I would like all
+libraries that verify this particular predicate to supply the ppx flag
+`-unused-code-warnings=force`", and more.
+
+You can setup [dunolint] as part of your CI checks to help enforcing
+properties and linting checks going forward.
+
+"""
+tags: [ "dune" "linter" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/dunolint/releases/download/0.0.20260306/dunolint-0.0.20260306.tbz"
+  checksum: [
+    "sha256=d92e0d705b661ea12b22dcc9bdd83815c507218c1de085d75140fd47bea0c5ec"
+    "sha512=fdf4fbb4906aba4aeab766dfa5202b64950c71c988b1b84363319dd05edb93b34142355f968a5687057977e40defdced20a2a17ee0614565096eb123655621f3"
+  ]
+}
+x-commit-hash: "b3dad0b66eb21cd15dbe3b697e54d6a298957b55"

--- a/packages/dunolint/dunolint.0.0.20260306/opam
+++ b/packages/dunolint/dunolint.0.0.20260306/opam
@@ -1,0 +1,85 @@
+opam-version: "2.0"
+synopsis: "A linter for build files in dune projects"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/dunolint"
+doc: "https://mbarbin.github.io/dunolint/"
+bug-reports: "https://github.com/mbarbin/dunolint/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.3"}
+  "base" {>= "v0.17"}
+  "cmdlang" {>= "0.0.9"}
+  "cmdlang-cmdliner-err-runner" {>= "0.0.16"}
+  "dunolint-lib" {= version}
+  "dunolint-lib-base" {= version}
+  "file-rewriter" {>= "0.0.3"}
+  "fmt" {>= "0.9.0"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.4.0"}
+  "loc" {>= "0.3.3"}
+  "logs" {>= "0.7.0"}
+  "pageantty" {>= "0.0.3"}
+  "parsexp" {>= "v0.17"}
+  "patdiff" {>= "v0.17"}
+  "pp" {>= "2.0.0"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-log" {>= "0.0.16"}
+  "pplumbing-log-cli" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
+  "ppx_compare" {>= "v0.17"}
+  "ppx_enumerate" {>= "v0.17"}
+  "ppx_hash" {>= "v0.17"}
+  "ppx_here" {>= "v0.17"}
+  "ppx_let" {>= "v0.17"}
+  "ppx_sexp_conv" {>= "v0.17"}
+  "ppx_sexp_value" {>= "v0.17"}
+  "ppxlib" {>= "0.35.0"}
+  "re" {>= "1.8.0"}
+  "sexplib0" {>= "v0.17"}
+  "sexps-rewriter" {>= "0.0.3"}
+  "stdio" {>= "v0.17"}
+  "volgo" {>= "0.0.21"}
+  "volgo-git-unix" {>= "0.0.21"}
+  "volgo-hg-unix" {>= "0.0.21"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/dunolint.git"
+description: """\
+
+[dunolint] is a set of OCaml libraries and a cli tool to lint and help
+manage files in (large) dune projects.
+
+[dunolint] is the package that implements the linter engine for
+dunolint configs as well as the [dunolint] command line tool.
+
+You may install it to get the [dunolint] cli, and/or if you want to
+use the linting libraries to write custom rewriters and linters.
+
+"""
+tags: [ "dune" "linter" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/dunolint/releases/download/0.0.20260306/dunolint-0.0.20260306.tbz"
+  checksum: [
+    "sha256=d92e0d705b661ea12b22dcc9bdd83815c507218c1de085d75140fd47bea0c5ec"
+    "sha512=fdf4fbb4906aba4aeab766dfa5202b64950c71c988b1b84363319dd05edb93b34142355f968a5687057977e40defdced20a2a17ee0614565096eb123655621f3"
+  ]
+}
+x-commit-hash: "b3dad0b66eb21cd15dbe3b697e54d6a298957b55"


### PR DESCRIPTION
This pull-request concerns:
- `dunolint.0.0.20260306`: A linter for build files in dune projects
- `dunolint-lib.0.0.20260306`: A library to create dunolint configs
- `dunolint-lib-base.0.0.20260306`: An extension of dunolint-lib for use with Base



---
* Homepage: https://github.com/mbarbin/dunolint
* Source repo: git+https://github.com/mbarbin/dunolint.git
* Bug tracker: https://github.com/mbarbin/dunolint/issues

---
## 0.0.20260306 (2026-03-06)

From this version, pre-compiled release binaries are included as compressed archives.

### Added

- Distribute compressed archived for release artifacts ([#183](https://github.com/mbarbin/dunolint/pull/183), @mbarbin).

### Changed

- Upgrade to recent `actions/attest` GitHub workflow ([#183](https://github.com/mbarbin/dunolint/pull/183), @mbarbin).

## 0.0.20260211 (2026-02-11)

Starting from this version we're using GitHub immutable releases.

### Added

- Add library modes `mem` variadic construct ([#174](https://github.com/mbarbin/dunolint/pull/174), @mbarbin).
- Adapt release artifacts jobs for immutable releases (@mbarbin).
- Added new CI workflow based on setup-dune (@mbarbin).
- Add some library and executable linter getters/setters ([#163](https://github.com/mbarbin/dunolint/pull/163), @mbarbin).

### Changed

- Extract dune lang format directly from enclosing context ([#177](https://github.com/mbarbin/dunolint/pull/177), @mbarbin).
- Support supplying flags to instrumentation backends ([#175](https://github.com/mbarbin/dunolint/pull/175), @mbarbin).
- Migrate main and doc CIs to `setup-dune` ([#171](https://github.com/mbarbin/dunolint/pull/171), @mbarbin).
- Assorted improvements to CI scripts. Upgrade an pin actions deps ([#173](https://github.com/mbarbin/dunolint/pull/173), @mbarbin).
- Generalize `Dunolint_engine.with_linter` helper ([#163](https://github.com/mbarbin/dunolint/pull/163), @mbarbin).

### Deprecated

- Deprecate `has_mode` and `has_modes` library modes, replaced by `mem` ([#172](https://github.com/mbarbin/dunolint/pull/172), @mbarbin).

### Fixed

- Fix new dune build target `unused-libs` ([#171](https://github.com/mbarbin/dunolint/pull/171), @mbarbin).
- Fix tests and prepare compatibility with `dune.3.21` ([#167](https://github.com/mbarbin/dunolint/pull/167), @mbarbin).

### Removed

- Removed deprecated `load_existing_libraries` private helper ([#163](https://github.com/mbarbin/dunolint/pull/163), @mbarbin).
- Removed root `dune-workspace` causing build issues with `dune.3.17`. (@mbarbin).

## 0.0.20260103 (2026-01-03)

### Added

- Show supported candidates in invalid construct sexp error ([#162](https://github.com/mbarbin/dunolint/pull/162), @mbarbin).
- Add initial support for `package` predicates in libraries ([#161](https://github.com/mbarbin/dunolint/pull/161), @mbarbin).
- Add new qualifier `if_present` to enforce only if field is present ([#159](https://github.com/mbarbin/dunolint/pull/159), @mbarbin).
- Add predicates for the `(inline_tests)` library stanza ([#157](https://github.com/mbarbin/dunolint/pull/157), @mbarbin).
- Add support for `DUNE_ROOT` environment variable ([#156](https://github.com/mbarbin/dunolint/pull/156), @mbarbin).
- Add initial support for linting `dune-workspace` files ([#153](https://github.com/mbarbin/dunolint/pull/153), @mbarbin).
- Add initial support for linting `dunolint` files ([#146](https://github.com/mbarbin/dunolint/pull/146), @mbarbin).
- Enabled OCaml `5.4` in CI ([#136](https://github.com/mbarbin/dunolint/pull/136), @mbarbin).
- Added new tests ([#132](https://github.com/mbarbin/dunolint/pull/132), @mbarbin).

### Changed

- Improve tests for sexp and equal functions and their coverage ([#162](https://github.com/mbarbin/dunolint/pull/162), @mbarbin).
- Support multiple input files in `tools lint-file --in-place` ([#158](https://github.com/mbarbin/dunolint/pull/158), @mbarbin).
- Make a few dunolint config parsing errors more friendly ([#155](https://github.com/mbarbin/dunolint/pull/155), @mbarbin).
- Refactor sexp parsing - prerequisite for future improvements ([#152](https://github.com/mbarbin/dunolint/pull/152), @mbarbin).
- Cleanup implementation of `equal` functions ([#151](https://github.com/mbarbin/dunolint/pull/151), @mbarbin).
- Extend lang version compare operators ([#145](https://github.com/mbarbin/dunolint/pull/145), @mbarbin).
- Upgrade `actions/checkout` to `v6` ([#138](https://github.com/mbarbin/dunolint/pull/138), @mbarbin).
- Improved licensing headers for vendored `blang` ([#144](https://github.com/mbarbin/dunolint/pull/144), @mbarbin).
- Refactor pkg directory structure ([#143](https://github.com/mbarbin/dunolint/pull/143), @mbarbin).
- Improve some format & diff in some internal tests ([#137](https://github.com/mbarbin/dunolint/pull/137), @mbarbin).
- Upgrade to and require fixes from `fpath-sexp0.0.4.0` ([#133](https://github.com/mbarbin/dunolint/pull/133), @mbarbin).
- Made some internal refactors suggested by the Zanuda linter ([#130](https://github.com/mbarbin/dunolint/pull/130), @mbarbin).

### Fixed

- Fix location of sexp error on invalid atoms ([#160](https://github.com/mbarbin/dunolint/pull/160), @mbarbin).
- Fix enforce on absent `public_name` fields ([#159](https://github.com/mbarbin/dunolint/pull/159), @mbarbin).
- Allow dash char in package names ([#154](https://github.com/mbarbin/dunolint/pull/154), @mbarbin).

### Removed

- Removed `expect_test_helpers_core` dependency ([#154](https://github.com/mbarbin/dunolint/pull/154), @mbarbin).
- Removed unused `compare` functions on rules & predicates ([#150](https://github.com/mbarbin/dunolint/pull/150), @mbarbin).
- Removed redundant `skip_paths` constructs from dunolint config ([#149](https://github.com/mbarbin/dunolint/pull/149), @mbarbin).
- Removed now unused `fpath` dependency from `dunolint-lib` ([#142](https://github.com/mbarbin/dunolint/pull/142), @mbarbin).
- Removed deprecated construct `path.equals` ([#142](https://github.com/mbarbin/dunolint/pull/142), @mbarbin).
- Removed support for config version `v0` ([#141](https://github.com/mbarbin/dunolint/pull/141), @mbarbin).


---
:camel: Pull-request generated by opam-publish v3.0.0