### PR TITLE
Packages bin_there.0.1.12 and ppx_bin_there.0.1.12

### DIFF
--- a/packages/bin_there/bin_there.0.1.12/opam
+++ b/packages/bin_there/bin_there.0.1.12/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Serialization/deserialization with support for shared values"
+description: """\
+bin_there provides a binary serialization and deserialization library for OCaml
+with first-class support for shared values (graph-shaped data)."""
+maintainer: "David 'Yoric' Teller yteller@gitlab.com"
+authors: "David 'Yoric' Teller yteller@gitlab.com"
+license: "MIT"
+homepage: "https://gitlab.com/yteller/binthere"
+bug-reports: "https://gitlab.com/yteller/binthere/-/work_items"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0"}
+  "alcotest" {with-test}
+  "base-threads" {with-test}
+  "qcheck-alcotest" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/yteller/binthere.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/81089450/packages/generic/bin_there/0.1.12/bin_there-0.1.12.tar.gz"
+  checksum: [
+    "md5=9f1dea3be08ce5cf113a3e0ab1ed035b"
+    "sha512=2e8feeba64f1f839c7d625474fcd6e21a31f6f5f68996a84b019725f1a13f4e121d8e5526e9b6e1c87b2196b8b6a0e6afdf89b587d1171ecdfd4eef20bfe2db5"
+  ]
+}

--- a/packages/ppx_bin_there/ppx_bin_there.0.1.12/opam
+++ b/packages/ppx_bin_there/ppx_bin_there.0.1.12/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis:
+  "PPX rewriter to derive bin_there serializers from type definitions"
+description: """\
+ppx_bin_there is a PPX rewriter that automatically derives write_* and read_*
+functions compatible with the bin_there library from OCaml type definitions,
+using [@@deriving bin_there]."""
+maintainer: "David 'Yoric' Teller yteller@gitlab.com"
+authors: "David 'Yoric' Teller yteller@gitlab.com"
+license: "MIT"
+homepage: "https://gitlab.com/yteller/binthere"
+bug-reports: "https://gitlab.com/yteller/binthere/-/work_items"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0"}
+  "ppxlib" {>= "0.28.0"}
+  "bin_there"
+  "alcotest" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/yteller/binthere.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/81089450/packages/generic/ppx_bin_there/0.1.12/ppx_bin_there-0.1.12.tar.gz"
+  checksum: [
+    "md5=d6f83d3defcbe94c64ce26b9c017bf74"
+    "sha512=808113083c9698b2d7137301b13e6b62b3e24e7fbecc9eb43fd540a3ac04cf514fdaf4d270db0afe474e310b78a402837da57cef565e83d2190f5d769dcbf568"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `bin_there.0.1.12`: Serialization/deserialization with support for shared values
- `ppx_bin_there.0.1.12`: PPX rewriter to derive bin_there serializers from type definitions



---
* Homepage: https://gitlab.com/yteller/binthere
* Source repo: git+https://gitlab.com/yteller/binthere.git
* Bug tracker: https://gitlab.com/yteller/binthere/-/work_items

---
:camel: Pull-request generated by opam-publish v3.0.0