### PR TITLE
[new release] textmate-language (0.6.0)

### DIFF
--- a/packages/textmate-language/textmate-language.0.6.0/opam
+++ b/packages/textmate-language/textmate-language.0.6.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Tokenizing code with TextMate grammars for syntax highlighting"
+description: """
+
+This package provides functions for reading TextMate grammars and tokenizing
+code on a line-by-line basis. `textmate-language` can read grammars from the
+document types of the `plist-xml`, `ezjsonm`, and `yojson` libraries."""
+maintainer: ["Alan Hu <alanh@ccs.neu.edu>"]
+authors: ["Alan Hu <alanh@ccs.neu.edu>"]
+license: "MIT"
+tags: ["highlighting"]
+homepage: "https://github.com/alan-j-hu/ocaml-textmate-language"
+bug-reports: "https://github.com/alan-j-hu/ocaml-textmate-language/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "oniguruma" {>= "0.2"}
+  "ocaml" {>= "4.13"}
+  "plist-xml" {>= "0.5" & with-test}
+  "alcotest" {>= "1.4" & with-test}
+  "ezjsonm" {>= "1.2" & with-test}
+  "yojson" {>= "1.7" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/alan-j-hu/ocaml-textmate-language.git"
+url {
+  src:
+    "https://github.com/alan-j-hu/ocaml-textmate-language/releases/download/0.6.0/textmate-language-0.6.0.tbz"
+  checksum: [
+    "sha256=b6f10288af44dadd2f7c7a24070b4a69362740aa4673e967f574b4d8c44bfb02"
+    "sha512=78215a4c4de5ee931efe27ee822d12ef4ca165c8a53b62f101d45f2bc843a1650da8e8976eeea55fb55231e63afca0ee3f915d70026afdcae390dacb4711df17"
+  ]
+}
+x-commit-hash: "d3f810d35bdc3f791cba4b1d87668e76e451963b"

--- a/packages/textmate-language/textmate-language.0.6.0/opam
+++ b/packages/textmate-language/textmate-language.0.6.0/opam
@@ -45,3 +45,4 @@ url {
   ]
 }
 x-commit-hash: "d3f810d35bdc3f791cba4b1d87668e76e451963b"
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
Tokenizing code with TextMate grammars for syntax highlighting

- Project page: <a href="https://github.com/alan-j-hu/ocaml-textmate-language">https://github.com/alan-j-hu/ocaml-textmate-language</a>

##### CHANGES:

- Prevent tokenizer hangs from zero-width regex loops by enforcing progress in
  `match`, `while`, and `begin`/`end` transitions (alan-j-hu/ocaml-textmate-language#2), contributed by
  @davesnx.
- Add regression tests for zero-width begin/end and zero-width match loop
  grammars (alan-j-hu/ocaml-textmate-language#2), contributed by @davesnx.
- Behavior change: zero-width rules that do not consume input are treated as
  non-progress and skipped/advanced for safety, so they no longer emit tokens
  (alan-j-hu/ocaml-textmate-language#2), contributed by @davesnx.
- Update the dependency `oniguruma` to version 0.2.
- Increase the minimum required OCaml version to 4.13.
