### PR TITLE
[new release] tm-grammars (1.0.1)

### DIFF
--- a/packages/tm-grammars/tm-grammars.1.0.1/opam
+++ b/packages/tm-grammars/tm-grammars.1.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "TextMate grammars as OCaml strings"
+description: "OCaml package that exposes TextMate grammars as JSON strings."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/davesnx/tm-grammars"
+bug-reports: "https://github.com/davesnx/tm-grammars/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/tm-grammars.git"
+url {
+  src:
+    "https://github.com/davesnx/tm-grammars/releases/download/1.0.1/tm-grammars-1.0.1.tbz"
+  checksum: [
+    "sha256=db846438528399b5e657ced04b004d56a5633b605039808c1fdb695a8d1bf4ed"
+    "sha512=6a83d6e79ef5a964f300942860373a583544f0e2cd9bb22e8fdfcaa12a0d834790b2da796873dbf334b7e448d7d8274a511c3b9224fc123a114de666db83fd53"
+  ]
+}
+x-commit-hash: "7bc690111b6d6a9c6896bc35aa17bfb854c33a2d"


### PR DESCRIPTION
TextMate grammars as OCaml strings

- Project page: <a href="https://github.com/davesnx/tm-grammars">https://github.com/davesnx/tm-grammars</a>

##### CHANGES:

- Published OCaml package that exposes TextMate grammars as JSON strings.
- Each language is a findlib sublibrary (e.g. `tm-grammars.ocaml`, `tm-grammars.tsx`).
- Downstream users depend on `tm-grammars` and add only the sublibraries they need to `(libraries ...)`.
- Generated package setup driven by `sources.json`.
