### PR TITLE
[new release] nats-client (2 packages) (0.0.5)

### DIFF
--- a/packages/nats-client-async/nats-client-async.0.0.5/opam
+++ b/packages/nats-client-async/nats-client-async.0.0.5/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Lean OCaml Async NATS client"
+description: "Async-based OCaml NATS client"
+maintainer: ["Hebilicious"]
+authors: ["Hebilicious"]
+license: "MIT"
+homepage: "https://github.com/hebilicious/nats-ml"
+bug-reports: "https://github.com/hebilicious/nats-ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.19"}
+  "core"
+  "async"
+  "async_unix"
+  "uri"
+  "yojson" {>= "2.0.0"}
+  "nats-client"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/hebilicious/nats-ml.git"
+x-maintenance-intent: ["(latest)"]
+available: [ os-distribution != "alpine" & arch != "riscv64" ]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/hebilicious/nats-ml/releases/download/v0.0.5/nats-client-0.0.5.tbz"
+  checksum: [
+    "sha256=7cf1511a58ec430e43ddccd00be96d4b8f979f945aebb2ac905335961db8c3dd"
+    "sha512=d40c804b072f2fad1cfb6a01e4bc1d11b147c399bebfab3aaae3ec7b2f6b87dfa5ea80512843813e541986eb2ad58045d55275a8ab322d9dc5cfff8d87b0179f"
+  ]
+}
+x-commit-hash: "fa74e43b486682c7e169d49b824a737f3262638b"

--- a/packages/nats-client/nats-client.0.0.5/opam
+++ b/packages/nats-client/nats-client.0.0.5/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Lean OCaml NATS protocol client"
+description: "Runtime-independent OCaml NATS protocol primitives"
+maintainer: ["Hebilicious"]
+authors: ["Hebilicious"]
+license: "MIT"
+homepage: "https://github.com/hebilicious/nats-ml"
+bug-reports: "https://github.com/hebilicious/nats-ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.19"}
+  "yojson"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/hebilicious/nats-ml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/hebilicious/nats-ml/releases/download/v0.0.5/nats-client-0.0.5.tbz"
+  checksum: [
+    "sha256=7cf1511a58ec430e43ddccd00be96d4b8f979f945aebb2ac905335961db8c3dd"
+    "sha512=d40c804b072f2fad1cfb6a01e4bc1d11b147c399bebfab3aaae3ec7b2f6b87dfa5ea80512843813e541986eb2ad58045d55275a8ab322d9dc5cfff8d87b0179f"
+  ]
+}
+x-commit-hash: "fa74e43b486682c7e169d49b824a737f3262638b"


### PR DESCRIPTION
Lean OCaml NATS protocol client

- Project page: <a href="https://github.com/hebilicious/nats-ml">https://github.com/hebilicious/nats-ml</a>

##### CHANGES:


- Fix the published opam package metadata and release CI so releases no longer ship repo-only tests and now cover the previously flaky upstream opam targets.
