### PR TITLE
[new release] opentelemetry (9 packages) (0.91)

### DIFF
--- a/packages/opentelemetry-client-cohttp-eio/opentelemetry-client-cohttp-eio.0.91/opam
+++ b/packages/opentelemetry-client-cohttp-eio/opentelemetry-client-cohttp-eio.0.91/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Collector client for opentelemetry, using cohttp + eio"
+maintainer: ["ocaml-tracing"]
+authors: ["ocaml-tracing" "ELLIOTTCABLE <opam@ell.io>" "the imandra team"]
+license: "MIT"
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "5.00"}
+  "mtime" {>= "1.4"}
+  "ca-certs"
+  "mirage-crypto-rng"
+  "ambient-context-eio"
+  "opentelemetry" {= version}
+  "opentelemetry-client" {= version}
+  "odoc" {with-doc}
+  "cohttp-eio" {>= "6.1.0"}
+  "eio_main" {with-test}
+  "tls-eio" {>= "2.0.1"}
+  "alcotest" {with-test}
+  "containers" {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "logs" {with-test}
+  "opentelemetry-lwt" {with-test & = version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.91/opentelemetry-0.91.tbz"
+  checksum: [
+    "sha256=4aaee2025957acf71434a027bd57ee699a9ae927e6b49804fb1e999e16a03694"
+    "sha512=f3ec030fc4ca0483c3fc143eaa802e2aa02b4c25e1a03ec967bd017fad8a4ef6287e9f9688486434d1ac2fc403217658b61d2c7f3709c092c939b93f412ee5c5"
+  ]
+}
+x-commit-hash: "5065cdd98560706f635b89645e8567d3abb54331"

--- a/packages/opentelemetry-client-cohttp-eio/opentelemetry-client-cohttp-eio.0.91/opam
+++ b/packages/opentelemetry-client-cohttp-eio/opentelemetry-client-cohttp-eio.0.91/opam
@@ -34,7 +34,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & os != "macos"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.91/opam
+++ b/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.91/opam
@@ -31,7 +31,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & os != "macos"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.91/opam
+++ b/packages/opentelemetry-client-cohttp-lwt/opentelemetry-client-cohttp-lwt.0.91/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Collector client for opentelemetry, using cohttp + lwt"
+maintainer: ["ocaml-tracing"]
+authors: ["ocaml-tracing" "ELLIOTTCABLE <opam@ell.io>" "the imandra team"]
+license: "MIT"
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "4.08"}
+  "mtime" {>= "1.4"}
+  "opentelemetry" {= version}
+  "opentelemetry-client" {= version}
+  "opentelemetry-lwt" {= version}
+  "ambient-context-lwt"
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "lwt_ppx" {>= "2.0"}
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "alcotest" {with-test}
+  "containers" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.91/opentelemetry-0.91.tbz"
+  checksum: [
+    "sha256=4aaee2025957acf71434a027bd57ee699a9ae927e6b49804fb1e999e16a03694"
+    "sha512=f3ec030fc4ca0483c3fc143eaa802e2aa02b4c25e1a03ec967bd017fad8a4ef6287e9f9688486434d1ac2fc403217658b61d2c7f3709c092c939b93f412ee5c5"
+  ]
+}
+x-commit-hash: "5065cdd98560706f635b89645e8567d3abb54331"

--- a/packages/opentelemetry-client-ocurl-lwt/opentelemetry-client-ocurl-lwt.0.91/opam
+++ b/packages/opentelemetry-client-ocurl-lwt/opentelemetry-client-ocurl-lwt.0.91/opam
@@ -32,7 +32,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & os != "macos"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/opentelemetry-client-ocurl-lwt/opentelemetry-client-ocurl-lwt.0.91/opam
+++ b/packages/opentelemetry-client-ocurl-lwt/opentelemetry-client-ocurl-lwt.0.91/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Collector client for opentelemetry, using ezcurl-lwt"
+maintainer: ["ocaml-tracing"]
+authors: ["ocaml-tracing" "ELLIOTTCABLE <opam@ell.io>" "the imandra team"]
+license: "MIT"
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "4.11"}
+  "mtime" {>= "1.4"}
+  "opentelemetry" {= version}
+  "opentelemetry-client" {= version}
+  "odoc" {with-doc}
+  "ezcurl-lwt" {>= "0.2.3"}
+  "ocurl"
+  "lwt" {>= "5.7.3"}
+  "lwt_ppx" {>= "2.0"}
+  "ambient-context-lwt"
+  "alcotest" {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "containers" {with-test}
+  "logs" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.91/opentelemetry-0.91.tbz"
+  checksum: [
+    "sha256=4aaee2025957acf71434a027bd57ee699a9ae927e6b49804fb1e999e16a03694"
+    "sha512=f3ec030fc4ca0483c3fc143eaa802e2aa02b4c25e1a03ec967bd017fad8a4ef6287e9f9688486434d1ac2fc403217658b61d2c7f3709c092c939b93f412ee5c5"
+  ]
+}
+x-commit-hash: "5065cdd98560706f635b89645e8567d3abb54331"

--- a/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.91/opam
+++ b/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.91/opam
@@ -29,7 +29,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & os != "macos"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.91/opam
+++ b/packages/opentelemetry-client-ocurl/opentelemetry-client-ocurl.0.91/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Collector client for opentelemetry, using http + ezcurl"
+maintainer: ["ocaml-tracing"]
+authors: ["ocaml-tracing" "ELLIOTTCABLE <opam@ell.io>" "the imandra team"]
+license: "MIT"
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "4.11"}
+  "mtime" {>= "1.4"}
+  "opentelemetry" {= version}
+  "opentelemetry-client" {= version}
+  "odoc" {with-doc}
+  "ezcurl" {>= "0.2.3"}
+  "curl"
+  "alcotest" {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "containers" {with-test}
+  "logs" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.91/opentelemetry-0.91.tbz"
+  checksum: [
+    "sha256=4aaee2025957acf71434a027bd57ee699a9ae927e6b49804fb1e999e16a03694"
+    "sha512=f3ec030fc4ca0483c3fc143eaa802e2aa02b4c25e1a03ec967bd017fad8a4ef6287e9f9688486434d1ac2fc403217658b61d2c7f3709c092c939b93f412ee5c5"
+  ]
+}
+x-commit-hash: "5065cdd98560706f635b89645e8567d3abb54331"

--- a/packages/opentelemetry-client/opentelemetry-client.0.91/opam
+++ b/packages/opentelemetry-client/opentelemetry-client.0.91/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Client SDK for https://opentelemetry.io"
+maintainer: ["ocaml-tracing"]
+authors: ["ocaml-tracing" "ELLIOTTCABLE <opam@ell.io>" "the imandra team"]
+license: "MIT"
+tags: ["tracing" "opentelemetry" "sdk"]
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "opentelemetry" {= version}
+  "odoc" {with-doc}
+  "alcotest" {with-test}
+  "thread-local-storage" {>= "0.2" & < "0.3"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.91/opentelemetry-0.91.tbz"
+  checksum: [
+    "sha256=4aaee2025957acf71434a027bd57ee699a9ae927e6b49804fb1e999e16a03694"
+    "sha512=f3ec030fc4ca0483c3fc143eaa802e2aa02b4c25e1a03ec967bd017fad8a4ef6287e9f9688486434d1ac2fc403217658b61d2c7f3709c092c939b93f412ee5c5"
+  ]
+}
+x-commit-hash: "5065cdd98560706f635b89645e8567d3abb54331"

--- a/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.91/opam
+++ b/packages/opentelemetry-cohttp-lwt/opentelemetry-cohttp-lwt.0.91/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Opentelemetry tracing for Cohttp HTTP servers"
+maintainer: ["ocaml-tracing"]
+authors: ["ocaml-tracing" "ELLIOTTCABLE <opam@ell.io>" "the imandra team"]
+license: "MIT"
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "4.08"}
+  "opentelemetry" {= version}
+  "opentelemetry-lwt" {= version}
+  "ambient-context-lwt"
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "cohttp" {>= "6.0.0"}
+  "cohttp-lwt" {>= "6.0.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.91/opentelemetry-0.91.tbz"
+  checksum: [
+    "sha256=4aaee2025957acf71434a027bd57ee699a9ae927e6b49804fb1e999e16a03694"
+    "sha512=f3ec030fc4ca0483c3fc143eaa802e2aa02b4c25e1a03ec967bd017fad8a4ef6287e9f9688486434d1ac2fc403217658b61d2c7f3709c092c939b93f412ee5c5"
+  ]
+}
+x-commit-hash: "5065cdd98560706f635b89645e8567d3abb54331"

--- a/packages/opentelemetry-logs/opentelemetry-logs.0.91/opam
+++ b/packages/opentelemetry-logs/opentelemetry-logs.0.91/opam
@@ -27,7 +27,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & os != "macos"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/opentelemetry-logs/opentelemetry-logs.0.91/opam
+++ b/packages/opentelemetry-logs/opentelemetry-logs.0.91/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Opentelemetry-based reporter for Logs"
+maintainer: ["ocaml-tracing"]
+authors: ["ocaml-tracing" "ELLIOTTCABLE <opam@ell.io>" "the imandra team"]
+license: "MIT"
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "4.08"}
+  "opentelemetry" {= version}
+  "odoc" {with-doc}
+  "logs" {>= "0.7.0"}
+  "alcotest" {with-test}
+  "containers" {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "opentelemetry-client-cohttp-lwt" {with-test & = version}
+  "opentelemetry-cohttp-lwt" {with-test & = version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.91/opentelemetry-0.91.tbz"
+  checksum: [
+    "sha256=4aaee2025957acf71434a027bd57ee699a9ae927e6b49804fb1e999e16a03694"
+    "sha512=f3ec030fc4ca0483c3fc143eaa802e2aa02b4c25e1a03ec967bd017fad8a4ef6287e9f9688486434d1ac2fc403217658b61d2c7f3709c092c939b93f412ee5c5"
+  ]
+}
+x-commit-hash: "5065cdd98560706f635b89645e8567d3abb54331"

--- a/packages/opentelemetry-lwt/opentelemetry-lwt.0.91/opam
+++ b/packages/opentelemetry-lwt/opentelemetry-lwt.0.91/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Lwt-compatible instrumentation for https://opentelemetry.io"
+maintainer: ["ocaml-tracing"]
+authors: ["ocaml-tracing" "ELLIOTTCABLE <opam@ell.io>" "the imandra team"]
+license: "MIT"
+tags: ["instrumentation" "tracing" "opentelemetry" "datadog" "lwt"]
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "4.08"}
+  "opentelemetry" {= version}
+  "ambient-context-lwt"
+  "cohttp-lwt-unix" {with-test}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3"}
+  "lwt_ppx" {>= "2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.91/opentelemetry-0.91.tbz"
+  checksum: [
+    "sha256=4aaee2025957acf71434a027bd57ee699a9ae927e6b49804fb1e999e16a03694"
+    "sha512=f3ec030fc4ca0483c3fc143eaa802e2aa02b4c25e1a03ec967bd017fad8a4ef6287e9f9688486434d1ac2fc403217658b61d2c7f3709c092c939b93f412ee5c5"
+  ]
+}
+x-commit-hash: "5065cdd98560706f635b89645e8567d3abb54331"

--- a/packages/opentelemetry/opentelemetry.0.91/opam
+++ b/packages/opentelemetry/opentelemetry.0.91/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis:
+  "Core library for instrumentation and serialization for https://opentelemetry.io"
+maintainer: ["ocaml-tracing"]
+authors: ["ocaml-tracing" "ELLIOTTCABLE <opam@ell.io>" "the imandra team"]
+license: "MIT"
+tags: ["instrumentation" "tracing" "opentelemetry" "datadog" "jaeger"]
+homepage: "https://github.com/ocaml-tracing/ocaml-opentelemetry"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-opentelemetry/issues"
+depends: [
+  "dune" {>= "3.11"}
+  "ocaml" {>= "4.08"}
+  "ptime"
+  "hmap"
+  "odoc" {with-doc}
+  "alcotest" {with-test}
+  "pbrt" {>= "4.0" & < "5.0"}
+  "pbrt_yojson" {>= "4.0" & < "5.0"}
+  "ambient-context" {>= "0.2"}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup & >= "0.27" & < "0.28"}
+  "mtime" {>= "1.4"}
+]
+depopts: ["atomic" "trace" "thread-local-storage" "lwt" "eio" "picos"]
+conflicts: [
+  "trace" {< "0.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-opentelemetry.git"
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-opentelemetry/releases/download/v0.91/opentelemetry-0.91.tbz"
+  checksum: [
+    "sha256=4aaee2025957acf71434a027bd57ee699a9ae927e6b49804fb1e999e16a03694"
+    "sha512=f3ec030fc4ca0483c3fc143eaa802e2aa02b4c25e1a03ec967bd017fad8a4ef6287e9f9688486434d1ac2fc403217658b61d2c7f3709c092c939b93f412ee5c5"
+  ]
+}
+x-commit-hash: "5065cdd98560706f635b89645e8567d3abb54331"


### PR DESCRIPTION
Core library for instrumentation and serialization for https://opentelemetry.io

- Project page: <a href="https://github.com/ocaml-tracing/ocaml-opentelemetry">https://github.com/ocaml-tracing/ocaml-opentelemetry</a>

##### CHANGES:

- expose Self_debug.level_above
- config: better defaults in Sdk, have batching enabled by default

- better error message for otlp http failures
- bounded queue: provide a per-item measure function for better errors/metrics
- fix: retries are self_debug logged at warning level
- move from ocurl to curl as a dep
