### PR TITLE
quill is not compatible with OCaml 5.5 (compiler-libs)

### DIFF
--- a/packages/quill/quill.1.0.0~alpha1/opam
+++ b/packages/quill/quill.1.0.0~alpha1/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/raven-ml/raven"
 doc: "https://raven-ml.dev/docs/"
 bug-reports: "https://github.com/raven-ml/raven/issues"
 depends: [
-  "ocaml" {>= "5.3.0"}
+  "ocaml" {>= "5.3.0" & < "5.5"}
   "dune" {>= "3.19"}
   "dune-site" {>= "3.19.0"}
   "cmdliner"

--- a/packages/quill/quill.1.0.0~alpha2/opam
+++ b/packages/quill/quill.1.0.0~alpha2/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/raven-ml/raven"
 doc: "https://raven-ml.dev/docs/"
 bug-reports: "https://github.com/raven-ml/raven/issues"
 depends: [
-  "ocaml" {>= "5.3.0"}
+  "ocaml" {>= "5.3.0" & < "5.5"}
   "dune" {>= "3.19"}
   "dune-site" {>= "3.19.0"}
   "cmdliner"

--- a/packages/quill/quill.1.0.0~alpha3/opam
+++ b/packages/quill/quill.1.0.0~alpha3/opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/raven-ml/raven"
 doc: "https://raven-ml.dev/docs/"
 bug-reports: "https://github.com/raven-ml/raven/issues"
 depends: [
-  "ocaml" {>= "5.2.0"}
+  "ocaml" {>= "5.2.0" & < "5.5"}
   "dune" {>= "3.21"}
   "cmarkit"
   "cmdliner"


### PR DESCRIPTION
```
#=== ERROR while compiling quill.1.0.0~alpha3 =================================#
# context              2.6.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/quill.1.0.0~alpha3
# command              ~/.opam/5.5/bin/dune build -p quill -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/quill-14-3b399e.env
# output-file          ~/.opam/log/quill-14-3b399e.out
### output ###
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -g -bin-annot -bin-annot-occurrences -I packages/quill/lib/quill-top/.quill_top.objs/byte -I /home/opam/.opam/5.5/lib/findlib -I /home/opam/.opam/5.5/lib/ocaml/compiler-libs -I /home/opam/.opam/5.5/lib/ocaml/threads -I /home/opam/.opam/5.5/lib/ocaml/unix -I packages/quill/lib/quill/.quill.objs/byte -H /home/opam/.opam/5.5/lib/findlib -H /home/opam/.opam/5.5/lib/ocaml/compiler-libs -H /home/opam/.opam/5.5/lib/ocaml/threads -cmi-file packages/quill/lib/quill-top/.quill_top.objs/byte/quill_top.cmi -no-alias-deps -o packages/quill/lib/quill-top/.quill_top.objs/byte/quill_top.cmo -c -impl packages/quill/lib/quill-top/quill_top.ml)
# File "packages/quill/lib/quill-top/quill_top.ml", line 155, characters 8-31:
# 155 |         Toploop.install_printer printer_path ty_expr f
#               ^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Toploop.install_printer
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlopt.opt -g -I packages/quill/lib/quill-top/.quill_top.objs/byte -I packages/quill/lib/quill-top/.quill_top.objs/native -I /home/opam/.opam/5.5/lib/findlib -I /home/opam/.opam/5.5/lib/ocaml/compiler-libs -I /home/opam/.opam/5.5/lib/ocaml/threads -I /home/opam/.opam/5.5/lib/ocaml/unix -I packages/quill/lib/quill/.quill.objs/byte -I packages/quill/lib/quill/.quill.objs/native -H /home/opam/.opam/5.5/lib/findlib -H /home/opam/.opam/5.5/lib/ocaml/compiler-libs -H /home/opam/.opam/5.5/lib/ocaml/threads -cmi-file packages/quill/lib/quill-top/.quill_top.objs/byte/quill_top.cmi -no-alias-deps -o packages/quill/lib/quill-top/.quill_top.objs/native/quill_top.cmx -c -impl packages/quill/lib/quill-top/quill_top.ml)
# File "packages/quill/lib/quill-top/quill_top.ml", line 155, characters 8-31:
# 155 |         Toploop.install_printer printer_path ty_expr f
#               ^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Toploop.install_printer
```