### PR TITLE
[new release] tls (6 packages) (2.0.4)

### DIFF
--- a/packages/tls-async/tls-async.2.0.4/opam
+++ b/packages/tls-async/tls-async.2.0.4/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "ptime" {>= "0.8.1"}
+  "async" {>= "v0.16"}
+  "async_unix" {>= "v0.16"}
+  "core" {>= "v0.16"}
+  "core_unix" {>= "v0.16"}
+  "cstruct-async"
+  "ppx_jane" {>= "v0.16"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, Async layer"
+description: """
+Tls-async provides Async-friendly tls bindings
+"""
+x-maintenance-intent: [ "(latest)" ]
+authors: [
+  "David Kaloper <david@numm.org>"
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "Eric Ebinger <github@eric.theebingers.com>"
+  "Calascibetta Romain <romain.calascibetta@gmail.com>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v2.0.4/tls-2.0.4.tbz"
+  checksum: [
+    "sha256=704f467af8a88c198f9162d0c0c44d823a16ecb1ebcb38d8e98ef48fe52eb5f1"
+    "sha512=87d7657d748470b8cb0137e04f4bad1c9ea0b9b68dfaca9d1b7807a379d2b50e27252b4fa9b8b2bd2052f12d5401390ecdaf05163b639cbc14a82efb98a62587"
+  ]
+}
+x-commit-hash: "2d33575a8a1d2b31bcc0ac971e6cc0749a6f6128"

--- a/packages/tls-eio/tls-eio.2.0.4/opam
+++ b/packages/tls-eio/tls-eio.2.0.4/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+authors:      ["Thomas Leonard"]
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
+]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "eio" {>= "0.12"}
+  "eio_main" {>= "0.12" & with-test}
+  "mdx" {with-test}
+  "crowbar" {>= "0.2.1" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "ptime" {>= "1.0.0"}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml - Eio"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read our [Usenix Security 2015 paper](https://www.usenix.org/conference/usenixsecurity15/technical-sessions/presentation/kaloper-mersinjak).
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v2.0.4/tls-2.0.4.tbz"
+  checksum: [
+    "sha256=704f467af8a88c198f9162d0c0c44d823a16ecb1ebcb38d8e98ef48fe52eb5f1"
+    "sha512=87d7657d748470b8cb0137e04f4bad1c9ea0b9b68dfaca9d1b7807a379d2b50e27252b4fa9b8b2bd2052f12d5401390ecdaf05163b639cbc14a82efb98a62587"
+  ]
+}
+x-commit-hash: "2d33575a8a1d2b31bcc0ac971e6cc0749a6f6128"

--- a/packages/tls-lwt/tls-lwt.2.0.4/opam
+++ b/packages/tls-lwt/tls-lwt.2.0.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "lwt" {>= "5.7.0"}
+  "cmdliner" {>= "1.1.0"}
+  "ptime" {>= "0.8.1"}
+  "randomconv" {with-test & >= "0.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, Lwt layer"
+description: """
+Tls-lwt provides an effectful Tls_lwt module to be used with Lwt.
+"""
+x-maintenance-intent: [ "(latest)" ]
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v2.0.4/tls-2.0.4.tbz"
+  checksum: [
+    "sha256=704f467af8a88c198f9162d0c0c44d823a16ecb1ebcb38d8e98ef48fe52eb5f1"
+    "sha512=87d7657d748470b8cb0137e04f4bad1c9ea0b9b68dfaca9d1b7807a379d2b50e27252b4fa9b8b2bd2052f12d5401390ecdaf05163b639cbc14a82efb98a62587"
+  ]
+}
+x-commit-hash: "2d33575a8a1d2b31bcc0ac971e6cc0749a6f6128"

--- a/packages/tls-miou-unix/tls-miou-unix.2.0.4/opam
+++ b/packages/tls-miou-unix/tls-miou-unix.2.0.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/"
+maintainer:   ["Romain Calascibetta <romain.calascibetta@gmail.com>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "mirage-crypto-rng-miou-unix" {>= "1.0.0" & with-test}
+  "x509" {>= "1.0.0"}
+  "miou" {>= "0.3.0"}
+  "crowbar" {with-test}
+  "rresult" {with-test}
+  "ohex" {with-test}
+  "ptime" {with-test}
+  "hxd" {with-test}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, Miou+Unix layer"
+description: """
+Tls-miou provides an effectful Tls_miou module to be used with Miou and Unix.
+"""
+x-maintenance-intent: [ "(latest)" ]
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v2.0.4/tls-2.0.4.tbz"
+  checksum: [
+    "sha256=704f467af8a88c198f9162d0c0c44d823a16ecb1ebcb38d8e98ef48fe52eb5f1"
+    "sha512=87d7657d748470b8cb0137e04f4bad1c9ea0b9b68dfaca9d1b7807a379d2b50e27252b4fa9b8b2bd2052f12d5401390ecdaf05163b639cbc14a82efb98a62587"
+  ]
+}
+x-commit-hash: "2d33575a8a1d2b31bcc0ac971e6cc0749a6f6128"

--- a/packages/tls-mirage/tls-mirage.2.0.4/opam
+++ b/packages/tls-mirage/tls-mirage.2.0.4/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "3.0.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-ptime" {>= "4.0.0"}
+  "ptime" {>= "0.8.1"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-pk" {>= "1.0.0"}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, MirageOS layer"
+description: """
+Tls-mirage provides an effectful FLOW module to be used in the MirageOS
+ecosystem.
+"""
+x-maintenance-intent: [ "(latest)" ]
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v2.0.4/tls-2.0.4.tbz"
+  checksum: [
+    "sha256=704f467af8a88c198f9162d0c0c44d823a16ecb1ebcb38d8e98ef48fe52eb5f1"
+    "sha512=87d7657d748470b8cb0137e04f4bad1c9ea0b9b68dfaca9d1b7807a379d2b50e27252b4fa9b8b2bd2052f12d5401390ecdaf05163b639cbc14a82efb98a62587"
+  ]
+}
+x-commit-hash: "2d33575a8a1d2b31bcc0ac971e6cc0749a6f6128"

--- a/packages/tls/tls.2.0.4/opam
+++ b/packages/tls/tls.2.0.4/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0"}
+  "mirage-crypto" {>= "1.1.0"}
+  "mirage-crypto-ec" {>= "1.0.0"}
+  "mirage-crypto-pk" {>= "1.0.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "x509" {>= "1.0.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt" {>= "0.8.7"}
+  "ounit2" {with-test & >= "2.2.0"}
+  "kdf" {>= "1.0.0"}
+  "logs"
+  "ipaddr"
+  "ohex" {>= "0.2.0"}
+  "digestif" {>= "1.2.0"}
+  "ptime" {>= "1.2.0"}
+  "alcotest" {with-test}
+  "cmdliner" {with-test & >= "1.3.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read our [Usenix Security 2015 paper](https://www.usenix.org/conference/usenixsecurity15/technical-sessions/presentation/kaloper-mersinjak).
+"""
+available: [ arch != "arm32" ] # see SIGBUS failures at https://github.com/ocaml/opam-repository/pull/26387
+x-maintenance-intent: [ "(latest)" ]
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v2.0.4/tls-2.0.4.tbz"
+  checksum: [
+    "sha256=704f467af8a88c198f9162d0c0c44d823a16ecb1ebcb38d8e98ef48fe52eb5f1"
+    "sha512=87d7657d748470b8cb0137e04f4bad1c9ea0b9b68dfaca9d1b7807a379d2b50e27252b4fa9b8b2bd2052f12d5401390ecdaf05163b639cbc14a82efb98a62587"
+  ]
+}
+x-commit-hash: "2d33575a8a1d2b31bcc0ac971e6cc0749a6f6128"


### PR DESCRIPTION
Transport Layer Security purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-tls">https://github.com/mirleft/ocaml-tls</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-tls/doc">https://mirleft.github.io/ocaml-tls/doc</a>

##### CHANGES:

* Fix exception in parse_change_cipher_spec on empty input (mirleft/ocaml-tls#519 @samoht)
  This has been present since the initial release 0.1.0.

Sponsored by Tarides