### PR TITLE
[new release] colombe, msendmail, sendmail-lwt, sendmail-miou-unix, sendmail-mirage and sendmail (0.13.0)

### DIFF
--- a/packages/colombe/colombe.0.13.0/opam
+++ b/packages/colombe/colombe.0.13.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+synopsis:     "SMTP protocol in OCaml"
+doc:          "https://mirage.github.io/colombe/"
+description: """SMTP protocol according RFC5321 without extension."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "3.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "ocaml-syntax-shims"
+  "alcotest" {with-test}
+  "crowbar" {>= "0.2" & with-test}
+]
+depopts: [ "emile" ]
+conflicts: [ "emile" {< "0.8"} ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.13.0/colombe-0.13.0.tbz"
+  checksum: [
+    "sha256=3d55b5baf77057239c1dc0a2893060303817c69f539c6f80d04f8f1c504cf24d"
+    "sha512=5eaa8ae98ce1d5bfd15e8093195492ec63b4b0277be63752428494d1090c6e7ceb54b7706b091ca6582b647f7ae4ce82c3cf475d61029855c0bc46d4762c61bb"
+  ]
+}
+x-commit-hash: "6b1655d5e552572c391430d53c9ce8d4eb858320"

--- a/packages/colombe/colombe.0.13.0/opam
+++ b/packages/colombe/colombe.0.13.0/opam
@@ -22,6 +22,7 @@ depends: [
   "angstrom" {>= "0.14.0"}
   "ocaml-syntax-shims"
   "alcotest" {with-test}
+  "emile" {with-test}
   "crowbar" {>= "0.2" & with-test}
 ]
 depopts: [ "emile" ]

--- a/packages/msendmail/msendmail.0.13.0/opam
+++ b/packages/msendmail/msendmail.0.13.0/opam
@@ -21,7 +21,7 @@ depends: [
   "domain-name"
   "mnet"
   "mnet-tls"
-  "flux"
+  "flux" {>= "0.0.1~beta4"}
   "mnet-happy-eyeballs"
   "ca-certs-nss" {>= "3.108-1"}
 ]

--- a/packages/msendmail/msendmail.0.13.0/opam
+++ b/packages/msendmail/msendmail.0.13.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command for Solo5/mkernel"
+description: """A library to be able to send an email for Solo5/mkernel"""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "5.3.0"}
+  "dune" {>= "2.0"}
+  "sendmail" {= version}
+  "domain-name"
+  "mnet"
+  "mnet-tls"
+  "flux"
+  "mnet-happy-eyeballs"
+  "ca-certs-nss" {>= "3.108-1"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.13.0/colombe-0.13.0.tbz"
+  checksum: [
+    "sha256=3d55b5baf77057239c1dc0a2893060303817c69f539c6f80d04f8f1c504cf24d"
+    "sha512=5eaa8ae98ce1d5bfd15e8093195492ec63b4b0277be63752428494d1090c6e7ceb54b7706b091ca6582b647f7ae4ce82c3cf475d61029855c0bc46d4762c61bb"
+  ]
+}
+x-commit-hash: "6b1655d5e552572c391430d53c9ce8d4eb858320"

--- a/packages/sendmail-lwt/sendmail-lwt.0.13.0/opam
+++ b/packages/sendmail-lwt/sendmail-lwt.0.13.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT and TLS."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "sendmail" {= version}
+  "domain-name"
+  "ipaddr"
+  "ca-certs"
+  "lwt"
+  "tls" {>= "0.13.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "x509" {>= "0.12.0"}
+  "alcotest" {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.13.0/colombe-0.13.0.tbz"
+  checksum: [
+    "sha256=3d55b5baf77057239c1dc0a2893060303817c69f539c6f80d04f8f1c504cf24d"
+    "sha512=5eaa8ae98ce1d5bfd15e8093195492ec63b4b0277be63752428494d1090c6e7ceb54b7706b091ca6582b647f7ae4ce82c3cf475d61029855c0bc46d4762c61bb"
+  ]
+}
+x-commit-hash: "6b1655d5e552572c391430d53c9ce8d4eb858320"

--- a/packages/sendmail-miou-unix/sendmail-miou-unix.0.13.0/opam
+++ b/packages/sendmail-miou-unix/sendmail-miou-unix.0.13.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over Miou"
+description: """A library to be able to send an email with Miou and TLS."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "2.0"}
+  "sendmail" {= version}
+  "domain-name"
+  "happy-eyeballs-miou-unix"
+  "tls-miou-unix" {>= "1.0.3"}
+  "x509"
+  "ca-certs"
+  "alcotest" {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.13.0/colombe-0.13.0.tbz"
+  checksum: [
+    "sha256=3d55b5baf77057239c1dc0a2893060303817c69f539c6f80d04f8f1c504cf24d"
+    "sha512=5eaa8ae98ce1d5bfd15e8093195492ec63b4b0277be63752428494d1090c6e7ceb54b7706b091ca6582b647f7ae4ce82c3cf475d61029855c0bc46d4762c61bb"
+  ]
+}
+x-commit-hash: "6b1655d5e552572c391430d53c9ce8d4eb858320"

--- a/packages/sendmail-mirage/sendmail-mirage.0.13.0/opam
+++ b/packages/sendmail-mirage/sendmail-mirage.0.13.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT and TLS."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "sendmail" {= version}
+  "domain-name"
+  "happy-eyeballs-mirage"
+  "mirage-flow"
+  "ca-certs-nss" {>= "3.108-1"}
+  "lwt"
+  "tls" {>= "0.13.0"}
+  "tls-mirage" {>= "0.16.0"}
+  "x509" {>= "0.12.0"}
+  "alcotest" {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.13.0/colombe-0.13.0.tbz"
+  checksum: [
+    "sha256=3d55b5baf77057239c1dc0a2893060303817c69f539c6f80d04f8f1c504cf24d"
+    "sha512=5eaa8ae98ce1d5bfd15e8093195492ec63b4b0277be63752428494d1090c6e7ceb54b7706b091ca6582b647f7ae4ce82c3cf475d61029855c0bc46d4762c61bb"
+  ]
+}
+x-commit-hash: "6b1655d5e552572c391430d53c9ce8d4eb858320"

--- a/packages/sendmail/sendmail.0.13.0/opam
+++ b/packages/sendmail/sendmail.0.13.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Gwenaëlle Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command"
+description: """A library to be able to send an email."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "5.2"}
+  "dune" {>= "2.0"}
+  "colombe" {= version}
+  "tls" {>= "1.0.2"}
+  "base64" {>= "3.0.0"}
+  "ke" {>= "0.4"}
+  "logs"
+  "rresult"
+  "hxd" {>= "0.3.2"}
+  "bigstringaf" {>= "0.2.0"}
+  "emile" {>= "0.8" & with-test}
+  "mrmime" {>= "0.3.2" & with-test}
+  "cstruct" {>= "6.0.0"}
+  "alcotest" {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.13.0/colombe-0.13.0.tbz"
+  checksum: [
+    "sha256=3d55b5baf77057239c1dc0a2893060303817c69f539c6f80d04f8f1c504cf24d"
+    "sha512=5eaa8ae98ce1d5bfd15e8093195492ec63b4b0277be63752428494d1090c6e7ceb54b7706b091ca6582b647f7ae4ce82c3cf475d61029855c0bc46d4762c61bb"
+  ]
+}
+x-commit-hash: "6b1655d5e552572c391430d53c9ce8d4eb858320"


### PR DESCRIPTION
SMTP protocol in OCaml

- Project page: <a href="https://github.com/mirage/colombe">https://github.com/mirage/colombe</a>
- Documentation: <a href="https://mirage.github.io/colombe/">https://mirage.github.io/colombe/</a>

##### CHANGES:

- Fix typo on `sendmail-miou-unix` (@kit-ty-kate, mirage/colombe#87)
- Provide the new package `msendmail` (@dinosaure, mirage/colombe#89)
- Implement `Sendmail_with_starttls.many` (@dinosaure, mirage/colombe#89)
- Fix buffer ownership on our reply decoder (@dinosaure, mirage/colombe#89)
- Improve `colombe.emile` (and avoid impossible failures) (@dinosaure, mirage/colombe#89)
- Handle the code 451 (@dinosaure, mirage/colombe#89)
- Add some tests for `colombe.emile` (@dinosaure, mirage/colombe#90)
- Add documentation for `msendmail` (@dinosaure, mirage/colombe#91)
