### PR TITLE
[new release] melange-fest (0.2.0)

### DIFF
--- a/packages/melange-fest/melange-fest.0.2.0/opam
+++ b/packages/melange-fest/melange-fest.0.2.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "A minimal test framework for Melange"
+description: "A minimal test framework for Melange using Node test runner"
+maintainer: [
+  "Feihong Hsu <feihong.hsu@ahrefs.com>"
+  "Javier Chávarri <javier.chavarri@ahrefs.com>"
+]
+authors: [
+  "Feihong Hsu <feihong.hsu@ahrefs.com>"
+  "Javier Chávarri <javier.chavarri@ahrefs.com>"
+]
+tags: ["melange" "node" "org:ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/melange-fest"
+bug-reports: "https://github.com/ahrefs/melange-fest/issues"
+dev-repo: "git+https://github.com/ahrefs/melange-fest.git"
+depends: [
+  "ocaml"
+  "dune" {>= "3.9"}
+  "melange" {>= "5.0.0"}
+  "reason" {with-test}
+  "reason-react" {with-test}
+  "reason-react-ppx" {with-test}
+  "melange-testing-library" {with-test}
+  "ocaml-lsp-server" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ahrefs/melange-fest/releases/download/0.2.0/melange-fest-0.2.0.tbz"
+  checksum: [
+    "sha256=9f578ecb9bc185a5bab983b59ac08aa079bd41058f19d3e902d94fdf552f9c88"
+    "sha512=2b59e1e23d4c027df99ebd94eeb9c49d0b5a024f22ebfd01ff19ea9497348c60adaf67f161aaac743ae94d8093240399463a0eb0dffce8351fa75a73d99a9c88"
+  ]
+}
+x-commit-hash: "d12e265cd22e9b2d6c3f56e118853239b226a3bb"


### PR DESCRIPTION
A minimal test framework for Melange

- Project page: <a href="https://github.com/ahrefs/melange-fest">https://github.com/ahrefs/melange-fest</a>

##### CHANGES:

- Migrate mel.send.pipe to mel.send for melange 6 [ahrefs/melange-fest#12](https://github.com/ahrefs/melange-fest/pull/12/changes)
- Introduce a `subtest` function and make `Promise.test` return just `unit`,
  [ahrefs/melange-fest#10](https://github.com/ahrefs/melange-fest/pull/10)
