### PR TITLE
ppx_import is not compatible with OCaml 5.5 (compiler-libs)

### DIFF
--- a/packages/ppx_import/ppx_import.1.12.0/opam
+++ b/packages/ppx_import/ppx_import.1.12.0/opam
@@ -10,9 +10,8 @@ dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
 tags: [ "syntax" ]
 
 depends: [
-   "ocaml"                   {>= "4.08.0" &  < "4.10.0"  }
-| ("ocaml"                   {>= "4.10.0"}
-   "ppx_sexp_conv" {with-test & >= "v0.13.0"})
+   "ocaml" {>= "4.08.0" & < "4.10.0"} |
+("ocaml" {>= "4.10.0" & < "5.5"} & "ppx_sexp_conv" {with-test & >= "v0.13.0"})
   "dune"                    {              >= "1.11.0"  }
   "ppxlib"                  {              >= "0.34.0"  }
   "ounit"                   { with-test                 }


### PR DESCRIPTION
```
#=== ERROR while compiling ppx_import.1.12.0 ==================================#
# context              2.6.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/ppx_import.1.12.0
# command              ~/.opam/5.5/bin/dune build -p ppx_import -j 1
# exit-code            1
# env-file             ~/.opam/log/ppx_import-14-6fbf79.env
# output-file          ~/.opam/log/ppx_import-14-6fbf79.out
### output ###
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/.ppx_import.objs/byte -I /home/opam/.opam/5.5/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.5/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.5/lib/ocaml/compiler-libs -I /home/opam/.opam/5.5/lib/ppx_derivers -I /home/opam/.opam/5.5/lib/ppxlib -I /home/opam/.opam/5.5/lib/ppxlib/ast -I /home/opam/.opam/5.5/lib/ppxlib/astlib -I /home/opam/.opam/5.5/lib/ppxlib/print_diff -I /home/opam/.opam/5.5/lib/ppxlib/stdppx -I /home/opam/.opam/5.5/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.5/lib/sexplib0 -I /home/opam/.opam/5.5/lib/stdlib-shims -no-alias-deps -open Ppx_import__ -o src/.ppx_import.objs/byte/ppx_import__Compat.cmo -c -impl src/compat.pp.ml)
# File "src/compat.ml", lines 44-48, characters 67-26:
# 44 | ...................................................................function
# 45 |   | Type_abstract _ -> Type_abstract
# 46 |   | Type_record (lbl, repr) -> Type_record (lbl, repr)
# 47 |   | Type_variant (cstr, _) -> Type_variant cstr
# 48 |   | Type_open -> Type_open
# Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
#   Here is an example of a case that is not matched: Type_external _
```