### PR TITLE
[new release] sm (0.1.1)

### DIFF
--- a/packages/sm/sm.0.1.1/opam
+++ b/packages/sm/sm.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Pure OCaml Chinese National Cryptographic Algorithm Library (SM2/SM3/SM4/ZUC)"
+description:
+  "Pure OCaml Chinese National Cryptographic Algorithm Library, supporting SM2 (key derivation, signature generation and verification, encryption and decryption, key exchange, DER/PEM/ASN.1 encoding/decoding), SM3 (digest), SM4 (single-block, CBC, CTR, GCM, streaming context), and ZUC-128 (keystream generation and stream encryption/decryption)."
+maintainer: ["days_v <days_v@qq.com>"]
+authors: ["days_v"]
+license: "MIT"
+homepage: "https://github.com/daysv/ocaml-sm"
+bug-reports: "https://github.com/daysv/ocaml-sm/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.14.2"}
+  "alcotest" {with-test & < "1.8.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/daysv/ocaml-sm.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/daysv/ocaml-sm/releases/download/0.1.1/sm-0.1.1.tbz"
+  checksum: [
+    "sha256=4d85071a2448f91c7d6d792c1563ca2690c20e22ba188ed7bd20356e4ba684dc"
+    "sha512=0e2bbcaaeeab12a9af1287ff4ae3e0197eb6f2eafdcc337d8baf9feefca0b1575fbc043517033b22b78918d214e9ae613c2db033fd51c97a5ca5a8d28cd2198c"
+  ]
+}
+x-commit-hash: "360fc6315694359f8f2eff4df62cb426b5d26f88"

--- a/packages/sm/sm.0.1.1/opam
+++ b/packages/sm/sm.0.1.1/opam
@@ -28,6 +28,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: arch != "arm32" & arch != "x86_32"
 dev-repo: "git+https://github.com/daysv/ocaml-sm.git"
 x-maintenance-intent: ["(latest)"]
 url {


### PR DESCRIPTION
Pure OCaml Chinese National Cryptographic Algorithm Library (SM2/SM3/SM4/ZUC)

- Project page: <a href="https://github.com/daysv/ocaml-sm">https://github.com/daysv/ocaml-sm</a>

##### CHANGES:

* SM2: Performance optimization and feature enhancements
  - Refactor U256 type to use int array for better performance (46ef62a)
  - Optimize U256 multiplication and arithmetic operations (83bef73)
  - Add double_mod function and Jacobian coordinates for scalar multiplication (dadc0e6, 2c3d584)
  - Implement SM2 public key verification (eda9043)

* SM3: Performance optimization and refactoring
  - Refactor state structure with w and w1 arrays for improved compression (dd6d2f9)
  - Optimize rotation functions and compression logic (3234313, 685c912)
  - Eliminate unnecessary array resets and restructure loops (04b5eaf)
  - Streamline initialization and update functions (6f146e8)

* SM4: Performance optimization
  - Implement precomputed T-tables for encryption (036dd65, 0cb2c9c)
  - Use unsafe array access and inline annotations for performance (f02b876)

* ZUC: Code consistency improvements
  - Optimize add31 and sbox_word functions to use Int32

* Additional changes
  - Add more test cases for SM3, SM4 and ZUC algorithms (fd3cb59)
  - Implement SM3 HMAC and KDF (eda9043)
  - Add benchmark module for SM3/SM4/SM2 performance testing (ab31bb3)
  - Update CI workflow for 32-bit system compatibility (d9fea9f)
  - Update documentation and version to 0.1.1 (62bacdb, f34acc1)
