### PR TITLE
[new release] ocaml-ai-sdk (2 packages) (0.3)

### DIFF
--- a/packages/ai-sdk-react/ai-sdk-react.0.3/opam
+++ b/packages/ai-sdk-react/ai-sdk-react.0.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Melange bindings for @ai-sdk/react"
+description: "Type-safe OCaml/Melange bindings for Vercel AI SDK)"
+maintainer: ["José Nogueira <jose.nogueira@ahrefs.com>"]
+authors: ["Ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/ocaml-ai-sdk"
+doc: "https://github.com/ahrefs/ocaml-ai-sdk"
+bug-reports: "https://github.com/ahrefs/ocaml-ai-sdk/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.14"}
+  "melange" {>= "4.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ocaml-ai-sdk.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ahrefs/ocaml-ai-sdk/releases/download/0.3/ocaml-ai-sdk-0.3.tbz"
+  checksum: [
+    "sha256=636d458cb1564ed88ca8c0250c432e91c2f822fd49ad2b923819e762bda10be6"
+    "sha512=361e476423ebc0f9cf561cc28ccd4531cf08e424e95eea43a67d6b8dbb457a49a25b418625ffa99f6327fc5df14e540e502d1aa8ed606111c5c010fe498eec2a"
+  ]
+}
+x-commit-hash: "5ad2eadaf18e5709174c84cc51a29f1b5b4f8575"

--- a/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.3/opam
+++ b/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.3/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "OCaml AI SDK - Provider abstraction for AI models"
+description:
+  "Type-safe, provider-agnostic AI model abstraction inspired by Vercel AI SDK"
+maintainer: ["José Nogueira <jose.nogueira@ahrefs.com>"]
+authors: ["Ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/ocaml-ai-sdk"
+doc: "https://github.com/ahrefs/ocaml-ai-sdk"
+bug-reports: "https://github.com/ahrefs/ocaml-ai-sdk/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.14"}
+  "lwt" {>= "5.9"}
+  "yojson" {>= "2.2"}
+  "jsonschema" {>= "0.1"}
+  "melange-json-native" {>= "2.0"}
+  "cohttp-lwt-unix" {>= "5.3"}
+  "lwt_ssl" {>= "1.2"}
+  "base64" {>= "1.3"}
+  "ppx_deriving" {>= "5.2"}
+  "lwt_ppx" {>= "5.9"}
+  "re2" {>= "0.16"}
+  "uuseg" {>= "17.0"}
+  "trace" {>= "0.12"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ocaml-ai-sdk.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ahrefs/ocaml-ai-sdk/releases/download/0.3/ocaml-ai-sdk-0.3.tbz"
+  checksum: [
+    "sha256=636d458cb1564ed88ca8c0250c432e91c2f822fd49ad2b923819e762bda10be6"
+    "sha512=361e476423ebc0f9cf561cc28ccd4531cf08e424e95eea43a67d6b8dbb457a49a25b418625ffa99f6327fc5df14e540e502d1aa8ed606111c5c010fe498eec2a"
+  ]
+}
+x-commit-hash: "5ad2eadaf18e5709174c84cc51a29f1b5b4f8575"


### PR DESCRIPTION
OCaml AI SDK - Provider abstraction for AI models

- Project page: <a href="https://github.com/ahrefs/ocaml-ai-sdk">https://github.com/ahrefs/ocaml-ai-sdk</a>
- Documentation: <a href="https://github.com/ahrefs/ocaml-ai-sdk">https://github.com/ahrefs/ocaml-ai-sdk</a>

##### CHANGES:

### Anthropic provider (`ai_provider_anthropic`)

- **Native Structured Outputs** — `Object_json` mode now uses Anthropic's
  native `output_config.format = { type: "json_schema", schema }` field on
  capable models (Haiku 4.5, Sonnet 4.5/4.6, Opus 4.5/4.6/4.7), matching
  upstream `@ai-sdk/anthropic`. Schema enforcement is handled by the provider,
  not by appending instructions to the system prompt.
- **Tool-use fallback** — on older models (Sonnet 4.0, Opus 4.0/4.1) and
  unknown `Custom` model ids, the provider synthesises a tool named `json`
  carrying the schema as `input_schema` and forces `tool_choice = { type:
  "tool", name: "json" }`. The caller's system prompt is left untouched.
- **Prompt injection removed** — the previous best-effort "Respond ONLY with
  JSON matching this schema…" system-prompt append has been deleted. Callers
  using `Object_json None` (no schema) now receive an `Unsupported_feature`
  warning because Anthropic cannot enforce JSON without a schema.
- **Model catalog** — added `Claude_opus_4_7`. The
  `supports_structured_output` capability flag is now accurate per model
  (previously defaulted to `true` for all known models).

### Core SDK (`ai_core`)

- **`Output.parse_output`** — when a step has no assistant text, falls back to
  decoding the `json` tool call's `args`. Enables end-to-end structured
  output on the Anthropic fallback path and on any future provider that
  adopts the same convention.
- **`Stream_text`** — `Tool_call_delta` events for the `json` tool drive the
  partial-output parser, so streaming callers see incremental JSON on the
  fallback path with the same UX as the native path.

### Provider abstraction (`ai_provider`)

- **HTTP timeouts.** New `Ai_provider.Http_timeouts` module and
  `Ai_provider.Http_client` wrapper. Defaults: 600s for response headers
  (`request_timeout`) and 300s for silence between streaming chunks
  (`stream_idle_timeout`). Override per-provider via `Config.create
  ?timeouts`. Conservative values chosen to catch stuck connections and
  bugs, not bound legitimate workloads — a 20-minute streaming response
  completes fine as long as chunks keep flowing.
- **New `Provider_error.Timeout` kind** with `phase`
  (`Request_headers` | `Stream_idle`), `elapsed_s`, and `limit_s`.
  `is_retryable` is derived: `Stream_idle` is retryable (connection is
  dead); `Request_headers` is not (server may already be processing the
  request).
- **Fix: `Sse.parse_events` no longer hangs consumers on upstream errors.**
  Previously, an exception from the upstream line stream left the output
  stream pending forever. It now closes cleanly (via `push None`) and
  re-raises to `Lwt.async_exception_hook` so the underlying bug stays
  visible.
- **`Mode.fallback_json_tool_name`** — exported constant (`"json"`) naming the
  synthetic tool used by the structured-output tool-use fallback convention.
  Shared between `ai_core` and providers so the convention has a single
  source of truth.

### Providers (`ai_provider_openai`, `ai_provider_anthropic`, `ai_provider_openrouter`)

- Each `Config.t` gains a `timeouts : Http_timeouts.t` field. All HTTP
  traffic now routes through `Http_client`, removing three copies of the
  unguarded `body_to_line_stream` helper.

### Examples

- `structured_output` — live-API smoke test exercising both the native and
  tool-fallback paths with `ppx_deriving_jsonschema` for schema derivation
  and `melange-json-native`'s `of_json` deriver for typed response decoding.
