### PR TITLE
[new release] nats-client (2 packages) (0.0.6)

### DIFF
--- a/packages/nats-client-async/nats-client-async.0.0.6/opam
+++ b/packages/nats-client-async/nats-client-async.0.0.6/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Lean OCaml Async NATS client"
+description: "Async-based OCaml NATS client"
+maintainer: ["Hebilicious"]
+authors: ["Hebilicious"]
+license: "MIT"
+homepage: "https://github.com/hebilicious/nats-ml"
+bug-reports: "https://github.com/hebilicious/nats-ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.19"}
+  "core"
+  "async"
+  "async_unix"
+  "uri"
+  "yojson" {>= "2.0.0"}
+  "nats-client"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/hebilicious/nats-ml.git"
+x-maintenance-intent: ["(latest)"]
+available: [ os-distribution != "alpine" & arch != "riscv64" ]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/hebilicious/nats-ml/releases/download/v0.0.6/nats-client-0.0.6.tbz"
+  checksum: [
+    "sha256=29039b9dff0428772075d425104249569c3560e1719f9fac41eef2e3b5ec92d1"
+    "sha512=170d4759100f5a47cc10bb9e24ba8cc7dfe3de218abb4b67ee662822f9310d0e3dd3312ba440a0e661f1ebe0c2198eded3f7b47d321d1b0494e55c73afa567bc"
+  ]
+}
+x-commit-hash: "05a7b209c9555e1f20c43e7bb703d64c3d44bcec"

--- a/packages/nats-client/nats-client.0.0.6/opam
+++ b/packages/nats-client/nats-client.0.0.6/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Lean OCaml NATS protocol client"
+description: "Runtime-independent OCaml NATS protocol primitives"
+maintainer: ["Hebilicious"]
+authors: ["Hebilicious"]
+license: "MIT"
+homepage: "https://github.com/hebilicious/nats-ml"
+bug-reports: "https://github.com/hebilicious/nats-ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.19"}
+  "yojson"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/hebilicious/nats-ml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/hebilicious/nats-ml/releases/download/v0.0.6/nats-client-0.0.6.tbz"
+  checksum: [
+    "sha256=29039b9dff0428772075d425104249569c3560e1719f9fac41eef2e3b5ec92d1"
+    "sha512=170d4759100f5a47cc10bb9e24ba8cc7dfe3de218abb4b67ee662822f9310d0e3dd3312ba440a0e661f1ebe0c2198eded3f7b47d321d1b0494e55c73afa567bc"
+  ]
+}
+x-commit-hash: "05a7b209c9555e1f20c43e7bb703d64c3d44bcec"


### PR DESCRIPTION
Lean OCaml NATS protocol client

- Project page: <a href="https://github.com/hebilicious/nats-ml">https://github.com/hebilicious/nats-ml</a>

##### CHANGES:


- Restore lightweight published package tests and keep the mirrored opam target checks minimal so opam releases still exercise the installed packages.
