### PR TITLE
Fix conf-gsl.2 on Centos 10

### DIFF
--- a/packages/conf-gsl/conf-gsl.2/opam
+++ b/packages/conf-gsl/conf-gsl.2/opam
@@ -8,7 +8,8 @@ depexts: [
   ["libgsl-dev"] {os-family = "debian"}
   ["libgsl-dev"] {os-family = "ubuntu"}
   ["libgsl-devel"] {os-distribution = "mageia"}
-  ["gsl-devel"] {os-distribution = "centos"}
+  ["epel-release" "gsl-devel"] {os-distribution = "centos" & os-version >= "10"}
+  ["gsl-devel"] {os-distribution = "centos" & os-version < "10"}
   ["gsl-devel"] {os-family = "fedora"}
   ["gsl-devel"] {os-distribution = "rhel"}
   ["gsl-dev"] {os-distribution = "alpine"}


### PR DESCRIPTION
Spotted on #29486:

https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/55e5209bbfb780103122968d39886bcc80fd10a3/variant/distributions,centos-10-ocaml-5.4,biotk.0.4
```
+ /usr/bin/sudo "yum" "install" "-y" "gsl-devel" "zlib-ng-compat-static"
[ERROR] System package install failed with exit code 1 at command:
            sudo yum install -y gsl-devel zlib-ng-compat-static
- Last metadata expiration check: 0:00:04 ago on Sat Mar  7 12:06:03 2026.
- No match for argument: gsl-devel
- Error: Unable to find a match: gsl-devel
```

On Centos 10 `gsl-devel` is however available through EPEL: https://pkgs.org/search/?q=gsl.pc