### PR TITLE
Add: cmdliner.2.1.1

### DIFF
--- a/packages/cmdliner/cmdliner.2.1.1/opam
+++ b/packages/cmdliner/cmdliner.2.1.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Declarative definition of command line interfaces for OCaml"
+description: """\
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles command line completion, syntax errors,
+help messages and UNIX man page generation. It supports programs with
+single or multiple commands and respects most of the [POSIX] and [GNU]
+conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+Homepage: <http://erratique.ch/software/cmdliner>
+
+[POSIX]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[GNU]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The cmdliner programmers"
+license: "ISC"
+tags: ["cli" "system" "declarative" "org:erratique"]
+homepage: "https://erratique.ch/software/cmdliner"
+doc: "https://erratique.ch/software/cmdliner/doc"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+]
+build: [make "all" "PREFIX=%{prefix}%"]
+install: [
+  [
+    make
+    "install"
+    "BINDIR=%{_:bin}%"
+    "LIBDIR=%{_:lib}%"
+    "DOCDIR=%{_:doc}%"
+    "SHAREDIR=%{share}%"
+    "MANDIR=%{man}%"
+  ]
+  [
+    make
+    "install-doc"
+    "LIBDIR=%{_:lib}%"
+    "DOCDIR=%{_:doc}%"
+    "SHAREDIR=%{share}%"
+    "MANDIR=%{man}%"
+  ]
+]
+dev-repo: "git+https://erratique.ch/repos/cmdliner.git"
+url {
+  src: "https://erratique.ch/software/cmdliner/releases/cmdliner-2.1.1.tbz"
+  checksum:
+    "sha512=cdc338ae2e56a72b7c75dae9564c57cca4e1fbfac454aabbf8303fcb612346284aede5984dfde7e8a7a496cc870bbd57ddf28cab3a38667279b31657f85c15dd"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `cmdliner.2.1.1` [home](https://erratique.ch/software/cmdliner), [doc](https://erratique.ch/software/cmdliner/doc), [issues](https://github.com/dbuenzli/cmdliner/issues)  
  *Declarative definition of command line interfaces for OCaml*


---

#### `cmdliner` v2.1.1 2026-04-21 La Forclaz (VS)

- bash completion: add compatibility with `bash-completions` < 2.12 ([#261](https://github.com/dbuenzli/cmdliner/issues/261)).
  Thanks to Brian Ward for the patch.

- Fix completion when `CMDLINER_LEGACY_PREFIXES` is enabled ([#262](https://github.com/dbuenzli/cmdliner/issues/262), [#263](https://github.com/dbuenzli/cmdliner/issues/263)).
  Thanks to Brian Ward for the report and the patch.

- Change hyphen escaping in groff output to make `man-db` and Debian
  tools happy ([#254](https://github.com/dbuenzli/cmdliner/issues/254), [#267](https://github.com/dbuenzli/cmdliner/issues/267)). Thanks to Benjamin Somers for suggesting
  and the patch.

- Better build environment insulation for byte-code only environments.
  We no longer look up the `.opt` tools and detect the availability of
  the native code toolchain by checking for the file 
  `$(ocamlc -where)/libasmrun$(LIB_EXT)` ([#268](https://github.com/dbuenzli/cmdliner/issues/268)). Thanks to Yuriy Krasilnikov
  for the report.

- Fix `cmdliner` tool on Windows when given Unix style paths. All
  given paths are converted on cli argument parsing to use the
  platform directory separator. This ensure that the `Stdlib.Filename`
  functions used by the tool munge paths correctly. [#257](https://github.com/dbuenzli/cmdliner/issues/257)

- Fix build on Windows with `sys-msvc`.
  Thanks to Antonin Décimo and Nicolás Ojeda Bär ([#253](https://github.com/dbuenzli/cmdliner/issues/253)).

- Add `.NOTPARALLEL` to makefile. 
  Thanks to Antonin Décimo for the report and patch ([#252](https://github.com/dbuenzli/cmdliner/issues/252)).

---

Use `b0 -- .opam publish cmdliner.2.1.1` to update the pull request.