### PR TITLE
goblint is not compatible with OCaml 5.5 (breaking typechecking change)

### DIFF
--- a/packages/goblint/goblint.1.1.1/opam
+++ b/packages/goblint/goblint.1.1.1/opam
@@ -18,7 +18,7 @@ homepage: "https://goblint.in.tum.de"
 doc: "https://goblint.readthedocs.io/en/latest/"
 bug-reports: "https://github.com/goblint/analyzer/issues"
 depends: [
-  "ocaml" {>= "4.09"}
+  "ocaml" {>= "4.09" & < "5.5"}
   "dune" {>= "2.9.1"}
   "goblint-cil" {>= "1.8.2" & < "2.0.0"}
   "batteries" {>= "3.2.0" & < "3.4.0"}

--- a/packages/goblint/goblint.2.2.1/opam
+++ b/packages/goblint/goblint.2.2.1/opam
@@ -19,11 +19,11 @@ doc: "https://goblint.readthedocs.io/en/latest/"
 bug-reports: "https://github.com/goblint/analyzer/issues"
 depends: [
   "dune" {>= "3.6"}
-  "ocaml" {>= "4.10"}
+  "ocaml" {>= "4.10" & < "5.5"}
   "goblint-cil" {>= "2.0.2" & < "2.0.4"}
   "batteries" {>= "3.5.0"}
   "zarith" {>= "1.8"}
-  "yojson" {>= "2.0.0" < "3"}
+  "yojson" {>= "2.0.0" & < "3"}
   "qcheck-core" {>= "0.19" & < "0.26"}
   "ppx_deriving"
   "ppx_deriving_hash"

--- a/packages/goblint/goblint.2.3.0/opam
+++ b/packages/goblint/goblint.2.3.0/opam
@@ -19,7 +19,7 @@ doc: "https://goblint.readthedocs.io/en/latest/"
 bug-reports: "https://github.com/goblint/analyzer/issues"
 depends: [
   "dune" {>= "3.7"}
-  "ocaml" {>= "4.10"}
+  "ocaml" {>= "4.10" & < "5.5"}
   "goblint-cil" {>= "2.0.3" & < "2.0.4"}
   "batteries" {>= "3.5.0"}
   "zarith" {>= "1.8"}

--- a/packages/goblint/goblint.2.4.0/opam
+++ b/packages/goblint/goblint.2.4.0/opam
@@ -35,7 +35,7 @@ doc: "https://goblint.readthedocs.io/en/latest/"
 bug-reports: "https://github.com/goblint/analyzer/issues"
 depends: [
   "dune" {>= "3.7"}
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.14" & < "5.5"}
   "goblint-cil" {>= "2.0.4" & < "2.0.5"}
   "batteries" {>= "3.5.1"}
   "zarith" {>= "1.10"}

--- a/packages/goblint/goblint.2.5.0/opam
+++ b/packages/goblint/goblint.2.5.0/opam
@@ -35,7 +35,7 @@ doc: "https://goblint.readthedocs.io/en/latest/"
 bug-reports: "https://github.com/goblint/analyzer/issues"
 depends: [
   "dune" {>= "3.7"}
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.14" & < "5.5"}
   "goblint-cil" {>= "2.0.5" & < "2.0.7"}
   "batteries" {>= "3.5.1"}
   "zarith" {>= "1.10"}

--- a/packages/goblint/goblint.2.6.0/opam
+++ b/packages/goblint/goblint.2.6.0/opam
@@ -35,7 +35,7 @@ doc: "https://goblint.readthedocs.io/en/latest/"
 bug-reports: "https://github.com/goblint/analyzer/issues"
 depends: [
   "dune" {>= "3.13"}
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.14" & < "5.5"}
   "goblint-cil" {>= "2.0.7"}
   "batteries" {>= "3.9.0"}
   "zarith" {>= "1.10"}

--- a/packages/goblint/goblint.2.7.1/opam
+++ b/packages/goblint/goblint.2.7.1/opam
@@ -37,7 +37,7 @@ doc: "https://goblint.readthedocs.io/en/latest/"
 bug-reports: "https://github.com/goblint/analyzer/issues"
 depends: [
   "dune" {>= "3.13"}
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.14" & < "5.5"}
   "goblint-cil" {>= "2.0.9"}
   "batteries" {>= "3.9.0"}
   "zarith" {>= "1.10"}


### PR DESCRIPTION
```
#=== ERROR while compiling goblint.2.7.1 ======================================#
# context              2.6.0~alpha1~dev | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/goblint.2.7.1
# command              ~/.opam/5.5/bin/dune build -p goblint -j 1 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/goblint-14-86872a.env
# output-file          ~/.opam/log/goblint-14-86872a.out
### output ###
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -warn-error -A -w -unused-var-strict -w -unused-functor-parameter -w +9 -open Goblint_std -open Goblint_logs -g -bin-annot -bin-annot-occurrences -I src/.goblint_lib.objs/byte -I /home/opam/.opam/5.5/lib/angstrom -I /home/opam/.opam/5.5/lib/arg-complete -I /home/opam/.opam/5.5/lib/astring -I /home/opam/.opam/5.5/lib/batteries/unthreaded -I /home/opam/.opam/5.5/lib/bigstringaf -I /home/opam/.opam/5.5/lib/bos -I /home/opam/.opam/5.5/lib/camlp-streams -I /home/opam/.opam/5.5/lib/catapult -I /home/opam/.opam/5.5/lib/catapult-file -I /home/opam/.opam/5.5/lib/catapult/utils -I /home/opam/.opam/5.5/lib/cpu -I /home/opam/.opam/5.5/lib/cstruct -I /home/opam/.opam/5.5/lib/ctypes -I /home/opam/.opam/5.5/lib/ctypes/stubs -I /home/opam/.opam/5.5/lib/domain-local-await -I /home/opam/.opam/5.5/lib/domain_shims -I /home/opam/.opam/5.5/lib/dune-build-info -I /home/opam/.opam/5.5/lib/dune-private-libs/dune-section -I /home/opam/.opam/5.5/lib/dune-site -I /home/opam/.opam/5.5/lib/dune-site/private -I /home/opam/.opam/5.5/lib/fileutils -I /home/opam/.opam/5.5/lib/fmt -I /home/opam/.opam/5.5/lib/fpath -I /home/opam/.opam/5.5/lib/goblint-cil -I /home/opam/.opam/5.5/lib/goblint-cil/pta -I /home/opam/.opam/5.5/lib/goblint-cil/syntacticsearch -I /home/opam/.opam/5.5/lib/hex -I /home/opam/.opam/5.5/lib/integers -I /home/opam/.opam/5.5/lib/json-data-encoding -I /home/opam/.opam/5.5/lib/json-data-encoding/stdlib -I /home/opam/.opam/5.5/lib/jsonrpc -I /home/opam/.opam/5.5/lib/logs -I /home/opam/.opam/5.5/lib/num -I /home/opam/.opam/5.5/lib/ocaml/str -I /home/opam/.opam/5.5/lib/ocaml/threads -I /home/opam/.opam/5.5/lib/ocaml/unix -I /home/opam/.opam/5.5/lib/ppx_deriving/runtime -I /home/opam/.opam/5.5/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.5/lib/qcheck-core -I /home/opam/.opam/5.5/lib/qcheck-core/runner -I /home/opam/.opam/5.5/lib/rresult -I /home/opam/.opam/5.5/lib/seq -I /home/opam/.opam/5.5/lib/sha -I /home/opam/.opam/5.5/lib/stdlib-shims -I /home/opam/.opam/5.5/lib/stringext -I /home/opam/.opam/5.5/lib/thread-table -I /home/opam/.opam/5.5/lib/uri -I /home/opam/.opam/5.5/lib/uuidm -I /home/opam/.opam/5.5/lib/yaml -I /home/opam/.opam/5.5/lib/yaml/bindings -I /home/opam/.opam/5.5/lib/yaml/bindings/types -I /home/opam/.opam/5.5/lib/yaml/c -I /home/opam/.opam/5.5/lib/yaml/ffi -I /home/opam/.opam/5.5/lib/yaml/types -I /home/opam/.opam/5.5/lib/yaml/unix -I /home/opam/.opam/5.5/lib/yojson -I /home/opam/.opam/5.5/lib/zarith -I src/build-info/.goblint_build_info.objs/byte -I src/cdomain/value/.goblint_cdomain_value.objs/byte -I src/common/.goblint_common.objs/byte -I src/config/.goblint_config.objs/byte -I src/constraint/.goblint_constraint.objs/byte -I src/domain/.goblint_domain.objs/byte -I src/incremental/.goblint_incremental.objs/byte -I src/sites/.goblint_sites.objs/byte -I src/solver/.goblint_solver.objs/byte -I src/util/backtrace/.goblint_backtrace.objs/byte -I src/util/library/.goblint_library.objs/byte -I src/util/logs/.goblint_logs.objs/byte -I src/util/parallel/.goblint_parallel.objs/byte -I src/util/std/.goblint_std.objs/byte -I src/util/timing/.goblint_timing.objs/byte -I src/util/tracing/.goblint_tracing.objs/byte -no-alias-deps -open Goblint_lib__ -o src/.goblint_lib.objs/byte/goblint_lib__Control.cmo -c -impl src/framework/control.pp.ml)
# File "src/framework/control.ml", line 863, characters 17-29:
# 863 |     analyze_loop (module CFG) file fs change_info
#                        ^^^^^^^^^^^^
# Error: The signature for this packaged module couldn't be inferred.
```
cc @samsa1 @octachron just to make extra sure that this breaking change is expected