### PR TITLE
Package http-date.0.2

### DIFF
--- a/packages/http-date/http-date.0.2/opam
+++ b/packages/http-date/http-date.0.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "HTTP Datetime encoder/decoder"
+description: "RFC 9110 compliant HTTP datetime decoder and encoder"
+maintainer: "Bikal Lem"
+authors: "Bikal Lem"
+license: "MPL-2.0"
+homepage: "https://github.com/bikallem/http-date"
+bug-reports: "https://github.com/bikallem/http-date/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "3.22"}
+  "alcobar" {with-test}
+  "mdx" {>= "2.1.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bikallem/http-date.git"
+url {
+  src: "https://github.com/bikallem/http-date/archive/refs/tags/v0.2.tar.gz"
+  checksum: [
+    "md5=c05dd250cd2bcef94b9dedc0fda6202d"
+    "sha512=00cf1c4c6ca9dd95042707fb9b815bdd30532f3d0830a846bbbc46e6fc064a7565484241d8f8c2f517c9b1184492eeb2b8ff3efa6831cfe42e6c00fc69b3e162"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `http-date.0.2`
HTTP Datetime encoder/decoder
RFC 9110 compliant HTTP datetime decoder and encoder



---
* Homepage: https://github.com/bikallem/http-date
* Source repo: git+https://github.com/bikallem/http-date.git
* Bug tracker: https://github.com/bikallem/http-date/issues

---
:camel: Pull-request generated by opam-publish v2.7.1