### PR TITLE
[new release] wire (0.9.0)

### DIFF
--- a/packages/wire/wire.0.9.0/opam
+++ b/packages/wire/wire.0.9.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Binary wire format DSL with EverParse 3D output"
+description:
+  "OCaml DSL for describing binary wire formats with EverParse 3D output. Define your wire format once, then use it for OCaml parsing via bytesrw or emit .3d files for verified C parser generation via EverParse."
+maintainer: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+license: "ISC"
+homepage: "https://github.com/parsimoni-labs/ocaml-wire"
+bug-reports: "https://github.com/parsimoni-labs/ocaml-wire/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "5.1"}
+  "bytesrw" {>= "0.1"}
+  "eio" {>= "1.0"}
+  "fmt" {>= "0.9"}
+  "memtrace" {with-test}
+  "alcotest" {with-test}
+  "alcobar" {with-test}
+  "re" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/parsimoni-labs/ocaml-wire.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/parsimoni-labs/ocaml-wire/releases/download/0.9.0/wire-0.9.0.tbz"
+  checksum: [
+    "sha256=dfd1fd578e84bd652ddb0064b3ee87d47780cc62e24180f3e5a92413bafad87a"
+    "sha512=125ada27127533b6130885d7b62f31c7ad4fc355a236258326b85c12792031c95d84fe68751264402f2efa7e09d70dd8bb5d06660e9a416e71a9a140f9658ed1"
+  ]
+}
+x-commit-hash: "e5d2f05e898289692aea64838e8154d6676696bd"


### PR DESCRIPTION
Binary wire format DSL with EverParse 3D output

- Project page: <a href="https://github.com/parsimoni-labs/ocaml-wire">https://github.com/parsimoni-labs/ocaml-wire</a>

##### CHANGES:

Initial release.
