### PR TITLE
Release ppxlib and ppxlib-tools 0.38.0

### DIFF
--- a/packages/ppxlib-tools/ppxlib-tools.0.38.0/opam
+++ b/packages/ppxlib-tools/ppxlib-tools.0.38.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Tools for PPX users and authors"
+description: """
+Set of helper tools for PPX users and authors.
+
+ppxlib-pp-ast: Command line tool to pretty print OCaml ASTs in a human readable
+format."""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0"}
+  "ppxlib" {= version}
+  "cmdliner" {>= "1.3.0"}
+  "yojson" {>= "2.2.2"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.38.0/ppxlib-0.38.0.tbz"
+  checksum: [
+    "sha256=89e049b3102f6670a213d34d802ea3ab0fc530a8959d2f1a1e8db830063429a3"
+    "sha512=2fbbf124fc61e1f22242d13505e9af39d4a3c7cf03def1c33ee8bd915195be9b817636667302e9c6ceddc74a9a4a54926340e21c96fd770a2bc6752400315cfd"
+  ]
+}
+x-commit-hash: "f7ffcd60a04f22ba85caefbde7f1eb4af6dba4ea"

--- a/packages/ppxlib/ppxlib.0.38.0/opam
+++ b/packages/ppxlib/ppxlib.0.38.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "Standard infrastructure for ppx rewriters"
+description: """
+Ppxlib is the standard infrastructure for ppx rewriters
+and other programs that manipulate the in-memory representation of
+OCaml programs, a.k.a the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0" & < "5.6.0"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0" {>= "v0.12"}
+  "sexplib0" {with-test & >= "v0.15"}
+  "stdlib-shims"
+  "ocamlfind" {with-test}
+  "re" {with-test & >= "1.9.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "ocamlformat" {with-dev-setup & = "0.28.1"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-migrate-parsetree" {< "2.0.0"}
+  "ocaml-base-compiler" {= "5.1.0~alpha1"}
+  "ocaml-variants" {= "5.1.0~alpha1+options"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.38.0/ppxlib-0.38.0.tbz"
+  checksum: [
+    "sha256=89e049b3102f6670a213d34d802ea3ab0fc530a8959d2f1a1e8db830063429a3"
+    "sha512=2fbbf124fc61e1f22242d13505e9af39d4a3c7cf03def1c33ee8bd915195be9b817636667302e9c6ceddc74a9a4a54926340e21c96fd770a2bc6752400315cfd"
+  ]
+}
+x-commit-hash: "f7ffcd60a04f22ba85caefbde7f1eb4af6dba4ea"


### PR DESCRIPTION
**Changes:**

- Add support for OCaml 5.5 (ocaml-ppx/ppxlib#622, @patricoferris, @NathanReb)

- Add support for OCaml 5.4 bivariant type parameters, they can now be used
  alongside ppx-es. (ocaml-ppx/ppxlib#629, @NathanReb)

- Add `Attribute.Floating.declare_with_attr_loc` and `.declare_with_name_loc`,
  by analogy to the same functions at top level of `Attribute`. (ocaml-ppx/ppxlib#631, @ceastlund)

- Migrate `Ptyp_open` nodes using an extension point (ocaml-ppx/ppxlib#625, @patricoferris)

- Add Ast_builder and Ast_pattern utilities to manipulate encoded
  effect patterns (ocaml-ppx/ppxlib#624, @NathanReb)

- Fix a bug where ppat_effects would be encoded/decoded instead of copied by
  the 5.4 <-> 5.3 migrations (ocaml-ppx/ppxlib#624, @NathanReb)

- Fix infinite loop when duplicate attributes are present, raising
  an error instead (ocaml-ppx/ppxlib#613, @ceastlund, @patricoferris)
- Ignore extensions inside attributes for the unused extension check
  (ocaml-ppx/ppxlib#616, @Skepfyr)
- Fix a bug that inserted `Location.none` into `Longident`s when using OCaml
  5.4 and above (ocaml-ppx/ppxlib#619, @patricoferris)

- Add support for OCaml 5.4 labeled tuples, they can now be used alongside
  ppx-es. Also adds Ast_builder and Ast_pattern utilities to manipulate them.
  (ocaml-ppx/ppxlib#607, @NathanReb)
