### PR TITLE
Add ocaml-option-llvm for cross-platform LLVM toolchain support

### DIFF
--- a/packages/ocaml-compiler/ocaml-compiler.5.3.0/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3.0/opam
@@ -77,7 +77,7 @@ build: [
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--without-zstd" {ocaml-option-no-compression:installed}
     "--enable-tsan" {ocaml-option-tsan:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & !ocaml-option-llvm:installed & (os = "openbsd" | os = "macos")}
     "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
@@ -92,6 +92,8 @@ build: [
     "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
     "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
     "LIBS=-static" {ocaml-option-static:installed}
+    "CC=clang-cl" {ocaml-option-llvm:installed & os = "win32"}
+    "CC=clang" {ocaml-option-llvm:installed & os != "win32"}
     "--disable-warn-error"
   ]
   [make "-j%{jobs}%"]
@@ -105,6 +107,7 @@ depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
+  "ocaml-option-llvm"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"

--- a/packages/ocaml-compiler/ocaml-compiler.5.3/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3/opam
@@ -95,7 +95,7 @@ build: [
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--without-zstd" {ocaml-option-no-compression:installed}
     "--enable-tsan" {ocaml-option-tsan:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & !ocaml-option-llvm:installed & (os = "openbsd" | os = "macos")}
     "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
@@ -110,6 +110,8 @@ build: [
     "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
     "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
     "LIBS=-static" {ocaml-option-static:installed}
+    "CC=clang-cl" {ocaml-option-llvm:installed & os = "win32"}
+    "CC=clang" {ocaml-option-llvm:installed & os != "win32"}
     "--disable-warn-error"
   ]
   [make "-j%{jobs}%"]
@@ -122,6 +124,7 @@ depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
+  "ocaml-option-llvm"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.0/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.0/opam
@@ -77,7 +77,7 @@ build: [
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--without-zstd" {ocaml-option-no-compression:installed}
     "--enable-tsan" {ocaml-option-tsan:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & !ocaml-option-llvm:installed & (os = "openbsd" | os = "macos")}
     "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
@@ -92,6 +92,8 @@ build: [
     "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
     "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
     "LIBS=-static" {ocaml-option-static:installed}
+    "CC=clang-cl" {ocaml-option-llvm:installed & os = "win32"}
+    "CC=clang" {ocaml-option-llvm:installed & os != "win32"}
     "--disable-warn-error"
   ]
   [make "-j%{jobs}%"]
@@ -105,6 +107,7 @@ depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
+  "ocaml-option-llvm"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.0~alpha1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.0~alpha1/opam
@@ -80,7 +80,7 @@ build: [
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--without-zstd" {ocaml-option-no-compression:installed}
     "--enable-tsan" {ocaml-option-tsan:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & !ocaml-option-llvm:installed & (os = "openbsd" | os = "macos")}
     "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
@@ -95,6 +95,8 @@ build: [
     "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
     "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
     "LIBS=-static" {ocaml-option-static:installed}
+    "CC=clang-cl" {ocaml-option-llvm:installed & os = "win32"}
+    "CC=clang" {ocaml-option-llvm:installed & os != "win32"}
     "--disable-warn-error"
   ]
   [make "-j%{jobs}%"]
@@ -108,6 +110,7 @@ depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
+  "ocaml-option-llvm"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.0~beta1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.0~beta1/opam
@@ -80,7 +80,7 @@ build: [
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--without-zstd" {ocaml-option-no-compression:installed}
     "--enable-tsan" {ocaml-option-tsan:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & !ocaml-option-llvm:installed & (os = "openbsd" | os = "macos")}
     "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
@@ -95,6 +95,8 @@ build: [
     "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
     "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
     "LIBS=-static" {ocaml-option-static:installed}
+    "CC=clang-cl" {ocaml-option-llvm:installed & os = "win32"}
+    "CC=clang" {ocaml-option-llvm:installed & os != "win32"}
     "--disable-warn-error"
   ]
   [make "-j%{jobs}%"]
@@ -108,6 +110,7 @@ depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
+  "ocaml-option-llvm"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.0~beta2/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.0~beta2/opam
@@ -80,7 +80,7 @@ build: [
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--without-zstd" {ocaml-option-no-compression:installed}
     "--enable-tsan" {ocaml-option-tsan:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & !ocaml-option-llvm:installed & (os = "openbsd" | os = "macos")}
     "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
@@ -95,6 +95,8 @@ build: [
     "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
     "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
     "LIBS=-static" {ocaml-option-static:installed}
+    "CC=clang-cl" {ocaml-option-llvm:installed & os = "win32"}
+    "CC=clang" {ocaml-option-llvm:installed & os != "win32"}
     "--disable-warn-error"
   ]
   [make "-j%{jobs}%"]
@@ -108,6 +110,7 @@ depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
+  "ocaml-option-llvm"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.0~rc1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.0~rc1/opam
@@ -80,7 +80,7 @@ build: [
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--without-zstd" {ocaml-option-no-compression:installed}
     "--enable-tsan" {ocaml-option-tsan:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & !ocaml-option-llvm:installed & (os = "openbsd" | os = "macos")}
     "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
@@ -95,6 +95,8 @@ build: [
     "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
     "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
     "LIBS=-static" {ocaml-option-static:installed}
+    "CC=clang-cl" {ocaml-option-llvm:installed & os = "win32"}
+    "CC=clang" {ocaml-option-llvm:installed & os != "win32"}
     "--disable-warn-error"
   ]
   [make "-j%{jobs}%"]
@@ -108,6 +110,7 @@ depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
+  "ocaml-option-llvm"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.1/opam
@@ -77,7 +77,7 @@ build: [
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--without-zstd" {ocaml-option-no-compression:installed}
     "--enable-tsan" {ocaml-option-tsan:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & !ocaml-option-llvm:installed & (os = "openbsd" | os = "macos")}
     "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
@@ -92,6 +92,8 @@ build: [
     "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
     "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
     "LIBS=-static" {ocaml-option-static:installed}
+    "CC=clang-cl" {ocaml-option-llvm:installed & os = "win32"}
+    "CC=clang" {ocaml-option-llvm:installed & os != "win32"}
     "--disable-warn-error"
   ]
   [make "-j%{jobs}%"]
@@ -105,6 +107,7 @@ depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
+  "ocaml-option-llvm"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"

--- a/packages/ocaml-compiler/ocaml-compiler.5.4/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4/opam
@@ -95,7 +95,7 @@ build: [
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--without-zstd" {ocaml-option-no-compression:installed}
     "--enable-tsan" {ocaml-option-tsan:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & !ocaml-option-llvm:installed & (os = "openbsd" | os = "macos")}
     "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
@@ -110,6 +110,8 @@ build: [
     "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
     "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
     "LIBS=-static" {ocaml-option-static:installed}
+    "CC=clang-cl" {ocaml-option-llvm:installed & os = "win32"}
+    "CC=clang" {ocaml-option-llvm:installed & os != "win32"}
     "--disable-warn-error"
   ]
   [make "-j%{jobs}%"]
@@ -122,6 +124,7 @@ depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
+  "ocaml-option-llvm"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"

--- a/packages/ocaml-compiler/ocaml-compiler.5.5.0~alpha1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.5.0~alpha1/opam
@@ -78,7 +78,7 @@ build: [
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--without-zstd" {ocaml-option-no-compression:installed}
     "--enable-tsan" {ocaml-option-tsan:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & !ocaml-option-llvm:installed & (os = "openbsd" | os = "macos")}
     "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
@@ -93,6 +93,8 @@ build: [
     "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
     "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
     "LIBS=-static" {ocaml-option-static:installed}
+    "CC=clang-cl" {ocaml-option-llvm:installed & os = "win32"}
+    "CC=clang" {ocaml-option-llvm:installed & os != "win32"}
     "--disable-warn-error"
   ]
 ]
@@ -105,6 +107,7 @@ depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
+  "ocaml-option-llvm"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"

--- a/packages/ocaml-compiler/ocaml-compiler.5.5/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.5/opam
@@ -95,7 +95,7 @@ build: [
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--without-zstd" {ocaml-option-no-compression:installed}
     "--enable-tsan" {ocaml-option-tsan:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & !ocaml-option-llvm:installed & (os = "openbsd" | os = "macos")}
     "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
@@ -110,6 +110,8 @@ build: [
     "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
     "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
     "LIBS=-static" {ocaml-option-static:installed}
+    "CC=clang-cl" {ocaml-option-llvm:installed & os = "win32"}
+    "CC=clang" {ocaml-option-llvm:installed & os != "win32"}
     "--disable-warn-error"
   ]
   [make "-j%{jobs}%"]
@@ -122,6 +124,7 @@ depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
+  "ocaml-option-llvm"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"

--- a/packages/ocaml-compiler/ocaml-compiler.5.6/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.6/opam
@@ -94,7 +94,7 @@ build: [
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--without-zstd" {ocaml-option-no-compression:installed}
     "--enable-tsan" {ocaml-option-tsan:installed}
-    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & !ocaml-option-llvm:installed & (os = "openbsd" | os = "macos")}
     "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
@@ -109,6 +109,8 @@ build: [
     "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
     "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
     "LIBS=-static" {ocaml-option-static:installed}
+    "CC=clang-cl" {ocaml-option-llvm:installed & os = "win32"}
+    "CC=clang" {ocaml-option-llvm:installed & os != "win32"}
     "--disable-warn-error"
   ]
   [make "-j%{jobs}%"]
@@ -121,6 +123,7 @@ depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
+  "ocaml-option-llvm"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"

--- a/packages/ocaml-option-llvm/ocaml-option-llvm.1/opam
+++ b/packages/ocaml-option-llvm/ocaml-option-llvm.1/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+synopsis: "Set OCaml to use the LLVM toolchain"
+authors: "Sora Morimoto"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "CC0-1.0+"
+depends: [
+  "ocaml-variants" {post & >= "5.2.0~"}
+  "system-msvc" {os = "win32"}
+]
+conflicts: [
+  "ocaml-option-32bit"
+  "ocaml-option-musl"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-leak-sanitizer"
+]
+maintainer: "Sora Morimoto <sora@morimoto.io>"
+flags: compiler

--- a/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
+++ b/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
@@ -15,6 +15,7 @@ depends: [
 conflicts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
+  "ocaml-option-llvm"
   # See equivalent constraint in ocaml-option-bytecode-only
   # Windows is permitted to install 32-bit versions of ocaml-base-compiler on
   # 64-bit systems hence the (temporary) addition of the `os = "win32"` here,

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+msvc/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+msvc/opam
@@ -70,6 +70,7 @@ build: [
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
     "--without-zstd" {ocaml-option-no-compression:installed}
+    "CC=clang-cl" {ocaml-option-llvm:installed}
     "--disable-warn-error"
   ]
   [make "-j%{jobs}%"]
@@ -83,6 +84,7 @@ depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
+  "ocaml-option-llvm"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
   "ocaml-option-fp"


### PR DESCRIPTION
## Summary

- Add `ocaml-option-llvm` package as a pure marker following the established `ocaml-option-*` pattern
- On Windows it sets `CC=clang-cl` (with a `system-msvc` dependency), whilst on other platforms it sets `CC=clang` (switching from GCC to Clang)
- As upstream OCaml gains support for specifying alternative linkers and assemblers, this package can be extended incrementally to configure `lld-link`, `llvm-ar`, `llvm-mt`, `llvm-rc`, etc. on all platforms

## Changes

- **New package**: `ocaml-option-llvm.1` — pure marker with `flags: compiler`, depends on `system-msvc` on Windows only, conflicts with `ocaml-option-32bit`, `ocaml-option-musl`, `ocaml-option-address-sanitizer`, `ocaml-option-leak-sanitizer`
- **`ocaml-options-vanilla`**: add unconditional conflict with `ocaml-option-llvm`
- **`ocaml-variants.5.2.0+msvc`**: add `ocaml-option-llvm` as depopt with `CC=clang-cl` build arg
- **`ocaml-compiler.5.3.0` through `5.6`** (12 packages): add `ocaml-option-llvm` as depopt with `CC=clang-cl` on Windows / `CC=clang` elsewhere; add `!ocaml-option-llvm:installed` guard to the existing `CC=cc` line on macOS/OpenBSD

## Design

Follows the same pattern as `ocaml-option-musl` (`CC=musl-gcc`): a pure marker package that compiler packages reference via `depopts` and `{ocaml-option-llvm:installed}` guards in their build sections. No `setenv` is used — the CC override is scoped to the compiler's `./configure` invocation only.

### Conflict analysis

All existing `CC=` overrides in the build sections were checked for potential conflicts:

- `CC=cc` on macOS/OpenBSD — guarded with `!ocaml-option-llvm:installed` to prevent double `CC=`
- `CC=clang` for tsan on macOS — compatible (same value), no conflict needed
- `CC=musl-gcc`, `CC=gcc -m32`, sanitiser `CC=` lines — all incompatible, declared as conflicts on the option package

`ocaml-option-tsan` is intentionally **not** conflicted — tsan already uses `CC=clang` on macOS (same as llvm), and on Linux it does not set `CC` at all, so the combination works correctly.

Ref: https://github.com/ocaml/setup-ocaml/issues/1073