### PR TITLE
[new release] alcobar (0.3.1)

### DIFF
--- a/packages/alcobar/alcobar.0.3.1/opam
+++ b/packages/alcobar/alcobar.0.3.1/opam
@@ -34,7 +34,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/alcobar/alcobar.0.3.1/opam
+++ b/packages/alcobar/alcobar.0.3.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Write tests, let a fuzzer find failing cases"
+description: """
+Alcobar is a library for testing code, combining QuickCheck-style
+property-based testing and the magical bug-finding powers of
+[afl-fuzz](http://lcamtuf.coredump.cx/afl/).
+"""
+maintainer: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+authors: ["Stephen Dolan <stephen.dolan@cl.cam.ac.uk>"]
+license: "MIT"
+homepage: "https://github.com/samoht/alcobar"
+bug-reports: "https://github.com/samoht/alcobar/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.08"}
+  "alcotest"
+  "cmdliner" {>= "1.1.0"}
+  "afl-persistent" {>= "1.1"}
+  "calendar" {>= "2.00" & with-test}
+  "fpath" {with-test}
+  "pprint" {with-test}
+  "uucp" {with-test}
+  "uunf" {with-test}
+  "uutf" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/samoht/alcobar.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/samoht/alcobar/releases/download/v0.3.1/alcobar-0.3.1.tbz"
+  checksum: [
+    "sha256=576527bcbaed7fe5d7929eee165ac8a7183af9f66ac21092fc9ec2dcdc3e7955"
+    "sha512=8b2fdeacef119c001c765c99eb603332a4ad0214e04ca32396935333d6abdd52095a4ec48e86c53c2bd7f8b5872ebbbf5bcea4065c94d5fcf1496897716e0158"
+  ]
+}
+x-commit-hash: "bbc76385515da5924d9bbc5dfbfdfab0e1b6ccfe"

--- a/packages/alcobar/alcobar.0.3.1/opam
+++ b/packages/alcobar/alcobar.0.3.1/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/samoht/alcobar"
 bug-reports: "https://github.com/samoht/alcobar/issues"
 depends: [
   "dune" {>= "3.21"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.10"}
   "alcotest"
   "cmdliner" {>= "1.1.0"}
   "afl-persistent" {>= "1.1"}


### PR DESCRIPTION
Write tests, let a fuzzer find failing cases

- Project page: <a href="https://github.com/samoht/alcobar">https://github.com/samoht/alcobar</a>

##### CHANGES:

Fork of Crowbar, renamed to Alcobar.

- New upstream: `samoht/alcobar` (maintainer: Thomas Gazagnaire).
- Adopt `ocamlformat` (version 0.29.0).
- Alcotest-compatible API: `test_case` and `run` replace the old
  `add_test` interface; property tests run via `Alcotest.run_with_args`,
  AFL mode is preserved by detecting a file argument. Examples now build
  as executables with an explicit `runtest` rule, so test binaries can
  be invoked directly with CLI flags.
- `--gen-corpus DIR` flag generates seed corpus files from passing
  test runs, capturing the exact bytes consumed by generators.
- Per-test timeout (`ALCOBAR_TIMEOUT` env var, `--timeout` flag);
  defaults to 2 seconds. Use `--timeout 0` to disable.
- Per-test time budget (`--budget SECONDS`); iteration stops when the
  budget is exhausted. Defaults to 2 seconds. Use `--budget 0` to disable.
- README rewritten for the alcobar fork.
- GitHub Actions CI on push and pull request.
- Library sources moved from `src/` to `lib/`.
- Restructure examples as fuzz runners: each directory has `fuzz.ml`
  plus a `fuzz_<lib>.ml[i]` module exporting a `suite` value.
- Require dune >= 3.21 and use `%{dune-warnings}` for dev flags.
