### PR TITLE
2 packages from rocq-prover/vsrocq at 2.4.2

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.4.2/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.4.2/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/rocq-prover/vsrocq"
+bug-reports: "https://github.com/rocq-prover/vsrocq/issues"
+dev-repo: "git+https://github.com/rocq-prover/vsrocq"
+depends: [
+  "vsrocq-language-server" {= version}
+]
+synopsis: "Compatibility meta package for the VsRocq language server after the Rocq renaming"
+available: arch != "arm32" & arch != "x86_32"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rocq-prover/vsrocq/releases/download/v2.4.2/vsrocq-language-server-2.4.2.tar.gz"
+  checksum: [
+    "md5=14aaed0f7dceed8e2c65c5f23e0f7967"
+    "sha512=5da14e40e648a53353fd00ad0229ae1b9f6eec911e7c449140dfdb600a0ac808b5c26e8c25b0b3c57c0995424839ef5e4ebd4a3dc8b148af41091b01e63961f2"
+  ]
+}

--- a/packages/vsrocq-language-server/vsrocq-language-server.2.4.2/opam
+++ b/packages/vsrocq-language-server/vsrocq-language-server.2.4.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/rocq-prover/vsrocq"
+bug-reports: "https://github.com/rocq-prover/vsrocq/issues"
+dev-repo: "git+https://github.com/rocq-prover/vsrocq"
+
+build: [
+  [make "dune-files"]
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { >= "4.14" }
+  "dune" { >= "3.5" }
+  (("coq-core" { ((>= "8.18" < "8.21") | (= "dev")) }
+    "coq-stdlib" { ((>= "8.18" < "8.21") | (= "dev")) })
+  | "rocq-core" { ((>= "9.0+rc1" < "9.3~") | (= "dev")) } )
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "ppx_optcomp"
+  "result" { >= "1.5" }
+  "lsp" { >= "1.15"}
+  "sel" {>= "0.6.0"}
+]
+conflicts: [
+    "vscoq-language-server" {< "2.2.7~"}
+]
+synopsis: "VSRocq language server"
+available: arch != "arm32" & arch != "x86_32"
+description: """
+LSP based language server for Rocq and its VSRocq user interface
+"""
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rocq-prover/vsrocq/releases/download/v2.4.2/vsrocq-language-server-2.4.2.tar.gz"
+  checksum: [
+    "md5=14aaed0f7dceed8e2c65c5f23e0f7967"
+    "sha512=5da14e40e648a53353fd00ad0229ae1b9f6eec911e7c449140dfdb600a0ac808b5c26e8c25b0b3c57c0995424839ef5e4ebd4a3dc8b148af41091b01e63961f2"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `vscoq-language-server.2.4.2`: Compatibility meta package for the VsRocq language server after the Rocq renaming
- `vsrocq-language-server.2.4.2`: VSRocq language server



---
* Homepage: https://github.com/rocq-prover/vsrocq
* Source repo: git+https://github.com/rocq-prover/vsrocq
* Bug tracker: https://github.com/rocq-prover/vsrocq/issues

---
:camel: Pull-request generated by opam-publish v2.5.0