### PR TITLE
Package valkey.0.1.0

### DIFF
--- a/packages/valkey/valkey.0.1.0/opam
+++ b/packages/valkey/valkey.0.1.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Modern Valkey client for OCaml 5 + Eio (RESP3-only)"
+description:
+  "Eio-native Valkey client targeting OCaml 5.3+ and Valkey 7.2+ (including Valkey 8.1 / 9 additions: SET IFEQ, DELIFEQ, hash field TTL). RESP3 only; no Lwt/Async/legacy fallback. Connection layer has auto-reconnect, byte-budget backpressure, circuit breaker, keepalive, TLS, and optional domain split so the parser can't stall socket I/O. Cluster router with quorum-based topology discovery, MOVED/ASK/CLUSTERDOWN/TRYAGAIN retry, periodic refresh, and Read_from-aware replica routing (incl. AZ affinity)."
+maintainer: "Avi Fenesh <aviarchi1994@gmail.com>"
+authors: "Avi Fenesh <aviarchi1994@gmail.com>"
+license: "MIT"
+tags: ["valkey" "redis" "eio" "client" "resp3" "cluster"]
+homepage: "https://github.com/avifenesh/ocaml-valkey"
+doc: "https://github.com/avifenesh/ocaml-valkey"
+bug-reports: "https://github.com/avifenesh/ocaml-valkey/issues"
+depends: [
+  "ocaml" {>= "5.3.0"}
+  "dune" {>= "3.16" & >= "3.16"}
+  "eio" {>= "1.3"}
+  "eio_main" {>= "1.3"}
+  "cstruct" {>= "6.2.0"}
+  "tls" {>= "2.0.0"}
+  "tls-eio" {>= "2.0.0"}
+  "x509" {>= "1.0.0"}
+  "ca-certs" {>= "1.0.0"}
+  "domain-name" {>= "0.4.0"}
+  "mirage-crypto-rng" {>= "2.0.0"}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "bisect_ppx" {with-dev-setup & >= "2.8.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/avifenesh/ocaml-valkey.git"
+url {
+  src:
+    "https://github.com/avifenesh/ocaml-valkey/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=9afc1fd664e4a025b58610bdd731c187"
+    "sha512=660549dc3f74de8af2baa72816941985dd725e47d48a279a2e9ddeba05b2f142afad9912bd9da88b17818c7d8931e4eb1690f7fd6b0bb5cedc1cdf82b4425dc2"
+  ]
+}


### PR DESCRIPTION
### `valkey.0.1.0`
Modern Valkey client for OCaml 5 + Eio (RESP3-only)
Eio-native Valkey client targeting OCaml 5.3+ and Valkey 7.2+ (including Valkey 8.1 / 9 additions: SET IFEQ, DELIFEQ, hash field TTL). RESP3 only; no Lwt/Async/legacy fallback. Connection layer has auto-reconnect, byte-budget backpressure, circuit breaker, keepalive, TLS, and optional domain split so the parser can't stall socket I/O. Cluster router with quorum-based topology discovery, MOVED/ASK/CLUSTERDOWN/TRYAGAIN retry, periodic refresh, and Read_from-aware replica routing (incl. AZ affinity).



---
* Homepage: https://github.com/avifenesh/ocaml-valkey
* Source repo: git+https://github.com/avifenesh/ocaml-valkey.git
* Bug tracker: https://github.com/avifenesh/ocaml-valkey/issues

---
:camel: Pull-request generated by opam-publish v2.7.1