### PR TITLE
[new release] dkim (4 packages) (0.11.0)

### DIFF
--- a/packages/dkim-bin/dkim-bin.0.11.0/opam
+++ b/packages/dkim-bin/dkim-bin.0.11.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/ocaml-dkim"
+bug-reports:  "https://github.com/mirage/ocaml-dkim/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-dkim.git"
+doc:          "https://mirage.github.io/ocaml-dkim/"
+license:      "MIT"
+synopsis:     "Implementation of DKIM in OCaml"
+description: """A library and a binary to verify and sign an email
+with the DKIM mechanism described by the RFC 6376"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.0.0"}
+  "dkim"              {= version}
+  "ca-certs"
+  "cmdliner"          {>= "1.1.0"}
+  "logs"
+  "fmt"               {>= "0.8.7"}
+  "fpath"
+  "dkim-lwt-unix"     {= version}
+  "alcotest"          {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dkim/releases/download/v0.11.0/dkim-0.11.0.tbz"
+  checksum: [
+    "sha256=d5e8e7572d5cdcc15af8cad90aa18eacd749e2287c0d508673d336af5aa3e524"
+    "sha512=3c5249a1e975fc0c6dd6aeb00b4a8c28c4c9c053ec2ee5bb534fefbcfba5c38c5611409930b2da37f4dadd9e7a1add1b359f291a96fc35b861c1e6dcfade3ea8"
+  ]
+}
+x-commit-hash: "b33247a45bf921a5362e1fd269640df4b93547e8"

--- a/packages/dkim-lwt-unix/dkim-lwt-unix.0.11.0/opam
+++ b/packages/dkim-lwt-unix/dkim-lwt-unix.0.11.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/ocaml-dkim"
+bug-reports:  "https://github.com/mirage/ocaml-dkim/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-dkim.git"
+doc:          "https://mirage.github.io/ocaml-dkim/"
+license:      "MIT"
+synopsis:     "Implementation of DKIM in OCaml with LWT"
+description: """A library and a binary to verify and sign an email
+with the DKIM mechanism described by the RFC 6376"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.0.0"}
+  "dkim"              {= version}
+  "lwt"
+  "dns-client-lwt"
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dkim/releases/download/v0.11.0/dkim-0.11.0.tbz"
+  checksum: [
+    "sha256=d5e8e7572d5cdcc15af8cad90aa18eacd749e2287c0d508673d336af5aa3e524"
+    "sha512=3c5249a1e975fc0c6dd6aeb00b4a8c28c4c9c053ec2ee5bb534fefbcfba5c38c5611409930b2da37f4dadd9e7a1add1b359f291a96fc35b861c1e6dcfade3ea8"
+  ]
+}
+x-commit-hash: "b33247a45bf921a5362e1fd269640df4b93547e8"

--- a/packages/dkim-mirage/dkim-mirage.0.11.0/opam
+++ b/packages/dkim-mirage/dkim-mirage.0.11.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/ocaml-dkim"
+bug-reports:  "https://github.com/mirage/ocaml-dkim/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-dkim.git"
+doc:          "https://mirage.github.io/ocaml-dkim/"
+license:      "MIT"
+synopsis:     "Implementation of DKIM in OCaml for MirageOS"
+description: """A light layer of the dkim library for MirageOS"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.0.0"}
+  "dkim"              {= version}
+  "dns-client-mirage" {>= "8.0.0"}
+  "mirage-ptime"
+  "lwt"
+  "alcotest"          {with-test}
+  "digestif"          {with-test}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test & >= "1.0.0"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dkim/releases/download/v0.11.0/dkim-0.11.0.tbz"
+  checksum: [
+    "sha256=d5e8e7572d5cdcc15af8cad90aa18eacd749e2287c0d508673d336af5aa3e524"
+    "sha512=3c5249a1e975fc0c6dd6aeb00b4a8c28c4c9c053ec2ee5bb534fefbcfba5c38c5611409930b2da37f4dadd9e7a1add1b359f291a96fc35b861c1e6dcfade3ea8"
+  ]
+}
+x-commit-hash: "b33247a45bf921a5362e1fd269640df4b93547e8"

--- a/packages/dkim/dkim.0.11.0/opam
+++ b/packages/dkim/dkim.0.11.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/ocaml-dkim"
+bug-reports:  "https://github.com/mirage/ocaml-dkim/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-dkim.git"
+doc:          "https://mirage.github.io/ocaml-dkim/"
+license:      "MIT"
+synopsis:     "Implementation of DKIM in OCaml"
+description: """A library and a binary to verify and sign an email
+with the DKIM mechanism described by the RFC 6376"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.0.0"}
+  "mrmime"            {>= "0.5.0"}
+  "digestif"          {>= "0.9.0"}
+  "ipaddr"
+  "base-unix"
+  "hmap"
+  "domain-name"
+  "dns-client"        {>= "6.4.0"}
+  "cmdliner"          {>= "1.1.0"}
+  "logs"
+  "fmt"               {>= "0.8.7"}
+  "fpath"
+  "base64"            {>= "3.0.0"}
+  "mirage-crypto"     {>= "1.0.0"}
+  "mirage-crypto-pk"  {>= "1.0.0"}
+  "x509"              {>= "1.0.0"}
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
+  "alcotest"          {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dkim/releases/download/v0.11.0/dkim-0.11.0.tbz"
+  checksum: [
+    "sha256=d5e8e7572d5cdcc15af8cad90aa18eacd749e2287c0d508673d336af5aa3e524"
+    "sha512=3c5249a1e975fc0c6dd6aeb00b4a8c28c4c9c053ec2ee5bb534fefbcfba5c38c5611409930b2da37f4dadd9e7a1add1b359f291a96fc35b861c1e6dcfade3ea8"
+  ]
+}
+x-commit-hash: "b33247a45bf921a5362e1fd269640df4b93547e8"


### PR DESCRIPTION
Implementation of DKIM in OCaml

- Project page: <a href="https://github.com/mirage/ocaml-dkim">https://github.com/mirage/ocaml-dkim</a>
- Documentation: <a href="https://mirage.github.io/ocaml-dkim/">https://mirage.github.io/ocaml-dkim/</a>

##### CHANGES:

- Add `with_selector` (@dinosaure, mirage/ocaml-dkim#63)
- Handle correctly `ed25519` algorithm (@dinosaure, mirage/ocaml-dkim#64)
- Lint and warn when the user tries to sign DKIM-Signature (@dinosaure, mirage/ocaml-dkim#65)
- Apply `ocamlformat.0.29.0` (@dinosaure, mirage/ocaml-dkim#67)
- Be able to not write v=DKIM1 when we encode a domain-key (for ARC) (@dinosaure, mirage/ocaml-dkim#68)
- Be able to not write DKIM version on our DKIM-Signature (@dinosaure, mirage/ocaml-dkim#69, mirage/ocaml-dkim#70)
