### PR TITLE
conf-perl.3, conf-perl-{string-shellquote,ipc-system-simple}.4: Cygwin/MSYS2 support

### DIFF
--- a/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.4/opam
+++ b/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "chetsky@gmail.com"
+homepage: "https://www.perl.org/"
+bug-reports: "chesky@gmail.com"
+license: "GPL-1.0-or-later"
+authors: "Larry Wall et. al."
+depends: [
+  "conf-perl" {>= "3"}
+]
+build: [
+  ["perl" "--version"]
+  # Cygwin and MSYS2 have no system packages for this module, so install it
+  # directly via the CPAN client bundled with perl. The -I flag loads the
+  # switch-local MyConfig.pm created by conf-perl (>= 3), which sets the
+  # correct make path and skips CPAN auto-configuration. PERL5LIB is
+  # propagated from conf-perl via setenv.
+  ["perl" "-I" "%{conf-perl:cpan_config_dir}%" "-MCPAN" "-e" "CPAN::Shell->notest('install', 'IPC::System::Simple')"]
+    { os-distribution = "cygwin" | os-distribution = "msys2" }
+  ["perl" "-MIPC::System::Simple" "-e" "1"] { os-distribution != "homebrew" }
+]
+depexts: [
+  ["libipc-system-simple-perl"] {os-family = "debian"}
+  ["libipc-system-simple-perl"] {os-family = "ubuntu"}
+  ["perl-ipc-system-simple"] {os-distribution = "alpine"}
+  ["epel-release" "perl-IPC-System-Simple"] {os-distribution = "centos"}
+  ["perl-IPC-System-Simple"] {os-distribution = "ol" & os-version >= "8"}
+  ["perl-IPC-System-Simple"] {os-family = "suse" | os-family = "opensuse"}
+  ["perl-IPC-System-Simple"] {os-family = "fedora"}
+  ["perl-ipc-system-simple"] {os-family = "arch"}
+  ["p5-ipc-system-simple"] {os-distribution = "macports" & os = "macos"}
+  ["p5-IPC-System-Simple"] {os = "freebsd"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-7"
+]
+synopsis: "Virtual package relying on perl's IPC::System::Simple"
+description:
+  "This package can only install if the specified perl packages are on the system."
+flags: conf

--- a/packages/conf-perl-string-shellquote/conf-perl-string-shellquote.4/opam
+++ b/packages/conf-perl-string-shellquote/conf-perl-string-shellquote.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "chetsky@gmail.com"
+homepage: "https://www.perl.org/"
+bug-reports: "chesky@gmail.com"
+license: "GPL-1.0-or-later"
+authors: "Larry Wall et. al."
+depends: [
+  "conf-perl" {>= "3"}
+]
+build: [
+  ["perl" "--version"]
+  # Cygwin and MSYS2 have no system packages for this module, so install it
+  # directly via the CPAN client bundled with perl. The -I flag loads the
+  # switch-local MyConfig.pm created by conf-perl (>= 3), which sets the
+  # correct make path and skips CPAN auto-configuration. PERL5LIB is
+  # propagated from conf-perl via setenv.
+  ["perl" "-I" "%{conf-perl:cpan_config_dir}%" "-MCPAN" "-e" "CPAN::Shell->notest('install', 'String::ShellQuote')"]
+    { os-distribution = "cygwin" | os-distribution = "msys2" }
+  ["perl" "-MString::ShellQuote" "-e" "1"] { os-distribution != "homebrew" }
+]
+depexts: [
+  ["libstring-shellquote-perl"] {os-family = "debian"}
+  ["libstring-shellquote-perl"] {os-family = "ubuntu"}
+  ["perl-string-shellquote"] {os-distribution = "alpine"}
+  ["perl-String-ShellQuote"] {os-distribution = "centos"}
+  ["perl-String-ShellQuote"] {os-distribution = "ol"}
+  ["perl-String-ShellQuote"] {os-family = "suse" | os-family = "opensuse"}
+  ["perl-String-ShellQuote"] {os-family = "fedora"}
+  ["perl-string-shellquote"] {os-family = "arch"}
+  ["p5-string-shellquote"] {os-distribution = "macports" & os = "macos"}
+  ["p5-String-ShellQuote"] {os = "freebsd"}
+]
+synopsis: "Virtual package relying on perl's String::ShellQuote"
+description:
+  "This package can only install if the specified perl packages are on the system."
+flags: conf

--- a/packages/conf-perl/conf-perl.3/opam
+++ b/packages/conf-perl/conf-perl.3/opam
@@ -22,7 +22,7 @@ build: [
   ["perl" "-e" "
     use File::Path qw(make_path);
     my $switch = '%{prefix}%';
-    $switch =~ s{\\\\}{/}g;
+    $switch =~ s{\\\\\\\\}{/}g;
     my $cpan_dir = qq{$switch/cpan-config};
     make_path(qq{$cpan_dir/CPAN});
     open my $fh, '>', qq{$cpan_dir/CPAN/MyConfig.pm} or die $!;

--- a/packages/conf-perl/conf-perl.3/opam
+++ b/packages/conf-perl/conf-perl.3/opam
@@ -22,6 +22,7 @@ build: [
   ["perl" "-e" "
     use File::Path qw(make_path);
     my $switch = '%{prefix}%';
+    $switch =~ s{\\\\}{/}g;
     my $cpan_dir = qq{$switch/cpan-config};
     make_path(qq{$cpan_dir/CPAN});
     open my $fh, '>', qq{$cpan_dir/CPAN/MyConfig.pm} or die $!;

--- a/packages/conf-perl/conf-perl.3/opam
+++ b/packages/conf-perl/conf-perl.3/opam
@@ -1,0 +1,90 @@
+opam-version: "2.0"
+maintainer: "tim@gfxmonk.net"
+homepage: "https://www.perl.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+authors: "Larry Wall"
+build-env: [
+  [SHELL = "/bin/sh"]
+  [PERL_MM_USE_DEFAULT = "1"]
+]
+build: [
+  ["perl" "--version"]
+  # On Cygwin/MSYS2, create a self-contained CPAN configuration inside
+  # the opam switch and export paths via .config so that dependent
+  # conf-perl-* packages can install and find modules.
+  #
+  # The MyConfig.pm includes all mandatory CPAN keys to skip
+  # auto-configuration, sets make to /usr/bin/make (avoiding the mingw
+  # make on MSYS2 which cannot handle POSIX paths), and sets shell to
+  # /bin/sh to work around a fileparse() crash in CPAN::FirstTime
+  # (RT #131313).
+  ["perl" "-e" "
+    use File::Path qw(make_path);
+    my $switch = '%{prefix}%';
+    my $cpan_dir = qq{$switch/cpan-config};
+    make_path(qq{$cpan_dir/CPAN});
+    open my $fh, '>', qq{$cpan_dir/CPAN/MyConfig.pm} or die $!;
+    print $fh qq{\\$CPAN::Config = {
+      'auto_commit' => '0',
+      'build_cache' => '10',
+      'build_dir' => \"\\$ENV{HOME}/.cpan/build\",
+      'cache_metadata' => '1',
+      'cpan_home' => \"\\$ENV{HOME}/.cpan\",
+      'ftp_proxy' => '',
+      'http_proxy' => '',
+      'index_expire' => '1',
+      'keep_source_where' => \"\\$ENV{HOME}/.cpan/sources\",
+      'make' => '/usr/bin/make',
+      'make_arg' => '',
+      'make_install_arg' => '',
+      'make_install_make_command' => '/usr/bin/make',
+      'makepl_arg' => '',
+      'mbuild_arg' => '',
+      'mbuild_install_arg' => '',
+      'mbuild_install_build_command' => './Build',
+      'mbuildpl_arg' => '',
+      'no_proxy' => '',
+      'prerequisites_policy' => 'follow',
+      'pushy_https' => '1',
+      'scan_cache' => 'atstart',
+      'shell' => '/bin/sh',
+      'urllist' => ['https://www.cpan.org/'],
+    };
+    1;
+    };
+    close $fh;
+    my $perl5lib = qq{$ENV{HOME}/perl5/lib/perl5};
+    open my $cfg, '>', 'conf-perl.config' or die $!;
+    print $cfg qq{opam-version: \"2.0\"
+    variables {
+      perl5lib: \"$perl5lib\"
+      cpan_config_dir: \"$cpan_dir\"
+    }
+    };
+    close $cfg;
+  "] { os-distribution = "cygwin" | os-distribution = "msys2" }
+]
+setenv: [
+  [SHELL = "/bin/sh"]
+  [PERL_MM_USE_DEFAULT = "1"]
+  [PERL5LIB += "%{_:perl5lib}%"]
+]
+depexts: [
+  ["perl"] {os-family = "debian"}
+  ["perl"] {os-family = "ubuntu"}
+  ["perl"] {os-distribution = "alpine"}
+  ["perl"] {os-distribution = "nixos"}
+  ["perl"] {os-distribution = "arch"}
+  ["perl-Pod-Html"] {os-family = "fedora"}
+  ["perl-Pod-Html"] {os-distribution = "centos" & os-version >= "8"}
+  ["perl5"] {os-distribution = "macports" & os = "macos"}
+  ["perl5"] {os = "freebsd"}
+  ["perl"] {os-distribution = "cygwin"}
+  # MSYS2 needs perl-devel for Config.pm (required by ExtUtils::MakeMaker).
+  ["perl" "perl-devel"] {os-distribution = "msys2"}
+]
+synopsis: "Virtual package relying on perl"
+description:
+  "This package can only install if the perl program is installed on the system."
+flags: conf


### PR DESCRIPTION
## Summary

Add Cygwin and MSYS2 support for conf-perl-* packages. These Perl modules have no corresponding system packages in either Cygwin or MSYS2 package repositories, so `depexts` alone cannot satisfy the dependency.

### Changes

**conf-perl.3** (new version):
- Creates a self-contained CPAN configuration (`MyConfig.pm`) inside the opam switch, avoiding conflicts with any existing user CPAN configuration
- Uses `%{prefix}%` to locate the switch directory and normalizes backslashes to forward slashes for Windows compatibility (opam → Cygwin command-line → Perl requires triple-layer escaping)
- Exports `perl5lib` and `cpan_config_dir` via `.config` file so dependent packages can find installed modules and use the switch-local CPAN config
- Sets `SHELL`, `PERL_MM_USE_DEFAULT`, and `PERL5LIB` via `setenv` for dependent packages
- On MSYS2, the `MyConfig.pm` sets `make` to `/usr/bin/make` to avoid the mingw make (`/mingw64/bin/make.EXE`) which cannot handle POSIX paths
- On MSYS2, adds `perl-devel` to `depexts` (provides `Config.pm` required by `ExtUtils::MakeMaker`)

**conf-perl-{string-shellquote,ipc-system-simple}.4** (new versions):
- Depend on `conf-perl >= 3`
- On Cygwin/MSYS2, install the required Perl module via `perl -I <cpan_config_dir> -MCPAN` using the switch-local CPAN configuration
- `SHELL`, `PERL_MM_USE_DEFAULT`, and `PERL5LIB` are propagated from `conf-perl` via `setenv`
- Verify the module is available via `perl -MModule -e 1`

### Background

Since setup-ocaml v3.5.0, opam uses `--cygwin-internal-install` which manages its own internal Cygwin. This means opam uses the internal Cygwin perl for `conf-perl-*` verification. The corresponding Cygwin/MSYS2 system packages for these Perl modules (`perl-String-ShellQuote`, etc.) do not exist in the Cygwin or MSYS2 package repositories, so `depexts` cannot resolve them.

The fix installs modules via the CPAN client bundled with perl, with platform-specific handling:
- **Cygwin**: `SHELL=/bin/sh` must be set to work around a `fileparse()` crash in `CPAN::FirstTime` (RT #131313)
- **MSYS2**: Additionally requires a custom `MyConfig.pm` that points `make` to `/usr/bin/make` (the MSYS2 POSIX make), because opam's PATH ordering places `/mingw64/bin/make.EXE` (mingw make) first, which cannot handle POSIX paths

### Windows path handling

On Windows, `%{prefix}%` returns a path with backslashes (e.g. `D:\a\opam-repository\opam-repository\_opam`). Since opam's `.config` file parser treats `\` as an escape character, the generated `conf-perl.config` must use forward slashes. The Perl script normalizes backslashes via `s{\\}{/}g`, but this requires 8 backslashes (`\\\\\\\\`) in the opam file to survive three escaping layers: opam string unescaping, Cygwin command-line processing, and Perl regex parsing.

Also requires setup-ocaml v3.6.0+ which installs the opam base packages (`make`, `tar`, `unzip`, `rsync`) on MSYS2 (ocaml/setup-ocaml#1096).

ref: ocaml/setup-ocaml#1094