### PR TITLE
[new release] parseff (0.1.0)

### DIFF
--- a/packages/parseff/parseff.0.1.0/opam
+++ b/packages/parseff/parseff.0.1.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Direct-style parser combinator library for OCaml 5 powered by algebraic effects"
+description:
+  "Parseff is a direct-style parser combinator library for OCaml 5 where parsers are plain functions (unit -> 'a), errors are typed via polymorphic variants, and algebraic effects handle control flow, backtracking, and streaming input. Designed for performance with zero-copy span APIs and fused operations."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/davesnx/parseff"
+bug-reports: "https://github.com/davesnx/parseff/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "5.3"}
+  "re" {>= "1.9.0"}
+  "alcotest" {with-test}
+  "benchmark" {with-test}
+  "angstrom" {with-test}
+  "mparser" {with-test}
+  "ocamlformat" {>= "0.26.1" & with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "odoc" {>= "3.1.0" & with-doc}
+  "odoc-parser" {with-doc}
+  "mdx" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/parseff.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/davesnx/parseff/releases/download/0.1.0/parseff-0.1.0.tbz"
+  checksum: [
+    "sha256=097c71a38b39ab5925518e16c0efdf3b77a6b3b2185c82f168e0f1f4cb0772bf"
+    "sha512=811fbd770148bf3004ffc764dc08fa1a3ded9b4613f5749a6d2841c1af868de7afff4dd6b808b38254d28592433e23613573707159dfa171687839c520e93bb3"
+  ]
+}
+x-commit-hash: "29656c3d10ee0baea5cc47e6f8bb2bf825318699"


### PR DESCRIPTION
Direct-style parser combinator library for OCaml 5 powered by algebraic effects

- Project page: <a href="https://github.com/davesnx/parseff">https://github.com/davesnx/parseff</a>

##### CHANGES:

Initial release of Parseff -- a direct-style parser combinator library for
OCaml 5 powered by algebraic effects.

- Direct-style parsers as plain `unit -> 'a` functions, no monadic or binding operators needed
- Algebraic effects for control flow, backtracking, and streaming input
- Typed errors via polymorphic variants with position tracking
- Built-in error variants: `` `Expected ``, `` `Unexpected_end_of_input ``, `` `Depth_limit_exceeded ``
- Automatic backtracking with `or_`, `one_of`, and `one_of_labeled`
- Primitive parsers: `consume`, `satisfy`, `char`, `match_regex`, `take_while`, `skip_while`, `fail`, `error`
- Repetition combinators: `many`, `sep_by`, `between`, `end_by`, `count`, `optional`
- Operator chains: `chainl`, `chainl1`, `chainr`, `chainr1` for expression parsing
- Look-ahead parsing and depth-limited recursion via `rec_` (default depth: 128)
- Convenience parsers: `digit`, `letter`, `alphanum`, `whitespace`, `any_char`
- Zero-copy span APIs: `take_while_span`, `sep_by_take_span` returning `{ buf; off; len }` records
- Fused operations for hot paths: `sep_by_take`, `fused_sep_take`, `skip_while_then_char`
- Streaming support via `Source.of_string`, `Source.of_channel`, `Source.of_function`
- Backtrack-across-chunk-boundary support for streaming sources
- Non-fatal diagnostics with `warn` / `warn_at`, rolled back on backtracking
- `parse_until_end` / `parse_source_until_end` runners that collect diagnostics
- Error labeling with `expect` and `one_of_labeled` for clear error messages
- Domain-safe: no global mutable state, independent parses run in parallel across OCaml 5 domains
- 2-4x faster than Angstrom and MParser on equivalent parsers
- Single runtime dependency: `re` for regex support
