### PR TITLE
[new release] runtime_events_tools (2 packages) (0.5.4)

### DIFF
--- a/packages/runtime_events_tools/runtime_events_tools.0.5.4/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.5.4/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Tools for the runtime events tracing system in OCaml"
+description: "Various tools for the runtime events tracing system in OCaml"
+maintainer: ["Sadiq Jaffer" "KC Sivaramakrishnan" "Sudha Parimala"]
+authors: ["Sadiq Jaffer"]
+license: "ISC"
+homepage: "https://github.com/tarides/runtime_events_tools"
+bug-reports: "https://github.com/tarides/runtime_events_tools/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.0.0~"}
+  "hdr_histogram"
+  "cmdliner" {>= "2.0.0"}
+  "trace-fuchsia" {>= "0.11"}
+  "trace" {>= "0.11"}
+  "menhir" {with-test}
+  "ocamlformat" {with-dev-setup & = "0.28.1"}
+  "alcotest" {with-test & >= "1.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/runtime_events_tools.git"
+x-maintenance-intent: ["(latest)"]
+available: os != "win32"
+url {
+  src:
+    "https://github.com/tarides/runtime_events_tools/releases/download/0.5.4/runtime_events_tools-0.5.4.tbz"
+  checksum: [
+    "sha256=1c4692699be627242c20850048138e1389f0a8828f968aa5ee82cbc38811a320"
+    "sha512=fc3225d0d0a3c21369589c6420495c8ac1323b83ab904a6a6102c679da00190f6f6c6c4348372a6e701c27eaa022bb7785d0091dbf94fc0fa5ad1b85b010c9fb"
+  ]
+}
+x-commit-hash: "9e4b7016c6533b0eea76b8ce9b9bb7af41ded8a1"

--- a/packages/runtime_events_tools_bare/runtime_events_tools_bare.0.5.4/opam
+++ b/packages/runtime_events_tools_bare/runtime_events_tools_bare.0.5.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Tools for the runtime events tracing system in OCaml"
+description:
+  "Various tools for the runtime events tracing system in OCaml: minimal dependencies"
+maintainer: ["Sadiq Jaffer" "KC Sivaramakrishnan" "Sudha Parimala"]
+authors: ["Sadiq Jaffer"]
+license: "ISC"
+homepage: "https://github.com/tarides/runtime_events_tools"
+bug-reports: "https://github.com/tarides/runtime_events_tools/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "5.0.0~"}
+  "cmdliner" {>= "2.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/runtime_events_tools.git"
+x-maintenance-intent: ["(latest)"]
+available: os != "win32"
+url {
+  src:
+    "https://github.com/tarides/runtime_events_tools/releases/download/0.5.4/runtime_events_tools-0.5.4.tbz"
+  checksum: [
+    "sha256=1c4692699be627242c20850048138e1389f0a8828f968aa5ee82cbc38811a320"
+    "sha512=fc3225d0d0a3c21369589c6420495c8ac1323b83ab904a6a6102c679da00190f6f6c6c4348372a6e701c27eaa022bb7785d0091dbf94fc0fa5ad1b85b010c9fb"
+  ]
+}
+x-commit-hash: "9e4b7016c6533b0eea76b8ce9b9bb7af41ded8a1"


### PR DESCRIPTION
Tools for the runtime events tracing system in OCaml

- Project page: <a href="https://github.com/tarides/runtime_events_tools">https://github.com/tarides/runtime_events_tools</a>

##### CHANGES:

* Reinstate olly latency command. (tarides/runtime_events_tools#86, @tmcgilchrist)
* Avoid overriding the user's OCAMLRUNPARAM settings. (tarides/runtime_events_tools#83, @gasche)
* Remove help subcommand, as it relies on cmdliner internals. (tarides/runtime_events_tools#81, @theAlexes)
* Fix cmdliner 2.0 compatibility. (tarides/runtime_events_tools#80, @krfantasy)
* Log path when create_cursor raises an exception. (tarides/runtime_events_tools#66, @tmcgilchrist)
* Add option to specify runtime events dir and log size. (tarides/runtime_events_tools#66, @tmcgilchrist)
