### PR TITLE
[new release] slipshow (0.10.0): Don't look `{up}`

### DIFF
--- a/packages/slipshow/slipshow.0.10.0/opam
+++ b/packages/slipshow/slipshow.0.10.0/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis: "A compiler from markdown to slipshow"
+description:
+  "Slipshow is an engine to write slips, a concept evolved from slides."
+maintainer: ["Paul-Elliot"]
+authors: ["Paul-Elliot"]
+license: ["GPL-3.0-or-later" "ISC" "BSD-3-Clause" "Apache-2.0" "OFL-1.1"]
+tags: ["slipshow" "presentation" "slideshow" "beamer"]
+homepage: "https://github.com/panglesd/slipshow"
+doc: "https://slipshow.readthedocs.io"
+bug-reports: "https://github.com/panglesd/slipshow/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.6"}
+  "grace" {>= "0.3.0"}
+  "crunch" {with-dev-setup}
+  "lambdasoup" {with-test}
+  "cmdliner" {>= "1.3.0"}
+  "base64"
+  "bos"
+  "lwt"
+  "inotify" {os = "linux"}
+  "cf-lwt" {>= "0.4"}
+  "astring"
+  "fmt"
+  "logs"
+  "fsevents-lwt"
+  "js_of_ocaml-compiler" {>= "6.0.1"}
+  "js_of_ocaml-lwt"
+  "magic-mime"
+  "dream" {>= "1.0.0~alpha5"}
+  "fpath"
+  "ppx_blob" {>= "0.8.0"}
+  "sexplib"
+  "ppx_sexp_conv"
+  "ppx_deriving_yojson"
+  "ansi" {>= "0.7.0"}
+  "odoc" {with-doc}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/panglesd/slipshow.git"
+# We avoid 32 bits arcitecture because our usage of ppx_blob generates strings
+# whose size exceed the maximum size in 32 bits OCaml...
+available: arch != "arm32" & arch != "x86_32"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/panglesd/slipshow/releases/download/v0.10.0/slipshow-0.10.0.tbz"
+  checksum: [
+    "sha256=89d7102e8e1e87ea3c0452c075c96ae3ebe1b9cc76210af2ec33bd431baca35b"
+    "sha512=8fb4914ca464bd4e1d53103a553b29765ff6731c1f25751a967421b3722dfd5d34894973204893f87712428c829860748986df03b0f5fcbfdc04269169cb9756"
+  ]
+}
+x-commit-hash: "80fb112e7e872d9637291e5318c40df8b2b4a7ee"


### PR DESCRIPTION
See the [release](https://github.com/panglesd/slipshow/releases/tag/v0.10.0) for a funny gif.

CHANGES:

### Added

- Helpful warnings at compile-time (panglesd/slipshow#213):
  - Action parsing failures,
  - Missing ID (and `external-ids` frontmatter field to selectively deactivate),
  - Duplicated ID,
  - Frontmatter parsing error,
  - Wrong target type for actions,
  - Missing file,
  - Unknown attribute,
  - ...

### Fixed

- Fixed drawing stopping slightly after pauses (panglesd/slipshow#216)
- Fixed keyboard shortcuts not working in serve mode until the preview was clicked (panglesd/slipshow#215)
- Fix shortcuts not working after saving a drawing (panglesd/slipshow#217)
- Fix wrong example links in docs (panglesd/slipshow#218)