### PR TITLE
Add: bos.0.3.0

### DIFF
--- a/packages/bos/bos.0.3.0/opam
+++ b/packages/bos/bos.0.3.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Basic OS interaction for OCaml"
+description: """\
+Bos provides support for basic and robust interaction with the
+operating system in OCaml. It has functions to access the process
+environment, parse command line arguments, interact with the file
+system and run command line programs.
+
+Bos works equally well on POSIX and Windows operating systems.
+
+Bos depends on [Rresult][rresult], [Astring][astring], [Fmt][fmt],
+[Fpath][fpath] and [Logs][logs] and the OCaml Unix library. It is
+distributed under the ISC license.
+
+[rresult]: http://erratique.ch/software/rresult
+[astring]: http://erratique.ch/software/astring
+[fmt]: http://erratique.ch/software/fmt
+[fpath]: http://erratique.ch/software/fpath
+[logs]: http://erratique.ch/software/logs
+
+Home page: http://erratique.ch/software/bos  
+Contact: Daniel Bünzli `<daniel.buenzl i@erratique.ch>`"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The bos programmers"
+license: "ISC"
+tags: [
+  "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique"
+]
+homepage: "https://erratique.ch/software/bos"
+doc: "https://erratique.ch/software/bos/doc"
+bug-reports: "https://github.com/dbuenzli/bos/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+  "base-unix"
+  "rresult" {>= "0.7.0"}
+  "astring"
+  "fpath"
+  "fmt" {>= "0.8.10"}
+  "logs"
+  "mtime" {with-test}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/bos.git"
+url {
+  src: "https://erratique.ch/software/bos/releases/bos-0.3.0.tbz"
+  checksum:
+    "sha512=b5f18693c487d9f18e45fe3aebb90a83d4d4305ddd0a229e91acb066a799d26af7c1a498fdb74790c3de4dca191be0ce7c5825117fb2fa011a3e234a316f922d"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `bos.0.3.0` [home](https://erratique.ch/software/bos), [doc](https://erratique.ch/software/bos/doc), [issues](https://github.com/dbuenzli/bos/issues)  
  *Basic OS interaction for OCaml*


---

#### `bos` v0.3.0 2026-04-22 La Forclaz (VS)

- Require OCaml >= 4.14.
- Move to one directory per library install convention.
- `bos` library: drop dependency on `rresult`. But the `bos` package
  still depends on it because of the `bos.setup` library.

- Fix sporadic deadlocks in `OS.Cmd.run_io` ([#105](https://github.com/dbuenzli/bos/issues/105)). Thanks to arvidj
  for the report and the fix.
- Fix `OS.File.{read,write,with_ic,with_oc,write_lines}` performing
  newline translation when the file is `Fpath.dash` ([#65](https://github.com/dbuenzli/bos/issues/65)). Thanks to
  Hezekiah M. Carty for the report.

- Add `Cmd.if'` and deprecate `Cmd.on`.
- Add `OS.Path.[exists_]realpath` ([#49](https://github.com/dbuenzli/bos/issues/49)).
- Add `OS.Dir.expand_tilde` ([#96](https://github.com/dbuenzli/bos/issues/96)), Thanks to Favonia for the patch.
- Add `OS.Dir.{config,data,cache,runtime,state}` looked up according
  to XDG conventions ([#93](https://github.com/dbuenzli/bos/issues/93)). Thanks to Favonia for suggesting.
- Tweak `OS.Dir.user` ([#77](https://github.com/dbuenzli/bos/issues/77), [#96](https://github.com/dbuenzli/bos/issues/96)). On Windows with MSVC++ or MinGW, only
  `USERPROFILE` is consulted. On Windows with Cygwin and other operating 
  systems, `HOME` is consulted first; previously, `getpwnam` was consulted 
  first. Thanks to Favonia for the patch.
 
- Internal. More subtle uninterruptible `Unix.close` function ([#72](https://github.com/dbuenzli/bos/issues/72)).
  Thanks to Tom Ridge for reporting.
- Internal. Remove a catch all exception handler in the implementation
  of a "`Unix.close_noerr`" function.

---

Use `b0 -- .opam publish bos.0.3.0` to update the pull request.