### PR TITLE
Partially revert "Merge pull request #29579 from ocaml/add-msys2-depexts

### DIFF
--- a/packages/conf-mingw-w64-bzip2-x86_64/conf-mingw-w64-bzip2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-bzip2-x86_64/conf-mingw-w64-bzip2-x86_64.1/opam
@@ -18,10 +18,10 @@ build: [
 ]
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  ("msys2-mingw64" {os = "win32" & os-distribution = "msys2"} | "msys2-ucrt64" {os = "win32" & os-distribution = "msys2"})
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
 ]
 depexts: [
   ["mingw64-x86_64-bzip2"] {os = "win32" & os-distribution = "cygwin"}
-  ["%{msys2:package-prefix}%-bzip2"] {os = "win32" & os-distribution = "msys2"}
+  ["mingw-w64-x86_64-bzip2"] {os = "win32" & os-distribution = "msys2"}
 ]

--- a/packages/conf-mingw-w64-gcc-x86_64/conf-mingw-w64-gcc-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gcc-x86_64/conf-mingw-w64-gcc-x86_64.1/opam
@@ -10,10 +10,10 @@ flags: conf
 available: os = "win32"
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  ("msys2-mingw64" {os = "win32" & os-distribution = "msys2"} | "msys2-ucrt64" {os = "win32" & os-distribution = "msys2"})
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
 ]
 build: ["x86_64-w64-mingw32-gcc" "--version"]
 depexts: [
   ["mingw64-x86_64-gcc-core"] {os = "win32" & os-distribution = "cygwin"}
-  ["%{msys2:package-prefix}%-gcc"] {os = "win32" & os-distribution = "msys2"}
+  ["mingw-w64-x86_64-gcc"] {os = "win32" & os-distribution = "msys2"}
 ]

--- a/packages/conf-mingw-w64-gmp-x86_64/conf-mingw-w64-gmp-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gmp-x86_64/conf-mingw-w64-gmp-x86_64.1/opam
@@ -11,11 +11,11 @@ available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "gmp"]
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  ("msys2-mingw64" {os = "win32" & os-distribution = "msys2"} | "msys2-ucrt64" {os = "win32" & os-distribution = "msys2"})
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]
 depexts: [
   ["mingw64-x86_64-gmp"] {os = "win32" & os-distribution = "cygwin"}
-  ["%{msys2:package-prefix}%-gmp"] {os = "win32" & os-distribution = "msys2"}
+  ["mingw-w64-x86_64-gmp"] {os = "win32" & os-distribution = "msys2"}
 ]

--- a/packages/conf-mingw-w64-pkgconf-x86_64/conf-mingw-w64-pkgconf-x86_64.1/opam
+++ b/packages/conf-mingw-w64-pkgconf-x86_64/conf-mingw-w64-pkgconf-x86_64.1/opam
@@ -10,9 +10,9 @@ flags: conf
 available: os = "win32" & os-distribution = "msys2"
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  ("msys2-mingw64" {os = "win32" & os-distribution = "msys2"} | "msys2-ucrt64" {os = "win32" & os-distribution = "msys2"})
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
 ]
 build: ["x86_64-w64-mingw32-pkgconf" "--version"]
 depexts: [
-  ["%{msys2:package-prefix}%-pkgconf"] {os = "win32" & os-distribution = "msys2"}
+  ["mingw-w64-x86_64-pkgconf"] {os = "win32" & os-distribution = "msys2"}
 ]

--- a/packages/conf-mingw-w64-zlib-x86_64/conf-mingw-w64-zlib-x86_64.1/opam
+++ b/packages/conf-mingw-w64-zlib-x86_64/conf-mingw-w64-zlib-x86_64.1/opam
@@ -11,11 +11,11 @@ available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "zlib"]
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  ("msys2-mingw64" {os = "win32" & os-distribution = "msys2"} | "msys2-ucrt64" {os = "win32" & os-distribution = "msys2"})
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]
 depexts: [
   ["mingw64-x86_64-zlib"] {os = "win32" & os-distribution = "cygwin"}
-  ["%{msys2:package-prefix}%-zlib"] {os = "win32" & os-distribution = "msys2"}
+  ["mingw-w64-x86_64-zlib"] {os = "win32" & os-distribution = "msys2"}
 ]

--- a/packages/conf-mingw-w64-zstd-x86_64/conf-mingw-w64-zstd-x86_64.1/opam
+++ b/packages/conf-mingw-w64-zstd-x86_64/conf-mingw-w64-zstd-x86_64.1/opam
@@ -11,11 +11,11 @@ available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libzstd"]
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  ("msys2-mingw64" {os = "win32" & os-distribution = "msys2"} | "msys2-ucrt64" {os = "win32" & os-distribution = "msys2"})
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]
 depexts: [
   ["mingw64-x86_64-zstd"] {os = "win32" & os-distribution = "cygwin"}
-  ["%{msys2:package-prefix}%-zstd"] {os = "win32" & os-distribution = "msys2"}
+  ["mingw-w64-x86_64-zstd"] {os = "win32" & os-distribution = "msys2"}
 ]


### PR DESCRIPTION
Reverts the updates which have broken packages. The very brief explanation is that additional packages need adding for ucrt64-support for this - e.g. (I think) conf-ucrt64-bzip2-x86_64.1 etc. and then plumbed in the main conf package.