### PR TITLE
[new release] nats-client (2 packages) (0.0.7)

### DIFF
--- a/packages/nats-client-async/nats-client-async.0.0.7/opam
+++ b/packages/nats-client-async/nats-client-async.0.0.7/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Lean OCaml Async NATS client"
+description: "Async-based OCaml NATS client"
+maintainer: ["Hebilicious"]
+authors: ["Hebilicious"]
+license: "MIT"
+homepage: "https://github.com/hebilicious/nats-ml"
+bug-reports: "https://github.com/hebilicious/nats-ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.19"}
+  "core"
+  "async"
+  "async_unix"
+  "uri"
+  "yojson" {>= "2.0.0"}
+  "nats-client"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/hebilicious/nats-ml.git"
+x-maintenance-intent: ["(latest)"]
+available: [ os-distribution != "alpine" & arch != "riscv64" ]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & opam-version >= "2.1" & arch != "x86_32" & arch != "arm32" & arch != "ppc64"}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/hebilicious/nats-ml/releases/download/v0.0.7/nats-client-0.0.7.tbz"
+  checksum: [
+    "sha256=1ef5a1fd5a70c4e9806f4f389721ca1e4288a5076f3e69506a31658df227bb5b"
+    "sha512=eff5d5c991faa9088e6bedb74f4b53227c0489121e558c716e6568a7f47176e087a36b000a7b462d97b77286d7128378b0b33bc271744829d154c91c206cc413"
+  ]
+}
+x-commit-hash: "aeea9d71d5daf7d4c6e6a38965584f6d5e0f6116"

--- a/packages/nats-client/nats-client.0.0.7/opam
+++ b/packages/nats-client/nats-client.0.0.7/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Lean OCaml NATS protocol client"
+description: "Runtime-independent OCaml NATS protocol primitives"
+maintainer: ["Hebilicious"]
+authors: ["Hebilicious"]
+license: "MIT"
+homepage: "https://github.com/hebilicious/nats-ml"
+bug-reports: "https://github.com/hebilicious/nats-ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.19"}
+  "yojson"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/hebilicious/nats-ml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & opam-version >= "2.1"}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/hebilicious/nats-ml/releases/download/v0.0.7/nats-client-0.0.7.tbz"
+  checksum: [
+    "sha256=1ef5a1fd5a70c4e9806f4f389721ca1e4288a5076f3e69506a31658df227bb5b"
+    "sha512=eff5d5c991faa9088e6bedb74f4b53227c0489121e558c716e6568a7f47176e087a36b000a7b462d97b77286d7128378b0b33bc271744829d154c91c206cc413"
+  ]
+}
+x-commit-hash: "aeea9d71d5daf7d4c6e6a38965584f6d5e0f6116"


### PR DESCRIPTION
Lean OCaml NATS protocol client

- Project page: <a href="https://github.com/hebilicious/nats-ml">https://github.com/hebilicious/nats-ml</a>

##### CHANGES:


- Skip published package tests on opam 2.0 and make the async package smoke test bytecode-only so opam-ci matches supported targets more closely.
