### PR TITLE
Package iri.1.2.0

### DIFF
--- a/packages/iri/iri.1.2.0/opam
+++ b/packages/iri/iri.1.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Implementation of Internationalized Resource Identifiers (IRIs)"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["iri" "web" "rfc3987"]
+homepage: "https://framagit.org/zoggy/ocaml-iri/"
+doc: "https://zoggy.frama.io/ocaml-iri/refdoc/iri/IRI/index.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-iri/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "sedlex" {>= "2.3"}
+  "uunf" {>= "0.9.7"}
+  "uutf" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-iri.git"
+url {
+  src: "https://zoggy.frama.io/ocaml-iri/releases/ocaml-iri-1.2.0.tar.bz2"
+  checksum: [
+    "md5=f7dc19c2feaceefb93060e1b13a53827"
+    "sha512=59cfb686d427b692e4638d4117999dfe43784790a570c0aff810d0b03aa45c48ef1803e4da12f7bd1b50f13b759141f27a60f71f101b6a2979c9b24203dc32b6"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `iri.1.2.0`
Implementation of Internationalized Resource Identifiers (IRIs)



---
* Homepage: https://framagit.org/zoggy/ocaml-iri/
* Source repo: git+https://framagit.org/zoggy/ocaml-iri.git
* Bug tracker: https://framagit.org/zoggy/ocaml-iri/issues

---
:camel: Pull-request generated by opam-publish v2.7.1