### PR TITLE
[new release] nats-client (2 packages) (0.0.8)

### DIFF
--- a/packages/nats-client-async/nats-client-async.0.0.8/opam
+++ b/packages/nats-client-async/nats-client-async.0.0.8/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Lean OCaml Async NATS client"
+description: "Async-based OCaml NATS client"
+maintainer: ["Hebilicious"]
+authors: ["Hebilicious"]
+license: "MIT"
+homepage: "https://github.com/hebilicious/nats-ml"
+bug-reports: "https://github.com/hebilicious/nats-ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.19"}
+  "core"
+  "async"
+  "async_unix"
+  "uri"
+  "yojson" {>= "1.7.0"}
+  "nats-client"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/hebilicious/nats-ml.git"
+x-maintenance-intent: ["(latest)"]
+available: [ os-distribution != "alpine" & arch != "riscv64" ]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & opam-version >= "2.1" & arch != "x86_32" & arch != "arm32" & arch != "ppc64"}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/hebilicious/nats-ml/releases/download/v0.0.8/nats-client-0.0.8.tbz"
+  checksum: [
+    "sha256=49c83c14fd7f2e2c2e10134824f9ddd6e4e18185a23907a95ac0f214edef6b4f"
+    "sha512=b10c31f5d28b6a09f95c0fa5e504de4dd3298ec6442b5c602b0ad6690570741ce38f94450c4115dc7236d3b4812cdf9d8f872bd84ad0fc9eb88265cb602184f3"
+  ]
+}
+x-commit-hash: "46cb3f69a22a05a14a689935c8e83b05fa5a32b8"

--- a/packages/nats-client/nats-client.0.0.8/opam
+++ b/packages/nats-client/nats-client.0.0.8/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Lean OCaml NATS protocol client"
+description: "Runtime-independent OCaml NATS protocol primitives"
+maintainer: ["Hebilicious"]
+authors: ["Hebilicious"]
+license: "MIT"
+homepage: "https://github.com/hebilicious/nats-ml"
+bug-reports: "https://github.com/hebilicious/nats-ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.19"}
+  "yojson"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/hebilicious/nats-ml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & opam-version >= "2.1"}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/hebilicious/nats-ml/releases/download/v0.0.8/nats-client-0.0.8.tbz"
+  checksum: [
+    "sha256=49c83c14fd7f2e2c2e10134824f9ddd6e4e18185a23907a95ac0f214edef6b4f"
+    "sha512=b10c31f5d28b6a09f95c0fa5e504de4dd3298ec6442b5c602b0ad6690570741ce38f94450c4115dc7236d3b4812cdf9d8f872bd84ad0fc9eb88265cb602184f3"
+  ]
+}
+x-commit-hash: "46cb3f69a22a05a14a689935c8e83b05fa5a32b8"


### PR DESCRIPTION
Lean OCaml NATS protocol client

- Project page: <a href="https://github.com/hebilicious/nats-ml">https://github.com/hebilicious/nats-ml</a>

##### CHANGES:


- Add package documentation landing pages and public API docs for ocaml.org.
- Relax the nats-client-async Yojson dependency lower bound to 1.7.0.
