### PR TITLE
Package cpdf.2.9

### DIFF
--- a/packages/cpdf/cpdf.2.9/opam
+++ b/packages/cpdf/cpdf.2.9/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "contact@coherentgraphics.co.uk"
+license: "AGPL-3.0-or-later"
+build: [[make]]
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "ocamlfind" {build}
+  "camlpdf" {= version}
+]
+homepage: "http://github.com/johnwhitington/cpdf-source"
+authors: ["John Whitington"]
+bug-reports: "http://github.com/johnwhitington/cpdf-source/issues"
+dev-repo: "git+https://github.com/johnwhitington/cpdf-source"
+install: [[make "install"]]
+synopsis: "PDF command line tools"
+url {
+  src:
+    "https://github.com/johnwhitington/cpdf-source/archive/refs/tags/v2.9.tar.gz"
+  checksum: [
+    "md5=14ad4b9168a0d6caebe37697540520d9"
+    "sha512=95244ee016258239d93b3098f45bd1ae43bb01711fd632d5b5005bded076231f1728075d17ed6d53b5d7420704a6adbb847a61ab95f08466d9dfdef353ce3212"
+  ]
+}


### PR DESCRIPTION
### `cpdf.2.9`
PDF command line tools



---
* Homepage: http://github.com/johnwhitington/cpdf-source
* Source repo: git+https://github.com/johnwhitington/cpdf-source
* Bug tracker: http://github.com/johnwhitington/cpdf-source/issues

---
:camel: Pull-request generated by opam-publish v3.0.0