### PR TITLE
tm-grammars 1.0.0: mark unavailable

### DIFF
--- a/packages/tm-grammars/tm-grammars.1.0.0/opam
+++ b/packages/tm-grammars/tm-grammars.1.0.0/opam
@@ -35,3 +35,4 @@ url {
   ]
 }
 x-commit-hash: "35481e590f4c80b55c7a904c0581fae1b5064cf1"
+available: false # the published release tarball URL is currently broken, and the old one could not be found in caches


### PR DESCRIPTION
Mark the package as unavailable due to a broken release tarball URL, see https://github.com/ocaml/opam-repository/pull/29528