### PR TITLE
eliom is not compatible with OCaml 5.5 (compiler-libs)

### DIFF
--- a/packages/eliom/eliom.12.0.0/opam
+++ b/packages/eliom/eliom.12.0.0/opam
@@ -17,7 +17,7 @@ homepage: "https://ocsigen.org/eliom/"
 bug-reports: "https://github.com/ocsigen/eliom/issues"
 depends: [
   "dune" {>= "3.19"}
-  "ocaml" {>= "4.12"}
+  "ocaml" {>= "4.12" & < "5.5"}
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.37"}

--- a/packages/eliom/eliom.12.0.1/opam
+++ b/packages/eliom/eliom.12.0.1/opam
@@ -17,7 +17,7 @@ homepage: "https://ocsigen.org/eliom/"
 bug-reports: "https://github.com/ocsigen/eliom/issues"
 depends: [
   "dune" {>= "3.19"}
-  "ocaml" {>= "4.12"}
+  "ocaml" {>= "4.12" & < "5.5"}
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.37"}


### PR DESCRIPTION
```
#=== ERROR while compiling eliom.12.0.1 =======================================#
# context              2.6.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/eliom.12.0.1
# command              ~/.opam/5.5/bin/dune build -p eliom -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/eliom-13-57727c.env
# output-file          ~/.opam/log/eliom-13-57727c.out
### output ###
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlopt.opt -w -40 -g -I src/ppx/.ppx_utils.objs/byte -I src/ppx/.ppx_utils.objs/native -I /home/opam/.opam/5.5/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.5/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.5/lib/ocaml/compiler-libs -I /home/opam/.opam/5.5/lib/ppx_derivers -I /home/opam/.opam/5.5/lib/ppxlib -I /home/opam/.opam/5.5/lib/ppxlib/ast -I /home/opam/.opam/5.5/lib/ppxlib/astlib -I /home/opam/.opam/5.5/lib/ppxlib/print_diff -I /home/opam/.opam/5.5/lib/ppxlib/stdppx -I /home/opam/.opam/5.5/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.5/lib/sexplib0 -I /home/opam/.opam/5.5/lib/stdlib-shims -cmi-file src/ppx/.ppx_utils.objs/byte/ppx_eliom_utils.cmi -no-alias-deps -o src/ppx/.ppx_utils.objs/native/ppx_eliom_utils.cmx -c -impl src/ppx/ppx_eliom_utils.pp.ml)
# File "src/ppx/ppx_eliom_utils.ml", line 420, characters 31-39:
# 420 |       | ((Otyp_object {fields; open_row}) [@if ocaml_version >= (5, 1, 0)]) ->
#                                      ^^^^^^^^
# Error: The field open_row is not part of the record argument for the Outcometree.out_type.Otyp_object constructor
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/ppx/.ppx_utils.objs/byte -I /home/opam/.opam/5.5/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.5/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.5/lib/ocaml/compiler-libs -I /home/opam/.opam/5.5/lib/ppx_derivers -I /home/opam/.opam/5.5/lib/ppxlib -I /home/opam/.opam/5.5/lib/ppxlib/ast -I /home/opam/.opam/5.5/lib/ppxlib/astlib -I /home/opam/.opam/5.5/lib/ppxlib/print_diff -I /home/opam/.opam/5.5/lib/ppxlib/stdppx -I /home/opam/.opam/5.5/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.5/lib/sexplib0 -I /home/opam/.opam/5.5/lib/stdlib-shims -cmi-file src/ppx/.ppx_utils.objs/byte/ppx_eliom_utils.cmi -no-alias-deps -o src/ppx/.ppx_utils.objs/byte/ppx_eliom_utils.cmo -c -impl src/ppx/ppx_eliom_utils.pp.ml)
# File "src/ppx/ppx_eliom_utils.ml", line 420, characters 31-39:
# 420 |       | ((Otyp_object {fields; open_row}) [@if ocaml_version >= (5, 1, 0)]) ->
#                                      ^^^^^^^^
# Error: The field open_row is not part of the record argument for the Outcometree.out_type.Otyp_object constructor
```