### PR TITLE
[new release] nats-client (2 packages) (0.0.4)

### DIFF
--- a/packages/nats-client-async/nats-client-async.0.0.4/opam
+++ b/packages/nats-client-async/nats-client-async.0.0.4/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Lean OCaml Async NATS client"
+description: "Async-based OCaml NATS client"
+maintainer: ["Hebilicious"]
+authors: ["Hebilicious"]
+license: "MIT"
+homepage: "https://github.com/hebilicious/nats-ml"
+bug-reports: "https://github.com/hebilicious/nats-ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.19"}
+  "core"
+  "async"
+  "async_unix"
+  "uri"
+  "yojson" {>= "2.0.0"}
+  "nats-client"
+  "alcotest"
+    {with-test & opam-version >= "2.1" & (arch = "x86_64" | arch = "arm64")}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/hebilicious/nats-ml.git"
+x-maintenance-intent: ["(latest)"]
+available: [ os-distribution != "alpine" & arch != "riscv64" ]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & opam-version >= "2.1" & (arch = "x86_64" | arch = "arm64")}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/hebilicious/nats-ml/releases/download/v0.0.4/nats-client-0.0.4.tbz"
+  checksum: [
+    "sha256=b0ff0a86fbf9b5263d7c23fa47373ac7b7c2fa0cb827c5d8b751639546abb0fa"
+    "sha512=edf64ff39581359f650e0a71260bcac062dd91a0e04a332ad20e989fb237fe0563520047992f5577ebc5661397e20ffd85a40ce81ec3907e0d460e99d7bbf768"
+  ]
+}
+x-commit-hash: "531a49e84f526bd349a2f4259dfed10059e89648"

--- a/packages/nats-client/nats-client.0.0.4/opam
+++ b/packages/nats-client/nats-client.0.0.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Lean OCaml NATS protocol client"
+description: "Runtime-independent OCaml NATS protocol primitives"
+maintainer: ["Hebilicious"]
+authors: ["Hebilicious"]
+license: "MIT"
+homepage: "https://github.com/hebilicious/nats-ml"
+bug-reports: "https://github.com/hebilicious/nats-ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.19"}
+  "yojson"
+  "alcotest" {with-test & opam-version >= "2.1"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/hebilicious/nats-ml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & opam-version >= "2.1"}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/hebilicious/nats-ml/releases/download/v0.0.4/nats-client-0.0.4.tbz"
+  checksum: [
+    "sha256=b0ff0a86fbf9b5263d7c23fa47373ac7b7c2fa0cb827c5d8b751639546abb0fa"
+    "sha512=edf64ff39581359f650e0a71260bcac062dd91a0e04a332ad20e989fb237fe0563520047992f5577ebc5661397e20ffd85a40ce81ec3907e0d460e99d7bbf768"
+  ]
+}
+x-commit-hash: "531a49e84f526bd349a2f4259dfed10059e89648"


### PR DESCRIPTION
Lean OCaml NATS protocol client

- Project page: <a href="https://github.com/hebilicious/nats-ml">https://github.com/hebilicious/nats-ml</a>

##### CHANGES:


- Skip published `nats-client-async` builds on Alpine and riscv64, where upstream `core_unix` fails under opam-ci.
- Run published package tests only on opam and architectures that match the opam-ci matrix we support.
- Split fast validation from slower opam reproduction, cache the slow opam roots between reruns, and mirror the remaining opam-ci platform failures and pending cross-arch checks in the slower workflow.
