### PR TITLE
[new release] prettym (0.0.5)

### DIFF
--- a/packages/prettym/prettym.0.0.5/opam
+++ b/packages/prettym/prettym.0.0.5/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/prettym"
+bug-reports:  "https://github.com/dinosaure/prettym/issues"
+dev-repo:     "git+https://github.com/dinosaure/prettym.git"
+doc:          "https://dinosaure.github.io/prettym/"
+license:      "MIT"
+synopsis:     "An memory-bounded encoder according to RFC 822"
+description:  """A best effort memory-bounded encoder to respect the 80 column limitation"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"            {>= "4.08.0"}
+  "dune"             {>= "2.8"}
+  "ke"               {>= "0.4"}
+  "bstr"
+  "ptime"            {with-test}
+  "alcotest"         {with-test}
+  "jsonm"            {with-test}
+  "base64"           {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/dinosaure/prettym/releases/download/0.0.5/prettym-0.0.5.tbz"
+  checksum: [
+    "sha256=dac159996f07a924c5f5441953a95cc62a4b5f5eedc49c31659211aff093d462"
+    "sha512=aa6b77d5d307a70936471ba0cd55b1c9081d30cf6cab98a609f3a24ac4acc8df752aa0f4e64a08a3dae73bc7590b1c62e98e8dd7e418d8b3702447bc28beca52"
+  ]
+}
+x-commit-hash: "1a230266bb6096aa39300319265628a15e03dd03"


### PR DESCRIPTION
An memory-bounded encoder according to RFC 822

- Project page: <a href="https://github.com/dinosaure/prettym">https://github.com/dinosaure/prettym</a>
- Documentation: <a href="https://dinosaure.github.io/prettym/">https://dinosaure.github.io/prettym/</a>

##### CHANGES:

- Add the ability to encode value without margin (@dinosaure, dinosaure/prettym#8)
