### PR TITLE
Add wadi.0.1.0

### DIFF
--- a/packages/wadi/wadi.0.1.0/opam
+++ b/packages/wadi/wadi.0.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Dune-free OCaml workspace toolbox"
+description: """
+Wadi is a Dune-free OCaml workspace tool with cohesive subtools for build,
+test, run, bench, migration, install, diagnostics, and bootstrap workflows.
+"""
+maintainer: ["Jef Newsom"]
+authors: ["Jef Newsom"]
+homepage: "https://github.com/improvingjef/wadi"
+bug-reports: "https://github.com/improvingjef/wadi/issues"
+dev-repo: "git+https://github.com/improvingjef/wadi.git"
+license: "MIT"
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "ocamlfind"
+]
+build: [
+  [make]
+]
+install: [
+  [
+    "./scripts/install_release_tree.sh"
+    "--package-root" "package"
+    "--binary" "_bootstrap/bin/wadi"
+    "--prefix" prefix
+  ]
+]
+url {
+  src: "https://github.com/improvingjef/wadi/releases/download/v0.1.0/wadi-0.1.0-source.tar.gz"
+  checksum: "sha256=75ee9643977cbc430115c5a617d432ffd9aa2629fea56532671d85608c76244a"
+}


### PR DESCRIPTION
## wadi.0.1.0

Wadi is a Dune-free OCaml workspace toolbox — a build system designed around a single `wadi.toml` manifest with content-based incremental builds.

**Homepage:** https://github.com/improvingjef/wadi
**License:** MIT
**Dependencies:** ocaml (>= 5.0.0), ocamlfind

### Features
- Single manifest file replaces dune's multi-file configuration
- Content-based incremental builds with fingerprinting
- 31 commands: build, run, test, explain, install, migrate, watch, format, lint, and more
- Library namespace wrapping for dune compatibility
- `wadi migrate` generates wadi.toml from existing dune projects