### PR TITLE
OCaml 5.5.0: first beta release

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.5.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.5.0~beta1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "First beta release of OCaml 5.5.0"
+maintainer: [
+  "David Allsopp <dra27@dra27.uk>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.5"
+depends: [
+  "ocaml-compiler" {= "5.5.0~beta1"}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
+  "ocaml-options-vanilla" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]

--- a/packages/ocaml-compiler/ocaml-compiler.5.5.0~beta1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.5.0~beta1/opam
@@ -1,0 +1,123 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First beta release of OCaml 5.5.0"
+maintainer: [
+  "David Allsopp <dra27@dra27.uk>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.5"
+depends: [
+  # This is OCaml 5.5.0
+  "ocaml" {= "5.5.0" & post}
+  "compiler-cloning" {build}
+
+  # General base- packages
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "base-effects" {post}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+      ("system-msvc" & "ocaml-option-no-compression" {os = "win32"}))) |
+  # i686 mingw-w64 / MSVC
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+      ("system-msvc" & "ocaml-option-no-compression" {os = "win32"}))) |
+  # Non-Windows systems need to install something to satisfy this formula, so
+  # repeat the base-unix dependency
+   "base-unix" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.44" & os = "win32"}
+]
+flags: [ avoid-version ]
+build-env: [
+  [MSYS2_ARG_CONV_EXCL = "*"]
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    "sh" "tools/opam/process.sh" make "-j%{jobs}%" _:build-id _:name compiler-cloning:version
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "--with-additional-stublibsdir"
+    "--with-relative-libdir"
+    "--enable-runtime-search"
+    "--enable-runtime-search-target=fallback"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--without-zstd" {ocaml-option-no-compression:installed}
+    "--enable-tsan" {ocaml-option-tsan:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
+    "CFLAGS=-Os -mno-outline-atomics" {ocaml-option-musl:installed & arch = "arm64"}
+    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+]
+install: ["sh" "tools/opam/process.sh" make "install" _:build-id _:name prefix]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.5.0-beta1.tar.gz"
+  checksum: "sha256=4828cb132d9df1e308127a8c257567deea3d83c4ce3bf0fbe54083ba4a938bcc"
+}
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-no-compression"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+  "ocaml-option-tsan"
+]
+post-messages: [
+"This switch had to be compiled from sources, but future switches with the 🐌
+same compiler version and configuration should assemble instantly." {!failure & !_:cloned & compiler-cloning:version != "disabled"}
+"As requested, this switch was compiled from sources 😴" {!failure & compiler-cloning:version = "disabled"}
+"Switch cloned by %{_:clone-mechanism}% from %{_:clone-source}% 💨" {!failure & _:cloned}
+]

--- a/packages/ocaml-variants/ocaml-variants.5.5.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.5.0~beta1+options/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First beta release of OCaml 5.5.0"
+maintainer: [
+  "David Allsopp <dra27@dra27.uk>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.4"
+depends: [
+  "ocaml-compiler" {= "5.5.0~beta1"}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]


### PR DESCRIPTION
This PR adds the three packages for the first beta of OCaml 5.5.0 
- ocaml-compiler: core compiler 
- ocaml-base-compiler: vanilla configuration
- ocaml-variants...+options: customizable configurations

Compared to the last alpha, this version contains two runtime fixes, two type system fixes and three fixes for error messages and warnings. Thus OCaml 5.5.0 seems to be converging nicely.

Changes since the last alpha
------------------------------------------

### Documentation update

- 14684: Improve ocamlopt's manual page
  (Samuel Hym, review by Florian Angeletti)

### Runtime fixes

- 14644, 14647: Fix a bug related to unhandled effects in bytecode.
  (Vincent Laviron, report by Thibaut Mattio,
   review by Nicolás Ojeda Bär, Stephen Dolan and Olivier Nicole)

- 14349, 14718: runtime, fix in the orphaning of ephemerons
  (Gabriel Scherer, review by Olivier Nicole and Damien Doligez,
   report by Jan Midtgaard)

### Type system fixes

- 14557, 12150, 14696: ensure that the self type of class cannot escape
  through type constraints.
  (Leo White, review by Florian Angeletti)

- 14667: enable application related warnings for module-dependent functions
  (Florian Angeletti, review by Gabriel Scherer)

### Error messages and warning fixes

- 14690: Fix `Name_type_mismatch` error message when the expected type is an
  alias: print the expanded path on the right-hand side of the equality, not
  the alias twice.
  (Weixie Cui, review by Florian Angeletti)

- 14719, 14721: compute arity correctly for module-dependent function
  (Florian Angeletti, report by Jeremy Yallop, review by Stefan Muenzel)

- 14655, 14691: check for size overflow in caml_ba_reshape
  (Stephen Dolan, review by Xavier Leroy)