### PR TITLE
conf-brotli: fix for cygwin

### DIFF
--- a/packages/conf-brotli/conf-brotli.0.0.1/opam
+++ b/packages/conf-brotli/conf-brotli.0.0.1/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "MIT"
 build: [
   "pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-  "pkg-config" {os != "win32"}
+  "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
   "libbrotlidec"
   "libbrotlienc"
 ]


### PR DESCRIPTION
Fixes the issue raised in https://github.com/ocaml/opam-repository/pull/29718/changes