### PR TITLE
[new release] yamlx (0.2.0)

### DIFF
--- a/packages/yamlx/yamlx.0.2.0/opam
+++ b/packages/yamlx/yamlx.0.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis:
+  "Pure-OCaml YAML 1.2/1.1 parser with a lossless, comment-preserving AST"
+description: """
+YAMLx is a pure-OCaml YAML 1.2 library. It passes all 371 tests from the yaml-test-suite and has no C bindings or external runtime dependencies. The parsed node tree preserves scalar styles, flow vs. block collection style, tags, anchors, source positions, and comments. A pretty-printer can round-trip the AST back to YAML. A typed-value resolver applies the YAML 1.2 JSON schema and returns Null / Bool / Int / Float / String / Seq / Map values. Structured errors carry line, column, and byte-offset information.
+
+YAMLx is currently released under the AGPL. A commercial license and a path to a fully permissive ISC license are available — see FUNDING.md."""
+maintainer: ["Martin Jambon <martin@mjambon.com>"]
+authors: ["Martin Jambon <martin@mjambon.com>"]
+license: "AGPL-3.0-only"
+tags: ["yaml" "parser" "serialization"]
+homepage: "https://github.com/mjambon/yamlx"
+doc: "https://mjambon.github.io/yamlx"
+bug-reports: "https://github.com/mjambon/yamlx/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.14.0"}
+  "ppx_deriving"
+  "testo" {with-test}
+  "afl-persistent" {dev}
+  "yaml" {dev}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mjambon/yamlx.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mjambon/yamlx/releases/download/0.2.0/yamlx-0.2.0.tbz"
+  checksum: [
+    "sha256=fba05467c9be884657ffea23f10afb46fde22242c7e49bd329c7c21473ff4ed0"
+    "sha512=2381310f1ca18e9adbd177840135add9898cada4f52c82d4baaa585aa5b01171710cbf810c9c1ba9a6296167a0b1100e0496f9e384b6a8dd0805b8aecc1da09d"
+  ]
+}
+x-commit-hash: "890bf79e6d33609764871eeebcccd45d8d197a7e"


### PR DESCRIPTION
Pure-OCaml YAML 1.2/1.1 parser with a lossless, comment-preserving AST

- Project page: <a href="https://github.com/mjambon/yamlx">https://github.com/mjambon/yamlx</a>
- Documentation: <a href="https://mjambon.github.io/yamlx">https://mjambon.github.io/yamlx</a>

##### CHANGES:

### Bug fixes

- Node `loc` fields now exclude trailing whitespace and line terminators
  ([mjambon/yamlx#27](https://github.com/mjambon/yamlx/issues/27)):
  - **Plain scalars** (block and flow context): `end_pos` is now right after
    the last content character, not past trailing spaces or consumed newlines.
  - **Block scalars** (`|`, `>`): `end_pos` is now at the line terminator of
    the last content line, not at the start of the next token's line.
- The `---` document separator is now always emitted on its own line. Previously
  it was followed by a space and the document content on the same line for
  scalar and flow-collection documents, e.g. `--- foo` instead of `---\nfoo`.
  ([mjambon/yamlx#25](https://github.com/mjambon/yamlx/issues/25))

### Comment attachment improvements ([mjambon/yamlx#20](https://github.com/mjambon/yamlx/issues/20))

- Comments between a mapping key and its value (when the value starts on the
  next line) are now correctly attached as `head_comments` of the value node.
  Previously they were silently discarded.
- Trailing comments after the last item of a block collection are now attached
  as `foot_comments` of the collection and printed at the correct indentation
  level.  Previously they were attached to the last item's `foot_comments` and
  printed at column 0.
- Block scalar header comments (`| # note`, `> # note`) are now captured and
  round-trip correctly.  Previously the comment was silently dropped.
- Standalone comments that appear between two documents (before `---`) are now
  attached as `foot_comments` of the preceding document rather than leaking
  into the `head_comments` of the following document's root node.
- Added `foot_comments : string list` field to `Scalar_node` and `Alias_node`
  (previously only collection nodes had this field).
