### PR TITLE
[new release] nats-client (2 packages) (0.0.3)

### DIFF
--- a/packages/nats-client-async/nats-client-async.0.0.3/opam
+++ b/packages/nats-client-async/nats-client-async.0.0.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Lean OCaml Async NATS client"
+description: "Async-based OCaml NATS client"
+maintainer: ["Hebilicious"]
+authors: ["Hebilicious"]
+license: "MIT"
+homepage: "https://github.com/hebilicious/nats-ml"
+bug-reports: "https://github.com/hebilicious/nats-ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.19"}
+  "core"
+  "async"
+  "async_unix"
+  "uri"
+  "yojson" {>= "2.0.0"}
+  "nats-client"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/hebilicious/nats-ml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/hebilicious/nats-ml/releases/download/v0.0.3/nats-client-0.0.3.tbz"
+  checksum: [
+    "sha256=14172f498704b5b25b84335c9c5315feb849d058d387a6d1f59c43ef4e956656"
+    "sha512=06a1f0de49fad1abd18179d8acda625bbaa6b15cdd6f0dfca51f4aed9dd95d0fb5d58b2a9c73ba7b75fb94a0b4b927defc3b6e3a9f6711662c4f2cd7c3a762a8"
+  ]
+}
+x-commit-hash: "32186465f8e2d1b508ee50be435f032af28eef3e"

--- a/packages/nats-client/nats-client.0.0.3/opam
+++ b/packages/nats-client/nats-client.0.0.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Lean OCaml NATS protocol client"
+description: "Runtime-independent OCaml NATS protocol primitives"
+maintainer: ["Hebilicious"]
+authors: ["Hebilicious"]
+license: "MIT"
+homepage: "https://github.com/hebilicious/nats-ml"
+bug-reports: "https://github.com/hebilicious/nats-ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.19"}
+  "yojson"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/hebilicious/nats-ml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/hebilicious/nats-ml/releases/download/v0.0.3/nats-client-0.0.3.tbz"
+  checksum: [
+    "sha256=14172f498704b5b25b84335c9c5315feb849d058d387a6d1f59c43ef4e956656"
+    "sha512=06a1f0de49fad1abd18179d8acda625bbaa6b15cdd6f0dfca51f4aed9dd95d0fb5d58b2a9c73ba7b75fb94a0b4b927defc3b6e3a9f6711662c4f2cd7c3a762a8"
+  ]
+}
+x-commit-hash: "32186465f8e2d1b508ee50be435f032af28eef3e"


### PR DESCRIPTION
Lean OCaml NATS protocol client

- Project page: <a href="https://github.com/hebilicious/nats-ml">https://github.com/hebilicious/nats-ml</a>

##### CHANGES:


- Publish only hermetic package tests and keep the TCP-listener async coverage in repo-only integration tests.
- Mirror the failing opam-repository lower-bounds and package install checks in CI before the next release is cut.
- Require `yojson >= 2.0.0` for `nats-client-async`.
