### PR TITLE
[new release] mrmime (0.7.2)

### DIFF
--- a/packages/mrmime/mrmime.0.7.2/opam
+++ b/packages/mrmime/mrmime.0.7.2/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/mrmime"
+bug-reports:  "https://github.com/mirage/mrmime/issues"
+dev-repo:     "git+https://github.com/mirage/mrmime.git"
+doc:          "https://mirage.github.io/mrmime/"
+license:      "MIT"
+synopsis:     "Mr. MIME"
+description:  """Parser and generator of mail in OCaml"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.7"}
+  "ke"                {>= "0.4"}
+  "bstr"              {>= "0.0.3"}
+  "unstrctrd"         {>= "0.3"}
+  "ptime"             {>= "0.8.2"}
+  "uutf"
+  "rosetta"           {>= "0.3.0"}
+  "ipaddr"            {>= "5.0.0"}
+  "emile"             {>= "1.0"}
+  "base64"            {>= "3.1.0"}
+  "pecu"              {>= "0.6"}
+  "prettym"           {>= "0.0.2"}
+  "angstrom"          {>= "0.14.0"}
+  "fpath"             {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test & >= "2.0.0"}
+  "ocplib-endian"     {with-test}
+  "afl-persistent"    {with-test}
+  "alcotest"          {with-test}
+  "jsonm"             {with-test}
+  "crowbar"           {with-test}
+  "lwt"               {with-test}
+  "cmdliner"          {with-test & >= "1.1.0"}
+  "logs"              {with-test}
+]
+conflicts: [
+  "result"            {< "1.5"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mrmime/releases/download/v0.7.2/mrmime-0.7.2.tbz"
+  checksum: [
+    "sha256=e89b8be0241108e6470a456aeb9b1b5b05baa01f6cdd23fc53257de55c2667cb"
+    "sha512=ddd232788fa80ee0650b22199c14877eb2b6dd08770fe96b37c4e0834ec6ccd7c2c44562eaa1690922203eb75d77a50e5eeda4dce7c3b7120d75fe52df785805"
+  ]
+}
+x-commit-hash: "c710c0d8928753179b6c03357c88042c4dfa1c2b"


### PR DESCRIPTION
Mr. MIME

- Project page: <a href="https://github.com/mirage/mrmime">https://github.com/mirage/mrmime</a>
- Documentation: <a href="https://mirage.github.io/mrmime/">https://mirage.github.io/mrmime/</a>

##### CHANGES:

- Add `Uchar.rep` when `pecu` is not able to parse ISO-8859 characters (@dinosaure, mirage/mrmime#112)
- Be more best-effort than before about body parts and remove some `assert false` (@dinosaure, mirage/mrmime#113)
