### PR TITLE
Add upper bound on stdune 3.22

### DIFF
--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.10.5/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.10.5/opam
@@ -24,7 +24,7 @@ depends: [
   "ppx_yojson_conv_lib" {>= "v0.14"}
   "dune-rpc" {< "3.22"}
   "dyn"
-  "stdune"
+  "stdune" {< "3.22"}
   "fiber"
   "xdg"
   "ordering"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.17.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.17.0/opam
@@ -25,7 +25,7 @@ depends: [
   "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
-  "stdune"
+  "stdune" {< "3.22"}
   "fiber" {>= "3.1.1" & < "4.0.0"}
   "xdg"
   "ordering"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0/opam
@@ -28,7 +28,7 @@ depends: [
   "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
-  "stdune"
+  "stdune" {< "3.22"}
   "fiber" {>= "3.1.1" & < "4.0.0"}
   "xdg"
   "ordering"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.20.1-4.14/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.20.1-4.14/opam
@@ -28,7 +28,7 @@ depends: [
   "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
-  "stdune"
+  "stdune" {< "3.22"}
   "fiber" {>= "3.1.1" & < "4.0.0"}
   "ocaml" {>= "4.14.0" & < "5.0"}
   "xdg"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.21.0-4.14/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.21.0-4.14/opam
@@ -28,7 +28,7 @@ depends: [
   "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
-  "stdune"
+  "stdune" {< "3.22"}
   "fiber" {>= "3.1.1" & < "4.0.0"}
   "ocaml" {>= "4.14.0" & < "5.0"}
   "xdg"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.21.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.21.0/opam
@@ -28,7 +28,7 @@ depends: [
   "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
-  "stdune"
+  "stdune" {< "3.22"}
   "fiber" {>= "3.1.1" & < "4.0.0"}
   "ocaml" {>= "5.2.0" & < "5.3"}
   "xdg"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.22.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.22.0/opam
@@ -28,7 +28,7 @@ depends: [
   "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
-  "stdune"
+  "stdune" {< "3.22"}
   "fiber" {>= "3.1.1" & < "4.0.0"}
   "ocaml" {>= "5.3" & < "5.4"}
   "xdg"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.23.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.23.0/opam
@@ -28,7 +28,7 @@ depends: [
   "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
-  "stdune"
+  "stdune" {< "3.22"}
   "fiber" {>= "3.1.1" & < "4.0.0"}
   "ocaml" {>= "5.3" & < "5.4"}
   "xdg"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.23.1/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.23.1/opam
@@ -28,7 +28,7 @@ depends: [
   "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
-  "stdune"
+  "stdune" {< "3.22"}
   "fiber" {>= "3.1.1" & < "4.0.0"}
   "ocaml" {>= "5.3" & < "5.4"}
   "xdg"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.24.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.24.0/opam
@@ -28,7 +28,7 @@ depends: [
   "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
-  "stdune"
+  "stdune" {< "3.22"}
   "fiber" {>= "3.1.1" & < "4.0.0"}
   "ocaml" {>= "5.4" & < "5.5"}
   "xdg"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.25.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.25.0/opam
@@ -28,7 +28,7 @@ depends: [
   "dune-rpc" {>= "3.4.0" & < "3.22"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
-  "stdune"
+  "stdune" {< "3.22"}
   "fiber" {>= "3.1.1" & < "4.0.0"}
   "ocaml" {>= "5.4" & < "5.5"}
   "xdg"


### PR DESCRIPTION
Required by a breaking API change in stdune

Discovered in https://github.com/ocaml/opam-repository/pull/29547#issuecomment-4079297909

@Alizter helped diagnose the root cause, which was a breaking API change in Stdune introduced in https://github.com/ocaml/dune/pull/13430, and explained at https://github.com/ocaml/dune/issues/13674#issuecomment-4086755357 .

We discussed this in the dun-dev meeting with @rgrinberg today.
 