### PR TITLE
3 packages from ocurrent/ocaml-dockerfile at 8.3.5

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.8.3.5/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.3.5/opam
@@ -66,8 +66,8 @@ url {
   src:
     "https://github.com/ocurrent/ocaml-dockerfile/releases/download/8.3.5/ocaml-dockerfile-8.3.5.tbz"
   checksum: [
-    "md5=450e9158499c6c1027edc67e825d54f3"
-    "sha512=baa9df57c36ae6f621ea5e5326cb24e98ad19c35398c28665d46d72339d6db48cd6ea5637c8d3ff4835b304bacd12afdf8aff8fd6b5d7aae567344c5c73ebfdf"
+    "md5=679d33e7f56fedf52d1e58e95b64e7ec"
+    "sha512=36e4d0769f2a44d0ecfc1524710a2220e5504392078bacbc7c2d4b35686c53053ac4aa7d381dd401fef904d281105d76c3d8b3a01055bdd76d3abbe27c0cd040"
   ]
 }
 x-maintenance-intent: ["(latest)"]

--- a/packages/dockerfile-cmd/dockerfile-cmd.8.3.5/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.3.5/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- generation support"
+description: """\
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically."""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "astring"
+  "bos" {>= "0.2"}
+  "cmdliner"
+  "dockerfile-opam" {= version}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/8.3.5/ocaml-dockerfile-8.3.5.tbz"
+  checksum: [
+    "md5=450e9158499c6c1027edc67e825d54f3"
+    "sha512=baa9df57c36ae6f621ea5e5326cb24e98ad19c35398c28665d46d72339d6db48cd6ea5637c8d3ff4835b304bacd12afdf8aff8fd6b5d7aae567344c5c73ebfdf"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/dockerfile-opam/dockerfile-opam.8.3.5/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.8.3.5/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """\
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution support
+for generating dockerfiles."""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "dockerfile" {= version}
+  "fmt" {>= "0.8.7"}
+  "ocaml-version" {>= "3.5.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+  "alcotest" {>= "1.9.1" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/8.3.5/ocaml-dockerfile-8.3.5.tbz"
+  checksum: [
+    "md5=450e9158499c6c1027edc67e825d54f3"
+    "sha512=baa9df57c36ae6f621ea5e5326cb24e98ad19c35398c28665d46d72339d6db48cd6ea5637c8d3ff4835b304bacd12afdf8aff8fd6b5d7aae567344c5c73ebfdf"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/dockerfile-opam/dockerfile-opam.8.3.5/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.8.3.5/opam
@@ -35,7 +35,7 @@ depends: [
   "dune" {>= "3.20"}
   "dockerfile" {= version}
   "fmt" {>= "0.8.7"}
-  "ocaml-version" {>= "3.5.0"}
+  "ocaml-version" {>= "3.6.4"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib0"
   "alcotest" {>= "1.9.1" & with-test}
@@ -64,8 +64,8 @@ url {
   src:
     "https://github.com/ocurrent/ocaml-dockerfile/releases/download/8.3.5/ocaml-dockerfile-8.3.5.tbz"
   checksum: [
-    "md5=450e9158499c6c1027edc67e825d54f3"
-    "sha512=baa9df57c36ae6f621ea5e5326cb24e98ad19c35398c28665d46d72339d6db48cd6ea5637c8d3ff4835b304bacd12afdf8aff8fd6b5d7aae567344c5c73ebfdf"
+    "md5=679d33e7f56fedf52d1e58e95b64e7ec"
+    "sha512=36e4d0769f2a44d0ecfc1524710a2220e5504392078bacbc7c2d4b35686c53053ac4aa7d381dd401fef904d281105d76c3d8b3a01055bdd76d3abbe27c0cd040"
   ]
 }
 x-maintenance-intent: ["(latest)"]

--- a/packages/dockerfile/dockerfile.8.3.5/opam
+++ b/packages/dockerfile/dockerfile.8.3.5/opam
@@ -60,8 +60,8 @@ url {
   src:
     "https://github.com/ocurrent/ocaml-dockerfile/releases/download/8.3.5/ocaml-dockerfile-8.3.5.tbz"
   checksum: [
-    "md5=450e9158499c6c1027edc67e825d54f3"
-    "sha512=baa9df57c36ae6f621ea5e5326cb24e98ad19c35398c28665d46d72339d6db48cd6ea5637c8d3ff4835b304bacd12afdf8aff8fd6b5d7aae567344c5c73ebfdf"
+    "md5=679d33e7f56fedf52d1e58e95b64e7ec"
+    "sha512=36e4d0769f2a44d0ecfc1524710a2220e5504392078bacbc7c2d4b35686c53053ac4aa7d381dd401fef904d281105d76c3d8b3a01055bdd76d3abbe27c0cd040"
   ]
 }
 x-maintenance-intent: ["(latest)"]

--- a/packages/dockerfile/dockerfile.8.3.5/opam
+++ b/packages/dockerfile/dockerfile.8.3.5/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """\
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly."""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.08"}
+  "fmt" {>= "0.8.7"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+  "alcotest" {>= "1.9.1" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/8.3.5/ocaml-dockerfile-8.3.5.tbz"
+  checksum: [
+    "md5=450e9158499c6c1027edc67e825d54f3"
+    "sha512=baa9df57c36ae6f621ea5e5326cb24e98ad19c35398c28665d46d72339d6db48cd6ea5637c8d3ff4835b304bacd12afdf8aff8fd6b5d7aae567344c5c73ebfdf"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `dockerfile.8.3.5`: Dockerfile eDSL in OCaml
- `dockerfile-cmd.8.3.5`: Dockerfile eDSL -- generation support
- `dockerfile-opam.8.3.5`: Dockerfile eDSL -- opam support



---
* Homepage: https://github.com/ocurrent/ocaml-dockerfile
* Source repo: git+https://github.com/ocurrent/ocaml-dockerfile.git
* Bug tracker: https://github.com/ocurrent/ocaml-dockerfile/issues

---
:camel: Pull-request generated by opam-publish v2.5.1