### PR TITLE
Upgrade the opam update alerts after the release of opam 2.5.1

### DIFF
--- a/repo
+++ b/repo
@@ -9,11 +9,14 @@ announce: [
       (opam-version >= "2.2.0~~" & opam-version < "2.2.1") |
       (opam-version >= "2.3.0~~" & opam-version < "2.3.0") |
       (opam-version >= "2.4.0~~" & opam-version < "2.4.1") |
-      (opam-version >= "2.5.0~~" & opam-version < "2.5.0") }
+      (opam-version >= "2.5.0~~" & opam-version < "2.5.1") }
 """
 [INFO] opam 2.1 and 2.2 include many performance and security improvements over 2.0; please consider upgrading (https://opam.ocaml.org/doc/Install.html)
 """ {opam-version >= "2.0.10" & opam-version < "2.1.0~~"}
 """
 [WARNING] please ensure to have GNU patch installed as `patch`. Otherwise update may fail silently (since it can't remove files).
 """ {os = "macos" & (opam-version < "2.1.6" | (opam-version >= "2.2.0~~" & opam-version < "2.2.0~beta2"))}
+"""
+[INFO] opam 2.5.1 includes security fixes; please consider upgrading (https://opam.ocaml.org/doc/Install.html)
+""" {opam-version >= "2.4.0~~" & opam-version < "2.5.1"}
 ]


### PR DESCRIPTION
The added INFO level warning is here to try to catch users that have installed opam 2.4 by hand and have not yet upgraded.

According to repology, nixpkgs stable 25.11 is the only distribution that still use 2.4.x. Most other distributions will upgrade to 2.5.1 soon enough or use <= 2.3.0 and will backport the fix with a patch.