### PR TITLE
[new release] html_of_jsx (0.0.9)

### DIFF
--- a/packages/html_of_jsx/html_of_jsx.0.0.9/opam
+++ b/packages/html_of_jsx/html_of_jsx.0.0.9/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Render HTML with JSX"
+description:
+  "html_of_jsx is a JSX transformation and a library to write HTML declaratively in OCaml (mlx) and Reason."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/davesnx/html_of_jsx"
+bug-reports: "https://github.com/davesnx/html_of_jsx/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "ppxlib" {>= "0.25.0"}
+  "pretty_expressive" {>= "0.5"}
+  "dune" {>= "3.17" & (>= "3.22" & with-doc = "true" | with-doc = "false")}
+  "odoc" {with-doc}
+  "odoc-parser" {with-doc}
+  "alcotest" {with-test}
+  "benchmark" {with-test}
+  "reason" {>= "3.10.0" & with-test}
+  "ocamlformat" {>= "0.26.1" & (with-dev-setup | with-test)}
+  "mlx" {with-test | with-dev-setup}
+  "ocamlformat-mlx" {with-dev-setup | with-test}
+  "ocaml-lsp-server" {with-dev-setup}
+  "tiny_httpd" {with-dev-setup}
+  "yocaml" {with-dev-setup}
+  "yocaml_unix" {with-dev-setup}
+  "ochre" {with-dev-setup}
+  "tm-grammars" {with-dev-setup}
+  "omd" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/html_of_jsx.git"
+url {
+  src:
+    "https://github.com/davesnx/html_of_jsx/releases/download/0.0.9/html_of_jsx-0.0.9.tbz"
+  checksum: [
+    "sha256=edc7d6d604820ef20d76611eaf7fdc29c691dd9fb48ed9930900f7f331dfea02"
+    "sha512=35eead27322cc1d3b34e32ed964449ff83a75f74f01c1127d54504145192b9c7726820f4825f5c793bde0887df202e4769946782d4f42c40b3a5a609daa4aada"
+  ]
+}
+x-commit-hash: "e92f6dd9c4cf2aea8257c1b6605b28a81aeabeed"


### PR DESCRIPTION
Render HTML with JSX

- Project page: <a href="https://github.com/davesnx/html_of_jsx">https://github.com/davesnx/html_of_jsx</a>

##### CHANGES:

- Fix `data-attributes` being rendered as `data_-attributes` (@davesnx)
- Add `JSX.pp` for pretty-printing HTML with indentation, powered by `pretty_expressive` (@davesnx)
- Add `JSX.stringf` for escaped `Printf`-style text formatting and teach the PPX to optimize literal-only `stringf` calls at compile time (@davesnx)
- Improve runtime render speed in `JSX.write` by replacing iterator-heavy paths with direct recursion and indexed array traversal (@davesnx)
- Reduce default render buffer sizes (`1024 -> 256`) and improve PPX-generated buffer capacity estimation for dynamic/optional attribute code paths (@davesnx)
- Add a compile-time fast path for static HTML escaping in `ppx/static_analysis.ml` to avoid buffer work when no escaping is required (@davesnx)
- Extend static optimization coverage for dynamic attributes: elements with dynamic attrs and dynamic string/mixed children now generate buffer-based optimized code instead of falling back to `JSX.node` (@davesnx)
