### PR TITLE
[new release] parseff (0.2.0)

### DIFF
--- a/packages/parseff/parseff.0.2.0/opam
+++ b/packages/parseff/parseff.0.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Direct-style parser combinator library for OCaml 5 powered by algebraic effects"
+description:
+  "Parseff is a direct-style parser combinator library for OCaml 5 where parsers are plain functions (unit -> 'a), errors are typed via polymorphic variants, and algebraic effects handle control flow, backtracking, and streaming input. Designed for performance with zero-copy span APIs and fused operations."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/davesnx/parseff"
+bug-reports: "https://github.com/davesnx/parseff/issues"
+depends: [
+  "dune" {>= "3.17" & (>= "3.22" & with-doc = "true" | with-doc = "false")}
+  "ocaml" {>= "5.3"}
+  "re" {>= "1.9.0"}
+  "alcotest" {with-test}
+  "benchmark" {with-test}
+  "angstrom" {with-test}
+  "mparser" {with-test}
+  "ocamlformat" {>= "0.29.0" & with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "odoc" {>= "3.1.0" & with-doc}
+  "odoc-parser" {with-doc}
+  "mdx" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/parseff.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/davesnx/parseff/releases/download/0.2.0/parseff-0.2.0.tbz"
+  checksum: [
+    "sha256=a49fa685546f8d9bc90d59a62ecc8204a24621b438164503745024e1038ebc9b"
+    "sha512=43baed140dcce2fd6e024a1f03daa71a923b1de19efa41c73eced3550528d5d911b8f0fc13dbb795f7af7a6fc963fc9d0a5fa8a9099ca752696e90345514f6ac"
+  ]
+}
+x-commit-hash: "086e713fad2b0757058263a61c5fe7c85aa2b8a1"


### PR DESCRIPTION
Direct-style parser combinator library for OCaml 5 powered by algebraic effects

- Project page: <a href="https://github.com/davesnx/parseff">https://github.com/davesnx/parseff</a>

##### CHANGES:

- **Unified `*1` variants into base combinators with `~at_least` parameter.**
  `many1` → `many ~at_least:1`, `take_while1` → `take_while ~at_least:1`,
  `sep_by1` → `sep_by ~at_least:1`, `end_by1` → `end_by ~at_least:1`,
  `whitespace1` → `whitespace ~at_least:1`. The `~at_least` parameter
  generalizes beyond the binary zero-vs-one distinction (e.g.,
  `many ~at_least:3` requires at least three matches). The old `chainl1` and
  `chainr1` were also removed in favor of making the `default` argument
  optional (see next item).

- **Renamed `chainl`/`chainr` to `fold_left`/`fold_right` with `~otherwise`.**
  `chainl1 p op` → `fold_left p op`, `chainl p op default` →
  `fold_left p op ~otherwise:default`, and likewise for `chainr`/`fold_right`.
  The new names better describe what the combinators do (parse and fold with
  associativity) and align with OCaml's `List.fold_left`/`List.fold_right`
  naming conventions. The `~otherwise` labeled argument replaces the old
  positional `default` parameter, providing a fallback value when zero elements
  match.
