### PR TITLE
[new release] sqlite3 (5.4.1)

### DIFF
--- a/packages/sqlite3/sqlite3.5.4.1/opam
+++ b/packages/sqlite3/sqlite3.5.4.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "SQLite3 bindings for OCaml"
+description: """
+sqlite3-ocaml is an OCaml library with bindings to the SQLite3 client API.
+Sqlite3 is a self-contained, serverless, zero-configuration, transactional SQL
+database engine with outstanding performance for many use cases."""
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christian Szegedy <csdontspam@metamatix.com>"
+]
+license: "MIT"
+tags: ["clib:sqlite3"]
+homepage: "https://mmottl.github.io/sqlite3-ocaml"
+doc: "https://mmottl.github.io/sqlite3-ocaml/api"
+bug-reports: "https://github.com/mmottl/sqlite3-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "dune-compiledb"
+  "dune-configurator"
+  "conf-sqlite3" {build}
+  "ppx_inline_test" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/sqlite3-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/sqlite3-ocaml/releases/download/5.4.1/sqlite3-5.4.1.tbz"
+  checksum: [
+    "sha256=729ec193fb1992bb1a2bce6736adbc82aa5bdb45d41c8cb715f84d5663a26135"
+    "sha512=bc63909cb26af143b554ce60c1fcc7aa7c8237efce174953e2407c0ee8906c7c1d516f140e1d91a54564720477f1d62e8a1147cb7ffe2544c6e25ebbcddfee39"
+  ]
+}
+x-commit-hash: "2c86cc5b9f7d3b432200d158916d6e8610ba6eff"


### PR DESCRIPTION
SQLite3 bindings for OCaml

- Project page: <a href="https://mmottl.github.io/sqlite3-ocaml">https://mmottl.github.io/sqlite3-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/sqlite3-ocaml/api">https://mmottl.github.io/sqlite3-ocaml/api</a>

##### CHANGES:

### Added

- Added a child-process regression test covering the `exec` callback and
  concurrent statement preparation/finalization on a shared `FULLMUTEX`
  connection.

### Changed

- Removed the `clib:pthread` OPAM tag, keeping only `clib:sqlite3` as package
  classification metadata.
- Bumped `ocamlformat` to version `0.29.0`.

### Fixed

- Released the OCaml runtime lock around more explicit SQLite API calls that can
  contend on SQLite connection or statement mutexes, reducing the risk of
  deadlocks in multi-threaded code.
