### PR TITLE
[new release] albatross (2.7.0)

### DIFF
--- a/packages/albatross/albatross.2.7.0/opam
+++ b/packages/albatross/albatross.2.7.0/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/robur-coop/albatross"
+dev-repo: "git+https://github.com/robur-coop/albatross.git"
+bug-reports: "https://github.com/robur-coop/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "2.7.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "conf-libev"
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "5.3.0"}
+  "logs"
+  "bos" {>= "0.2.0"}
+  "ptime" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "1.0.0"}
+  "tls" {>= "1.0.2"}
+  "tls-lwt" {>= "1.0.2"}
+  "asn1-combinators" {>= "0.3.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "metrics" {>= "0.5.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "ohex" {>= "0.2.0"}
+  "http-lwt-client" {>= "0.3.0"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.4.0"}
+  "cachet" {>= "0.0.3"}
+  "bstr"
+  "fpath" {>= "0.7.3"}
+  "logs-syslog" {>= "0.4.1"}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+available: os != "openbsd"
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/albatross/releases/download/v2.7.0/albatross-2.7.0.tbz"
+  checksum: [
+    "sha256=6577b96d36d194132e6b1e1101bb1019918a31ba2b34cd757ead1dc7a7611b3d"
+    "sha512=035cf84ebdb66526be03fec45f4f7c3f5b1d1fcef31917ff86e994b663dfbee4b323b754df637cc538c4f1af9ab8b2e61e61390329a3cc8dbf4be6d2d24ca0cf"
+  ]
+}
+x-commit-hash: "3d46e87834e67c78099977425a0dea8ee4d3b0b9"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/robur-coop/albatross">https://github.com/robur-coop/albatross</a>

##### CHANGES:

* Be able to start and monitor BHyve virtual machines (robur-coop/albatross#250, fixes robur-coop/albatross#54 @hannesm
  @reynir)
  - extends the unikernel with numcpus and linux_boot_partition, cpuids is a set
  - typ can be either `Solo5 or `BHyve
  - there's an escape for /dev/zvol (to have block devices which are zfs
    volumes) (until we have a separate block device daemon) via the albatrossd
    command-line option --allow-dev-zvol=<user>
* Albatross-daemon: avoid dumping when a restart-on-failure unikernel is
  restarted (robur-coop/albatross#249 robur-coop/albatross#257 @hannesm)
* Accept URLs without a trailing slash (robur-coop/albatross#245 @reynir)
* Document and provide hints when statistics gathering fails
  (robur-coop/albatross#251 robur-coop/albatross#253, fixes robur-coop/albatross#252 @hannesm @reynir)
* Vmm_resource: remove unusued functions (reserve_block, commit_block)
  (robur-coop/albatross#254 @hannesm)
* Vmm_resources.insert_unikernel now returns a result, and does not raise an
  exception (robur-coop/albatross#256, fixes robur-coop/albatross#255 @hannesm)
* Albatross-client: add a replace-policy subcommand (alias to add-policy)
  (robur-coop/albatross#261 @reynir)
* Escape console data when printing (robur-coop/albatross#266 @reynir)
* Remove Old_unikernel_info3 and Old_restart (robur-coop/albatross#231 @hannesm)
