### PR TITLE
[new release] starred_ml (0.0.9)

### DIFF
--- a/packages/starred_ml/starred_ml.0.0.9/opam
+++ b/packages/starred_ml/starred_ml.0.0.9/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Generates an Awesome-style markdown list from GitHub stars"
+description: "Turn your starred items into a awesomeness list of repos"
+maintainer: ["Paulo Suzart"]
+authors: ["Paulo Suzart"]
+license: "CC0-1.0"
+homepage: "https://github.com/paulosuzart/starred_ml"
+bug-reports: "https://github.com/paulosuzart/starred_ml/issues"
+depends: [
+  "cmdliner" {>= "1.2.0"}
+  "re2" {>= "v0.16.0"}
+  "alcotest" {>= "1.9.1" & with-test}
+  "yojson" {>= "2.1.2"}
+  "tls-eio" {>= "1.0.4"}
+  "ppx_deriving_yojson" {>= "3.7.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "logs" {>= "0.7.0"}
+  "jingoo" {>= "1.5.2"}
+  "fmt" {>= "0.9.0"}
+  "eio_main" {>= "1.3"}
+  "eio" {>= "1.3"}
+  "cohttp-eio" {>= "6.2.1"}
+  "ocaml" {>= "5.2.0"}
+  "dune" {>= "3.21"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/paulosuzart/starred_ml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/paulosuzart/starred_ml/releases/download/0.0.9/starred_ml-0.0.9.tbz"
+  checksum: [
+    "sha256=4c8349ee2a6b3a83d0cfa632127a0aa7c986a6ade8c310684bb78057c460d5de"
+    "sha512=4cf3a0bf10d7467b003063f3336d4be961dcb989145718449301203b944f1fca455d1f816b5a45b5f19aa1ec11266623af3f29dec37b1e522200d412a934d2cc"
+  ]
+}
+x-commit-hash: "d2d43ed4688dd20806f20472893edea09c52a2a6"


### PR DESCRIPTION
Generates an Awesome-style markdown list from GitHub stars

- Project page: <a href="https://github.com/paulosuzart/starred_ml">https://github.com/paulosuzart/starred_ml</a>

##### CHANGES:

- Extracted HTTP fetch logic into a dedicated `Fetcher` module (`bin/fetcher.ml`), separating it from CLI argument definitions in `bin/main.ml`.
- Added terminal progress spinner on stderr showing current page and optional page cap (e.g. `/ Fetching page 3 of 5...`); clears itself when done so stdout redirection (e.g. `> out.md`) is unaffected.
- Added post-fetch summary on stderr: pages fetched, repository count, and elapsed time in seconds (e.g. `✓ 5 pages  •  487 repositories  •  3.2s`).
- Bumped `jingoo` dependency to `>= 1.5.2`.
- Fixed `Re2` regex compiled once at module load instead of on every paginated response.
- Cleaned up `github.mli`: removed `[@@deriving ...]` attributes from type declarations and replaced with explicit `val` signatures for the functions actually used externally, narrowing the public API surface.
- Added `unix` to `bin/dune` library dependencies.
- Using [Eio.Stream](https://ocaml-multicore.github.io/eio/eio/Eio/Stream/index.html) to accumulate responses.
- Added `PAGE_SIZE` cli parameter.
- Added `--timeout` / `-T` CLI arg (default 600s): per-request timeout in seconds passed to the HTTP fetcher.
- Added `--max-retries` / `-r` CLI arg (default 3): number of retry attempts on transient failures or timeouts.
- Added per-request timeout and exponential-backoff retry in `Http_util.fetch` using `Eio.Time.Timeout`.
