### PR TITLE
[new release] duration (0.3.1)

### DIFF
--- a/packages/duration/duration.0.3.1/opam
+++ b/packages/duration/duration.0.3.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/hannesm/duration"
+doc: "https://hannesm.github.io/duration/doc"
+bug-reports: "https://github.com/hannesm/duration/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/duration.git"
+synopsis: "Conversions to various time units"
+description: """
+A duration is represented in nanoseconds as an unsigned 64 bit integer.  This
+has a range of up to 584 years.  Functions provided check the input and raise
+on negative or out of bound input.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/hannesm/duration/releases/download/v0.3.1/duration-0.3.1.tbz"
+  checksum: [
+    "sha256=cd88da693951e1212ea83e24ce17f767e95a39a9ce2adda0654b32d75ce68c13"
+    "sha512=248fec8ba9ebf6ac7cc91055307496658974e402bb9de6d37027fbe51b6708247530392cc60f954cf8d7ed8a03ce0d2da440fbd9f8720e398a446e0a43f590ad"
+  ]
+}
+x-commit-hash: "7bf34d3c03586b9a8680a617f2b3a30f16513710"


### PR DESCRIPTION
Conversions to various time units

- Project page: <a href="https://github.com/hannesm/duration">https://github.com/hannesm/duration</a>
- Documentation: <a href="https://hannesm.github.io/duration/doc">https://hannesm.github.io/duration/doc</a>

##### CHANGES:

* Support micro seconds in of_string (hannesm/duration#11 @reynir)
