### PR TITLE
abella.2.0.8 is not compatible with OCaml 5.5 (compiler-libs)

### DIFF
--- a/packages/abella/abella.2.0.8/opam
+++ b/packages/abella/abella.2.0.8/opam
@@ -12,7 +12,7 @@ build: [
   [make "all-release" "abella.install"]
 ]
 depends: [
-  "ocaml"    { >= "4.12.0" }
+  "ocaml" {>= "4.12.0" & < "5.5"}
   "cmdliner" { >= "1.2.0" }
   "menhir"   { >= "20211012" }
   "yojson"   { >= "2.1.1" }


### PR DESCRIPTION
```
#=== ERROR while compiling abella.2.0.8 =======================================#
# context              2.6.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/abella.2.0.8
# command              /usr/bin/make all-release abella.install
# exit-code            2
# env-file             ~/.opam/log/abella-14-51799f.env
# output-file          ~/.opam/log/abella-14-51799f.out
### output ###
# dune build --release src/abella.exe src/abella_doc.exe src/abella_dep.exe
# (cd _build/.sandbox/b4570de7371edb53c1259af05bf9fdc8/default && /home/opam/.opam/5.5/bin/menhir --explain src/parser.mly --base src/parser --infer-read-reply src/parser__mock.mli.inferred)
# Warning: one state has shift/reduce conflicts.
# Warning: one shift/reduce conflict was arbitrarily resolved.
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/.abella_lib.objs/byte -I /home/opam/.opam/5.5/lib/yojson -no-alias-deps -o src/.abella_lib.objs/byte/depend.cmo -c -impl src/depend.ml)
# File "src/depend.ml", line 55, characters 63-74:
# 55 |       let deps = filename :: List.flatten_map (lp_dependencies (module Lp)) imms in
#                                                                     ^^^^^^^^^^^
# Error: The signature for this packaged module couldn't be inferred.
# make: *** [Makefile:10: all-release] Error 1
```