### PR TITLE
[new release] ocaml-ai-sdk (2 packages) (0.2)

### DIFF
--- a/packages/ai-sdk-react/ai-sdk-react.0.2/opam
+++ b/packages/ai-sdk-react/ai-sdk-react.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Melange bindings for @ai-sdk/react"
+description: "Type-safe OCaml/Melange bindings for Vercel AI SDK)"
+maintainer: ["José Nogueira <jose.nogueira@ahrefs.com>"]
+authors: ["Ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/ocaml-ai-sdk"
+doc: "https://github.com/ahrefs/ocaml-ai-sdk"
+bug-reports: "https://github.com/ahrefs/ocaml-ai-sdk/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.14"}
+  "melange" {>= "4.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ocaml-ai-sdk.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ahrefs/ocaml-ai-sdk/releases/download/0.2/ocaml-ai-sdk-0.2.tbz"
+  checksum: [
+    "sha256=17063971a74ccd72619a43ecfcb29d28cdf08f90d406a960bd475f65fee1a0d9"
+    "sha512=1f3f2d1d7fa4f53843cc1b303cbf9d6dcc85780e7c768ced723f3de83ea897748fa231b48e729216abcc069dee818edc6751a45271541e8a007369bf6e9d23e3"
+  ]
+}
+x-commit-hash: "923b35a426780abf2fe421107f2769b141757be8"

--- a/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.2/opam
+++ b/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "OCaml AI SDK - Provider abstraction for AI models"
+description:
+  "Type-safe, provider-agnostic AI model abstraction inspired by Vercel AI SDK"
+maintainer: ["José Nogueira <jose.nogueira@ahrefs.com>"]
+authors: ["Ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/ocaml-ai-sdk"
+doc: "https://github.com/ahrefs/ocaml-ai-sdk"
+bug-reports: "https://github.com/ahrefs/ocaml-ai-sdk/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.14"}
+  "lwt" {>= "5.9"}
+  "yojson" {>= "2.2"}
+  "jsonschema" {>= "0.1"}
+  "melange-json-native" {>= "2.0"}
+  "cohttp-lwt-unix" {>= "5.3"}
+  "lwt_ssl" {>= "1.2"}
+  "base64" {>= "1.3"}
+  "ppx_deriving" {>= "5.2"}
+  "lwt_ppx" {>= "5.9"}
+  "re2" {>= "0.16"}
+  "uuseg" {>= "17.0"}
+  "trace" {>= "0.12"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ocaml-ai-sdk.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ahrefs/ocaml-ai-sdk/releases/download/0.2/ocaml-ai-sdk-0.2.tbz"
+  checksum: [
+    "sha256=17063971a74ccd72619a43ecfcb29d28cdf08f90d406a960bd475f65fee1a0d9"
+    "sha512=1f3f2d1d7fa4f53843cc1b303cbf9d6dcc85780e7c768ced723f3de83ea897748fa231b48e729216abcc069dee818edc6751a45271541e8a007369bf6e9d23e3"
+  ]
+}
+x-commit-hash: "923b35a426780abf2fe421107f2769b141757be8"


### PR DESCRIPTION
OCaml AI SDK - Provider abstraction for AI models

- Project page: <a href="https://github.com/ahrefs/ocaml-ai-sdk">https://github.com/ahrefs/ocaml-ai-sdk</a>
- Documentation: <a href="https://github.com/ahrefs/ocaml-ai-sdk">https://github.com/ahrefs/ocaml-ai-sdk</a>

##### CHANGES:

### Core SDK (`ai_core`)

- **`Smooth_stream`** — stream transformer that buffers `Text_delta` and
  `Reasoning_delta` chunks and re-emits them in controlled pieces with
  configurable inter-chunk delays. Five chunking modes: `Word` (default),
  `Line`, `Regex` (custom Re2 pattern), `Segmenter` (Unicode UAX#29 word
  boundaries via uuseg, recommended for CJK), and `Custom` (user function).
  Matches the upstream AI SDK's `smoothStream` transform.
- **`?transform` parameter** on `stream_text` and `server_handler.handle_chat` —
  generic stream transformer (`Text_stream_part.t Lwt_stream.t ->
  Text_stream_part.t Lwt_stream.t`) applied between the raw event stream and
  consumer-facing streams. Both `full_stream` and `text_stream` reflect the
  transformed output.
- **Retry with exponential backoff** — `Retry` module with jitter, configurable
  initial delay and backoff factor, and parameter validation. `?max_retries`
  threaded through `generate_text`, `stream_text`, and
  `server_handler.handle_chat`. Retries only on errors marked retryable.
- **Telemetry / observability** — `Telemetry` module with OpenTelemetry-compatible
  span instrumentation via the `trace` library (ocaml-trace). Configurable
  `Telemetry.t` settings control enable/disable, input/output recording privacy,
  function ID, custom metadata, and lifecycle integration callbacks (`on_start`,
  `on_step_finish`, `on_tool_call_start`, `on_tool_call_finish`, `on_finish`).
  Span hierarchy matches upstream AI SDK: `ai.generateText` /
  `ai.streamText` root spans, `*.doGenerate` / `*.doStream` step spans, and
  `ai.toolCall` tool execution spans. `?telemetry` parameter threaded through
  `generate_text`, `stream_text`, and `server_handler.handle_chat`.

### Provider Abstraction Layer (`ai_provider`)

- **`is_retryable` field** on `Provider_error.t` — defaults from HTTP status
  code (429, 5xx are retryable). Anthropic and OpenAI providers set it
  explicitly based on error classification.

### Examples

- `smooth_streaming` — demonstrates all five chunking modes
- `telemetry_logging` — demonstrates integration callbacks for lifecycle logging

### Dependencies

- Added `re2` (>= 0.16) and `uuseg` (>= 17.0) to `ai_core`
- Added `trace` (>= 0.12) to `ai_core`
