### PR TITLE
8 packages from www.good-eris.net/ocaml-rdf/archives/ocaml-rdf-1.2.0.tar.bz2

### DIFF
--- a/packages/rdf/rdf.1.2.0/opam
+++ b/packages/rdf/rdf.1.2.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "OCaml library to manipulate RDF graphs; implements SPARQL"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://www.good-eris.net/ocaml-rdf/"
+doc: "https://www.good-eris.net/ocaml-rdf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "dune-build-info" {>= "2.9.1"}
+  "fmt" {>= "0.9.0"}
+  "iri" {>= "1.2.0"}
+  "jsonm" {>= "1.0.2"}
+  "logs" {>= "0.7.0"}
+  "menhir" {>= "20231231"}
+  "pcre" {>= "7.5.0"}
+  "ptime" {>= "1.1.0"}
+  "re" {>= "1.11.0"}
+  "sedlex" {>= "3.2"}
+  "uri" {>= "4.4.0"}
+  "uucp" {>= "15.1.0"}
+  "uuidm" {>= "0.9.9"}
+  "uutf" {>= "1.0.3"}
+  "xmlm" {>= "1.4.0"}
+  "yojson" {>= "2.1.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-rdf.git"
+url {
+  src: "https://www.good-eris.net/ocaml-rdf/archives/ocaml-rdf-1.2.0.tar.bz2"
+  checksum: [
+    "md5=3a2e9b663c73ad9b21970d6788a15d82"
+    "sha512=bd5fe48a74af493f4cd94d26e8e5b3a8fbaba1dfb79d83090f1bb124351033524db5ca71c828eec937d44cacdbf51fd4aae961baea97cb1d154978ae61ce2b56"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/rdf_impls/rdf_impls.1.2.0/opam
+++ b/packages/rdf_impls/rdf_impls.1.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "C implementations (using Cyrptokit and Pcre) of functions used by Rdf"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://www.good-eris.net/ocaml-rdf/"
+doc: "https://www.good-eris.net/ocaml-rdf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "rdf" {= version}
+  "cryptokit" {>= "1.19"}
+  "pcre" {>= "7.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-rdf.git"
+url {
+  src: "https://www.good-eris.net/ocaml-rdf/archives/ocaml-rdf-1.2.0.tar.bz2"
+  checksum: [
+    "md5=3a2e9b663c73ad9b21970d6788a15d82"
+    "sha512=bd5fe48a74af493f4cd94d26e8e5b3a8fbaba1dfb79d83090f1bb124351033524db5ca71c828eec937d44cacdbf51fd4aae961baea97cb1d154978ae61ce2b56"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/rdf_json_ld/rdf_json_ld.1.2.0/opam
+++ b/packages/rdf_json_ld/rdf_json_ld.1.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Json-ld"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://www.good-eris.net/ocaml-rdf/"
+doc: "https://www.good-eris.net/ocaml-rdf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "rdf" {= version}
+  "cohttp-lwt-unix" {>= "5.3.0"}
+  "jsonm" {>= "1.0.2"}
+  "lwt" {>= "5.7.0"}
+  "lwt_ppx" {>= "2.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-rdf.git"
+url {
+  src: "https://www.good-eris.net/ocaml-rdf/archives/ocaml-rdf-1.2.0.tar.bz2"
+  checksum: [
+    "md5=3a2e9b663c73ad9b21970d6788a15d82"
+    "sha512=bd5fe48a74af493f4cd94d26e8e5b3a8fbaba1dfb79d83090f1bb124351033524db5ca71c828eec937d44cacdbf51fd4aae961baea97cb1d154978ae61ce2b56"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/rdf_lwt/rdf_lwt.1.2.0/opam
+++ b/packages/rdf_lwt/rdf_lwt.1.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Sparql HTTP with Lwt"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://www.good-eris.net/ocaml-rdf/"
+doc: "https://www.good-eris.net/ocaml-rdf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "rdf" {= version}
+  "cohttp-lwt-unix" {>= "5.3.0"}
+  "lwt" {>= "5.7.0"}
+  "lwt_ppx" {>= "2.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-rdf.git"
+url {
+  src: "https://www.good-eris.net/ocaml-rdf/archives/ocaml-rdf-1.2.0.tar.bz2"
+  checksum: [
+    "md5=3a2e9b663c73ad9b21970d6788a15d82"
+    "sha512=bd5fe48a74af493f4cd94d26e8e5b3a8fbaba1dfb79d83090f1bb124351033524db5ca71c828eec937d44cacdbf51fd4aae961baea97cb1d154978ae61ce2b56"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/rdf_mysql/rdf_mysql.1.2.0/opam
+++ b/packages/rdf_mysql/rdf_mysql.1.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Mysql backend for rdf"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://www.good-eris.net/ocaml-rdf/"
+doc: "https://www.good-eris.net/ocaml-rdf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "rdf" {= version}
+  "mysql" {>= "1.2.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-rdf.git"
+url {
+  src: "https://www.good-eris.net/ocaml-rdf/archives/ocaml-rdf-1.2.0.tar.bz2"
+  checksum: [
+    "md5=3a2e9b663c73ad9b21970d6788a15d82"
+    "sha512=bd5fe48a74af493f4cd94d26e8e5b3a8fbaba1dfb79d83090f1bb124351033524db5ca71c828eec937d44cacdbf51fd4aae961baea97cb1d154978ae61ce2b56"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/rdf_postgresql/rdf_postgresql.1.2.0/opam
+++ b/packages/rdf_postgresql/rdf_postgresql.1.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Postgresql backend for rdf"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://www.good-eris.net/ocaml-rdf/"
+doc: "https://www.good-eris.net/ocaml-rdf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "rdf" {= version}
+  "postgresql" {>= "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-rdf.git"
+url {
+  src: "https://www.good-eris.net/ocaml-rdf/archives/ocaml-rdf-1.2.0.tar.bz2"
+  checksum: [
+    "md5=3a2e9b663c73ad9b21970d6788a15d82"
+    "sha512=bd5fe48a74af493f4cd94d26e8e5b3a8fbaba1dfb79d83090f1bb124351033524db5ca71c828eec937d44cacdbf51fd4aae961baea97cb1d154978ae61ce2b56"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/rdf_ppx/rdf_ppx.1.2.0/opam
+++ b/packages/rdf_ppx/rdf_ppx.1.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Syntax extension for rdf"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://www.good-eris.net/ocaml-rdf/"
+doc: "https://www.good-eris.net/ocaml-rdf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "rdf" {= version}
+  "ppxlib" {>= "0.37.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-rdf.git"
+url {
+  src: "https://www.good-eris.net/ocaml-rdf/archives/ocaml-rdf-1.2.0.tar.bz2"
+  checksum: [
+    "md5=3a2e9b663c73ad9b21970d6788a15d82"
+    "sha512=bd5fe48a74af493f4cd94d26e8e5b3a8fbaba1dfb79d83090f1bb124351033524db5ca71c828eec937d44cacdbf51fd4aae961baea97cb1d154978ae61ce2b56"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/rdf_rdfa/rdf_rdfa.1.2.0/opam
+++ b/packages/rdf_rdfa/rdf_rdfa.1.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "RDFA 1.1 processing"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://www.good-eris.net/ocaml-rdf/"
+doc: "https://www.good-eris.net/ocaml-rdf/doc.html"
+bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "rdf" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-rdf.git"
+url {
+  src: "https://www.good-eris.net/ocaml-rdf/archives/ocaml-rdf-1.2.0.tar.bz2"
+  checksum: [
+    "md5=3a2e9b663c73ad9b21970d6788a15d82"
+    "sha512=bd5fe48a74af493f4cd94d26e8e5b3a8fbaba1dfb79d83090f1bb124351033524db5ca71c828eec937d44cacdbf51fd4aae961baea97cb1d154978ae61ce2b56"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `rdf.1.2.0`: OCaml library to manipulate RDF graphs; implements SPARQL
- `rdf_impls.1.2.0`: C implementations (using Cyrptokit and Pcre) of functions used by
  Rdf
- `rdf_json_ld.1.2.0`: Json-ld
- `rdf_lwt.1.2.0`: Sparql HTTP with Lwt
- `rdf_mysql.1.2.0`: Mysql backend for rdf
- `rdf_postgresql.1.2.0`: Postgresql backend for rdf
- `rdf_ppx.1.2.0`: Syntax extension for rdf
- `rdf_rdfa.1.2.0`: RDFA 1.1 processing



---
* Homepage: https://www.good-eris.net/ocaml-rdf/
* Source repo: git+https://framagit.org/zoggy/ocaml-rdf.git
* Bug tracker: https://framagit.org/zoggy/ocaml-rdf/issues

---
:camel: Pull-request generated by opam-publish v2.7.1