### PR TITLE
Add dnsrobot.0.1.0

### DIFF
--- a/packages/dnsrobot/dnsrobot.0.1.0/opam
+++ b/packages/dnsrobot/dnsrobot.0.1.0/opam
@@ -1,6 +1,4 @@
 opam-version: "2.0"
-name: "dnsrobot"
-version: "0.1.0"
 synopsis: "OCaml client for DNS Robot API - DNS lookups, WHOIS, SSL checks, and network tools"
 description: """
 Official OCaml client for DNS Robot (dnsrobot.net).


### PR DESCRIPTION
## dnsrobot 0.1.0

Official OCaml client for [DNS Robot](https://dnsrobot.net) - DNS lookups, WHOIS, SSL checks, and 50+ network tools.

**Homepage**: https://dnsrobot.net
**Source**: https://github.com/dnsrobot/dnsrobot-ocaml
**License**: MIT

### Features

- 11 API methods: DNS lookup, WHOIS, SSL check, SPF/DKIM/DMARC, MX/NS, IP lookup, HTTP headers, port check
- Uses cohttp-lwt-unix, yojson, lwt
- Lwt-based async API