### PR TITLE
Package crs.0.0.20260307

### DIFF
--- a/packages/crs/crs.0.0.20260307/opam
+++ b/packages/crs/crs.0.0.20260307/opam
@@ -1,0 +1,90 @@
+opam-version: "2.0"
+synopsis:
+  "A tool for managing inline review comments embedded in source code"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/mbarbin/crs"
+doc: "https://mbarbin.github.io/crs/"
+bug-reports: "https://github.com/mbarbin/crs/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "cmdlang" {>= "0.0.9"}
+  "cmdlang-cmdliner-err-runner" {>= "0.0.16"}
+  "dyn" {>= "3.17"}
+  "file-rewriter" {>= "0.0.3"}
+  "fpath" {>= "0.7.3"}
+  "fpath-sexp0" {>= "0.4.0"}
+  "loc" {>= "0.3.3"}
+  "ordering" {>= "3.17"}
+  "pageantty" {>= "0.0.3"}
+  "pp" {>= "2.0.0"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
+  "print-table" {>= "0.1.3"}
+  "re" {>= "1.12.0"}
+  "sexplib0" {>= "v0.17"}
+  "spawn" {>= "v0.17"}
+  "volgo" {>= "0.0.21"}
+  "volgo-git-unix" {>= "0.0.21"}
+  "volgo-hg-unix" {>= "0.0.21"}
+  "yojson" {>= "2.2.2"}
+  "yojson-five" {>= "2.2.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/crs.git"
+description: """\
+
+The [crs] package provides libraries and a CLI to help manage inline
+review comments embedded directly in source code using a specialized
+syntax.
+
+With [crs] you can locate, parse, and manipulate these comments
+easily, and perform tasks such as systematically updating comments
+across multiple files, changing their priority, marking them as
+resolved, modifying reporter or assignee information, and more.
+
+This tool can be used during development or integrated into your CI
+pipeline. For example, you can use [crs] to ensure no unresolved
+comments remain before merging a pull request or releasing a new
+version of your software.
+
+Beyond its standalone functionality, [crs] is intended to serve as a
+sharable building block for more comprehensive code review systems and
+collaborative workflows.
+
+The [crs] projects builds upon ideas from [iron], a code review system
+built by Jane Street and released as open source in 2016-2017. We
+deeply appreciate Jane Street’s willingness to share [iron], which has
+provided a valuable starting point for exploring and advancing these
+ideas.
+
+[iron]: https://github.com/janestreet/iron
+
+"""
+tags: [ "code-review" "inline-comments" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/crs/releases/download/0.0.20260307/crs-0.0.20260307.tbz"
+  checksum: [
+    "sha256=77f77c61e908a6716fa876f5648f662ffaf7e24be4a7889fd6b53121592311bb"
+    "sha512=5fc6252650571c4127ebb1e61fecf78c5d4ce35e2832dff47125cda1448e07ea6d4da5e3a9a28643e3491d3594b0ee8857214241f98bd0296ada2c35ea8daa4b"
+  ]
+}
+x-commit-hash: "0afd1c434be4b8003dc94f4e2e6f1ab8da141907"


### PR DESCRIPTION
### `crs.0.0.20260307`
A tool for managing inline review comments embedded in source code
The [crs] package provides libraries and a CLI to help manage inline
review comments embedded directly in source code using a specialized
syntax.

With [crs] you can locate, parse, and manipulate these comments
easily, and perform tasks such as systematically updating comments
across multiple files, changing their priority, marking them as
resolved, modifying reporter or assignee information, and more.

This tool can be used during development or integrated into your CI
pipeline. For example, you can use [crs] to ensure no unresolved
comments remain before merging a pull request or releasing a new
version of your software.

Beyond its standalone functionality, [crs] is intended to serve as a
sharable building block for more comprehensive code review systems and
collaborative workflows.

The [crs] projects builds upon ideas from [iron], a code review system
built by Jane Street and released as open source in 2016-2017. We
deeply appreciate Jane Street’s willingness to share [iron], which has
provided a valuable starting point for exploring and advancing these
ideas.

[iron]: https://github.com/janestreet/iron



---
* Homepage: https://github.com/mbarbin/crs
* Source repo: git+https://github.com/mbarbin/crs.git
* Bug tracker: https://github.com/mbarbin/crs/issues

---
## 0.0.20260307 (2026-03-07)

From this version, pre-compiled release binaries are included as compressed archives.

### Added

- Distribute compressed archived for release artifacts (4637ac, @mbarbin).

### Changed

- Upgrade to recent `actions/attest` GitHub workflow (3db216, @mbarbin).

## 0.0.20260202 (2026-02-02)

Starting from this version we're using GitHub immutable releases.

### Added

- Added new CI workflow based on setup-dune ([#115](https://github.com/mbarbin/crs/pull/115), @mbarbin).
- Upgrade dunolint and add new invariants ([#114](https://github.com/mbarbin/crs/pull/114), @mbarbin).
- Add tests to monitor dependabot workflows issue ([#82](https://github.com/mbarbin/crs/pull/82), [#112](https://github.com/mbarbin/crs/pull/112), @mbarbin).

### Changed

- Improve project synopsis and update source headers ([#123](https://github.com/mbarbin/crs/pull/123), @mbarbin).
- Migrate main and doc CIs to `setup-dune` ([#122](https://github.com/mbarbin/crs/pull/122), @mbarbin).
- Increase some lower bounds to ease maintenance ([#119](https://github.com/mbarbin/crs/pull/119), @mbarbin).
- Adapt release artifacts jobs for immutable releases (@mbarbin).
- Make type `User_handle` independent instead of from `Vcs` ([#116](https://github.com/mbarbin/crs/pull/116), @mbarbin).
- Refactor systematic internal scope propagation ([#116](https://github.com/mbarbin/crs/pull/116), @mbarbin).
- Assorted improvements to CI scripts. Upgrade an pin actions deps (@mbarbin).
- Use json instead of sexp in output of some commands ([#106](https://github.com/mbarbin/crs/pull/106), [#111](https://github.com/mbarbin/crs/pull/111), @mbarbin).
- Refactor packages directory structure ([#107](https://github.com/mbarbin/crs/pull/107), @mbarbin).
- Internal refactors to reduce dependencies ([#103](https://github.com/mbarbin/crs/pull/103), [#104](https://github.com/mbarbin/crs/pull/104), [#105](https://github.com/mbarbin/crs/pull/105), [#108](https://github.com/mbarbin/crs/pull/108), [#109](https://github.com/mbarbin/crs/pull/109), [#110](https://github.com/mbarbin/crs/pull/110), @mbarbin).
- Use dyn syntax instead of sexp in expect tests ([#104](https://github.com/mbarbin/crs/pull/104), @mbarbin).
- Upgrade test deps `ocaml-protoc` & all to `4.0` ([#99](https://github.com/mbarbin/crs/pull/99), @mbarbin).
- Reduce printed context in some tests diffs ([#99](https://github.com/mbarbin/crs/pull/99), @mbarbin).
- Enable OCaml 5.4 in CI ([#98](https://github.com/mbarbin/crs/pull/98), @mbarbin).
- Add OCaml alerts to deprecated api ([#94](https://github.com/mbarbin/crs/pull/94), @mbarbin).
- Upgrade to fpath-base 0.4.0 ([#95](https://github.com/mbarbin/crs/pull/95), @mbarbin).
- Refactor JSON config parsing ([#93](https://github.com/mbarbin/crs/pull/93), @mbarbin).

### Fixed

- Support "dependabot[bot]" user as PR author ([#82](https://github.com/mbarbin/crs/pull/82), [#116](https://github.com/mbarbin/crs/pull/116), [#117](https://github.com/mbarbin/crs/pull/117), @mbarbin).

## 0.0.20251014 (2025-10-14)

### Added

- Distribute a json schema for `crs-config.json` files ([#92](https://github.com/mbarbin/crs/pull/92), @mbarbin).
- Added local dunolint invariants ([#91](https://github.com/mbarbin/crs/pull/91), @mbarbin).

### Changed

- Switch to `pplumbing-*` split packages ([#87](https://github.com/mbarbin/crs/pull/87), @mbarbin).


---
:camel: Pull-request generated by opam-publish v3.0.0