### PR TITLE
Fix piqi build failures

### DIFF
--- a/packages/piqilib/piqilib.0.6.14/opam
+++ b/packages/piqilib/piqilib.0.6.14/opam
@@ -30,6 +30,7 @@ depends: [
   "ulex"
   "xmlm"
   "base64" {>= "2.0.0" & < "3.0.0"}
+  "conf-which"
 ]
 dev-repo: "git+https://github.com/alavrik/piqi"
 url {

--- a/packages/piqilib/piqilib.0.6.16/opam
+++ b/packages/piqilib/piqilib.0.6.16/opam
@@ -13,6 +13,7 @@ depends: [
   "sedlex" {>= "2.0" & < "3.0"}
   "xmlm"
   "base64" {>= "3.1.0"}
+  "conf-which"
 ]
 dev-repo: "git+https://github.com/alavrik/piqi"
 build: [


### PR DESCRIPTION
I've seen piqi fail with this error:

```
       > piqi_c_impl.c: In function 'camlidl_piqi_c_piqi_strtoull':
       > piqi_c_impl.c:84:7: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
       >    84 |   str = String_val(_v_str);
       >       |       ^
       > piqi_c_impl.c:86:11: error: implicit declaration of function 'copy_int64'; did you mean 'caml_copy_int64'? [-Wimplicit-function-declaration]
       >    86 |   _vres = copy_int64(_res);
       >       |           ^~~~~~~~~~
       >       |           caml_copy_int64
```

But apparently that's from piqi version 0.6.16 (which isn't on opam-repository), so this PR is an attempt to see if and which piqi version actually build. Hence a draft for now until the CI gives me some insight on what can be built and where.