### PR TITLE
charset is not compatible with OCaml 5.5 (stdlib change)

### DIFF
--- a/packages/charset/charset.0.2.0/opam
+++ b/packages/charset/charset.0.2.0/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.11.0" & < "5.5"}
   "dune" {>= "2.3"}
   "ocaml_intrinsics" {>= "v0.15.0" & os != "win32"}
   "ounit2" {with-test}


### PR DESCRIPTION
```
#=== ERROR while compiling charset.0.2.0 ======================================#
# context              2.6.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/charset.0.2.0
# command              ~/.opam/5.5/bin/dune build -p charset -j 1
# exit-code            1
# env-file             ~/.opam/log/charset-14-90e5b3.env
# output-file          ~/.opam/log/charset-14-90e5b3.out
### output ###
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I lib/.charset.objs/byte -I /home/opam/.opam/5.5/lib/ocaml_intrinsics -I /home/opam/.opam/5.5/lib/ocaml_intrinsics_kernel -cmi-file lib/.charset.objs/byte/charset.cmi -no-alias-deps -o lib/.charset.objs/byte/charset.cmo -c -impl lib/charset.ml)
# File "lib/charset.ml", line 1:
# Error: The implementation lib/charset.ml
#        does not match the interface lib/charset.mli: 
#        The value is_singleton is required but not provided
#        File "set.mli", line 263, characters 4-31: Expected declaration
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlopt.opt -w -40 -g -I lib/.charset.objs/byte -I lib/.charset.objs/native -I /home/opam/.opam/5.5/lib/ocaml_intrinsics -I /home/opam/.opam/5.5/lib/ocaml_intrinsics_kernel -cmi-file lib/.charset.objs/byte/charset.cmi -no-alias-deps -o lib/.charset.objs/native/charset.cmx -c -impl lib/charset.ml)
# File "lib/charset.ml", line 1:
# Error: The implementation lib/charset.ml
#        does not match the interface lib/charset.mli: 
#        The value is_singleton is required but not provided
#        File "set.mli", line 263, characters 4-31: Expected declaration
```