### PR TITLE
New package: olint.0.1.0

### DIFF
--- a/packages/olint/olint.0.1.0/opam
+++ b/packages/olint/olint.0.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "A linter for OCaml. The first serious one."
+synopsis: "A somewhat serious linter for OCaml"
 description: """
 Think clippy for OCaml. Catches antipatterns, partial function misuse,
 naming violations, and the kind of code that compiles perfectly but


### PR DESCRIPTION
A linter for OCaml, inspired by Rust's Clippy.

Catches antipatterns, partial function misuse, naming convention violations, and code that compiles perfectly but keeps you up at night. 10 rules covering unused opens, redundant matches, List.length comparisons, partial functions, naming conventions, boolean redundancy, eta reduction, and exception control flow.

- Uses `compiler-libs` directly on the untyped AST (Parsetree)
- No `.cmt` file dependency
- Inline suppression via comments (`olint:disable`, `olint:enable`, `olint:disable-next-line`)
- JSON output for CI integration
- Message localisation support
- Dependencies: `ocaml >= 5.4.0`, `cmdliner >= 1.3.0`, `dune >= 3.21`

Repository: https://github.com/Zaneham/Olint
License: Apache-2.0