### PR TITLE
bitmasks is not compatible with OCaml 5.5 (stdlib change)

### DIFF
--- a/packages/bitmasks/bitmasks.1.5.0/opam
+++ b/packages/bitmasks/bitmasks.1.5.0/opam
@@ -10,7 +10,7 @@ build: [
   [ make "doc" ] {with-doc}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.5"}
   "dune"
   "stdlib-shims"
   "seq"


### PR DESCRIPTION
```
#=== ERROR while compiling bitmasks.1.5.0 =====================================#
# context              2.6.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/bitmasks.1.5.0
# command              ~/.opam/5.5/bin/dune build -p bitmasks -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/bitmasks-14-6d935e.env
# output-file          ~/.opam/log/bitmasks-14-6d935e.out
### output ###
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlopt.opt -w -40 -g -I .bitmasks.objs/byte -I .bitmasks.objs/native -I /home/opam/.opam/5.5/lib/seq -I /home/opam/.opam/5.5/lib/stdlib-shims -cmi-file .bitmasks.objs/byte/bitMaskSet.cmi -no-alias-deps -o .bitmasks.objs/native/bitMaskSet.cmx -c -impl BitMaskSet.ml)
# File "BitMaskSet.ml", lines 124-663, characters 8-5:
# 124 | ........struct
# 125 |     type storage = Mask.storage
# 126 |     type t = Mask.storage
# 127 | 
# 128 |     (* ****************************************************************************************** *
# ...
# 660 |     let add_seq s set = Seq.fold_left (fun set flag -> add flag set) set s
# 661 | 
# 662 |     let of_seq s = add_seq s empty
# 663 |   end
# Error: Signature mismatch:
#        ...
#        The value is_singleton is required but not provided
#        File "BitMaskSet.ml", lines 118-121, characters 12-29:
#          Expected declaration
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I .bitmasks.objs/byte -I /home/opam/.opam/5.5/lib/seq -I /home/opam/.opam/5.5/lib/stdlib-shims -cmi-file .bitmasks.objs/byte/bitMaskSet.cmi -no-alias-deps -o .bitmasks.objs/byte/bitMaskSet.cmo -c -impl BitMaskSet.ml)
# File "BitMaskSet.ml", lines 124-663, characters 8-5:
# 124 | ........struct
# 125 |     type storage = Mask.storage
# 126 |     type t = Mask.storage
# 127 | 
# 128 |     (* ****************************************************************************************** *
# ...
# 660 |     let add_seq s set = Seq.fold_left (fun set flag -> add flag set) set s
# 661 | 
# 662 |     let of_seq s = add_seq s empty
# 663 |   end
# Error: Signature mismatch:
#        ...
#        The value is_singleton is required but not provided
#        File "BitMaskSet.ml", lines 118-121, characters 12-29:
#          Expected declaration
```