### PR TITLE
earlybird is not compatible with OCaml 5.5 (compiler-libs)

### DIFF
--- a/packages/earlybird/earlybird.1.3.4/opam
+++ b/packages/earlybird/earlybird.1.3.4/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/hackwaly/ocamlearlybird"
 bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
 depends: [
   "dune" {>= "3.7"}
-  "ocaml" {>= "4.12.0" & < "4.14.3" | >= "5.0"}
+  "ocaml" {>= "4.12.0" & < "4.14.3" | >= "5.0" & < "5.5"}
   "ppx_deriving" {>= "5.1"}
   "ppx_deriving_yojson" {>= "3.6.1"}
   "menhir" {>= "20201216" & build}

--- a/packages/earlybird/earlybird.1.3.5/opam
+++ b/packages/earlybird/earlybird.1.3.5/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/hackwaly/ocamlearlybird"
 bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
 depends: [
   "dune" {>= "3.7"}
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "5.5"}
   "ppx_deriving" {>= "5.1"}
   "ppx_deriving_yojson" {>= "3.6.1"}
   "menhir" {>= "20201216" & build}


### PR DESCRIPTION
```
#=== ERROR while compiling earlybird.1.3.5 ====================================#
# context              2.6.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/earlybird.1.3.5
# command              ~/.opam/5.5/bin/dune build -p earlybird -j 1 @install
# exit-code            1
# env-file             ~/.opam/log/earlybird-14-69d6de.env
# output-file          ~/.opam/log/earlybird-14-69d6de.out
### output ###
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlopt.opt -w -40 -w -9 -g -I src/typenv/.typenv.objs/byte -I src/typenv/.typenv.objs/native -I /home/opam/.opam/5.5/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.5/lib/ocaml/compiler-libs -cmi-file src/typenv/.typenv.objs/byte/typenv.cmi -no-alias-deps -open Typenv__ -o src/typenv/.typenv.objs/native/typenv.cmx -c -impl src/typenv/typenv.pp.ml)
# File "src/typenv/typenv.ml", line 88, characters 30-33:
# 88 |    let env' = Env.add_module ?arg id presence mty env in
#                                    ^^^
# Error: The function applied to this argument has type
#          ?noalias:bool -> ?shape:Shape.t -> Env.t
# This argument cannot be applied with label ?arg
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/debugger/.debugger.objs/byte -I /home/opam/.opam/5.5/lib/bytes -I /home/opam/.opam/5.5/lib/iter -I /home/opam/.opam/5.5/lib/logs -I /home/opam/.opam/5.5/lib/lru -I /home/opam/.opam/5.5/lib/lwt -I /home/opam/.opam/5.5/lib/lwt/unix -I /home/opam/.opam/5.5/lib/lwt_react -I /home/opam/.opam/5.5/lib/menhirLib -I /home/opam/.opam/5.5/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.5/lib/ocaml/compiler-libs -I /home/opam/.opam/5.5/lib/ocaml/str -I /home/opam/.opam/5.5/lib/ocaml/threads -I /home/opam/.opam/5.5/lib/ocaml/unix -I /home/opam/.opam/5.5/lib/ocplib-endian -I /home/opam/.opam/5.5/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.5/lib/path_glob -I /home/opam/.opam/5.5/lib/ppx_deriving/runtime -I /home/opam/.opam/5.5/lib/psq -I /home/opam/.opam/5.5/lib/react -I /home/opam/.opam/5.5/lib/seq -I src/global/.global.objs/byte -I src/ground/.ground.objs/byte -I src/trivia_check/.trivia_check.objs/byte -I src/typenv/.typenv.objs/byte -no-alias-deps -open Debugger__ -o src/debugger/.debugger.objs/byte/debugger__Value_module.cmo -c -impl src/debugger/inspect/value_module.pp.ml)
# File "src/debugger/inspect/value_module.ml", line 93, characters 32-42:
# 93 |   | Tpackage {pack_path = path; pack_cstrs = []} [@if ocaml_version >= (5, 4, 0)] -> (
#                                      ^^^^^^^^^^
# Error: This record pattern is expected to have type Debugger__.Types.package
#        There is no field pack_cstrs within type Debugger__.Types.package
```