### PR TITLE
[new release] libinput (1.29)

### DIFF
--- a/packages/libinput/libinput.1.29/opam
+++ b/packages/libinput/libinput.1.29/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for libinput"
+description: "Input device management and event handling library"
+maintainer: ["Thomas Leonard"]
+authors: ["Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/talex5/libinput-ocaml"
+doc: "https://talex5.github.io/libinput-ocaml/"
+bug-reports: "https://github.com/talex5/libinput-ocaml/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.3.0"}
+  "ctypes" {>= "0.23.0"}
+  "ctypes-foreign" {>= "0.23.0"}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+  "conf-libinput"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/talex5/libinput-ocaml.git"
+x-maintenance-intent: ["(latest)"]
+x-ci-accept-failures: [ "centos-9" ]
+available: [ os = "linux" & arch != "arm32" & arch != "x86_32" ]
+url {
+  src:
+    "https://github.com/talex5/libinput-ocaml/releases/download/v1.29/libinput-1.29.tbz"
+  checksum: [
+    "sha256=3de44543b3995d15d0c3ff2dbc1788403427a2c907716552cded9134681880fd"
+    "sha512=9e92438c6183d0e6e7d76c28e67133ce25d230686881a47a874a07d0e79163d3033606f69d07225d2d6eaea687a57d943429b9d5b533d344a773262e951e662e"
+  ]
+}
+x-commit-hash: "54cd505e66bd4f524317dcf5c24f46b11d782065"


### PR DESCRIPTION
OCaml bindings for libinput

- Project page: <a href="https://github.com/talex5/libinput-ocaml">https://github.com/talex5/libinput-ocaml</a>
- Documentation: <a href="https://talex5.github.io/libinput-ocaml/">https://talex5.github.io/libinput-ocaml/</a>

##### CHANGES:

- Add support for older versions of libinput going back to libinput 1.20.
  This allows the library to be used on Ubuntu 22.04 and Debian 12.

- Give a clear compile-time error if the C libinput is too old.

- The libinput-ocaml version number now indicates which version of libinput
  it is up-to-date with.
