### PR TITLE
[new release] starred_ml (0.0.8)

### DIFF
--- a/packages/starred_ml/starred_ml.0.0.8/opam
+++ b/packages/starred_ml/starred_ml.0.0.8/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Generates a awesome list markdown"
+synopsis: "Generates an Awesome-style markdown list from GitHub stars"
 description: "Turn your starred items into a awesomeness list of repos"
 maintainer: ["Paulo Suzart"]
 authors: ["Paulo Suzart"]


### PR DESCRIPTION
Generates a awesome list markdown

- Project page: <a href="https://github.com/paulosuzart/starred_ml">https://github.com/paulosuzart/starred_ml</a>

##### CHANGES:

- Replaced deprecated `Mirage_crypto_rng_eio.run` with `Mirage_crypto_rng_unix.use_default` from `mirage-crypto-rng.unix`.
- Improved error handling: HTTP errors (4xx/5xx) print a clean message; unexpected failures show a full stack trace.
- Bumped dependencies: `eio` and `eio_main` >= 1.3, `cohttp-eio` >= 6.2.1, `mirage-crypto-rng` >= 1.2.0, `alcotest` >= 1.9.1, `dune` lang 3.21.
- Updated CI to OCaml 5.4.1.
- Updated README with development setup instructions.
- Updated OCaml setup GitHub Actions version.
