### PR TITLE
[new release] cascade (1.0.0)

### DIFF
--- a/packages/cascade/cascade.1.0.0/opam
+++ b/packages/cascade/cascade.1.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "CSS generation and manipulation library for OCaml"
+description: """
+Cascade provides a typed CSS AST, parser, pretty-printer, and optimizer.
+   Supports selectors, properties, values, media queries, container queries,
+   @supports, @property, @layer, @keyframes, @font-face, and CSS variables."""
+maintainer: ["Thomas Gazagnaire"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/samoht/cascade"
+bug-reports: "https://github.com/samoht/cascade/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0"}
+  "dune-build-info"
+  "alcotest" {with-test}
+  "alcobar" {with-test}
+  "astring" {with-test}
+  "fmt"
+  "cmdliner"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/samoht/cascade.git"
+url {
+  src:
+    "https://github.com/samoht/cascade/releases/download/1.0.0/cascade-1.0.0.tbz"
+  checksum: [
+    "sha256=78913d85f9c97c963793462df79d89930b62f6535c8c0f3ec5fd07f9c55b40f1"
+    "sha512=184c169afcc8c6a09f482b2d922c44d806038cdbd116a19924a02b2154fc62f8f5ae3f5c83ce69933f81f5763ad50586d59e8cf8fecde91af02ab36034e66b70"
+  ]
+}
+x-commit-hash: "4c8962d1931b08839c45d894d5fd07bf5035a707"


### PR DESCRIPTION
CSS generation and manipulation library for OCaml

- Project page: <a href="https://github.com/samoht/cascade">https://github.com/samoht/cascade</a>

##### CHANGES:

### Added

- Initial release of Cascade as a standalone CSS library
- Typed CSS AST with selectors, properties, values, declarations, and stylesheets
- CSS parser with error recovery (`Css.of_string`)
- CSS pretty-printer with minification support (`Css.to_string`)
- CSS optimizer: deduplication, rule merging, selector combining (`Css.optimize`)
- CSS custom properties with `@property` registration and typed syntax
- At-rules: `@media`, `@supports`, `@layer`, `@keyframes`, `@font-face`,
  `@container`, `@property`, `@starting-style`
- Modern color spaces: oklch, oklab, lch, hwb, color-mix, system colors
- Logical properties (inline/block variants)
- `cascade` CLI tool for formatting, minifying, and optimizing CSS
- `cssdiff` CLI tool for structural CSS comparison
- `cascade.tools` sub-library for programmatic CSS diffing
