### PR TITLE
camldiets is not compatible with OCaml 5.5 (stdlib change)

### DIFF
--- a/packages/camldiets/camldiets.0.3/opam
+++ b/packages/camldiets/camldiets.0.3/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 homepage: "https://github.com/tcsprojects/camldiets"
 bug-reports: "https://github.com/tcsprojects/camldiets/issues"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.5"}
   "dune" {>= "3.10"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling camldiets.0.3 ======================================#
# context              2.6.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/camldiets.0.3
# command              ~/.opam/5.5/bin/dune build -p camldiets -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/camldiets-14-f8cae0.env
# output-file          ~/.opam/log/camldiets-14-f8cae0.out
### output ###
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlopt.opt -w -40 -g -I src/.camldiets.objs/byte -I src/.camldiets.objs/native -cmi-file src/.camldiets.objs/byte/camldiets.cmi -no-alias-deps -o src/.camldiets.objs/native/camldiets.cmx -c -impl src/camldiets.ml)
# File "src/camldiets.ml", line 1:
# Error: The implementation src/camldiets.ml
#        does not match the interface src/camldiets.mli:  ... ...
#        In module Make:
#        The value is_singleton is required but not provided
#        File "set.mli", line 263, characters 4-31: Expected declaration
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/.camldiets.objs/byte -cmi-file src/.camldiets.objs/byte/camldiets.cmi -no-alias-deps -o src/.camldiets.objs/byte/camldiets.cmo -c -impl src/camldiets.ml)
# File "src/camldiets.ml", line 1:
# Error: The implementation src/camldiets.ml
#        does not match the interface src/camldiets.mli:  ... ...
#        In module Make:
#        The value is_singleton is required but not provided
#        File "set.mli", line 263, characters 4-31: Expected declaration
```