### PR TITLE
[new release] Ortac 0.8.0

### DIFF
--- a/packages/ortac-core/ortac-core.0.8.0/opam
+++ b/packages/ortac-core/ortac-core.0.8.0/opam
@@ -59,7 +59,7 @@ x-maintenance-intent: ["(latest)"]
 url {
   src: "https://github.com/ocaml-gospel/ortac/archive/refs/tags/0.8.0/.tar.gz"
   checksum: [
-    "md5=de9cf96baa03936410a46232e61878e0"
-    "sha512=a137775b581fab56218edf1efd6fc4db219c6f23de41901b2cd7927d0eb4e52fd30e2b83d8c9a2d6069349976e4df9868ab1fcedf9b664f7de2f08ffeaac288b"
+    "md5=1bbffc8b2ecf943c2d66bdf9c72b994a"
+    "sha512=f23537bc18149e5cf5f5035139fac0541b55f7087127b1ca963f16d8852096d7fbdd5378b9fbb7703a3ce175b4a90ad8a7dfafc4292b5f1196fa11fbef43a178"
   ]
 }

--- a/packages/ortac-dune/ortac-dune.0.8.0/opam
+++ b/packages/ortac-dune/ortac-dune.0.8.0/opam
@@ -41,7 +41,7 @@ x-maintenance-intent: ["(latest)"]
 url {
   src: "https://github.com/ocaml-gospel/ortac/archive/refs/tags/0.8.0/.tar.gz"
   checksum: [
-    "md5=de9cf96baa03936410a46232e61878e0"
-    "sha512=a137775b581fab56218edf1efd6fc4db219c6f23de41901b2cd7927d0eb4e52fd30e2b83d8c9a2d6069349976e4df9868ab1fcedf9b664f7de2f08ffeaac288b"
+    "md5=1bbffc8b2ecf943c2d66bdf9c72b994a"
+    "sha512=f23537bc18149e5cf5f5035139fac0541b55f7087127b1ca963f16d8852096d7fbdd5378b9fbb7703a3ce175b4a90ad8a7dfafc4292b5f1196fa11fbef43a178"
   ]
 }

--- a/packages/ortac-qcheck-stm/ortac-qcheck-stm.0.8.0/opam
+++ b/packages/ortac-qcheck-stm/ortac-qcheck-stm.0.8.0/opam
@@ -48,7 +48,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version > "5.2"}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]
@@ -58,7 +58,7 @@ x-maintenance-intent: ["(latest)"]
 url {
   src: "https://github.com/ocaml-gospel/ortac/archive/refs/tags/0.8.0/.tar.gz"
   checksum: [
-    "md5=de9cf96baa03936410a46232e61878e0"
-    "sha512=a137775b581fab56218edf1efd6fc4db219c6f23de41901b2cd7927d0eb4e52fd30e2b83d8c9a2d6069349976e4df9868ab1fcedf9b664f7de2f08ffeaac288b"
+    "md5=1bbffc8b2ecf943c2d66bdf9c72b994a"
+    "sha512=f23537bc18149e5cf5f5035139fac0541b55f7087127b1ca963f16d8852096d7fbdd5378b9fbb7703a3ce175b4a90ad8a7dfafc4292b5f1196fa11fbef43a178"
   ]
 }

--- a/packages/ortac-runtime-qcheck-stm/ortac-runtime-qcheck-stm.0.8.0/opam
+++ b/packages/ortac-runtime-qcheck-stm/ortac-runtime-qcheck-stm.0.8.0/opam
@@ -45,7 +45,7 @@ x-maintenance-intent: ["(latest)"]
 url {
   src: "https://github.com/ocaml-gospel/ortac/archive/refs/tags/0.8.0/.tar.gz"
   checksum: [
-    "md5=de9cf96baa03936410a46232e61878e0"
-    "sha512=a137775b581fab56218edf1efd6fc4db219c6f23de41901b2cd7927d0eb4e52fd30e2b83d8c9a2d6069349976e4df9868ab1fcedf9b664f7de2f08ffeaac288b"
+    "md5=1bbffc8b2ecf943c2d66bdf9c72b994a"
+    "sha512=f23537bc18149e5cf5f5035139fac0541b55f7087127b1ca963f16d8852096d7fbdd5378b9fbb7703a3ce175b4a90ad8a7dfafc4292b5f1196fa11fbef43a178"
   ]
 }

--- a/packages/ortac-runtime/ortac-runtime.0.8.0/opam
+++ b/packages/ortac-runtime/ortac-runtime.0.8.0/opam
@@ -46,7 +46,7 @@ x-maintenance-intent: ["(latest)"]
 url {
   src: "https://github.com/ocaml-gospel/ortac/archive/refs/tags/0.8.0/.tar.gz"
   checksum: [
-    "md5=de9cf96baa03936410a46232e61878e0"
-    "sha512=a137775b581fab56218edf1efd6fc4db219c6f23de41901b2cd7927d0eb4e52fd30e2b83d8c9a2d6069349976e4df9868ab1fcedf9b664f7de2f08ffeaac288b"
+    "md5=1bbffc8b2ecf943c2d66bdf9c72b994a"
+    "sha512=f23537bc18149e5cf5f5035139fac0541b55f7087127b1ca963f16d8852096d7fbdd5378b9fbb7703a3ce175b4a90ad8a7dfafc4292b5f1196fa11fbef43a178"
   ]
 }

--- a/packages/ortac-wrapper/ortac-wrapper.0.8.0/opam
+++ b/packages/ortac-wrapper/ortac-wrapper.0.8.0/opam
@@ -51,7 +51,7 @@ x-maintenance-intent: ["(latest)"]
 url {
   src: "https://github.com/ocaml-gospel/ortac/archive/refs/tags/0.8.0/.tar.gz"
   checksum: [
-    "md5=de9cf96baa03936410a46232e61878e0"
-    "sha512=a137775b581fab56218edf1efd6fc4db219c6f23de41901b2cd7927d0eb4e52fd30e2b83d8c9a2d6069349976e4df9868ab1fcedf9b664f7de2f08ffeaac288b"
+    "md5=1bbffc8b2ecf943c2d66bdf9c72b994a"
+    "sha512=f23537bc18149e5cf5f5035139fac0541b55f7087127b1ca963f16d8852096d7fbdd5378b9fbb7703a3ce175b4a90ad8a7dfafc4292b5f1196fa11fbef43a178"
   ]
 }


### PR DESCRIPTION
This release brings the possibility of generating QCheck-STM+Domains tests. The main issues were to handle the SUTs created during the run of the generated programs and to adapt the bug report feature to parallel programs. This adds a new `ortac_runtime_qcheck_stm_domain` library, that is enabled only if ocaml version is at least 5.

Other changes:

- Fix field access in check clauses in wrapper plugin
- Add optional argument to control aliases in dune plugin
- Add a count argument to `ortac qcheck-stm` and `ortac dune qcheck-stm`
- Update to QCheck 0.90 great renaming
- Allow user to provide weight per command and per program sub-part in Ortac/QCheck-STM configuration file, to be used in the generated command generator
- Allow user to provide complete custom command generators in Ortac/QCheck-STM configuration file
- Add some new examples and tests to demonstrate testing in a parallel context