### PR TITLE
[new release] letsencrypt (4 packages) (2.0.0)

### DIFF
--- a/packages/letsencrypt-app/letsencrypt-app.2.0.0/opam
+++ b/packages/letsencrypt-app/letsencrypt-app.2.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An ACME client implementation of the ACME protocol (RFC 8555) for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/robur-coop/ocaml-letsencrypt"
+bug-reports: "https://github.com/robur-coop/ocaml-letsencrypt/issues"
+doc: "https://robur-coop.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "letsencrypt-dns" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "logs"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "2.6.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "ptime"
+  "bos"
+  "fpath"
+  "randomconv" {>= "0.2.0"}
+  "ipaddr" {>= "5.6.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/ocaml-letsencrypt.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-letsencrypt/releases/download/v2.0.0/letsencrypt-2.0.0.tbz"
+  checksum: [
+    "sha256=9d0d4a3c4d1793137933e645945c262dc6cdcaff8ad6f6630c30ec900423d1c3"
+    "sha512=dda4c7cd00ea700aea038bd3245ae51300cf51a1dd56f3afc3928d6f29a680a8a3fa367fa7aef7c6cb1883bb6b235287c12a9263af14be75ba5e4367db17895a"
+  ]
+}
+x-commit-hash: "8b631c1e969d9804accd0c5d8be512568d7b230c"

--- a/packages/letsencrypt-dns/letsencrypt-dns.2.0.0/opam
+++ b/packages/letsencrypt-dns/letsencrypt-dns.2.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "DNS solver for ACME implementation in OCaml"
+description: "A DNS solver for the ACME implementation in OCaml."
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/robur-coop/ocaml-letsencrypt"
+bug-reports: "https://github.com/robur-coop/ocaml-letsencrypt/issues"
+doc: "https://robur-coop.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "logs"
+  "fmt" {>= "0.8.7"}
+  "dns" {>= "9.0.0"}
+  "dns-tsig" {>= "9.0.0"}
+  "domain-name" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/ocaml-letsencrypt.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-letsencrypt/releases/download/v2.0.0/letsencrypt-2.0.0.tbz"
+  checksum: [
+    "sha256=9d0d4a3c4d1793137933e645945c262dc6cdcaff8ad6f6630c30ec900423d1c3"
+    "sha512=dda4c7cd00ea700aea038bd3245ae51300cf51a1dd56f3afc3928d6f29a680a8a3fa367fa7aef7c6cb1883bb6b235287c12a9263af14be75ba5e4367db17895a"
+  ]
+}
+x-commit-hash: "8b631c1e969d9804accd0c5d8be512568d7b230c"

--- a/packages/letsencrypt-mirage/letsencrypt-mirage.2.0.0/opam
+++ b/packages/letsencrypt-mirage/letsencrypt-mirage.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml for MirageOS"
+description: "An ACME client implementation of the ACME protocol (RFC 8555) for OCaml & MirageOS"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/robur-coop/ocaml-letsencrypt"
+bug-reports: "https://github.com/robur-coop/ocaml-letsencrypt/issues"
+doc: "https://robur-coop.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "http-mirage-client" {>= "0.0.10"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-sleep" {>= "4.0.0"}
+  "duration"
+  "emile" {>= "1.1"}
+  "paf" {>= "0.8.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/ocaml-letsencrypt.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-letsencrypt/releases/download/v2.0.0/letsencrypt-2.0.0.tbz"
+  checksum: [
+    "sha256=9d0d4a3c4d1793137933e645945c262dc6cdcaff8ad6f6630c30ec900423d1c3"
+    "sha512=dda4c7cd00ea700aea038bd3245ae51300cf51a1dd56f3afc3928d6f29a680a8a3fa367fa7aef7c6cb1883bb6b235287c12a9263af14be75ba5e4367db17895a"
+  ]
+}
+x-commit-hash: "8b631c1e969d9804accd0c5d8be512568d7b230c"

--- a/packages/letsencrypt/letsencrypt.2.0.0/opam
+++ b/packages/letsencrypt/letsencrypt.2.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An implementation of the ACME protocol (RFC 8555) for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/robur-coop/ocaml-letsencrypt"
+bug-reports: "https://github.com/robur-coop/ocaml-letsencrypt/issues"
+doc: "https://robur-coop.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.2.0"}
+  "logs"
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "1.0.0"}
+  "ounit2" {with-test}
+  "ptime"
+  "jws"
+  "lun"
+  "domain-name" {>= "0.2.0"}
+  "asn1-combinators" {>= "0.3.2"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/ocaml-letsencrypt.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-letsencrypt/releases/download/v2.0.0/letsencrypt-2.0.0.tbz"
+  checksum: [
+    "sha256=9d0d4a3c4d1793137933e645945c262dc6cdcaff8ad6f6630c30ec900423d1c3"
+    "sha512=dda4c7cd00ea700aea038bd3245ae51300cf51a1dd56f3afc3928d6f29a680a8a3fa367fa7aef7c6cb1883bb6b235287c12a9263af14be75ba5e4367db17895a"
+  ]
+}
+x-commit-hash: "8b631c1e969d9804accd0c5d8be512568d7b230c"


### PR DESCRIPTION
ACME implementation in OCaml

- Project page: <a href="https://github.com/robur-coop/ocaml-letsencrypt">https://github.com/robur-coop/ocaml-letsencrypt</a>
- Documentation: <a href="https://robur-coop.github.io/ocaml-letsencrypt">https://robur-coop.github.io/ocaml-letsencrypt</a>

##### CHANGES:

* Use jws, lun, and jsont, remove yojson (robur-coop/ocaml-letsencrypt#38 #dinosaure)
* Remove lwt and uri dependencies from the core, now functorized over scheduler
  (robur-coop/ocaml-letsencrypt#39 @dinosaure @hannesm)
