### PR TITLE
conf-brotli: fix build field syntax

### DIFF
--- a/packages/conf-brotli/conf-brotli.0.0.1/opam
+++ b/packages/conf-brotli/conf-brotli.0.0.1/opam
@@ -5,12 +5,10 @@ homepage: "https://github.com/google/brotli"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "MIT"
 build: [
-  ["pkgconf"]
+  ["pkgconf" "libbrotlidec" "libbrotlienc"]
     {os = "win32" & os-distribution != "cygwinports"}
-  ["pkg-config"]
+  ["pkg-config" "libbrotlidec" "libbrotlienc"]
     {os != "win32"}
-  "libbrotlidec"
-  "libbrotlienc"
 ]
 depexts: [
   ["brotli-dev"] {os-distribution = "alpine"}
@@ -21,6 +19,7 @@ depexts: [
   ["brotli"] {os = "freebsd"}
   ["brotli"] {os-distribution = "homebrew" & os = "macos"}
   ["libbrotli-devel"] {os-distribution = "cygwin"}
+  ["mingw-w64-x86_64-brotli"] {os-distribution = "msys2"}
 ]
 x-ci-accept-failures: [
   "oraclelinux-8" "oraclelinux-9" # not available

--- a/packages/conf-brotli/conf-brotli.0.0.1/opam
+++ b/packages/conf-brotli/conf-brotli.0.0.1/opam
@@ -5,11 +5,11 @@ homepage: "https://github.com/google/brotli"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "MIT"
 build: [
-  ["pkgconf" "libbrotlidec" "libbrotlienc"]
-    {os = "win32" & os-distribution != "cygwinports"}
-  ["pkg-config" "libbrotlidec" "libbrotlienc"]
-    {os != "win32"}
-]
+  "pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+  "pkg-config" {os != "win32"}
+  "libbrotlidec"
+  "libbrotlienc"
+  ]
 depexts: [
   ["brotli-dev"] {os-distribution = "alpine"}
   ["brotli"] {os-distribution = "arch"}

--- a/packages/conf-brotli/conf-brotli.0.0.1/opam
+++ b/packages/conf-brotli/conf-brotli.0.0.1/opam
@@ -9,7 +9,7 @@ build: [
   "pkg-config" {os != "win32"}
   "libbrotlidec"
   "libbrotlienc"
-  ]
+]
 depexts: [
   ["brotli-dev"] {os-distribution = "alpine"}
   ["brotli"] {os-distribution = "arch"}


### PR DESCRIPTION
Arguments `libbrotlidec` and `libbrotlienc` must be part of each command list, not free-standing strings. The previous commit (2a45163) left them as bare strings outside any command, causing opam to silently ignore the entire `build` field.

Add missing MSYS2 depext `mingw-w64-x86_64-brotli` so that pkgconf can find the library after system package installation.