### PR TITLE
Add upper bound on dune-rpc at 3.22

### DIFF
--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.10.5/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.10.5/opam
@@ -22,7 +22,7 @@ depends: [
   "yojson" {< "3"}
   "re" {>= "1.5.0"}
   "ppx_yojson_conv_lib" {>= "v0.14"}
-  "dune-rpc"
+  "dune-rpc" {< "3.22"}
   "dyn"
   "stdune"
   "fiber"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.17.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.17.0/opam
@@ -22,7 +22,7 @@ depends: [
   "yojson" {< "3"}
   "re" {>= "1.5.0"}
   "ppx_yojson_conv_lib" {>= "v0.14"}
-  "dune-rpc" {>= "3.4.0"}
+  "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
   "stdune"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0/opam
@@ -25,7 +25,7 @@ depends: [
   "jsonrpc" {= version}
   "re" {>= "1.5.0"}
   "ppx_yojson_conv_lib" {>= "v0.14"}
-  "dune-rpc" {>= "3.4.0"}
+  "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
   "stdune"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.20.1-4.14/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.20.1-4.14/opam
@@ -25,7 +25,7 @@ depends: [
   "jsonrpc" {= "1.20.1"}
   "re" {>= "1.5.0"}
   "ppx_yojson_conv_lib" {>= "v0.14"}
-  "dune-rpc" {>= "3.4.0"}
+  "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
   "stdune"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.21.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.21.0/opam
@@ -25,7 +25,7 @@ depends: [
   "jsonrpc" {= version}
   "re" {>= "1.5.0"}
   "ppx_yojson_conv_lib" {>= "v0.14"}
-  "dune-rpc" {>= "3.4.0"}
+  "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
   "stdune"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.22.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.22.0/opam
@@ -25,7 +25,7 @@ depends: [
   "jsonrpc" {= version}
   "re" {>= "1.5.0"}
   "ppx_yojson_conv_lib" {>= "v0.14"}
-  "dune-rpc" {>= "3.4.0"}
+  "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
   "stdune"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.23.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.23.0/opam
@@ -25,7 +25,7 @@ depends: [
   "jsonrpc" {= version}
   "re" {>= "1.5.0"}
   "ppx_yojson_conv_lib" {>= "v0.14"}
-  "dune-rpc" {>= "3.4.0"}
+  "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
   "stdune"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.23.1/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.23.1/opam
@@ -25,7 +25,7 @@ depends: [
   "jsonrpc" {= version}
   "re" {>= "1.5.0"}
   "ppx_yojson_conv_lib" {>= "v0.14"}
-  "dune-rpc" {>= "3.4.0"}
+  "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
   "stdune"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.24.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.24.0/opam
@@ -25,7 +25,7 @@ depends: [
   "jsonrpc" {= version}
   "re" {>= "1.5.0"}
   "ppx_yojson_conv_lib" {>= "v0.14"}
-  "dune-rpc" {>= "3.4.0"}
+  "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
   "stdune"


### PR DESCRIPTION
A breaking API change was introduced

Followup to https://github.com/ocaml/opam-repository/pull/29544 which missed some necessary bounds (as shown by CI results in https://github.com/ocaml/opam-repository/pull/29547). This time I used `opam admin` to ensure the bound as added to all versions of the affected package.