### PR TITLE
[new release] server-reason-react (0.5.0)

### DIFF
--- a/packages/server-reason-react/server-reason-react.0.5.0/opam
+++ b/packages/server-reason-react/server-reason-react.0.5.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Rendering React components on the server natively"
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/server-reason-react"
+bug-reports: "https://github.com/ml-in-barcelona/server-reason-react/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "4.14.1"}
+  "reason" {>= "3.17.2"}
+  "melange" {>= "3.0.0" & (< "7.0.0" | >= "7.0.1")}
+  "uucp" {>= "16.0.0"}
+  "ppxlib" {>= "0.36.0"}
+  "quickjs" {>= "0.5.0" & < "0.6.0"}
+  "lwt" {>= "5.9.2"}
+  "lwt_ppx" {>= "2.1.0"}
+  "uri" {>= "4.2.0"}
+  "yojson" {>= "2.2.0"}
+  "integers" {>= "0.7.0"}
+  "zarith" {>= "1.14"}
+  "uutf" {>= "1.0.3"}
+  "melange-fetch" {>= "0.2.0"}
+  "melange-json" {>= "2.0.0"}
+  "melange-json-native" {>= "2.0.0"}
+  "melange-webapi" {>= "0.21.0"}
+  "reason-react" {>= "0.16.0"}
+  "odoc" {with-doc}
+  "ocamlformat" {= "0.28.1" & with-test}
+  "ocaml-lsp-server" {with-dev-setup}
+  "dream" {= "1.0.0~alpha8" & with-dev-setup}
+  "reason-react-ppx" {with-dev-setup}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "fmt" {with-test}
+  "merlin" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ml-in-barcelona/server-reason-react.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ml-in-barcelona/server-reason-react/releases/download/0.5.0/server-reason-react-0.5.0.tbz"
+  checksum: [
+    "sha256=fd0fdcb8480e07f82a06b7fbce1819c629b76568e0db9c1de3a6a25940c9192b"
+    "sha512=a20a0787252387451bf4c4ee723e82aac9b62356993f1440c6ca1c6f9123bd1fa9391f744dcc5742da69cacfe354a5349dee1f0e876b9c73bddac5b6191225fe"
+  ]
+}
+x-commit-hash: "902ca32f00708a9cf0657e8d90675800bef0218e"

--- a/packages/server-reason-react/server-reason-react.0.5.0/opam
+++ b/packages/server-reason-react/server-reason-react.0.5.0/opam
@@ -26,6 +26,7 @@ depends: [
   "melange-webapi" {>= "0.21.0"}
   "reason-react" {>= "0.16.0"}
   "odoc" {with-doc}
+  "conf-npm" {with-test}
   "ocamlformat" {= "0.28.1" & with-test}
   "ocaml-lsp-server" {with-dev-setup}
   "dream" {= "1.0.0~alpha8" & with-dev-setup}


### PR DESCRIPTION
Rendering React components on the server natively

- Project page: <a href="https://github.com/ml-in-barcelona/server-reason-react">https://github.com/ml-in-barcelona/server-reason-react</a>

##### CHANGES:

* Add runtime error with clear message when `React.cloneElement` is used with uppercase components by @davesnx
* Allow `[@platform js]` and `[@browser_only]` on externals to conditionally exclude them from native builds. Fixes https://github.com/ml-in-barcelona/server-reason-react/issues/170 by @davesnx
* Generate `makeProps` in the PPX by @davesnx in https://github.com/ml-in-barcelona/server-reason-react/pull/364
* Implement `Js.t` natively with `Js.Internal` and a type registry by @davesnx in https://github.com/ml-in-barcelona/server-reason-react/pull/363
* Add `React.useActionState` by @davesnx
* Add `key` into client components by @davesnx
* Fix several functions in Belt to match specification (`Belt.Array.setExn`, `Belt.Array.concat`, `Belt.MutableMap.remove`, `Belt.HashMap.keepMapInPlace`, and avoid double callback evaluation) by @yasunariw in https://github.com/ml-in-barcelona/server-reason-react/pull/362
* Implement `Belt.Array.getUndefined` and annotate `Belt.Array.push` as not implemented by @davesnx
* Remove deprecated folder from Belt and reorganise Belt tests by @davesnx
* Fix leaking `was_previous` when node was closing by @davesnx in https://github.com/ml-in-barcelona/server-reason-react/pull/361
* Fix `React.cloneElement` on `Static {}` components by @davesnx in https://github.com/ml-in-barcelona/server-reason-react/pull/359
* Require ppxlib >= 0.36 by @davesnx
