### PR TITLE
[new release] duration (0.3.0)

### DIFF
--- a/packages/duration/duration.0.3.0/opam
+++ b/packages/duration/duration.0.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/hannesm/duration"
+doc: "https://hannesm.github.io/duration/doc"
+bug-reports: "https://github.com/hannesm/duration/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/duration.git"
+synopsis: "Conversions to various time units"
+description: """
+A duration is represented in nanoseconds as an unsigned 64 bit integer.  This
+has a range of up to 584 years.  Functions provided check the input and raise
+on negative or out of bound input.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/hannesm/duration/releases/download/v0.3.0/duration-0.3.0.tbz"
+  checksum: [
+    "sha256=62fd738fe1ee4825b3c70e7ac8cc859ed37bae147783daa583bb743bba052b75"
+    "sha512=543a152c6c26612cdaf52974ee7cb98c8931be73ae8002be6a152878af8e6031abacb771f37bd2acb6e3b29eec29d34fe8806f37ddf5211df582918379983290"
+  ]
+}
+x-commit-hash: "0b278aa46102707d3c8b4633dd408862b30f6643"


### PR DESCRIPTION
Conversions to various time units

- Project page: <a href="https://github.com/hannesm/duration">https://github.com/hannesm/duration</a>
- Documentation: <a href="https://hannesm.github.io/duration/doc">https://hannesm.github.io/duration/doc</a>

##### CHANGES:

* Add Duration.of_string and Duration.of_string_exn (hannesm/duration#10 @dinosaure)
