### PR TITLE
[new release] yamlx (0.3.0)

### DIFF
--- a/packages/yamlx/yamlx.0.3.0/opam
+++ b/packages/yamlx/yamlx.0.3.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis:
+  "Pure-OCaml YAML 1.2/1.1 parser with a lossless, comment-preserving AST"
+description: """
+YAMLx is a pure-OCaml YAML 1.2 library. It passes all 371 tests from the yaml-test-suite and has no C bindings or external runtime dependencies. The parsed node tree preserves scalar styles, flow vs. block collection style, tags, anchors, source positions, and comments. A pretty-printer can round-trip the AST back to YAML. A typed-value resolver applies the YAML 1.2 JSON schema and returns Null / Bool / Int / Float / String / Seq / Map values. Structured errors carry line, column, and byte-offset information.
+
+YAMLx is currently released under the AGPL. A commercial license and a path to a fully permissive ISC license are available — see FUNDING.md."""
+maintainer: ["Martin Jambon <martin@mjambon.com>"]
+authors: ["Martin Jambon <martin@mjambon.com>"]
+license: "AGPL-3.0-only"
+tags: ["yaml" "parser" "serialization"]
+homepage: "https://github.com/mjambon/yamlx"
+doc: "https://mjambon.github.io/yamlx"
+bug-reports: "https://github.com/mjambon/yamlx/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.14.0"}
+  "ppx_deriving"
+  "testo" {with-test}
+  "afl-persistent" {dev}
+  "yaml" {dev}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mjambon/yamlx.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mjambon/yamlx/releases/download/0.3.0/yamlx-0.3.0.tbz"
+  checksum: [
+    "sha256=f691a9e174828cc130b14a87b70a322c129351d3e399871ca9a53774b9205738"
+    "sha512=ba0e837f1773ba0b09cd0d9720c033f9b0d6b9816dbad8cb9f3b167cac6ae855d6b8fd39db2956e91f575e886689db38324a5e879593127b3e726771151a2a4b"
+  ]
+}
+x-commit-hash: "40bd0e59b124b1671b76470d00954302ee3453e6"


### PR DESCRIPTION
Pure-OCaml YAML 1.2/1.1 parser with a lossless, comment-preserving AST

- Project page: <a href="https://github.com/mjambon/yamlx">https://github.com/mjambon/yamlx</a>
- Documentation: <a href="https://mjambon.github.io/yamlx">https://mjambon.github.io/yamlx</a>

##### CHANGES:

### New features

- **`Node` submodule** — single-node interface for the lossless AST
  ([mjambon/yamlx#37](https://github.com/mjambon/yamlx/issues/37),
  [mjambon/yamlx#38](https://github.com/mjambon/yamlx/pull/38)).
  Mirrors the `Value` module for the `node` type:
  - `Node.t` — forwarding type alias for `node`, exposing all four
    constructors (`Node.Scalar_node`, `Node.Sequence_node`,
    `Node.Mapping_node`, `Node.Alias_node`) alongside the top-level names.
  - `Node.has_comments : Node.t -> bool` — returns `true` if the node or
    any descendant carries a comment (head, line, or foot).
  - `Node.pp` / `Node.show` — aliases for `pp_node` / `show_node`.
  - `Nodes.has_comments : Nodes.t -> bool` — returns `true` if any document
    in the parsed stream contains a comment. Both `Node` and `Nodes` expose
    `has_comments` on their own `t`.

- **`Value.t` forwarding type**
  ([mjambon/yamlx#36](https://github.com/mjambon/yamlx/pull/36)).
  `Value.t` is an alias for `value` that re-exports all constructors
  (`Value.Null`, `Value.Bool`, etc.) under the `Value` namespace.

- **`Value` submodule** — single-document interface for typed YAML values
  ([mjambon/yamlx#32](https://github.com/mjambon/yamlx/issues/32)).
  Most config files contain exactly one YAML document; the new `Value` module
  provides a cleaner API for this common case:
  - `Value.of_yaml` / `of_yaml_exn`: parse a string expecting one document.
  - `Value.of_yaml_file`: read and parse a file expecting one document.
  - `Value.to_yaml` / `to_yaml_file`: serialize a single value back to YAML.
  - `Value.equal`: structural equality ignoring source locations.
  - `Value.compare`: total order on values ignoring source locations.
  - `Value.pp` / `Value.show`: pretty-printer and string renderer (aliases for
    the PPX-derived `pp_value` / `show_value`, which remain undeprecated for
    use by `[@@deriving show]` on types that embed `value`).
  - `Value.loc`: extract the source location from any value constructor.
  The `Values.one_of_yaml` / `one_of_yaml_exn` / `one_of_yaml_file` functions
  and `YAMLx.equal_value` and `YAMLx.value_loc` are now deprecated in favor
  of their `Value.*` equivalents.

- **Block scalar heuristics for `Values.to_nodes` / `Values.to_yaml`**
  ([mjambon/yamlx#30](https://github.com/mjambon/yamlx/issues/30)).
  String values longer than 70 characters are now serialized using block
  scalar styles where appropriate:
  - Strings with internal newlines and only safe characters → literal block
    (`|` or `|-`), preserving newlines exactly.
  - Single-line strings with spaces and only printable characters → folded
    block (`>` or `>-`), with lines wrapped at approximately 70 characters.
  - Short strings and strings containing control characters continue to use
    `Plain` or `Double_quoted` as before.

- **`reformat` output format** for the `yamlx` CLI
  ([mjambon/yamlx#30](https://github.com/mjambon/yamlx/issues/30)).
  `yamlx -f reformat` reads the input through the typed-value layer (dropping
  comments, anchors, and tags) and re-serializes using the block scalar
  heuristics above. This produces a normalized, human-readable YAML output
  from any conforming input.
