### PR TITLE
[new release] lsp (3 packages) (1.26.0-5.5~preview)

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.26.0-5.5~preview/opam
+++ b/packages/jsonrpc/jsonrpc.1.26.0-5.5~preview/opam
@@ -23,6 +23,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
+flags: avoid-version
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/lsp/lsp.1.26.0-5.5~preview/opam
+++ b/packages/lsp/lsp.1.26.0-5.5~preview/opam
@@ -33,6 +33,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "ppx_yojson_conv" {with-dev-setup}
 ]
+flags: avoid-version
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.26.0-5.5~preview/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.26.0-5.5~preview/opam
@@ -48,6 +48,7 @@ depends: [
   "ocaml-index" {post}
   "ppx_yojson_conv" {with-dev-setup}
 ]
+flags: avoid-version
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
LSP protocol implementation in OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-lsp">https://github.com/ocaml/ocaml-lsp</a>

##### CHANGES:

## Fixes

- Improve the readability of signature-help for long signatures (ocaml/ocaml-lsp#1580)

## Features

- Add `destruct` custom request (ocaml/ocaml-lsp#1583)

- Allow to configure merlin using build systems other than dune.

  If `$OCAMLLSP_PROJECT_BUILD_SYSTEM` environment variable is set then OCaml
  LSP will execute `$OCAMLLSP_PROJECT_BUILD_SYSTEM ocaml-merlin` command to get
  merlin configuration for a module. It is expected the command to communicate
  using `merlin-dot-protocol`.

  If `$OCAMLLSP_PROJECT_ROOT` environment variable is set then OCaml LSP will
  use it as a project root directory.
