### PR TITLE
charrua-client 3.0.0 & 3.1.0: avoid these versions

### DIFF
--- a/packages/charrua-client/charrua-client.3.0.0/opam
+++ b/packages/charrua-client/charrua-client.3.0.0/opam
@@ -52,3 +52,4 @@ url {
   ]
 }
 x-commit-hash: "60bcf1c6bed96fe10d4ca42758d27e3edd02276a"
+flags: avoid-version

--- a/packages/charrua-client/charrua-client.3.1.0/opam
+++ b/packages/charrua-client/charrua-client.3.1.0/opam
@@ -52,3 +52,4 @@ url {
   ]
 }
 x-commit-hash: "03e1e7fe918318d7202c172eb04bd7396f6f75d5"
+flags: avoid-version


### PR DESCRIPTION
they have some issues with the MirageOS network stack, 3.1.1 has a fix for them

/cc @reynir 