### PR TITLE
[new release] postgresql (5.4.0)

### DIFF
--- a/packages/postgresql/postgresql.5.4.0/opam
+++ b/packages/postgresql/postgresql.5.4.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Bindings to the PostgreSQL library"
+description:
+  "Postgresql offers library functions for accessing PostgreSQL databases."
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Petter Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://mmottl.github.io/postgresql-ocaml"
+doc: "https://mmottl.github.io/postgresql-ocaml/api"
+bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "5.00"}
+  "dune-compiledb"
+  "dune-configurator"
+  "conf-postgresql" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/postgresql-ocaml/releases/download/5.4.0/postgresql-5.4.0.tbz"
+  checksum: [
+    "sha256=ce4248be9b09a6a04a6ba09ef6009c699ee996ec9a2ba5755bc252e5045fc6c0"
+    "sha512=e0e7c79900988457f441f2b901a76b877608397f31e71db6707fe25d0f7a8b72dec564d3f71de2ee9cccb8c233836bbdf3ad2b753d2b571b6514e273aa24da38"
+  ]
+}
+x-commit-hash: "2016e29dbed31a7fb3da80838e2ed3c31f5ec4d1"


### PR DESCRIPTION
Bindings to the PostgreSQL library

- Project page: <a href="https://mmottl.github.io/postgresql-ocaml">https://mmottl.github.io/postgresql-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/postgresql-ocaml/api">https://mmottl.github.io/postgresql-ocaml/api</a>

##### CHANGES:

### Added

- `connection#socket_descr`, which exposes the libpq socket as a
  `Unix.file_descr` suitable for readiness-based waiting without `Obj.magic`.

### Changed

- Updated asynchronous and notification examples to use `socket_descr` instead
  of coercing `socket` with `Obj.magic`.

### Fixed

- `string_of_error` now normalizes trailing newlines in backend-provided error
  messages and avoids odd punctuation for empty `Unexpected_status` details.
