### PR TITLE
Package base.v0.15.2

### DIFF
--- a/packages/base/base.v0.15.2/opam
+++ b/packages/base/base.v0.15.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/base"
+bug-reports: "https://github.com/janestreet/base/issues"
+dev-repo: "git+https://github.com/janestreet/base.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"             {>= "4.10.0"}
+  "sexplib0"          {>= "v0.15" & < "v0.16"}
+  "dune"              {>= "2.0.0"}
+  "dune-configurator"
+]
+synopsis: "Full standard library replacement for OCaml"
+description: "
+Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio
+"
+url {
+  src: "https://github.com/janestreet/base/archive/refs/tags/v0.15.2.tar.gz"
+  checksum: [
+    "md5=40f8af2c23f65eb9093492381c5555d9"
+    "sha512=2032126573fad9a6d575f58e7cc9ad00201b146c4325aa1473a81cf80e652c815243f39f8bd098a555948a5e54ee5dd91877418b515b940d77671ea7de2fd916"
+  ]
+}


### PR DESCRIPTION
### `base.v0.15.2`
Full standard library replacement for OCaml
Full standard library replacement for OCaml

Base is a complete and portable alternative to the OCaml standard
library. It provides all standard functionalities one would expect
from a language standard library. It uses consistent conventions
across all of its module.

Base aims to be usable in any context. As a result system dependent
features such as I/O are not offered by Base. They are instead
provided by companion libraries such as stdio:

  https://github.com/janestreet/stdio



---
* Homepage: https://github.com/janestreet/base
* Source repo: git+https://github.com/janestreet/base.git
* Bug tracker: https://github.com/janestreet/base/issues

---
:camel: Pull-request generated by opam-publish v3.0.0