### PR TITLE
mdx < 2.5.2 is not compatible with OCaml 5.5 (compiler-libs)

### DIFF
--- a/packages/mdx/mdx.2.5.1/opam
+++ b/packages/mdx/mdx.2.5.1/opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/realworldocaml/mdx"
 bug-reports: "https://github.com/realworldocaml/mdx/issues"
 depends: [
   "dune" {>= "3.5"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.5"}
   "ocamlfind"
   "fmt" {>= "0.8.7"}
   "cppo" {build & >= "1.1.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling mdx.2.5.1 ==========================================#
# context              2.6.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/mdx.2.5.1
# command              ~/.opam/5.5/bin/dune build -p mdx -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/mdx-14-11650b.env
# output-file          ~/.opam/log/mdx-14-11650b.out
### output ###
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I lib/top/.mdx_top.objs/byte -I /home/opam/.opam/5.5/lib/astring -I /home/opam/.opam/5.5/lib/camlp-streams -I /home/opam/.opam/5.5/lib/csexp -I /home/opam/.opam/5.5/lib/findlib -I /home/opam/.opam/5.5/lib/fmt -I /home/opam/.opam/5.5/lib/logs -I /home/opam/.opam/5.5/lib/ocaml-version -I /home/opam/.opam/5.5/lib/ocaml/compiler-libs -I /home/opam/.opam/5.5/lib/ocaml/str -I /home/opam/.opam/5.5/lib/ocaml/threads -I /home/opam/.opam/5.5/lib/ocaml/unix -I /home/opam/.opam/5.5/lib/re -I /home/opam/.opam/5.5/lib/result -I lib/.mdx.objs/byte -I vendor/odoc-parser/src/.odoc_parser.objs/byte -cmi-file lib/top/.mdx_top.objs/byte/mdx_top__Compat_top.cmi -no-alias-deps -open Mdx_top__ -o lib/top/.mdx_top.objs/byte/mdx_top__Compat_top.cmo -c -impl lib/top/compat_top.pp.ml)
# File "lib/top/compat_top.ml", line 130, characters 4-19:
# Error: This variant pattern is expected to have type Env.summary
#        There is no constructor Env_functor_arg within type Env.summary
```